### PR TITLE
LPS-111973 - Fix dropdown with btn-link

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
@@ -162,7 +162,7 @@
 	);
 }
 
-.btn-link {
+.btn-link:not(.dropdown-item) {
 	@include button-cp(
 		var(--transparent),
 		var(--transparent),


### PR DESCRIPTION
This PR fix the problem with CSS properties and an old dropdown with the combination of `dropdown-item` and `btn-link`.

![image](https://user-images.githubusercontent.com/7963804/87297248-6b5eb300-c508-11ea-82fe-f20aa8d83434.png)


**Testing the PR:**

To test the PR you will need:
- Create a widget page
- Add Documents and Media portlet
- Configure portlet to show actions:
![image](https://user-images.githubusercontent.com/7963804/87297082-1fac0980-c508-11ea-9c24-d0e4964d7ca2.png)
- Upload some doc/image
- Select it on the list and now you have access to the actions, open the dropdown:

You will see:
![image](https://user-images.githubusercontent.com/7963804/87297200-541fc580-c508-11ea-8d49-8d6099454b0b.png)
