### PR TITLE
LPS-113561 Avoid use of Liferay.provide in my-subscriptions-web

### DIFF
--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/subscription_action.jsp
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/subscription_action.jsp
@@ -59,11 +59,12 @@ AssetRenderer<?> assetRenderer = MySubscriptionsUtil.getAssetRenderer(subscripti
 		String displayPopupURL = assetRenderer.getURLView(liferayPortletResponse, LiferayWindowState.POP_UP);
 
 		if (Validator.isNotNull(displayPopupURL)) {
-			StringBundler sb = new StringBundler(7);
+			StringBundler sb = new StringBundler(8);
 
 			sb.append("javascript:");
+			sb.append("Liferay.Subscriptions['");
 			sb.append(liferayPortletResponse.getNamespace());
-			sb.append("displayPopup('");
+			sb.append("displayPopup']('");
 			sb.append(displayPopupURL);
 			sb.append("', '");
 			sb.append(UnicodeLanguageUtil.get(request, "my-subscription"));

--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/subscription_action.jsp
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/subscription_action.jsp
@@ -59,10 +59,11 @@ AssetRenderer<?> assetRenderer = MySubscriptionsUtil.getAssetRenderer(subscripti
 		String displayPopupURL = assetRenderer.getURLView(liferayPortletResponse, LiferayWindowState.POP_UP);
 
 		if (Validator.isNotNull(displayPopupURL)) {
-			StringBundler sb = new StringBundler(6);
+			StringBundler sb = new StringBundler(7);
 
 			sb.append("javascript:");
-			sb.append("Liferay.Subscriptions.displayPopup('");
+			sb.append(liferayPortletResponse.getNamespace());
+			sb.append("displayPopup('");
 			sb.append(displayPopupURL);
 			sb.append("', '");
 			sb.append(UnicodeLanguageUtil.get(request, "my-subscription"));

--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/subscription_action.jsp
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/subscription_action.jsp
@@ -59,12 +59,10 @@ AssetRenderer<?> assetRenderer = MySubscriptionsUtil.getAssetRenderer(subscripti
 		String displayPopupURL = assetRenderer.getURLView(liferayPortletResponse, LiferayWindowState.POP_UP);
 
 		if (Validator.isNotNull(displayPopupURL)) {
-			StringBundler sb = new StringBundler(8);
+			StringBundler sb = new StringBundler(6);
 
 			sb.append("javascript:");
-			sb.append("Liferay.Subscriptions['");
-			sb.append(liferayPortletResponse.getNamespace());
-			sb.append("displayPopup']('");
+			sb.append("Liferay.Subscriptions.displayPopup('");
 			sb.append(displayPopupURL);
 			sb.append("', '");
 			sb.append(UnicodeLanguageUtil.get(request, "my-subscription"));

--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
@@ -114,12 +114,8 @@ int subscriptionsCount = mySubscriptionsManagementToolbarDisplayContext.getTotal
 </clay:container-fluid>
 
 <aui:script>
-	var Subscriptions = {};
-
-	Liferay.provide(
-		Subscriptions,
-		'<portlet:namespace />displayPopup',
-		function (url, title) {
+	var Subscriptions = {
+		displayPopup: function (url, title) {
 			Liferay.Util.Window.getWindow({
 				dialog: {
 					align: {
@@ -136,8 +132,7 @@ int subscriptionsCount = mySubscriptionsManagementToolbarDisplayContext.getTotal
 				uri: url,
 			});
 		},
-		[]
-	);
+	};
 
 	Liferay.Subscriptions = Subscriptions;
 </aui:script>

--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
@@ -115,20 +115,11 @@ int subscriptionsCount = mySubscriptionsManagementToolbarDisplayContext.getTotal
 
 <aui:script>
 	window['<portlet:namespace />displayPopup'] = function (url, title) {
-		Liferay.Util.Window.getWindow({
-			dialog: {
-				align: {
-					node: null,
-					points: ['tc', 'tc'],
-				},
-				constrain2view: true,
-				cssClass: 'portlet-my-subscription',
-				modal: true,
-				resizable: true,
-				width: 950,
-			},
+		Liferay.Util.openModal({
+			iframeBodyCssClass: 'portlet-my-subscription',
+			size: 'full-screen',
 			title: title,
-			uri: url,
+			url: url,
 		});
 	};
 </aui:script>

--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
@@ -114,8 +114,10 @@ int subscriptionsCount = mySubscriptionsManagementToolbarDisplayContext.getTotal
 </clay:container-fluid>
 
 <aui:script>
+	var Subscriptions = {};
+
 	Liferay.provide(
-		window,
+		Subscriptions,
 		'<portlet:namespace />displayPopup',
 		function (url, title) {
 			Liferay.Util.Window.getWindow({
@@ -134,8 +136,10 @@ int subscriptionsCount = mySubscriptionsManagementToolbarDisplayContext.getTotal
 				uri: url,
 			});
 		},
-		['liferay-util-window']
+		[]
 	);
+
+	Liferay.Subscriptions = Subscriptions;
 </aui:script>
 
 <aui:script sandbox="<%= true %>">

--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
@@ -114,27 +114,23 @@ int subscriptionsCount = mySubscriptionsManagementToolbarDisplayContext.getTotal
 </clay:container-fluid>
 
 <aui:script>
-	var Subscriptions = {
-		displayPopup: function (url, title) {
-			Liferay.Util.Window.getWindow({
-				dialog: {
-					align: {
-						node: null,
-						points: ['tc', 'tc'],
-					},
-					constrain2view: true,
-					cssClass: 'portlet-my-subscription',
-					modal: true,
-					resizable: true,
-					width: 950,
+	window['<portlet:namespace />displayPopup'] = function (url, title) {
+		Liferay.Util.Window.getWindow({
+			dialog: {
+				align: {
+					node: null,
+					points: ['tc', 'tc'],
 				},
-				title: title,
-				uri: url,
-			});
-		},
+				constrain2view: true,
+				cssClass: 'portlet-my-subscription',
+				modal: true,
+				resizable: true,
+				width: 950,
+			},
+			title: title,
+			uri: url,
+		});
 	};
-
-	Liferay.Subscriptions = Subscriptions;
 </aui:script>
 
 <aui:script sandbox="<%= true %>">


### PR DESCRIPTION
Previously reviewed at https://github.com/wincent/liferay-portal/pull/338 but it has been updated since then and needs the tests to re-run, so I am moving it here.

cc @julien

Original message follows.

---

This was split off as one of six PRs from a bigger PR as described here: [#320 (comment)](https://github.com/wincent/liferay-portal/pull/320#issuecomment-641223200)

To test this change:

- Navigate to "Site Builder > Pages"
- Click on the "+" button to create a new page
- Select the "Blank" basic template
- Enter a name for your page (for example Page 01)
- Click on the "Add" button
- Drag and drop the "Message boards" widget to the page
- Drag and drop the "My Subscriptions" widget to the page
- Click on the "Publish Button"
- Go back to your site
- Go to your newly created page
- From the "Message Boards" widget click on the "New Thread" button
- Enter a subject and a message
- Scroll down and click on the "Publish" button
- Go back to the page created previously
- In the "My Subscriptions" widget, click on the "kebab" menu to the
  right of the Message Board thread you created previously
- Click on "View in Popup"

As a result you should see a modal window open with the contents of your message board thread.