### PR TITLE
LPS-115880 - Fix global menu horizontal scroll

### DIFF
--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
@@ -35,10 +35,11 @@ $tab-header-height: 38px;
 }
 
 .global-apps-nav {
+	margin: 0;
 	padding: 1rem;
 
 	@include media-breakpoint-up(sm) {
-		padding: 1.5rem 2.2rem;
+		padding: 1.5rem 2.5rem 1.5rem 1.75rem;
 	}
 
 	.global-apps-nav-header {


### PR DESCRIPTION
This PR solves the error with the unwanted horizontal scroll in the Global menu by adjusting the spacing:
![image](https://user-images.githubusercontent.com/7963804/85285619-7b4b2000-b491-11ea-8935-e61f69b95612.png)

---

**Usage Tests:**

To test the fix it is necessary to have a mouse connected to your mac / windows / linux, then you just have to start Liferay portal and click on the Global Menu icon:

![image](https://user-images.githubusercontent.com/7963804/85285675-96b62b00-b491-11ea-8837-8c121bd5a053.png)

The menu will appear without the horizontal scroll:

![image](https://user-images.githubusercontent.com/7963804/85285723-aa619180-b491-11ea-9a90-fe950a212930.png)
