### PR TITLE
LPS-114069 Replace layout classes with new clay components in headless-discovery-web

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/package.json
+++ b/modules/apps/data-engine/data-engine-taglib/package.json
@@ -6,6 +6,7 @@
 		"@clayui/form": "3.8.0",
 		"@clayui/icon": "3.0.5",
 		"@clayui/label": "3.3.0",
+		"@clayui/layout": "3.0.1",
 		"@clayui/link": "3.1.1",
 		"@clayui/list": "3.2.5",
 		"@clayui/loading-indicator": "3.1.0",

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldType.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldType.es.js
@@ -13,6 +13,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClaySticker from '@clayui/sticker';
 import {ClayTooltipProvider} from '@clayui/tooltip';
@@ -84,32 +85,27 @@ export default (props) => {
 	const fieldIcon = ICONS[icon] ? ICONS[icon] : icon;
 
 	return (
-		<div
-			className={classnames(
-				className,
-				'autofit-row',
-				'autofit-row-center',
-				'field-type',
-				{
-					active,
-					disabled,
-					dragging,
-					loading,
-				}
-			)}
+		<ClayLayout.ContentRow
+			className={classnames(className, 'field-type', {
+				active,
+				disabled,
+				dragging,
+				loading,
+			})}
 			data-field-type-name={name}
 			onClick={onClick && handleOnClick}
 			onDoubleClick={onDoubleClick && handleOnDoubleClick}
 			ref={drag}
+			verticalAlign="center"
 		>
 			{dragAlignment === 'left' && (
-				<div className="autofit-col pl-2 pr-2">
+				<ClayLayout.ContentCol className="pl-2 pr-2">
 					<ClayIcon symbol="drag" />
-				</div>
+				</ClayLayout.ContentCol>
 			)}
 
-			<div
-				className={classnames('autofit-col', 'pr-2', {
+			<ClayLayout.ContentCol
+				className={classnames('pr-2', {
 					'pl-2': dragAlignment === 'right',
 				})}
 			>
@@ -120,9 +116,9 @@ export default (props) => {
 				>
 					<ClayIcon symbol={fieldIcon} />
 				</ClaySticker>
-			</div>
+			</ClayLayout.ContentCol>
 
-			<div className="autofit-col autofit-col-expand pr-2">
+			<ClayLayout.ContentCol className="pr-2" expand>
 				<h4 className="list-group-title text-truncate">
 					<span>{label}</span>
 				</h4>
@@ -132,12 +128,12 @@ export default (props) => {
 						<small>{description}</small>
 					</p>
 				)}
-			</div>
+			</ClayLayout.ContentCol>
 
 			{dragAlignment === 'right' && (
-				<div className="autofit-col pr-2">
+				<ClayLayout.ContentCol className="pr-2">
 					<ClayIcon symbol="drag" />
-				</div>
+				</ClayLayout.ContentCol>
 			)}
 
 			{onDelete && (
@@ -171,6 +167,6 @@ export default (props) => {
 					)}
 				</div>
 			)}
-		</div>
+		</ClayLayout.ContentRow>
 	);
 };

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rules/RuleList.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rules/RuleList.es.js
@@ -13,6 +13,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import ClayLayout from '@clayui/layout';
 import React, {useContext} from 'react';
 
 import AppContext from '../../AppContext.es';
@@ -56,7 +57,7 @@ export default ({keywords, toggleRulesEditorVisibility}) => {
 					small
 				/>
 			) : (
-				<div className="autofit-col rule-list">
+				<ClayLayout.ContentCol className="rule-list">
 					<hr />
 					{filteredDataRules.map((rule, index) => (
 						<RuleItem
@@ -67,7 +68,7 @@ export default ({keywords, toggleRulesEditorVisibility}) => {
 							}
 						/>
 					))}
-				</div>
+				</ClayLayout.ContentCol>
 			)}
 		</>
 	);

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/Sidebar.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/Sidebar.es.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import ClayLayout from '@clayui/layout';
 import classNames from 'classnames';
 import React, {useState} from 'react';
 
