### PR TITLE
LPS-113552 Deprecated and replaced Liferay.Alert usages with Liferay.Util.openToast

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/config.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/config.js
@@ -50,11 +50,7 @@
 					},
 					'liferay-calendar-message-util': {
 						path: 'message_util.js',
-						requires: [
-							'aui-alert',
-							'liferay-alert',
-							'liferay-util-window',
-						],
+						requires: ['liferay-util-window'],
 					},
 					'liferay-calendar-recurrence-converter': {
 						path: 'recurrence_converter.js',

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/message_util.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/message_util.js
@@ -209,86 +209,40 @@ AUI.add(
 				queue.run();
 			},
 
-			showAlert(container, message) {
-				new A.Alert({
-					animated: true,
-					bodyContent: message,
-					closeable: true,
-					cssClass: 'alert-success',
-					destroyOnHide: true,
-					duration: 1,
-				}).render(container);
+			showAlert(containerId, message) {
+				Liferay.Util.openToast({
+					containerId,
+					message,
+					type: 'success',
+				});
 			},
 
 			showErrorMessage(container, errorMessage) {
-				var instance = this;
-
-				var alert = instance._alert;
-
-				if (alert) {
-					alert.destroy();
-				}
-
-				alert = new Liferay.Alert({
-					closeable: true,
-					delay: {
-						hide: 3000,
-						show: 0,
-					},
-					icon: 'exclamation-full',
+				Liferay.Util.openToast({
+					container,
 					message: errorMessage,
 					type: 'danger',
 				});
-
-				if (!alert.get('rendered')) {
-					alert.render(container);
-				}
-
-				alert.show();
-
-				instance._alert = alert;
 			},
 
 			showSuccessMessage(container, message) {
-				var instance = this;
-
 				if (!message) {
 					message = Liferay.Language.get(
 						'your-request-completed-successfully'
 					);
 				}
 
-				var alert = instance._alert;
-
-				if (alert) {
-					alert._alertsContainer._node.innerHTML = '';
-
-					alert.destroy();
-				}
-
-				alert = new Liferay.Alert({
-					closeable: true,
-					delay: {
-						hide: 3000,
-						show: 0,
-					},
-					icon: 'check',
+				Liferay.Util.openToast({
+					container,
 					message,
+					title: Liferay.Language.get('success'),
 					type: 'success',
 				});
-
-				if (!alert.get('rendered')) {
-					alert.render(container);
-				}
-
-				alert.show();
-
-				instance._alert = alert;
 			},
 		};
 	},
 	'',
 	{
-		requires: ['aui-alert', 'liferay-alert', 'liferay-util-window'],
+		requires: ['liferay-util-window'],
 	}
 );

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/remote_services.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/remote_services.js
@@ -178,7 +178,7 @@ AUI.add(
 								if (success) {
 									success.call(instance, data);
 									MessageUtil.showSuccessMessage(
-										instance.get('rootNode')
+										instance.get('rootNode')._node
 									);
 								}
 							},
@@ -207,7 +207,7 @@ AUI.add(
 								if (success) {
 									success.call(instance, data);
 									MessageUtil.showSuccessMessage(
-										instance.get('rootNode')
+										instance.get('rootNode')._node
 									);
 								}
 							},
@@ -472,7 +472,7 @@ AUI.add(
 								if (data.exception) {
 									CalendarUtil.destroyEvent(schedulerEvent);
 									MessageUtil.showErrorMessage(
-										instance.get('rootNode'),
+										instance.get('rootNode')._node,
 										data.exception
 									);
 								}
@@ -485,7 +485,7 @@ AUI.add(
 									if (success) {
 										success.call(instance, data);
 										MessageUtil.showSuccessMessage(
-											instance.get('rootNode')
+											instance.get('rootNode')._node
 										);
 									}
 								}

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
@@ -365,7 +365,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 										<portlet:namespace />scheduler.load();
 
 										Liferay.CalendarMessageUtil.showAlert(
-											'#<portlet:namespace />alert',
+											'<portlet:namespace />alert',
 											'<liferay-ui:message key="the-calendar-was-deleted-successfully" />'
 										);
 									}

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
@@ -367,12 +367,12 @@ class ImageEditor extends PortletBase {
 	 * @param  {String} message The error message to display.
 	 * @protected
 	 */
-	showError_(message) {
+	showError_({message}) {
 		this.components.loading.show = false;
 
 		Liferay.Util.openToast({
 			container: this.element,
-			message: message.message,
+			message: message,
 			type: 'danger',
 		});
 	}

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
@@ -370,17 +370,10 @@ class ImageEditor extends PortletBase {
 	showError_(message) {
 		this.components.loading.show = false;
 
-		AUI().use('liferay-alert', () => {
-			new Liferay.Alert({
-				delay: {
-					hide: 2000,
-					show: 0,
-				},
-				duration: 3000,
-				icon: 'exclamation-circle',
-				message: message.message,
-				type: 'danger',
-			}).render(this.element);
+		Liferay.Util.openToast({
+			container: this.element,
+			message: message.message,
+			type: 'danger',
 		});
 	}
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
@@ -372,7 +372,7 @@ class ImageEditor extends PortletBase {
 
 		Liferay.Util.openToast({
 			container: this.element,
-			message: message,
+			message,
 			type: 'danger',
 		});
 	}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/alert.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/alert.js
@@ -13,7 +13,7 @@
  */
 
 /*
- * @deprecated As of Athanasius (7.3.x), replaced by Liferay.Util.getCropRegion
+ * @deprecated As of Athanasius (7.3.x), replaced by Liferay.Util.openToast
  * @module liferay-alert
  */
 AUI.add(

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/alert.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/alert.js
@@ -12,6 +12,10 @@
  * details.
  */
 
+/*
+ * @deprecated As of Athanasius (7.3.x), replaced by Liferay.Util.getCropRegion
+ * @module liferay-alert
+ */
 AUI.add(
 	'liferay-alert',
 	(A) => {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_repository_entry_browser.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_repository_entry_browser.js
@@ -398,17 +398,11 @@ AUI.add(
 				_showError(message) {
 					var instance = this;
 
-					new Liferay.Alert({
-						closeable: true,
-						delay: {
-							hide: 5000,
-							show: 0,
-						},
-						duration: 250,
-						icon: 'exclamation-full',
+					Liferay.Util.openToast({
+						container: instance.rootNode,
 						message,
 						type: 'danger',
-					}).render(instance.rootNode);
+					});
 				},
 
 				_showFile(file, preview) {
@@ -545,7 +539,6 @@ AUI.add(
 	'',
 	{
 		requires: [
-			'liferay-alert',
 			'liferay-item-selector-uploader',
 			'liferay-item-viewer',
 			'liferay-portlet-base',

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/logo_editor.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/logo_editor.js
@@ -283,16 +283,10 @@ AUI.add(
 				},
 
 				_showError(message) {
-					new Liferay.Alert({
-						closeable: true,
-						delay: {
-							hide: 3000,
-							show: 0,
-						},
-						duration: 500,
+					Liferay.Util.openToast({
 						message,
 						type: 'danger',
-					}).render();
+					});
 				},
 
 				bindUI() {
@@ -374,10 +368,6 @@ AUI.add(
 	},
 	'',
 	{
-		requires: [
-			'aui-image-cropper',
-			'liferay-alert',
-			'liferay-portlet-base',
-		],
+		requires: ['aui-image-cropper', 'liferay-portlet-base'],
 	}
 );

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
@@ -351,11 +351,7 @@
 					},
 					'liferay-logo-editor': {
 						path: 'logo_editor.js',
-						requires: [
-							'aui-image-cropper',
-							'liferay-alert',
-							'liferay-portlet-base',
-						],
+						requires: ['aui-image-cropper', 'liferay-portlet-base'],
 					},
 					'liferay-logo-selector': {
 						path: 'logo_selector.js',

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -49,7 +49,9 @@ function AlertContainer({children, hasWrapper = true}) {
  * Function that implements the Toast pattern, which allows to present feedback
  * to user actions as a toast message in the lower left corner of the page
  *
- * @param {number} autoClose Flag to indicate alert should automatically call `onClose`.
+ * @param {number|boolean} autoClose Flag to indicate alert should automatically call onClose.
+ * It also accepts a duration (in ms) which indicates how long to wait. If true is passed in, the
+ * timeout will be 10000ms. See https://clayui.com/docs/components/alert.html for more details.
  * @param {HTMLElement} container A container to be used to the Alert being positioned relatively.
  * @param {string} containerId A containerId of the element to be opened relatively.
  * @param {string} message The message to show in the toast notification

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -25,25 +25,36 @@ const DEFAULT_RENDER_DATA = {
 
 const TOAST_AUTO_CLOSE_INTERVAL = 5000;
 
-const getDefaultAlertContainer = () => {
-	let container = document.getElementById(DEFAULT_ALERT_CONTAINER_ID);
+/**
+ * Function used to obtain the root element for rendering the Toast React component.
+ *
+ * When providing a container or a containerId, an element will be added as a first
+ * child of the element for preventing React replace the container/containerId DOM
+ * when rendering. Otherwise, the element will be appended to the body.
+ *
+ * When a container and containerId were provided, the container have precedence.
+ *
+ * @param {HTMLElement} container A container to be used to the Alert being positioned relatively.
+ * @param {string} containerId A containerId of the element to be opened relatively.
+ * @returns {HTMLElement} An element used to
+ */
+const getContainerElement = ({container, containerId}) => {
+	const fragment = document.createElement('div');
+	fragment.id = DEFAULT_ALERT_CONTAINER_ID;
 
-	if (!container) {
-		container = document.createElement('div');
-		container.id = DEFAULT_ALERT_CONTAINER_ID;
-		document.body.appendChild(container);
+	if (container || containerId) {
+		const element = container || document.getElementById(containerId);
+
+		element.appendChild(fragment);
+
+		return fragment;
 	}
+	else {
+		document.body.appendChild(fragment);
 
-	return container;
+		return fragment;
+	}
 };
-
-function AlertContainer({children, hasWrapper = true}) {
-	if (hasWrapper) {
-		return <ClayAlert.ToastContainer>{children}</ClayAlert.ToastContainer>;
-	}
-
-	return <>children</>;
-}
 
 /**
  * Function that implements the Toast pattern, which allows to present feedback
@@ -73,17 +84,17 @@ function openToast({
 	type = 'success',
 	variant,
 }) {
-	const componentContainer =
-		container ||
-		document.getElementById(containerId) ||
-		getDefaultAlertContainer();
+	const rootElement = getContainerElement({container, containerId});
 
-	unmountComponentAtNode(componentContainer);
+	unmountComponentAtNode(rootElement);
 
-	const onClose = () => unmountComponentAtNode(componentContainer);
+	const onClose = () => unmountComponentAtNode(rootElement);
+
+	const Container =
+		container || containerId ? React.Fragment : ClayAlert.ToastContainer;
 
 	render(
-		<AlertContainer hasWrapper={!containerId}>
+		<Container>
 			<ClayAlert
 				autoClose={autoClose}
 				displayType={type}
@@ -94,9 +105,9 @@ function openToast({
 			>
 				{message}
 			</ClayAlert>
-		</AlertContainer>,
+		</Container>,
 		renderData,
-		componentContainer
+		rootElement
 	);
 }
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -26,7 +26,7 @@ const DEFAULT_RENDER_DATA = {
 const TOAST_AUTO_CLOSE_INTERVAL = 5000;
 
 /**
- * Function used to obtain the root element for rendering the Toast React component.
+ * Function used to obtain the root element for mounting the React Toast component.
  *
  * When providing a container or a containerId, an element will be added as a first
  * child of the element for preventing React replace the container/containerId DOM
@@ -34,8 +34,8 @@ const TOAST_AUTO_CLOSE_INTERVAL = 5000;
  *
  * When a container and containerId were provided, the container have precedence.
  *
- * @param {HTMLElement} container A container to be used to the Alert being positioned relatively.
- * @param {string} containerId A containerId of the element to be opened relatively.
+ * @param {HTMLElement} container Target element where the toast React component should be mounted.
+ * @param {string} containerId The id of the element where the toast React component should be mounted.
  * @returns {HTMLElement} An element used to
  */
 const getContainerElement = ({container, containerId}) => {
@@ -63,8 +63,8 @@ const getContainerElement = ({container, containerId}) => {
  * @param {number|boolean} autoClose Flag to indicate alert should automatically call onClose.
  * It also accepts a duration (in ms) which indicates how long to wait. If true is passed in, the
  * timeout will be 10000ms. See https://clayui.com/docs/components/alert.html for more details.
- * @param {HTMLElement} container A container to be used to the Alert being positioned relatively.
- * @param {string} containerId A containerId of the element to be opened relatively.
+ * @param {HTMLElement} container Target element where the toast React component should be mounted.
+ * @param {string} containerId The id of the element where the toast React component should be mounted.
  * @param {string} message The message to show in the toast notification
  * @param {string} title The title associated with the message
  * @param {string} displayType The displayType of notification to show. It can be one of the

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -37,10 +37,21 @@ const getDefaultAlertContainer = () => {
 	return container;
 };
 
+function AlertContainer({children, hasWrapper = true}) {
+	if (hasWrapper) {
+		return <ClayAlert.ToastContainer>{children}</ClayAlert.ToastContainer>;
+	}
+
+	return children;
+}
+
 /**
  * Function that implements the Toast pattern, which allows to present feedback
  * to user actions as a toast message in the lower left corner of the page
  *
+ * @param {number} autoClose Flag to indicate alert should automatically call `onClose`.
+ * @param {HTMLElement} container A container to be used to the Alert being positioned relatively.
+ * @param {string} containerId A containerId of the element to be opened relatively.
  * @param {string} message The message to show in the toast notification
  * @param {string} title The title associated with the message
  * @param {string} displayType The displayType of notification to show. It can be one of the
@@ -50,6 +61,8 @@ const getDefaultAlertContainer = () => {
  */
 
 function openToast({
+	autoClose = TOAST_AUTO_CLOSE_INTERVAL,
+	container,
 	containerId,
 	message = '',
 	renderData = DEFAULT_RENDER_DATA,
@@ -58,17 +71,19 @@ function openToast({
 	type = 'success',
 	variant,
 }) {
-	const container =
-		document.getElementById(containerId) || getDefaultAlertContainer();
+	const componentContainer =
+		container ||
+		document.getElementById(containerId) ||
+		getDefaultAlertContainer();
 
-	unmountComponentAtNode(container);
+	unmountComponentAtNode(componentContainer);
 
-	const onClose = () => unmountComponentAtNode(container);
+	const onClose = () => unmountComponentAtNode(componentContainer);
 
 	render(
-		<ClayAlert.ToastContainer>
+		<AlertContainer hasWrapper={!containerId}>
 			<ClayAlert
-				autoClose={TOAST_AUTO_CLOSE_INTERVAL}
+				autoClose={autoClose}
 				displayType={type}
 				onClose={onClose}
 				title={title}
@@ -77,9 +92,9 @@ function openToast({
 			>
 				{message}
 			</ClayAlert>
-		</ClayAlert.ToastContainer>,
+		</AlertContainer>,
 		renderData,
-		container
+		componentContainer
 	);
 }
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -42,7 +42,7 @@ function AlertContainer({children, hasWrapper = true}) {
 		return <ClayAlert.ToastContainer>{children}</ClayAlert.ToastContainer>;
 	}
 
-	return children;
+	return <>children</>;
 }
 
 /**

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_template.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_template.jsp
@@ -72,7 +72,7 @@ AssetRendererFactory<JournalArticle> assetRendererFactory = AssetRendererFactory
 AssetRenderer<JournalArticle> assetRenderer = assetRendererFactory.getAssetRenderer(article, 0);
 %>
 
-<aui:script use="aui-parse-content,liferay-alert">
+<aui:script use="aui-parse-content">
 	var templatePreview = A.one('.template-preview-content');
 	var form = A.one('#<%= refererPortletName %>fm');
 	var templateKeyInput = A.one('#<%= refererPortletName + "ddmTemplateKey" %>');
@@ -97,12 +97,6 @@ AssetRenderer<JournalArticle> assetRenderer = assetRendererFactory.getAssetRende
 			event.preventDefault();
 
 			var instance = this;
-
-			var alert = instance._alert;
-
-			if (alert) {
-				alert.destroy();
-			}
 
 			Liferay.Util.openModal({
 				onSelect: function (selectedItem) {
@@ -143,22 +137,12 @@ AssetRenderer<JournalArticle> assetRenderer = assetRendererFactory.getAssetRende
 							);
 						});
 
-					alert = new Liferay.Alert({
-						closeable: true,
-						delay: {
-							hide: 0,
-							show: 0,
-						},
-						duration: 500,
-						icon: 'info-circle',
+					Liferay.Util.openToast({
+						container: form,
 						message:
 							'<%= HtmlUtil.escapeJS(LanguageUtil.get(resourceBundle, "changing-the-template-will-not-affect-the-original-web-content-defautl-template.-the-change-only-applies-to-this-web-content-display")) %>',
-						namespace: '<portlet:namespace />',
-						title: '',
 						type: 'info',
-					}).render(form);
-
-					instance._alert = alert;
+					});
 				},
 				selectEventName:
 					'<%= PortalUtil.getPortletNamespace(portletId) + "selectDDMTemplate" %>',

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
@@ -115,7 +115,7 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 	</liferay-frontend:edit-form>
 </clay:container-fluid>
 
-<aui:script use="liferay-alert">
+<aui:script>
 	var form = document.<portlet:namespace />fm;
 
 	form.addEventListener('submit', function (event) {
@@ -167,16 +167,10 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 					});
 				}
 				else {
-					new Liferay.Alert({
-						delay: {
-							hide: 3000,
-							show: 0,
-						},
-						duration: 500,
-						icon: 'exclamation-circle',
+					Liferay.Util.openToast({
 						message: response.errorMessage,
 						type: 'danger',
-					}).render();
+					});
 				}
 			});
 	});

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/js/main.js
@@ -16,8 +16,6 @@ AUI.add(
 	'liferay-workflow-web',
 	(A) => {
 		var WorkflowWeb = {
-			_alert: null,
-
 			_doToggleDefinitionLinkEditionMode(namespace) {
 				var instance = this;
 
@@ -391,38 +389,17 @@ AUI.add(
 			},
 
 			showActionUndoneSuccessMessage() {
-				var instance = this;
-
 				var successMessage = Liferay.Language.get('action-undone');
 
-				var alert = instance._alert;
-
-				if (alert) {
-					alert.destroy();
-				}
-
-				alert = new Liferay.Alert({
-					closeable: true,
-					delay: {
-						hide: 5000,
-						show: 0,
-					},
+				Liferay.Util.openToast({
+					container: document.querySelector('.portlet-column'),
 					message: successMessage,
+					title: Liferay.Language.get('success'),
 					type: 'success',
 				});
-
-				if (!alert.get('rendered')) {
-					alert.render('.portlet-column');
-				}
-
-				alert.show();
-
-				instance._alert = alert;
 			},
 
 			showDefinitionImportSuccessMessage(namespace) {
-				var instance = this;
-
 				var undo = Liferay.Language.get('undo');
 
 				var undoEvent = "'" + namespace + "undoDefinition'";
@@ -440,29 +417,12 @@ AUI.add(
 
 				successMessage += undoLink;
 
-				var alert = instance._alert;
-
-				if (alert) {
-					alert.destroy();
-				}
-
-				alert = new Liferay.Alert({
-					closeable: true,
-					delay: {
-						hide: 10000,
-						show: 0,
-					},
+				Liferay.Util.openToast({
+					container: document.querySelector('.portlet-column'),
 					message: successMessage,
+					title: Liferay.Language.get('success'),
 					type: 'success',
 				});
-
-				if (!alert.get('rendered')) {
-					alert.render('.portlet-column');
-				}
-
-				alert.show();
-
-				instance._alert = alert;
 			},
 
 			toggleDefinitionLinkEditionMode(event, namespace) {
@@ -526,6 +486,6 @@ AUI.add(
 	},
 	'',
 	{
-		requires: ['liferay-alert', 'liferay-util-window'],
+		requires: ['liferay-util-window'],
 	}
 );

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/add_site_navigation_menu_item.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/add_site_navigation_menu_item.jsp
@@ -65,7 +65,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "add-x", siteNavigationMenu
 	</aui:button-row>
 </aui:form>
 
-<aui:script use="liferay-alert">
+<aui:script>
 	var addButton = document.getElementById('<portlet:namespace />addButton');
 
 	if (addButton) {
@@ -113,16 +113,10 @@ renderResponse.setTitle(LanguageUtil.format(request, "add-x", siteNavigationMenu
 						});
 					}
 					else {
-						new Liferay.Alert({
-							delay: {
-								hide: 500,
-								show: 0,
-							},
-							duration: 500,
-							icon: 'exclamation-circle',
+						Liferay.Util.openToast({
 							message: response.errorMessage,
 							type: 'danger',
-						}).render();
+						});
 					}
 				});
 		});

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/tests/Kaleodesigner.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/tests/Kaleodesigner.testcase
@@ -540,9 +540,12 @@ definition {
 			line = "29");
 	}
 
+	// Quarantine flaky test from investigation LRQA-59507
+
 	@priority = "5"
 	test DeleteConnectors {
 		property portal.acceptance = "true";
+		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "Kaleodesigner#DeleteConnectors";
 		property testray.component.names = "Training";
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/dialogs.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/dialogs.js
@@ -168,38 +168,17 @@ AUI.add(
 		};
 
 		var showActionUndoneSuccessMessage = function () {
-			var instance = this;
-
 			var successMessage = Liferay.Language.get('action-undone');
 
-			var alert = instance._alert;
-
-			if (alert) {
-				alert.destroy();
-			}
-
-			alert = new Liferay.Alert({
-				closeable: true,
-				delay: {
-					hide: 5000,
-					show: 0,
-				},
+			Liferay.Util.openToast({
+				container: document.querySelector('.portlet-column'),
 				message: successMessage,
+				title: Liferay.Language.get('success'),
 				type: 'success',
 			});
-
-			if (!alert.get('rendered')) {
-				alert.render('.portlet-column');
-			}
-
-			alert.show();
-
-			instance._alert = alert;
 		};
 
 		var showDefinitionImportSuccessMessage = function (namespace) {
-			var instance = this;
-
 			var undo = Liferay.Language.get('undo');
 
 			var undoEvent = "'" + namespace + "undoDefinition'";
@@ -217,29 +196,12 @@ AUI.add(
 
 			successMessage += undoLink;
 
-			var alert = instance._alert;
-
-			if (alert) {
-				alert.destroy();
-			}
-
-			alert = new Liferay.Alert({
-				closeable: true,
-				delay: {
-					hide: 10000,
-					show: 0,
-				},
+			Liferay.Util.openToast({
+				container: document.querySelector('.portlet-column'),
 				message: successMessage,
+				title: Liferay.Language.get('success'),
 				type: 'success',
 			});
-
-			if (!alert.get('rendered')) {
-				alert.render('.portlet-column');
-			}
-
-			alert.show();
-
-			instance._alert = alert;
 		};
 
 		KaleoDesignerDialogs.openConfirmDeleteDialog = openConfirmDeleteDialog;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/main.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/main.js
@@ -499,36 +499,16 @@ AUI.add(
 				},
 
 				showSuccessMessage() {
-					var instance = this;
-
 					var successMessage = Liferay.Language.get(
 						'definition-imported-sucessfully'
 					);
 
-					var alert = instance._alert;
-
-					if (alert) {
-						alert.destroy();
-					}
-
-					alert = new Liferay.Alert({
-						closeable: true,
-						delay: {
-							hide: 3000,
-							show: 0,
-						},
-						icon: 'check',
+					Liferay.Util.openToast({
+						container: document.querySelector('.portlet-column'),
 						message: successMessage,
+						title: Liferay.Language.get('success'),
 						type: 'success',
 					});
-
-					if (!alert.get('rendered')) {
-						alert.render('.portlet-column');
-					}
-
-					alert.show();
-
-					instance._alert = alert;
 				},
 			},
 		});


### PR DESCRIPTION
Originally: https://github.com/wincent/liferay-portal/pull/334

Forwarding this here to keep everything under liferay-frontend user.

cc @diegonvs 

Original message follows.

---

## AUI liferay-alert Deprecation

When rendering the component, running:

```js
AUI().use('liferay-alert', () => {
   new Liferay.Alert({
        closeable: true,
        delay: {
            hide: 3000,
            show: 0,
        },
        duration: 500,
        message: 'can you hear me major tom?',
        type: 'danger',
	}).render();
});
```

I noticed that styles of Alert are very similar to openToast:

However, liferay-alert has wrong styles. So, a migration for using  `openToast` will be nicer for improving not just the style but deprecating an old AUI component.

### Finding the usages “grepping”:

- [`git grep '\bLiferay\.Alert\b'`](https://gist.github.com/diegonvs/597f519da80e4bf5d51e42c24718280c)
- [`git grep liferay-alert`](https://gist.github.com/diegonvs/319b589500c725297a3ee9e9e9fb7ce2)

`liferay-logo-editor` AUI component is currently using `liferay-alert` and was replaced with `openToast`. This alert don’t have a title, by default the `openToast` command adds a `Success` title. This behaviour was changed here: [LPS-113582|LPS-113583 Replaces the usages of `Liferay.Notification` and `Liferay.Notice`  with `Liferay.Util.openToast` by diegonvs · Pull Request #309 · wincent/liferay-portal · GitHub](https://github.com/wincent/liferay-portal/pull/309/commits/c71c41b4f5dd3fae956b8b92c67ac05545493f33#diff-112d3d1fda54125b4833c896715647c3R28)

## API Usages:

/I noticed for some examples, an element or a selector is being passed to the component (via render function) and the toast will open near this element.

Considering this, I’m using the openToast like:

```js
Liferay.Util.openToast(
	{
		message: 'aaaa',
		containerId: 		'_com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet_-container'
	})
```

Or 

```js
Liferay.Util.openToast(
	{
		message: 'aaaa',
		container: document.querySelector('.portlet-column')
	})
```

Or 
```js
Liferay.Util.openToast({
	message: 'aaaaaaa',
	container: instance.node
});
```

`liferay-notification` AUI Plugin also depends on `liferay-alert`. However this plugin was deprecated at https://github.com/wincent/liferay-portal/pull/309.

`ImageEditor` component was using `liferay-alert` dynamic requiring the module using `AUI().use`. The usage can be easily replaced with `openToast`.

On `journal_template.jsp`, the plugin was easily replaced. The alert element inserted to the templatePreview doesn’t have the function of Liferay.Alert and don’t depend on it.

On `add_layout.jsp`, it was very easy for change to replace and I also changed the script tag from `aui:script` to `script`. Since `liferay-alert` dependency is not being used more.

On `add_site_navigation_menu_item.jsp`, I conducted the same as the JSP above.

On `portal-workflow-web`, it was quickly replaced by `Liferay.Util.openToast`.

On `calendar-web`, I noticed that they gives a container to the Alert component. e.g `instance.get(‘rootNode) `. I solved this using `instance.get('rootNode')._node` that returns the corresponding DOM element of the Y.Node. Also, `showAlert` was changed from `Y.Alert` to openToast.

## Questions:

There are some cases using data-dismiss=“liferay-alert”. Is this alert support depending on `liferay-alert` or `aui-alert`? cc @markocikos