### PR TITLE
LPS-115798 Escape html string from JSP before passing to the `message` property on openToast

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -87,7 +87,11 @@ function openToast({
 				autoClose={TOAST_AUTO_CLOSE_INTERVAL}
 				displayType={type}
 				onClick={(event) => onClick({event, onClose})}
-				onClose={onClose}
+				onClose={(event) => {
+					onClose(event);
+
+					Liferay.fire('toastClosed', {...event, renderData});
+				}}
 				title={
 					<Text allowHTML={titleType === TYPES.HTML} string={title} />
 				}

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -848,7 +848,8 @@ public class PortalImpl implements Portal {
 
 		PortalMessages.add(
 			httpServletRequest, PortalMessages.KEY_ANIMATION, false);
-		PortalMessages.add(httpServletRequest, PortalMessages.KEY_DISPLAY_TYPE, "info");
+		PortalMessages.add(
+			httpServletRequest, PortalMessages.KEY_DISPLAY_TYPE, "info");
 		PortalMessages.add(
 			httpServletRequest, PortalMessages.KEY_JSP_PATH,
 			"/html/common/themes/user_locale_options.jsp");

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -848,6 +848,7 @@ public class PortalImpl implements Portal {
 
 		PortalMessages.add(
 			httpServletRequest, PortalMessages.KEY_ANIMATION, false);
+		PortalMessages.add(httpServletRequest, PortalMessages.KEY_DISPLAY_TYPE, "info");
 		PortalMessages.add(
 			httpServletRequest, PortalMessages.KEY_JSP_PATH,
 			"/html/common/themes/user_locale_options.jsp");

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -849,8 +849,6 @@ public class PortalImpl implements Portal {
 		PortalMessages.add(
 			httpServletRequest, PortalMessages.KEY_ANIMATION, false);
 		PortalMessages.add(
-			httpServletRequest, PortalMessages.KEY_DISPLAY_TYPE, "info");
-		PortalMessages.add(
 			httpServletRequest, PortalMessages.KEY_JSP_PATH,
 			"/html/common/themes/user_locale_options.jsp");
 		PortalMessages.add(httpServletRequest, PortalMessages.KEY_TIMEOUT, -1);

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java
@@ -40,6 +40,8 @@ public class PortalMessages {
 
 	public static final String KEY_CSS_CLASS = "cssClass";
 
+	public static final String KEY_DISPLAY_TYPE = "displayType";
+
 	public static final String KEY_JSP_PATH = "jspPath";
 
 	public static final String KEY_MESSAGE = "message";
@@ -47,6 +49,7 @@ public class PortalMessages {
 	public static final String KEY_PORTLET_ID = "portletId";
 
 	public static final String KEY_TIMEOUT = "timeout";
+
 
 	public static void add(
 		HttpServletRequest httpServletRequest, Class<?> clazz) {

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java
@@ -50,7 +50,6 @@ public class PortalMessages {
 
 	public static final String KEY_TIMEOUT = "timeout";
 
-
 	public static void add(
 		HttpServletRequest httpServletRequest, Class<?> clazz) {
 

--- a/portal-web/docroot/html/common/themes/top_messages.jsp
+++ b/portal-web/docroot/html/common/themes/top_messages.jsp
@@ -32,17 +32,22 @@ if (Validator.isNotNull(jspPath) || Validator.isNotNull(message)) {
 	int timeout = GetterUtil.getInteger(PortalMessages.get(request, PortalMessages.KEY_TIMEOUT), 10000);
 %>
 
+	<liferay-util:buffer
+		var="alertMessage"
+	>
+		<c:choose>
+			<c:when test="<%= Validator.isNotNull(jspPath) %>">
+				<liferay-util:include page="<%= jspPath %>" portletId="<%= portletId %>" />
+			</c:when>
+			<c:otherwise>
+				<liferay-ui:message key="<%= message %>" />
+			</c:otherwise>
+		</c:choose>
+	</liferay-util:buffer>
+
 	<aui:script>
 		Liferay.Util.openToast({
-			message: "
-				<c:choose>
-					<c:when test="<%= Validator.isNotNull(jspPath) %>">
-						<liferay-util:include page="<%= jspPath %>" portletId="<%= portletId %>" />
-					</c:when>
-					<c:otherwise>
-						<liferay-ui:message key="<%= message %>" />
-					</c:otherwise>
-				</c:choose>",
+			message: '<%= HtmlUtil.escapeJS(alertMessage) %>',
 			messageType: 'html',
 			renderData: {
 				portletId: <%= portletId %>

--- a/portal-web/docroot/html/common/themes/top_messages.jsp
+++ b/portal-web/docroot/html/common/themes/top_messages.jsp
@@ -28,6 +28,7 @@ String message = (String)PortalMessages.get(request, PortalMessages.KEY_MESSAGE)
 
 if (Validator.isNotNull(jspPath) || Validator.isNotNull(message)) {
 	String cssClass = GetterUtil.getString(PortalMessages.get(request, PortalMessages.KEY_CSS_CLASS), "alert-info");
+	String displayType = GetterUtil.getString(PortalMessages.get(request, PortalMessages.KEY_DISPLAY_TYPE), "success");
 	String portletId = (String)PortalMessages.get(request, PortalMessages.KEY_PORTLET_ID);
 	int timeout = GetterUtil.getInteger(PortalMessages.get(request, PortalMessages.KEY_TIMEOUT), 10000);
 %>
@@ -57,8 +58,8 @@ if (Validator.isNotNull(jspPath) || Validator.isNotNull(message)) {
 			toastProps: {
 				autoClose: <%= timeout %>,
 				className: '<%= cssClass %>',
-				style: {top: 0},
-			}
+			},
+			type: '<%= displayType %>'
 		});
 	</aui:script>
 

--- a/portal-web/docroot/html/common/themes/top_messages.jsp
+++ b/portal-web/docroot/html/common/themes/top_messages.jsp
@@ -50,7 +50,8 @@ if (Validator.isNotNull(jspPath) || Validator.isNotNull(message)) {
 			message: '<%= HtmlUtil.escapeJS(alertMessage) %>',
 			messageType: 'html',
 			renderData: {
-				portletId: <%= portletId %>
+				portletId: '<%= portletId %>',
+				jspPath: '<%= jspPath %>',
 			},
 			title: null,
 			toastProps: {

--- a/portal-web/docroot/html/common/themes/top_messages.jsp
+++ b/portal-web/docroot/html/common/themes/top_messages.jsp
@@ -56,7 +56,7 @@ if (Validator.isNotNull(jspPath) || Validator.isNotNull(message)) {
 			},
 			title: null,
 			toastProps: {
-				autoClose: <%= timeout %>,
+				autoClose: <%= timeout %> !== -1 ? <%= timeout %> : null,
 				className: '<%= cssClass %>',
 			},
 			type: '<%= displayType %>'

--- a/portal-web/docroot/html/common/themes/top_messages.jsp
+++ b/portal-web/docroot/html/common/themes/top_messages.jsp
@@ -27,8 +27,8 @@ String jspPath = (String)PortalMessages.get(request, PortalMessages.KEY_JSP_PATH
 String message = (String)PortalMessages.get(request, PortalMessages.KEY_MESSAGE);
 
 if (Validator.isNotNull(jspPath) || Validator.isNotNull(message)) {
-	String cssClass = GetterUtil.getString(PortalMessages.get(request, PortalMessages.KEY_CSS_CLASS), "alert-info");
-	String displayType = GetterUtil.getString(PortalMessages.get(request, PortalMessages.KEY_DISPLAY_TYPE), "success");
+	String cssClass = GetterUtil.getString(PortalMessages.get(request, PortalMessages.KEY_CSS_CLASS), "");
+	String displayType = GetterUtil.getString(PortalMessages.get(request, PortalMessages.KEY_DISPLAY_TYPE), "info");
 	String portletId = (String)PortalMessages.get(request, PortalMessages.KEY_PORTLET_ID);
 	int timeout = GetterUtil.getInteger(PortalMessages.get(request, PortalMessages.KEY_TIMEOUT), 10000);
 %>

--- a/portal-web/docroot/html/common/themes/user_locale_options.jsp
+++ b/portal-web/docroot/html/common/themes/user_locale_options.jsp
@@ -28,8 +28,6 @@ String currentURL = PortalUtil.getCurrentURL(request);
 
 	<div dir="<%= LanguageUtil.get(userLocale, "lang.dir") %>">
 		<div class="d-block">
-			<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" id="ignoreUserLocaleOptions" type="button">&times;</button>
-
 			<%= LanguageUtil.format(userLocale, "this-page-is-displayed-in-x", locale.getDisplayName(userLocale)) %>
 		</div>
 
@@ -47,14 +45,11 @@ String currentURL = PortalUtil.getCurrentURL(request);
 	</div>
 
 	<aui:script use="aui-base,liferay-store">
-		var ignoreUserLocaleOptionsNode = A.one('#ignoreUserLocaleOptions');
-
-		ignoreUserLocaleOptionsNode.on(
-			'click',
-			function() {
+		Liferay.once('toastClosed', function (event) {
+			if (event.renderData && event.renderData.jspPath === '/html/common/themes/user_locale_options.jsp') {
 				Liferay.Util.Session.set('ignoreUserLocaleOptions', true);
 				Liferay.Util.Session.set('useHttpSession', true);
 			}
-		);
+		});
 	</aui:script>
 </c:if>


### PR DESCRIPTION
### Test Case:

Load a page in a different language from the default.
Like:
```
- Create a new site called Site Name with a public page called Home.
- Add an es_ES translation for Home page. eg. Casa.
- Navigate to the following url:
http://localhost:8080/es/web/site-name/home
```

### Description(Read while reading the code):

Generally I fixed a problem with escaping text before passing to `message` openToast parameter and I adjusted some code for cover all cases on these JSPs with openToast.

### What I did: 

* I noticed the HTML rendered from the `liferay-util:include` contains a lot of spaces causing an error on the browser, for solving this I wrapped the HTML string on a liferay-buffer for escaping this content for message props render this prop adequately.

* `user_locale_options.jsp` content is being imported via include taglib inside `top_message.jsp` taglib, a close button was being passed there and this button is unnecessary since it breaks with Lexicon standards and it can't call openToast callbacks because it was in a completely different context.

For solving this last point, I added an event on Liferay global event handler and for detecting when the openToast was closed. I consider this [LOC](https://github.com/liferay-frontend/liferay-portal/pull/39/files#diff-a86aa4def898981ade5704ca95af6e5eR49
) very dirty but I don't had any ideas to solve it adequately considering the limitations(rendering a html string inside a JSP which is using openToast). I would love your suggestions 💖 

Thanks!