### PR TITLE
LPS-114082 Replace layout classes with new clay components in segments-experiment-web

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
@@ -5,6 +5,7 @@
 		"@clayui/drop-down": "3.4.4",
 		"@clayui/form": "3.8.0",
 		"@clayui/icon": "3.0.5",
+		"@clayui/layout": "3.1.0",
 		"@clayui/link": "3.2.0",
 		"@clayui/loading-indicator": "3.1.0",
 		"@clayui/management-toolbar": "3.2.1",

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import ClayTabs from '@clayui/tabs';
 import {PropTypes} from 'prop-types';
 import React, {Component} from 'react';
@@ -692,8 +693,11 @@ class ResultRankingsForm extends Component {
 					onPublish={this._handlePublish}
 				/>
 
-				<div className="container-fluid container-fluid-max-xl container-form-lg result-rankings-container">
-					<div className="form-section-header sheet sheet-lg">
+				<ClayLayout.ContainerFluid
+					className="result-rankings-container"
+					formSize="lg"
+				>
+					<ClayLayout.Sheet className="form-section-header">
 						<label>{Liferay.Language.get('query')}</label>
 
 						<h2 className="sheet-title">{`${searchQuery}`}</h2>
@@ -707,9 +711,9 @@ class ResultRankingsForm extends Component {
 								onChange={this._handleUpdateAliases}
 							/>
 						</ErrorBoundary>
-					</div>
+					</ClayLayout.Sheet>
 
-					<div className="form-section-body sheet sheet-lg">
+					<ClayLayout.Sheet className="form-section-body">
 						<div className="results-title sheet-text">
 							{Liferay.Language.get('results')}
 						</div>
@@ -804,8 +808,8 @@ class ResultRankingsForm extends Component {
 								</ClayTabs.Content>
 							</div>
 						</ErrorBoundary>
-					</div>
-				</div>
+					</ClayLayout.Sheet>
+				</ClayLayout.ContainerFluid>
 
 				{showDebugger && (
 					<FormValueDebugger

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/add_result/AddResultModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/add_result/AddResultModal.es.js
@@ -13,6 +13,7 @@ import ClayButton from '@clayui/button';
 import {useResource} from '@clayui/data-provider';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal from '@clayui/modal';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
@@ -294,7 +295,11 @@ function AddResultModal({
 			);
 		}
 
-		return <div className="add-result-sheet sheet">{emptyState}</div>;
+		return (
+			<ClayLayout.Sheet className="add-result-sheet">
+				{emptyState}
+			</ClayLayout.Sheet>
+		);
 	}
 
 	/**
@@ -328,9 +333,9 @@ function AddResultModal({
 
 		return (
 			<>
-				<div className="add-result-sheet sheet">
+				<ClayLayout.Sheet className="add-result-sheet">
 					<div className={classManagementBar}>
-						<div className="container-fluid container-fluid-max-xl">
+						<ClayLayout.ContainerFluid>
 							<ul className="navbar-nav navbar-nav-expand">
 								<li className="nav-item">
 									<ClayCheckbox
@@ -364,7 +369,7 @@ function AddResultModal({
 									</li>
 								)}
 							</ul>
-						</div>
+						</ClayLayout.ContainerFluid>
 					</div>
 
 					<ul className="list-group" data-testid="add-result-items">
@@ -387,7 +392,7 @@ function AddResultModal({
 							/>
 						))}
 					</ul>
-				</div>
+				</ClayLayout.Sheet>
 
 				<div className="add-result-container">
 					<ClayPaginationBarWithBasicItems
@@ -451,13 +456,13 @@ function AddResultModal({
 
 					<div className="add-result-scroller">
 						{loading && (
-							<div className="add-result-sheet sheet">
+							<ClayLayout.Sheet className="add-result-sheet">
 								<div className="sheet-title">
 									<div className="load-more-container">
 										<ClayLoadingIndicator />
 									</div>
 								</div>
-							</div>
+							</ClayLayout.Sheet>
 						)}
 
 						{!loading &&

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/add_result/AddResultSearchBar.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/add_result/AddResultSearchBar.es.js
@@ -11,6 +11,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import {PropTypes} from 'prop-types';
 import React from 'react';
 
@@ -24,7 +25,7 @@ const AddResultSearchBar = ({
 	onSearchSubmit,
 	searchQuery,
 }) => (
-	<div className="add-result-container container-fluid">
+	<ClayLayout.ContainerFluid className="add-result-container">
 		<div className="management-bar navbar-expand-md">
 			<div className="navbar-form navbar-form-autofit">
 				<div className="input-group">
@@ -56,7 +57,7 @@ const AddResultSearchBar = ({
 				</div>
 			</div>
 		</div>
-	</div>
+	</ClayLayout.ContainerFluid>
 );
 
 AddResultSearchBar.propTypes = {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/Item.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/Item.es.js
@@ -13,6 +13,7 @@ import ClayButton from '@clayui/button';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
+import ClayLayout from '@clayui/layout';
 import ClaySticker from '@clayui/sticker';
 import getCN from 'classnames';
 import {PropTypes} from 'prop-types';
@@ -442,8 +443,8 @@ class Item extends PureComponent {
 				style={style}
 				tabIndex={0}
 			>
-				<div
-					className="autofit-col result-drag"
+				<ClayLayout.ContentCol
+					className="result-drag"
 					data-testid="DRAG_ICON"
 					style={{visibility: pinned ? 'visible' : 'hidden'}}
 				>
@@ -452,24 +453,24 @@ class Item extends PureComponent {
 							<ClayIcon symbol="drag" />
 						</span>
 					)}
-				</div>
+				</ClayLayout.ContentCol>
 
-				<div className="autofit-col">
+				<ClayLayout.ContentCol>
 					<ClayCheckbox
 						aria-label={Liferay.Language.get('select')}
 						checked={selected}
 						onChange={this._handleSelect}
 					/>
-				</div>
+				</ClayLayout.ContentCol>
 
-				<div className="autofit-col">
+				<ClayLayout.ContentCol>
 					<ClaySticker className={classSticker} displayType="light">
 						<ClayIcon symbol={icon ? icon : DEFAULT_ICON} />
 					</ClaySticker>
-				</div>
+				</ClayLayout.ContentCol>
 
-				<div className="autofit-col autofit-col-expand">
-					<section className="autofit-section">
+				<ClayLayout.ContentCol expand>
+					<ClayLayout.ContentSection containerElement="section">
 						<div className="list-group-title">
 							<span className="text-truncate-inline">
 								{viewURL ? (
@@ -516,10 +517,10 @@ class Item extends PureComponent {
 								{description}
 							</p>
 						)}
-					</section>
-				</div>
+					</ClayLayout.ContentSection>
+				</ClayLayout.ContentCol>
 
-				<div className="autofit-col">
+				<ClayLayout.ContentCol>
 					{pinned && <ResultPinIconDisplay />}
 
 					<div className="quick-action-menu">
@@ -568,7 +569,7 @@ class Item extends PureComponent {
 							pinned={pinned}
 						/>
 					)}
-				</div>
+				</ClayLayout.ContentCol>
 
 				{!isNil(clicks) && (
 					<div className="click-count list-group-text sticker-bottom-right">

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/stories/index.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/stories/index.es.js
@@ -20,6 +20,7 @@ import React from 'react';
 import '../../src/main/resources/META-INF/resources/css/main.scss';
 
 import {ClayIconSpriteContext} from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 
 import ThemeContext from '../../src/main/resources/META-INF/resources/js/ThemeContext.es';
 import PageToolbar from '../../src/main/resources/META-INF/resources/js/components/PageToolbar.es';
@@ -64,9 +65,7 @@ addDecorator((storyFn) => {
 });
 
 const withSheet = (storyFn) => (
-	<div className="sheet sheet-lg" style={{marginTop: '24px'}}>
-		{storyFn()}
-	</div>
+	<ClayLayout.Sheet style={{marginTop: '24px'}}>{storyFn()}</ClayLayout.Sheet>
 );
 
 storiesOf('Pages|ResultRankingsForm', module).add('default', () => (

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
@@ -7,6 +7,7 @@
 		"@clayui/drop-down": "3.4.4",
 		"@clayui/form": "3.8.0",
 		"@clayui/icon": "3.0.5",
+		"@clayui/layout": "3.1.0",
 		"@clayui/list": "3.2.5",
 		"@clayui/management-toolbar": "3.2.1",
 		"@clayui/modal": "3.5.1",

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/InstanceListPageBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/InstanceListPageBody.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useContext, useMemo} from 'react';
 
 import ContentView from '../../shared/components/content-view/ContentView.es';
@@ -65,7 +66,7 @@ const Body = ({
 
 	return (
 		<PromisesResolver promises={promises}>
-			<div className="container-fluid-1280 mt-4">
+			<ClayLayout.ContainerFluid className="mt-4">
 				<ContentView {...statesProps}>
 					{totalCount > 0 && (
 						<>
@@ -78,7 +79,7 @@ const Body = ({
 						</>
 					)}
 				</ContentView>
-			</div>
+			</ClayLayout.ContainerFluid>
 
 			<Body.ModalWrapper />
 		</PromisesResolver>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/InstanceListPageHeader.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/InstanceListPageHeader.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import {usePrevious} from 'frontend-js-react-web';
 import React, {useCallback, useContext, useEffect, useMemo} from 'react';
@@ -196,12 +197,9 @@ const Header = ({
 			>
 				{toolbarActive ? (
 					<ClayManagementToolbar.Item className="navbar-nav-last">
-						<div
-							className="autofit-col"
-							data-testid="headerQuickAction"
-						>
+						<ClayLayout.ContentCol data-testid="headerQuickAction">
 							<QuickActionKebab items={kebabItems} />
-						</div>
+						</ClayLayout.ContentCol>
 					</ClayManagementToolbar.Item>
 				) : (
 					<>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/InstanceListPageItem.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/InstanceListPageItem.es.js
@@ -11,6 +11,7 @@
 
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import ClayTable from '@clayui/table';
 import React, {useContext} from 'react';
 
@@ -240,9 +241,9 @@ const QuickActionMenu = ({disabled, instance}) => {
 	}
 
 	return (
-		<div className="autofit-col">
+		<ClayLayout.ContentCol>
 			<QuickActionKebab disabled={disabled} items={kebabItems} />
-		</div>
+		</ClayLayout.ContentCol>
 	);
 };
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/instance-details/InstanceDetailsModalBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/instance-details/InstanceDetailsModalBody.es.js
@@ -11,6 +11,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import ClayModal from '@clayui/modal';
 import React, {useMemo} from 'react';
 
@@ -192,15 +193,23 @@ const SectionSubTitle = ({children}) => {
 
 const SectionAttribute = ({description, detail}) => {
 	return (
-		<p className="row">
-			<span className="col-2 font-weight-medium small text-secondary">
+		<ClayLayout.Row containerElement="p">
+			<ClayLayout.Col
+				className="font-weight-medium small text-secondary"
+				containerElement="span"
+				size="2"
+			>
 				{`${description}`}
-			</span>
+			</ClayLayout.Col>
 
-			<span className="col small" data-testid="instanceDetailSpan">
+			<ClayLayout.Col
+				className="small"
+				containerElement="span"
+				data-testid="instanceDetailSpan"
+			>
 				{detail}
-			</span>
-		</p>
+			</ClayLayout.Col>
+		</ClayLayout.Row>
 	);
 };
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/performance-by-assignee-page/PerformanceByAssigneePageBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/performance-by-assignee-page/PerformanceByAssigneePageBody.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
 import ContentView from '../../shared/components/content-view/ContentView.es';
@@ -38,7 +39,7 @@ const Body = ({filtered, items, page, pageSize, totalCount}) => {
 	);
 
 	return (
-		<div className="container-fluid-1280 mt-4">
+		<ClayLayout.ContainerFluid className="mt-4">
 			<ContentView {...statesProps}>
 				{totalCount > 0 && (
 					<>
@@ -52,7 +53,7 @@ const Body = ({filtered, items, page, pageSize, totalCount}) => {
 					</>
 				)}
 			</ContentView>
-		</div>
+		</ClayLayout.ContainerFluid>
 	);
 };
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/performance-by-step-page/PerformanceByStepPageBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/performance-by-step-page/PerformanceByStepPageBody.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
 import ContentView from '../../shared/components/content-view/ContentView.es';
@@ -33,8 +34,8 @@ const Body = ({filtered, items, page, pageSize, totalCount}) => {
 	);
 
 	return (
-		<div
-			className="container-fluid-1280 mt-4 workflow-process-dashboard"
+		<ClayLayout.ContainerFluid
+			className="mt-4 workflow-process-dashboard"
 			data-testid="performanceByStepBody"
 		>
 			<ContentView {...statesProps}>
@@ -50,7 +51,7 @@ const Body = ({filtered, items, page, pageSize, totalCount}) => {
 					</>
 				)}
 			</ContentView>
-		</div>
+		</ClayLayout.ContainerFluid>
 	);
 };
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-list-page/ProcessListPageBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-list-page/ProcessListPageBody.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
 import ContentView from '../../shared/components/content-view/ContentView.es';
@@ -39,7 +40,7 @@ const Body = ({filtered, items, page, pageSize, totalCount}) => {
 	);
 
 	return (
-		<div className="container-fluid-1280 mt-4">
+		<ClayLayout.ContainerFluid className="mt-4">
 			<ContentView {...statesProps}>
 				{totalCount > 0 && (
 					<>
@@ -53,7 +54,7 @@ const Body = ({filtered, items, page, pageSize, totalCount}) => {
 					</>
 				)}
 			</ContentView>
-		</div>
+		</ClayLayout.ContainerFluid>
 	);
 };
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/ProcessMetricsContainer.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/ProcessMetricsContainer.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useContext, useMemo} from 'react';
 import {Route, Switch} from 'react-router-dom';
 
@@ -41,19 +42,19 @@ const DashboardTab = ({history, ...otherProps}) => {
 	}, [history]);
 
 	return (
-		<div className="container-fluid-1280">
-			<div className="row">
-				<div className="col-md-9 p-0">
+		<ClayLayout.ContainerFluid>
+			<ClayLayout.Row>
+				<ClayLayout.Col className="p-0" md="9">
 					<PendingItemsCard {...otherProps} />
 
 					<WorkloadByStepCard {...otherProps} />
-				</div>
+				</ClayLayout.Col>
 
-				<div className="col-md-3 p-0">
+				<ClayLayout.Col className="p-0" md="3">
 					<WorkloadByAssigneeCard {...otherProps} />
-				</div>
-			</div>
-		</div>
+				</ClayLayout.Col>
+			</ClayLayout.Row>
+		</ClayLayout.ContainerFluid>
 	);
 };
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/SLAInfo.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/SLAInfo.es.js
@@ -10,6 +10,7 @@
  */
 
 import ClayAlert from '@clayui/alert';
+import ClayLayout from '@clayui/layout';
 import React, {useContext, useEffect, useState} from 'react';
 
 import ChildLink from '../../shared/components/router/ChildLink.es';
@@ -70,7 +71,7 @@ const SLAInfo = ({processId}) => {
 	return (
 		<>
 			{alert && (
-				<div className="container-fluid-1280">
+				<ClayLayout.ContainerFluid>
 					<ClayAlert
 						className="mb-0"
 						data-testid="slaInfoAlert"
@@ -87,7 +88,7 @@ const SLAInfo = ({processId}) => {
 							{alert.linkText}
 						</ChildLink>
 					</ClayAlert>
-				</div>
+				</ClayLayout.ContainerFluid>
 			)}
 		</>
 	);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/CompletionVelocityCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/CompletionVelocityCard.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
 import Panel from '../../../shared/components/Panel.es';
@@ -103,7 +104,7 @@ const Header = ({disableFilters, prefixKey, timeRange}) => {
 			elementClasses="dashboard-panel-header pb-0"
 			title={Liferay.Language.get('completion-velocity')}
 		>
-			<div className="autofit-col m-0 management-bar management-bar-light navbar">
+			<ClayLayout.ContentCol className="m-0 management-bar management-bar-light navbar">
 				<ul className="navbar-nav">
 					<TimeRangeFilter
 						disabled={disableFilters}
@@ -118,7 +119,7 @@ const Header = ({disableFilters, prefixKey, timeRange}) => {
 						timeRange={timeRange}
 					/>
 				</ul>
-			</div>
+			</ClayLayout.ContentCol>
 		</Panel.HeaderWithOptions>
 	);
 };

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-assignee-card/PerformanceByAssigneeCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-assignee-card/PerformanceByAssigneeCard.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
 import Panel from '../../../shared/components/Panel.es';
@@ -29,7 +30,7 @@ const Header = ({disableFilters, prefixKey, processId}) => {
 			elementClasses="dashboard-panel-header"
 			title={Liferay.Language.get('performance-by-assignee')}
 		>
-			<div className="autofit-col m-0 management-bar management-bar-light navbar">
+			<ClayLayout.ContentCol className="m-0 management-bar management-bar-light navbar">
 				<ul className="navbar-nav">
 					<ProcessStepFilter
 						disabled={disableFilters}
@@ -51,7 +52,7 @@ const Header = ({disableFilters, prefixKey, processId}) => {
 						prefixKey={prefixKey}
 					/>
 				</ul>
-			</div>
+			</ClayLayout.ContentCol>
 		</Panel.HeaderWithOptions>
 	);
 };

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-step-card/PerformanceByStepCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-step-card/PerformanceByStepCard.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
 import Panel from '../../../shared/components/Panel.es';
@@ -25,7 +26,7 @@ const Header = ({disableFilters, prefixKey, totalCount}) => (
 		elementClasses="dashboard-panel-header"
 		title={Liferay.Language.get('performance-by-step')}
 	>
-		<div className="autofit-col m-0 management-bar management-bar-light navbar">
+		<ClayLayout.ContentCol className="m-0 management-bar management-bar-light navbar">
 			<ul className="navbar-nav">
 				<TimeRangeFilter
 					disabled={!totalCount || disableFilters}
@@ -33,7 +34,7 @@ const Header = ({disableFilters, prefixKey, totalCount}) => (
 					prefixKey={prefixKey}
 				/>
 			</ul>
-		</div>
+		</ClayLayout.ContentCol>
 	</Panel.HeaderWithOptions>
 );
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/process-items/ProcessItemsCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/process-items/ProcessItemsCard.es.js
@@ -11,6 +11,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useMemo} from 'react';
 
@@ -110,8 +111,8 @@ const Header = ({children, data, description, title}) => (
 	<Panel.Header
 		elementClasses={['dashboard-panel-header', children && 'pb-0']}
 	>
-		<div className="autofit-row">
-			<div className="autofit-col autofit-col-expand flex-row">
+		<ClayLayout.ContentRow>
+			<ClayLayout.ContentCol className="flex-row" expand>
 				<span className="mr-2">{title}</span>
 
 				<ClayTooltipProvider>
@@ -125,14 +126,14 @@ const Header = ({children, data, description, title}) => (
 						</span>
 					</span>
 				</ClayTooltipProvider>
-			</div>
+			</ClayLayout.ContentCol>
 
 			{children && data && (
-				<div className="autofit-col m-0 management-bar management-bar-light navbar">
+				<ClayLayout.ContentCol className="m-0 management-bar management-bar-light navbar">
 					<ul className="navbar-nav">{children}</ul>
-				</div>
+				</ClayLayout.ContentCol>
 			)}
-		</div>
+		</ClayLayout.ContentRow>
 	</Panel.Header>
 );
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-step-card/WorkloadByStepCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-step-card/WorkloadByStepCard.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
 import Panel from '../../../shared/components/Panel.es';
@@ -26,17 +27,19 @@ const WorkloadByStepCard = ({processId, routeParams}) => {
 
 	return (
 		<PromisesResolver promises={promises}>
-			<Panel className="container-fluid-1280 mt-4">
-				<Panel.HeaderWithOptions
-					description={Liferay.Language.get(
-						'workload-by-step-description'
-					)}
-					elementClasses="dashboard-panel-header"
-					title={Liferay.Language.get('workload-by-step')}
-					tooltipPosition="bottom"
-				/>
+			<Panel>
+				<ClayLayout.ContainerFluid className="mt-4">
+					<Panel.HeaderWithOptions
+						description={Liferay.Language.get(
+							'workload-by-step-description'
+						)}
+						elementClasses="dashboard-panel-header"
+						title={Liferay.Language.get('workload-by-step')}
+						tooltipPosition="bottom"
+					/>
 
-				<WorkloadByStepCard.Body {...data} {...routeParams} />
+					<WorkloadByStepCard.Body {...data} {...routeParams} />
+				</ClayLayout.ContainerFluid>
 			</Panel>
 		</PromisesResolver>
 	);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/settings/indexes-page/IndexesPage.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/settings/indexes-page/IndexesPage.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
 import PromisesResolver from '../../../shared/components/promises-resolver/PromisesResolver.es';
@@ -21,7 +22,7 @@ const IndexesPage = () => {
 	const promises = useMemo(() => [fetchData()], [fetchData]);
 
 	return (
-		<div className="container-fluid-1280">
+		<ClayLayout.ContainerFluid>
 			<h3 className="font-weight-semi-bold my-4" data-testid="pageTitle">
 				{Liferay.Language.get('workflow-index-actions')}
 			</h3>
@@ -29,7 +30,7 @@ const IndexesPage = () => {
 			<PromisesResolver promises={promises}>
 				<IndexesPage.Body {...data} />
 			</PromisesResolver>
-		</div>
+		</ClayLayout.ContainerFluid>
 	);
 };
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/settings/indexes-page/IndexesPageBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/settings/indexes-page/IndexesPageBody.es.js
@@ -10,6 +10,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import ClayLayout from '@clayui/layout';
 import ClayProgressBar from '@clayui/progress-bar';
 import React from 'react';
 
@@ -33,18 +34,18 @@ const Body = ({items = []}) => {
 
 	return (
 		<>
-			<div className="mb-4 p-3 sheet">
-				<div className="autofit-row autofit-row-center">
-					<div className="autofit-col autofit-col-expand">
+			<ClayLayout.Sheet className="mb-4">
+				<ClayLayout.ContentRow verticalAlign="center">
+					<ClayLayout.ContentCol expand>
 						<h5
 							className="font-weight-semi-bold m-0 py-2"
 							data-testid="reindexAllLabel"
 						>
 							{Liferay.Language.get('workflow-indexes')}
 						</h5>
-					</div>
+					</ClayLayout.ContentCol>
 
-					<div className="autofit-col">
+					<ClayLayout.ContentCol>
 						{isReindexing(ALL_INDEXES_KEY) ? (
 							<ClayProgressBar
 								data-testid="reindexAllStatus"
@@ -59,9 +60,9 @@ const Body = ({items = []}) => {
 								{Liferay.Language.get('reindex-all')}
 							</ClayButton>
 						)}
-					</div>
-				</div>
-			</div>
+					</ClayLayout.ContentCol>
+				</ClayLayout.ContentRow>
+			</ClayLayout.Sheet>
 
 			<PromisesResolver.Resolved>
 				{Object.values(groups).map((group, index) => (

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/form-page/SLAFormPageBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/form-page/SLAFormPageBody.es.js
@@ -11,6 +11,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
+import ClayLayout from '@clayui/layout';
 import React, {useCallback, useContext} from 'react';
 
 import ContentView from '../../../shared/components/content-view/ContentView.es';
@@ -176,76 +177,86 @@ const Body = ({history, id, processId, query}) => {
 				{sla.status === 2 && <Body.AlertChange />}
 			</div>
 
-			<ClayForm className="sheet sheet-lg">
-				<div className="mb-0 sheet-header">
-					<h2 className="sheet-title" data-testid="sheetTitle">
-						{Liferay.Language.get('sla-definition')}
-					</h2>
-				</div>
+			<ClayForm>
+				<ClayLayout.Sheet>
+					<ClayLayout.SheetHeader className="mb-0">
+						<h2 className="sheet-title" data-testid="sheetTitle">
+							{Liferay.Language.get('sla-definition')}
+						</h2>
+					</ClayLayout.SheetHeader>
 
-				<div className="mb-0 sheet-section">
-					<div className="row">
-						<FormGroupWithStatus
-							className="col col-sm-5 form-group"
-							data-testid="nameField"
-							error={errors[NAME]}
-							htmlFor="slaName"
-							label={Liferay.Language.get('name')}
-							requiredLabel
-						>
-							<ClayInput
-								autoFocus
-								className="form-control"
-								id="slaName"
-								maxLength={75}
-								name="name"
-								onChange={onChangeHandler(onNameChanged)}
-								type="text"
-								value={sla.name}
-							/>
-						</FormGroupWithStatus>
+					<ClayLayout.SheetSection className="mb-0">
+						<ClayLayout.Row>
+							<ClayLayout.Col sm="5">
+								<FormGroupWithStatus
+									className="form-group"
+									data-testid="nameField"
+									error={errors[NAME]}
+									htmlFor="slaName"
+									label={Liferay.Language.get('name')}
+									requiredLabel
+								>
+									<ClayInput
+										autoFocus
+										className="form-control"
+										id="slaName"
+										maxLength={75}
+										name="name"
+										onChange={onChangeHandler(
+											onNameChanged
+										)}
+										type="text"
+										value={sla.name}
+									/>
+								</FormGroupWithStatus>
+							</ClayLayout.Col>
 
-						<FormGroupWithStatus
-							className="col col-sm-7 form-group"
-							data-testid="descriptionField"
-							htmlFor="slaDescription"
-							label={Liferay.Language.get('description')}
-						>
-							<ClayInput
-								id="slaDescription"
-								name="description"
-								onChange={onChangeHandler()}
-								type="text"
-								value={sla.description}
-							/>
-						</FormGroupWithStatus>
-					</div>
+							<ClayLayout.Col sm="7">
+								<FormGroupWithStatus
+									className="form-group"
+									data-testid="descriptionField"
+									htmlFor="slaDescription"
+									label={Liferay.Language.get('description')}
+								>
+									<ClayInput
+										id="slaDescription"
+										name="description"
+										onChange={onChangeHandler()}
+										type="text"
+										value={sla.description}
+									/>
+								</FormGroupWithStatus>
+							</ClayLayout.Col>
+						</ClayLayout.Row>
 
-					<Body.TimeFrameSection />
+						<Body.TimeFrameSection />
 
-					<Body.DurationSection onChangeHandler={onChangeHandler} />
-				</div>
+						<Body.DurationSection
+							onChangeHandler={onChangeHandler}
+						/>
+					</ClayLayout.SheetSection>
 
-				<div className="sheet-footer sheet-footer-btn-block-sm-down">
-					<ClayButton.Group spaced>
-						<ClayButton
-							data-testid="saveButton"
-							onClick={handleSubmit}
-						>
-							{id
-								? Liferay.Language.get('update')
-								: Liferay.Language.get('save')}
-						</ClayButton>
+					<ClayLayout.SheetFooter className="sheet-footer-btn-block-sm-down">
+						<ClayButton.Group spaced>
+							<ClayButton
+								data-testid="saveButton"
+								onClick={handleSubmit}
+							>
+								{id
+									? Liferay.Language.get('update')
+									: Liferay.Language.get('save')}
+							</ClayButton>
 
-						<ClayButton
-							data-testid="cancelButton"
-							displayType="secondary"
-							onClick={() => history.goBack()}
-						>
-							{Liferay.Language.get('cancel')}
-						</ClayButton>
-					</ClayButton.Group>
-				</div>
+							<ClayButton
+								data-testid="cancelButton"
+								displayType="secondary"
+								onClick={() => history.goBack()}
+							>
+								{Liferay.Language.get('cancel')}
+							</ClayButton>
+						</ClayButton.Group>
+					</ClayLayout.SheetFooter>
+				</ClayLayout.Sheet>
 			</ClayForm>
 		</ContentView>
 	);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/form-page/sections/DurationSection.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/form-page/sections/DurationSection.es.js
@@ -10,6 +10,7 @@
  */
 
 import ClayForm from '@clayui/form';
+import ClayLayout from '@clayui/layout';
 import React, {useCallback, useContext, useMemo} from 'react';
 import MaskedInput from 'react-text-mask';
 import createNumberMask from 'text-mask-addons/dist/createNumberMask';
@@ -99,78 +100,86 @@ const DurationSection = ({onChangeHandler}) => {
 					: Liferay.Language.get('define-the-sla-duration')}
 			</div>
 
-			<div className="row">
-				<FormGroupWithStatus
-					className="col col-sm-3 form-group"
-					data-testid="daysField"
-					error={errors[DURATION]}
-					htmlFor="slaDurationDays"
-					label={Liferay.Language.get('days')}
-				>
-					<MaskedInput
-						className="form-control"
-						id="slaDurationDays"
-						mask={daysMask}
-						maxLength={4}
-						name={DAYS}
-						onChange={onChangeHandler(onDurationChanged)}
-						value={days}
-					/>
+			<ClayLayout.Row>
+				<ClayLayout.Col sm="3">
+					<FormGroupWithStatus
+						className="form-group"
+						data-testid="daysField"
+						error={errors[DURATION]}
+						htmlFor="slaDurationDays"
+						label={Liferay.Language.get('days')}
+					>
+						<MaskedInput
+							className="form-control"
+							id="slaDurationDays"
+							mask={daysMask}
+							maxLength={4}
+							name={DAYS}
+							onChange={onChangeHandler(onDurationChanged)}
+							value={days}
+						/>
 
-					<ClayForm.FeedbackGroup>
-						<ClayForm.FeedbackItem>
-							<ClayForm.Text data-testid="durationDaysDescription">
-								{Liferay.Language.get('enter-a-whole-number')}
-							</ClayForm.Text>
-						</ClayForm.FeedbackItem>
-					</ClayForm.FeedbackGroup>
-				</FormGroupWithStatus>
+						<ClayForm.FeedbackGroup>
+							<ClayForm.FeedbackItem>
+								<ClayForm.Text data-testid="durationDaysDescription">
+									{Liferay.Language.get(
+										'enter-a-whole-number'
+									)}
+								</ClayForm.Text>
+							</ClayForm.FeedbackItem>
+						</ClayForm.FeedbackGroup>
+					</FormGroupWithStatus>
+				</ClayLayout.Col>
 
-				<FormGroupWithStatus
-					className="col col-sm-3 form-group"
-					data-testid="hoursField"
-					error={errors[DURATION] || errors[HOURS]}
-					htmlFor="slaDurationHours"
-					label={Liferay.Language.get('hours')}
-				>
-					<MaskedInput
-						className="form-control"
-						id="slaDurationHours"
-						mask={[/\d/, /\d/, ':', /\d/, /\d/]}
-						name={HOURS}
-						onBlur={onHoursBlurred}
-						onChange={onChangeHandler(onDurationChanged)}
-						placeholder="00:00"
-						value={hours}
-					/>
-				</FormGroupWithStatus>
+				<ClayLayout.Col sm="3">
+					<FormGroupWithStatus
+						className="form-group"
+						data-testid="hoursField"
+						error={errors[DURATION] || errors[HOURS]}
+						htmlFor="slaDurationHours"
+						label={Liferay.Language.get('hours')}
+					>
+						<MaskedInput
+							className="form-control"
+							id="slaDurationHours"
+							mask={[/\d/, /\d/, ':', /\d/, /\d/]}
+							name={HOURS}
+							onBlur={onHoursBlurred}
+							onChange={onChangeHandler(onDurationChanged)}
+							placeholder="00:00"
+							value={hours}
+						/>
+					</FormGroupWithStatus>
+				</ClayLayout.Col>
 
 				{calendars.length > 1 && (
-					<FormGroupWithStatus
-						className="col col-sm-6 form-group"
-						htmlFor="slaCalendarKey"
-						label={Liferay.Language.get('calendar')}
-					>
-						<select
-							className="form-control"
-							id="slaCalendarKey"
-							name={CALENDAR_KEY}
-							onChange={onChangeHandler()}
-							value={calendarKey}
+					<ClayLayout.Col sm="6">
+						<FormGroupWithStatus
+							className="form-group"
+							htmlFor="slaCalendarKey"
+							label={Liferay.Language.get('calendar')}
 						>
-							{calendars.map((calendar, index) => (
-								<option key={index} value={calendar.key}>
-									{calendar.title}{' '}
-									{calendar.defaultCalendar &&
-										`(${Liferay.Language.get(
-											'system-default'
-										)})`}
-								</option>
-							))}
-						</select>
-					</FormGroupWithStatus>
+							<select
+								className="form-control"
+								id="slaCalendarKey"
+								name={CALENDAR_KEY}
+								onChange={onChangeHandler()}
+								value={calendarKey}
+							>
+								{calendars.map((calendar, index) => (
+									<option key={index} value={calendar.key}>
+										{calendar.title}{' '}
+										{calendar.defaultCalendar &&
+											`(${Liferay.Language.get(
+												'system-default'
+											)})`}
+									</option>
+								))}
+							</select>
+						</FormGroupWithStatus>
+					</ClayLayout.Col>
 				)}
-			</div>
+			</ClayLayout.Row>
 		</>
 	);
 };

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/form-page/sections/TimeFrameSection.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/form-page/sections/TimeFrameSection.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useContext} from 'react';
 
 import {AutocompleteMultiSelect} from '../../../../shared/components/autocomplete/AutocompleteMultiSelect.es';
@@ -66,91 +67,112 @@ const TimeFrameSection = () => {
 				)}
 			</div>
 
-			<div className="row">
-				<FormGroupWithStatus
-					className="col col-sm-12 form-group"
-					data-testid="startField"
-					error={errors[START_NODE_KEYS]}
-					htmlFor="slaTimeStart"
-					label={Liferay.Language.get('start')}
-					requiredLabel
-				>
-					<div className="form-text" data-testid="startDescription">
-						{Liferay.Language.get('time-will-begin-counting-when')}
-					</div>
+			<ClayLayout.Row>
+				<ClayLayout.Col>
+					<FormGroupWithStatus
+						className="form-group"
+						data-testid="startField"
+						error={errors[START_NODE_KEYS]}
+						htmlFor="slaTimeStart"
+						label={Liferay.Language.get('start')}
+						requiredLabel
+					>
+						<div
+							className="form-text"
+							data-testid="startDescription"
+						>
+							{Liferay.Language.get(
+								'time-will-begin-counting-when'
+							)}
+						</div>
 
-					<AutocompleteMultiSelect
-						fieldId="compositeId"
-						fieldName="desc"
-						id="start"
-						items={getStartNodes(pauseNodeKeys, stopNodeKeys)}
-						onChange={changeNodesKeys(
-							START_NODE_KEYS,
-							nodes,
-							checkNodeErrors(START_NODE_KEYS)
-						)}
-						selectedItems={getNodeTags(
-							getStartNodes(pauseNodeKeys, stopNodeKeys),
-							startNodeKeys
-						)}
-					/>
-				</FormGroupWithStatus>
+						<AutocompleteMultiSelect
+							fieldId="compositeId"
+							fieldName="desc"
+							id="start"
+							items={getStartNodes(pauseNodeKeys, stopNodeKeys)}
+							onChange={changeNodesKeys(
+								START_NODE_KEYS,
+								nodes,
+								checkNodeErrors(START_NODE_KEYS)
+							)}
+							selectedItems={getNodeTags(
+								getStartNodes(pauseNodeKeys, stopNodeKeys),
+								startNodeKeys
+							)}
+						/>
+					</FormGroupWithStatus>
+				</ClayLayout.Col>
 
-				<FormGroupWithStatus
-					className="col col-sm-12 form-group"
-					data-testid="pauseField"
-					htmlFor="slaTimePause"
-					label={Liferay.Language.get('pause')}
-				>
-					<div className="form-text" data-testid="pauseDescription">
-						{Liferay.Language.get('time-wont-be-considered-when')}
-					</div>
+				<ClayLayout.Col>
+					<FormGroupWithStatus
+						className="form-group"
+						data-testid="pauseField"
+						htmlFor="slaTimePause"
+						label={Liferay.Language.get('pause')}
+					>
+						<div
+							className="form-text"
+							data-testid="pauseDescription"
+						>
+							{Liferay.Language.get(
+								'time-wont-be-considered-when'
+							)}
+						</div>
 
-					<AutocompleteMultiSelect
-						fieldId="compositeId"
-						fieldName="desc"
-						id="pause"
-						items={getPauseNodes(startNodeKeys, stopNodeKeys)}
-						onChange={changePauseNodes(
-							getPauseNodes(startNodeKeys, stopNodeKeys),
-							checkNodeErrors(PAUSE_NODE_KEYS)
-						)}
-						selectedItems={getPauseNodeTags(
-							getPauseNodes(startNodeKeys, stopNodeKeys),
-							pauseNodeKeys
-						)}
-					/>
-				</FormGroupWithStatus>
+						<AutocompleteMultiSelect
+							fieldId="compositeId"
+							fieldName="desc"
+							id="pause"
+							items={getPauseNodes(startNodeKeys, stopNodeKeys)}
+							onChange={changePauseNodes(
+								getPauseNodes(startNodeKeys, stopNodeKeys),
+								checkNodeErrors(PAUSE_NODE_KEYS)
+							)}
+							selectedItems={getPauseNodeTags(
+								getPauseNodes(startNodeKeys, stopNodeKeys),
+								pauseNodeKeys
+							)}
+						/>
+					</FormGroupWithStatus>
+				</ClayLayout.Col>
 
-				<FormGroupWithStatus
-					className="col col-sm-12 form-group"
-					data-testid="stopField"
-					error={errors[STOP_NODE_KEYS]}
-					htmlFor="slaTimeStop"
-					label={Liferay.Language.get('stop')}
-					requiredLabel
-				>
-					<div className="form-text" data-testid="stopDescription">
-						{Liferay.Language.get('time-will-stop-counting-when')}
-					</div>
+				<ClayLayout.Col>
+					<FormGroupWithStatus
+						className="form-group"
+						data-testid="stopField"
+						error={errors[STOP_NODE_KEYS]}
+						htmlFor="slaTimeStop"
+						label={Liferay.Language.get('stop')}
+						requiredLabel
+					>
+						<div
+							className="form-text"
+							data-testid="stopDescription"
+						>
+							{Liferay.Language.get(
+								'time-will-stop-counting-when'
+							)}
+						</div>
 
-					<AutocompleteMultiSelect
-						fieldId="compositeId"
-						fieldName="desc"
-						id="stop"
-						items={getStopNodes(pauseNodeKeys, startNodeKeys)}
-						onChange={changeNodesKeys(
-							STOP_NODE_KEYS,
-							nodes,
-							checkNodeErrors(STOP_NODE_KEYS)
-						)}
-						selectedItems={getNodeTags(
-							getStopNodes(pauseNodeKeys, startNodeKeys),
-							stopNodeKeys
-						)}
-					/>
-				</FormGroupWithStatus>
-			</div>
+						<AutocompleteMultiSelect
+							fieldId="compositeId"
+							fieldName="desc"
+							id="stop"
+							items={getStopNodes(pauseNodeKeys, startNodeKeys)}
+							onChange={changeNodesKeys(
+								STOP_NODE_KEYS,
+								nodes,
+								checkNodeErrors(STOP_NODE_KEYS)
+							)}
+							selectedItems={getNodeTags(
+								getStopNodes(pauseNodeKeys, startNodeKeys),
+								stopNodeKeys
+							)}
+						/>
+					</FormGroupWithStatus>
+				</ClayLayout.Col>
+			</ClayLayout.Row>
 		</>
 	);
 };

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/list-page/SLAListPage.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/list-page/SLAListPage.es.js
@@ -10,6 +10,7 @@
  */
 
 import ClayAlert from '@clayui/alert';
+import ClayLayout from '@clayui/layout';
 import React, {createContext, useContext, useMemo, useState} from 'react';
 
 import PromisesResolver from '../../../shared/components/promises-resolver/PromisesResolver.es';
@@ -56,7 +57,7 @@ const SLAListPage = ({page, pageSize, processId}) => {
 		<SLAListPageContext.Provider value={slaContextState}>
 			<SLAListPage.Header processId={processId} />
 
-			<div className="container-fluid-1280">
+			<ClayLayout.ContainerFluid>
 				<BlockedSLAInfo processId={processId} />
 
 				{SLAUpdated && (
@@ -85,7 +86,7 @@ const SLAListPage = ({page, pageSize, processId}) => {
 				</PromisesResolver>
 
 				<SLAListPage.DeleteSLAModal />
-			</div>
+			</ClayLayout.ContainerFluid>
 		</SLAListPageContext.Provider>
 	);
 };

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/list-page/SLAListPageTableItem.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/list-page/SLAListPageTableItem.es.js
@@ -10,6 +10,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import ClayTable from '@clayui/table';
 import React, {useCallback, useContext} from 'react';
 
@@ -102,9 +103,9 @@ const Item = ({
 			</ClayTable.Cell>
 
 			<ClayTable.Cell className="actions">
-				<div className="autofit-col">
+				<ClayLayout.ContentCol>
 					<QuickActionKebab dropDownItems={dropDownItems} />
-				</div>
+				</ClayLayout.ContentCol>
 			</ClayTable.Cell>
 		</ClayTable.Row>
 	);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/workload-by-assignee-page/WorkloadByAssigneePageBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/workload-by-assignee-page/WorkloadByAssigneePageBody.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
 import ContentView from '../../shared/components/content-view/ContentView.es';
@@ -41,7 +42,7 @@ const Body = ({
 	);
 
 	return (
-		<div className="container-fluid-1280 mt-4">
+		<ClayLayout.ContainerFluid className="mt-4">
 			<ContentView {...statesProps}>
 				{totalCount > 0 && (
 					<>
@@ -59,7 +60,7 @@ const Body = ({
 					</>
 				)}
 			</ContentView>
-		</div>
+		</ClayLayout.ContainerFluid>
 	);
 };
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/Panel.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/Panel.es.js
@@ -10,6 +10,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import getCN from 'classnames';
 import React from 'react';
@@ -64,8 +65,8 @@ const HeaderWithOptions = ({
 }) => {
 	return (
 		<Header elementClasses={elementClasses}>
-			<div className="autofit-row">
-				<div className="autofit-col autofit-col-expand flex-row">
+			<ClayLayout.ContentRow>
+				<ClayLayout.ContentRow className="flex-row" expand>
 					<span className="mr-2">{title}</span>
 
 					<ClayTooltipProvider>
@@ -79,10 +80,10 @@ const HeaderWithOptions = ({
 							</span>
 						</span>
 					</ClayTooltipProvider>
-				</div>
+				</ClayLayout.ContentRow>
 
 				{children}
-			</div>
+			</ClayLayout.ContentRow>
 		</Header>
 	);
 };
@@ -91,11 +92,11 @@ const Panel = ({children, elementClasses}) => {
 	const classes = getCN('panel', 'panel-secondary', elementClasses);
 
 	return (
-		<div className="container-fluid-1280 mt-4">
+		<ClayLayout.ContainerFluid className="mt-4">
 			<div className={classes} data-testid="panel">
 				{children}
 			</div>
-		</div>
+		</ClayLayout.ContainerFluid>
 	);
 };
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/autocomplete/AutocompleteMultiSelect.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/autocomplete/AutocompleteMultiSelect.es.js
@@ -11,6 +11,7 @@
 
 import ClayAutocomplete from '@clayui/autocomplete';
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {
@@ -153,7 +154,7 @@ const AutocompleteMultiSelect = ({
 	return (
 		<ClayAutocomplete>
 			<div className={className} ref={wrapperRef}>
-				<div className="col-11 d-flex flex-wrap p-0">
+				<ClayLayout.Col className="d-flex flex-wrap p-0" size="11">
 					{selectedItems.map(
 						({[fieldId]: id, [fieldName]: name}, index) => (
 							<AutocompleteMultiSelect.Item
@@ -173,14 +174,15 @@ const AutocompleteMultiSelect = ({
 						placeholder={!selectedItems.length ? placeholder : ''}
 						type="text"
 					/>
-				</div>
+				</ClayLayout.Col>
 
-				<div
-					className="col-1 drop-icon mt-1 text-right"
+				<ClayLayout.Col
+					className="drop-icon mt-1 text-right"
 					onClick={handleFocus}
+					size="1"
 				>
 					<ClayIcon symbol="caret-double" />
-				</div>
+				</ClayLayout.Col>
 
 				<Autocomplete.DropDown
 					active={active}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/results-bar/ResultsBar.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/results-bar/ResultsBar.es.js
@@ -11,6 +11,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import React, {useCallback} from 'react';
 
 import {useFilter} from '../../hooks/useFilter.es';
@@ -25,9 +26,9 @@ import {
 const ResultsBar = ({children}) => {
 	return (
 		<nav className="mt-0 subnav-tbar subnav-tbar-primary tbar tbar-inline-xs-down">
-			<div className="container-fluid container-fluid-max-xl">
+			<ClayLayout.ContainerFluid>
 				<ul className="tbar-nav tbar-nav-wrap">{children}</ul>
-			</div>
+			</ClayLayout.ContainerFluid>
 		</nav>
 	);
 };

--- a/modules/dxp/apps/segments/segments-experiment-web/package.json
+++ b/modules/dxp/apps/segments/segments-experiment-web/package.json
@@ -5,6 +5,7 @@
 		"@clayui/drop-down": "3.4.4",
 		"@clayui/form": "3.8.0",
 		"@clayui/icon": "3.0.5",
+		"@clayui/layout": "3.1.0",
 		"@clayui/link": "3.2.0",
 		"@clayui/modal": "3.5.1",
 		"@clayui/tabs": "3.2.1",

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -11,6 +11,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import {useEventListener} from 'frontend-js-react-web';
@@ -124,12 +125,16 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 				</h4>
 
 				{state.selectedTarget && (
-					<dl className="autofit-row">
-						<dt className="autofit-col">
+					<ClayLayout.ContentRow containerElement="dl">
+						<ClayLayout.ContentCol containerElement="dt">
 							{Liferay.Language.get('element')}:
-						</dt>
+						</ClayLayout.ContentCol>
 
-						<dd className="autofit-col autofit-col-expand mb-0 ml-2 text-truncate-inline">
+						<ClayLayout.ContentCol
+							className="mb-0 ml-2 text-truncate-inline"
+							containerElement="dd"
+							expand
+						>
 							<ClayLink
 								className="text-truncate"
 								href={state.selectedTarget}
@@ -138,8 +143,8 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 							>
 								{state.selectedTarget}
 							</ClayLink>
-						</dd>
-					</dl>
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
 				)}
 
 				{!state.selectedTarget && (


### PR DESCRIPTION
This is simple code replacement of the layout classes with the new Clay Layout Component.

To test these modules we need to set the "DXP" environment with `ant setup-profile-dxp` + `ant all`

I've launched all the test I could as you can see from the image

![Group 5](https://user-images.githubusercontent.com/46778114/85608343-41c31200-b655-11ea-94f7-7a03f7d347cd.jpg)

So this should be ok

---

On the other hand there are still usages of the layout classes  like `.sheet`, `.autofit-row`, `.autofit-col` in the module `portal-workflow-metrics-web` but I think we can't upgrade them easily, a few examples:

 - https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/settings/indexes-page/IndexesPageBodyList.es.js#L23
- https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/list-page/SLAListPageHeader.es.js#L21
- https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/form-page/SLAFormPageBody.es.js#L160
- https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/workload-by-assignee-page/WorkloadByAssigneePageBody.es.js#L38
