### PR TITLE
LPS-116193 - As a developer I can specify custom tokens so that the style editor provides a form to edit those tokens instead of the Liferay-standard ones

### DIFF
--- a/token_values_example_draft_v2.json
+++ b/token_values_example_draft_v2.json
@@ -1,0 +1,32 @@
+{
+	"tokenValues": [
+		{
+			"name": "linkColor",
+			"value": "Salmon"
+		},
+		{
+			"name": "jerseyType",
+			"value": "Away"
+		},
+		{
+			"name": "linkTextUnderline",
+			"value": false
+		},
+		{
+			"name": "linkHoverColor",
+			"value": "#0B53F0"
+		},
+		{
+			"name": "linkHoverTextUnderline",
+			"value": true
+		},
+		{
+			"name": "gridNumberOfColumns",
+			"value": 3
+		},
+		{
+			"name": "gridGutterWidth",
+			"value": "30px"
+		}
+	]
+}

--- a/token_values_json_schema_draft_v2.json
+++ b/token_values_json_schema_draft_v2.json
@@ -1,0 +1,44 @@
+{
+	"$id": "http://example.com/root.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"definitions": {
+		"TokenValue" : {
+			"additionalProperties": false,
+			"properties": {
+				"name": {
+					"title": "Name of the Token",
+					"type": "string"
+				},
+				"value": {
+					"title": "The Value of the Token",
+					"type": [
+						"boolean",
+						"integer",
+						"number",
+						"string"
+					]
+				}
+			},
+			"required": [
+				"name",
+				"value"
+			],
+			"type": "object"
+		}
+	},
+	"properties": {
+		"tokenValues": {
+			"items": {
+				"$ref": "#/definitions/TokenValue"
+			},
+			"title": "Token Values",
+			"type": "array"
+		}
+	},
+	"required": [
+		"tokensValues"
+	],
+	"title": "The Design Token Values Schema",
+	"type": "object"
+}

--- a/tokens_definition_example_draft_v2.json
+++ b/tokens_definition_example_draft_v2.json
@@ -52,7 +52,7 @@
 			],
 			"tokenCategoryName":  "general",
 			"tokenSetName": "links",
