### PR TITLE
LPS-113561 Avoid Liferay.provide in document-library-web

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
@@ -380,78 +380,76 @@ renderResponse.setTitle(headerTitle);
 		}
 	}
 
-	Liferay.provide(
-		window,
-		'<portlet:namespace />selectFileEntryType',
-		function (fileEntryTypeId, fileEntryTypeName) {
-			var A = AUI();
+	window['<portlet:namespace />selectFileEntryType'] = function (
+		fileEntryTypeId,
+		fileEntryTypeName
+	) {
+		var A = AUI();
 
-			var searchContainer = Liferay.SearchContainer.get(
-				'<portlet:namespace />dlFileEntryTypesSearchContainer'
-			);
+		var searchContainer = Liferay.SearchContainer.get(
+			'<portlet:namespace />dlFileEntryTypesSearchContainer'
+		);
 
-			var fileEntryTypeLink =
-				'<a class="modify-link" data-rowId="' +
+		var fileEntryTypeLink =
+			'<a class="modify-link" data-rowId="' +
+			fileEntryTypeId +
+			'" href="javascript:;"><%= UnicodeFormatter.toString(removeFileEntryTypeIcon) %></a>';
+
+		<c:choose>
+			<c:when test="<%= workflowEnabled %>">
+				var restrictionTypeWorkflow = A.one(
+					'#<portlet:namespace />restrictionTypeWorkflow'
+				);
+
+				restrictionTypeWorkflow.hide();
+
+				var workflowDefinitions =
+					'<%= UnicodeFormatter.toString(workflowDefinitionsBuffer) %>';
+
+				workflowDefinitions = workflowDefinitions.replace(
+					/LIFERAY_WORKFLOW_DEFINITION_FILE_ENTRY_TYPE/g,
+					'workflowDefinition' + fileEntryTypeId
+				);
+
+				<portlet:namespace />documentTypesChanged = true;
+
+				searchContainer.addRow(
+					[fileEntryTypeName, workflowDefinitions, fileEntryTypeLink],
+					fileEntryTypeId
+				);
+			</c:when>
+			<c:otherwise>
+				searchContainer.addRow(
+					[fileEntryTypeName, fileEntryTypeLink],
+					fileEntryTypeId
+				);
+			</c:otherwise>
+		</c:choose>
+
+		searchContainer.updateDataStore();
+
+		var select = A.one('#<portlet:namespace />defaultFileEntryTypeId');
+
+		var selectContainer = A.one(
+			'#<portlet:namespace />restrictionTypeDefinedDiv .default-document-type'
+		);
+
+		selectContainer.show();
+
+		var option = A.Node.create(
+			'<option id="<portlet:namespace />defaultFileEntryTypeId-' +
 				fileEntryTypeId +
-				'" href="javascript:;"><%= UnicodeFormatter.toString(removeFileEntryTypeIcon) %></a>';
+				'" value="' +
+				fileEntryTypeId +
+				'">' +
+				fileEntryTypeName +
+				'</option>'
+		);
 
-			<c:choose>
-				<c:when test="<%= workflowEnabled %>">
-					var restrictionTypeWorkflow = A.one(
-						'#<portlet:namespace />restrictionTypeWorkflow'
-					);
+		select.show();
 
-					restrictionTypeWorkflow.hide();
-
-					var workflowDefinitions =
-						'<%= UnicodeFormatter.toString(workflowDefinitionsBuffer) %>';
-
-					workflowDefinitions = workflowDefinitions.replace(
-						/LIFERAY_WORKFLOW_DEFINITION_FILE_ENTRY_TYPE/g,
-						'workflowDefinition' + fileEntryTypeId
-					);
-
-					<portlet:namespace />documentTypesChanged = true;
-
-					searchContainer.addRow(
-						[fileEntryTypeName, workflowDefinitions, fileEntryTypeLink],
-						fileEntryTypeId
-					);
-				</c:when>
-				<c:otherwise>
-					searchContainer.addRow(
-						[fileEntryTypeName, fileEntryTypeLink],
-						fileEntryTypeId
-					);
-				</c:otherwise>
-			</c:choose>
-
-			searchContainer.updateDataStore();
-
-			var select = A.one('#<portlet:namespace />defaultFileEntryTypeId');
-
-			var selectContainer = A.one(
-				'#<portlet:namespace />restrictionTypeDefinedDiv .default-document-type'
-			);
-
-			selectContainer.show();
-
-			var option = A.Node.create(
-				'<option id="<portlet:namespace />defaultFileEntryTypeId-' +
-					fileEntryTypeId +
-					'" value="' +
-					fileEntryTypeId +
-					'">' +
-					fileEntryTypeName +
-					'</option>'
-			);
-
-			select.show();
-
-			select.append(option);
-		},
-		['liferay-search-container']
-	);
+		select.append(option);
+	};
 
 	Liferay.Util.toggleRadio('<portlet:namespace />restrictionTypeInherit', '', [
 		'<portlet:namespace />restrictionTypeDefinedDiv',

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
@@ -330,10 +330,10 @@ renderResponse.setTitle(headerTitle);
 	</c:if>
 </liferay-util:buffer>
 
-<aui:script>
+<aui:script use="liferay-search-container">
 	var <portlet:namespace />documentTypesChanged = false;
 
-	function <portlet:namespace />openFileEntryTypeSelector() {
+	window['<portlet:namespace />openFileEntryTypeSelector'] = function () {
 		var searchContainer = Liferay.SearchContainer.get(
 			'<portlet:namespace />dlFileEntryTypesSearchContainer'
 		);
@@ -361,9 +361,9 @@ renderResponse.setTitle(headerTitle);
 			url:
 				'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/document_library/select_restricted_file_entry_type.jsp" /><portlet:param name="includeBasicFileEntryType" value="<%= Boolean.TRUE.toString() %>" /></portlet:renderURL>',
 		});
-	}
+	};
 