@@ -47,15 +48,15 @@ const SidebarHeader = ({children, className}) => {
 };
 
 const SidebarSearchInput = ({children, onSearch}) => (
-	<div className="autofit-row sidebar-section">
-		<div className="autofit-col autofit-col-expand">
+	<ClayLayout.ContentRow className="sidebar-section">
+		<ClayLayout.ContentCol expand>
 			{onSearch && (
 				<SearchInput onChange={(searchText) => onSearch(searchText)} />
 			)}
-		</div>
+		</ClayLayout.ContentCol>
 
 		{children}
-	</div>
+	</ClayLayout.ContentRow>
 );
 
 const SidebarTabs = ({initialSelectedTab = 0, tabs}) => {
@@ -77,7 +78,7 @@ const SidebarTabs = ({initialSelectedTab = 0, tabs}) => {
 const SidebarTab = ({onTabClick, selectedTab, tabs}) => {
 	return (
 		<nav className="component-tbar tbar">
-			<div className="container-fluid">
+			<ClayLayout.ContainerFluid>
 				<ul className="nav nav-underline" role="tablist">
 					{tabs.map(({label}, index) => (
 						<li className="nav-item" key={index}>
@@ -100,7 +101,7 @@ const SidebarTab = ({onTabClick, selectedTab, tabs}) => {
 						</li>
 					))}
 				</ul>
-			</div>
+			</ClayLayout.ContainerFluid>
 		</nav>
 	);
 };
@@ -116,13 +117,13 @@ const SidebarTabContent = ({children}) => {
 };
 
 const SidebarTitle = ({title}) => (
-	<div className="autofit-row mb-3 sidebar-section">
-		<div className="autofit-col autofit-col-expand">
+	<ClayLayout.ContentRow className="mb-3 sidebar-section">
+		<ClayLayout.ContentCol expand>
 			<div className="component-title">
 				<span className="text-truncate-inline">{title}</span>
 			</div>
-		</div>
-	</div>
+		</ClayLayout.ContentCol>
+	</ClayLayout.ContentRow>
 );
 
 Sidebar.Body = SidebarBody;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/data-layout-builder/DataLayoutBuilder.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/data-layout-builder/DataLayoutBuilder.es.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import ClayLayout from '@clayui/layout';
 import classNames from 'classnames';
 import FormBuilderWithLayoutProvider from 'dynamic-data-mapping-form-builder';
 import {PagesVisitor} from 'dynamic-data-mapping-form-renderer';
@@ -429,7 +430,7 @@ class DataLayoutBuilder extends React.Component {
 					}
 				)}
 			>
-				<div className="sheet" ref={this.containerRef} />
+				<ClayLayout.Sheet ref={this.containerRef} />
 			</div>
 		);
 	}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/plugins/rules-sidebar/components/RulesSidebar.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/plugins/rules-sidebar/components/RulesSidebar.es.js
@@ -14,6 +14,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm from '@clayui/form';
+import ClayLayout from '@clayui/layout';
 import React, {useState} from 'react';
 
 import RuleEditorModal from '../../../components/rules/RuleEditorModal.es';
