### PR TITLE
LPS-116254 Localization - alert success notifications are not displayed correctly

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -51,15 +51,24 @@ const getRootElement = ({container, containerId}) => {
 		}
 	}
 
-	container = document.getElementById(DEFAULT_ALERT_CONTAINER_ID);
+	let alertFixed = document.getElementById(DEFAULT_ALERT_CONTAINER_ID);
 
-	if (!container) {
-		container = document.createElement('div');
+	if (!alertFixed) {
+		const alertContainer = document.createElement('div');
+		alertContainer.className = 'alert-container container';
+		document.body.appendChild(alertContainer);
 
-		container.id = DEFAULT_ALERT_CONTAINER_ID;
-
-		document.body.appendChild(container);
+		alertFixed = document.createElement('div');
+		alertFixed.id = DEFAULT_ALERT_CONTAINER_ID;
+		alertFixed.className = 'alert-notifications alert-notifications-fixed';
+		alertContainer.appendChild(alertFixed);
 	}
+
+	// Creates a fragment for preventing React to unmount the alertContainer
+	container = document.createElement('div');
+	container.className = 'mb-3';
+
+	alertFixed.appendChild(container);
 
 	return container;
 };
@@ -100,19 +109,20 @@ function openToast({
 
 	unmountComponentAtNode(rootElement);
 
-	const Container =
-		container || containerId ? React.Fragment : ClayAlert.ToastContainer;
-
 	const onCloseFn = (event) => {
 		if (onClose) {
 			onClose({event});
+		}
+
+		if (!container || !containerId) {
+			rootElement.parentNode.removeChild(rootElement);
 		}
 
 		unmountComponentAtNode(rootElement);
 	};
 
 	render(
-		<Container>
+		<>
 			<ClayAlert
 				autoClose={autoClose}
 				displayType={type}
@@ -131,7 +141,7 @@ function openToast({
 			>
 				<Text allowHTML={messageType === TYPES.HTML} string={message} />
 			</ClayAlert>
-		</Container>,
+		</>,
 		renderData,
 		rootElement
 	);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -17,7 +17,7 @@ import {render} from 'frontend-js-react-web';
 import React from 'react';
 import {unmountComponentAtNode} from 'react-dom';
 
-const DEFAULT_ALERT_CONTAINER_ID = 'alertContainer';
+const DEFAULT_ALERT_CONTAINER_ID = 'ToastAlertContainer';
 
 const DEFAULT_RENDER_DATA = {
 	portletId: 'UNKNOWN_PORTLET_ID',

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -14,6 +14,7 @@
 
 import ClayAlert from '@clayui/alert';
 import {render} from 'frontend-js-react-web';
+import {buildFragment} from 'metal-dom';
 import React from 'react';
 import {unmountComponentAtNode} from 'react-dom';
 
@@ -29,6 +30,12 @@ const TYPES = {
 	HTML: 'html',
 	TEXT: 'text',
 };
+
+const TPL_ALERT_CONTAINER = `
+	<div class="alert-container container">
+		<div class="alert-notifications alert-notifications-fixed" id=${DEFAULT_ALERT_CONTAINER_ID}></div>
+	</div>
+`;
 
 const Text = ({allowHTML, string = null}) => {
 	if (allowHTML) {
@@ -54,21 +61,23 @@ const getRootElement = ({container, containerId}) => {
 	let alertFixed = document.getElementById(DEFAULT_ALERT_CONTAINER_ID);
 
 	if (!alertFixed) {
-		const alertContainer = document.createElement('div');
-		alertContainer.className = 'alert-container container';
-		document.body.appendChild(alertContainer);
+		alertFixed = buildFragment(TPL_ALERT_CONTAINER).querySelector(
+			'.alert-container.container'
+		);
 
-		alertFixed = document.createElement('div');
-		alertFixed.id = DEFAULT_ALERT_CONTAINER_ID;
-		alertFixed.className = 'alert-notifications alert-notifications-fixed';
-		alertContainer.appendChild(alertFixed);
+		alertFixed = document.body.appendChild(alertFixed);
 	}
 
 	// Creates a fragment for preventing React to unmount the alertContainer
+
 	container = document.createElement('div');
 	container.className = 'mb-3';
 
-	alertFixed.appendChild(container);
+	const fragmentContainer = document.querySelector(
+		`.alert-notifications.alert-notifications-fixed`
+	);
+
+	fragmentContainer.appendChild(container);
 
 	return container;
 };
@@ -122,26 +131,21 @@ function openToast({
 	};
 
 	render(
-		<>
-			<ClayAlert
-				autoClose={autoClose}
-				displayType={type}
-				onClick={(event) => onClick({event, onClose: onCloseFn})}
-				onClose={onCloseFn}
-				title={
-					title && (
-						<Text
-							allowHTML={titleType === TYPES.HTML}
-							string={title}
-						/>
-					)
-				}
-				variant={variant}
-				{...toastProps}
-			>
-				<Text allowHTML={messageType === TYPES.HTML} string={message} />
-			</ClayAlert>
-		</>,
+		<ClayAlert
+			autoClose={autoClose}
+			displayType={type}
+			onClick={(event) => onClick({event, onClose: onCloseFn})}
+			onClose={onCloseFn}
+			title={
+				title && (
+					<Text allowHTML={titleType === TYPES.HTML} string={title} />
+				)
+			}
+			variant={variant}
+			{...toastProps}
+		>
+			<Text allowHTML={messageType === TYPES.HTML} string={message} />
+		</ClayAlert>,
 		renderData,
 		rootElement
 	);

--- a/portal-web/docroot/html/taglib/ui/error/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/error/page.jsp
@@ -46,46 +46,12 @@ String rowBreak = (String)request.getAttribute("liferay-ui:error:rowBreak");
 		<%= rowBreak %>
 	</c:when>
 	<c:otherwise>
-		<aui:script require="metal-dom/src/all/dom as dom,clay-alert/src/ClayToast as ClayToast">
-			let alertContainer = document.getElementById('alertContainer');
-
-			if (!alertContainer) {
-				alertContainer = document.createElement('div');
-				alertContainer.id = 'alertContainer';
-
-				dom.addClasses(alertContainer, 'alert-notifications alert-notifications-fixed');
-				dom.enterDocument(alertContainer);
-			}
-			else {
-				dom.removeChildren(alertContainer);
-			}
-
-			const clayToast = new ClayToast.default(
-				{
-					autoClose: true,
-					destroyOnHide: true,
-					events: {
-						'disposed': function(event) {
-							if (!alertContainer.hasChildNodes()) {
-								dom.exitDocument(alertContainer);
-							}
-						}
-					},
-					message: '<%= HtmlUtil.escapeJS(alertMessage) %>',
-					spritemap: '<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg',
-					style: '<%= alertStyle %>',
-					title: '<%= alertTitle %>'
-				},
-				alertContainer
-			);
-
-			dom.removeClasses(clayToast.element, 'show');
-
-			requestAnimationFrame(
-				function() {
-					dom.addClasses(clayToast.element, 'show');
-				}
-			);
+		<aui:script>
+			Liferay.Util.openToast({
+			   displayType: '<%= alertStyle %>',
+			   message: '<%= HtmlUtil.escapeJS(alertMessage) %>',
+			   title: '<%= alertTitle %>'
+			});
 		</aui:script>
 	</c:otherwise>
 </c:choose>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SignIn.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SignIn.macro
@@ -114,7 +114,7 @@ definition {
 
 		Pause(locator1 = "3000");
 
-		WaitForElementPresent(locator1 = "//script[contains(@src,'ClayToast.js')]");
+		WaitForElementPresent(locator1 = "//script[contains(@src,'OpenToast.es.js')]");
 
 		Alert.viewSuccessMessage();
 

--- a/util-taglib/src/com/liferay/taglib/ui/SuccessTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SuccessTag.java
@@ -132,8 +132,6 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 		}
 
 		Map<String, String> values = HashMapBuilder.put(
-			"pathThemeImages", themeDisplay.getPathThemeImages()
-		).put(
 			"title", LanguageUtil.get(resourceBundle, "success-colon")
 		).build();
 
@@ -157,8 +155,7 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 
 			ScriptTag.doTag(
 				null,
-				"metal-dom/src/all/dom as dom,clay-alert/src/ClayToast as " +
-					"ClayToast",
+				null,
 				null, result, getBodyContent(), pageContext);
 		}
 

--- a/util-taglib/src/com/liferay/taglib/ui/SuccessTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SuccessTag.java
@@ -154,9 +154,7 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 				values);
 
 			ScriptTag.doTag(
-				null,
-				null,
-				null, result, getBodyContent(), pageContext);
+				null, null, null, result, getBodyContent(), pageContext);
 		}
 
 		return EVAL_PAGE;

--- a/util-taglib/src/com/liferay/taglib/ui/success/toast.tmpl
+++ b/util-taglib/src/com/liferay/taglib/ui/success/toast.tmpl
@@ -1,39 +1,5 @@
-let alertContainer = document.getElementById('alertContainer');
-
-if (!alertContainer) {
-    alertContainer = document.createElement('div');
-    alertContainer.id = 'alertContainer';
-
-    dom.addClasses(alertContainer, 'alert-notifications alert-notifications-fixed');
-    dom.enterDocument(alertContainer);
-}
-else {
-    dom.removeChildren(alertContainer);
-}
-
-const clayToast = new ClayToast.default(
-    {
-        autoClose: true,
-        destroyOnHide: true,
-        events: {
-            'disposed': function(event) {
-                if (!alertContainer.hasChildNodes()) {
-                    dom.exitDocument(alertContainer);
-                }
-            }
-        },
-        message: '$message$'.replace(/&amp;/g, '&'),
-        spritemap: '$pathThemeImages$/lexicon/icons.svg',
-        style: 'success',
-        title: '$title$'
-    },
-    alertContainer
-);
-
-dom.removeClasses(clayToast.element, 'show');
-
-requestAnimationFrame(
-    function() {
-        dom.addClasses(clayToast.element, 'show');
-    }
-);
+Liferay.Util.openToast({
+   displayType: 'success',
+   message: '$message$'.replace(/&amp;/g, '&'),
+   title: '$title$'
+});


### PR DESCRIPTION
## Test Case:

* Open Blogs
* Change the language to another language replacing the URL before `/group` adding for example `pt` e.g(`http://localhost:8080/pt/group/guest/~/control_panel/manage?p_p_id=com_liferay_blogs_web_portlet_BlogsAdminPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&p_p_auth=UJfDKe6X`)
* Click to add a new blog entry
* Fill the blog post with required things and then publish

Expected results:

No JS errors on console and the toast message (Your request was finished) will be shown adequately.

## What I did

I noticed other toast containers created by JSP for example can be conflicting with React renderization of openToast. So, I decided to replace the DEFAULT_CONTAINER_ID to a unique ID used on the openToast, for not conflicting with [others](https://gist.github.com/diegonvs/5771f259c1497a780b9141940233cc1b). 

## Questions

However the result was:

<img width="426" alt="Screen Shot 2020-07-03 at 18 44 54" src="https://user-images.githubusercontent.com/7663513/86498679-4bd3c780-bd5d-11ea-9339-6976164c3153.png">

We aren't able to stack toast Alerts with this current implementation.

One possible thing to fix this issue is creating another command like openAlert for isolate the logic for containerId oriented alerts and left the openToast behaviour like the past API(Where We could just stack toasts and We aren't using it for every alert We got).

What do you think about it folks?

/cc @wincent @jbalsas @matuzalemsteles @markocikos @brunobasto 
