### PR TITLE
LPS-114074 - layout-taglib - Replace container div with ClayLayout

### DIFF
--- a/modules/apps/layout/layout-taglib/package.json
+++ b/modules/apps/layout/layout-taglib/package.json
@@ -2,6 +2,7 @@
 	"dependencies": {
 		"@clayui/button": "3.3.1",
 		"@clayui/form": "3.8.0",
+		"@clayui/layout": "3.0.1",
 		"@clayui/management-toolbar": "3.2.0",
 		"frontend-js-components-web": "*",
 		"prop-types": "15.7.2",

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
@@ -14,6 +14,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
+import ClayLayout from '@clayui/layout';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import {Treeview} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
@@ -123,8 +124,8 @@ const SelectLayout = ({
 				</ClayManagementToolbar.Search>
 			</ClayManagementToolbar>
 
-			<div
-				className="container-fluid-1280 layouts-selector"
+			<ClayLayout.ContainerFluid
+				className="layouts-selector"
 				id={`${namespace}selectLayoutFm`}
 			>
 				<fieldset className="panel-body">
@@ -141,7 +142,7 @@ const SelectLayout = ({
 						/>
 					</div>
 				</fieldset>
-			</div>
+			</ClayLayout.ContainerFluid>
 		</div>
 	);
 };


### PR DESCRIPTION
Was here: https://github.com/wincent/liferay-portal/pull/336

Moving it here to centralize and run tests.

cc @kresimir-coko 

Original message:

---

Hey @wincent pretty simple PR, I checked and it looks the same in the UI as it did before the change. Happy reviewing. You can find it in the UI by going to Site Builder > Navigation Menus > New Page