### PR TITLE
LPS-113561 Avoid Liferay.provide in sharing-web

### DIFF
--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/dynamic_include/bottom.jsp
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/dynamic_include/bottom.jsp
@@ -28,52 +28,46 @@ sharingURL.setWindowState(LiferayWindowState.POP_UP);
 
 <aui:script sandbox="<%= true %>">
 	function showDialog(uri, title) {
-		Liferay.Util.openWindow({
-			dialog: {
-				centered: true,
-				constrain: true,
-				cssClass: 'sharing-dialog',
-				destroyOnHide: true,
-				modal: true,
-				height: 540,
-				width: 600,
-			},
+		Liferay.Util.openModal({
 			id: 'sharingDialog',
+			iframeBodyCssClass: 'sharing-dialog',
 			title: Liferay.Util.escapeHTML(title),
-			uri: uri,
+			url: uri,
 		});
 	}
 
-	Liferay.Sharing = Liferay.Sharing || {};
+	var Sharing = {
+		manageCollaborators: function (classNameId, classPK) {
+			var manageCollaboratorsParameters = {
+				classNameId: classNameId,
+				classPK: classPK,
+			};
 
-	Liferay.Sharing.share = function (classNameId, classPK, title) {
-		var sharingParameters = {
-			classNameId: classNameId,
-			classPK: classPK,
-		};
+			var manageCollaboratorsURL = Liferay.Util.PortletURL.createPortletURL(
+				'<%= manageCollaboratorsURL.toString() %>',
+				manageCollaboratorsParameters
+			);
 
-		var sharingURL = Liferay.Util.PortletURL.createPortletURL(
-			'<%= sharingURL.toString() %>',
-			sharingParameters
-		);
+			showDialog(
+				manageCollaboratorsURL.toString(),
+				'<%= LanguageUtil.get(resourceBundle, "manage-collaborators") %>'
+			);
+		},
 
-		showDialog(sharingURL.toString(), title);
+		share: function (classNameId, classPK, title) {
+			var sharingParameters = {
+				classNameId: classNameId,
+				classPK: classPK,
+			};
+
+			var sharingURL = Liferay.Util.PortletURL.createPortletURL(
+				'<%= sharingURL.toString() %>',
+				sharingParameters
+			);
+
+			showDialog(sharingURL.toString(), title);
+		},
 	};
 
-	Liferay.Sharing.manageCollaborators = function (classNameId, classPK) {
-		var manageCollaboratorsParameters = {
-			classNameId: classNameId,
-			classPK: classPK,
-		};
-
-		var manageCollaboratorsURL = Liferay.Util.PortletURL.createPortletURL(
-			'<%= manageCollaboratorsURL.toString() %>',
-			manageCollaboratorsParameters
-		);
-
-		showDialog(
-			manageCollaboratorsURL.toString(),
-			'<%= LanguageUtil.get(resourceBundle, "manage-collaborators") %>'
-		);
-	};
+	Liferay.Sharing = Sharing;
 </aui:script>

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/dynamic_include/bottom.jsp
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/dynamic_include/bottom.jsp
@@ -44,48 +44,36 @@ sharingURL.setWindowState(LiferayWindowState.POP_UP);
 		});
 	}
 
-	var Sharing = {};
+	Liferay.Sharing = Liferay.Sharing || {};
 
-	Liferay.provide(
-		Sharing,
-		'share',
-		function (classNameId, classPK, title) {
-			var sharingParameters = {
-				classNameId: classNameId,
-				classPK: classPK,
-			};
+	Liferay.Sharing.share = function (classNameId, classPK, title) {
+		var sharingParameters = {
+			classNameId: classNameId,
+			classPK: classPK,
+		};
 
-			var sharingURL = Liferay.Util.PortletURL.createPortletURL(
-				'<%= sharingURL.toString() %>',
-				sharingParameters
-			);
+		var sharingURL = Liferay.Util.PortletURL.createPortletURL(
+			'<%= sharingURL.toString() %>',
+			sharingParameters
+		);
 
-			showDialog(sharingURL.toString(), title);
-		},
-		[]
-	);
+		showDialog(sharingURL.toString(), title);
+	};
 
