### PR TITLE
LPS-116792 - Add new global menu mobile pattern

### DIFF
--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
@@ -5,6 +5,27 @@ $tab-header-height: 38px;
 
 .global-apps-menu-modal {
 	.global-apps-menu-header {
+		.autofit-row {
+			@include media-breakpoint-down(xs) {
+				flex-wrap: wrap;
+			}
+		}
+
+		.global-apps-menu-tabs {
+			@include media-breakpoint-down(xs) {
+				order: 1;
+				width: 100%;
+			}
+		}
+
+		.control-menu-level-1-heading {
+			@include media-breakpoint-down(xs) {
+				flex-grow: 1;
+				flex-shrink: 1;
+				min-height: 3.25rem;
+			}
+		}
+
 		.nav-link {
 			line-height: 1.6rem;
 
@@ -17,6 +38,10 @@ $tab-header-height: 38px;
 	.modal-full {
 		margin-top: 0;
 		width: 100%;
+
+		@include media-breakpoint-down(xs) {
+			margin: 0;
+		}
 
 		.modal-body {
 			padding: 0;
@@ -36,7 +61,7 @@ $tab-header-height: 38px;
 
 .global-apps-nav {
 	margin: 0;
-	padding: 1rem;
+	padding: 0.2rem;
 
 	@include media-breakpoint-up(sm) {
 		padding: 1.5rem 2.5rem 1.5rem 1.75rem;

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -85,7 +85,10 @@ const AppsPanel = ({
 						<ClayLayout.ContentCol className="c-mr-3 c-pl-1 c-pr-3 control-menu-level-1-heading">
 							{companyName}
 						</ClayLayout.ContentCol>
-						<ClayLayout.ContentCol expand>
+						<ClayLayout.ContentCol
+							className="global-apps-menu-tabs"
+							expand
+						>
 							<ClayTabs modern>
 								{categories.map(({key, label}, index) => (
 									<ClayTabs.Item


### PR DESCRIPTION
- This PR adds the new behavior for global menu in mobile, here an example:

![global-menu-mobile](https://user-images.githubusercontent.com/7963804/87040100-7bb51c00-c1f0-11ea-877e-d0d7bd5ae91c.gif)

- To test the PR you only have to open the global menu in mobile or resize your screen as you can see in the previous gif