### PR TITLE
LPS-116165 - Add a separator line to navigation-bar-light

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
@@ -4,6 +4,16 @@ $border-color: #f1f2f5;
 $lead-font-weight: 400;
 $small-font-size: 0.875rem;
 
+$navigation-bar-size: (
+	border-bottom-width: 0.0625rem,
+	active-border-offset-bottom: -0.5625rem,
+	active-border-offset-bottom-mobile: -0.5625rem,
+);
+
+$navigation-bar-light: (
+	border-color: $border-color,
+);
+
 // Compat
 
 $compat-alerts: false;

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
@@ -12,6 +12,16 @@ $small-font-size: 0.875rem;
 $portlet-decorate-bg: #fff;
 $portlet-decorate-border: 1px solid $light-color;
 
+$navigation-bar-size: (
+	border-bottom-width: 0.0625rem,
+	active-border-offset-bottom: -0.5625rem,
+	active-border-offset-bottom-mobile: -0.5625rem,
+);
+
+$navigation-bar-light: (
+	border-color: $border-color,
+);
+
 // Compat
 
 $compat-alerts: false;


### PR DESCRIPTION
**Only for testing and @victorvalle quick review**

This PR adds a separator line under `navigation-bar-light`

![image](https://user-images.githubusercontent.com/7963804/86939716-3803d900-c142-11ea-9273-8b3d2755b813.png)

To test this PR we only need to go to `User and Organizations`