### PR TITLE
LPS-115204 Adds hydration support to clay:navigation-bar

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewMoreMenuItemsDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewMoreMenuItemsDisplayContext.java
@@ -21,7 +21,6 @@ import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeServiceUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.DisplayTerms;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -76,7 +75,6 @@ public class DLViewMoreMenuItemsDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 				navigationItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "document-types"));
 			}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/display/context/DDLDisplayContext.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/display/context/DDLDisplayContext.java
@@ -319,7 +319,6 @@ public class DDLDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 
 				HttpServletRequest httpServletRequest =
 					_ddlRequestHelper.getRequest();

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/display/context/DDLViewRecordsDisplayContext.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/display/context/DDLViewRecordsDisplayContext.java
@@ -256,7 +256,6 @@ public class DDLViewRecordsDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 				navigationItem.setLabel(
 					HtmlUtil.extractText(
 						_ddlRecordSet.getName(_ddlRequestHelper.getLocale())));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
@@ -56,7 +56,7 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 	</div>
 
 	<clay:navigation-bar
-		elementClasses="ddm-form-report-tabs"
+		cssClass="ddm-form-report-tabs"
 		navigationItems='<%=
 			new JSPNavigationItemList(pageContext) {
 				{
@@ -89,7 +89,7 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 			var navLink = navItem.querySelector('.nav-link');
 
 			document
-				.querySelector('.ddm-form-report-tabs li > a.active')
+				.querySelector('.ddm-form-report-tabs li > .active')
 				.classList.remove('active');
 			navLink.classList.add('active');
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
@@ -63,7 +63,6 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 					add(
 						navigationItem -> {
 							navigationItem.setActive(true);
-							navigationItem.setHref(StringPool.BLANK);
 							navigationItem.setLabel(LanguageUtil.get(request, "summary"));
 						}
 					);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
@@ -444,7 +444,6 @@ public class DDMFormAdminDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 
 				HttpServletRequest httpServletRequest =
 					formAdminRequestHelper.getRequest();
@@ -542,14 +541,12 @@ public class DDMFormAdminDisplayContext {
 			navigationItem -> {
 				navigationItem.putData("action", "showForm");
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 				navigationItem.setLabel(
 					LanguageUtil.get(httpServletRequest, "form"));
 			}
 		).add(
 			navigationItem -> {
 				navigationItem.putData("action", "showRules");
-				navigationItem.setHref(StringPool.BLANK);
 				navigationItem.setLabel(
 					LanguageUtil.get(httpServletRequest, "rules"));
 			}
@@ -557,7 +554,6 @@ public class DDMFormAdminDisplayContext {
 			this::isShowReport,
 			navigationItem -> {
 				navigationItem.putData("action", "showReport");
-				navigationItem.setHref(StringPool.BLANK);
 				navigationItem.setLabel(
 					LanguageUtil.get(httpServletRequest, "entries"));
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordsDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordsDisplayContext.java
@@ -221,7 +221,6 @@ public class DDMFormViewFormInstanceRecordsDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 
 				DDMFormInstance ddmFormInstance = getDDMFormInstance();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
@@ -211,7 +211,7 @@ td.lfr-name-column {
 		width: inherit;
 	}
 
-	.forms-management-bar,
+	.forms-navigation-bar,
 	.navigation-bar-secondary,
 	.management-bar {
 		position: sticky;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -47,7 +47,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 
 <div class="portlet-forms" id="<portlet:namespace />formContainer">
 	<clay:navigation-bar
-		cssClass="forms-management-bar"
+		cssClass="forms-navigation-bar"
 		id="formsNavigationBar"
 		inverted="<%= true %>"
 		navigationItems="<%= ddmFormAdminDisplayContext.getFormBuilderNavigationItems() %>"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -181,7 +181,7 @@ class Form extends Component {
 				this._handleBackButtonClicked
 			),
 			dom.on(
-				'.forms-management-bar li',
+				'.forms-navigation-bar li',
 				'click',
 				this._handleFormNavClicked
 			)
@@ -735,7 +735,7 @@ class Form extends Component {
 		const navLink = navItem.querySelector('.nav-link');
 
 		document
-			.querySelector('.forms-management-bar li > a.active')
+			.querySelector('.forms-navigation-bar li > .active')
 			.classList.remove('active');
 		navLink.classList.add('active');
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
@@ -209,7 +209,6 @@ public class DDMDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 				navigationItem.setLabel(getScopedStructureLabel());
 			}
 		).build();

--- a/modules/apps/expando/expando-web/src/main/java/com/liferay/expando/web/internal/display/context/ExpandoDisplayContext.java
+++ b/modules/apps/expando/expando-web/src/main/java/com/liferay/expando/web/internal/display/context/ExpandoDisplayContext.java
@@ -22,7 +22,6 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuil
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -98,7 +97,6 @@ public class ExpandoDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 				navigationItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, label));
 			}

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -259,9 +259,11 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 					</h2>
 
 					<clay:sheet-section>
-						<clay:navigation-bar
-							navigationItems="<%= fragmentDisplayContext.getNavigationItems() %>"
-						/>
+						<c:if test="<%= fragmentDisplayContext.getNavigationItems().size() > 0 %>">
+							<clay:navigation-bar
+								navigationItems="<%= fragmentDisplayContext.getNavigationItems() %>"
+							/>
+						</c:if>
 
 						<c:choose>
 							<c:when test="<%= fragmentDisplayContext.isSelectedFragmentCollectionContributor() %>">

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -39,6 +39,7 @@
 		"@clayui/time-picker": "3.1.3",
 		"@clayui/tooltip": "3.3.0",
 		"@clayui/upper-toolbar": "3.1.0",
+		"classnames": "2.2.6",
 		"clay-alert": "2.21.3",
 		"clay-autocomplete": "2.21.3",
 		"clay-badge": "2.21.3",

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
@@ -19,6 +19,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.jsp.JspException;
@@ -80,6 +81,11 @@ public class NavigationBarTag extends BaseContainerTag {
 	}
 
 	@Override
+	protected String getHydratedModuleName() {
+		return "frontend-taglib-clay/NavigationBar";
+	}
+
+	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("navbar");
 		cssClasses.add("navbar-collapse-absolute");
@@ -91,6 +97,14 @@ public class NavigationBarTag extends BaseContainerTag {
 			_inverted ? "navigation-bar-secondary" : "navigation-bar-light");
 
 		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected Map<String, Object> processData(Map<String, Object> data) {
+		data.put("inverted", _inverted);
+		data.put("navigationItems", _navigationItems);
+
+		return super.processData(data);
 	}
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/NavigationItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/NavigationItem.java
@@ -14,7 +14,6 @@
 
 package com.liferay.frontend.taglib.clay.servlet.taglib.util;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashMap;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/NavigationItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/NavigationItem.java
@@ -27,10 +27,6 @@ import javax.portlet.PortletURL;
  */
 public class NavigationItem extends HashMap<String, Object> {
 
-	public NavigationItem() {
-		setHref(StringPool.BLANK);
-	}
-
 	public void putData(String key, String value) {
 		Map<String, Object> data = (Map<String, Object>)get("data");
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayLayout from '@clayui/layout';
+import ClayLink from '@clayui/link';
+import ClayNavigationBar from '@clayui/navigation-bar';
+import classNames from 'classnames';
+import React from 'react';
+
+export default function NavigationBar({cssClass, inverted, navigationItems}) {
+	return (
+		<ClayLayout.ContainerFluid className={classNames('p-0', cssClass)}>
+			<ClayNavigationBar
+				inverted={inverted}
+				triggerLabel={navigationItems.find(({active}) => active).label}
+			>
+				{navigationItems.map(({active, href, label}) => (
+					<ClayNavigationBar.Item active={active} key={label}>
+						<ClayLink
+							className="nav-link"
+							displayType="unstyled"
+							href={href}
+						>
+							{label}
+						</ClayLink>
+					</ClayNavigationBar.Item>
+				))}
+			</ClayNavigationBar>
+		</ClayLayout.ContainerFluid>
+	);
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
@@ -25,25 +25,17 @@ export default function NavigationBar({cssClass, inverted, navigationItems}) {
 				inverted={inverted}
 				triggerLabel={navigationItems.find(({active}) => active)?.label}
 			>
-				{navigationItems.map(({active, href, label}, index) => {
-					const linkAttributes = href ? {href} : {};
-
-					return (
-						<ClayNavigationBar.Item
-							active={active}
-							data-nav-item-index={index}
-							key={label}
+				{navigationItems.map(({active, href, label}) => (
+					<ClayNavigationBar.Item active={active} key={label}>
+						<ClayLink
+							className="nav-link"
+							displayType="unstyled"
+							{...{href}}
 						>
-							<ClayLink
-								className="nav-link"
-								displayType="unstyled"
-								{...linkAttributes}
-							>
-								{label}
-							</ClayLink>
-						</ClayNavigationBar.Item>
-					);
-				})}
+							{label}
+						</ClayLink>
+					</ClayNavigationBar.Item>
+				))}
 			</ClayNavigationBar>
 		</ClayLayout.ContainerFluid>
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import ClayButton from '@clayui/button';
 import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayNavigationBar from '@clayui/navigation-bar';
@@ -25,17 +26,32 @@ export default function NavigationBar({cssClass, inverted, navigationItems}) {
 				inverted={inverted}
 				triggerLabel={navigationItems.find(({active}) => active)?.label}
 			>
-				{navigationItems.map(({active, href, label}) => (
-					<ClayNavigationBar.Item active={active} key={label}>
-						<ClayLink
-							className="nav-link"
-							displayType="unstyled"
-							{...{href}}
+				{navigationItems.map(({active, href, label}, index) => {
+					return (
+						<ClayNavigationBar.Item
+							active={active}
+							data-nav-item-index={index}
+							key={label}
 						>
-							{label}
-						</ClayLink>
-					</ClayNavigationBar.Item>
-				))}
+							{href ? (
+								<ClayLink
+									className="nav-link"
+									displayType="unstyled"
+									href={href}
+								>
+									{label}
+								</ClayLink>
+							) : (
+								<ClayButton
+									className="nav-link"
+									displayType="unstyled"
+								>
+									{label}
+								</ClayButton>
+							)}
+						</ClayNavigationBar.Item>
+					);
+				})}
 			</ClayNavigationBar>
 		</ClayLayout.ContainerFluid>
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
@@ -25,17 +25,25 @@ export default function NavigationBar({cssClass, inverted, navigationItems}) {
 				inverted={inverted}
 				triggerLabel={navigationItems.find(({active}) => active)?.label}
 			>
-				{navigationItems.map(({active, href, label}) => (
-					<ClayNavigationBar.Item active={active} key={label}>
-						<ClayLink
-							className="nav-link"
-							displayType="unstyled"
-							href={href}
+				{navigationItems.map(({active, href, label}, index) => {
+					const linkAttributes = href ? {href} : {};
+
+					return (
+						<ClayNavigationBar.Item
+							active={active}
+							data-nav-item-index={index}
+							key={label}
 						>
-							{label}
-						</ClayLink>
-					</ClayNavigationBar.Item>
-				))}
+							<ClayLink
+								className="nav-link"
+								displayType="unstyled"
+								{...linkAttributes}
+							>
+								{label}
+							</ClayLink>
+						</ClayNavigationBar.Item>
+					);
+				})}
 			</ClayNavigationBar>
 		</ClayLayout.ContainerFluid>
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
@@ -23,7 +23,7 @@ export default function NavigationBar({cssClass, inverted, navigationItems}) {
 		<ClayLayout.ContainerFluid className={classNames('p-0', cssClass)}>
 			<ClayNavigationBar
 				inverted={inverted}
-				triggerLabel={navigationItems.find(({active}) => active).label}
+				triggerLabel={navigationItems.find(({active}) => active)?.label}
 			>
 				{navigationItems.map(({active, href, label}) => (
 					<ClayNavigationBar.Item active={active} key={label}>

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -660,7 +660,6 @@ public class JournalDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 				navigationItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "details"));
 			}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryDisplayContext.java
@@ -19,7 +19,6 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBu
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleServiceUtil;
 import com.liferay.journal.web.internal.util.JournalPortletUtil;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -110,7 +109,6 @@ public class JournalHistoryDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 				navigationItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "versions"));
 			}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalViewMoreMenuItemsDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalViewMoreMenuItemsDisplayContext.java
@@ -19,7 +19,6 @@ import com.liferay.dynamic.data.mapping.util.comparator.StructureModifiedDateCom
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
 import com.liferay.journal.service.JournalFolderServiceUtil;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -128,7 +127,6 @@ public class JournalViewMoreMenuItemsDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 				navigationItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "all-menu-items"));
 			}

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/display/context/PasswordPolicyDisplayContext.java
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/display/context/PasswordPolicyDisplayContext.java
@@ -16,7 +16,6 @@ package com.liferay.password.policies.admin.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -143,7 +142,6 @@ public class PasswordPolicyDisplayContext {
 		NavigationItem entriesNavigationItem = new NavigationItem();
 
 		entriesNavigationItem.setActive(true);
-		entriesNavigationItem.setHref(StringPool.BLANK);
 		entriesNavigationItem.setLabel(
 			LanguageUtil.get(_httpServletRequest, tabs2));
 

--- a/modules/apps/polls/polls-web/src/main/java/com/liferay/polls/web/internal/portlet/display/context/PollsDisplayContext.java
+++ b/modules/apps/polls/polls-web/src/main/java/com/liferay/polls/web/internal/portlet/display/context/PollsDisplayContext.java
@@ -137,7 +137,6 @@ public class PollsDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 
 				ThemeDisplay themeDisplay = getThemeDisplay();
 

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/MyWorkflowTasks.path
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/MyWorkflowTasks.path
@@ -10,7 +10,7 @@
 <tbody>
 <tr>
 	<td>ASSIGNED_TO_ME_ACTIVE</td>
-	<td>//a[contains(@class,'active')]/span[contains(.,'Assigned to Me')]</td>
+	<td>//*[(@class='nav-link active') and contains(.,'Assigned to Me')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/MyWorkflowTasks.path
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/MyWorkflowTasks.path
@@ -10,7 +10,7 @@
 <tbody>
 <tr>
 	<td>ASSIGNED_TO_ME_ACTIVE</td>
-	<td>//*[(@class='nav-link active') and contains(.,'Assigned to Me')]</td>
+	<td>//*[contains(@class,'nav-link active') and contains(.,'Assigned to Me')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -93,7 +93,6 @@ request.setAttribute("edit_roles.jsp-portletURL", portletURL);
 					add(
 						navigationItem -> {
 							navigationItem.setActive(true);
-							navigationItem.setHref(StringPool.BLANK);
 							navigationItem.setLabel(LanguageUtil.get(request, "roles"));
 						});
 				}

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_export_processes.jsp
@@ -38,7 +38,6 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 				add(
 					navigationItem -> {
 						navigationItem.setActive(true);
-						navigationItem.setHref(StringPool.BLANK);
 						navigationItem.setLabel(LanguageUtil.get(request, "export-processes"));
 					});
 			}

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/select_user_group_users.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/select_user_group_users.jsp
@@ -35,7 +35,6 @@ List<NavigationItem> navigationItems = new ArrayList<>();
 NavigationItem entriesNavigationItem = new NavigationItem();
 
 entriesNavigationItem.setActive(true);
-entriesNavigationItem.setHref(StringPool.BLANK);
 entriesNavigationItem.setLabel(LanguageUtil.get(request, "users"));
 
 navigationItems.add(entriesNavigationItem);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/paths/KaleoDesignerEditWorkflow.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/paths/KaleoDesignerEditWorkflow.path
@@ -20,7 +20,7 @@
 </tr>
 <tr>
 	<td>DETAILS_ACTIVE</td>
-	<td>//a[(@class='nav-link active') and contains(.,'Details')]</td>
+	<td>//*[(@class='nav-link active') and contains(.,'Details')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/java/com/liferay/portal/workflow/kaleo/forms/web/internal/display/context/KaleoFormsAdminDisplayContext.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/java/com/liferay/portal/workflow/kaleo/forms/web/internal/display/context/KaleoFormsAdminDisplayContext.java
@@ -258,7 +258,6 @@ public class KaleoFormsAdminDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 				navigationItem.setLabel(
 					LanguageUtil.get(
 						_kaleoFormsAdminRequestHelper.getRequest(),

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/java/com/liferay/portal/workflow/kaleo/forms/web/internal/display/context/KaleoFormsViewRecordsDisplayContext.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/java/com/liferay/portal/workflow/kaleo/forms/web/internal/display/context/KaleoFormsViewRecordsDisplayContext.java
@@ -259,7 +259,6 @@ public class KaleoFormsViewRecordsDisplayContext {
 		return NavigationItemListBuilder.add(
 			navigationItem -> {
 				navigationItem.setActive(true);
-				navigationItem.setHref(StringPool.BLANK);
 
 				ThemeDisplay themeDisplay = getThemeDisplay();
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/FormsAdminNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/FormsAdminNavigator.macro
@@ -87,11 +87,11 @@ definition {
 		var key_assetTitle = "Form";
 
 		WaitForElementPresent(
-			locator1 = "NavBar#ASSET_TITLE_LINK",
+			locator1 = "NavBar#ASSET_TITLE",
 			value1 = "Form");
 
 		AssertClick(
-			locator1 = "NavBar#ASSET_TITLE_LINK",
+			locator1 = "NavBar#ASSET_TITLE",
 			value1 = "Form");
 	}
 
@@ -133,11 +133,11 @@ definition {
 		var key_assetTitle = "Rules";
 
 		WaitForElementPresent(
-			locator1 = "NavBar#ASSET_TITLE_LINK",
+			locator1 = "NavBar#ASSET_TITLE",
 			value1 = "Rules");
 
 		AssertClick(
-			locator1 = "NavBar#ASSET_TITLE_LINK",
+			locator1 = "NavBar#ASSET_TITLE",
 			value1 = "Rules");
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
@@ -775,7 +775,7 @@
 </tr>
 <tr>
 	<td>UNSUBSCRIBE</td>
-	<td>//button[contains(.,'Unsubscribe')] | //li[contains(@class,'nav-item')]/button[contains(@class,'nav-link')]</td>
+	<td>//button[contains(.,'Unsubscribe')] | //li[contains(@class,'nav-item')]/*[contains(@class,'nav-link')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavBar.path
@@ -39,11 +39,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>ASSET_TITLE_LINK</td>
-	<td>//*[contains(@class,'nav-link')]//span[contains(text(),'${key_assetTitle}')]/../../a</td>
-	<td></td>
-</tr>
-<tr>
 	<td>CONTAINER</td>
 	<td>//div[@class='navbar ' or contains(@class,'navbar-default')]//div[contains(@class,'container')] | //div[contains(@class,'navbar-collapse')]/div[contains(@class,'container')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavBar.path
@@ -20,7 +20,7 @@
 </tr>
 <tr>
 	<td>ADDRESSES</td>
-	<td>//a[contains(@class,'nav-link') and contains(.,'Addresses')]</td>
+	<td>//*[contains(@class,'nav-link') and contains(.,'Addresses')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -30,17 +30,17 @@
 </tr>
 <tr>
 	<td>ASSET_LIBRARIES</td>
-	<td>//a[contains(@class,'nav-link')]/span[contains(.,'Asset Libraries')]</td>
+	<td>//*[contains(@class,'nav-link')]/span[contains(.,'Asset Libraries')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>ASSET_TITLE</td>
-	<td>//a[contains(@class,'nav-link') and contains(text(),'${key_assetTitle}')] | //a[.='${key_assetTitle}']</td>
+	<td>//*[contains(@class,'nav-link') and contains(text(),'${key_assetTitle}')] | //a[.='${key_assetTitle}']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>ASSET_TITLE_LINK</td>
-	<td>//a[contains(@class,'nav-link')]//span[contains(text(),'${key_assetTitle}')]/../../a</td>
+	<td>//*[contains(@class,'nav-link')]//span[contains(text(),'${key_assetTitle}')]/../../a</td>
 	<td></td>
 </tr>
 <tr>
@@ -65,7 +65,7 @@
 </tr>
 <tr>
 	<td>MY_SITES</td>
-	<td>//a[contains(@class,'nav-link')]/span[contains(.,'My Sites')]</td>
+	<td>//*[contains(@class,'nav-link')]/span[contains(.,'My Sites')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -75,7 +75,7 @@
 </tr>
 <tr>
 	<td>NAV_ITEM_REDIRECTION</td>
-	<td>//a[contains(@class,'nav-link')]/span[contains(.,'${key_navItem}')]</td>
+	<td>//*[contains(@class,'nav-link')]/span[contains(.,'${key_navItem}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/notifications/Notifications.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/notifications/Notifications.path
@@ -174,7 +174,7 @@
 <!--REQUESTS-->
 <tr>
 	<td>REQUESTS_LIST_TAB</td>
-	<td>//a[contains(@class,'nav-link') and contains(.,'${key_navLinkOption}')]</td>
+	<td>//*[contains(@class,'nav-link') and contains(.,'${key_navLinkOption}')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/SystemSettings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/SystemSettings.path
@@ -25,7 +25,7 @@
 </tr>
 <tr>
 	<td>SCOPED_CONFIGURATION_NAME</td>
-	<td>//a[contains(.,'${key_configurationScope}')]/following-sibling::div//a[contains(@class,'nav-link') and normalize-space(./text())='${key_configurationName}']</td>
+	<td>//a[contains(.,'${key_configurationScope}')]/following-sibling::div//*[contains(@class,'nav-link') and normalize-space(./text())='${key_configurationName}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/Form.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/Form.path
@@ -288,7 +288,7 @@
 </tr>
 <tr>
     <td>SIDEBAR_ELEMENT_SETS_TAB</td>
-    <td>//a[contains(@class,'nav-link') and .='Element Sets']</td>
+    <td>//*[contains(@class,'nav-link') and .='Element Sets']</td>
     <td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Based on [liferay-frontend#8](https://github.com/liferay-frontend/liferay-portal/pull/8)

--- 

This is a resend of the hydration of the `NavigationBar` component that was supposed to fix [The dropdown list of the site scope is missing in the define permission](https://issues.liferay.com/browse/LPS-115204) but [got reverted](https://github.com/brianchandotcom/liferay-portal/pull/90123) because it caused [Property 'label' is undefined when click Import button of page fragment collections
](https://issues.liferay.com/browse/LPS-115521) and in fact also [Clicking on rules tab redirects to form builder](https://issues.liferay.com/browse/LPS-115498)

This PR aims to bring back the fix without introducing the other regressions 🤞 

Based on this [comment](https://github.com/wincent/liferay-portal/pull/356/commits/585b85c1a0893e4b572ef002f152f687fc7688f7#r440372317)

> When ClayLink renders the a element, React won't insert an empty href attribute in the DOM. At least, if href is undefined (in contrast, if it is an empty string, it will):

I've taken the liberty to push a couple of additional commits to make sure we don't set `StringPool.BLANK` as the default value in `NavigationItem` objects so values are more explicit and easier to reason with. We can drop those if they cause any trouble.

Additionally... there's the question about what to do if `navigationItems` are not passed to the component... I thought about just no rendering anything from the backend if no items were passed... or simply not render anything from React... but it feels like making a very strong assumption about what the user wants, so I've tabled that for further discussion and simply [stopped rendering clay:navigation-bar when unneeeded](https://github.com/liferay-frontend/liferay-portal/pull/8/commits/679406323fada79d2a2ba03e0f477fc812761e4e).