### PR TITLE
LPS-115075 Update modal usages in asset modules

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
@@ -137,33 +137,26 @@ PortletURL portletURL = editAssetListDisplayContext.getPortletURL();
 		selectManageableGroupIcon.addEventListener('click', function (event) {
 			event.preventDefault();
 
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						destroyOnHide: true,
-					},
-					eventName:
-						'<%= editAssetListDisplayContext.getSelectGroupEventName() %>',
-					id:
-						'<%= editAssetListDisplayContext.getSelectGroupEventName() %>',
-					title: '<liferay-ui:message key="scopes" />',
-					uri:
-						'<%= editAssetListDisplayContext.getGroupItemSelectorURL() %>',
-				},
-				function (event) {
-					var entityId = event.groupid;
+			Liferay.Util.openModal({
+				id: '<%= editAssetListDisplayContext.getSelectGroupEventName() %>',
+				onSelect: function (selectedItem) {
+					var entityId = selectedItem.groupid;
 
 					var searchContainerData = searchContainer.getData();
 
 					if (searchContainerData.indexOf(entityId) == -1) {
 						<portlet:namespace />addRow(
 							entityId,
-							event.groupdescriptivename,
-							event.groupscopelabel
+							selectedItem.groupdescriptivename,
+							selectedItem.groupscopelabel
 						);
 					}
-				}
-			);
+				},
+				selectEventName:
+					'<%= editAssetListDisplayContext.getSelectGroupEventName() %>',
+				title: '<liferay-ui:message key="scopes" />',
+				url: '<%= editAssetListDisplayContext.getGroupItemSelectorURL() %>',
+			});
 		});
 	}
 

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -550,46 +550,40 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 
 		var btn = delegateTarget.querySelector('.btn');
 
-		var uri = btn.dataset.href;
+		var url = btn.dataset.href;
 
-		uri = Util.addParams(
+		url = Util.addParams(
 			'<portlet:namespace />ddmStructureDisplayFieldValue=' +
 				encodeURIComponent(ddmStructureDisplayFieldValueInput.value),
-			uri
+			url
 		);
-		uri = Util.addParams(
+		url = Util.addParams(
 			'<portlet:namespace />ddmStructureFieldName=' +
 				encodeURIComponent(ddmStructureFieldNameInput.value),
-			uri
+			url
 		);
-		uri = Util.addParams(
+		url = Util.addParams(
 			'<portlet:namespace />ddmStructureFieldValue=' +
 				encodeURIComponent(ddmStructureFieldValueInput.value),
-			uri
+			url
 		);
 
-		Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					modal: true,
-				},
-				eventName: '<portlet:namespace />selectDDMStructureField',
-				id: '<portlet:namespace />selectDDMStructure' + delegateTarget.id,
-				title:
-					'<liferay-ui:message arguments="structure-field" key="select-x" />',
-				uri: uri,
-			},
-			function (event) {
+		Util.openModal({
+			id: '<portlet:namespace />selectDDMStructure' + delegateTarget.id,
+			onSelect: function (selectedItem) {
 				setDDMFields(
-					event.className,
-					event.name,
-					event.value,
-					event.displayValue,
-					event.label + ': ' + event.displayValue
+					selectedItem.className,
+					selectedItem.name,
+					selectedItem.value,
+					selectedItem.displayValue,
+					selectedItem.label + ': ' + selectedItem.displayValue
 				);
-			}
-		);
+			},
+			selectEventName: '<portlet:namespace />selectDDMStructureField',
+			title:
+				'<liferay-ui:message arguments="structure-field" key="select-x" />',
+			url: url,
+		});
 	});
 
 	function setDDMFields(className, name, value, displayValue, message) {

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -151,26 +151,20 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 	</portlet:actionURL>
 
 	function <portlet:namespace />openSelectSegmentsEntryDialog() {
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					modal: true,
-				},
-				id: '<portlet:namespace />selectEntity',
-				title:
-					'<liferay-ui:message arguments="personalized-variation" key="new-x" />',
-				uri:
-					'<%= editAssetListDisplayContext.getSelectSegmentsEntryURL() %>',
-			},
-			function (event) {
+		Liferay.Util.openModal({
+			id: '<portlet:namespace />selectEntity',
+			onSelect: function (selectedItem) {
 				Liferay.Util.postForm(document.<portlet:namespace />fm, {
 					data: {
-						segmentsEntryId: event.entityid,
+						segmentsEntryId: selectedItem.entityid,
 					},
 					url: '<%= addAssetListEntryVariationURL %>',
 				});
-			}
-		);
+			},
+			selectEventName: '<portlet:namespace />selectEntity',
+			title:
+				'<liferay-ui:message arguments="personalized-variation" key="new-x" />',
+			url: '<%= editAssetListDisplayContext.getSelectSegmentsEntryURL() %>',
+		});
 	}
 </script>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/AssetEntryListDropdownDefaultEventHandler.es.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/AssetEntryListDropdownDefaultEventHandler.es.js
