### PR TITLE
LPS-115675 Input Localized: on default language change move the flag element to the first place

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -230,6 +230,25 @@ AUI.add(
 					return '#' + namespace + id + '_' + languageId;
 				},
 
+				_moveDefaultLanguageFlagToFirstPosition(defaultLanguageId) {
+					var instance = this;
+
+					var flags = instance._flags.getDOMNode();
+
+					var languageNode = flags.querySelector(
+						'[data-languageid="' + defaultLanguageId + '"]'
+					)?.parentElement;
+
+					if (languageNode) {
+						flags.removeChild(languageNode);
+
+						flags.insertBefore(
+							languageNode,
+							flags.firstElementChild
+						);
+					}
+				},
+
 				_onDefaultLocaleChanged(event) {
 					var instance = this;
 
@@ -256,6 +275,10 @@ AUI.add(
 
 					instance._updateTranslationStatus(defaultLanguageId);
 					instance._updateTranslationStatus(prevDefaultLanguageId);
+
+					instance._moveDefaultLanguageFlagToFirstPosition(
+						defaultLanguageId
+					);
 
 					Liferay.fire('inputLocalized:localeChanged', {
 						item: event.item,


### PR DESCRIPTION
Move the flag element to the first place when the default language is changed.
This is the default behavior when loading the page, this change adds this functionality when changing the default language after rendering the page.
