### PR TITLE
LPS-113561 Avoid use of Liferay.provide in dynamic-data-lists-web

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -268,12 +268,14 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 		var displayingRecordSetIdHolder = document.querySelector(
 			'.displaying-record-set-id-holder'
 		);
+		displayingRecordSetIdHolder.classList.remove('hide');
 		displayingRecordSetIdHolder.removeAttribute('hidden');
 		displayingRecordSetIdHolder.style.display = '';
 
 		var displayingHelpMessageHolder = document.querySelector(
 			'.displaying-help-message-holder'
 		);
+		displayingHelpMessageHolder.classList.add('hide');
 		displayingHelpMessageHolder.setAttribute('hidden', 'hidden');
 		displayingHelpMessageHolder.style.display = 'none';
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -96,11 +96,10 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 									>
 
 										<%
-										StringBundler sb = new StringBundler(7);
+										StringBundler sb = new StringBundler(6);
 
 										sb.append("javascript:");
-										sb.append(renderResponse.getNamespace());
-										sb.append("selectRecordSet('");
+										sb.append("Liferay.DynamicDataLists.selectRecordSet('");
 										sb.append(recordSet.getRecordSetId());
 										sb.append("','");
 										sb.append(HtmlUtil.escapeJS(recordSet.getName(locale)));
@@ -259,10 +258,8 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 </aui:script>
 
 <aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />selectRecordSet',
-		function (recordSetId, recordSetName) {
+	var DynamicDataLists = {
+		selectRecordSet: function (recordSetId, recordSetName) {
 			var A = AUI();
 
 			document.<portlet:namespace />fm.<portlet:namespace />recordSetId.value = recordSetId;
@@ -278,8 +275,9 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 			);
 			displayRecordSetId.addClass('modified');
 		},
-		['aui-base']
-	);
+	};
+
+	Liferay.DynamicDataLists = DynamicDataLists;
 </aui:script>
 
 <%!

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -96,10 +96,11 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 									>
 
 										<%
-										StringBundler sb = new StringBundler(6);
+										StringBundler sb = new StringBundler(7);
 
 										sb.append("javascript:");
-										sb.append("Liferay.DynamicDataLists.selectRecordSet('");
+										sb.append(renderResponse.getNamespace());
+										sb.append("selectRecordSet('");
 										sb.append(recordSet.getRecordSetId());
 										sb.append("','");
 										sb.append(HtmlUtil.escapeJS(recordSet.getName(locale)));
@@ -258,26 +259,25 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 </aui:script>
 
 <aui:script>