@@ -44,23 +45,23 @@ export default function ({title}) {
 			<Sidebar.Header>
 				<Sidebar.Title title={title} />
 
-				<div className="autofit-row sidebar-section">
-					<div className="autofit-col autofit-col-expand">
+				<ClayLayout.ContentRow className="sidebar-section">
+					<ClayLayout.ContentCol expand>
 						<ClayForm onSubmit={(event) => event.preventDefault()}>
 							<Sidebar.SearchInput
 								onSearch={(keywords) => setKeywords(keywords)}
 							/>
 						</ClayForm>
-					</div>
+					</ClayLayout.ContentCol>
 
-					<div className="autofit-col ml-2">
+					<ClayLayout.ContentCol className="ml-2">
 						<ClayButtonWithIcon
 							displayType="primary"
 							onClick={() => toggleRulesEditorVisibility()}
 							symbol="plus"
 						/>
-					</div>
-				</div>
+					</ClayLayout.ContentCol>
+				</ClayLayout.ContentRow>
 			</Sidebar.Header>
 			<Sidebar.Body>
 				<RuleList

--- a/modules/apps/depot/depot-web/package.json
+++ b/modules/apps/depot/depot-web/package.json
@@ -6,6 +6,7 @@
 		"@clayui/form": "3.8.0",
 		"@clayui/icon": "3.0.5",
 		"@clayui/label": "3.3.0",
+		"@clayui/layout": "3.0.1",
 		"@clayui/modal": "3.5.0",
 		"@clayui/table": "3.0.7",
 		"frontend-js-web": "*",

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/LanguageListItemEditable.es.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/LanguageListItemEditable.es.js
@@ -16,6 +16,7 @@ import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
+import ClayLayout from '@clayui/layout';
 import ClayTable from '@clayui/table';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -160,21 +161,25 @@ const LanguageListItem = ({
 			ref={itemRef}
 		>
 			<ClayTable.Cell expanded>
-				<div className="autofit-row autofit-row-center">
-					<div className="autofit-col autofit-padded-no-gutters">
+				<ClayLayout.ContentRow verticalAlign="center">
+					<ClayLayout.ContentCol className="autofit-padded-no-gutters">
 						<div className="language-drag-handler">
 							<ClayIcon symbol="drag" />
 						</div>
-					</div>
-					<div className="align-items-center autofit-col autofit-col-expand autofit-padded-no-gutters flex-row justify-content-start">
+					</ClayLayout.ContentCol>
+
+					<ClayLayout.ContentCol
+						className="align-items-center autofit-padded-no-gutters flex-row justify-content-start"
+						expand
+					>
 						{displayName}
 						{isDefault && (
 							<ClayLabel className="ml-3" displayType="info">
 								{Liferay.Language.get('default')}
 							</ClayLabel>
 						)}
-					</div>
-				</div>
+					</ClayLayout.ContentCol>
+				</ClayLayout.ContentRow>
 			</ClayTable.Cell>
 			<ClayTable.Cell align="right">
 				<ClayDropDown

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
@@ -6,6 +6,7 @@
 		"@clayui/form": "3.8.0",
 		"@clayui/icon": "3.0.5",
 		"@clayui/label": "3.3.0",
+		"@clayui/layout": "3.0.1",
 		"@clayui/panel": "3.2.0",
 		"@clayui/tabs": "3.2.0",
 		"graphiql": "1.0.0-alpha.8",

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIDisplay.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIDisplay.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import ClayLayout from '@clayui/layout';
 import ClayTabs from '@clayui/tabs';
 import React, {useState} from 'react';
 
@@ -46,7 +47,7 @@ const APIDisplay = () => {
 
 	return (
 		<div>
-			<div className="mb-2 sheet-header">
+			<ClayLayout.SheetHeader className="mb-2">
 				<h2 className="mb-2 sheet-title">{path}</h2>
 
 				<div className="align-items-center d-flex sheet-text">
@@ -76,12 +77,12 @@ const APIDisplay = () => {
 				{methodData.description && (
 					<div className="sheet-text">{methodData.description}</div>
 				)}
-			</div>
+			</ClayLayout.SheetHeader>
 
 			<APIForm />
 
 			{apiResponse && (
-				<div className="sheet-section">
+				<ClayLayout.SheetSection>
 					<h3 className="sheet-subtitle">{'Response'}</h3>
 
 					<ClayTabs>
@@ -120,7 +121,7 @@ const APIDisplay = () => {
 							/>
 						</ClayTabs.TabPane>
 					</ClayTabs.Content>
-				</div>
+				</ClayLayout.SheetSection>
 			)}
 		</div>
 	);

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIFormBase.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIFormBase.js
@@ -14,6 +14,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayForm from '@clayui/form';
+import ClayLayout from '@clayui/layout';
 import {withFormik} from 'formik';
 import React, {useEffect} from 'react';
 
@@ -64,7 +65,7 @@ const APIFormBase = (props) => {
 
 	return (
 		<form onSubmit={handleSubmit}>
-			<div className="sheet-section">
+			<ClayLayout.SheetSection>
 				{parameters && <h3 className="sheet-subtitle">Parameters</h3>}
 
 				{parameters &&
@@ -113,7 +114,7 @@ const APIFormBase = (props) => {
 						Execute
 					</ClayButton>
 				</ClayForm.Group>
-			</div>
+			</ClayLayout.SheetSection>
 		</form>
 	);
 };

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIGUI.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIGUI.js
@@ -15,6 +15,7 @@
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput, ClaySelect} from '@clayui/form';
+import ClayLayout from '@clayui/layout';
 import ClayModal, {useModal} from '@clayui/modal';
 import GraphiQL from 'graphiql';
 import React, {useCallback, useEffect, useState} from 'react';
@@ -155,10 +156,11 @@ const APIGUI = () => {
 
 	return (
 		<div className="api-gui-root">
-			<div className="container container-fluid">
+			<ClayLayout.ContainerFluid>
 				{showHeaders && (
 					<ClayModal observer={observer} size="lg" status="info">
 						<ClayModal.Header>{'Headers'}</ClayModal.Header>
+
 						<ClayModal.Body>
 							<h1>
 								Add, edit, and remove headers in your request.
@@ -178,6 +180,7 @@ const APIGUI = () => {
 											value={header.key}
 										/>
 									</div>
+
 									<div className="form-group-item">
 										<input
 											className="form-control"
@@ -190,6 +193,7 @@ const APIGUI = () => {
 											value={header.value}
 										/>
 									</div>
+
 									<ClayButton
 										className="btn btn-warning"
 										displayType={'secondary'}
@@ -204,6 +208,7 @@ const APIGUI = () => {
 								</div>
 							))}
 						</ClayModal.Body>
+
 						<ClayModal.Footer
 							first={
 								<ClayButton.Group spaced>
@@ -237,9 +242,9 @@ const APIGUI = () => {
 					</ClayModal>
 				)}
 
-				<div className="row">
-					<div
-						className="col col-push-3"
+				<ClayLayout.Row>
+					<ClayLayout.Col
+						className="col-push-3"
 						style={{textAlign: 'right'}}
 					>
 						<button
@@ -267,8 +272,8 @@ const APIGUI = () => {
 						>
 							{showGraphQL ? 'Hide GraphQL' : 'Show GraphQL'}
 						</button>
-					</div>
-				</div>
+					</ClayLayout.Col>
+				</ClayLayout.Row>
 
 				{showSwagger && !showGraphQL && (
 					<SwaggerUI
@@ -285,14 +290,19 @@ const APIGUI = () => {
 						).get('category')}/v1.0/openapi.json`}
 					/>
 				)}
+
 				{showGraphQL && !showSwagger && (
-					<div className="row vh-100">
+					<ClayLayout.Row className="vh-100">
 						<GraphiQL fetcher={graphQLFetcher} />
-					</div>
+					</ClayLayout.Row>
 				)}
+
 				{!showGraphQL && !showSwagger && (
-					<div className="row">
-						<div className="border col col-md-5 overflow-auto p-0 vh-100">
+					<ClayLayout.Row>
+						<ClayLayout.Col
+							className="border overflow-auto p-0 vh-100"
+							md="5"
+						>
 							<ClayForm.Group className="pt-3 px-3">
 								<label
 									className="d-flex justify-content-between"
@@ -314,6 +324,7 @@ const APIGUI = () => {
 										</button>
 									)}
 								</label>
+
 								<ClaySelect
 									aria-label="Select API Category"
 									onChange={(e) => {
@@ -342,6 +353,7 @@ const APIGUI = () => {
 								>
 									Description
 								</label>
+
 								<p>{info && info.description}</p>
 							</ClayForm.Group>
 
@@ -380,9 +392,12 @@ const APIGUI = () => {
 									/>
 								)}
 							</div>
-						</div>
+						</ClayLayout.Col>
 
-						<div className="border col col-md-7 overflow-auto p-3 vh-100">
+						<ClayLayout.Col
+							className="border overflow-auto p-3 vh-100"
+							md="7"
+						>
 							{paths && path && method && !showSchemas && (
 								<APIDisplay />
 							)}
@@ -404,10 +419,10 @@ const APIGUI = () => {
 									schemas={schemas}
 								/>
 							)}
-						</div>
-					</div>
+						</ClayLayout.Col>
+					</ClayLayout.Row>
 				)}
-			</div>
+			</ClayLayout.ContainerFluid>
 		</div>
 	);
 };


### PR DESCRIPTION
This is a simple code replacement of the old layout classes with the new clay layout components

We had some problems testing the original bundle but I've decided to remove the module that was causing problems and work on it separately

https://github.com/eduardoallegrini/liferay-portal/pull/92