### PR TITLE
LPS-115669 Adds missing taglib-mappings.properties descriptor

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/META-INF/resources/taglib-mappings.properties
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/META-INF/resources/taglib-mappings.properties
@@ -1,0 +1,1 @@
+react=/META-INF/react.tld


### PR DESCRIPTION
Self explanatory commit. For reference:

> The taglib-mappings.properties file descriptor is used by our FreeMarker
engine to automatically populate the FreeMarker context with all exposed
JSP tags.
> 
> This change allows tags in this module to be used from a FreeMarker
context as `<@react['component']>`.