### PR TITLE
LPS-116140 Custom event listeners in openModal util are initialized multiple times

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -19,7 +19,7 @@ import classNames from 'classnames';
 import {render} from 'frontend-js-react-web';
 import dom from 'metal-dom';
 import PropTypes from 'prop-types';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import './Modal.scss';
 import navigate from '../util/navigate.es';
@@ -103,7 +103,7 @@ const openPortletWindow = ({bodyCssClass, portlet, uri, ...otherProps}) => {
 const Modal = ({
 	bodyHTML,
 	buttons,
-	customEvents = [],
+	customEvents,
 	headerHTML,
 	height,
 	id,
@@ -183,7 +183,7 @@ const Modal = ({
 		}
 	};
 
-	const processClose = () => {
+	const processClose = useCallback(() => {
 		setVisible(false);
 
 		document.body.classList.remove('modal-open');
@@ -199,7 +199,7 @@ const Modal = ({
 		if (onClose) {
 			onClose();
 		}
-	};
+	}, [eventHandlersRef, onClose]);
 
 	const Body = ({html}) => {
 		const bodyRef = useRef();
@@ -239,15 +239,20 @@ const Modal = ({
 			eventHandlers.push(selectEventHandler);
 		}
 
-		customEvents.forEach((customEvent) => {
-			if (customEvent.name && customEvent.onEvent) {
-				const eventHandler = Liferay.on(customEvent.name, (event) => {
-					customEvent.onEvent(event);
-				});
+		if (customEvents) {
+			customEvents.forEach((customEvent) => {
+				if (customEvent.name && customEvent.onEvent) {
+					const eventHandler = Liferay.on(
+						customEvent.name,
+						(event) => {
+							customEvent.onEvent(event);
+						}
+					);
 
-				eventHandlers.push(eventHandler);
-			}
-		});
+					eventHandlers.push(eventHandler);
+				}
+			});
+		}
 
 		const closeEventHandler = Liferay.on('closeModal', (event) => {
 			if (event.id && id && event.id !== id) {
@@ -270,8 +275,16 @@ const Modal = ({
 
 			eventHandlers.splice(0, eventHandlers.length);
 		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [
+		customEvents,
+		eventHandlersRef,
+		id,
+		onClose,
+		onOpen,
+		onSelect,
+		processClose,
+		selectEventName,
+	]);
 
 	return (
 		<>

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -226,47 +226,42 @@ const Modal = ({
 	useEffect(() => {
 		const eventHandlers = eventHandlersRef.current;
 
-		if (visible) {
-			if (onSelect && selectEventName) {
-				const selectEventHandler = Liferay.once(
-					selectEventName,
-					(selectedItem) => {
-						processClose();
+		if (onSelect && selectEventName) {
+			const selectEventHandler = Liferay.on(
+				selectEventName,
+				(selectedItem) => {
+					processClose();
 
-						onSelect(selectedItem);
-					}
-				);
+					onSelect(selectedItem);
+				}
+			);
 
-				eventHandlers.push(selectEventHandler);
+			eventHandlers.push(selectEventHandler);
+		}
+
+		customEvents.forEach((customEvent) => {
+			if (customEvent.name && customEvent.onEvent) {
+				const eventHandler = Liferay.on(customEvent.name, (event) => {
+					customEvent.onEvent(event);
+				});
+
+				eventHandlers.push(eventHandler);
+			}
+		});
+
+		const closeEventHandler = Liferay.on('closeModal', (event) => {
+			if (event.id && id && event.id !== id) {
+				return;
 			}
 
-			customEvents.forEach((customEvent) => {
-				if (customEvent.name && customEvent.onEvent) {
-					const eventHandler = Liferay.on(
-						customEvent.name,
-						(event) => {
-							customEvent.onEvent(event);
-						}
-					);
+			processClose();
 
-					eventHandlers.push(eventHandler);
-				}
-			});
+			if (event.redirect) {
+				navigate(event.redirect);
+			}
+		});
 
-			const closeEventHandler = Liferay.on('closeModal', (event) => {
-				if (event.id && id && event.id !== id) {
-					return;
-				}
-
-				processClose();
-
-				if (event.redirect) {
-					navigate(event.redirect);
-				}
-			});
-
-			eventHandlers.push(closeEventHandler);
-		}
+		eventHandlers.push(closeEventHandler);
 
 		return () => {
 			eventHandlers.forEach((eventHandler) => {
@@ -284,7 +279,6 @@ const Modal = ({
 		onSelect,
 		processClose,
 		selectEventName,
-		visible,
 	]);
 
 	return (

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -19,7 +19,7 @@ import classNames from 'classnames';
 import {render} from 'frontend-js-react-web';
 import dom from 'metal-dom';
 import PropTypes from 'prop-types';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 import './Modal.scss';
 import navigate from '../util/navigate.es';
@@ -183,7 +183,7 @@ const Modal = ({
 		}
 	};
 
-	const processClose = useCallback(() => {
+	const processClose = () => {
 		setVisible(false);
 
 		document.body.classList.remove('modal-open');
@@ -199,7 +199,7 @@ const Modal = ({
 		if (onClose) {
 			onClose();
 		}
-	}, [eventHandlersRef, onClose]);
+	};
 
 	const Body = ({html}) => {
 		const bodyRef = useRef();
@@ -270,16 +270,8 @@ const Modal = ({
 
 			eventHandlers.splice(0, eventHandlers.length);
 		};
-	}, [
-		customEvents,
-		eventHandlersRef,
-		id,
-		onClose,
-		onOpen,
-		onSelect,
-		processClose,
-		selectEventName,
-	]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	return (
 		<>


### PR DESCRIPTION
@wincent @jbalsas 

In https://github.com/liferay-frontend/liferay-portal/pull/11 and https://github.com/liferay-frontend/liferay-portal/pull/50, we noticed an issue with multiplication of custom events execution in modals. The workaround was https://github.com/brianchandotcom/liferay-portal/commit/df771f0. In this PR we are reverting the workaround and fixing the root cause of the issue.

To reproduce the issue:
1. On master branch, revert the [workaround commit](https://github.com/liferay-frontend/liferay-portal/commit/b397c789f774ed42e390a5a2cdb873c6e6272613). Or, remove the [fix commit](https://github.com/liferay-frontend/liferay-portal/commit/d85d190c19f7d25bdfe355e7a00cbb862cad75c3) on this branch.
1. On Documents and Media page create a folder
1. Folder item options > Edit
1. Document Type Restrictions and Workflow > Define Specific Document Type Restrictions and Workflow for This Folder > Select Document Type. This opens modal.
1. Close modal on (x)
1. Open modal.
1. Select a type.

That type is now added twice to the main page. If modal is opened x times, type will be added x times.

The root cause is that `useEffect` is triggered multiple times. It is suppose to trigger only once on mount, but it triggers three times. It behaves like the component is unmounted and mounted multiple times. This cancels out so we are not noticing this issue everywhere, but it also triggers multiple times on close, where it shouldn't, and that causes the noticeable issue. The [standard form](https://reactjs.org/docs/hooks-effect.html) for hook-based code we want to execute on mount and unmount is to have and empty array as an argument of `useEffect`:
```js
useEffect({
    // on mount
}, []);
```
This clashes with our source formatter, where anything used in `useEffect` must be added as an argument. So in this PR, we are adding an exception. We didn't do this before because we were assuming that arguments with constant values can be safely used. This is true for prop strings, like `selectEventName` and `id`, but, as it turns out, is not true for functions and refs. Any change in them causes change in `useEffect`. For example, in our case, in `onClose` we change `visible` state, and that triggers `useEffect` update.

@wincent I know we had this issue before, it may be a good idea to drop the `react-hooks/exhaustive-deps` rule.

---

Now, there is a separate issue: we have a small memory leak when we close modal and reopen it. It comes from the fact that we don't unmount component on close, and create new component on open. This doesn't cause the issue in this task, because we are [explicitly cleaning up event handlers on close](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js#L191-L197).

It is a small memory leak, as the components stay alive only until user navigates to a different page. Then, [unmount handlers](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js#L271-L277) of all components execute. Note - nothing really happens in those unmount handlers: we are cleaning up event handlers, but they have all been previously cleaned in close event. This is more of a security cleanup, for some future unanticipated edge case.

I am not sure that this can be fixed, without changing how we integrate React components into Liferay portal. In React, I don't think there is a way to explicitly unmount a component. What we would do is to propagate `visible` to the parent component and have `visible && <Modal>` in it. But, by using `render(Modal)`, we don't have a parent component. I also don't see a way to make any kind of a singleton pattern, it would have to be something on a lever higher than `Modal` component, maybe in the `render` implementation?

Ultimately, I feel this issue is minor, I don't think there is any reasonable use case where modal is opened and closed so many times that the increased memory usage becomes noticeable. If fixing this would require major restructuring, I don't think it is worth it.