### PR TITLE
LPS-116549 Revert "LPS-113561 Replace AUI-based `openWindow` with Clay-based `openModal`"

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -401,6 +401,19 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 										}
 									};
 
+									Liferay.provide(
+										window,
+										'<portlet:namespace />closeKaleoDialog',
+										function () {
+											var dialog = Liferay.Util.getWindow();
+
+											if (dialog) {
+												dialog.destroy();
+											}
+										},
+										['aui-base']
+									);
+
 									<%
 									String saveCallback = ParamUtil.getString(request, "saveCallback");
 									%>
@@ -686,6 +699,44 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 											}
 										</c:when>
 									</c:choose>
+
+									var dialog = Liferay.Util.getWindow();
+
+									if (dialog && !dialog._dialogAction) {
+										dialog._dialogAction = function (event) {
+											if (!event.newVal) {
+
+												<%
+												boolean refreshOpenerOnClose = ParamUtil.getBoolean(request, "refreshOpenerOnClose");
+												%>
+
+												<c:if test="<%= Validator.isNotNull(portletResourceNamespace) && refreshOpenerOnClose %>">
+
+													<%
+													String openerWindowName = ParamUtil.getString(request, "openerWindowName");
+													%>
+
+													var openerWindow = Liferay.Util.getTop();
+
+													<c:if test="<%= Validator.isNotNull(openerWindowName) %>">
+														var openerDialog = Liferay.Util.getWindow(
+															'<%= HtmlUtil.escapeJS(openerWindowName) %>'
+														);
+
+														openerWindow = openerDialog.iframe.node
+															.get('contentWindow')
+															.getDOM();
+													</c:if>
+
+													openerWindow.Liferay.Portlet.refresh(
+														'#p_p_id<%= HtmlUtil.escapeJS(portletResourceNamespace) %>'
+													);
+												</c:if>
+											}
+										};
+
+										dialog.on('visibleChange', dialog._dialogAction);
+									}
 								</aui:script>
 							</aui:fieldset>
 						</aui:fieldset-group>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -401,18 +401,13 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 										}
 									};
 
-									Liferay.provide(
-										window,
-										'<portlet:namespace />closeKaleoDialog',
-										function () {
-											var dialog = Liferay.Util.getWindow();
+									window['<portlet:namespace />closeKaleoDialog'] = function () {
+										var dialog = Liferay.Util.getWindow();
 
-											if (dialog) {
-												dialog.destroy();
-											}
-										},
-										['aui-base']
-									);
+										if (dialog) {
+											dialog.destroy();
+										}
+									};
 
 									<%
 									String saveCallback = ParamUtil.getString(request, "saveCallback");

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
@@ -258,9 +258,7 @@ if (tabs1.equals("published")) {
 	);
 
 	window['<portlet:namespace />editWorkflow'] = function (uri) {
-		var A = AUI();
-
-		A.use('liferay-util', function () {
+		AUI().use('liferay-util', function (A) {
 			var WIN = A.config.win;
 
 			Liferay.Util.openWindow({

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
@@ -260,13 +260,15 @@ if (tabs1.equals("published")) {
 	window['<portlet:namespace />editWorkflow'] = function (uri) {
 		var A = AUI();
 
-		var WIN = A.config.win;
+		A.use('liferay-util', function () {
+			var WIN = A.config.win;
 
-		Liferay.Util.openWindow({
-			id: A.guid(),
-			refreshWindow: WIN,
-			title: '<liferay-ui:message key="workflow" />',
-			uri: uri,
+			Liferay.Util.openWindow({
+				id: A.guid(),
+				refreshWindow: WIN,
+				title: '<liferay-ui:message key="workflow" />',
+				uri: uri,
+			});
 		});
 	};
 </aui:script>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
@@ -257,13 +257,21 @@ if (tabs1.equals("published")) {
 		['aui-base']
 	);
 
-	window['<portlet:namespace />editWorkflow'] = function (url) {
-		Liferay.Util.openModal({
-			onClose: function () {
-				window.location.reload();
-			},
-			title: '<liferay-ui:message key="workflow" />',
-			url: url,
-		});
-	};
+	Liferay.provide(
+		window,
+		'<portlet:namespace />editWorkflow',
+		function (uri) {
+			var A = AUI();
+
+			var WIN = A.config.win;
+
+			Liferay.Util.openWindow({
+				id: A.guid(),
+				refreshWindow: WIN,
+				title: '<liferay-ui:message key="workflow" />',
+				uri: uri,
+			});
+		},
+		['liferay-util']
+	);
 </aui:script>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
@@ -257,21 +257,16 @@ if (tabs1.equals("published")) {
 		['aui-base']
 	);
 
-	Liferay.provide(
-		window,
-		'<portlet:namespace />editWorkflow',
-		function (uri) {
-			var A = AUI();
+	window['<portlet:namespace />editWorkflow'] = function (uri) {
+		var A = AUI();
 
-			var WIN = A.config.win;
+		var WIN = A.config.win;
 
-			Liferay.Util.openWindow({
-				id: A.guid(),
-				refreshWindow: WIN,
-				title: '<liferay-ui:message key="workflow" />',
-				uri: uri,
-			});
-		},
-		['liferay-util']
-	);
+		Liferay.Util.openWindow({
+			id: A.guid(),
+			refreshWindow: WIN,
+			title: '<liferay-ui:message key="workflow" />',
+			uri: uri,
+		});
+	};
 </aui:script>


### PR DESCRIPTION
This reverts commit [df1c93d78ea501ec9ef88aa17a71109657a2a114](https://github.com/liferay/liferay-portal/commit/df1c93d78ea501ec9ef88aa17a71109657a2a114).

Until we have the same behavior with `openModal` we've agreed with @markocikos to revert this commit:

In `portal-workflow` the workflow is as follows:

- Open a modal window
- If the modal window is closed, do nothing
- Submit a form
- When the form is submitted, close the modal window
- When the modal window is closed, redirect to page that will show data modified by the form submission

We don't have an API in `openModal` to allow modifying the `onClose` behavior from an external context.
In the commit we are [reverting]((https://github.com/liferay/liferay-portal/commit/df1c93d78ea501ec9ef88aa17a71109657a2a114), we were always refreshing the page when the modal was closed, which causes the bug described in this ticket.

We could either refactor `portal-workflow` to use a standard form submission or adapt `openModal` to allow the current behavior used in workflow



