### PR TITLE
LPS-116105 Fix style of view-all in global-app-menu

### DIFF
--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -200,6 +200,7 @@ const AppsPanel = ({
 									{sites.viewAllURL && (
 										<li>
 											<ClayButton
+												className="c-pl-0"
 												displayType="link"
 												onClick={() => {
 													Liferay.Util.openModal({


### PR DESCRIPTION
The request was to align the `view all` button to the left of the sites column

![image](https://user-images.githubusercontent.com/46778114/86784402-c2284080-c061-11ea-85a5-12e83a9f6617.png)

I took into consideration the following solutions:
- Add the class `.btn-unstyled` to the button
  - the btn-unstyled reset the font-size and we wanted to preserve it small
- Add a `negative-margin-left` to the button
  - not the best practice because out of context it could overlap other components
- Remove the `padding-left` from the button
  - I prefer this option and used the Clay utility class `.c-pl-0` that does exactly what we needed without causing the `!important` attribute problem.

**Result:**

![image](https://user-images.githubusercontent.com/46778114/86784987-70cc8100-c062-11ea-9e9a-004b70e860c3.png)