@@ -12,7 +12,11 @@
  * details.
  */
 
-import {DefaultEventHandler, openSimpleInputModal} from 'frontend-js-web';
+import {
+	DefaultEventHandler,
+	openModal,
+	openSimpleInputModal,
+} from 'frontend-js-web';
 import {Config} from 'metal-state';
 
 class AssetEntryListDropdownDefaultEventHandler extends DefaultEventHandler {
@@ -27,10 +31,10 @@ class AssetEntryListDropdownDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	permissionsAssetEntryList(itemData) {
-		this._openWindow(
-			Liferay.Language.get('permissions'),
-			itemData.permissionsAssetEntryListURL
-		);
+		openModal({
+			title: Liferay.Language.get('permissions'),
+			url: itemData.permissionsAssetEntryListURL,
+		});
 	}
 
 	renameAssetListEntry(itemData) {
@@ -45,20 +49,6 @@ class AssetEntryListDropdownDefaultEventHandler extends DefaultEventHandler {
 			mainFieldValue: itemData.assetListEntryTitle,
 			namespace: this.namespace,
 			spritemap: this.spritemap,
-		});
-	}
-
-	_openWindow(label, url) {
-		Liferay.Util.openWindow({
-			dialog: {
-				destroyOnHide: true,
-				modal: true,
-			},
-			dialogIframe: {
-				bodyCssClass: 'dialog-with-footer',
-			},
-			title: Liferay.Language.get(label),
-			uri: url,
 		});
 	}
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/scope.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/scope.jsp
@@ -158,28 +158,23 @@ itemSelectorURL.setParameter("portletResource", assetPublisherDisplayContext.get
 				searchContainerData = searchContainerData.split(',');
 			}
 
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						modal: true,
-					},
-					eventName: '<%= eventName %>',
-					id: '<%= eventName %>' + event.currentTarget.id,
-					selectedData: searchContainerData,
-					title: '<liferay-ui:message key="scopes" />',
-					uri: '<%= itemSelectorURL.toString() %>',
-				},
-				function (event) {
+			var opener = Liferay.Util.getOpener();
+
+			opener.Liferay.Util.openModal({
+				id: '<%= eventName %>' + event.currentTarget.id,
+				onSelect: function (event) {
 					Liferay.Util.postForm(form, {
 						data: {
 							cmd: 'add-scope',
 							groupId: event.groupid,
 						},
 					});
-				}
-			);
+				},
+				selectEventName: '<%= eventName %>',
+				selectedData: searchContainerData,
+				title: '<liferay-ui:message key="scopes" />',
+				url: '<%= itemSelectorURL.toString() %>',
+			});
 		});
 	}
 </aui:script>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -545,46 +545,40 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 
 		var btn = delegateTarget.querySelector('.btn');
 
-		var uri = btn.dataset.href;
+		var url = btn.dataset.href;
 