-	var DynamicDataLists = {
-		selectRecordSet: function (recordSetId, recordSetName) {
-			var A = AUI();
+	window['<portlet:namespace />selectRecordSet'] = function (
+		recordSetId,
+		recordSetName
+	) {
+		var A = AUI();
 
-			document.<portlet:namespace />fm.<portlet:namespace />recordSetId.value = recordSetId;
+		document.<portlet:namespace />fm.<portlet:namespace />recordSetId.value = recordSetId;
 
-			A.one('.displaying-record-set-id-holder').show();
-			A.one('.displaying-help-message-holder').hide();
+		A.one('.displaying-record-set-id-holder').show();
+		A.one('.displaying-help-message-holder').hide();
 
-			var displayRecordSetId = A.one('.displaying-record-set-id');
+		var displayRecordSetId = A.one('.displaying-record-set-id');
 
-			displayRecordSetId.set(
-				'innerHTML',
-				recordSetName + ' (<liferay-ui:message key="modified" />)'
-			);
-			displayRecordSetId.addClass('modified');
-		},
+		displayRecordSetId.set(
+			'innerHTML',
+			recordSetName + ' (<liferay-ui:message key="modified" />)'
+		);
+		displayRecordSetId.addClass('modified');
 	};
-
-	Liferay.DynamicDataLists = DynamicDataLists;
 </aui:script>
 
 <%!

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -263,20 +263,26 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 		recordSetId,
 		recordSetName
 	) {
-		var A = AUI();
-
 		document.<portlet:namespace />fm.<portlet:namespace />recordSetId.value = recordSetId;
 
-		A.one('.displaying-record-set-id-holder').show();
-		A.one('.displaying-help-message-holder').hide();
-
-		var displayRecordSetId = A.one('.displaying-record-set-id');
-
-		displayRecordSetId.set(
-			'innerHTML',
-			recordSetName + ' (<liferay-ui:message key="modified" />)'
+		var displayingRecordSetIdHolder = document.querySelector(
+			'.displaying-record-set-id-holder'
 		);
-		displayRecordSetId.addClass('modified');
+		displayingRecordSetIdHolder.removeAttribute('hidden');
+		displayingRecordSetIdHolder.style.display = '';
+
+		var displayingHelpMessageHolder = document.querySelector(
+			'.displaying-help-message-holder'
+		);
+		displayingHelpMessageHolder.setAttribute('hidden', 'hidden');
+		displayingHelpMessageHolder.style.display = 'none';
+
+		var displayRecordSetId = document.querySelector(
+			'.displaying-record-set-id'
+		);
+		displayRecordSetId.innerHTML =
+			recordSetName + ' (<liferay-ui:message key="modified" />)';
+		displayRecordSetId.classList.add('modified');
 	};
 </aui:script>
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
@@ -50,77 +50,73 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 </div>
 
 <aui:script>
-	var DynamicDataLists = {
-		exportRecordSet: function (url) {
-			var A = AUI();
+	window['<portlet:namespace />exportRecordSet'] = function (url) {
+		var A = AUI();
 
-			var form = A.Node.create('<form />');
+		var form = A.Node.create('<form />');
 
-			form.attr('method', 'POST');
+		form.attr('method', 'POST');
 
-			var content = A.one('#<portlet:namespace />exportList');
+		var content = A.one('#<portlet:namespace />exportList');
 
-			var fileExtensionSelect = A.one('#<portlet:namespace />fileExtension');
+		var fileExtensionSelect = A.one('#<portlet:namespace />fileExtension');
 
-			var showCSVWarning = function () {
-				var csvWarning = A.one('#<portlet:namespace />csvWarning');
+		var showCSVWarning = function () {
+			var csvWarning = A.one('#<portlet:namespace />csvWarning');
 
-				if (fileExtensionSelect.val() === 'csv' && <%= showCSVWarning %>) {
-					csvWarning.show();
-				}
-				else {
-					csvWarning.hide();
-				}
-			};
+			if (fileExtensionSelect.val() === 'csv' && <%= showCSVWarning %>) {
+				csvWarning.show();
+			}
+			else {
+				csvWarning.hide();
+			}
+		};
 
-			if (content) {
-				if (fileExtensionSelect) {
-					showCSVWarning();
+		if (content) {
+			if (fileExtensionSelect) {
+				showCSVWarning();
 
-					fileExtensionSelect.on('change', showCSVWarning);
-				}
-
-				form.append(content);
-
-				content.show();
+				fileExtensionSelect.on('change', showCSVWarning);
 			}
 
-			var dialog = Liferay.Util.Window.getWindow({
-				dialog: {
-					bodyContent: form,
-					cssClass: 'ddl-record-set-export-modal',
-					resizable: false,
-					toolbars: {
-						footer: [
-							{
-								cssClass: 'btn-secondary',
-								label: '<liferay-ui:message key="cancel" />',
-								on: {
-									click: function () {
-										dialog.hide();
-									},
-								},
-							},
-							{
-								cssClass: 'btn-primary',
-								label: '<liferay-ui:message key="ok" />',
-								on: {
-									click: function () {
-										submitForm(form, url, false);
+			form.append(content);
 
-										dialog.hide();
-									},
+			content.show();
+		}
+
+		var dialog = Liferay.Util.Window.getWindow({
+			dialog: {
+				bodyContent: form,
+				cssClass: 'ddl-record-set-export-modal',
+				resizable: false,
+				toolbars: {
+					footer: [
+						{
+							cssClass: 'btn-secondary',
+							label: '<liferay-ui:message key="cancel" />',
+							on: {
+								click: function () {
+									dialog.hide();
 								},
-								primary: true,
 							},
-						],
-					},
-					width: 600,
+						},
+						{
+							cssClass: 'btn-primary',
+							label: '<liferay-ui:message key="ok" />',
+							on: {
+								click: function () {
+									submitForm(form, url, false);
+
+									dialog.hide();
+								},
+							},
+							primary: true,
+						},
+					],
 				},
-				title: '<%= UnicodeLanguageUtil.get(request, "export") %>',
-			});
-		},
+				width: 600,
+			},
+			title: '<%= UnicodeLanguageUtil.get(request, "export") %>',
+		});
 	};
-
-	Liferay.DynamicDataLists = DynamicDataLists;
 </aui:script>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
@@ -50,8 +50,10 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 </div>
 
 <aui:script>
+	var DynamicDataLists = {};
+
 	Liferay.provide(
-		window,
+		DynamicDataLists,
 		'<portlet:namespace />exportRecordSet',
 		function (url) {
 			var A = AUI();
@@ -122,6 +124,8 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 				title: '<%= UnicodeLanguageUtil.get(request, "export") %>',
 			});
 		},
-		['aui-alert', 'liferay-util-window']
+		[]
 	);
+
+	Liferay.DynamicDataLists = DynamicDataLists;
 </aui:script>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
@@ -70,10 +70,12 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 			);
 
 			if (fileExtensionSelect.value === 'csv' && <%= showCSVWarning %>) {
+				csvWarning.classList.remove('hide');
 				csvWarning.removeAttribute('hidden');
 				csvWarning.style.display = '';
 			}
 			else {
+				csvWarning.classList.add('hide');
 				csvWarning.setAttribute('hidden', 'hidden');
 				csvWarning.style.display = 'none';
 			}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
@@ -51,70 +51,113 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 
 <aui:script>
 	window['<portlet:namespace />exportRecordSet'] = function (url) {
-		var A = AUI();
+		var form = document.createElement('form');
+		form.setAttribute('id', '<portlet:namespace />exportForm');
 
-		var form = A.Node.create('<form />');
-
-		form.attr('method', 'POST');
-
-		var content = A.one('#<portlet:namespace />exportList');
-
-		var fileExtensionSelect = A.one('#<portlet:namespace />fileExtension');
-
-		var showCSVWarning = function () {
-			var csvWarning = A.one('#<portlet:namespace />csvWarning');
-
-			if (fileExtensionSelect.val() === 'csv' && <%= showCSVWarning %>) {
-				csvWarning.show();
-			}
-			else {
-				csvWarning.hide();
-			}
-		};
+		var content = document.getElementById('<portlet:namespace />exportList');
 
 		if (content) {
-			if (fileExtensionSelect) {
-				showCSVWarning();
+			form.appendChild(content);
 
-				fileExtensionSelect.on('change', showCSVWarning);
-			}
-
-			form.append(content);
-
-			content.show();
+			content.classList.remove('hide');
+			content.removeAttribute('hidden');
+			content.style.display = '';
 		}
 
-		var dialog = Liferay.Util.Window.getWindow({
-			dialog: {
-				bodyContent: form,
-				cssClass: 'ddl-record-set-export-modal',
-				resizable: false,
-				toolbars: {
-					footer: [
-						{
-							cssClass: 'btn-secondary',
-							label: '<liferay-ui:message key="cancel" />',
-							on: {
-								click: function () {
-									dialog.hide();
-								},
-							},
-						},
-						{
-							cssClass: 'btn-primary',
-							label: '<liferay-ui:message key="ok" />',
-							on: {
-								click: function () {
-									submitForm(form, url, false);
+		function showCSVWarning() {
+			var csvWarning = document.getElementById(
+				'<portlet:namespace />csvWarning'
+			);
 
-									dialog.hide();
-								},
-							},
-							primary: true,
-						},
-					],
+			if (fileExtensionSelect.value === 'csv' && <%= showCSVWarning %>) {
+				csvWarning.removeAttribute('hidden');
+				csvWarning.style.display = '';
+			}
+			else {
+				csvWarning.setAttribute('hidden', 'hidden');
+				csvWarning.style.display = 'none';
+			}
+		}
+
+		function handleClose() {
+			content.classList.add('hide');
+			content.setAttribute('hidden', 'hidden');
+			content.style.display = 'none';
+
+			document.body.appendChild(content);
+		}
+
+		Liferay.Util.openModal({
+			bodyHTML: form.outerHTML,
+			buttons: [
+				{
+					displayType: 'secondary',
+					label: '<liferay-ui:message key="cancel" />',
+					type: 'cancel',
 				},
-				width: 600,
+				{
+					label: '<liferay-ui:message key="ok" />',
+					onClick: function () {
+						var filename;
+						var formData = new FormData();
+						formData.append(
+							fileExtensionSelect.getAttribute('id'),
+							fileExtensionSelect.value
+						);
+
+						Liferay.Util.fetch(url, {body: formData, method: 'POST'})
+							.then(function (response) {
+								var filenamePattern = /filename=\"(.*)\"/;
+								var match = filenamePattern.exec(
+									response.headers.get('content-disposition')
+								);
+								if (match) {
+									filename = match[1];
+								}
+								return response.blob();
+							})
+							.then(function (blob) {
+								var link = document.createElement('a');
+								link.setAttribute(
+									'href',
+									URL.createObjectURL(blob)
+								);
+								if (filename) {
+									link.setAttribute('download', filename);
+								}
+								link.click();
+
+								Liferay.fire('closeModal');
+							})
+							.catch(function (error) {
+								Liferay.Util.openToast({
+									message: Liferay.Language.get(
+										'an-unexpected-system-error-occurred'
+									),
+									title: Liferay.Language.get('error'),
+									type: 'danger',
+								});
+							});
+					},
+					type: 'submit',
+				},
+			],
+			iframeBodyCssClass: 'ddl-record-set-export-modal',
+			onClose: handleClose,
+			onOpen: function () {
+				content = document.getElementById(
+					'<portlet:namespace />exportList'
+				);
+
+				fileExtensionSelect = document.getElementById(
+					'<portlet:namespace />fileExtension'
+				);
+
+				if (fileExtensionSelect) {
+					showCSVWarning();
+
+					fileExtensionSelect.addEventListener('change', showCSVWarning);
+				}
 			},
 			title: '<%= UnicodeLanguageUtil.get(request, "export") %>',
 		});

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
@@ -50,12 +50,8 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 </div>
 
 <aui:script>
-	var DynamicDataLists = {};
-
-	Liferay.provide(
-		DynamicDataLists,
-		'<portlet:namespace />exportRecordSet',
-		function (url) {
+	var DynamicDataLists = {
+		exportRecordSet: function (url) {
 			var A = AUI();
 
 			var form = A.Node.create('<form />');
@@ -124,8 +120,7 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 				title: '<%= UnicodeLanguageUtil.get(request, "export") %>',
 			});
 		},
-		[]
-	);
+	};
 
 	Liferay.DynamicDataLists = DynamicDataLists;
 </aui:script>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/record_set_action.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/record_set_action.jsp
@@ -81,10 +81,11 @@ boolean hasViewPermission = ddlDisplayContext.isAdminPortlet() && DDLRecordSetPe
 		</liferay-portlet:resourceURL>
 
 		<%
-		StringBundler sb = new StringBundler(4);
+		StringBundler sb = new StringBundler(5);
 
 		sb.append("javascript:");
-		sb.append("Liferay.DynamicDataLists.exportRecordSet('");
+		sb.append(renderResponse.getNamespace());
+		sb.append("exportRecordSet('");
 		sb.append(exportRecordSetURL);
 		sb.append("');");
 		%>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/record_set_action.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/record_set_action.jsp
@@ -81,11 +81,12 @@ boolean hasViewPermission = ddlDisplayContext.isAdminPortlet() && DDLRecordSetPe
 		</liferay-portlet:resourceURL>
 
 		<%
-		StringBundler sb = new StringBundler(5);
+		StringBundler sb = new StringBundler(6);
 
 		sb.append("javascript:");
+		sb.append("Liferay.DynamicDataLists['");
 		sb.append(renderResponse.getNamespace());
-		sb.append("exportRecordSet('");
+		sb.append("exportRecordSet']('");
 		sb.append(exportRecordSetURL);
 		sb.append("');");
 		%>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/record_set_action.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/record_set_action.jsp
@@ -81,12 +81,10 @@ boolean hasViewPermission = ddlDisplayContext.isAdminPortlet() && DDLRecordSetPe
 		</liferay-portlet:resourceURL>
 
 		<%
-		StringBundler sb = new StringBundler(6);
+		StringBundler sb = new StringBundler(4);
 
 		sb.append("javascript:");
-		sb.append("Liferay.DynamicDataLists['");
-		sb.append(renderResponse.getNamespace());
-		sb.append("exportRecordSet']('");
+		sb.append("Liferay.DynamicDataLists.exportRecordSet('");
 		sb.append(exportRecordSetURL);
 		sb.append("');");
 		%>


### PR DESCRIPTION
Moving this here from https://github.com/wincent/liferay-portal/pull/339 to keep things centralized.

cc @julien 

Description copied from commit:

---

As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561), we eventually want to deprecate the `Liferay.provide` function.

In this change, we avoid declaring the `<portlet:namespace />selectRecordSet` function as a global on the `window` object, and also remove the `<portlet:namespace />` prefix from the `selectRecordSet` function.

To test this change:

- Navigate to "Content And Data > Dynamic Data Lists"
- Click on the "+" button to create a new Dynamic Data List
- Enter a name for your list
- Click the "Select" button underneath the "Data Definition" input field
- In the modal window that appears, click on "Contacts"
- Click on the "Save" button
- Navigate to "Site Builder > Pages"
- Click on the "+" button to create a new page
- Select the "Blank" template from "Basic Templates"
- Enter a name for your page (for example Page)
- Drag and drop the "Dynamic Data Lists Display" widget on the page
- Click the kebab menu on the right side of the "Dynamic Data Lists Display" widget
- Click on "Configuration"
- In the modal window that appears, click on the Dynamic Data List's name created previously
- Click on the "Save" button

As a result, a success notification should be displayed confirming you have successfully updated the widget's configuration, and no JS errors should appear in the browser's console.