-	Liferay.provide(
-		Sharing,
-		'manageCollaborators',
-		function (classNameId, classPK) {
-			var manageCollaboratorsParameters = {
-				classNameId: classNameId,
-				classPK: classPK,
-			};
+	Liferay.Sharing.manageCollaborators = function (classNameId, classPK) {
+		var manageCollaboratorsParameters = {
+			classNameId: classNameId,
+			classPK: classPK,
+		};
 
-			var manageCollaboratorsURL = Liferay.Util.PortletURL.createPortletURL(
-				'<%= manageCollaboratorsURL.toString() %>',
-				manageCollaboratorsParameters
-			);
+		var manageCollaboratorsURL = Liferay.Util.PortletURL.createPortletURL(
+			'<%= manageCollaboratorsURL.toString() %>',
+			manageCollaboratorsParameters
+		);
 
-			showDialog(
-				manageCollaboratorsURL.toString(),
-				'<%= LanguageUtil.get(resourceBundle, "manage-collaborators") %>'
-			);
-		},
-		[]
-	);
-
-	Liferay.Sharing = Sharing;
+		showDialog(
+			manageCollaboratorsURL.toString(),
+			'<%= LanguageUtil.get(resourceBundle, "manage-collaborators") %>'
+		);
+	};
 </aui:script>

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/js/ManageCollaborators.es.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/js/ManageCollaborators.es.js
@@ -36,7 +36,6 @@ const ManageCollaborators = ({
 	classNameId,
 	classPK,
 	collaborators,
-	dialogId,
 	portletNamespace,
 }) => {
 	const [currentCollaborators, setCurrentCollaborators] = useState(
@@ -69,11 +68,9 @@ const ManageCollaborators = ({
 	};
 
 	const closeDialog = () => {
-		const collaboratorsDialog = Liferay.Util.getWindow(dialogId);
-
-		if (collaboratorsDialog && collaboratorsDialog.hide) {
-			collaboratorsDialog.hide();
-		}
+		Liferay.Util.getOpener().Liferay.fire('closeModal', {
+			id: 'sharingDialog',
+		});
 	};
 
 	const objectToPairArray = (object) => {
@@ -255,9 +252,9 @@ const ManageCollaborators = ({
 					classPK,
 				});
 
-				showNotification(json.successMessage);
-
 				setLoadingResponse(false);
+
+				showNotification(json.successMessage);
 			})
 			.catch((error) => {
 				showNotification(error.message, true);

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/sharing/js/Sharing.es.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/sharing/js/Sharing.es.js
@@ -42,7 +42,6 @@ const Sharing = ({
 	autocompleteUserURL,
 	classNameId,
 	classPK,
-	dialogId,
 	portletNamespace,
 	shareActionURL,
 	sharingEntryPermissionDisplayActionId,
@@ -59,11 +58,9 @@ const Sharing = ({
 	const emailValidationInProgress = useRef(false);
 
 	const closeDialog = () => {
-		const sharingDialog = Liferay.Util.getWindow(dialogId);
-
-		if (sharingDialog && sharingDialog.hide) {
-			sharingDialog.hide();
-		}
+		Liferay.Util.getOpener().Liferay.fire('closeModal', {
+			id: 'sharingDialog',
+		});
 	};
 
 	const showNotification = (message, error) => {
@@ -122,14 +119,6 @@ const Sharing = ({
 			.catch((error) => {
 				showNotification(error.message, true);
 			});
-	};
-
-	const onModalClose = () => {
-		const sharingDialog = Liferay.Util.getWindow(dialogId);
-
-		if (sharingDialog && sharingDialog.hide) {
-			sharingDialog.hide();
-		}
 	};
 
 	const isEmailAddressValid = (email) => {
@@ -357,7 +346,7 @@ const Sharing = ({
 					<ClayButton.Group spaced>
 						<ClayButton
 							displayType="secondary"
-							onClick={onModalClose}
+							onClick={closeDialog}
 						>
 							{Liferay.Language.get('cancel')}
 						</ClayButton>


### PR DESCRIPTION
As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561) we
eventually want to deprecate the `Liferay.provide` function.

To test this change:
- Navigate to "Content and Data > Blogs"
- Click on the "+" button
- Provide a title and some content for your blog entry and click on
  the "Publish" button
- Open the kebab menu to the right of your blog entry and click on "Share"
- Enter the name of a user you want to share your blog entry with
- Click on your profile picture in the top right and click on "Shared
  Content"
- Select the "Shared by Me" tab
- Open the kebab menu to the right of the blog entry created previously
  and click on "Manage Collaborators"
- Change the permissions of your collaborators and click on "Save"