### PR TITLE
LPS-116099 Move product menu title padding to its theme contributor

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
@@ -191,6 +191,14 @@
 		}
 	}
 
+	.panel-title > .collapse-icon {
+		padding: 12px 8px 12px 16px;
+
+		@include media-breakpoint-up(sm) {
+			padding-left: 24px;
+		}
+	}
+
 	.list-group-heading {
 		background-color: $product-menu-list-group-item-bg;
 		font-weight: 600;

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_no_collapsible.jspf
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_no_collapsible.jspf
@@ -14,7 +14,7 @@
  */
 --%>
 
-<span class="collapse-icon pl-4 pr-2" data-qa-id="productMenuSiteAdministrationPanelCategory">
+<span class="collapse-icon" data-qa-id="productMenuSiteAdministrationPanelCategory">
 	<clay:content-row
 		verticalAlign="center"
 	>

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_no_collapsible.jspf
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_no_collapsible.jspf
@@ -14,7 +14,7 @@
  */
 --%>
 
-<span class="collapse-icon pr-2" data-qa-id="productMenuSiteAdministrationPanelCategory">
+<span class="collapse-icon pl-4 pr-2" data-qa-id="productMenuSiteAdministrationPanelCategory">
 	<clay:content-row
 		verticalAlign="center"
 	>


### PR DESCRIPTION
This PR resolve an align problem in the product menu site title:
![image](https://user-images.githubusercontent.com/7963804/85702180-6ca57880-b6de-11ea-8cc9-e125b0b6b26b.png)

The Eudaldo's commit dint fix the issue completely, in mobile it still designed in mobile:
![image](https://user-images.githubusercontent.com/7963804/85702771-04a36200-b6df-11ea-8c2a-2d8203dc9b50.png)

After applying this PR site icon looks aligned, even when the global menu is not activated:
![image](https://user-images.githubusercontent.com/7963804/85703654-da9e6f80-b6df-11ea-99c2-3093bd36d532.png)

---

**Why I moved the styles to the product menu contributor?**
Currently, the paddings applied are a mix of styles from compatibility layer and bootstrap helpers si I consider this specific style for product me u should be allocated in product menu contributor

---

To test the pr:

Open the product menu and see the correct alignment.