### PR TITLE
LPS-113561 LPS-113561 Avoid use of Liferay.provide in dynamic-data-lists-web

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -259,27 +259,33 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 </aui:script>
 
 <aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />selectRecordSet',
-		function (recordSetId, recordSetName) {
-			var A = AUI();
+	window['<portlet:namespace />selectRecordSet'] = function (
+		recordSetId,
+		recordSetName
+	) {
+		document.<portlet:namespace />fm.<portlet:namespace />recordSetId.value = recordSetId;
 
-			document.<portlet:namespace />fm.<portlet:namespace />recordSetId.value = recordSetId;
+		var displayingRecordSetIdHolder = document.querySelector(
+			'.displaying-record-set-id-holder'
+		);
+		displayingRecordSetIdHolder.classList.remove('hide');
+		displayingRecordSetIdHolder.removeAttribute('hidden');
+		displayingRecordSetIdHolder.style.display = '';
 
-			A.one('.displaying-record-set-id-holder').show();
-			A.one('.displaying-help-message-holder').hide();
+		var displayingHelpMessageHolder = document.querySelector(
+			'.displaying-help-message-holder'
+		);
+		displayingHelpMessageHolder.classList.add('hide');
+		displayingHelpMessageHolder.setAttribute('hidden', 'hidden');
+		displayingHelpMessageHolder.style.display = 'none';
 
-			var displayRecordSetId = A.one('.displaying-record-set-id');
-
-			displayRecordSetId.set(
-				'innerHTML',
-				recordSetName + ' (<liferay-ui:message key="modified" />)'
-			);
-			displayRecordSetId.addClass('modified');
-		},
-		['aui-base']
-	);
+		var displayRecordSetId = document.querySelector(
+			'.displaying-record-set-id'
+		);
+		displayRecordSetId.innerHTML =
+			recordSetName + ' (<liferay-ui:message key="modified" />)';
+		displayRecordSetId.classList.add('modified');
+	};
 </aui:script>
 
 <%!

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
@@ -48,78 +48,118 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 </div>
 
 <aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />exportRecordSet',
