### PR TITLE
LPS-116518 Enable to use Collections.singletonMap as content in ComponentTag

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/build.gradle
+++ b/modules/apps/frontend-taglib/frontend-taglib/build.gradle
@@ -19,4 +19,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":core:registry-api")
+
+	testCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testCompile group: "org.jsoup", name: "jsoup", version: "1.10.2"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTag.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.json.JSONSerializer;
 import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -32,7 +33,6 @@ import com.liferay.taglib.util.ParamAndPropertyAncestorTagImpl;
 
 import java.io.IOException;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.ServletContext;
@@ -198,24 +198,21 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 
 		sb.append(".default(");
 
-		Map<String, Object> context = getContext();
-
-		if (context == null) {
-			context = new HashMap<>();
-		}
-
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
-		context.put("namespace", portletDisplay.getNamespace());
-
-		context.put(
-			"spritemap",
-			themeDisplay.getPathThemeImages() + "/lexicon/icons.svg");
-
-		sb.append(_jsonSerializer.serializeDeep(context));
+		sb.append(
+			_jsonSerializer.serializeDeep(
+				new HashMapBuilder<>().putAll(
+					getContext()
+				).put(
+					"namespace", portletDisplay.getNamespace()
+				).put(
+					"spritemap",
+					themeDisplay.getPathThemeImages() + "/lexicon/icons.svg"
+				).build()));
 
 		String containerId = getContainerId();
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTagTest.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTagTest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.servlet.taglib;
+
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolvedPackageNameUtil;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletConfig;
+import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PortalImpl;
+import com.liferay.portal.util.PropsImpl;
+
+import java.io.StringWriter;
+
+import java.net.URL;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockPageContext;
+
+/**
+ * @author Cristina González
+ */
+public class ComponentTagTest {
+
+	@BeforeClass
+	public static void setUpClass() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+
+		PortalClassLoaderUtil.setClassLoader(PortalImpl.class.getClassLoader());
+
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(new PortalImpl());
+
+		PropsUtil.setProps(new PropsImpl());
+	}
+
+	@Test
+	public void testDoEndTag() throws Exception {
+		ComponentTag componentTag = new ComponentTag();
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest();
+
+		componentTag.setComponentId("componentId");
+
+		componentTag.setContext(
+			new HashMapBuilder().<String, Object>put(
+				"name", "value"
+			).build());
+
+		componentTag.setModule("module");
+		componentTag.setPageContext(
+			new MockPageContext(_getServletContext(), httpServletRequest));
+
+		componentTag.doEndTag();
+
+		Document document = _toDocument(
+			(ScriptData)httpServletRequest.getAttribute(
+				WebKeys.AUI_SCRIPT_DATA));
+
+		Elements elements = document.select("script[type='text/javascript']");
+
+		Assert.assertEquals(1, elements.size());
+
+		Element element = elements.get(0);
+
+		Assert.assertEquals(_expectedResult(), element.html());
+	}
+
+	private String _expectedResult() throws Exception {
+		Class<?> clazz = getClass();
+
+		URL url = clazz.getResource("componentTag.txt");
+
+		return new String(Files.readAllBytes(Paths.get(url.toURI())));
+	}
+
+	private HttpServletRequest _getHttpServletRequest() {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		portletDisplay.setNamespace("namespace");
+
+		LiferayPortletConfig liferayPortletConfig = Mockito.mock(
+			LiferayPortletConfig.class);
+
+		Mockito.when(
+			liferayPortletConfig.getPortletId()
+		).thenReturn(
+			"portletId"
+		);
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_CONFIG, liferayPortletConfig);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return mockHttpServletRequest;
+	}
+
+	private ServletContext _getServletContext() {
+		ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+		servletContext.setAttribute(
+			NPMResolvedPackageNameUtil.class.getName(),
+			"NPMResolvedPackageNameUtil");
+
+		return servletContext;
+	}
+
+	private Document _toDocument(ScriptData scriptData) throws Exception {
+		StringWriter stringWriter = new StringWriter();
+
+		scriptData.writeTo(stringWriter);
+
+		StringBuffer stringBuffer = stringWriter.getBuffer();
+
+		return Jsoup.parse(stringBuffer.toString());
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTagTest.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTagTest.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletConfig;
 import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -36,6 +35,8 @@ import java.net.URL;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import java.util.Collections;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -81,12 +82,7 @@ public class ComponentTagTest {
 		HttpServletRequest httpServletRequest = _getHttpServletRequest();
 
 		componentTag.setComponentId("componentId");
-
-		componentTag.setContext(
-			new HashMapBuilder().<String, Object>put(
-				"name", "value"
-			).build());
-
+		componentTag.setContext(Collections.singletonMap("name", "value"));
 		componentTag.setModule("module");
 		componentTag.setPageContext(
 			new MockPageContext(_getServletContext(), httpServletRequest));

--- a/modules/apps/frontend-taglib/frontend-taglib/src/test/resources/com/liferay/frontend/taglib/servlet/taglib/componentTag.txt
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/test/resources/com/liferay/frontend/taglib/servlet/taglib/componentTag.txt
@@ -3,7 +3,7 @@ Liferay.Loader.require('null/module', function(nullModule) {
 try {
 (function() {
 var module = nullModule;
-Liferay.component('componentId', new module.default({"spritemap":"\/lexicon\/icons.svg","name":"value","namespace":"namespace"}), { destroyOnNavigate: true, portletId: ''});
+Liferay.component('componentId', new module.default({"name":"value","namespace":"namespace","spritemap":"\/lexicon\/icons.svg"}), { destroyOnNavigate: true, portletId: ''});
 })();
 } catch (err) {
 	console.error(err);

--- a/modules/apps/frontend-taglib/frontend-taglib/src/test/resources/com/liferay/frontend/taglib/servlet/taglib/componentTag.txt
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/test/resources/com/liferay/frontend/taglib/servlet/taglib/componentTag.txt
@@ -1,0 +1,12 @@
+// <![CDATA[
+Liferay.Loader.require('null/module', function(nullModule) {
+try {
+(function() {
+var module = nullModule;
+Liferay.component('componentId', new module.default({"spritemap":"\/lexicon\/icons.svg","name":"value","namespace":"namespace"}), { destroyOnNavigate: true, portletId: ''});
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -410,10 +410,9 @@ public class JournalDisplayContext {
 	}
 
 	public Map<String, Object> getComponentContext() throws Exception {
-		return HashMapBuilder.<String, Object>put(
+		return Collections.singletonMap(
 			"trashEnabled",
-			_trashHelper.isTrashEnabled(_themeDisplay.getScopeGroupId())
-		).build();
+			_trashHelper.isTrashEnabled(_themeDisplay.getScopeGroupId()));
 	}
 
 	public String getDDMStructureKey() {


### PR DESCRIPTION
**Motivation:**

- Immutable maps are prevented from being used as context in liferay-frontend:component (because the current implementation add values to the current map).
- Sometimes use Collections.singletonMap or another immutable map could improve the code that we generate as backend developers (Simplify, decrease memory footprint, ..).
Provided solution

**Provided solution**

I know this is a complex issue, and that many other solutions could be provided, but I would suggest, if it is not a performance decision, to copy the context map into a new enriched one.

**How to test it**

In the pull, I have included test myself, but if you want to test it in Portal, you can test it displaying the Info Panel in Journal:

1. Go to web content
2. Create a web content
3. Select the created web content
4. Click the info button

*Expected result*

The info panel is correctly loaded a there are not server-side log errors.


**Feedback about fronted-taglib module**

To send this pull request I have suffered the lack of back-end test, I have added a back-end test, so in the future, we can improve back-end coverage in this pull