### PR TITLE
LPS-113586 Deprecates `liferay-progress` AUI component

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/progress.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/progress.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 AUI.add(
 	'liferay-progress',
 	(A) => {


### PR DESCRIPTION
This component is just being used on [`liferay-ui:progress` taglib](https://github.com/liferay/liferay-portal/blob/master/portal-web/docroot/html/taglib/ui/progress/page.jsp#L25). However, when trying to use this taglib inside a JSP that is currently using other `liferay-ui` namespaced taglibs the following error occurs:

```
Execution failed for task ':apps:dynamic-data-mapping:dynamic-data-mapping-web:generateJSPJava'.
> file:/Users/diegonascimento/workspace/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/classes/META-INF/resources/view.jsp(52,0) PWC6142: No tag "progress" defined in tag library imported with prefix "liferay-ui"
```

We couldn't find any official `.tld` related to this taglib, I just one that apparently was used on an older project template: https://github.com/liferay/liferay-portal/blob/master/modules/sdk/project-templates/project-templates-war-mvc-portlet/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/tld/liferay-ui.tld#L3569

Note that inside the tld this taglib was deprecated in 7.0.x.﻿
