### PR TITLE
LPS-113561 Avoid use of Liferay.provide in sync-web

### DIFF
--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/edit_default_file_permissions.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/edit_default_file_permissions.jsp
@@ -27,6 +27,8 @@ if (groupIds.length == 1) {
 
 	currentPermissions = GetterUtil.getInteger(group.getTypeSettingsProperty("syncSiteMemberFilePermissions"));
 }
+
+String selectEventName = ParamUtil.getString(request, "selectEventName");
 %>
 
 <liferay-ui:header
@@ -129,20 +131,12 @@ if (groupIds.length == 1) {
 </table>
 
 <aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />setPermissions',
-		function (uri) {
-			Liferay.Util.fetch(uri, {method: 'POST'})
-				.then(function (response) {
-					return response.text();
-				})
-				.then(function () {
-					Liferay.Util.getWindow(
-						'<portlet:namespace />editDefaultFilePermissionsDialog'
-					).destroy();
-				});
-		},
-		['liferay-util-window']
-	);
+	window['<portlet:namespace />setPermissions'] = function (uri) {
+		Liferay.Util.getOpener().Liferay.fire(
+			'<%= HtmlUtil.escape(selectEventName) %>',
+			{
+				uri: uri,
+			}
+		);
+	};
 </aui:script>

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/init.jsp
@@ -40,6 +40,7 @@ page import="com.liferay.portal.kernel.portlet.PortletURLUtil" %><%@
 page import="com.liferay.portal.kernel.security.permission.ResourceActionsUtil" %><%@
 page import="com.liferay.portal.kernel.service.GroupLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.LinkedHashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@
 page import="com.liferay.portal.kernel.util.OrderByComparator" %><%@

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites.jsp
@@ -236,8 +236,6 @@ portletURL.setParameter("delta", String.valueOf(delta));
 	}
 
 	function <portlet:namespace />editSitesDefaultFilePermissions() {
-		var A = AUI();
-
 		var form = document.querySelector('#<portlet:namespace />fm');
 
 		if (form) {
@@ -247,33 +245,49 @@ portletURL.setParameter("delta", String.valueOf(delta));
 			);
 
 			if (groupIds) {
-				Liferay.Util.openWindow({
-					dialog: {
-						destroyOnHide: true,
-						on: {
-							destroy: function () {
+
+				<%
+				String selectEventName = renderResponse.getNamespace() + "itemSelected";
+				%>
+
+				<portlet:renderURL var="editSitesDefaultFilePermissionsURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+					<portlet:param name="groupIds" value="{groupIds}" />
+					<portlet:param name="mvcPath" value="/edit_default_file_permissions.jsp" />
+					<portlet:param name="selectEventName" value="<%= selectEventName %>" />
+				</portlet:renderURL>
+
+				var url = Liferay.Util.sub(
+					decodeURIComponent('<%= editSitesDefaultFilePermissionsURL %>'),
+					{
+						groupIds: groupIds,
+					}
+				);
+
+				Liferay.Util.openModal({
+					id: '<portlet:namespace />editDefaultFilePermissionsDialog',
+					onSelect: function (selectedItem) {
+						Liferay.Util.fetch(selectedItem.uri, {method: 'POST'})
+							.then(function (response) {
+								return response.text();
+							})
+							.then(function () {
 								Liferay.Portlet.refresh(
 									'#p_p_id<portlet:namespace />'
 								);
-							},
-						},
+							})
+							.catch(function (error) {
+								Liferay.Util.openToast({
+									message: Liferay.Language.get(
+										'an-unexpected-system-error-occurred'
+									),
+									title: Liferay.Language.get('error'),
+									type: 'danger',
+								});
+							});
 					},
-					id: '<portlet:namespace />editDefaultFilePermissionsDialog',
+					selectEventName: '<%= selectEventName %>',
 					title: '<liferay-ui:message key="default-file-permissions" />',
-
-					<portlet:renderURL var="editSitesDefaultFilePermissionsURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-						<portlet:param name="groupIds" value="{groupIds}" />
-						<portlet:param name="mvcPath" value="/edit_default_file_permissions.jsp" />
-					</portlet:renderURL>
-
-					uri: A.Lang.sub(
-						decodeURIComponent(
-							'<%= editSitesDefaultFilePermissionsURL %>'
-						),
-						{
-							groupIds: groupIds,
-						}
-					),
+					url: url,
 				});
 			}
 		}

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites_action.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites_action.jsp
@@ -70,31 +70,47 @@ String groupId = String.valueOf(group.getGroupId());
 
 <aui:script>
 	function <portlet:namespace />editDefaultFilePermissions(groupId) {
-		var A = AUI();
 
-		Liferay.Util.openWindow({
-			dialog: {
-				destroyOnHide: true,
-				on: {
-					destroy: function () {
-						Liferay.Portlet.refresh('#p_p_id<portlet:namespace />');
-					},
-				},
-			},
+		<%
+		String selectEventName = renderResponse.getNamespace() + "itemSelected";
+		%>
+
+		<portlet:renderURL var="editDefaultFilePermissionsURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+			<portlet:param name="groupIds" value="{groupId}" />
+			<portlet:param name="mvcPath" value="/edit_default_file_permissions.jsp" />
+			<portlet:param name="selectEventName" value="<%= selectEventName %>" />
+		</portlet:renderURL>
+
+		var url = Liferay.Util.sub(
+			decodeURIComponent('<%= editDefaultFilePermissionsURL %>'),
+			{
+				groupId: groupId,
+			}
+		);
+
+		Liferay.Util.openModal({
 			id: '<portlet:namespace />editDefaultFilePermissionsDialog',
+			onSelect: function (selectedItem) {
+				Liferay.Util.fetch(selectedItem.uri, {method: 'POST'})
+					.then(function (response) {
+						return response.text();
+					})
+					.then(function () {
+						Liferay.Portlet.refresh('#p_p_id<portlet:namespace />');
+					})
+					.catch(function (error) {
+						Liferay.Util.openToast({
+							message: Liferay.Language.get(
+								'an-unexpected-system-error-occurred'
+							),
+							title: Liferay.Language.get('error'),
+							type: 'danger',
+						});
+					});
+			},
+			selectEventName: '<%= selectEventName %>',
 			title: '<liferay-ui:message key="default-file-permissions" />',
-
-			<portlet:renderURL var="editDefaultFilePermissionsURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-				<portlet:param name="groupIds" value="{groupId}" />
-				<portlet:param name="mvcPath" value="/edit_default_file_permissions.jsp" />
-			</portlet:renderURL>
-
-			uri: A.Lang.sub(
-				decodeURIComponent('<%= editDefaultFilePermissionsURL %>'),
-				{
-					groupId: groupId,
-				}
-			),
+			url: url,
 		});
 	}
 </aui:script>


### PR DESCRIPTION
Initially reviewed [here](https://github.com/wincent/liferay-portal/pull/353) 

---

As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561) we eventually want to deprecate the `Liferay.provide` function. Additionally, the `Liferay.Util.getWindow` and `Liferay.Util.openWindow` functions have been replaced with the `Liferay.Util.getOpenener` and `Liferay.Util.openModal` functions.

To test this change:

- From the "Global Menu" select the "Control Panel" tab
- Click on "Sync Connector Admin"
- Select the "Sites" tab
- In the sites list, click the kebab menu and select "Default File Permissions"
- Select one of the permissions in the modal window

As a result, the new permissions should be set for the site and no JS errors should appear in the browser's console.