### PR TITLE
LPS-114050 Use new Layout Tags in JSPs in ratings-taglib

### DIFF
--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -16,7 +16,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/page.jsp
@@ -35,11 +35,16 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ratings
 <c:choose>
 	<c:when test="<%= type.equals(RatingsType.LIKE.getValue()) %>">
 		<div>
-			<button class="btn btn-outline-borderless btn-outline-secondary btn-sm" disabled type="button">
-				<svg class="lexicon-icon lexicon-icon-heart">
-					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#heart" />
-				</svg>
-			</button>
+			<clay:button
+				borderless="<%= true %>"
+				disabled="<%= true %>"
+				displayType="secondary"
+				small="<%= true %>"
+			>
+				<clay:icon
+					symbol="heart"
+				/>
+			</clay:button>
 
 			<react:component
 				data="<%= data %>"
@@ -48,18 +53,29 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ratings
 		</div>
 	</c:when>
 	<c:when test="<%= type.equals(RatingsType.THUMBS.getValue()) %>">
-		<div>
-			<button class="btn btn-outline-borderless btn-outline-secondary btn-sm" disabled type="button">
-				<svg class="lexicon-icon lexicon-icon-thumbs-up">
-					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#thumbs-up" />
-				</svg>
-			</button>
+		<div class="rating">
+			<clay:button
+				borderless="<%= true %>"
+				disabled="<%= true %>"
+				displayType="secondary"
+				small="<%= true %>"
+			>
+				<clay:icon
+					symbol="thumbs-up"
+				/>
+			</clay:button>
 
-			<button class="btn btn-outline-borderless btn-outline-secondary btn-sm" disabled type="button">
-				<svg class="lexicon-icon lexicon-icon-thumbs-down">
-					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#thumbs-down" />
-				</svg>
-			</button>
+			<clay:button
+				borderless="<%= true %>"
+				disabled="<%= true %>"
+				displayType="secondary"
+				icon="thumbs-down"
+				small="<%= true %>"
+			>
+				<clay:icon
+					symbol="thumbs-down"
+				/>
+			</clay:button>
 
 			<react:component
 				data="<%= data %>"
@@ -69,25 +85,35 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ratings
 	</c:when>
 	<c:when test="<%= type.equals(RatingsType.STARS.getValue()) %>">
 		<div>
-			<div class="autofit-row autofit-row-center ratings ratings-stars">
-				<div class="autofit-col">
+			<clay:content-row
+				cssClass="ratings ratings-stars"
+				verticalAlign="center"
+			>
+				<clay:content-col>
 					<div class="dropdown">
-						<button class="btn btn-outline-borderless btn-outline-secondary dropdown-toggle btn-sm" disabled type="button">
-							<svg class="lexicon-icon lexicon-icon-star-o">
-								<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#star-o" />
-							</svg>
+						<clay:button
+							borderless="<%= true %>"
+							cssClass="dropdown-toggle"
+							disabled="<%= true %>"
+							displayType="secondary"
+							small="<%= true %>"
+						>
+							<clay:icon
+								symbol="star-o"
+							/>
 
 							<span>-</span>
-						</button>
+						</clay:button>
 					</div>
-				</div>
+				</clay:content-col>
 
-				<div class="autofit-col">
-					<svg class="lexicon-icon lexicon-icon-star ratings-stars-average-icon">
-						<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#star" />
-					</svg>
-				</div>
-			</div>
+				<clay:content-col>
+					<clay:icon
+						cssClass="ratings-stars-average-icon"
+						symbol="star"
+					/>
+				</clay:content-col>
+			</clay:content-row>
 
 			<react:component
 				data="<%= data %>"


### PR DESCRIPTION
This PR just replaces current raw html markup with proper `clay:*` tags.

See below screenshots of the different display types available through the `ratings` tag:

### Thumbs
<img width="182" alt="Screen Shot 2020-06-22 at 12 49 36" src="https://user-images.githubusercontent.com/905006/85280025-aa5c9400-b487-11ea-9964-eedbdfa5342f.png">

### Stars
<img width="303" alt="Screen Shot 2020-06-22 at 12 52 28" src="https://user-images.githubusercontent.com/905006/85280041-af214800-b487-11ea-8d94-becf2ffa0fd8.png">

### Stacked Stars
<img width="192" alt="Screen Shot 2020-06-22 at 12 53 14" src="https://user-images.githubusercontent.com/905006/85280045-b0eb0b80-b487-11ea-86ea-83a5246e5dd5.png">

Not sure if the `(1 Vote)` misalignment is also present in `master`... will check later.

**Edit:** The component looks the same currently in `master` (unless my test was wrong), so team Lima can take that for the future if they wish.

### Like
<img width="97" alt="Screen Shot 2020-06-22 at 12 53 39" src="https://user-images.githubusercontent.com/905006/85280075-b9434680-b487-11ea-91e5-8b73f50bdb26.png">
