### PR TITLE
LPS-116295 Re-center CKEditor's dialog dynamically on browser resize

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
@@ -14,6 +14,8 @@
 
 CKEDITOR.on('dialogDefinition', (event) => {
 	if (event.editor === ckEditor) {
+		var boundingWindow = event.editor.window;
+
 		var dialogDefinition = event.data.definition;
 
 		var onShow = dialogDefinition.onShow;
@@ -56,5 +58,14 @@ CKEDITOR.on('dialogDefinition', (event) => {
 
 			instance.move(x, y, false);
 		}
+
+		AUI().use('aui-debounce', A => {
+			boundingWindow.on(
+				'resize',
+				A.debounce(() => {
+					centerDialog();
+				}, 250)
+			);
+		});
 	}
 });

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
@@ -66,6 +66,12 @@ CKEDITOR.on('dialogDefinition', (event) => {
 					centerDialog();
 				}, 250)
 			);
+
+			var clearEventHandler = function() {
+				Liferay.detach('resize', boundingWindow);
+            };
+
+            Liferay.once('destroyPortlet', clearEventHandler);
 		});
 	}
 });

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
@@ -22,8 +22,7 @@ CKEDITOR.on('dialogDefinition', (event) => {
 
 		var onShow = dialogDefinition.onShow;
 
-		dialogDefinition.onShow = function() {
-
+		dialogDefinition.onShow = function () {
 			if (typeof onShow === 'function') {
 				onShow.apply(this, arguments);
 			}
@@ -54,9 +53,9 @@ CKEDITOR.on('dialogDefinition', (event) => {
 					window.scrollY);
 
 			dialog.move(x, y, false);
-		}
+		};
 
-		AUI().use('aui-debounce', A => {
+		AUI().use('aui-debounce', (A) => {
 			boundingWindow.on(
 				'resize',
 				A.debounce(() => {
@@ -65,7 +64,7 @@ CKEDITOR.on('dialogDefinition', (event) => {
 			);
 		});
 
-		var clearEventHandler = function() {
+		var clearEventHandler = function () {
 			Liferay.detach('resize', boundingWindow);
 		};
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
@@ -63,12 +63,12 @@ CKEDITOR.on('dialogDefinition', (event) => {
 					centerDialog();
 				}, 250)
 			);
-
-			var clearEventHandler = function() {
-				Liferay.detach('resize', boundingWindow);
-            };
-
-            Liferay.once('destroyPortlet', clearEventHandler);
 		});
+
+		var clearEventHandler = function() {
+			Liferay.detach('resize', boundingWindow);
+		};
+
+		Liferay.once('destroyPortlet', clearEventHandler);
 	}
 });

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
@@ -18,18 +18,28 @@ CKEDITOR.on('dialogDefinition', (event) => {
 
 		var onShow = dialogDefinition.onShow;
 
-		dialogDefinition.onShow = function () {
+		var dialog;
+
+		dialogDefinition.onShow = function() {
+			dialog = this;
+
 			if (typeof onShow === 'function') {
 				onShow.apply(this, arguments);
 			}
 
-			var editorElement = this.getParentEditor().container;
+			centerDialog();
+		};
+
+		var centerDialog = function () {
+			var instance = dialog;
+
+			var editorElement = instance.getParentEditor().container;
 
 			var documentPosition = editorElement
 				.getLast()
 				.getDocumentPosition();
 
-			var dialogSize = this.getSize();
+			var dialogSize = instance.getSize();
 
 			var x =
 				documentPosition.x +
@@ -44,7 +54,7 @@ CKEDITOR.on('dialogDefinition', (event) => {
 					2 -
 					window.scrollY);
 
-			this.move(x, y, false);
-		};
+			instance.move(x, y, false);
+		}
 	}
 });

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
@@ -18,12 +18,11 @@ CKEDITOR.on('dialogDefinition', (event) => {
 
 		var dialogDefinition = event.data.definition;
 
+		var dialog = event.data.dialog;
+
 		var onShow = dialogDefinition.onShow;
 
-		var dialog;
-
 		dialogDefinition.onShow = function() {
-			dialog = this;
 
 			if (typeof onShow === 'function') {
 				onShow.apply(this, arguments);
@@ -33,15 +32,13 @@ CKEDITOR.on('dialogDefinition', (event) => {
 		};
 
 		var centerDialog = function () {
-			var instance = dialog;
-
-			var editorElement = instance.getParentEditor().container;
+			var editorElement = dialog.getParentEditor().container;
 
 			var documentPosition = editorElement
 				.getLast()
 				.getDocumentPosition();
 
-			var dialogSize = instance.getSize();
+			var dialogSize = dialog.getSize();
 
 			var x =
 				documentPosition.x +
@@ -56,7 +53,7 @@ CKEDITOR.on('dialogDefinition', (event) => {
 					2 -
 					window.scrollY);
 
-			instance.move(x, y, false);
+			dialog.move(x, y, false);
 		}
 
 		AUI().use('aui-debounce', A => {


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

You can get more information about the issue and the steps to reproduce it in [LPS-116295](https://issues.liferay.com/browse/LPS-116295).

This issue was originally caused by CKEditors upgrade in [LPS-107869](https://issues.liferay.com/browse/LPS-107869) (v4.11.4 to v4.13.1) and it was partially fixed by [LPS-111979: Center CKEditor dialogs](https://issues.liferay.com/browse/LPS-111979). However after resizing the browser, they stopped being positioned in the center.

Thanks.

Regards.

/cc @NemethNorbert