### PR TITLE
LPS-116176 Workflow definition source is not displayed and the user cannot type on it when creating a Workflow through Kaleo Forms Admin

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -700,7 +700,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 									</c:if>
 
 									<c:if test="<%= Validator.isNotNull(closeRedirect) %>">
-										<aui:button onClick='<%= liferayPortletResponse.getNamespace() + "closeKaleoDialog();" %>' value="cancel" />
+										<aui:button type="cancel" />
 									</c:if>
 
 									<span class="lfr-portlet-workflowdesigner-message" id="<portlet:namespace />toolbarMessage"></span>


### PR DESCRIPTION
In this PR, we are fixing the issue described in https://issues.liferay.com/browse/LPS-116176

The problem was that the height and width calculations in ACE editor are thrown off by the loading indicator. We are always inserting the loading indicator with `openModal`, we didn't use to do it with legacy modals. The editor height is calculated eagerly, while DOM is still not there.

We are now delaying initialization until the modal iframe is loaded.

As an added bonus, we are fixing closing of the modal on the 'cancel' button. This was a part of the original solution but somehow got lost.

If we discover something wrong with this fix, we can revert the original solution, as in https://github.com/liferay-frontend/liferay-portal/pull/62

/cc @julien @jbalsas @john-co 