### PR TITLE
LPS-113561 Avoid use of Liferay.provide in users-admin-web

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -718,8 +718,8 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 			function <portlet:namespace />deleteGroupRole(roleId, groupId) {
 				for (var i = 0; i < <portlet:namespace />addGroupRolesRoleIds.length; i++) {
 					if (
-						<portlet:namespace />addGroupRolesGroupIds[i] == groupId &&
-						<portlet:namespace />addGroupRolesRoleIds[i] == roleId
+						<portlet:namespace />addGroupRolesGroupIds[i] === groupId &&
+						<portlet:namespace />addGroupRolesRoleIds[i] === roleId
 					) {
 						<portlet:namespace />addGroupRolesGroupIds.splice(i, 1);
 						<portlet:namespace />addGroupRolesRoleIds.splice(i, 1);
@@ -798,8 +798,8 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 						i++
 					) {
 						if (
-							<portlet:namespace />deleteGroupRolesGroupIds[i] == groupId &&
-							<portlet:namespace />deleteGroupRolesRoleIds[i] == roleId
+							<portlet:namespace />deleteGroupRolesGroupIds[i] === groupId &&
+							<portlet:namespace />deleteGroupRolesRoleIds[i] === roleId
 						) {
 							<portlet:namespace />deleteGroupRolesGroupIds.splice(i, 1);
 							<portlet:namespace />deleteGroupRolesRoleIds.splice(i, 1);

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -133,7 +133,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 	</liferay-ui:search-container>
 
 	<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
-		<aui:script sandbox="<%= true %>">
+		<aui:script sandbox="<%= true %>" use="liferay-search-container">
 			var selectRegularRoleLink = document.getElementById(
 				'<portlet:namespace />selectRegularRoleLink'
 			);
@@ -171,7 +171,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 							uri: '<%= selectRegularRoleURL.toString() %>',
 						},
 						function (event) {
-							Liferay.Users['<portlet:namespace />selectRole'](
+							<portlet:namespace />selectRole(
 								event.entityid,
 								event.entityname,
 								event.searchcontainername,
@@ -384,7 +384,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 	</c:if>
 
 	<c:if test="<%= !organizations.isEmpty() && !portletName.equals(myAccountPortletId) %>">
-		<aui:script sandbox="<%= true %>">
+		<aui:script sandbox="<%= true %>" use="liferay-search-container">
 			var selectOrganizationRoleLink = document.getElementById(
 				'<portlet:namespace />selectOrganizationRoleLink'
 			);
@@ -426,7 +426,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 							uri: '<%= selectOrganizationRoleURL.toString() %>',
 						},
 						function (event) {
-							Liferay.Users['<portlet:namespace />selectRole'](
+							<portlet:namespace />selectRole(
 								event.entityid,
 								event.entityname,
 								event.searchcontainername,
@@ -622,7 +622,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 							uri: '<%= selectSiteRoleURL.toString() %>',
 						},
 						function (event) {
-							Liferay.Users['<portlet:namespace />selectRole'](
+							<portlet:namespace />selectRole(
 								event.entityid,
 								event.entityname,
 								event.searchcontainername,
@@ -757,102 +757,98 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 				);
 			}
 
-			Liferay.provide(
-				Users,
-				'<portlet:namespace />selectRole',
-				function (roleId, name, searchContainer, groupName, groupId, iconCssClass) {
-					var A = AUI();
-					var LString = A.Lang.String;
+			window['<portlet:namespace />selectRole'] = function (
+				roleId,
+				name,
+				searchContainer,
+				groupName,
+				groupId,
+				iconCssClass
+			) {
+				var A = AUI();
+				var LString = A.Lang.String;
 
-					var searchContainerName =
-						'<portlet:namespace />' + searchContainer + 'SearchContainer';
+				var searchContainerName =
+					'<portlet:namespace />' + searchContainer + 'SearchContainer';
 
-					searchContainer = Liferay.SearchContainer.get(searchContainerName);
+				searchContainer = Liferay.SearchContainer.get(searchContainerName);
 
-					var rowColumns = [];
+				var rowColumns = [];
 
+				rowColumns.push(
+					'<i class="' + iconCssClass + '"></i> ' + Liferay.Util.escapeHTML(name)
+				);
+
+				if (groupName) {
+					rowColumns.push(groupName);
+				}
+
+				if (groupId) {
 					rowColumns.push(
-						'<i class="' +
-							iconCssClass +
-							'"></i> ' +
-							Liferay.Util.escapeHTML(name)
+						'<a class="modify-link" data-groupId="' +
+							groupId +
+							'" data-rowId="' +
+							roleId +
+							'" href="javascript:;"><%= UnicodeFormatter.toString(removeRoleIcon) %></a>'
 					);
 
-					if (groupName) {
-						rowColumns.push(groupName);
-					}
-
-					if (groupId) {
-						rowColumns.push(
-							'<a class="modify-link" data-groupId="' +
-								groupId +
-								'" data-rowId="' +
-								roleId +
-								'" href="javascript:;"><%= UnicodeFormatter.toString(removeRoleIcon) %></a>'
-						);
-
-						for (
-							var i = 0;
-							i < <portlet:namespace />deleteGroupRolesRoleIds.length;
-							i++
+					for (
+						var i = 0;
+						i < <portlet:namespace />deleteGroupRolesRoleIds.length;
+						i++
+					) {
+						if (
+							<portlet:namespace />deleteGroupRolesGroupIds[i] == groupId &&
+							<portlet:namespace />deleteGroupRolesRoleIds[i] == roleId
 						) {
-							if (
-								<portlet:namespace />deleteGroupRolesGroupIds[i] ==
-									groupId &&
-								<portlet:namespace />deleteGroupRolesRoleIds[i] == roleId
-							) {
-								<portlet:namespace />deleteGroupRolesGroupIds.splice(i, 1);
-								<portlet:namespace />deleteGroupRolesRoleIds.splice(i, 1);
+							<portlet:namespace />deleteGroupRolesGroupIds.splice(i, 1);
+							<portlet:namespace />deleteGroupRolesRoleIds.splice(i, 1);
 
-								break;
-							}
+							break;
 						}
-
-						<portlet:namespace />addGroupRolesGroupIds.push(groupId);
-						<portlet:namespace />addGroupRolesRoleIds.push(roleId);
-
-						document.<portlet:namespace />fm.<portlet:namespace />addGroupRolesGroupIds.value = <portlet:namespace />addGroupRolesGroupIds.join(
-							','
-						);
-						document.<portlet:namespace />fm.<portlet:namespace />addGroupRolesRoleIds.value = <portlet:namespace />addGroupRolesRoleIds.join(
-							','
-						);
-						document.<portlet:namespace />fm.<portlet:namespace />deleteGroupRolesGroupIds.value = <portlet:namespace />deleteGroupRolesGroupIds.join(
-							','
-						);
-						document.<portlet:namespace />fm.<portlet:namespace />deleteGroupRolesRoleIds.value = <portlet:namespace />deleteGroupRolesRoleIds.join(
-							','
-						);
-
-						searchContainer.addRow(rowColumns, groupId + '-' + roleId);
-					}
-					else {
-						rowColumns.push(
-							'<a class="modify-link" data-rowId="' +
-								roleId +
-								'" href="javascript:;"><%= UnicodeFormatter.toString(removeRoleIcon) %></a>'
-						);
-
-						A.Array.removeItem(<portlet:namespace />deleteRoleIds, roleId);
-
-						<portlet:namespace />addRoleIds.push(roleId);
-
-						document.<portlet:namespace />fm.<portlet:namespace />addRoleIds.value = <portlet:namespace />addRoleIds.join(
-							','
-						);
-						document.<portlet:namespace />fm.<portlet:namespace />deleteRoleIds.value = <portlet:namespace />deleteRoleIds.join(
-							','
-						);
-
-						searchContainer.addRow(rowColumns, roleId);
 					}
 
-					searchContainer.updateDataStore();
-				},
-				[]
-			);
+					<portlet:namespace />addGroupRolesGroupIds.push(groupId);
+					<portlet:namespace />addGroupRolesRoleIds.push(roleId);
 
-			Liferay.Users = Users;
+					document.<portlet:namespace />fm.<portlet:namespace />addGroupRolesGroupIds.value = <portlet:namespace />addGroupRolesGroupIds.join(
+						','
+					);
+					document.<portlet:namespace />fm.<portlet:namespace />addGroupRolesRoleIds.value = <portlet:namespace />addGroupRolesRoleIds.join(
+						','
+					);
+					document.<portlet:namespace />fm.<portlet:namespace />deleteGroupRolesGroupIds.value = <portlet:namespace />deleteGroupRolesGroupIds.join(
+						','
+					);
+					document.<portlet:namespace />fm.<portlet:namespace />deleteGroupRolesRoleIds.value = <portlet:namespace />deleteGroupRolesRoleIds.join(
+						','
+					);
+
+					searchContainer.addRow(rowColumns, groupId + '-' + roleId);
+				}
+				else {
+					rowColumns.push(
+						'<a class="modify-link" data-rowId="' +
+							roleId +
+							'" href="javascript:;"><%= UnicodeFormatter.toString(removeRoleIcon) %></a>'
+					);
+
+					A.Array.removeItem(<portlet:namespace />deleteRoleIds, roleId);
+
+					<portlet:namespace />addRoleIds.push(roleId);
+
+					document.<portlet:namespace />fm.<portlet:namespace />addRoleIds.value = <portlet:namespace />addRoleIds.join(
+						','
+					);
+					document.<portlet:namespace />fm.<portlet:namespace />deleteRoleIds.value = <portlet:namespace />deleteRoleIds.join(
+						','
+					);
+
+					searchContainer.addRow(rowColumns, roleId);
+				}
+
+				searchContainer.updateDataStore();
+			};
 		</aui:script>
 
 		<aui:script use="liferay-search-container">

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -171,7 +171,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 							uri: '<%= selectRegularRoleURL.toString() %>',
 						},
 						function (event) {
-							<portlet:namespace />selectRole(
+							Liferay.Users['<portlet:namespace />selectRole'](
 								event.entityid,
 								event.entityname,
 								event.searchcontainername,
@@ -426,7 +426,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 							uri: '<%= selectOrganizationRoleURL.toString() %>',
 						},
 						function (event) {
-							<portlet:namespace />selectRole(
+							Liferay.Users['<portlet:namespace />selectRole'](
 								event.entityid,
 								event.entityname,
 								event.searchcontainername,
@@ -622,7 +622,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 							uri: '<%= selectSiteRoleURL.toString() %>',
 						},
 						function (event) {
-							<portlet:namespace />selectRole(
+							Liferay.Users['<portlet:namespace />selectRole'](
 								event.entityid,
 								event.entityname,
 								event.searchcontainername,
@@ -758,7 +758,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 			}
 
 			Liferay.provide(
-				window,
+				Users,
 				'<portlet:namespace />selectRole',
 				function (roleId, name, searchContainer, groupName, groupId, iconCssClass) {
 					var A = AUI();
@@ -849,8 +849,10 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "roles"
 
 					searchContainer.updateDataStore();
 				},
-				['liferay-search-container']
+				[]
 			);
+
+			Liferay.Users = Users;
 		</aui:script>
 
 		<aui:script use="liferay-search-container">

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -95,257 +95,257 @@ else {
 </c:choose>
 
 <aui:script>
-	function <portlet:namespace />deleteOrganization(
+function <portlet:namespace />deleteOrganization(
+	organizationId,
+	organizationsRedirect
+) {
+	<portlet:namespace />doDeleteOrganization(
+		'<%= Organization.class.getName() %>',
 		organizationId,
 		organizationsRedirect
-	) {
-		<portlet:namespace />doDeleteOrganization(
-			'<%= Organization.class.getName() %>',
-			organizationId,
-			organizationsRedirect
-		);
-	}
+	);
+}
 
-	function <portlet:namespace />deleteOrganizations(organizationsRedirect) {
-		<portlet:namespace />doDeleteOrganization(
-			'<%= Organization.class.getName() %>',
-			Liferay.Util.listCheckedExcept(
-				document.<portlet:namespace />fm,
-				'<portlet:namespace />allRowIds',
-				'<portlet:namespace />rowIdsOrganization'
-			),
-			organizationsRedirect
-		);
-	}
-
-	function <portlet:namespace />deleteUsers(cmd) {
-		if (
-			(cmd == '<%= Constants.DEACTIVATE %>' &&
-				confirm(
-					'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-deactivate-the-selected-users") %>'
-				)) ||
-			(cmd == '<%= Constants.DELETE %>' &&
-				confirm(
-					'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-permanently-delete-the-selected-users") %>'
-				)) ||
-			cmd == '<%= Constants.RESTORE %>'
-		) {
-			var form = document.<portlet:namespace />fm;
-
-			Liferay.Util.postForm(form, {
-				data: {
-					deleteUserIds: Liferay.Util.listCheckedExcept(
-						form,
-						'<portlet:namespace />allRowIds',
-						'<portlet:namespace />rowIdsUser'
-					),
-					redirect: '<%= currentURL %>',
-					<%= Constants.CMD %>: cmd,
-				},
-				url: '<portlet:actionURL name="/users_admin/edit_user" />',
-			});
-		}
-	}
-
-	function <portlet:namespace />doDeleteOrganization(
-		className,
-		ids,
+function <portlet:namespace />deleteOrganizations(organizationsRedirect) {
+	<portlet:namespace />doDeleteOrganization(
+		'<%= Organization.class.getName() %>',
+		Liferay.Util.listCheckedExcept(
+			document.<portlet:namespace />fm,
+			'<portlet:namespace />allRowIds',
+			'<portlet:namespace />rowIdsOrganization'
+		),
 		organizationsRedirect
-	) {
-		var status = <%= WorkflowConstants.STATUS_INACTIVE %>;
+	);
+}
 
-		<portlet:namespace />getUsersCount(className, ids, status, function (
-			responseData
-		) {
-			var count = parseInt(responseData, 10);
-
-			if (count > 0) {
-				status = <%= WorkflowConstants.STATUS_APPROVED %>;
-
-				<portlet:namespace />getUsersCount(
-					className,
-					ids,
-					status,
-					function (responseData) {
-						count = parseInt(responseData, 10);
-
-						if (count > 0) {
-							if (
-								confirm(
-									'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
-								)
-							) {
-								<portlet:namespace />doDeleteOrganizations(
-									ids,
-									organizationsRedirect
-								);
-							}
-						}
-						else {
-							var message;
-
-							if (ids && ids.toString().split(',').length > 1) {
-								message =
-									'<%= UnicodeLanguageUtil.get(request, "one-or-more-organizations-are-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-organizations-by-automatically-unassociating-the-deactivated-users") %>';
-							}
-							else {
-								message =
-									'<%= UnicodeLanguageUtil.get(request, "the-selected-organization-is-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-organization-by-automatically-unassociating-the-deactivated-users") %>';
-							}
-
-							if (confirm(message)) {
-								<portlet:namespace />doDeleteOrganizations(
-									ids,
-									organizationsRedirect
-								);
-							}
-						}
-					}
-				);
-			}
-			else if (
-				confirm(
-					'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
-				)
-			) {
-				<portlet:namespace />doDeleteOrganizations(
-					ids,
-					organizationsRedirect
-				);
-			}
-		});
-	}
-
-	function <portlet:namespace />doDeleteOrganizations(
-		organizationIds,
-		organizationsRedirect
+function <portlet:namespace />deleteUsers(cmd) {
+	if (
+		(cmd == '<%= Constants.DEACTIVATE %>' &&
+			confirm(
+				'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-deactivate-the-selected-users") %>'
+			)) ||
+		(cmd == '<%= Constants.DELETE %>' &&
+			confirm(
+				'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-permanently-delete-the-selected-users") %>'
+			)) ||
+		cmd == '<%= Constants.RESTORE %>'
 	) {
 		var form = document.<portlet:namespace />fm;
 
-		if (organizationsRedirect) {
-			Liferay.Util.setFormValues(form, {
-				redirect: organizationsRedirect,
-			});
-		}
-
 		Liferay.Util.postForm(form, {
 			data: {
-				deleteOrganizationIds: organizationIds,
-				<%= Constants.CMD %>: '<%= Constants.DELETE %>',
+				deleteUserIds: Liferay.Util.listCheckedExcept(
+					form,
+					'<portlet:namespace />allRowIds',
+					'<portlet:namespace />rowIdsUser'
+				),
+				redirect: '<%= currentURL %>',
+				<%= Constants.CMD %>: cmd,
 			},
-			url: '<portlet:actionURL name="/users_admin/edit_organization" />',
+			url: '<portlet:actionURL name="/users_admin/edit_user" />',
+		});
+	}
+}
+
+function <portlet:namespace />doDeleteOrganization(
+	className,
+	ids,
+	organizationsRedirect
+) {
+	var status = <%= WorkflowConstants.STATUS_INACTIVE %>;
+
+	<portlet:namespace />getUsersCount(className, ids, status, function (
+		responseData
+	) {
+		var count = parseInt(responseData, 10);
+
+		if (count > 0) {
+			status = <%= WorkflowConstants.STATUS_APPROVED %>;
+
+			<portlet:namespace />getUsersCount(
+				className,
+				ids,
+				status,
+				function (responseData) {
+					count = parseInt(responseData, 10);
+
+					if (count > 0) {
+						if (
+							confirm(
+								'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
+							)
+						) {
+							<portlet:namespace />doDeleteOrganizations(
+								ids,
+								organizationsRedirect
+							);
+						}
+					}
+					else {
+						var message;
+
+						if (ids && ids.toString().split(',').length > 1) {
+							message =
+								'<%= UnicodeLanguageUtil.get(request, "one-or-more-organizations-are-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-organizations-by-automatically-unassociating-the-deactivated-users") %>';
+						}
+						else {
+							message =
+								'<%= UnicodeLanguageUtil.get(request, "the-selected-organization-is-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-organization-by-automatically-unassociating-the-deactivated-users") %>';
+						}
+
+						if (confirm(message)) {
+							<portlet:namespace />doDeleteOrganizations(
+								ids,
+								organizationsRedirect
+							);
+						}
+					}
+				}
+			);
+		}
+		else if (
+			confirm(
+				'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
+			)
+		) {
+			<portlet:namespace />doDeleteOrganizations(
+				ids,
+				organizationsRedirect
+			);
+		}
+	});
+}
+
+function <portlet:namespace />doDeleteOrganizations(
+	organizationIds,
+	organizationsRedirect
+) {
+	var form = document.<portlet:namespace />fm;
+
+	if (organizationsRedirect) {
+		Liferay.Util.setFormValues(form, {
+			redirect: organizationsRedirect,
 		});
 	}
 
-	function <portlet:namespace />getUsersCount(className, ids, status, callback) {
-		var formData = new FormData();
-
-		formData.append('className', className);
-		formData.append('ids', ids);
-		formData.append('status', status);
-
-		Liferay.Util.fetch(
-			'<liferay-portlet:resourceURL id="/users_admin/get_users_count" />',
-			{
-				body: formData,
-				method: 'POST',
-			}
-		)
-			.then(function (response) {
-				return response.text();
-			})
-			.then(function (response) {
-				callback(response);
-			});
-	}
-
-	function <portlet:namespace />showUsers(status) {
-
-		<%
-		PortletURL showUsersURL = renderResponse.createRenderURL();
-
-		showUsersURL.setParameter("mvcRenderCommandName", "/users_admin/view");
-		showUsersURL.setParameter("toolbarItem", toolbarItem);
-		showUsersURL.setParameter("usersListView", usersListView);
-
-		organizationId = ParamUtil.getLong(request, "organizationId", OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID);
-
-		if (organizationId != OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID) {
-			showUsersURL.setParameter("organizationId", String.valueOf(organizationId));
-		}
-
-		if (Validator.isNotNull(viewUsersRedirect)) {
-			showUsersURL.setParameter("viewUsersRedirect", viewUsersRedirect);
-		}
-		%>
-
-		location.href = Liferay.Util.addParams(
-			'<portlet:namespace />status=' + status.value,
-			'<%= HtmlUtil.escapeJS(showUsersURL.toString()) %>'
-		);
-	}
-
-	Liferay.provide(window, '<portlet:namespace />openSelectUsersDialog', function (
-		organizationId
-	) {
-		<portlet:renderURL var="selectUsersURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-			<portlet:param name="mvcPath" value="/select_organization_users.jsp" />
-		</portlet:renderURL>
-
-		var selectUsersURL = Liferay.Util.PortletURL.createPortletURL(
-			'<%= selectUsersURL.toString() %>',
-			{
-				organizationId: organizationId,
-			}
-		);
-
-		Liferay.Loader.require(
-			'frontend-js-web/liferay/ItemSelectorDialog.es',
-			function (ItemSelectorDialog) {
-				var itemSelectorDialog = new ItemSelectorDialog.default({
-					buttonAddLabel: '<liferay-ui:message key="done" />',
-					eventName: '<portlet:namespace />selectUsers',
-					title: '<liferay-ui:message key="assign-users" />',
-					url: selectUsersURL.toString(),
-				});
-
-				itemSelectorDialog.on('selectedItemChange', function (event) {
-					var data = event.selectedItem;
-
-					if (data) {
-						<portlet:renderURL var="assignmentsURL">
-							<portlet:param name="mvcRenderCommandName" value="/users_admin/view" />
-							<portlet:param name="toolbarItem" value="view-all-organizations" />
-							<portlet:param name="usersListView" value="<%= UserConstants.LIST_VIEW_TREE %>" />
-						</portlet:renderURL>
-
-						var assignmentsRedirectURL = Liferay.Util.PortletURL.createPortletURL(
-							'<%= assignmentsURL.toString() %>',
-							{
-								organizationId: organizationId,
-							}
-						);
-
-						var editAssignmentParameters = {
-							addUserIds: data.value,
-							assignmentsRedirect: assignmentsRedirectURL.toString(),
-							organizationId: organizationId,
-						};
-
-						var editAssignmentURL = Liferay.Util.PortletURL.createPortletURL(
-							'<portlet:actionURL name="/users_admin/edit_organization_assignments" />',
-							editAssignmentParameters
-						);
-
-						submitForm(
-							document.<portlet:namespace />fm,
-							editAssignmentURL.toString()
-						);
-					}
-				});
-
-				itemSelectorDialog.open();
-			}
-		);
+	Liferay.Util.postForm(form, {
+		data: {
+			deleteOrganizationIds: organizationIds,
+			<%= Constants.CMD %>: '<%= Constants.DELETE %>',
+		},
+		url: '<portlet:actionURL name="/users_admin/edit_organization" />',
 	});
+}
+
+function <portlet:namespace />getUsersCount(className, ids, status, callback) {
+	var formData = new FormData();
+
+	formData.append('className', className);
+	formData.append('ids', ids);
+	formData.append('status', status);
+
+	Liferay.Util.fetch(
+		'<liferay-portlet:resourceURL id="/users_admin/get_users_count" />',
+		{
+			body: formData,
+			method: 'POST',
+		}
+	)
+		.then(function (response) {
+			return response.text();
+		})
+		.then(function (response) {
+			callback(response);
+		});
+}
+
+function <portlet:namespace />showUsers(status) {
+
+	<%
+	PortletURL showUsersURL = renderResponse.createRenderURL();
+
+	showUsersURL.setParameter("mvcRenderCommandName", "/users_admin/view");
+	showUsersURL.setParameter("toolbarItem", toolbarItem);
+	showUsersURL.setParameter("usersListView", usersListView);
+
+	organizationId = ParamUtil.getLong(request, "organizationId", OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID);
+
+	if (organizationId != OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID) {
+		showUsersURL.setParameter("organizationId", String.valueOf(organizationId));
+	}
+
+	if (Validator.isNotNull(viewUsersRedirect)) {
+		showUsersURL.setParameter("viewUsersRedirect", viewUsersRedirect);
+	}
+	%>
+
+	location.href = Liferay.Util.addParams(
+		'<portlet:namespace />status=' + status.value,
+		'<%= HtmlUtil.escapeJS(showUsersURL.toString()) %>'
+	);
+}
+
+window['<portlet:namespace />openSelectUsersDialog'] = function (
+	organizationId
+) {
+	<portlet:renderURL var="selectUsersURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+		<portlet:param name="mvcPath" value="/select_organization_users.jsp" />
+	</portlet:renderURL>
+
+	var selectUsersURL = Liferay.Util.PortletURL.createPortletURL(
+		'<%= selectUsersURL.toString() %>',
+		{
+			organizationId: organizationId,
+		}
+	);
+
+	Liferay.Loader.require(
+		'frontend-js-web/liferay/ItemSelectorDialog.es',
+		function (ItemSelectorDialog) {
+			var itemSelectorDialog = new ItemSelectorDialog.default({
+				buttonAddLabel: '<liferay-ui:message key="done" />',
+				eventName: '<portlet:namespace />selectUsers',
+				title: '<liferay-ui:message key="assign-users" />',
+				url: selectUsersURL.toString(),
+			});
+
+			itemSelectorDialog.on('selectedItemChange', function (event) {
+				var data = event.selectedItem;
+
+				if (data) {
+					<portlet:renderURL var="assignmentsURL">
+						<portlet:param name="mvcRenderCommandName" value="/users_admin/view" />
+						<portlet:param name="toolbarItem" value="view-all-organizations" />
+						<portlet:param name="usersListView" value="<%= UserConstants.LIST_VIEW_TREE %>" />
+					</portlet:renderURL>
+
+					var assignmentsRedirectURL = Liferay.Util.PortletURL.createPortletURL(
+						'<%= assignmentsURL.toString() %>',
+						{
+							organizationId: organizationId,
+						}
+					);
+
+					var editAssignmentParameters = {
+						addUserIds: data.value,
+						assignmentsRedirect: assignmentsRedirectURL.toString(),
+						organizationId: organizationId,
+					};
+
+					var editAssignmentURL = Liferay.Util.PortletURL.createPortletURL(
+						'<portlet:actionURL name="/users_admin/edit_organization_assignments" />',
+						editAssignmentParameters
+					);
+
+					submitForm(
+						document.<portlet:namespace />fm,
+						editAssignmentURL.toString()
+					);
+				}
+			});
+
+			itemSelectorDialog.open();
+		}
+	);
+};
 </aui:script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -256,6 +256,15 @@ function <portlet:namespace />getUsersCount(className, ids, status, callback) {
 		})
 		.then(function (response) {
 			callback(response);
+		})
+		.catch(function (error) {
+			Liferay.Util.openToast({
+				message: Liferay.Language.get(
+					'an-unexpected-system-error-occurred'
+				),
+				title: Liferay.Language.get('error'),
+				type: 'danger',
+			});
 		});
 }
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -120,15 +120,15 @@ function <portlet:namespace />deleteOrganizations(organizationsRedirect) {
 
 function <portlet:namespace />deleteUsers(cmd) {
 	if (
-		(cmd == '<%= Constants.DEACTIVATE %>' &&
+		(cmd === '<%= Constants.DEACTIVATE %>' &&
 			confirm(
 				'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-deactivate-the-selected-users") %>'
 			)) ||
-		(cmd == '<%= Constants.DELETE %>' &&
+		(cmd === '<%= Constants.DELETE %>' &&
 			confirm(
 				'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-permanently-delete-the-selected-users") %>'
 			)) ||
-		cmd == '<%= Constants.RESTORE %>'
+		cmd === '<%= Constants.RESTORE %>'
 	) {
 		var form = document.<portlet:namespace />fm;
 


### PR DESCRIPTION
As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561) we 
eventually want to deprecate the `Liferay.provide` function

To test this change:
- From the "Global Menu" select the "Control Panel" tab
- Click on "Users and Organizations"

You should be able to:

- Create new users 
- Assign roles to users
- Create organizations
- Add users to organizations









