### PR TITLE
LPS-115680 - Add clay CSS components

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/clay/_components.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/clay/_components.scss
@@ -10,6 +10,7 @@
 @import 'components/_breadcrumbs';
 @import 'components/_button-groups';
 @import 'components/_buttons';
+@import 'components/_empty-state';
 @import 'components/_labels';
 @import 'components/_stickers';
 
@@ -21,12 +22,14 @@
 @import 'components/_links';
 
 @import 'components/_range';
+@import 'components/_reorder';
 
 @import 'components/_clay-color';
 @import 'components/_custom-forms';
 @import 'components/_time';
 
 @import 'components/_date-picker';
+@import 'components/_dual-listbox';
 @import 'components/_form-validation';
 @import 'components/_icons';
 @import 'components/_input-groups';
@@ -51,6 +54,7 @@
 @import 'components/_sheets';
 @import 'components/_side-navigation';
 @import 'components/_sidebar';
+@import 'components/_slideout';
 @import 'components/_tables';
 @import 'components/_tbar';
 @import 'components/_timelines';

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/clay/_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/clay/_variables.scss
@@ -7,6 +7,7 @@
 @import 'variables/_badges';
 @import 'variables/_breadcrumbs';
 @import 'variables/_buttons';
+@import 'variables/_empty-state';
 @import 'variables/_labels';
 @import 'variables/_stickers';
 
@@ -18,12 +19,14 @@
 @import 'variables/_links';
 
 @import 'variables/_range';
+@import 'variables/_reorder';
 
 @import 'variables/_clay-color';
 @import 'variables/_custom-forms';
 @import 'variables/_time';
 
 @import 'variables/_date-picker';
+@import 'variables/_dual-listbox';
 @import 'variables/_list-group';
 @import 'variables/_loaders';
 @import 'variables/_modals';
@@ -46,6 +49,7 @@
 @import 'variables/_sheets';
 @import 'variables/_side-navigation';
 @import 'variables/_sidebar';
+@import 'variables/_slideout';
 @import 'variables/_tables';
 @import 'variables/_tbar';
 @import 'variables/_timelines';

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/clay/atlas/_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/clay/atlas/_variables.scss
@@ -17,6 +17,7 @@
 @import 'variables/_links';
 
 @import 'variables/_range';
+@import 'variables/_reorder';
 
 @import 'variables/_clay-color';
 @import 'variables/_custom-forms';


### PR DESCRIPTION
Updated files as a reflection of original ones:

https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/_variables.scss
https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/atlas/_variables.scss

Main bug related to empty state fixed:


![image](https://user-images.githubusercontent.com/7963804/85110749-a4f71380-b213-11ea-825d-01d6cdeaeb07.png)
(markup testing in-home page)