-	function <portlet:namespace />savePage() {
+	window['<portlet:namespace />savePage'] = function () {
 		var message =
 			'<%= UnicodeLanguageUtil.get(request, workflowEnabled ? "change-document-types-and-workflow-message" : "change-document-types-message") %>';
 
@@ -378,7 +378,7 @@ renderResponse.setTitle(headerTitle);
 		if (submit) {
 			submitForm(document.<portlet:namespace />fm);
 		}
-	}
+	};
 
 	window['<portlet:namespace />selectFileEntryType'] = function (
 		fileEntryTypeId,

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
@@ -384,8 +384,6 @@ renderResponse.setTitle(headerTitle);
 		fileEntryTypeId,
 		fileEntryTypeName
 	) {
-		var A = AUI();
-
 		var searchContainer = Liferay.SearchContainer.get(
 			'<portlet:namespace />dlFileEntryTypesSearchContainer'
 		);
@@ -397,11 +395,13 @@ renderResponse.setTitle(headerTitle);
 
 		<c:choose>
 			<c:when test="<%= workflowEnabled %>">
-				var restrictionTypeWorkflow = A.one(
-					'#<portlet:namespace />restrictionTypeWorkflow'
+				var restrictionTypeWorkflow = document.getElementById(
+					'<portlet:namespace />restrictionTypeWorkflow'
 				);
 
-				restrictionTypeWorkflow.hide();
+				restrictionTypeWorkflow.classList.add('hide');
+				restrictionTypeWorkflow.setAttribute('hidden', 'hidden');
+				restrictionTypeWorkflow.style.display = 'none';
 
 				var workflowDefinitions =
 					'<%= UnicodeFormatter.toString(workflowDefinitionsBuffer) %>';
@@ -428,27 +428,31 @@ renderResponse.setTitle(headerTitle);
 
 		searchContainer.updateDataStore();
 
-		var select = A.one('#<portlet:namespace />defaultFileEntryTypeId');
+		var select = document.getElementById(
+			'<portlet:namespace />defaultFileEntryTypeId'
+		);
 
-		var selectContainer = A.one(
+		var selectContainer = document.querySelector(
 			'#<portlet:namespace />restrictionTypeDefinedDiv .default-document-type'
 		);
 
-		selectContainer.show();
+		selectContainer.classList.remove('hide');
+		selectContainer.removeAttribute('hidden');
+		selectContainer.style.display = '';
 
-		var option = A.Node.create(
-			'<option id="<portlet:namespace />defaultFileEntryTypeId-' +
-				fileEntryTypeId +
-				'" value="' +
-				fileEntryTypeId +
-				'">' +
-				fileEntryTypeName +
-				'</option>'
+		var option = document.createElement('option');
+		option.setAttribute(
+			'id',
+			'<portlet:namespace />defaultFileEntryTypeId-' + fileEntryTypeId
 		);
+		option.setAttribute('value', fileEntryTypeId);
+		option.text = fileEntryTypeName;
 
-		select.show();
+		select.classList.remove('hide');
+		select.removeAttribute('hidden');
+		select.style.display = '';
 
-		select.append(option);
+		select.appendChild(option);
 	};
 
 	Liferay.Util.toggleRadio('<portlet:namespace />restrictionTypeInherit', '', [
@@ -486,34 +490,42 @@ renderResponse.setTitle(headerTitle);
 
 			searchContainer.deleteRow(tr, link.getAttribute('data-rowId'));
 
-			A.one(
-				'#<portlet:namespace />defaultFileEntryTypeId-' +
+			var option = document.getElementById(
+				'<portlet:namespace />defaultFileEntryTypeId-' +
 					link.getAttribute('data-rowId')
-			).remove();
+			);
+
+			option.parentElement.removeChild(option);
 
 			<portlet:namespace />documentTypesChanged = true;
 
-			var select = A.one(
-				'#<%= liferayPortletResponse.getNamespace() + "workflowDefinition" + DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL %>'
+			var select = document.getElementById(
+				'<%= liferayPortletResponse.getNamespace() + "workflowDefinition" + DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL %>'
 			);
 
-			var selectContainer = A.one(
-				'#<portlet:namespace />restrictionTypeWorkflow'
+			var selectContainer = document.getElementById(
+				'<portlet:namespace />restrictionTypeWorkflow'
 			);
 
-			var fileEntryTypesCount = select.get('children').size();
+			var fileEntryTypesCount = select.children.length;
 
 			if (fileEntryTypesCount == 0) {
-				selectContainer.hide();
+				selectContainer.classList.add('hide');
+				selectContainer.setAttribute('hidden', 'hidden');
+				selectContainer.style.display = 'none';
 
-				var restrictionTypeWorkflow = A.one(
-					'#<portlet:namespace />restrictionTypeWorkflow'
+				var restrictionTypeWorkflow = document.getElementById(
+					'<portlet:namespace />restrictionTypeWorkflow'
 				);
 
-				restrictionTypeWorkflow.show();
+				restrictionTypeWorkflow.classList.remove('hide');
+				restrictionTypeWorkflow.removeAttribute('hidden');
+				restrictionTypeWorkflow.style.display = '';
 			}
 			else {
-				selectContainer.show();
+				selectContainer.classList.remove('hide');
+				selectContainer.removeAttribute('hidden');
+				selectContainer.style.display = '';
 			}
 		},
 		'.modify-link'

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
@@ -472,9 +472,7 @@ renderResponse.setTitle(headerTitle);
 			'<portlet:namespace />restrictionTypeDefinedDiv'
 		);
 	</c:if>
-</aui:script>
 
-<aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get(
 		'<portlet:namespace />dlFileEntryTypesSearchContainer'
 	);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries.jsp
@@ -121,164 +121,159 @@ if (portletTitleBasedNavigation) {
 									});
 								});
 
-								Liferay.provide(
-									window,
-									'<portlet:namespace />updateMultipleFiles',
-									function () {
-										var Lang = A.Lang;
+								window['<portlet:namespace />updateMultipleFiles'] = function () {
+									var Lang = A.Lang;
 
-										var commonFileMetadataContainer = A.one(
-											'#<portlet:namespace />commonFileMetadataContainer'
+									var commonFileMetadataContainer = A.one(
+										'#<portlet:namespace />commonFileMetadataContainer'
+									);
+									var selectedFileNameContainer = A.one(
+										'#<portlet:namespace />selectedFileNameContainer'
+									);
+									var ddmFormFieldNamespaces = A.all(
+										'#<portlet:namespace />ddmFormFieldNamespace'
+									).val();
+
+									var inputTpl =
+										'<input id="<portlet:namespace />selectedFileName{0}" name="<portlet:namespace />selectedFileName" type="hidden" value="{1}" />';
+
+									var values = A.all(
+										'input[name=<portlet:namespace />selectUploadedFile]:checked'
+									).val();
+
+									var buffer = [];
+									var dataBuffer = [];
+									var length = values.length;
+
+									for (var i = 0; i < length; i++) {
+										dataBuffer[0] = i;
+										dataBuffer[1] = values[i];
+
+										buffer[i] = Lang.sub(inputTpl, dataBuffer);
+									}
+
+									selectedFileNameContainer.html(buffer.join(''));
+
+									commonFileMetadataContainer.plug(A.LoadingMask);
+
+									commonFileMetadataContainer.loadingmask.show();
+
+									for (var i = 0; i < ddmFormFieldNamespaces.length; i++) {
+										var ddmFormFieldNamespace = ddmFormFieldNamespaces[i];
+
+										var ddmForm = Liferay.component(
+											'<portlet:namespace />' + ddmFormFieldNamespace + 'ddmForm'
 										);
-										var selectedFileNameContainer = A.one(
-											'#<portlet:namespace />selectedFileNameContainer'
-										);
-										var ddmFormFieldNamespaces = A.all(
-											'#<portlet:namespace />ddmFormFieldNamespace'
-										).val();
 
-										var inputTpl =
-											'<input id="<portlet:namespace />selectedFileName{0}" name="<portlet:namespace />selectedFileName" type="hidden" value="{1}" />';
+										ddmForm.updateDDMFormInputValue();
+									}
 
-										var values = A.all(
-											'input[name=<portlet:namespace />selectUploadedFile]:checked'
-										).val();
-
-										var buffer = [];
-										var dataBuffer = [];
-										var length = values.length;
-
-										for (var i = 0; i < length; i++) {
-											dataBuffer[0] = i;
-											dataBuffer[1] = values[i];
-
-											buffer[i] = Lang.sub(inputTpl, dataBuffer);
-										}
-
-										selectedFileNameContainer.html(buffer.join(''));
-
-										commonFileMetadataContainer.plug(A.LoadingMask);
-
-										commonFileMetadataContainer.loadingmask.show();
-
-										for (var i = 0; i < ddmFormFieldNamespaces.length; i++) {
-											var ddmFormFieldNamespace = ddmFormFieldNamespaces[i];
-
-											var ddmForm = Liferay.component(
-												'<portlet:namespace />' + ddmFormFieldNamespace + 'ddmForm'
-											);
-
-											ddmForm.updateDDMFormInputValue();
-										}
-
-										Liferay.Util.fetch(document.<portlet:namespace />fm2.action, {
-											body: new FormData(document.<portlet:namespace />fm2),
-											method: 'POST',
+									Liferay.Util.fetch(document.<portlet:namespace />fm2.action, {
+										body: new FormData(document.<portlet:namespace />fm2),
+										method: 'POST',
+									})
+										.then(function (response) {
+											return response.json();
 										})
-											.then(function (response) {
-												return response.json();
-											})
-											.then(function (response) {
-												var itemFailed = false;
+										.then(function (response) {
+											var itemFailed = false;
 
-												for (var i = 0; i < response.length; i++) {
-													var item = response[i];
+											for (var i = 0; i < response.length; i++) {
+												var item = response[i];
 
-													var checkBox = A.one(
-														'input[data-fileName="' + item.originalFileName + '"]'
+												var checkBox = A.one(
+													'input[data-fileName="' + item.originalFileName + '"]'
+												);
+
+												var li = checkBox.ancestor();
+
+												checkBox.remove(true);
+
+												li.removeClass('selectable').removeClass('selected');
+
+												var cssClass = null;
+												var childHTML = null;
+
+												if (item.added) {
+													cssClass = 'file-saved';
+
+													var originalFileName = item.originalFileName;
+
+													var pos = originalFileName.indexOf(
+														'<%= TempFileEntryUtil.TEMP_RANDOM_SUFFIX %>'
 													);
 
-													var li = checkBox.ancestor();
+													if (pos != -1) {
+														originalFileName = originalFileName.substr(0, pos);
+													}
 
-													checkBox.remove(true);
-
-													li.removeClass('selectable').removeClass('selected');
-
-													var cssClass = null;
-													var childHTML = null;
-
-													if (item.added) {
-														cssClass = 'file-saved';
-
-														var originalFileName = item.originalFileName;
-
-														var pos = originalFileName.indexOf(
-															'<%= TempFileEntryUtil.TEMP_RANDOM_SUFFIX %>'
-														);
-
-														if (pos != -1) {
-															originalFileName = originalFileName.substr(0, pos);
-														}
-
-														if (originalFileName === item.fileName) {
-															childHTML =
-																'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %></span>';
-														}
-														else {
-															childHTML =
-																'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %> (' +
-																item.fileName +
-																')</span>';
-														}
+													if (originalFileName === item.fileName) {
+														childHTML =
+															'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %></span>';
 													}
 													else {
-														cssClass = 'upload-error';
-
 														childHTML =
-															'<span class="card-bottom error-message">' +
-															item.errorMessage +
-															'</span>';
-
-														itemFailed = true;
+															'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %> (' +
+															item.fileName +
+															')</span>';
 													}
-
-													li.addClass(cssClass);
-													li.append(childHTML);
-												}
-
-												<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/document_library/upload_multiple_file_entries" var="uploadMultipleFileEntries">
-													<portlet:param name="repositoryId" value="<%= String.valueOf(repositoryId) %>" />
-													<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
-												</liferay-portlet:resourceURL>
-
-												if (commonFileMetadataContainer.io) {
-													commonFileMetadataContainer.io.start();
 												}
 												else {
-													commonFileMetadataContainer.load(
-														'<%= uploadMultipleFileEntries %>'
-													);
+													cssClass = 'upload-error';
+
+													childHTML =
+														'<span class="card-bottom error-message">' +
+														item.errorMessage +
+														'</span>';
+
+													itemFailed = true;
 												}
 
-												Liferay.fire('filesSaved');
+												li.addClass(cssClass);
+												li.append(childHTML);
+											}
 
-												commonFileMetadataContainer.unplug(A.LoadingMask);
+											<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/document_library/upload_multiple_file_entries" var="uploadMultipleFileEntries">
+												<portlet:param name="repositoryId" value="<%= String.valueOf(repositoryId) %>" />
+												<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
+											</liferay-portlet:resourceURL>
 
-												if (!itemFailed) {
-													location.href = '<%= HtmlUtil.escapeJS(redirect) %>';
-												}
-											})
-											.catch(function (error) {
-												var selectedItems = A.all(
-													'#<portlet:namespace />fileUpload li.selected'
+											if (commonFileMetadataContainer.io) {
+												commonFileMetadataContainer.io.start();
+											}
+											else {
+												commonFileMetadataContainer.load(
+													'<%= uploadMultipleFileEntries %>'
 												);
+											}
 
-												selectedItems
-													.removeClass('selectable')
-													.removeClass('selected')
-													.addClass('upload-error');
+											Liferay.fire('filesSaved');
 
-												selectedItems.append(
-													'<span class="card-bottom error-message"><%= UnicodeLanguageUtil.get(request, "an-unexpected-error-occurred-while-deleting-the-file") %></span>'
-												);
+											commonFileMetadataContainer.unplug(A.LoadingMask);
 
-												selectedItems.all('input').remove(true);
+											if (!itemFailed) {
+												location.href = '<%= HtmlUtil.escapeJS(redirect) %>';
+											}
+										})
+										.catch(function (error) {
+											var selectedItems = A.all(
+												'#<portlet:namespace />fileUpload li.selected'
+											);
 
-												commonFileMetadataContainer.loadingmask.hide();
-											});
-									},
-									['aui-base']
-								);
+											selectedItems
+												.removeClass('selectable')
+												.removeClass('selected')
+												.addClass('upload-error');
+
+											selectedItems.append(
+												'<span class="card-bottom error-message"><%= UnicodeLanguageUtil.get(request, "an-unexpected-error-occurred-while-deleting-the-file") %></span>'
+											);
+
+											selectedItems.all('input').remove(true);
+
+											commonFileMetadataContainer.loadingmask.hide();
+										});
+								};
 							</aui:script>
 						</clay:col>
 					</clay:row>


### PR DESCRIPTION
As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561) we
eventually want to deprecate the `Liferay.provide` function

To test the change for the `<portlet:namspace />selectFileEntryType`
function:

- Navigate to "Content and Data > Documents and Media"
- Click on the "+" button and choose "Folder"
- Type a name for the folder you want to create
- Click on the "Save" button
- Click on the kebab menu to the right of the folder you created and
  choose "Edit"
- Select the radio button with the label
  "Define Specific Document Type Restrictions and Workflow for This
   Folder (A folder)"
- Click on "Select Document Type"
- In the modal window choose one of the document types and click on
  "Choose"
- Click on the "Save button"

As a result, a notification should be displayed letting you know your
request has completed successfully and no JS errors should appear in the
browser's console.

To test the change for the `<portlet:namspace />updateMultipleFiles`
function:

- Navigate to "Content and Data > Documents and Media"
- Click on the "+" button and choose "Multiple Files Upload"
- Click on the "Select Files" button
- Upload at least 2 files (images or text documents are OK)
- Click on the "Publish" button

As a result, the files you uploaded should be visible in the "Documents"
list and no JS errors should appear in the console.