### PR TITLE
LPS-115551 - Add border color light in admin and classic themes

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
@@ -1,4 +1,5 @@
 $bg-color: #f1f2f5;
+$border-color: #f1f2f5;
 
 $lead-font-weight: 400;
 $small-font-size: 0.875rem;

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
@@ -1,4 +1,5 @@
 $body-bg: #fff;
+$border-color: #f1f2f5;
 $bright-color: #1865fb;
 $complementary-color: #30313f;
 $dark-color: #272833;

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -71,6 +71,7 @@ a.control-menu-icon,
 
 .control-menu-level-1-light {
 	background-color: $control-menu-level-1-light-bg;
+	border-bottom: $control-menu-level-1-light-border;
 	color: $control-menu-level-1-light-color;
 
 	a:not(.dropdown-item),
@@ -80,6 +81,14 @@ a.control-menu-icon,
 		&:hover {
 			background-color: $control-menu-level-1-light-link-background-color;
 			color: $control-menu-level-1-light-link-hover-color;
+		}
+	}
+
+	> .container-fluid {
+		padding-bottom: $control-menu-level-1-padding - 1px;
+
+		@include media-breakpoint-up(sm) {
+			padding-bottom: $control-menu-level-1-padding-desktop - 1px;
 		}
 	}
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_variables.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_variables.scss
@@ -5,6 +5,9 @@ $control-menu-focus-box-shadow: 0 0 0 2px $white, 0 0 0 4px $primary-l1 !default
 
 $control-menu-css-transition: all 0.5s ease !default;
 
+$control-menu-level-1-padding: 8px;
+$control-menu-level-1-padding-desktop: 12px;
+
 $control-menu-level-1-active-border: $primary-l1 !default;
 $control-menu-level-1-active-border-width: 2px !default;
 $control-menu-level-1-bg: $dark-l1 !default;
@@ -14,6 +17,7 @@ $control-menu-level-1-link-hover-color: $white !default;
 $control-menu-level-1-link-background-color: fade_out($white, 0.97) !default;
 
 $control-menu-level-1-light-bg: $white !default;
+$control-menu-level-1-light-border: 1px solid $light;
 $control-menu-level-1-light-color: $gray-600 !default;
 $control-menu-level-1-light-link-color: $gray-600 !default;
 $control-menu-level-1-light-link-hover-color: $gray-800 !default;


### PR DESCRIPTION
New design for control-menu-light version, with bottom border in light color:

![image](https://user-images.githubusercontent.com/7963804/84777572-0899fa80-afe2-11ea-8fcb-d36b1c914d2b.png)

To use the same border in modals and navbars with management-bar below, developers will need to add to navbar the class called `border-bottom` (actually they are currently doing this).

To validate the design you can go to navigate to any section of applications (Global menu).

![image](https://user-images.githubusercontent.com/7963804/84777785-57479480-afe2-11ea-828e-bd8e1b61db62.png)
