### PR TITLE
LPS-116677 - Add a separator line to navigation-bar-light

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/_custom.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/_custom.scss
@@ -1,5 +1,6 @@
 @import 'components/breadcrumb';
 @import 'components/group-item';
+@import 'components/navigation-bar';
 @import 'components/sidebar';
 @import 'components/splitter';
 @import 'components/table';

--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/components/_navigation-bar.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/components/_navigation-bar.scss
@@ -1,0 +1,3 @@
+.navigation-bar-light {
+	border-bottom: $navbar-border-bottom-width solid $gray-200;
+}

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_custom.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_custom.scss
@@ -3,6 +3,7 @@
 @import 'components/group-item';
 @import 'components/info-panel';
 @import 'components/navbars';
+@import 'components/navigation-bar';
 @import 'components/sidebar';
 @import 'components/splitter';
 @import 'components/table';

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/components/_navigation-bar.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/components/_navigation-bar.scss
@@ -1,0 +1,3 @@
+.navigation-bar-light {
+	border-bottom: $navbar-border-bottom-width solid $gray-200;
+}


### PR DESCRIPTION
**Only for testing and @victorvalle quick review**

This PR adds a separator line under `navigation-bar-light`

![image](https://user-images.githubusercontent.com/7963804/86939716-3803d900-c142-11ea-9273-8b3d2755b813.png)

To test this PR we only need to go to `User and Organizations`