-		uri = Util.addParams(
+		url = Util.addParams(
 			'_<%= HtmlUtil.escapeJS(assetPublisherDisplayContext.getPortletResource()) %>_ddmStructureDisplayFieldValue=' +
 				encodeURIComponent(ddmStructureDisplayFieldValueInput.value),
-			uri
+			url
 		);
-		uri = Util.addParams(
+		url = Util.addParams(
 			'_<%= HtmlUtil.escapeJS(assetPublisherDisplayContext.getPortletResource()) %>_ddmStructureFieldName=' +
 				encodeURIComponent(ddmStructureFieldNameInput.value),
-			uri
+			url
 		);
-		uri = Util.addParams(
+		url = Util.addParams(
 			'_<%= HtmlUtil.escapeJS(assetPublisherDisplayContext.getPortletResource()) %>_ddmStructureFieldValue=' +
 				encodeURIComponent(ddmStructureFieldValueInput.value),
-			uri
+			url
 		);
 
-		Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					modal: true,
-				},
-				eventName: '<portlet:namespace />selectDDMStructureField',
-				id: '<portlet:namespace />selectDDMStructure' + delegateTarget.id,
-				title:
-					'<liferay-ui:message arguments="structure-field" key="select-x" />',
-				uri: uri,
-			},
-			function (event) {
+		Util.openModal({
+			id: '<portlet:namespace />selectDDMStructure' + delegateTarget.id,
+			onSelect: function (selectedItem) {
 				setDDMFields(
-					event.className,
-					event.name,
-					event.value,
-					event.displayValue,
-					event.label + ': ' + event.displayValue
+					selectedItem.className,
+					selectedItem.name,
+					selectedItem.value,
+					selectedItem.displayValue,
+					selectedItem.label + ': ' + selectedItem.displayValue
 				);
-			}
-		);
+			},
+			selectEventName: '<portlet:namespace />selectDDMStructureField',
+			title:
+				'<liferay-ui:message arguments="structure-field" key="select-x" />',
+			url: url,
+		});
 	});
 
 	function setDDMFields(className, name, value, displayValue, message) {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/com/liferay/asset/publisher/web/portlet/template/dependencies/portlet_display_template_rich_summary.ftl
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/com/liferay/asset/publisher/web/portlet/template/dependencies/portlet_display_template_rich_summary.ftl
@@ -162,7 +162,7 @@
 			icon="print"
 			markupView="lexicon"
 			message="print"
-			url="javascript:Liferay.Util.openWindow({id:'" + renderResponse.getNamespace() + "printAsset', title: '" + languageUtil.format(locale, "print-x-x", ["hide-accessible", entryTitle], false) + "', uri: '" + htmlUtil.escapeURL(printURL.toString()) + "'});"
+			url="javascript:Liferay.Util.openModal({headerHTML: '" + languageUtil.format(locale, "print-x-x", ["hide-accessible", entryTitle], false) + "', id:'" + renderResponse.getNamespace() + "printAsset', url: '" + htmlUtil.escapeURL(printURL.toString()) + "'});"
 		/>
 	</#if>
 </#macro>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_add_button/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_add_button/page.jsp
@@ -96,7 +96,7 @@ private String _getURL(long groupId, long plid, PortletURL addPortletURL, String
 	String addPortletURLString = assetHelper.getAddURLPopUp(groupId, plid, addPortletURL, addDisplayPageParameter, layout);
 
 	if (useDialog) {
-		return "javascript:Liferay.Util.openWindow({dialog: {destroyOnHide: true}, dialogIframe: {bodyCssClass: 'dialog-with-footer'}, id: '" + portletResponse.getNamespace() + "editAsset', title: '" + HtmlUtil.escapeJS(LanguageUtil.format((HttpServletRequest) pageContext.getRequest(), "new-x", HtmlUtil.escape(message), false)) + "', uri: '" + HtmlUtil.escapeJS(addPortletURLString) + "'});";
+		return "javascript:Liferay.Util.openModal({headerHTML: '" + HtmlUtil.escapeJS(LanguageUtil.format((HttpServletRequest)pageContext.getRequest(), "new-x", HtmlUtil.escape(message), false)) + "', id: '" + portletResponse.getNamespace() + "editAsset', url: '" + HtmlUtil.escapeJS(addPortletURLString) + "'});";
 	}
 
 	return addPortletURLString;

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/page.jsp
@@ -82,16 +82,10 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 			function (event) {
 				var delegateTarget = event.delegateTarget;
 
-				Liferay.Util.openWindow({
-					dialog: {
-						destroyOnHide: true,
-						modal: true,
-					},
-					dialogIframe: {
-						bodyCssClass: 'dialog-with-footer article-preview',
-					},
+				Liferay.Util.openModal({
+					iframeBodyCssClass: 'article-preview',
 					title: '<liferay-ui:message key="preview" />',
-					uri: delegateTarget.getAttribute('data-href'),
+					url: delegateTarget.getAttribute('data-href'),
 				});
 			}
 		);

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
@@ -132,15 +132,9 @@
 
 	if (previewDefaultDisplayPageButton) {
 		previewDefaultDisplayPageButton.addEventListener('click', function (event) {
-			Liferay.Util.openWindow({
-				dialog: {
-					destroyOnHide: true,
-				},
-				dialogIframe: {
-					bodyCssClass: 'dialog-with-footer',
-				},
+			Liferay.Util.openModal({
 				title: '<liferay-ui:message key="preview" />',
-				uri:
+				url:
 					'<%= selectAssetDisplayPageDisplayContext.getURLViewInContext() %>',
 			});
 		});
@@ -150,15 +144,9 @@
 		previewSpecificDisplayPageButton.addEventListener('click', function (
 			event
 		) {
-			Liferay.Util.openWindow({
-				dialog: {
-					destroyOnHide: true,
-				},
-				dialogIframe: {
-					bodyCssClass: 'dialog-with-footer',
-				},
+			Liferay.Util.openModal({
 				title: '<liferay-ui:message key="preview" />',
-				uri:
+				url:
 					'<%= selectAssetDisplayPageDisplayContext.getURLViewInContext() %>',
 			});
 		});


### PR DESCRIPTION
In this PR, we are updating modals in asset modules. I think this is the first update PR where we don't need to extend `openModal` API :open_mouth: 

Usage Tests:
1. Asset Publisher app > Configuration > Setup > Scope > Select > Other Site or Asset Library...
- modal in modal
---
1. Asset Publisher app > Configuration > Setup > Source > Set Asset Type 'Document'
1. Set Document Type 'Google Drive Shortcut'
1. Flip 'Filter by Field' to 'Yes'
1. Select a field
---
1. Asset Publisher app > Configuration > Setup > Display Settings > Display Template > Choose 'Rich Summary'
1. Check 'Print'
1. Save & close
1. Publish page
1. Asset item > Click on printer icon on the right
- This looks a bit broken in master, in this PR we don't increase brokenness
---
1. Site > Content & Data > Collections > (+) > Add a Dynamic Selection Collection
1. Scope > Select > Other Site or Asset Library...
---
1. Site > Content & Data > Collections > Dynamic Selection item > Edit
1. Source > Set Asset Type 'Document'
1. Set Document Type 'Google Drive Shortcut'
1. Flip 'Filter by Field' to 'Yes'
1. Select a field
---
1. Site > Content & Data > Collection item > Permissions
---
1. Site > People > Segments > (+) > Create a new segment
1. Site > Content & Data > Collections > New Personalized Variation
---
1. Site > Site Builder > Page Templates > (+) > Create a page template
1. Site > Site Builder > Page Templates > Display Page Templates > (+) > Create a display page template
1. Display page template options > Mark As Default 
1. Site > Content & Data > Web Content item > Edit
1. Display Page Template > Default Display Page Template > Eye Icon
---
1. The same as above, except last step Display Page Template > Specific Display Page Template > Eye Icon
- I don't know why this icon does not show, I manually added it, by hacking [this condition](https://github.com/liferay/liferay-portal/blob/288a2a276f51e85ac153d3403267c870aa2cfa42/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp#L61) to `<c:if test="<%= true %>">`. This may be an unrelated bug in master.
---
1. Modal in asset_add_button/page.jsp is not used anywhere. It is in <liferay-asset:asset-add-button> and its only use has `useDialog="<%= false %>"`
---
1. Modal in asset_view_usages/page.jsp is not used anywhere. It is in <liferay-asset:asset-view-usages>, a deprecated and replaced tag. I still updated it, so it doesn't show up in searches.