### PR TITLE
[LPS-112460, LPS-112460, LPS-116360] Updates DropdownMenu and DropdownActions tags and adds AdditionalProps mechanism to clay:* tags

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ItemSelectorDialog} from 'frontend-js-web';
+
+const ACTIONS = {
+	deleteVocabularies({
+		deleteVocabulariesURL,
+		portletNamespace,
+		viewVocabulariesURL,
+	}) {
+		const vocabulariesForm = document.createElement('form');
+
+		vocabulariesForm.setAttribute('method', 'post');
+
+		const itemSelectorDialog = new ItemSelectorDialog({
+			buttonAddLabel: Liferay.Language.get('delete'),
+			eventName: `${portletNamespace}selectVocabularies`,
+			title: Liferay.Language.get('delete-vocabulary'),
+			url: viewVocabulariesURL,
+		});
+
+		itemSelectorDialog.on('selectedItemChange', (event) => {
+			const selectedItems = event.selectedItem;
+
+			if (selectedItems) {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-the-selected-entries'
+						)
+					)
+				) {
+					selectedItems.forEach((item) => {
+						vocabulariesForm.appendChild(item.cloneNode(true));
+					});
+
+					submitForm(vocabulariesForm, deleteVocabulariesURL);
+				}
+			}
+		});
+
+		itemSelectorDialog.open();
+	},
+};
+
+export default function propsTransformer({
+	deleteVocabulariesURL,
+	items,
+	portletNamespace,
+	viewVocabulariesURL,
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action]({
+							deleteVocabulariesURL,
+							portletNamespace,
+							viewVocabulariesURL,
+						});
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -52,18 +52,34 @@
 													PortletURL editVocabularyURL = assetCategoriesDisplayContext.getEditVocabularyURL();
 													%>
 
-													<liferay-ui:icon
+													<clay:link
+														buttonStyle="borderless"
+														href="<%= editVocabularyURL.toString() %>"
 														icon="plus"
-														iconCssClass="btn btn-monospaced btn-outline-borderless btn-outline-secondary btn-sm"
-														markupView="lexicon"
-														url="<%= editVocabularyURL.toString() %>"
 													/>
 												</c:if>
 											</li>
 											<li>
+												<liferay-portlet:actionURL copyCurrentRenderParameters="<%= false %>" name="deleteVocabulary" var="deleteVocabulariesURL">
+													<portlet:param name="redirect" value="<%= assetCategoriesDisplayContext.getDefaultRedirect() %>" />
+												</liferay-portlet:actionURL>
+
+												<portlet:renderURL var="viewVocabulariesURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+													<portlet:param name="mvcPath" value="/view_vocabularies.jsp" />
+												</portlet:renderURL>
+
+												<%
+												Map<String, Object> additionalProps = HashMapBuilder.<String, Object>put(
+													"deleteVocabulariesURL", deleteVocabulariesURL.toString()
+												).put(
+													"viewVocabulariesURL", viewVocabulariesURL.toString()
+												).build();
+												%>
+
 												<clay:dropdown-actions
-													componentId="actionsComponent"
+													additionalProps="<%= additionalProps %>"
 													dropdownItems="<%= assetCategoriesDisplayContext.getVocabulariesDropdownItems() %>"
+													propsTransformer="js/ActionsComponentPropsTransformer"
 												/>
 											</li>
 										</ul>
@@ -185,70 +201,3 @@
 		</clay:col>
 	</clay:row>
 </clay:container-fluid>
-
-<aui:form cssClass="hide" name="vocabulariesFm">
-</aui:form>
-
-<aui:script require="metal-dom/src/dom as dom, frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
-	var deleteVocabularies = function () {
-		var vocabulariesFm = document.<portlet:namespace />vocabulariesFm;
-
-		if (vocabulariesFm) {
-			var itemSelectorDialog = new ItemSelectorDialog.default({
-				buttonAddLabel: '<liferay-ui:message key="delete" />',
-				eventName: '<portlet:namespace />selectVocabularies',
-				title: '<liferay-ui:message key="delete-vocabulary" />',
-				url:
-					'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/view_vocabularies.jsp" /></portlet:renderURL>',
-			});
-
-			itemSelectorDialog.on('selectedItemChange', function (event) {
-				var selectedItems = event.selectedItem;
-
-				if (selectedItems) {
-					if (
-						confirm(
-							'<liferay-ui:message key="are-you-sure-you-want-to-delete-the-selected-entries" />'
-						)
-					) {
-						Array.prototype.forEach.call(selectedItems, function (
-							item,
-							index
-						) {
-							dom.append(vocabulariesFm, item);
-						});
-
-						<liferay-portlet:actionURL copyCurrentRenderParameters="<%= false %>" name="deleteVocabulary" var="deleteVocabulariesURL">
-							<portlet:param name="redirect" value="<%= assetCategoriesDisplayContext.getDefaultRedirect() %>" />
-						</liferay-portlet:actionURL>
-
-						submitForm(vocabulariesFm, '<%= deleteVocabulariesURL %>');
-					}
-				}
-			});
-
-			itemSelectorDialog.open();
-		}
-	};
-
-	var ACTIONS = {
-		deleteVocabularies: deleteVocabularies,
-	};
-
-	Liferay.componentReady('actionsComponent').then(function (actionsComponent) {
-		actionsComponent.on(['click', 'itemClicked'], function (event, facade) {
-			var itemData;
-
-			if (event.data && event.data.item) {
-				itemData = event.data.item.data;
-			}
-			else if (!event.data && facade && facade.target) {
-				itemData = facade.target.data;
-			}
-
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
-</aui:script>

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
@@ -361,7 +361,6 @@ public class AssetListDisplayContext {
 			dropdownItem.putData(
 				"addAssetListEntryURL", _getAddAssetListEntryURL(type));
 			dropdownItem.putData("title", _getAddAssetListTitle(title));
-			dropdownItem.setHref("#");
 			dropdownItem.setLabel(LanguageUtil.get(_httpServletRequest, label));
 		};
 	}

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/constants/DepotAdminWebKeys.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/constants/DepotAdminWebKeys.java
@@ -21,6 +21,10 @@ public class DepotAdminWebKeys {
 
 	public static final String ACTION_COMMAND_NAME = "ACTION_COMMAND_NAME";
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String CONNECTED_SITE_DROPDOWN_DEFAULT_EVENT_HANDLER =
 		"CONNECTED_SITE_DROPDOWN_DEFAULT_EVENT_HANDLER";
 

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/ConnectedSiteDropdownPropsTransformer.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/ConnectedSiteDropdownPropsTransformer.js
@@ -12,9 +12,7 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
-
-class ConnectedSiteDropdownDefaultEventHandler extends DefaultEventHandler {
+const ACTIONS = {
 	disconnect(itemData) {
 		if (
 			confirm(
@@ -25,7 +23,25 @@ class ConnectedSiteDropdownDefaultEventHandler extends DefaultEventHandler {
 		) {
 			submitForm(document.hrefFm, itemData.disconnectSiteActionURL);
 		}
-	}
-}
+	},
+};
 
-export default ConnectedSiteDropdownDefaultEventHandler;
+export default function propsTransformer({items, ...otherProps}) {
+	return {
+		...otherProps,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/Languages.es.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/Languages.es.js
@@ -109,7 +109,7 @@ const Languages = ({
 	return (
 		<div className="mt-5">
 			<ClayRadioGroup
-				name={`_${portletNamespace}_TypeSettingsProperties--inheritLocales--`}
+				name={`${portletNamespace}TypeSettingsProperties--inheritLocales--`}
 				onSelectedValueChange={setCurrentInheritLocales}
 				selectedValue={currentInheritLocales}
 			>
@@ -136,13 +136,13 @@ const Languages = ({
 			) : (
 				<>
 					<input
-						name={`_${portletNamespace}_TypeSettingsProperties--languageId--`}
+						name={`${portletNamespace}TypeSettingsProperties--languageId--`}
 						type="hidden"
 						value={customDefaultLocaleId}
 					/>
 
 					<input
-						name={`_${portletNamespace}_TypeSettingsProperties--locales--`}
+						name={`${portletNamespace}TypeSettingsProperties--locales--`}
 						type="hidden"
 						value={localesInputValue}
 					/>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
@@ -83,11 +83,13 @@ List<DepotEntryGroupRel> depotEntryGroupRels = depotAdminSitesDisplayContext.get
 
 			<liferay-ui:search-container-column-text>
 				<clay:dropdown-menu
-					defaultEventHandler="<%= DepotAdminWebKeys.CONNECTED_SITE_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
+					borderless="<%= true %>"
+					displayType="secondary"
 					dropdownItems="<%= depotAdminSitesDisplayContext.getConnectedSiteDropdownItems(depotEntryGroupRel) %>"
 					icon="ellipsis-v"
-					style="secondary"
-					triggerCssClasses="btn-monospaced btn-outline-borderless btn-secondary btn-sm"
+					monospaced="<%= true %>"
+					propsTransformer="js/ConnectedSiteDropdownPropsTransformer"
+					small="<%= true %>"
 				/>
 			</liferay-ui:search-container-column-text>
 		</liferay-ui:search-container-row>
@@ -96,11 +98,6 @@ List<DepotEntryGroupRel> depotEntryGroupRels = depotAdminSitesDisplayContext.get
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-
-	<liferay-frontend:component
-		componentId="<%= DepotAdminWebKeys.CONNECTED_SITE_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
-		module="js/ConnectedSiteDropdownDefaultEventHandler.es"
-	/>
 
 	<aui:script require="metal-dom/src/all/dom as dom">
 		var addConnectedSiteButton = document.querySelector(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -173,9 +173,8 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 															}
 														}
 													%>'
-													label='<%= LanguageUtil.get(request, "download") %>'
-													style="primary"
-													triggerCssClasses="btn-sm"
+													label="download"
+													small="<%= true %>"
 												/>
 											</div>
 										</c:when>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/checkin/Checkin.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/checkin/Checkin.es.js
@@ -17,7 +17,7 @@ import React, {useState} from 'react';
 
 import CheckinModal from './CheckinModal.es';
 
-function Checkin({
+export default function Checkin({
 	checkedOut,
 	dlVersionNumberIncreaseValues,
 	portletNamespace,
@@ -63,11 +63,5 @@ function Checkin({
 				/>
 			)}
 		</>
-	);
-}
-
-export default function (props) {
-	return (
-		<Checkin {...props} portletNamespace={`_${props.portletNamespace}_`} />
 	);
 }

--- a/modules/apps/document-library/document-library-web/test/document_library/js/checkin/Checkin.es.js
+++ b/modules/apps/document-library/document-library-web/test/document_library/js/checkin/Checkin.es.js
@@ -36,7 +36,7 @@ function _renderCheckinComponent({checkedOut = true} = {}) {
 		<Checkin
 			checkedOut={checkedOut}
 			dlVersionNumberIncreaseValues={dlVersionNumberIncreaseValues}
-			portletNamespace="portletNamespace"
+			portletNamespace="_portletNamespace_"
 		/>,
 		{
 			baseElement: document.body,

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionsViewDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionsViewDefaultEventHandler.es.js
@@ -12,73 +12,33 @@
  * details.
  */
 
-import {ItemSelectorDialog, PortletBase, openModal} from 'frontend-js-web';
+import {
+	DefaultEventHandler,
+	ItemSelectorDialog,
+	openModal,
+} from 'frontend-js-web';
 import {Config} from 'metal-state';
 
 /**
- * @class FragmentCollectionsView
+ * @class FragmentCollectionsViewDefaultEventHandler
  */
-class FragmentCollectionsView extends PortletBase {
-
-	/**
-	 * @inheritdoc
-	 * @review
-	 */
-	created() {
-		this._fragmentCollectionsFm =
-			document[this.ns('fragmentCollectionsFm')];
-		this._handleComponentReady = this._handleComponentReady.bind(this);
-
-		Liferay.componentReady(this.ns('actionsComponent')).then(
-			this._handleComponentReady
-		);
-
-		Liferay.componentReady(this.ns('emptyResultMessageComponent')).then(
-			this._handleComponentReady
-		);
-	}
-
-	/**
-	 * Handles a componentReady event and adds a click handler to the
-	 * given fragment.
-	 * @param {{ on: function }} component
-	 * @private
-	 * @review
-	 */
-	_handleComponentReady(component) {
-		const ACTIONS = {
-			deleteCollections: this._deleteCollections,
-			exportCollections: this._exportCollections,
-			openImportView: this._openImportView,
-		};
-
-		component.on(['click', 'itemClicked'], (event, facade) => {
-			let itemData;
-
-			if (event.data && event.data.item) {
-				itemData = event.data.item.data;
-			}
-			else if (!event.data && facade && facade.target) {
-				itemData = facade.target.data;
-			}
-
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action].call(this);
-			}
-		});
-	}
+class FragmentCollectionsViewDefaultEventHandler extends DefaultEventHandler {
 
 	/**
 	 * Opens an item selector to remove selected collections
 	 * @private
 	 * @review
 	 */
-	_deleteCollections() {
+	deleteCollections() {
 		this._openFragmentCollectionsItemSelector(
 			Liferay.Language.get('delete'),
 			Liferay.Language.get('delete-collection'),
 			this.viewDeleteFragmentCollectionsURL,
 			(selectedItems) => {
+				const fragmentCollectionsForm = document.getElementById(
+					this.ns('fragmentCollectionsFm')
+				);
+
 				if (
 					confirm(
 						Liferay.Language.get(
@@ -87,12 +47,14 @@ class FragmentCollectionsView extends PortletBase {
 					)
 				) {
 					selectedItems.forEach((item) => {
-						this._fragmentCollectionsFm.appendChild(item);
+						fragmentCollectionsForm.appendChild(
+							item.cloneNode(true)
+						);
 					});
 				}
 
 				submitForm(
-					this._fragmentCollectionsFm,
+					fragmentCollectionsForm,
 					this.deleteFragmentCollectionURL
 				);
 			}
@@ -104,18 +66,22 @@ class FragmentCollectionsView extends PortletBase {
 	 * @private
 	 * @review
 	 */
-	_exportCollections() {
+	exportCollections() {
 		this._openFragmentCollectionsItemSelector(
 			Liferay.Language.get('export'),
 			Liferay.Language.get('export-collection'),
 			this.viewExportFragmentCollectionsURL,
 			(selectedItems) => {
+				const fragmentCollectionsForm = document.getElementById(
+					this.ns('fragmentCollectionsFm')
+				);
+
 				selectedItems.forEach((item) => {
-					this._fragmentCollectionsFm.append(item);
+					fragmentCollectionsForm.appendChild(item.cloneNode(true));
 				});
 
 				submitForm(
-					this._fragmentCollectionsFm,
+					fragmentCollectionsForm,
 					this.exportFragmentCollectionsURL
 				);
 			}
@@ -159,7 +125,7 @@ class FragmentCollectionsView extends PortletBase {
 	 * @private
 	 * @review
 	 */
-	_openImportView() {
+	openImportView() {
 		openModal({
 			buttons: [
 				{
@@ -182,22 +148,12 @@ class FragmentCollectionsView extends PortletBase {
 	}
 }
 
-FragmentCollectionsView.STATE = {
-
-	/**
-	 * Collections form used for updating backend
-	 * @default undefined
-	 * @instance
-	 * @memberof FragmentCollectionsView
-	 * @review
-	 * @type {HTMLFormElement|undefined}
-	 */
-	_fragmentCollectionsFm: Config.instanceOf(HTMLFormElement).internal(),
+FragmentCollectionsViewDefaultEventHandler.STATE = {
 
 	/**
 	 * @default undefined
 	 * @instance
-	 * @memberof FragmentCollectionsView
+	 * @memberof FragmentCollectionsViewDefaultEventHandler
 	 * @review
 	 * @type {string}
 	 */
@@ -206,7 +162,7 @@ FragmentCollectionsView.STATE = {
 	/**
 	 * @default undefined
 	 * @instance
-	 * @memberof FragmentCollectionsView
+	 * @memberof FragmentCollectionsViewDefaultEventHandler
 	 * @review
 	 * @type {string}
 	 */
@@ -215,7 +171,7 @@ FragmentCollectionsView.STATE = {
 	/**
 	 * @default undefined
 	 * @instance
-	 * @memberof FragmentCollectionsView
+	 * @memberof FragmentCollectionsViewDefaultEventHandler
 	 * @review
 	 * @type {string}
 	 */
@@ -224,7 +180,7 @@ FragmentCollectionsView.STATE = {
 	/**
 	 * @default undefined
 	 * @instance
-	 * @memberof FragmentCollectionsView
+	 * @memberof FragmentCollectionsViewDefaultEventHandler
 	 * @review
 	 * @type {string}
 	 */
@@ -233,11 +189,11 @@ FragmentCollectionsView.STATE = {
 	/**
 	 * @default undefined
 	 * @instance
-	 * @memberof FragmentCollectionsView
+	 * @memberof FragmentCollectionsViewDefaultEventHandler
 	 * @review
 	 * @type {string}
 	 */
 	viewImportURL: Config.string().required(),
 };
 
-export default FragmentCollectionsView;
+export default FragmentCollectionsViewDefaultEventHandler;

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -57,17 +57,16 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 										<ul class="navbar-nav">
 											<li>
 												<c:if test="<%= FragmentPermission.contains(permissionChecker, scopeGroupId, FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES) %>">
-													<liferay-ui:icon
+													<clay:link
+														buttonStyle="borderless"
+														href="<%= editFragmentCollectionURL %>"
 														icon="plus"
-														iconCssClass="btn btn-monospaced btn-outline-borderless btn-outline-secondary btn-sm"
-														markupView="lexicon"
-														url="<%= editFragmentCollectionURL %>"
 													/>
 												</c:if>
 											</li>
 											<li>
 												<clay:dropdown-actions
-													componentId='<%= liferayPortletResponse.getNamespace() + "actionsComponent" %>'
+													defaultEventHandler="FragmentCollectionsViewDefaultEventHandler"
 													dropdownItems="<%= fragmentDisplayContext.getCollectionsDropdownItems() %>"
 												/>
 											</li>
@@ -224,7 +223,7 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 								<liferay-frontend:empty-result-message
 									actionDropdownItems="<%= FragmentPermission.contains(permissionChecker, scopeGroupId, FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES) ? fragmentDisplayContext.getActionDropdownItems() : null %>"
 									animationType="<%= EmptyResultMessageKeys.AnimationType.NONE %>"
-									componentId='<%= liferayPortletResponse.getNamespace() + "emptyResultMessageComponent" %>'
+									defaultEventHandler="FragmentCollectionsViewDefaultEventHandler"
 									description='<%= LanguageUtil.get(request, "collections-are-needed-to-create-fragments") %>'
 									elementType='<%= LanguageUtil.get(request, "collections") %>'
 								/>
@@ -291,6 +290,7 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 </aui:form>
 
 <liferay-frontend:component
+	componentId="FragmentCollectionsViewDefaultEventHandler"
 	context="<%= fragmentDisplayContext.getFragmentCollectionsViewContext() %>"
-	module="js/FragmentCollectionsView.es"
+	module="js/FragmentCollectionsViewDefaultEventHandler.es"
 />

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
@@ -62,7 +62,11 @@ export default function render(renderable, renderData, container) {
 			}
 		);
 
-		const Component = typeof renderable === 'function' ? renderable : null;
+		const Component =
+			typeof renderable === 'function' ||
+			renderable.$$typeof === Symbol.for('react.forward_ref')
+				? renderable
+				: null;
 
 		// eslint-disable-next-line liferay-portal/no-react-dom-render
 		ReactDOM.render(

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 4.0.4
+Bundle-Version: 5.0.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.data,\
 	com.liferay.frontend.taglib.clay.data.set,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -90,5 +90,5 @@
 		"format": "liferay-npm-scripts fix",
 		"test": "liferay-npm-scripts test"
 	},
-	"version": "4.0.4"
+	"version": "5.0.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.util.TagResourceBundleUtil;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.jsp.JspException;
@@ -252,6 +253,29 @@ public class ButtonTag extends BaseContainerTag {
 		_small = false;
 		_title = null;
 		_type = "button";
+	}
+
+	@Override
+	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("block", _block);
+		props.put("borderless", _borderless);
+		props.put("displayType", _displayType);
+		props.put("icon", _icon);
+
+		if (Validator.isNotNull(_label)) {
+			props.put(
+				"label",
+				LanguageUtil.get(
+					TagResourceBundleUtil.getResourceBundle(pageContext),
+					_label));
+		}
+
+		props.put("monospaced", _monospaced);
+		props.put("outline", _outline);
+		props.put("small", _small);
+		props.put("type", _type);
+
+		return super.prepareProps(props);
 	}
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownActionsTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownActionsTag.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import javax.servlet.jsp.JspException;
+
+/**
+ * @author Chema Balsas
+ */
+public class DropdownActionsTag extends DropdownMenuTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		setDisplayType("unstyled");
+		setIcon("ellipsis-v");
+		setMonospaced(true);
+
+		return super.doStartTag();
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:dropdown-actions:";
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.jsp.JspException;
+
+/**
+ * @author Chema Balsas
+ */
+public class DropdownMenuTag extends ButtonTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		return super.doStartTag();
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getLabel()}
+	 */
+	@Deprecated
+	public String getButtonLabel() {
+		return getLabel();
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getDisplayType()}
+	 */
+	@Deprecated
+	public String getButtonStyle() {
+		return getDisplayType();
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getButtonType() {
+		return _buttonType;
+	}
+
+	public List<DropdownItem> getDropdownItems() {
+		return _dropdownItems;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public boolean getExpanded() {
+		return _expanded;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getItemsIconAlignment() {
+		return _itemsIconAlignment;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public boolean getSearchable() {
+		return _searchable;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public boolean getShowToggleIcon() {
+		return _showToggleIcon;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getCssClass()}
+	 */
+	@Deprecated
+	public String getTriggerCssClasses() {
+		return getCssClass();
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getTriggerTitle() {
+		return _triggerTitle;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setLabel(String)}
+	 */
+	@Deprecated
+	public void setButtonLabel(String buttonLabel) {
+		setLabel(buttonLabel);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setDisplayType(String)}
+	 */
+	@Deprecated
+	public void setButtonStyle(String buttonStyle) {
+		setDisplayType(buttonStyle);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setButtonType(String buttonType) {
+		_buttonType = buttonType;
+	}
+
+	public void setDropdownItems(List<DropdownItem> dropdownItems) {
+		_dropdownItems = dropdownItems;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setExpanded(boolean expanded) {
+		_expanded = expanded;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setItemsIconAlignment(String itemsIconAlignment) {
+		_itemsIconAlignment = itemsIconAlignment;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setSearchable(boolean searchable) {
+		_searchable = searchable;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setShowToggleIcon(boolean showToggleIcon) {
+		_showToggleIcon = showToggleIcon;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setCssClas(String)}
+	 */
+	@Deprecated
+	public void setTriggerCssClasses(String triggerCssClasses) {
+		setCssClass(triggerCssClasses);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setTriggerTitle(String triggerTitle) {
+		_triggerTitle = triggerTitle;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_buttonType = null;
+		_dropdownItems = null;
+		_expanded = false;
+		_itemsIconAlignment = null;
+		_searchable = false;
+		_showToggleIcon = false;
+		_triggerTitle = null;
+	}
+
+	@Override
+	protected String getHydratedModuleName() {
+		return "frontend-taglib-clay/DropdownMenu";
+	}
+
+	@Override
+	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("items", _dropdownItems);
+
+		return super.prepareProps(props);
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:dropdown-menu:";
+
+	private String _buttonType;
+	private List<DropdownItem> _dropdownItems;
+	private boolean _expanded;
+	private String _itemsIconAlignment;
+	private boolean _searchable;
+	private boolean _showToggleIcon;
+	private String _triggerTitle;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
@@ -86,6 +86,14 @@ public class NavigationBarTag extends BaseContainerTag {
 	}
 
 	@Override
+	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("inverted", _inverted);
+		props.put("navigationItems", _navigationItems);
+
+		return super.prepareProps(props);
+	}
+
+	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("navbar");
 		cssClasses.add("navbar-collapse-absolute");
@@ -97,14 +105,6 @@ public class NavigationBarTag extends BaseContainerTag {
 			_inverted ? "navigation-bar-secondary" : "navigation-bar-light");
 
 		return super.processCssClasses(cssClasses);
-	}
-
-	@Override
-	protected Map<String, Object> processData(Map<String, Object> data) {
-		data.put("inverted", _inverted);
-		data.put("navigationItems", _navigationItems);
-
-		return super.processData(data);
 	}
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -728,47 +728,77 @@
 	<tag>
 		<description></description>
 		<name>dropdown-menu</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.DropdownMenuTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.DropdownMenuTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
+			<name>additionalProps</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>block</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>borderless</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>label</code>]]>.</description>
 			<name>buttonLabel</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
 			<name>buttonStyle</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>buttonType</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>displayType</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -779,13 +809,13 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>expanded</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -803,7 +833,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>itemsIconAlignment</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -816,46 +846,65 @@
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>searchable</name>
+			<name>monospaced</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>propsTransformer</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
+			<name>searchable</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>showToggleIcon</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>small</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
 			<name>style</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>triggerCssClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>triggerTitle</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>type</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -626,52 +626,58 @@
 	<tag>
 		<description></description>
 		<name>dropdown-actions</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.DropdownActionsTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.DropdownActionsTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
+			<name>additionalProps</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>label</code>]]>.</description>
 			<name>buttonLabel</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
 			<name>buttonStyle</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>buttonType</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
-			<name>caption</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -683,20 +689,14 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>expanded</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description></description>
-			<name>helpText</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -707,23 +707,60 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>itemsIconAlignment</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>propsTransformer</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
+			<name>searchable</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
+			<name>showToggleIcon</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
+			<name>style</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>triggerCssClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
+			<name>triggerTitle</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
+			<name>type</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DefaultEventHandlersPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DefaultEventHandlersPropsTransformer.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function propsTransformer({
+	defaultEventHandler,
+	items,
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						Liferay.componentReady(defaultEventHandler).then(
+							(eventHandler) => {
+								eventHandler[action](item.data);
+							}
+						);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton from '@clayui/button';
+import {ClayDropDownWithItems} from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+import React from 'react';
+
+export default function DropdownMenu({
+	componentId: _componentId,
+	cssClass,
+	icon,
+	items,
+	label,
+	portletId: _portletId,
+	portletNamespace: _portletNamespace,
+	...otherProps
+}) {
+	return (
+		<ClayDropDownWithItems
+			items={items.map(({data, ...rest}) => {
+				const dataAttributes = data
+					? Object.entries(data).reduce((acc, [key, value]) => {
+							acc[`data-${key}`] = value;
+
+							return acc;
+					  }, {})
+					: {};
+
+				return {
+					...dataAttributes,
+					...rest,
+				};
+			})}
+			trigger={
+				<ClayButton className={cssClass} {...otherProps}>
+					{icon && (
+						<span
+							className={classNames({
+								'inline-item': label,
+								'inline-item-before': label,
+							})}
+						>
+							<ClayIcon symbol={icon} />
+						</span>
+					)}
+
+					{label}
+				</ClayButton>
+			}
+		/>
+	);
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/components/LocaleSelector.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/components/LocaleSelector.js
@@ -24,7 +24,7 @@ export default function LocaleSelector({
 	return (
 		<ClayForm.Group>
 			<ClaySelect
-				name={`_${portletNamespace}_languageId`}
+				name={`${portletNamespace}languageId`}
 				onChange={onChange}
 				value={selectedLanguageId}
 			>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/index.js
@@ -60,12 +60,12 @@ function Comparator({
 			const diffURL = new URL(resourceURL);
 
 			diffURL.searchParams.append(
-				`_${portletNamespace}_filterSourceVersion`,
+				`${portletNamespace}filterSourceVersion`,
 				sourceVersion
 			);
 
 			diffURL.searchParams.append(
-				`_${portletNamespace}_filterTargetVersion`,
+				`${portletNamespace}filterTargetVersion`,
 				filterTargetVersion
 			);
 
@@ -155,13 +155,13 @@ function Comparator({
 			ref={formRef}
 		>
 			<ClayInput
-				name={`_${portletNamespace}_sourceVersion`}
+				name={`${portletNamespace}sourceVersion`}
 				type="hidden"
 				value={sourceVersion}
 			/>
 
 			<ClayInput
-				name={`_${portletNamespace}_targetVersion`}
+				name={`${portletNamespace}targetVersion`}
 				type="hidden"
 				value={targetVersion}
 			/>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
@@ -43,10 +43,10 @@
 					<clay:dropdown-menu
 						componentId="<%= componentId %>"
 						defaultEventHandler="<%= defaultEventHandler %>"
+						displayType="<%= buttonCssClass %>"
 						dropdownItems="<%= actionDropdownItems %>"
-						label='<%= LanguageUtil.get(request, "new") %>'
-						style="<%= buttonCssClass %>"
-						triggerCssClasses="btn-sm"
+						label="new"
+						small="<%= true %>"
 					/>
 				</c:when>
 				<c:otherwise>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translate/TranslateLanguagesSelector.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translate/TranslateLanguagesSelector.js
@@ -24,7 +24,7 @@ const TranslateLanguagesSelector = ({
 	targetAvailableLanguages,
 	targetLanguageId,
 }) => {
-	const namespace = `_${portletNamespace}_`;
+	const namespace = `${portletNamespace}`;
 
 	const refreshPage = (sourceId, targetId) => {
 		const url = new URL(currentUrl);

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/friendly_url_history/FriendlyURLHistory.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/friendly_url_history/FriendlyURLHistory.js
@@ -19,7 +19,7 @@ import React, {useState} from 'react';
 
 import FriendlyURLHistoryModal from './FriendlyURLHistoryModal';
 
-function FriendlyURLHistory({portletNamespace, ...restProps}) {
+export default function FriendlyURLHistory({portletNamespace, ...restProps}) {
 	const [showModal, setShowModal] = useState(false);
 	const [selectedLanguageId, setSelectedLanguageId] = useState();
 
@@ -65,12 +65,3 @@ function FriendlyURLHistory({portletNamespace, ...restProps}) {
 FriendlyURLHistory.propTypes = {
 	portletNamespace: PropTypes.string.isRequired,
 };
-
-export default function (props) {
-	return (
-		<FriendlyURLHistory
-			{...props}
-			portletNamespace={`_${props.portletNamespace}_`}
-		/>
-	);
-}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ItemSelectorDialog} from 'frontend-js-web';
+
+const ACTIONS = {
+	deleteCollections({
+		deleteLayoutPageTemplateCollectionURL,
+		portletNamespace,
+		viewLayoutPageTemplateCollectionURL,
+	}) {
+		const layoutPageTemplateCollectionsForm = document.createElement(
+			'form'
+		);
+
+		layoutPageTemplateCollectionsForm.setAttribute('method', 'post');
+
+		const itemSelectorDialog = new ItemSelectorDialog({
+			buttonAddLabel: Liferay.Language.get('delete'),
+			eventName: `${portletNamespace}selectCollections`,
+			title: Liferay.Language.get('delete-collection'),
+			url: viewLayoutPageTemplateCollectionURL,
+		});
+
+		itemSelectorDialog.on('selectedItemChange', (event) => {
+			var selectedItems = event.selectedItem;
+
+			if (selectedItems) {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-the-selected-entries'
+						)
+					)
+				) {
+					selectedItems.forEach((item) => {
+						layoutPageTemplateCollectionsForm.appendChild(
+							item.cloneNode(true)
+						);
+					});
+
+					submitForm(
+						layoutPageTemplateCollectionsForm,
+						deleteLayoutPageTemplateCollectionURL
+					);
+				}
+			}
+		});
+
+		itemSelectorDialog.open();
+	},
+};
+
+export default function propsTransformer({
+	deleteLayoutPageTemplateCollectionURL,
+	items,
+	portletNamespace,
+	viewLayoutPageTemplateCollectionURL,
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action]({
+							deleteLayoutPageTemplateCollectionURL,
+							portletNamespace,
+							viewLayoutPageTemplateCollectionURL,
+						});
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
@@ -63,19 +63,39 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 										<ul class="navbar-nav">
 											<c:if test="<%= layoutPageTemplateDisplayContext.isShowAddButton(LayoutPageTemplateActionKeys.ADD_LAYOUT_PAGE_TEMPLATE_COLLECTION) %>">
 												<li>
-													<liferay-ui:icon
+													<clay:link
+														buttonStyle="borderless"
+														href="<%= editLayoutPageTemplateCollectionURL.toString() %>"
 														icon="plus"
-														iconCssClass="btn btn-monospaced btn-outline-borderless btn-outline-secondary"
-														markupView="lexicon"
-														url="<%= editLayoutPageTemplateCollectionURL %>"
 													/>
 												</li>
 											</c:if>
 
 											<li>
+												<portlet:renderURL var="viewLayoutPageTemplateCollectionURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+													<portlet:param name="mvcRenderCommandName" value="/layout_page_template/select_layout_page_template_collections" />
+												</portlet:renderURL>
+
+												<portlet:renderURL var="redirectURL">
+													<portlet:param name="tabs1" value="page-templates" />
+												</portlet:renderURL>
+
+												<liferay-portlet:actionURL copyCurrentRenderParameters="<%= false %>" name="/layout_page_template/delete_layout_page_template_collection" var="deleteLayoutPageTemplateCollectionURL">
+													<portlet:param name="redirect" value="<%= redirectURL %>" />
+												</liferay-portlet:actionURL>
+
+												<%
+												Map<String, Object> additionalProps = HashMapBuilder.<String, Object>put(
+													"deleteLayoutPageTemplateCollectionURL", deleteLayoutPageTemplateCollectionURL.toString()
+												).put(
+													"viewLayoutPageTemplateCollectionURL", viewLayoutPageTemplateCollectionURL.toString()
+												).build();
+												%>
+
 												<clay:dropdown-actions
-													componentId="actionsComponent"
+													additionalProps="<%= additionalProps %>"
 													dropdownItems="<%= layoutPageTemplateDisplayContext.getCollectionsDropdownItems() %>"
+													propsTransformer="js/ActionsComponentPropsTransformer"
 												/>
 											</li>
 										</ul>
@@ -165,78 +185,3 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 		</clay:col>
 	</clay:row>
 </clay:container-fluid>
-
-<aui:form cssClass="hide" name="layoutPageTemplateCollectionsFm">
-</aui:form>
-
-<aui:script require="metal-dom/src/dom as dom, frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
-	var deleteCollections = function () {
-		var layoutPageTemplateCollectionsFm =
-			document.<portlet:namespace />layoutPageTemplateCollectionsFm;
-
-		if (layoutPageTemplateCollectionsFm) {
-			var itemSelectorDialog = new ItemSelectorDialog.default({
-				buttonAddLabel: '<liferay-ui:message key="delete" />',
-				eventName: '<portlet:namespace />selectCollections',
-				title: '<liferay-ui:message key="delete-collection" />',
-				url:
-					'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/layout_page_template/select_layout_page_template_collections" /></portlet:renderURL>',
-			});
-
-			itemSelectorDialog.on('selectedItemChange', function (event) {
-				var selectedItems = event.selectedItem;
-
-				if (selectedItems) {
-					if (
-						confirm(
-							'<liferay-ui:message key="are-you-sure-you-want-to-delete-the-selected-entries" />'
-						)
-					) {
-						Array.prototype.forEach.call(selectedItems, function (
-							item,
-							index
-						) {
-							dom.append(layoutPageTemplateCollectionsFm, item);
-						});
-
-						<portlet:renderURL var="redirectURL">
-							<portlet:param name="tabs1" value="page-templates" />
-						</portlet:renderURL>
-
-						<liferay-portlet:actionURL copyCurrentRenderParameters="<%= false %>" name="/layout_page_template/delete_layout_page_template_collection" var="deleteLayoutPageTemplateCollectionURL">
-							<portlet:param name="redirect" value="<%= redirectURL %>" />
-						</liferay-portlet:actionURL>
-
-						submitForm(
-							layoutPageTemplateCollectionsFm,
-							'<%= deleteLayoutPageTemplateCollectionURL %>'
-						);
-					}
-				}
-			});
-
-			itemSelectorDialog.open();
-		}
-	};
-
-	var ACTIONS = {
-		deleteCollections: deleteCollections,
-	};
-
-	Liferay.componentReady('actionsComponent').then(function (actionsComponent) {
-		actionsComponent.on(['click', 'itemClicked'], function (event, facade) {
-			var itemData;
-
-			if (event.data && event.data.item) {
-				itemData = event.data.item.data;
-			}
-			else if (!event.data && facade && facade.target) {
-				itemData = facade.target.data;
-			}
-
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
-</aui:script>

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/PreviewSeo.es.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/PreviewSeo.es.js
@@ -272,10 +272,5 @@ PreviewSeoContainer.propTypes = {
 };
 
 export default function (props) {
-	return (
-		<PreviewSeoContainer
-			{...props}
-			portletNamespace={`_${props.portletNamespace}_`}
-		/>
-	);
+	return <PreviewSeoContainer {...props} />;
 }

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/OpenGraphMapping.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/OpenGraphMapping.js
@@ -18,7 +18,7 @@ import React from 'react';
 import MappingInputs from './components/MappingInputs';
 import lang from './utils/lang';
 
-function OpenGraphMapping({
+export default function OpenGraphMapping({
 	fields,
 	openGraphDescription,
 	openGraphImage,
@@ -107,12 +107,3 @@ OpenGraphMapping.propTypes = {
 		classTypeLabel: PropTypes.string,
 	}).isRequired,
 };
-
-export default function (props) {
-	return (
-		<OpenGraphMapping
-			{...props}
-			portletNamespace={`_${props.portletNamespace}_`}
-		/>
-	);
-}

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/SeoMapping.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/SeoMapping.js
@@ -18,7 +18,7 @@ import React from 'react';
 import MappingInputs from './components/MappingInputs';
 import lang from './utils/lang';
 
-function SeoMapping({
+export default function SeoMapping({
 	description,
 	fields,
 	portletNamespace,
@@ -75,12 +75,3 @@ SeoMapping.propTypes = {
 	}).isRequired,
 	title: PropTypes.string,
 };
-
-export default function (props) {
-	return (
-		<SeoMapping
-			{...props}
-			portletNamespace={`_${props.portletNamespace}_`}
-		/>
-	);
-}

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/page_template/edit_menu.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/page_template/edit_menu.jsp
@@ -21,7 +21,9 @@ EditDisplayPageMenuDisplayContext editDisplayPageMenuDisplayContext = new EditDi
 %>
 
 <clay:dropdown-menu
+	borderless="<%= true %>"
+	displayType="secondary"
 	dropdownItems="<%= editDisplayPageMenuDisplayContext.getDropdownItems() %>"
 	icon="pencil"
-	triggerCssClasses="icon-monospaced"
+	monospaced="<%= true %>"
 />

--- a/modules/apps/portal-template/portal-template-react-renderer-api/bnd.bnd
+++ b/modules/apps/portal-template/portal-template-react-renderer-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Portal Template React Renderer API
 Bundle-SymbolicName: com.liferay.portal.template.react.renderer.api
-Bundle-Version: 4.0.5
+Bundle-Version: 4.1.0
 Export-Package: com.liferay.portal.template.react.renderer

--- a/modules/apps/portal-template/portal-template-react-renderer-api/src/main/java/com/liferay/portal/template/react/renderer/ComponentDescriptor.java
+++ b/modules/apps/portal-template/portal-template-react-renderer-api/src/main/java/com/liferay/portal/template/react/renderer/ComponentDescriptor.java
@@ -41,6 +41,13 @@ public class ComponentDescriptor {
 		String module, String componentId, Collection<String> dependencies,
 		boolean positionInLine) {
 
+		this(module, componentId, dependencies, positionInLine, null);
+	}
+
+	public ComponentDescriptor(
+		String module, String componentId, Collection<String> dependencies,
+		boolean positionInLine, String propsTransformer) {
+
 		_module = module;
 		_componentId = componentId;
 
@@ -49,6 +56,7 @@ public class ComponentDescriptor {
 		}
 
 		_positionInLine = positionInLine;
+		_propsTransformer = propsTransformer;
 	}
 
 	public String getComponentId() {
@@ -63,6 +71,10 @@ public class ComponentDescriptor {
 		return _module;
 	}
 
+	public String getPropsTransformer() {
+		return _propsTransformer;
+	}
+
 	public boolean isPositionInLine() {
 		return _positionInLine;
 	}
@@ -71,5 +83,6 @@ public class ComponentDescriptor {
 	private final Set<String> _dependencies = new HashSet<>();
 	private final String _module;
 	private final boolean _positionInLine;
+	private final String _propsTransformer;
 
 }

--- a/modules/apps/portal-template/portal-template-react-renderer-api/src/main/resources/com/liferay/portal/template/react/renderer/packageinfo
+++ b/modules/apps/portal-template/portal-template-react-renderer-api/src/main/resources/com/liferay/portal/template/react/renderer/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-template/portal-template-react-renderer-impl/src/main/java/com/liferay/portal/template/react/renderer/internal/ReactRendererUtil.java
+++ b/modules/apps/portal-template/portal-template-react-renderer-impl/src/main/java/com/liferay/portal/template/react/renderer/internal/ReactRendererUtil.java
@@ -39,7 +39,7 @@ import javax.servlet.http.HttpServletRequest;
 public class ReactRendererUtil {
 
 	public static void renderReact(
-			ComponentDescriptor componentDescriptor, Map<String, Object> data,
+			ComponentDescriptor componentDescriptor, Map<String, Object> props,
 			HttpServletRequest httpServletRequest,
 			String npmResolvedPackageName, Portal portal, Writer writer)
 		throws IOException {
@@ -49,62 +49,62 @@ public class ReactRendererUtil {
 		_renderPlaceholder(writer, placeholderId);
 
 		_renderJavaScript(
-			componentDescriptor, data, httpServletRequest,
+			componentDescriptor, props, httpServletRequest,
 			npmResolvedPackageName, placeholderId, portal, writer);
 	}
 
-	private static Map<String, Object> _prepareData(
-		ComponentDescriptor componentDescriptor, Map<String, Object> data,
+	private static Map<String, Object> _prepareProps(
+		ComponentDescriptor componentDescriptor, Map<String, Object> props,
 		HttpServletRequest httpServletRequest) {
 
-		Map<String, Object> modifiedData = null;
+		Map<String, Object> modifiedProps = null;
 
-		if (!data.containsKey("componentId")) {
-			if (modifiedData == null) {
-				modifiedData = new HashMap<>(data);
+		if (!props.containsKey("componentId")) {
+			if (modifiedProps == null) {
+				modifiedProps = new HashMap<>(props);
 			}
 
-			modifiedData.put(
+			modifiedProps.put(
 				"componentId", componentDescriptor.getComponentId());
 		}
 
-		if (!data.containsKey("locale")) {
-			if (modifiedData == null) {
-				modifiedData = new HashMap<>(data);
+		if (!props.containsKey("locale")) {
+			if (modifiedProps == null) {
+				modifiedProps = new HashMap<>(props);
 			}
 
-			modifiedData.put("locale", LocaleUtil.getMostRelevantLocale());
+			modifiedProps.put("locale", LocaleUtil.getMostRelevantLocale());
 		}
 
-		if (!data.containsKey("portletId")) {
-			if (modifiedData == null) {
-				modifiedData = new HashMap<>(data);
+		if (!props.containsKey("portletId")) {
+			if (modifiedProps == null) {
+				modifiedProps = new HashMap<>(props);
 			}
 
-			modifiedData.put(
+			modifiedProps.put(
 				"portletId",
 				httpServletRequest.getAttribute(WebKeys.PORTLET_ID));
 		}
 
-		if (!data.containsKey("portletNamespace")) {
-			if (modifiedData == null) {
-				modifiedData = new HashMap<>(data);
+		if (!props.containsKey("portletNamespace")) {
+			if (modifiedProps == null) {
+				modifiedProps = new HashMap<>(props);
 			}
 
-			modifiedData.put(
+			modifiedProps.put(
 				"portletNamespace",
 				httpServletRequest.getAttribute(WebKeys.PORTLET_ID));
 		}
 
-		if (modifiedData == null) {
-			return data;
+		if (modifiedProps == null) {
+			return props;
 		}
 
-		return modifiedData;
+		return modifiedProps;
 	}
 
 	private static void _renderJavaScript(
-			ComponentDescriptor componentDescriptor, Map<String, Object> data,
+			ComponentDescriptor componentDescriptor, Map<String, Object> props,
 			HttpServletRequest httpServletRequest,
 			String npmResolvedPackageName, String placeholderId, Portal portal,
 			Writer writer)
@@ -145,15 +145,15 @@ public class ReactRendererUtil {
 			javascriptSB.append(".default(");
 			javascriptSB.append(
 				jsonSerializer.serializeDeep(
-					_prepareData(
-						componentDescriptor, data, httpServletRequest)));
+					_prepareProps(
+						componentDescriptor, props, httpServletRequest)));
 			javascriptSB.append(")");
 		}
 		else {
 			javascriptSB.append(
 				jsonSerializer.serializeDeep(
-					_prepareData(
-						componentDescriptor, data, httpServletRequest)));
+					_prepareProps(
+						componentDescriptor, props, httpServletRequest)));
 		}
 
 		javascriptSB.append(", '");

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/macros/Workflow.macro
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/macros/Workflow.macro
@@ -312,11 +312,11 @@ definition {
 
 		Click.pauseClickAt(locator1 = "Icon#INFO");
 
-		if (IsElementNotPresent(locator1 = "Icon#VERTICAL_ELLIPSIS_BUTTON")) {
+		if (IsElementNotPresent(locator1 = "Icon#SIDEBAR_HEADER_ACTION_VERTICAL_ELLIPSIS_BUTTON")) {
 			Click.pauseClickAt(locator1 = "Icon#INFO");
 		}
 
-		Click(locator1 = "Icon#VERTICAL_ELLIPSIS_BUTTON");
+		Click(locator1 = "Icon#SIDEBAR_HEADER_ACTION_VERTICAL_ELLIPSIS_BUTTON");
 
 		MenuItem.click(menuItem = "Edit");
 

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/content/content.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/content/content.jsp
@@ -74,9 +74,12 @@ ContentPanelCategoryDisplayContext contentPanelCategoryDisplayContext = new Cont
 
 						<clay:content-col>
 							<clay:dropdown-menu
+								borderless="<%= true %>"
+								cssClass="text-light"
+								displayType="secondary"
 								dropdownItems="<%= contentPanelCategoryDisplayContext.getScopesDropdownItemList() %>"
 								icon="cog"
-								triggerCssClasses="dropdown-toggle icon-monospaced text-light"
+								monospaced="<%= true %>"
 							/>
 						</clay:content-col>
 					</clay:content-row>

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/ChainedRedirections.js
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/ChainedRedirections.js
@@ -18,7 +18,7 @@ import React, {useState} from 'react';
 
 import ChainedRedirectionsModal from './ChainedRedirectionsModal';
 
-function ChainedRedirections({portletNamespace, ...restProps}) {
+export default function ChainedRedirections({portletNamespace, ...restProps}) {
 	const [redirectEntryChainCause, setRedirectEntryChainCause] = useState(
 		null
 	);
@@ -68,12 +68,3 @@ function ChainedRedirections({portletNamespace, ...restProps}) {
 ChainedRedirections.propTypes = {
 	portletNamespace: PropTypes.string.isRequired,
 };
-
-export default function (props) {
-	return (
-		<ChainedRedirections
-			{...props}
-			portletNamespace={`_${props.portletNamespace}_`}
-		/>
-	);
-}

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/GroupLabels.es.js
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/GroupLabels.es.js
@@ -17,7 +17,11 @@ import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import React, {useEffect, useState} from 'react';
 
-function GroupLabels({itemSelectorURL, portletNamespace, target}) {
+export default function GroupLabels({
+	itemSelectorURL,
+	portletNamespace,
+	target,
+}) {
 	const [groupIds, setGroupIds] = useState([]);
 	const [groupNames, setGroupNames] = useState([]);
 
@@ -128,7 +132,3 @@ function GroupLabels({itemSelectorURL, portletNamespace, target}) {
 		</>
 	);
 }
-
-export default (props) => (
-	<GroupLabels {...props} portletNamespace={`_${props.portletNamespace}_`} />
-);

--- a/modules/apps/social/social-bookmarks-taglib/package.json
+++ b/modules/apps/social/social-bookmarks-taglib/package.json
@@ -1,0 +1,12 @@
+{
+	"dependencies": {
+		"react": "16.12.0"
+	},
+	"name": "social-bookmarks-taglib",
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "3.0.8"
+}

--- a/modules/apps/social/social-bookmarks-taglib/src/main/java/com/liferay/social/bookmarks/taglib/internal/util/SocialBookmarksTagUtil.java
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/java/com/liferay/social/bookmarks/taglib/internal/util/SocialBookmarksTagUtil.java
@@ -63,7 +63,6 @@ public class SocialBookmarksTagUtil {
 								socialBookmark.getPostURL(title, url));
 							dropdownItem.putData("type", type);
 							dropdownItem.putData("url", url);
-							dropdownItem.setHref("#");
 							dropdownItem.setLabel(
 								socialBookmark.getName(locale));
 						});

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/SocialBookmarksDropdownPropsTransformer.js
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/SocialBookmarksDropdownPropsTransformer.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const SHARE_WINDOW_HEIGHT = 436;
+const SHARE_WINDOW_WIDTH = 626;
+
+function openSocialBookmark({className, classPK, postURL, type, url}) {
+	const shareWindowFeatures = `
+		height=${SHARE_WINDOW_HEIGHT},
+		left=${window.innerWidth / 2 - SHARE_WINDOW_WIDTH / 2},
+		status=0,
+		toolbar=0,
+		top=${window.innerHeight / 2 - SHARE_WINDOW_HEIGHT / 2},
+		width=${SHARE_WINDOW_WIDTH}
+	`;
+
+	window.open(postURL, null, shareWindowFeatures).focus();
+
+	Liferay.fire('socialBookmarks:share', {
+		className,
+		classPK,
+		type,
+		url,
+	});
+
+	return false;
+}
+
+export default function propsTransformer({items, ...otherProps}) {
+	return {
+		...otherProps,
+		items: items.map(({data, ...rest}) => {
+			return {
+				...rest,
+				onClick() {
+					openSocialBookmark(data);
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
@@ -18,8 +18,6 @@
 
 <%
 String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_social_bookmarks_page") + StringPool.UNDERLINE;
-
-String dropdownMenuComponentId = randomNamespace + "socialBookmarksDropdownMenu";
 %>
 
 <liferay-util:html-top
@@ -32,12 +30,14 @@ String dropdownMenuComponentId = randomNamespace + "socialBookmarksDropdownMenu"
 	<c:choose>
 		<c:when test='<%= displayStyle.equals("menu") || BrowserSnifferUtil.isMobile(request) %>'>
 			<clay:dropdown-menu
-				componentId="<%= dropdownMenuComponentId %>"
+				borderless="<%= true %>"
+				displayType="secondary"
 				dropdownItems="<%= SocialBookmarksTagUtil.getDropdownItems(request.getLocale(), types, className, classPK, title, url) %>"
 				icon="share"
-				label='<%= BrowserSnifferUtil.isMobile(request) ? null : LanguageUtil.get(request, "share") %>'
-				style="secondary"
-				triggerCssClasses="btn-outline-borderless btn-outline-secondary btn-sm"
+				label='<%= BrowserSnifferUtil.isMobile(request) ? null : "share" %>'
+				monospaced="<%= true %>"
+				propsTransformer="bookmarks/SocialBookmarksDropdownPropsTransformer"
+				small="<%= true %>"
 			/>
 		</c:when>
 		<c:otherwise>
@@ -74,12 +74,14 @@ String dropdownMenuComponentId = randomNamespace + "socialBookmarksDropdownMenu"
 				%>
 
 				<clay:dropdown-menu
-					componentId="<%= dropdownMenuComponentId %>"
+					borderless="<%= true %>"
+					displayType="secondary"
 					dropdownItems="<%= SocialBookmarksTagUtil.getDropdownItems(request.getLocale(), remainingTypes, className, classPK, title, url) %>"
 					icon="share"
-					style="secondary"
-					triggerCssClasses="btn-monospaced btn-outline-borderless btn-outline-secondary btn-sm"
-					triggerTitle='<%= LanguageUtil.get(request, "share") %>'
+					label="share"
+					monospaced="<%= true %>"
+					propsTransformer="bookmarks/SocialBookmarksDropdownPropsTransformer"
+					small="<%= true %>"
 				/>
 
 			<%
@@ -88,66 +90,4 @@ String dropdownMenuComponentId = randomNamespace + "socialBookmarksDropdownMenu"
 
 		</c:otherwise>
 	</c:choose>
-
-	<liferay-util:html-bottom
-		outputKey="social_bookmarks"
-	>
-		<aui:script>
-			function socialBookmarks_handleItemClick(
-				event,
-				className,
-				classPK,
-				type,
-				postURL,
-				url
-			) {
-				var SHARE_WINDOW_HEIGHT = 436;
-				var SHARE_WINDOW_WIDTH = 626;
-
-				var shareWindowFeatures = [
-					'left=' + (window.innerWidth / 2 - SHARE_WINDOW_WIDTH / 2),
-					'height=' + SHARE_WINDOW_HEIGHT,
-					'toolbar=0',
-					'top=' + (window.innerHeight / 2 - SHARE_WINDOW_HEIGHT / 2),
-					'status=0',
-					'width=' + SHARE_WINDOW_WIDTH,
-				];
-
-				event.preventDefault();
-				event.stopPropagation();
-
-				window.open(postURL, null, shareWindowFeatures.join()).focus();
-
-				Liferay.fire('socialBookmarks:share', {
-					className: className,
-					classPK: classPK,
-					type: type,
-					url: url,
-				});
-
-				return false;
-			}
-		</aui:script>
-	</liferay-util:html-bottom>
-
-	<aui:script sandbox="<%= true %>">
-		Liferay.componentReady('<%= dropdownMenuComponentId %>').then(function (
-			dropdownMenu
-		) {
-			dropdownMenu.on(['itemClicked'], function (event) {
-				event.preventDefault();
-
-				var data = event.data.item.data;
-
-				socialBookmarks_handleItemClick(
-					event,
-					data.className,
-					parseInt(data.classPK),
-					data.type,
-					data.postURL,
-					data.url
-				);
-			});
-		});
-	</aui:script>
 </div>

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -27,7 +27,6 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.configuration.Filter" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.BrowserSnifferUtil" %><%@
 page import="com.liferay.portal.kernel.util.ArrayUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderController.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderController.es.js
@@ -21,7 +21,7 @@ const HeaderController = ({basePath}) => {
 
 	const container = useMemo(() => {
 		const header = document.getElementById(
-			`_${portletNamespace}_controlMenu`
+			`${portletNamespace}controlMenu`
 		);
 
 		if (!header) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/App.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/App.es.js
@@ -67,7 +67,7 @@ const mockProps = {
 	getClient: jest.fn(() => client),
 	isAmPm: false,
 	maxPages: 15,
-	portletNamespace: 'workflow',
+	portletNamespace: '_workflow_',
 	reindexStatuses: [],
 };
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
@@ -65,7 +65,7 @@
 </tr>
 <tr>
 	<td>ANY</td>
-	<td>//*[contains(@class,'btn')][normalize-space(text())='${key_text}']</td>
+	<td>//*[contains(@class,'btn')][normalize-space(text())='${key_text}'] | //button[normalize-space(text())='${key_text}']</td>
 	<td></td>
 </tr>
 <tr>
@@ -460,7 +460,7 @@
 </tr>
 <tr>
 	<td>PLUS</td>
-	<td>//*[@data-qa-id='addButton'] | //a[contains(@class,'btn') and @aria-label='add'] | //a[contains(@class,'btn') and *[contains(@class,'icon-plus')]] | //button[*[contains(@class,'icon-plus')]]</td>
+	<td>//*[@data-qa-id='addButton'] | //a[contains(@class,'btn') and @aria-label='add'] | //a[contains(@class,'nav-btn') and *[contains(@class,'icon-plus')]] | //button[*[contains(@class,'icon-plus')]]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Icon.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Icon.path
@@ -300,6 +300,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>SIDEBAR_HEADER_ACTION_VERTICAL_ELLIPSIS_BUTTON</td>
+	<td>//*[contains(@class,'sidebar-header-actions')]//button[contains(@class,'dropdown-toggle')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>BODY_VERTICAL_ELLIPSIS</td>
 	<td>//div[contains(@class,'portlet') and contains(@class,'container')]//a[span/*[name()='svg'][contains(@class,'icon-ellipsis')]]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavNested.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavNested.path
@@ -25,7 +25,7 @@
 </tr>
 <tr>
 	<td>NAV_NESTED_PLUS</td>
-	<td>//ul[contains(@class,'nav-nested')]//span[*[name()='svg'][contains(@class,'icon-plus')]]</td>
+	<td>//ul[contains(@class,'nav-nested')]//*[*[name()='svg'][contains(@class,'icon-plus')]]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Big and important PR that:
- Updates the `clay:dropdown-menu` tag to our Clay3 React components
- Updates the `clay:dropdown-actions` tag to our Clay3 React components
- Adds support for `additionalProps` and `propsTransformer` to `react:component` and the aforementioned `clay:*` tags
- Fixes wrong `portletNamespace` param value being passed from `react:component`

### Changes in react:component

These pave the way for future (and present) improvements:

- **Allows passing `additionalProps` and `propsTransformer` attributes** to extend the map of props passed to a component and to define a JS function to operate on them. This is the key to being able to easily attach event listeners to react components without having to do an independent `addEventListener like this:

```html
<clay:button
    propsTransformer="ButtonPropsTransformer"
/>
```

```javascript
export default function propsTransformer() {
    return {
        onClick(event) {
            // Do Something
        }
    };
};
```

- **Renames `data` to `props`** internally so that params stay consistent. We've also created [Provide props API to replace data attribute in react:component tag](https://issues.liferay.com/browse/LPS-116504) to update the public API

- **Fixes wrong `portletNamespace` value** where `portletId` was being sent instead causing a confusion in userland code.

### Changes in `clay:dropdown-menu` and `clay:dropdown-action`

- **Updated implementation to rely on a `Java` + `React` version
- **Provided a fallback defaultEventHandler** mechanism through `propsTransformer` so current usages continue working
- **Updates some defaultEventHandler** use cases to show the new pattern.
