### PR TITLE
LPS-113561 Avoid Liferay.provide in akismet-web

### DIFF
--- a/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view.jsp
@@ -28,7 +28,7 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 
 <%@ include file="/message_boards.jspf" %>
 
-<aui:script use="liferay-util-list-fields">
+<aui:script>
 	window['<portlet:namespace />deleteMBMessages'] = function (dicussion) {
 		var deleteMBMessageIds = Liferay.Util.listCheckedExcept(
 			document.<portlet:namespace />fm,

--- a/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view.jsp
@@ -28,64 +28,54 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 
 <%@ include file="/message_boards.jspf" %>
 
-<aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />deleteMBMessages',
-		function (dicussion) {
-			var deleteMBMessageIds = Liferay.Util.listCheckedExcept(
-				document.<portlet:namespace />fm,
-				'<portlet:namespace />allRowIds'
-			);
+<aui:script use="liferay-util-list-fields">
+	window['<portlet:namespace />deleteMBMessages'] = function (dicussion) {
+		var deleteMBMessageIds = Liferay.Util.listCheckedExcept(
+			document.<portlet:namespace />fm,
+			'<portlet:namespace />allRowIds'
+		);
 
-			if (
-				deleteMBMessageIds &&
-				confirm(
-					'<%= UnicodeLanguageUtil.get(portletConfig.getResourceBundle(locale), "are-you-sure-you-want-to-delete-the-selected-messages") %>'
-				)
-			) {
-				document.<portlet:namespace />fm.<portlet:namespace />deleteMBMessageIds.value = deleteMBMessageIds;
+		if (
+			deleteMBMessageIds &&
+			confirm(
+				'<%= UnicodeLanguageUtil.get(portletConfig.getResourceBundle(locale), "are-you-sure-you-want-to-delete-the-selected-messages") %>'
+			)
+		) {
+			document.<portlet:namespace />fm.<portlet:namespace />deleteMBMessageIds.value = deleteMBMessageIds;
 
-				if (dicussion) {
-					submitForm(
-						document.<portlet:namespace />fm,
-						'<portlet:actionURL name="deleteDiscussionMBMessages"><portlet:param name="redirect" value="<%= portletURL.toString() %>" /></portlet:actionURL>'
-					);
-				}
-				else {
-					submitForm(
-						document.<portlet:namespace />fm,
-						'<portlet:actionURL name="deleteMBMessages"><portlet:param name="redirect" value="<%= portletURL.toString() %>" /></portlet:actionURL>'
-					);
-				}
-			}
-		},
-		['liferay-util-list-fields']
-	);
-
-	Liferay.provide(
-		window,
-		'<portlet:namespace />notSpamMBMessages',
-		function () {
-			var notSpamMBMessageIds = Liferay.Util.listCheckedExcept(
-				document.<portlet:namespace />fm,
-				'<portlet:namespace />allRowIds'
-			);
-
-			if (
-				notSpamMBMessageIds &&
-				confirm(
-					'<%= UnicodeLanguageUtil.get(portletConfig.getResourceBundle(locale), "are-you-sure-you-want-to-mark-the-selected-messages-as-not-spam") %>'
-				)
-			) {
-				document.<portlet:namespace />fm.<portlet:namespace />notSpamMBMessageIds.value = notSpamMBMessageIds;
-
+			if (dicussion) {
 				submitForm(
 					document.<portlet:namespace />fm,
-					'<portlet:actionURL name="markNotSpamMBMessages"><portlet:param name="redirect" value="<%= portletURL.toString() %>" /></portlet:actionURL>'
+					'<portlet:actionURL name="deleteDiscussionMBMessages"><portlet:param name="redirect" value="<%= portletURL.toString() %>" /></portlet:actionURL>'
 				);
 			}
-		},
-		['liferay-util-list-fields']
-	);
+			else {
+				submitForm(
+					document.<portlet:namespace />fm,
+					'<portlet:actionURL name="deleteMBMessages"><portlet:param name="redirect" value="<%= portletURL.toString() %>" /></portlet:actionURL>'
+				);
+			}
+		}
+	};
+
+	window['<portlet:namespace />notSpamMBMessages'] = function () {
+		var notSpamMBMessageIds = Liferay.Util.listCheckedExcept(
+			document.<portlet:namespace />fm,
+			'<portlet:namespace />allRowIds'
+		);
+
+		if (
+			notSpamMBMessageIds &&
+			confirm(
+				'<%= UnicodeLanguageUtil.get(portletConfig.getResourceBundle(locale), "are-you-sure-you-want-to-mark-the-selected-messages-as-not-spam") %>'
+			)
+		) {
+			document.<portlet:namespace />fm.<portlet:namespace />notSpamMBMessageIds.value = notSpamMBMessageIds;
+
+			submitForm(
+				document.<portlet:namespace />fm,
+				'<portlet:actionURL name="markNotSpamMBMessages"><portlet:param name="redirect" value="<%= portletURL.toString() %>" /></portlet:actionURL>'
+			);
+		}
+	};
 </aui:script>


### PR DESCRIPTION
As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561) we
eventually want to deprecate the `Liferay.provide` function

To test this change

- Make sure you're run `ant setup-profile-dxp` before running `ant all`
- Visit https://help.liferay.com/hc/en-us/articles/360017905232-Akismet
  to understand how to enable this module
- Once the module is deployed and configured, add a "Message Board"
  widget to a content page
- Add a message in the "Message Boards" widget and once it's published,
  mark is a spam
- Navigate to "Content and Data > Spam Moderation"
- Select the message previously marked as spam and click on the "Delete"
  button
- Add another message to the "Message Boards" widget and mark it as spam
- Navigate to "Content and Data > Spam Moderation"
- Select the message previously marked as spam and click on the "Not
  Spam" button

As a result, you should be able to delete or discard messages marked as
spam