### PR TITLE
LPS-116099 Fix style of product-menu items in mobile

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
@@ -203,9 +203,12 @@
 		background-color: $product-menu-list-group-item-bg;
 		font-weight: 600;
 		overflow: hidden;
-		padding-left: 24px;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+
+		@include media-breakpoint-up(sm) {
+			padding-left: 24px;
+		}
 
 		@include overflow-wrap(normal);
 
@@ -259,7 +262,11 @@
 	.list-group .list-group-item {
 		border-width: $product-menu-list-group-item-border-width;
 		color: $product-menu-nav-link-color;
-		padding: 8px 8px 8px 24px;
+		padding: 8px 8px 8px 16px;
+
+		@include media-breakpoint-up(sm) {
+			padding-left: 24px;
+		}
 	}
 
 	.collapse,


### PR DESCRIPTION
This is a simple style fix, I added the required responsive change and a further modification for the sub-navigation items.

Here's the result

<img width="827" alt="Screenshot 2020-07-02 at 16 14 56" src="https://user-images.githubusercontent.com/46778114/86371265-f924dd80-bc80-11ea-81b1-c7ecdbde9994.png">
<img width="353" alt="Screenshot 2020-07-02 at 16 14 14" src="https://user-images.githubusercontent.com/46778114/86371251-f5915680-bc80-11ea-85e6-ce4610706c32.png">

---

Having said that, @jbalsas if we are planning to keep this menu, we should consider a renovation of the markup and CSS, right now there are 10 different `.product-menu`s and a lot of "noise" in the file https://github.com/liferay/liferay-portal/blob/master/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss

/cc @marcoscv-work 
