### PR TITLE
LPS-113561 Avoid Liferay.provide in saml-web

### DIFF
--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_identity_provider_connection.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_identity_provider_connection.jsp
@@ -102,20 +102,15 @@ long clockSkew = GetterUtil.getLong(request.getAttribute(SamlWebKeys.SAML_CLOCK_
 </aui:form>
 
 <aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />uploadMetadataXml',
-		function () {
-			var A = AUI();
+	window['<portlet:namespace />uploadMetadataXml'] = function () {
+		var uploadMetadataXmlForm = document.getElementById(
+			'<portlet:namespace />uploadMetadataXmlForm'
+		);
 
-			var uploadMetadataXmlForm = A.one(
-				'#<portlet:namespace />uploadMetadataXmlForm'
-			);
-
-			if (uploadMetadataXmlForm) {
-				uploadMetadataXmlForm.show();
-			}
-		},
-		['aui-base']
-	);
+		if (uploadMetadataXmlForm) {
+			uploadMetadataXmlForm.classList.remove('hide');
+			uploadMetadataXmlForm.removeAttribute('hidden');
+			uploadMetadataXmlForm.style.display = '';
+		}
+	};
 </aui:script>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_service_provider_connection.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_service_provider_connection.jsp
@@ -109,20 +109,15 @@ long assertionLifetime = GetterUtil.getLong(request.getAttribute(SamlWebKeys.SAM
 </aui:form>
 
 <aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />uploadMetadataXml',
-		function () {
-			var A = AUI();
+	window['<portlet:namespace />uploadMetadataXml'] = function () {
+		var uploadMetadataXmlForm = document.getElementById(
+			'<portlet:namespace />uploadMetadataXmlForm'
+		);
 
-			var uploadMetadataXmlForm = A.one(
-				'#<portlet:namespace />uploadMetadataXmlForm'
-			);
-
-			if (uploadMetadataXmlForm) {
-				uploadMetadataXmlForm.show();
-			}
-		},
-		['aui-base']
-	);
+		if (uploadMetadataXmlForm) {
+			uploadMetadataXmlForm.classList.remove('hide');
+			uploadMetadataXmlForm.removeAttribute('hidden');
+			uploadMetadataXmlForm.style.display = '';
+		}
+	};
 </aui:script>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/general.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/general.jsp
@@ -111,40 +111,27 @@ if (samlRoleIdpOptionDisabled) {
 </c:choose>
 
 <aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />showCertificateDialog',
-		function (uri) {
-			var dialog = Liferay.Util.Window.getWindow({
-				id: '<portlet:namespace />certificateDialog',
-				title:
-					'<%= UnicodeLanguageUtil.get(request, "certificate-and-private-key") %>',
-				uri: uri,
-				dialog: {
-					cache: false,
-					modal: true,
-				},
-				dialogIframe: {
-					bodyCssClass: 'dialog-with-footer',
-				},
-			});
-		},
-		['aui-io', 'aui-io-plugin-deprecated', 'liferay-util-window']
-	);
+	window['<portlet:namespace />showCertificateDialog'] = function (uri) {
+		var id = '<portlet:namespace />certificateDialog';
+
+		Liferay.Util.openModal({
+			id: id,
+			iframeBodyCssClass: 'dialog-with-footer',
+			title:
+				'<%= UnicodeLanguageUtil.get(request, "certificate-and-private-key") %>',
+			url: uri,
+		});
+	};
 
 	<portlet:renderURL var="refreshViewURL" />
 
-	Liferay.provide(
-		window,
-		'<portlet:namespace />closeDialog',
-		function (dialogId, stateChange) {
-			var namespace = window.parent.namespace;
-			var dialog = Liferay.Util.getWindow(dialogId);
-			dialog.destroy();
-			if (stateChange) {
-				window.location.replace('<%= HtmlUtil.escapeJS(refreshViewURL) %>');
-			}
-		},
-		['aui-base', 'aui-dialog', 'aui-dialog-iframe']
-	);
+	window['<portlet:namespace />closeDialog'] = function (dialogId, stateChange) {
+		Liferay.fire('closeModal', {
+			id: dialogId,
+		});
+
+		if (stateChange) {
+			window.location.replace('<%= HtmlUtil.escapeJS(refreshViewURL) %>');
+		}
+	};
 </aui:script>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/general.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/general.jsp
@@ -112,10 +112,8 @@ if (samlRoleIdpOptionDisabled) {
 
 <aui:script>
 	window['<portlet:namespace />showCertificateDialog'] = function (uri) {
-		var id = '<portlet:namespace />certificateDialog';
-
 		Liferay.Util.openModal({
-			id: id,
+			id: '<portlet:namespace />certificateDialog',
 			iframeBodyCssClass: 'dialog-with-footer',
 			title:
 				'<%= UnicodeLanguageUtil.get(request, "certificate-and-private-key") %>',

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/update_certificate.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/update_certificate.jsp
@@ -25,14 +25,12 @@ X509Certificate x509Certificate = (X509Certificate)request.getAttribute(SamlWebK
 %>
 
 <aui:script>
-	Liferay.provide(window, '<portlet:namespace />requestCloseDialog', function (
-		stateChange
-	) {
+	window['<portlet:namespace />requestCloseDialog'] = function (stateChange) {
 		Liferay.Util.getOpener().<portlet:namespace />closeDialog(
 			'<portlet:namespace/>certificateDialog',
 			stateChange
 		);
-	});
+	};
 </aui:script>
 
 <c:if test='<%= cmd.equals("replace") || cmd.equals("import") %>'>


### PR DESCRIPTION
As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561) we eventually want to deprecate the `Liferay.provide` function.

To test this change:

- Make sure you've compiled DXP (run `ant setup-profile-dxp` before running `ant all`)
- From the "Global Menu" click on the "Control Panel" tab
- Click on "SAML Admin"
- In the "General" tab, enter a value for "Entity ID" (You can use "1234", it doesn't really matter here)
- Click on the "Save" button
- Click on the "Create Certificate" button

As a result, a modal window should open to let you configure the certificate, this modal window should be closed if you click on the "Cancel" button, or if you provide the required information and click on the "Save" button

- Click on the "Identity Provider Connections" tab
- Click on the "Add Identity Provider" button
- Scroll down and click on the "Upload Metadata XML" button

As a result, a form should appear to let you upload the "Metadata XML" file and no JS errors should appear in your browser's console.