### PR TITLE
LPS-116690 Adds maxItems attributes to liferay-ui:input-move-boxes

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
@@ -137,6 +137,13 @@ AUI.add(
 					});
 				},
 
+				_onChange(event) {
+					var instance = this;
+
+					instance._toggleBtnMove(event);
+					instance._toggleBtnSort(event);
+				},
+
 				_onSelectFocus(event, box) {
 					var instance = this;
 
@@ -283,6 +290,10 @@ AUI.add(
 					var moveBtnRight = contentBox.one('.move-right');
 
 					var target = event.target;
+					var selectedOptions = target
+						.get('options')
+						.getDOMNodes()
+						.filter((option) => option.selected).length;
 
 					if (moveBtnLeft && moveBtnRight && target) {
 						var btnDisabledLeft = true;
@@ -292,7 +303,8 @@ AUI.add(
 							if (target === instance._rightBox) {
 								if (
 									leftBoxMaxItems === -1 ||
-									instance._leftBox.get('length') <
+									instance._leftBox.get('length') +
+										selectedOptions <=
 										leftBoxMaxItems
 								) {
 									btnDisabledLeft = false;
@@ -301,7 +313,8 @@ AUI.add(
 							else if (target === instance._leftBox) {
 								if (
 									rightBoxMaxItems === -1 ||
-									instance._rightBox.get('length') <
+									instance._rightBox.get('length') +
+										selectedOptions <=
 										rightBoxMaxItems
 								) {
 									btnDisabledRight = false;
@@ -425,18 +438,20 @@ AUI.add(
 					);
 
 					instance._leftBox.after(
-						'valuechange',
-						A.bind('_toggleBtnSort', instance)
+						'change',
+						A.bind('_onChange', instance)
 					);
+
 					instance._leftBox.on(
 						'focus',
 						A.rbind('_onSelectFocus', instance, instance._rightBox)
 					);
 
 					instance._rightBox.after(
-						'valuechange',
-						A.bind('_toggleBtnSort', instance)
+						'change',
+						A.bind('_onChange', instance)
 					);
+
 					instance._rightBox.on(
 						'focus',
 						A.rbind('_onSelectFocus', instance, instance._leftBox)

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
@@ -25,7 +25,11 @@ AUI.add(
 
 		var InputMoveBoxes = A.Component.create({
 			ATTRS: {
+				leftBoxMaxItems: -1,
+
 				leftReorder: {},
+
+				rightBoxMaxItems: -1,
 
 				rightReorder: {},
 
@@ -272,6 +276,8 @@ AUI.add(
 					var instance = this;
 
 					var contentBox = instance.get('contentBox');
+					var leftBoxMaxItems = instance.get('leftBoxMaxItems');
+					var rightBoxMaxItems = instance.get('rightBoxMaxItems');
 
 					var moveBtnLeft = contentBox.one('.move-left');
 					var moveBtnRight = contentBox.one('.move-right');
@@ -283,11 +289,23 @@ AUI.add(
 						var btnDisabledRight = true;
 
 						if (target.get('length') > 0) {
-							if (target == instance._rightBox) {
-								btnDisabledLeft = false;
+							if (target === instance._rightBox) {
+								if (
+									leftBoxMaxItems === -1 ||
+									instance._leftBox.get('length') <
+										leftBoxMaxItems
+								) {
+									btnDisabledLeft = false;
+								}
 							}
-							else if (target == instance._leftBox) {
-								btnDisabledRight = false;
+							else if (target === instance._leftBox) {
+								if (
+									rightBoxMaxItems === -1 ||
+									instance._rightBox.get('length') <
+										rightBoxMaxItems
+								) {
+									btnDisabledRight = false;
+								}
 							}
 						}
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
@@ -25,11 +25,11 @@ AUI.add(
 
 		var InputMoveBoxes = A.Component.create({
 			ATTRS: {
-				leftBoxMaxItems: -1,
+				leftBoxMaxItems: Infinity,
 
 				leftReorder: {},
 
-				rightBoxMaxItems: -1,
+				rightBoxMaxItems: Infinity,
 
 				rightReorder: {},
 
@@ -137,7 +137,7 @@ AUI.add(
 					});
 				},
 
-				_onChange(event) {
+				_onSelectChange(event) {
 					var instance = this;
 
 					instance._toggleBtnMove(event);
@@ -282,52 +282,28 @@ AUI.add(
 				_toggleBtnMove(event) {
 					var instance = this;
 
-					var contentBox = instance.get('contentBox');
-					var leftBoxMaxItems = instance.get('leftBoxMaxItems');
-					var rightBoxMaxItems = instance.get('rightBoxMaxItems');
+					var sourceBox = event.target;
 
-					var moveBtnLeft = contentBox.one('.move-left');
-					var moveBtnRight = contentBox.one('.move-right');
-
-					var target = event.target;
-					var selectedOptions = target
+					var selectedOptions = sourceBox
 						.get('options')
 						.getDOMNodes()
-						.filter((option) => option.selected).length;
+						.filter((option) => option.selected);
 
-					if (moveBtnLeft && moveBtnRight && target) {
-						var btnDisabledLeft = true;
-						var btnDisabledRight = true;
+					var direction =
+						sourceBox === instance._rightBox ? 'left' : 'right';
 
-						if (target.get('length') > 0) {
-							if (target === instance._rightBox) {
-								if (
-									leftBoxMaxItems === -1 ||
-									instance._leftBox.get('length') +
-										selectedOptions <=
-										leftBoxMaxItems
-								) {
-									btnDisabledLeft = false;
-								}
-							}
-							else if (target === instance._leftBox) {
-								if (
-									rightBoxMaxItems === -1 ||
-									instance._rightBox.get('length') +
-										selectedOptions <=
-										rightBoxMaxItems
-								) {
-									btnDisabledRight = false;
-								}
-							}
-						}
+					var destinationBox = instance[`_${direction}Box`];
+					var destinationBoxMaxItems = instance.get(
+						`${direction}BoxMaxItems`
+					);
 
-						instance._toggleBtnState(moveBtnLeft, btnDisabledLeft);
-						instance._toggleBtnState(
-							moveBtnRight,
-							btnDisabledRight
-						);
-					}
+					var contentBox = instance.get('contentBox');
+
+					instance._toggleBtnState(
+						contentBox.one(`.move-${direction}`),
+						destinationBox.get('length') + selectedOptions.length >
+							destinationBoxMaxItems
+					);
 				},
 
 				_toggleBtnSort(event) {
@@ -439,7 +415,7 @@ AUI.add(
 
 					instance._leftBox.after(
 						'change',
-						A.bind('_onChange', instance)
+						A.bind('_onSelectChange', instance)
 					);
 
 					instance._leftBox.on(
@@ -449,7 +425,7 @@ AUI.add(
 
 					instance._rightBox.after(
 						'change',
-						A.bind('_onChange', instance)
+						A.bind('_onSelectChange', instance)
 					);
 
 					instance._rightBox.on(

--- a/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
@@ -21,6 +21,9 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_input_
 
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-move-boxes:cssClass"));
 
+int leftBoxMaxItems = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-move-boxes:leftBoxMaxItems"));
+int rightBoxMaxItems = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-move-boxes:rightBoxMaxItems"));
+
 String leftTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute("liferay-ui:input-move-boxes:leftTitle"));
 String rightTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute("liferay-ui:input-move-boxes:rightTitle"));
 
@@ -87,6 +90,8 @@ Map<String, Object> data = new HashMap<String, Object>();
 	new Liferay.InputMoveBoxes(
 		{
 			contentBox: '#<%= randomNamespace + "input-move-boxes" %>',
+			leftBoxMaxItems: <%= leftBoxMaxItems %>,
+			rightBoxMaxItems: <%= rightBoxMaxItems %>,
 			strings: {
 				LEFT_MOVE_DOWN: '<%= UnicodeLanguageUtil.format(request, "move-selected-item-in-x-one-position-down", leftTitle, false) %>',
 				LEFT_MOVE_UP: '<%= UnicodeLanguageUtil.format(request, "move-selected-item-in-x-one-position-up", leftTitle, false) %>',

--- a/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
@@ -25,7 +25,7 @@ String leftTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute
 String rightTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute("liferay-ui:input-move-boxes:rightTitle"));
 
 Integer leftBoxMaxItems = (Integer)request.getAttribute("liferay-ui:input-move-boxes:leftBoxMaxItems");
-Integer rightBoxMaxItems =(Integer)request.getAttribute("liferay-ui:input-move-boxes:rightBoxMaxItems");
+Integer rightBoxMaxItems = (Integer)request.getAttribute("liferay-ui:input-move-boxes:rightBoxMaxItems");
 
 String leftBoxName = (String)request.getAttribute("liferay-ui:input-move-boxes:leftBoxName");
 String rightBoxName = (String)request.getAttribute("liferay-ui:input-move-boxes:rightBoxName");

--- a/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
@@ -21,11 +21,11 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_input_
 
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-move-boxes:cssClass"));
 
-int leftBoxMaxItems = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-move-boxes:leftBoxMaxItems"));
-int rightBoxMaxItems = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-move-boxes:rightBoxMaxItems"));
-
 String leftTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute("liferay-ui:input-move-boxes:leftTitle"));
 String rightTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute("liferay-ui:input-move-boxes:rightTitle"));
+
+Integer leftBoxMaxItems = (Integer)request.getAttribute("liferay-ui:input-move-boxes:leftBoxMaxItems");
+Integer rightBoxMaxItems =(Integer)request.getAttribute("liferay-ui:input-move-boxes:rightBoxMaxItems");
 
 String leftBoxName = (String)request.getAttribute("liferay-ui:input-move-boxes:leftBoxName");
 String rightBoxName = (String)request.getAttribute("liferay-ui:input-move-boxes:rightBoxName");
@@ -90,8 +90,15 @@ Map<String, Object> data = new HashMap<String, Object>();
 	new Liferay.InputMoveBoxes(
 		{
 			contentBox: '#<%= randomNamespace + "input-move-boxes" %>',
-			leftBoxMaxItems: <%= leftBoxMaxItems %>,
-			rightBoxMaxItems: <%= rightBoxMaxItems %>,
+
+			<c:if test="<%= leftBoxMaxItems != null %>">
+				leftBoxMaxItems: <%= leftBoxMaxItems %>,
+			</c:if>
+
+			<c:if test="<%= rightBoxMaxItems != null %>">
+				rightBoxMaxItems: <%= rightBoxMaxItems %>,
+			</c:if>
+
 			strings: {
 				LEFT_MOVE_DOWN: '<%= UnicodeLanguageUtil.format(request, "move-selected-item-in-x-one-position-down", leftTitle, false) %>',
 				LEFT_MOVE_UP: '<%= UnicodeLanguageUtil.format(request, "move-selected-item-in-x-one-position-up", leftTitle, false) %>',

--- a/util-taglib/bnd.bnd
+++ b/util-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 5.1.2
+Bundle-Version: 5.2.0
 Export-Package:\
 	com.liferay.alloy.taglib.*;version="3.0.0",\
 	com.liferay.taglib.*

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -1973,6 +1973,13 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>Sets the maximum number of items on the left box. The default value is <![CDATA[<code>-1</code>]]> that represents unlimited items.</description>
+			<name>leftBoxMaxItems</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>int</type>
+		</attribute>
+		<attribute>
 			<description>A name for the left box.</description>
 			<name>leftBoxName</name>
 			<required>true</required>
@@ -2003,6 +2010,13 @@
 			<name>leftTitle</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Sets the maximum number of items on the right box. The default value is <![CDATA[<code>-1</code>]]> that represents unlimited items.</description>
+			<name>rightBoxMaxItems</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>int</type>
 		</attribute>
 		<attribute>
 			<description>A name for the right box.</description>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -1973,7 +1973,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Sets the maximum number of items on the left box. The default value is <![CDATA[<code>-1</code>]]> that represents unlimited items.</description>
+			<description>Sets the maximum number of items on the left box. The default value is <![CDATA[<code>Infinity</code>]]> that represents unlimited items.</description>
 			<name>leftBoxMaxItems</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2012,7 +2012,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Sets the maximum number of items on the right box. The default value is <![CDATA[<code>-1</code>]]> that represents unlimited items.</description>
+			<description>Sets the maximum number of items on the right box. The default value is <![CDATA[<code>Infinity</code>]]> that represents unlimited items.</description>
 			<name>rightBoxMaxItems</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/util-taglib/src/com/liferay/taglib/ui/InputMoveBoxesTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputMoveBoxesTag.java
@@ -30,6 +30,10 @@ public class InputMoveBoxesTag extends IncludeTag {
 		return _cssClass;
 	}
 
+	public int getLeftBoxMaxItems() {
+		return _leftBoxMaxItems;
+	}
+
 	public String getLeftBoxName() {
 		return _leftBoxName;
 	}
@@ -48,6 +52,10 @@ public class InputMoveBoxesTag extends IncludeTag {
 
 	public String getLeftTitle() {
 		return _leftTitle;
+	}
+
+	public int getRightBoxMaxItems() {
+		return _rightBoxMaxItems;
 	}
 
 	public String getRightBoxName() {
@@ -74,6 +82,10 @@ public class InputMoveBoxesTag extends IncludeTag {
 		_cssClass = cssClass;
 	}
 
+	public void setLeftBoxMaxItems(int leftBoxMaxItems) {
+		_leftBoxMaxItems = leftBoxMaxItems;
+	}
+
 	public void setLeftBoxName(String leftBoxName) {
 		_leftBoxName = leftBoxName;
 	}
@@ -92,6 +104,10 @@ public class InputMoveBoxesTag extends IncludeTag {
 
 	public void setLeftTitle(String leftTitle) {
 		_leftTitle = leftTitle;
+	}
+
+	public void setRightBoxMaxItems(int rightBoxMaxItems) {
+		_rightBoxMaxItems = rightBoxMaxItems;
 	}
 
 	public void setRightBoxName(String rightBoxName) {
@@ -119,11 +135,13 @@ public class InputMoveBoxesTag extends IncludeTag {
 		super.cleanUp();
 
 		_cssClass = null;
+		_leftBoxMaxItems = -1;
 		_leftBoxName = null;
 		_leftList = null;
 		_leftOnChange = null;
 		_leftReorder = null;
 		_leftTitle = null;
+		_rightBoxMaxItems = -1;
 		_rightBoxName = null;
 		_rightList = null;
 		_rightOnChange = null;
@@ -141,6 +159,9 @@ public class InputMoveBoxesTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:cssClass", _cssClass);
 		httpServletRequest.setAttribute(
+			"liferay-ui:input-move-boxes:leftBoxMaxItems",
+			String.valueOf(_leftBoxMaxItems));
+		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:leftBoxName", _leftBoxName);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:leftList", _leftList);
@@ -150,6 +171,9 @@ public class InputMoveBoxesTag extends IncludeTag {
 			"liferay-ui:input-move-boxes:leftReorder", _leftReorder);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:leftTitle", _leftTitle);
+		httpServletRequest.setAttribute(
+			"liferay-ui:input-move-boxes:rightBoxMaxItems",
+			String.valueOf(_rightBoxMaxItems));
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:rightBoxName", _rightBoxName);
 		httpServletRequest.setAttribute(
@@ -166,11 +190,13 @@ public class InputMoveBoxesTag extends IncludeTag {
 		"/html/taglib/ui/input_move_boxes/page.jsp";
 
 	private String _cssClass;
+	private int _leftBoxMaxItems = -1;
 	private String _leftBoxName;
 	private List<KeyValuePair> _leftList;
 	private String _leftOnChange;
 	private String _leftReorder;
 	private String _leftTitle;
+	private int _rightBoxMaxItems = -1;
 	private String _rightBoxName;
 	private List<KeyValuePair> _rightList;
 	private String _rightOnChange;

--- a/util-taglib/src/com/liferay/taglib/ui/InputMoveBoxesTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputMoveBoxesTag.java
@@ -135,13 +135,13 @@ public class InputMoveBoxesTag extends IncludeTag {
 		super.cleanUp();
 
 		_cssClass = null;
-		_leftBoxMaxItems = -1;
+		_leftBoxMaxItems = null;
 		_leftBoxName = null;
 		_leftList = null;
 		_leftOnChange = null;
 		_leftReorder = null;
 		_leftTitle = null;
-		_rightBoxMaxItems = -1;
+		_rightBoxMaxItems = null;
 		_rightBoxName = null;
 		_rightList = null;
 		_rightOnChange = null;
@@ -159,8 +159,7 @@ public class InputMoveBoxesTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:cssClass", _cssClass);
 		httpServletRequest.setAttribute(
-			"liferay-ui:input-move-boxes:leftBoxMaxItems",
-			String.valueOf(_leftBoxMaxItems));
+			"liferay-ui:input-move-boxes:leftBoxMaxItems", _leftBoxMaxItems);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:leftBoxName", _leftBoxName);
 		httpServletRequest.setAttribute(
@@ -172,8 +171,7 @@ public class InputMoveBoxesTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:leftTitle", _leftTitle);
 		httpServletRequest.setAttribute(
-			"liferay-ui:input-move-boxes:rightBoxMaxItems",
-			String.valueOf(_rightBoxMaxItems));
+			"liferay-ui:input-move-boxes:rightBoxMaxItems", _rightBoxMaxItems);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:rightBoxName", _rightBoxName);
 		httpServletRequest.setAttribute(
@@ -190,13 +188,13 @@ public class InputMoveBoxesTag extends IncludeTag {
 		"/html/taglib/ui/input_move_boxes/page.jsp";
 
 	private String _cssClass;
-	private int _leftBoxMaxItems = -1;
+	private Integer _leftBoxMaxItems;
 	private String _leftBoxName;
 	private List<KeyValuePair> _leftList;
 	private String _leftOnChange;
 	private String _leftReorder;
 	private String _leftTitle;
-	private int _rightBoxMaxItems = -1;
+	private Integer _rightBoxMaxItems;
 	private String _rightBoxName;
 	private List<KeyValuePair> _rightList;
 	private String _rightOnChange;

--- a/util-taglib/src/com/liferay/taglib/ui/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/ui/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.1.0


### PR DESCRIPTION
First, I conducted to see what is the behaviour of `liferay-ui:input-move-boxes` taglib. For reproducing I took these steps:

1. Open D&M
2. Upload multiple images
3. Adds Media Gallery widget to a page
4. Click on configurations from Media Gallery Widget

On JSP side We create a property called `leftBoxMaxItems` and `rightBoxMaxItems` for controlling when these buttons can be disabled or not and use on JSP side like:

```java
<liferay-ui:input-move-boxes
    leftBoxMaxItems="3"
    leftBoxName="currentMimeTypes"
    leftList="<%= dlPortletInstanceSettingsHelper.getCurrentMimeTypes() %>"
    leftReorder="<%= Boolean.TRUE.toString() %>"
    leftTitle="current"
    rightBoxMaxItems="5"
    rightBoxName="availableMimeTypes"
    rightList="<%= dlPortletInstanceSettingsHelper.getAvailableMimeTypes() %>"
    rightTitle="available"
 />
``` 

/cc @ealonso @victorg1991 @jbalsas @wincent 