### PR TITLE
LPS-113561 Avoid Liferay.provide in portal-reports-engine-console-web

### DIFF
--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/data_source/edit_data_source.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/data_source/edit_data_source.jsp
@@ -80,97 +80,78 @@ renderResponse.setTitle((source != null) ? LanguageUtil.format(request, "edit-x"
 </aui:form>
 
 <aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />testDatabaseConnection',
-		function () {
-			var A = AUI();
+	window['<portlet:namespace />testDatabaseConnection'] = function () {
+		var baseUrl =
+			'<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcPath" value="/admin/data_source/test_database_connection.jsp" /></portlet:renderURL>';
 
-			var url =
-				'<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcPath" value="/admin/data_source/test_database_connection.jsp" /></portlet:renderURL>';
+		var data = {};
 
-			var data = {};
+		<c:if test="<%= source != null %>">
+			data.<portlet:namespace />sourceId =
+				document.<portlet:namespace />fm['<portlet:namespace />sourceId'].value;
+		</c:if>
 
-			<c:if test="<%= source != null %>">
-				data.<portlet:namespace />sourceId =
-					document.<portlet:namespace />fm[
-						'<portlet:namespace />sourceId'
-					].value;
-			</c:if>
+		data.<portlet:namespace />driverClassName =
+			document.<portlet:namespace />fm[
+				'<portlet:namespace />driverClassName'
+			].value;
+		data.<portlet:namespace />driverUrl =
+			document.<portlet:namespace />fm[
+				'<portlet:namespace />driverUrl'
+			].value;
+		data.<portlet:namespace />driverUserName =
+			document.<portlet:namespace />fm[
+				'<portlet:namespace />driverUserName'
+			].value;
+		data.<portlet:namespace />driverPassword =
+			document.<portlet:namespace />fm[
+				'<portlet:namespace />driverPassword'
+			].value;
 
-			data.<portlet:namespace />driverClassName =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace />driverClassName'
-				].value;
-			data.<portlet:namespace />driverUrl =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace />driverUrl'
-				].value;
-			data.<portlet:namespace />driverUserName =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace />driverUserName'
-				].value;
-			data.<portlet:namespace />driverPassword =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace />driverPassword'
-				].value;
+		if (baseUrl != null) {
+			var searchParams = new URLSearchParams(data);
 
-			if (url != null) {
-				var databaseConnectionModal = Liferay.Util.Window.getWindow({
-					dialog: {
-						centered: true,
-						destroyOnHide: true,
-						height: 300,
-						hideOn: [],
-						modal: true,
-						resizable: false,
-						toolbars: {
-							footer: [
-								{
-									cssClass: 'btn-lg btn-primary',
-									label: '<liferay-ui:message key="close" />',
-									on: {
-										click: function () {
-											databaseConnectionModal.hide();
-										},
-									},
+			var url = new URL(baseUrl);
+
+			searchParams.forEach(function (value, key) {
+				url.searchParams.append(key, value);
+			});
+
+			var id = '<portlet:namespace />databaseConnectionModal';
+
+			Liferay.Util.fetch(url)
+				.then(function (response) {
+					return response.text();
+				})
+				.then(function (text) {
+					Liferay.Util.openModal({
+						bodyHTML: text,
+						buttons: [
+							{
+								label: '<liferay-ui:message key="close" />',
+								onClick: function () {
+									Liferay.Util.getOpener().Liferay.fire(
+										'closeModal',
+										{
+											id: id,
+										}
+									);
 								},
-							],
-							header: [
-								{
-									cssClass: 'close',
-									discardDefaultButtonCssClasses: true,
-									labelHTML: Liferay.Util.getLexiconIconTpl(
-										'times'
-									),
-									on: {
-										click: function () {
-											databaseConnectionModal.hide();
-										},
-									},
-								},
-							],
-						},
-						width: 600,
-					},
-					title: '<liferay-ui:message key="source" />',
+							},
+						],
+						id: id,
+						title: '<liferay-ui:message key="source" />',
+					});
+				})
+				.catch(function (error) {
+					Liferay.Util.openToast({
+						message: Liferay.Language.get(
+							'an-unexpected-system-error-occurred'
+						),
+						title: Liferay.Language.get('error'),
+						type: 'danger',
+					});
 				});
-
-				databaseConnectionModal.render();
-
-				A.io.request(url, {
-					after: {
-						success: function () {
-							var response = this.get('responseData');
-
-							databaseConnectionModal.bodyNode.append(response);
-							databaseConnectionModal.show();
-						},
-					},
-					data: data,
-				});
-			}
-		},
-		['aui-dialog', 'aui-io']
-	);
+		}
+	};
 </aui:script>


### PR DESCRIPTION
As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561) we
eventually want to deprecate the `Liferay.provide` function, the
`<portlet:namespace />testDatabaseConnection` function is now directly declared,
on the `window` object and it's AUI dependencies have been removed.

An interesting detail about this change is that in my case the
`<portlet:namespace />testDababaseConnection` function was failing
because of a missing AUI dependency as can be seen
[here](https://git.io/Jf5Cf).

To test this change:

- Make sure you're running DXP:
  run `ant setup-profile-dxp` before running `ant all`
- Navigate to "Configuration > Reports Admin"
- Click on the "Sources" tab
- Click on the "+" button to add a new source
- Enter a name
- Enter a value for "JDBC Driver Class Name"
  (com.mysql.cj.jdbc.Driver)
- Enter a value for "JDBC URL"
  (jdbc:mysql://localhost/lportal_master?useUnicode=true&characterEncoding=UTF-8&serverTimezone=UTC)
- Enter a value for "JDBC User Name"
- Enter a value for "JDBC Password"
- Click on the "Test Database Connection" button

As a result, and depending on the values you entered in the form, you
should see a modal window appear notifying you that the connection to
the database was either successful or that it failed, and no JS errors
should appear in your browser's console.