### PR TITLE
LPS-115680 - Add clay empty-state reorder dual-listbox and slideout components

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/clay/_components.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/clay/_components.scss
@@ -10,6 +10,7 @@
 @import 'components/_breadcrumbs';
 @import 'components/_button-groups';
 @import 'components/_buttons';
+@import 'components/_empty-state';
 @import 'components/_labels';
 @import 'components/_stickers';
 
@@ -21,12 +22,14 @@
 @import 'components/_links';
 
 @import 'components/_range';
+@import 'components/_reorder';
 
 @import 'components/_clay-color';
 @import 'components/_custom-forms';
 @import 'components/_time';
 
 @import 'components/_date-picker';
+@import 'components/_dual-listbox';
 @import 'components/_form-validation';
 @import 'components/_icons';
 @import 'components/_input-groups';
@@ -51,6 +54,7 @@
 @import 'components/_sheets';
 @import 'components/_side-navigation';
 @import 'components/_sidebar';
+@import 'components/_slideout';
 @import 'components/_tables';
 @import 'components/_tbar';
 @import 'components/_timelines';

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/clay/_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/clay/_variables.scss
@@ -7,6 +7,7 @@
 @import 'variables/_badges';
 @import 'variables/_breadcrumbs';
 @import 'variables/_buttons';
+@import 'variables/_empty-state';
 @import 'variables/_labels';
 @import 'variables/_stickers';
 
@@ -18,12 +19,14 @@
 @import 'variables/_links';
 
 @import 'variables/_range';
+@import 'variables/_reorder';
 
 @import 'variables/_clay-color';
 @import 'variables/_custom-forms';
 @import 'variables/_time';
 
 @import 'variables/_date-picker';
+@import 'variables/_dual-listbox';
 @import 'variables/_list-group';
 @import 'variables/_loaders';
 @import 'variables/_modals';
@@ -46,6 +49,7 @@
 @import 'variables/_sheets';
 @import 'variables/_side-navigation';
 @import 'variables/_sidebar';
+@import 'variables/_slideout';
 @import 'variables/_tables';
 @import 'variables/_tbar';
 @import 'variables/_timelines';


### PR DESCRIPTION
Some new Clay components are not been including in Liferay portal themes.
After this adding we should be able to apply new components markup like:

https://clayui.com/docs/components/empty-state.html
https://clayui.com/docs/components/dual-list_box.html
