### PR TITLE
LPS-115278 Change image icon is disabled for blogs cover image

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -220,6 +220,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/page.jsp
@@ -116,7 +116,7 @@ if (fileEntryId != 0) {
 	<div class="change-image-controls <%= (fileEntryId != 0) ? StringPool.BLANK : "hide" %>">
 		<clay:button
 			cssClass="browse-image"
-			displaytype="secondary"
+			displayType="secondary"
 			icon="picture"
 			title="change-image"
 		/>


### PR DESCRIPTION
This PR adds `cssClass` attribute to recover the CSS class in the render of `<clay:button`.

**Test plan:** 
1. Site > Content & Data > Blogs
1. Add a new blog entry with cover image
1. Click the browse image button to change the cover image

**Actual result**
Can not open the select file modal after clicking the browse image button

**Expected result**
Can open the select file modal after clicking the browse image button