-		function (url) {
-			var A = AUI();
+	window['<portlet:namespace />exportRecordSet'] = function (url) {
+		var form = document.createElement('form');
+		form.setAttribute('id', '<portlet:namespace />exportForm');
 
-			var form = A.Node.create('<form />');
+		var content = document.getElementById('<portlet:namespace />exportList');
 
-			form.attr('method', 'POST');
+		if (content) {
+			form.appendChild(content);
 
-			var content = A.one('#<portlet:namespace />exportList');
+			content.classList.remove('hide');
+			content.removeAttribute('hidden');
+			content.style.display = '';
+		}
 
-			var fileExtensionSelect = A.one('#<portlet:namespace />fileExtension');
+		function showCSVWarning() {
+			var csvWarning = document.getElementById(
+				'<portlet:namespace />csvWarning'
+			);
 
-			var showCSVWarning = function () {
-				var csvWarning = A.one('#<portlet:namespace />csvWarning');
+			if (fileExtensionSelect.value === 'csv' && <%= showCSVWarning %>) {
+				csvWarning.classList.remove('hide');
+				csvWarning.removeAttribute('hidden');
+				csvWarning.style.display = '';
+			}
+			else {
+				csvWarning.classList.add('hide');
+				csvWarning.setAttribute('hidden', 'hidden');
+				csvWarning.style.display = 'none';
+			}
+		}
 
-				if (fileExtensionSelect.val() === 'csv' && <%= showCSVWarning %>) {
-					csvWarning.show();
-				}
-				else {
-					csvWarning.hide();
-				}
-			};
+		function handleClose() {
+			content.classList.add('hide');
+			content.setAttribute('hidden', 'hidden');
+			content.style.display = 'none';
 
-			if (content) {
+			document.body.appendChild(content);
+		}
+
+		Liferay.Util.openModal({
+			bodyHTML: form.outerHTML,
+			buttons: [
+				{
+					displayType: 'secondary',
+					label: '<liferay-ui:message key="cancel" />',
+					type: 'cancel',
+				},
+				{
+					label: '<liferay-ui:message key="ok" />',
+					onClick: function () {
+						var filename;
+						var formData = new FormData();
+						formData.append(
+							fileExtensionSelect.getAttribute('id'),
+							fileExtensionSelect.value
+						);
+
+						Liferay.Util.fetch(url, {body: formData, method: 'POST'})
+							.then(function (response) {
+								var filenamePattern = /filename=\"(.*)\"/;
+								var match = filenamePattern.exec(
+									response.headers.get('content-disposition')
+								);
+								if (match) {
+									filename = match[1];
+								}
+								return response.blob();
+							})
+							.then(function (blob) {
+								var link = document.createElement('a');
+								link.setAttribute(
+									'href',
+									URL.createObjectURL(blob)
+								);
+								if (filename) {
+									link.setAttribute('download', filename);
+								}
+								link.click();
+
+								Liferay.fire('closeModal');
+							})
+							.catch(function (error) {
+								Liferay.Util.openToast({
+									message: Liferay.Language.get(
+										'an-unexpected-system-error-occurred'
+									),
+									title: Liferay.Language.get('error'),
+									type: 'danger',
+								});
+							});
+					},
+					type: 'submit',
+				},
+			],
+			iframeBodyCssClass: 'ddl-record-set-export-modal',
+			onClose: handleClose,
+			onOpen: function () {
+				content = document.getElementById(
+					'<portlet:namespace />exportList'
+				);
+
+				fileExtensionSelect = document.getElementById(
+					'<portlet:namespace />fileExtension'
+				);
+
 				if (fileExtensionSelect) {
 					showCSVWarning();
 
-					fileExtensionSelect.on('change', showCSVWarning);
+					fileExtensionSelect.addEventListener('change', showCSVWarning);
 				}
-
-				form.append(content);
-
-				content.show();
-			}
-
-			var dialog = Liferay.Util.Window.getWindow({
-				dialog: {
-					bodyContent: form,
-					cssClass: 'ddl-record-set-export-modal',
-					resizable: false,
-					toolbars: {
-						footer: [
-							{
-								cssClass: 'btn-secondary',
-								label: '<liferay-ui:message key="cancel" />',
-								on: {
-									click: function () {
-										dialog.hide();
-									},
-								},
-							},
-							{
-								cssClass: 'btn-primary',
-								label: '<liferay-ui:message key="ok" />',
-								on: {
-									click: function () {
-										submitForm(form, url, false);
-
-										dialog.hide();
-									},
-								},
-								primary: true,
-							},
-						],
-					},
-					width: 600,
-				},
-				title: '<%= UnicodeLanguageUtil.get(request, "export") %>',
-			});
-		},
-		['aui-alert', 'liferay-util-window']
-	);
+			},
+			title: '<%= UnicodeLanguageUtil.get(request, "export") %>',
+		});
+	};
 </aui:script>


### PR DESCRIPTION
Originally:

- https://github.com/wincent/liferay-portal/pull/339
- https://github.com/liferay-frontend/liferay-portal/pull/12

CI was flaky on that last one ([QA confirmed failures were not related](https://github.com/liferay-frontend/liferay-portal/pull/12#issuecomment-645627717)), so trying again here; that gives us an opportunity to squash the messy history anyway.

cc @julien 

Previous description follows:

---

As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561), we eventually want to deprecate the `Liferay.provide` function.

In this change, we avoid declaring the `<portlet:namespace />selectRecordSet` function as a global on the `window` object, and also remove the `<portlet:namespace />` prefix from the `selectRecordSet` function.

To test this change:

- Navigate to "Content And Data > Dynamic Data Lists"
- Click on the "+" button to create a new Dynamic Data List
- Enter a name for your list
- Click the "Select" button underneath the "Data Definition" input field
- In the modal window that appears, click on "Contacts"
- Click on the "Save" button
- Navigate to "Site Builder > Pages"
- Click on the "+" button to create a new page
- Select the "Blank" template from "Basic Templates"
- Enter a name for your page (for example Page)
- Drag and drop the "Dynamic Data Lists Display" widget on the page
- Click the kebab menu on the right side of the "Dynamic Data Lists Display" widget
- Click on "Configuration"
- In the modal window that appears, click on the Dynamic Data List's name created previously
- Click on the "Save" button

As a result, a success notification should be displayed confirming you have successfully updated the widget's configuration, and no JS errors should appear in the browser's console.