-			"type": "Color"
+			"type": "String"
 		},
 		{
 			"label": "jersey-type",

--- a/tokens_definition_example_draft_v2.json
+++ b/tokens_definition_example_draft_v2.json
@@ -21,22 +21,6 @@
 	],
 	"tokens": [
 		{
-			"mappings" : [
-				{
-					"name": "CSSVariable",
-					"outputKey": "$link-color",
-					"outputValues": [
-						{
-							"tokenValue": "Red",
-							"mappedValue": "#FF0000"
-						},
-						{
-							"tokenValue": "Salmon",
-							"mappedValue": "#FA8072"
-						}
-					]
-				}
-			],
 			"editorType": "ColorPicker",
 			"label": "link-color",
 			"name": "linkColor",
@@ -56,26 +40,6 @@
 		},
 		{
 			"label": "jersey-type",
-			"mappings" : [
-				{
-					"name": "CSSStyleTemplate",
-					"outputKey": ".jersey-type",
-					"outputValues": [
-						{
-							"tokenValue": "Home",
-							"mappedValue": "color: #552583; background-color: #fdba21; border-color: #ffffff;"
-						},
-						{
-							"tokenValue": "Away",
-							"mappedValue": "color: #fdba21; background-color: #552583; border-color: #ffffff;"
-						},
-						{
-							"tokenValue": "Third",
-							"mappedValue": "color: #552583; background-color: #ffffff; border-color: #fdba21;"
-						}
-					]
-				}
-			],
 			"name": "jerseyType",
 			"tokenCategoryName": "colors",
 			"tokenSetName": "colorCombinations",
@@ -97,22 +61,6 @@
 		},
 		{
 			"label": "text-underline",
-			"mappings" : [
-				{
-					"name": "CSSVariable",
-					"outputKey": "$link-text-decoration",
-					"outputValues": [
-						{
-							"tokenValue": false,
-							"mappedValue": "none"
-						},
-						{
-							"tokenValue": true,
-							"mappedValue": "underline"
-						}
-					]
-				}
-			],
 			"name": "linkTextUnderline",
 			"tokenCategoryName": "general",
 			"tokenSetName": "links",
@@ -121,12 +69,6 @@
 		{
 			"editorType": "ColorPicker",
 			"label": "link-hover-color",
-			"mappings" : [
-				{
-					"name": "CSSVariable",
-					"outputKey": "$link-hover-color"
-				}
-			],
 			"name": "linkHoverColor",
 			"tokenCategoryName": "general",
 			"tokenSetName": "links",
@@ -134,22 +76,6 @@
 		},
 		{
 			"label": "text-underline",
-			"mappings" : [
-				{
-					"name": "CSSVariable",
-					"outputKey": "$link-hover-text-decoration",
-					"outputValues": [
-						{
-							"tokenValue": false,
-							"mappedValue": "none"
-						},
-						{
-							"tokenValue": true,
-							"mappedValue": "underline"
-						}
-					]
-				}
-			],
 			"name": "linkHoverTextUnderline",
 			"tokenCategoryName": "general",
 			"tokenSetName": "links",
@@ -157,22 +83,6 @@
 		},
 		{
 			"label": "number-of-columns",
-			"mappings" : [
-				{
-					"name": "CSSVariable",
-					"outputKey": "$grid-columns",
-					"outputValues": [
-						{
-							"tokenValue": 1,
-							"mappedValue": "1"
-						},
-						{
-							"tokenValue": 3,
-							"mappedValue": "3"
-						}
-					]
-				}
-			],
 			"name": "gridNumberOfColumns",
 			"tokenCategoryName": "layout",
 			"tokenSetName": "grid",
@@ -190,12 +100,6 @@
 		},
 		{
 			"label": "gutter",
-			"mappings" : [
-				{
-					"name": "CSSVariable",
-					"outputKey": "grid-gutter-width"
-				}
-			],
 			"name": "gridGutterWidth",
 			"tokenCategoryName": "layout",
 			"tokenSetName": "grid",

--- a/tokens_definition_example_draft_v2.json
+++ b/tokens_definition_example_draft_v2.json
@@ -1,0 +1,205 @@
+{
+	"tokenCategories" : [
+		{
+			"label": "general",
+			"name": "general"
+		},
+		{
+			"label": "layout",
+			"name": "layout"
+		}
+	],
+	"tokenSets" : [
+		{
+			"label": "grid",
+			"name": "grid"
+		},
+		{
+			"label": "links",
+			"name": "links"
+		}
+	],
+	"tokens": [
+		{
+			"mappings" : [
+				{
+					"name": "CSSVariable",
+					"outputKey": "$link-color",
+					"outputValues": [
+						{
+							"tokenValue": "Red",
+							"mappedValue": "#FF0000"
+						},
+						{
+							"tokenValue": "Salmon",
+							"mappedValue": "#FA8072"
+						}
+					]
+				}
+			],
+			"editorType": "ColorPicker",
+			"label": "link-color",
+			"name": "linkColor",
+			"validValues": [
+				{
+					"label": "salmon",
+					"value" : "Salmon"
+				},
+				{
+					"label": "red",
+					"value" : "Red"
+				}
+			],
+			"tokenCategoryName":  "general",
+			"tokenSetName": "links",
+			"type": "Color"
+		},
+		{
+			"label": "jersey-type",
+			"mappings" : [
+				{
+					"name": "CSSStyleTemplate",
+					"outputKey": ".jersey-type",
+					"outputValues": [
+						{
+							"tokenValue": "Home",
+							"mappedValue": "color: #552583; background-color: #fdba21; border-color: #ffffff;"
+						},
+						{
+							"tokenValue": "Away",
+							"mappedValue": "color: #fdba21; background-color: #552583; border-color: #ffffff;"
+						},
+						{
+							"tokenValue": "Third",
+							"mappedValue": "color: #552583; background-color: #ffffff; border-color: #fdba21;"
+						}
+					]
+				}
+			],
+			"name": "jerseyType",
+			"tokenCategoryName": "colors",
+			"tokenSetName": "colorCombinations",
+			"type": "String",
+			"validValues": [
+				{
+					"label": "home",
+					"value" : "Home"
+				},
+				{
+					"label": "away",
+					"value" : "Away"
+				},
+				{
+					"label": "third",
+					"value" : "Third"
+				}
+			]
+		},
+		{
+			"label": "text-underline",
+			"mappings" : [
+				{
+					"name": "CSSVariable",
+					"outputKey": "$link-text-decoration",
+					"outputValues": [
+						{
+							"tokenValue": false,
+							"mappedValue": "none"
+						},
+						{
+							"tokenValue": true,
+							"mappedValue": "underline"
+						}
+					]
+				}
+			],
+			"name": "linkTextUnderline",
+			"tokenCategoryName": "general",
+			"tokenSetName": "links",
+			"type": "Boolean"
+		},
+		{
+			"editorType": "ColorPicker",
+			"label": "link-hover-color",
+			"mappings" : [
+				{
+					"name": "CSSVariable",
+					"outputKey": "$link-hover-color"
+				}
+			],
+			"name": "linkHoverColor",
+			"tokenCategoryName": "general",
+			"tokenSetName": "links",
+			"type": "String"
+		},
+		{
+			"label": "text-underline",
+			"mappings" : [
+				{
+					"name": "CSSVariable",
+					"outputKey": "$link-hover-text-decoration",
+					"outputValues": [
+						{
+							"tokenValue": false,
+							"mappedValue": "none"
+						},
+						{
+							"tokenValue": true,
+							"mappedValue": "underline"
+						}
+					]
+				}
+			],
+			"name": "linkHoverTextUnderline",
+			"tokenCategoryName": "general",
+			"tokenSetName": "links",
+			"type": "Boolean"
+		},
+		{
+			"label": "number-of-columns",
+			"mappings" : [
+				{
+					"name": "CSSVariable",
+					"outputKey": "$grid-columns",
+					"outputValues": [
+						{
+							"tokenValue": 1,
+							"mappedValue": "1"
+						},
+						{
+							"tokenValue": 3,
+							"mappedValue": "3"
+						}
+					]
+				}
+			],
+			"name": "gridNumberOfColumns",
+			"tokenCategoryName": "layout",
+			"tokenSetName": "grid",
+			"type": "Integer",
+			"validValues": [
+				{
+					"label": "1",
+					"value" : 1
+				},
+				{
+					"label": "3",
+					"value" : 3
+				}
+			]
+		},
+		{
+			"label": "gutter",
+			"mappings" : [
+				{
+					"name": "CSSVariable",
+					"outputKey": "grid-gutter-width"
+				}
+			],
+			"name": "gridGutterWidth",
+			"tokenCategoryName": "layout",
+			"tokenSetName": "grid",
+			"type": "String"
+		}
+	]
+}

--- a/tokens_definition_json_schema_draft_v2.json
+++ b/tokens_definition_json_schema_draft_v2.json
@@ -1,0 +1,200 @@
+{
+	"$id": "http://example.com/root.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"definitions": {
+		"Token" : {
+			"additionalProperties": false,
+			"properties": {
+				"editorType": {
+					"enum": [
+						"ColorPicker"
+					],
+					"title": "The Editor Type used to edit the Token",
+					"type": "string"
+				},
+				"label": {
+					"title": "The Language Key of the Token Label",
+					"type": "string"
+				},
+				"mappings": {
+					"items": {
+						"additionalProperties": false,
+						"not": {
+							"type": "null"
+						},
+						"properties": {
+							"name" : {
+								"enum": [
+									"CSSVariable",
+									"CSSStyleTemplate"
+								],
+								"title" : "The Name of the Mapping",
+								"type" : "string"
+							},
+							"outputKey": {
+								"title": "The Output Key of the Mapping for the Token",
+								"type": "string"
+							},
+							"outputValues": {
+								"items": {
+									"additionalProperties": false,
+									"not": {
+										"type": "null"
+									},
+									"properties": {
+										"tokenValue": {
+											"title": "The Valid Token Value",
+											"type": [
+												"boolean",
+												"integer",
+												"number",
+												"string"
+											]
+										},
+										"mappedValue": {
+											"title": "The Mapped value for the corresponding Token Valid Value",
+											"type": "string"
+										}
+									},
+									"required": [
+										"value"
+									],
+									"title": "Valid Value",
+									"type": "object"
+								},
+								"minItems": 1,
+								"title": "The Output Values for the defined Valid Values",
+								"type": "array"
+							}
+						},
+						"required": [
+							"name",
+							"outputKey"
+						],
+						"type": "object"
+					},
+					"minItems": 1,
+					"title": "The Mappings of the Token",
+					"type": "array"
+				},
+				"name": {
+					"title": "Name of the Token",
+					"type": "string"
+				},
+				"tokenCategoryName": {
+					"title": "Name of the TokenCategory associated to the Token",
+					"type": "string"
+				},
+				"tokenSetName": {
+					"title": "Name of the TokenSet associated to the Token",
+					"type": "string"
+				},
+				"type": {
+					"enum": [
+						"Boolean",
+						"Integer",
+						"Number",
+						"String"
+					],
+					"title": "Type of the Token",
+					"type": "string"
+				},
+				"validValues": {
+					"items": {
+						"additionalProperties": false,
+						"not": {
+							"type": "null"
+						},
+						"properties": {
+							"label": {
+								"title": "The Language Key of the Valid Value",
+								"type": "string"
+							},
+							"value": {
+								"title": "Value",
+								"type": "string"
+							}
+						},
+						"required": [
+							"value"
+						],
+						"title": "Valid Value",
+						"type": "object"
+					},
+					"minItems": 1,
+					"title": "Valid Values",
+					"type": "array"
+				}
+			},
+			"required": [
+				"mappings",
+				"name",
+				"type"
+			],
+			"type": "object"
+		},
+		"TokenCategory" : {
+			"additionalProperties": false,
+			"properties": {
+				"label": {
+					"title": "The Language Key to obtain the label of the Token Category",
+					"type": "string"
+				},
+				"name": {
+					"title": "Name of the Token Category",
+					"type": "string"
+				}
+			},
+			"required": [
+				"name"
+			],
+			"type": "object"
+		},
+		"TokenSet" : {
+			"additionalProperties": false,
+			"properties": {
+				"label": {
+					"title": "The Language Key to obtain the label of the Token Set",
+					"type": "string"
+				},
+				"name": {
+					"title": "Name of the Token Set",
+					"type": "string"
+				}
+			},
+			"required": [
+				"name"
+			],
+			"type": "object"
+		}
+	},
+	"properties": {
+		"tokenCategories": {
+			"items": {
+				"$ref": "#/definitions/TokenCategory"
+			},
+			"title": "Tokens",
+			"type": "array"
+		},
+		"tokens": {
+			"items": {
+				"$ref": "#/definitions/Token"
+			},
+			"title": "Tokens",
+			"type": "array"
+		},
+		"tokenSets": {
+			"items": {
+				"$ref": "#/definitions/TokenSet"
+			},
+			"title": "Tokens",
+			"type": "array"
+		}
+	},
+	"required": [
+		"tokens"
+	],
+	"title": "The Design Tokens Definition Schema",
+	"type": "object"
+}

--- a/tokens_definition_json_schema_draft_v2.json
+++ b/tokens_definition_json_schema_draft_v2.json
@@ -17,67 +17,6 @@
 					"title": "The Language Key of the Token Label",
 					"type": "string"
 				},
-				"mappings": {
-					"items": {
-						"additionalProperties": false,
-						"not": {
-							"type": "null"
-						},
-						"properties": {
-							"name" : {
-								"enum": [
-									"CSSVariable",
-									"CSSStyleTemplate"
-								],
-								"title" : "The Name of the Mapping",
-								"type" : "string"
-							},
-							"outputKey": {
-								"title": "The Output Key of the Mapping for the Token",
-								"type": "string"
-							},
-							"outputValues": {
-								"items": {
-									"additionalProperties": false,
-									"not": {
-										"type": "null"
-									},
-									"properties": {
-										"tokenValue": {
-											"title": "The Valid Token Value",
-											"type": [
-												"boolean",
-												"integer",
-												"number",
-												"string"
-											]
-										},
-										"mappedValue": {
-											"title": "The Mapped value for the corresponding Token Valid Value",
-											"type": "string"
-										}
-									},
-									"required": [
-										"value"
-									],
-									"title": "Valid Value",
-									"type": "object"
-								},
-								"minItems": 1,
-								"title": "The Output Values for the defined Valid Values",
-								"type": "array"
-							}
-						},
-						"required": [
-							"name",
-							"outputKey"
-						],
-						"type": "object"
-					},
-					"minItems": 1,
-					"title": "The Mappings of the Token",
-					"type": "array"
-				},
 				"name": {
 					"title": "Name of the Token",
 					"type": "string"

--- a/tokens_definition_json_schema_draft_v2.json
+++ b/tokens_definition_json_schema_draft_v2.json
@@ -17,6 +17,31 @@
 					"title": "The Language Key of the Token Label",
 					"type": "string"
 				},
+				"mappings": {
+					"items": {
+						"additionalProperties": false,
+						"not": {
+							"type": "null"
+						},
+						"properties": {
+							"type" : {
+								"title" : "The Type of the Mapping",
+								"type" : "string"
+							},
+							"value": {
+								"title": "The Value of the Mapping for the Token",
+								"type": "string"
+							}
+						},
+						"required": [
+							"type",
+							"value"
+						],
+						"type": "object"
+					},
+					"title": "The Mappings of the Token",
+					"type": "array"
+				},
 				"name": {
 					"title": "Name of the Token",
 					"type": "string"


### PR DESCRIPTION
This is a follow-up PR of https://github.com/jbalsas/liferay-portal/pull/2218

I have tried to incorporate all the feedback received in the previous PR:

This PR contains:
- A second draft version of the tokens definition JSON Schema file
- An example tokens definition JSON file following the tokens definition JSON schema.

- A token values JSON Schema file
- An example token values JSON file following the token values JSON Schema
(I think it makes sense to start thinking already about how the token values JSON file should look like)

Summary of the most important changes:
- Flattened structure replacing the hierarchical structure following. I agree with @jbalsas this will give us more flexibility for introducing changes (@jbalsas, @izaera)
- Attribute `cssVariable` has been replaced by a more generic `mappings` attribute. I have tried to illustrate how a mapping for a CSS Style Template would look like [here](https://github.com/liferay-frontend/liferay-portal/pull/99/commits/1aee422d19c213a77c638d163f2dacb66f968acf#r452557946) (@jbalsas, @izaera)
- An optional `validValues` attribute has been added (@jbalsas, @JorgeFerrer)
- Attribute `type` has been split into `type` (with possible values `Boolean`, `Integer`, `Number`, `String`) and `editorType` (for now only with possible values `ColorPicker`).  (@izaera)
- Labels have been simplified to `"label": "key` (@jbalsas, @izaera)
- `tokenSetCategories` has been renamed to `TokenCategories` (@JorgeFerrer)
- `"type": "object"` has been explicitly added in the cases where it was missing (@wincent )
- The list of required attributes has been revisited (@wincent )
- The `repeatable` attribute has been removed for now for simplicity

Opened questions to clarify:
- `CSSVariablesProviders` are expected to return a collection of `ScopedCSSVariables` objects, each of which has a `scope`.
Would it make sense to include `outputScope` as an additional property of a `Mapping` item?

Any additional feedback is also greatly appreciated!

//cc @ealonso @victorg1991