### PR TITLE
LPS-116114 Remove the `.col-md` class in favor of ClayLayout.Col

### DIFF
--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
@@ -70,6 +70,28 @@ $tab-header-height: 38px;
 			font-weight: 700;
 		}
 	}
+
+	.global-apps-nav-columns {
+		column-count: 1;
+		orphans: 1;
+		widows: 1;
+
+		@include media-breakpoint-up(sm) {
+			column-count: 2;
+		}
+
+		@include media-breakpoint-up(md) {
+			column-count: 3;
+		}
+
+		@include media-breakpoint-up(lg) {
+			column-count: 4;
+		}
+
+		.col-md {
+			display: inline-block;
+		}
+	}
 }
 
 .global-apps-sites {

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
@@ -45,7 +45,7 @@ $tab-header-height: 38px;
 	.global-apps-nav-header {
 		color: $secondary;
 		font-size: 0.875rem;
-		font-weight: 600;
+		font-weight: 700;
 		line-height: 3rem;
 		text-transform: uppercase;
 	}
@@ -67,7 +67,7 @@ $tab-header-height: 38px;
 		line-height: 1.5rem;
 
 		&.active {
-			font-weight: 700;
+			font-weight: 600;
 		}
 	}
 

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -123,43 +123,53 @@ const AppsPanel = ({
 						key={`tabPane-${index}`}
 					>
 						<ClayLayout.Row className="global-apps-nav">
-							{childCategories.map(({key, label, panelApps}) => (
-								<ClayLayout.Col key={key} md>
-									<ul className="list-unstyled">
-										<li className="global-apps-nav-header">
-											{label}
-										</li>
+							<div className="c-p-0 col-md">
+								<div className="global-apps-nav-columns">
+									{childCategories.map(
+										({key, label, panelApps}) => (
+											<ClayLayout.Col key={key} md>
+												<ul className="list-unstyled">
+													<li className="global-apps-nav-header">
+														{label}
+													</li>
 
-										{panelApps.map(
-											({label, portletId, url}) => (
-												<li
-													className="global-apps-nav-item"
-													key={portletId}
-												>
-													<a
-														className={classNames(
-															'component-link global-apps-nav-link',
-															{
-																active:
-																	portletId ===
-																	selectedPortletId,
-															}
-														)}
-														href={url}
-													>
-														<span
-															className="c-inner"
-															tabIndex="-1"
-														>
-															{label}
-														</span>
-													</a>
-												</li>
-											)
-										)}
-									</ul>
-								</ClayLayout.Col>
-							))}
+													{panelApps.map(
+														({
+															label,
+															portletId,
+															url,
+														}) => (
+															<li
+																className="global-apps-nav-item"
+																key={portletId}
+															>
+																<a
+																	className={classNames(
+																		'component-link global-apps-nav-link',
+																		{
+																			active:
+																				portletId ===
+																				selectedPortletId,
+																		}
+																	)}
+																	href={url}
+																>
+																	<span
+																		className="c-inner"
+																		tabIndex="-1"
+																	>
+																		{label}
+																	</span>
+																</a>
+															</li>
+														)
+													)}
+												</ul>
+											</ClayLayout.Col>
+										)
+									)}
+								</div>
+							</div>
 
 							<div className="global-apps-sites">
 								<ul className="bg-light list-unstyled rounded">

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -123,7 +123,7 @@ const AppsPanel = ({
 						key={`tabPane-${index}`}
 					>
 						<ClayLayout.Row className="global-apps-nav">
-							<div className="c-p-0 col-md">
+							<ClayLayout.Col className="c-p-0" md>
 								<div className="global-apps-nav-columns">
 									{childCategories.map(
 										({key, label, panelApps}) => (
@@ -169,7 +169,7 @@ const AppsPanel = ({
 										)
 									)}
 								</div>
-							</div>
+							</ClayLayout.Col>
 
 							<div className="global-apps-sites">
 								<ul className="bg-light list-unstyled rounded">


### PR DESCRIPTION
Originally sent here: https://github.com/liferay-frontend/liferay-portal/pull/61
I couldn't push the additional commit directly to @marcoscv-work 

This PR adds the layout behavior which @victorvalle wanted and he validated in the codepen testing:
https://codepen.io/marcoscv/pen/RwrgexR

I attach a gif:

![global_grid](https://user-images.githubusercontent.com/7963804/85841190-03853a00-b79e-11ea-8fd0-4c3902046e19.gif)

The second commit is a weight font change.

We were worried about the IE support but the PR was tested on IE11 and works perfectly.
![image](https://user-images.githubusercontent.com/7963804/85840767-527e9f80-b79d-11ea-9f82-24b65ec988fd.png)

---

To test the PR:

1º Open Global menu
2º See the auto columns layout
3º Check the new font weights

![image](https://user-images.githubusercontent.com/7963804/85840538-ebf98180-b79c-11ea-883e-37c8b2381642.png)
