### PR TITLE
LPS-116988 Update react-dnd to v11.1.1

### DIFF
--- a/modules/apps/app-builder/app-builder-web/package.json
+++ b/modules/apps/app-builder/app-builder-web/package.json
@@ -25,8 +25,8 @@
 		"prop-types": "15.7.2",
 		"qs": "6.7.0",
 		"react": "16.12.0",
-		"react-dnd": "10.0.1",
-		"react-dnd-html5-backend": "10.0.1",
+		"react-dnd": "11.1.1",
+		"react-dnd-html5-backend": "11.1.1",
 		"react-router-dom": "^5.0.1"
 	},
 	"description": "",

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/App.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/App.es.js
@@ -15,7 +15,7 @@
 import {ClayModalProvider} from '@clayui/modal';
 import React, {useContext} from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 import {HashRouter as Router, Route, Switch} from 'react-router-dom';
 
 import {AppContext, AppContextProvider} from './AppContext.es';

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormView.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormView.es.js
@@ -14,7 +14,7 @@
 
 import React, {useContext, useState} from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 import {createPortal} from 'react-dom';
 
 import {AppContext} from '../../AppContext.es';

--- a/modules/apps/app-builder/app-builder-web/test/js/pages/table-view/EditTableView.es.js
+++ b/modules/apps/app-builder/app-builder-web/test/js/pages/table-view/EditTableView.es.js
@@ -17,7 +17,7 @@ import userEvent from '@testing-library/user-event';
 import {createMemoryHistory} from 'history';
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 import {Route, Router} from 'react-router-dom';
 
 import EditTableView from '../../../../src/main/resources/META-INF/resources/js/pages/table-view/EditTableView.es';

--- a/modules/apps/data-engine/data-engine-taglib/package.json
+++ b/modules/apps/data-engine/data-engine-taglib/package.json
@@ -27,8 +27,8 @@
 		"moment": "^2.24.0",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "10.0.1",
-		"react-dnd-html5-backend": "10.0.1",
+		"react-dnd": "11.1.1",
+		"react-dnd-html5-backend": "11.1.1",
 		"react-router-dom": "^5.0.1"
 	},
 	"jest": {

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/App.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/App.es.js
@@ -15,7 +15,7 @@
 import {ClayModalProvider} from '@clayui/modal';
 import React, {useContext, useEffect, useState} from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import AppContext from './AppContext.es';
 import AppContextProvider from './AppContextProvider.es';

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/drag-and-drop/withDragAndDropContext.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/drag-and-drop/withDragAndDropContext.es.js
@@ -13,7 +13,7 @@
  */
 
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 export default function withDragAndDropContext(Component) {
 	return (props) => (

--- a/modules/apps/depot/depot-web/package.json
+++ b/modules/apps/depot/depot-web/package.json
@@ -13,8 +13,8 @@
 		"metal-dom": "2.16.8",
 		"metal-state": "2.16.8",
 		"react": "16.12.0",
-		"react-dnd": "10.0.1",
-		"react-dnd-html5-backend": "10.0.1"
+		"react-dnd": "11.1.1",
+		"react-dnd-html5-backend": "11.1.1"
 	},
 	"name": "depot-web",
 	"scripts": {

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/LanguagesList.es.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/LanguagesList.es.js
@@ -17,7 +17,7 @@ import ClayTable from '@clayui/table';
 import PropTypes from 'prop-types';
 import React, {useRef} from 'react';
 import {DndProvider, createDndContext} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import LanguageListItem from './LanguageListItem.es';
 import LanguageListItemEditable from './LanguageListItemEditable.es';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Options/Options.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Options/Options.es.js
@@ -16,7 +16,7 @@ import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
 import KeyValue from '../KeyValue/KeyValue.es';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/Pages.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/Pages.es.js
@@ -18,7 +18,7 @@ import {ClayIconSpriteContext} from '@clayui/icon';
 import classNames from 'classnames';
 import React, {useRef} from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {useFieldTypesResource} from '../hooks/useResource.es';
 import Page from './PageRenderer/index';

--- a/modules/apps/frontend-js/frontend-js-react-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-react-web/.npmbundlerrc
@@ -1,6 +1,10 @@
 {
 	"config": {
 		"imports": {
+			"frontend-js-node-shims": {
+				"domain": "*",
+				"process": "*"
+			},
 			"frontend-taglib-clay": {
 				"@clayui/icon": ">=3.0.0-alpha.1"
 			}

--- a/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -5,13 +5,13 @@
 		"formik": "2.1.4",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "10.0.1",
-		"react-dnd-html5-backend": "10.0.1",
+		"react-dnd": "11.1.1",
+		"react-dnd-html5-backend": "11.1.1",
 		"react-dom": "16.12.0"
 	},
 	"devDependencies": {
-		"react-dnd-test-backend": "10.0.1",
-		"react-dnd-test-utils": "10.0.1"
+		"react-dnd-test-backend": "11.1.1",
+		"react-dnd-test-utils": "11.1.1"
 	},
 	"main": "js/index.es.js",
 	"name": "frontend-js-react-web",

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.es.js
@@ -18,3 +18,13 @@ export {default as useInterval} from './hooks/useInterval.es';
 export {default as useIsMounted} from './hooks/useIsMounted.es';
 export {default as usePrevious} from './hooks/usePrevious.es';
 export {default as useTimeout} from './hooks/useTimeout.es';
+
+// Egregious hack because react-dnd expects `window.process` to exist:
+//
+// https://github.com/react-dnd/asap/blob/b6bebeb734/src/node/asap.ts#L24
+
+import process from 'process';
+
+if (!window.process) {
+	window.process = process;
+}

--- a/modules/apps/layout/layout-admin-web/package.json
+++ b/modules/apps/layout/layout-admin-web/package.json
@@ -25,8 +25,8 @@
 		"metal-throttle": "3.0.1",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "10.0.1",
-		"react-dnd-html5-backend": "10.0.1"
+		"react-dnd": "11.1.1",
+		"react-dnd-html5-backend": "11.1.1"
 	},
 	"name": "layout-admin-web",
 	"scripts": {

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumns.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumns.js
@@ -15,7 +15,7 @@
 import {usePrevious} from 'frontend-js-react-web';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import DragPreview from './DragPreview';
 import MillerColumnsColumn from './MillerColumnsColumn';

--- a/modules/apps/layout/layout-content-page-editor-web/package.json
+++ b/modules/apps/layout/layout-content-page-editor-web/package.json
@@ -17,8 +17,8 @@
 		"metal-position": "2.1.2",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "10.0.1",
-		"react-dnd-html5-backend": "10.0.1",
+		"react-dnd": "11.1.1",
+		"react-dnd-html5-backend": "11.1.1",
 		"react-dom": "16.12.0"
 	},
 	"name": "layout-content-page-editor-web",

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/index.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/index.js
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {INIT} from '../app/actions/types';
 import App from './components/App';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/createDNDBackend.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/createDNDBackend.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import createBackend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 export default function createDNDBackend(manager, mainContext) {
 
@@ -57,7 +57,7 @@ export default function createDNDBackend(manager, mainContext) {
 
 			contexts.forEach((context) => {
 				if (!connections.has(context)) {
-					const backend = createBackend(manager, context);
+					const backend = HTML5Backend(manager, context);
 
 					backend.setup();
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Collection.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Collection.test.js
@@ -16,7 +16,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {act, cleanup, getByText, render} from '@testing-library/react';
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {CollectionItemWithControls} from '../../../../src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items';
 import Collection from '../../../../src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/Collection';

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Topper.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Topper.test.js
@@ -16,7 +16,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {ControlsProvider} from '../../../../src/main/resources/META-INF/resources/page_editor/app/components/Controls';
 import Topper from '../../../../src/main/resources/META-INF/resources/page_editor/app/components/Topper';

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/TopperEmpty.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/TopperEmpty.test.js
@@ -16,7 +16,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {ControlsProvider} from '../../../../src/main/resources/META-INF/resources/page_editor/app/components/Controls';
 import TopperEmpty from '../../../../src/main/resources/META-INF/resources/page_editor/app/components/Topper';

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout-data-items/CollectionWithControls.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout-data-items/CollectionWithControls.test.js
@@ -16,7 +16,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {
 	ControlsProvider,

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout-data-items/ColumnWithControls.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout-data-items/ColumnWithControls.test.js
@@ -16,7 +16,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {
 	ControlsProvider,

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout-data-items/ContainerWithControls.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout-data-items/ContainerWithControls.test.js
@@ -16,7 +16,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, queryByText, render} from '@testing-library/react';
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {
 	ControlsProvider,

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout-data-items/FragmentWithControls.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout-data-items/FragmentWithControls.test.js
@@ -16,7 +16,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {act, cleanup, queryByText, render} from '@testing-library/react';
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {
 	ControlsProvider,

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout-data-items/RowWithControls.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout-data-items/RowWithControls.test.js
@@ -16,7 +16,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, queryByText, render} from '@testing-library/react';
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {
 	ControlsProvider,

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/package.json
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/package.json
@@ -7,8 +7,8 @@
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "10.0.1",
-		"react-dnd-html5-backend": "10.0.1"
+		"react-dnd": "11.1.1",
+		"react-dnd-html5-backend": "11.1.1"
 	},
 	"name": "product-navigation-control-menu",
 	"scripts": {

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/AddPanel.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/AddPanel.js
@@ -16,7 +16,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useEffect, useMemo, useState} from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import DragAndDrop from './DragAndDrop';
 import DragPreview from './DragPreview';

--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -16,8 +16,8 @@
 		"odata-v4-parser": "^0.1.29",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "10.0.1",
-		"react-dnd-html5-backend": "10.0.1"
+		"react-dnd": "11.1.1",
+		"react-dnd-html5-backend": "11.1.1"
 	},
 	"description": "",
 	"jest": {

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -19,7 +19,7 @@ import getCN from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {
 	conjunctionShape,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
@@ -20,8 +20,8 @@
 		"lodash.times": "^4.3.2",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "10.0.1",
-		"react-dnd-html5-backend": "10.0.1",
+		"react-dnd": "11.1.1",
+		"react-dnd-html5-backend": "11.1.1",
 		"react-dom": "16.12.0"
 	},
 	"jest": {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
@@ -14,7 +14,7 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {PropTypes} from 'prop-types';
 import React, {PureComponent} from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {KEY_CODES} from '../../utils/constants.es';
 import {isNull, toggleListItem} from '../../utils/util.es';

--- a/modules/package.json
+++ b/modules/package.json
@@ -9,9 +9,6 @@
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,
-	"resolutions": {
-		"dnd-core": "10.0.1"
-	},
 	"scripts": {
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1895,6 +1895,11 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
+"@react-dnd/asap@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-4.0.0.tgz#b300eeed83e9801f51bd66b0337c9a6f04548651"
+  integrity sha512-0XhqJSc6pPoNnf8DhdsPHtUhRzZALVzYMTzRwV4VI6DJNJ/5xxfL9OQUwb8IH5/2x7lSf7nAZrnzUD+16VyOVQ==
+
 "@react-dnd/invariant@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-2.0.0.tgz#09d2e81cd39e0e767d7da62df9325860f24e517e"
@@ -2890,11 +2895,6 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
 
-"@types/asap@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/asap/-/asap-2.0.0.tgz#d529e9608c83499a62ae08c871c5e62271aa2963"
-  integrity sha512-upIS0Gt9Mc8eEpCbYMZ1K8rhNosfKUtimNcINce+zLwJF5UpM3Vv7yz3S5l/1IX+DxTa8lTkUjqynvjRXyJzsg==
-
 "@types/babel__core@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.0.tgz#710f2487dda4dcfd010ca6abb2b4dc7394365c51"
@@ -3847,7 +3847,7 @@ arrify@^1.0.0, arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@^2.0.6, asap@~2.0.3:
+asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -7270,14 +7270,13 @@ discontinuous-range@1.0.0:
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
-dnd-core@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-10.0.1.tgz#151d95cd3a7fa47b210905c301364c0828203029"
-  integrity sha512-PokpWzFSKbpmJSWbSIfVJtIsRdx3DP5e3//agNNzV8L1k9T4/IFKtgjjwKeLKmP9qMuTXdZZGSS40w+eZ8MmUg==
+dnd-core@^11.1.1:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-11.1.3.tgz#f92099ba7245e49729d2433157031a6267afcc98"
+  integrity sha512-QugF55dNW+h+vzxVJ/LSJeTeUw9MCJ2cllhmVThVPEtF16ooBkxj0WBE5RB+AceFxMFo1rO6bJKXtqKl+JNnyA==
   dependencies:
+    "@react-dnd/asap" "^4.0.0"
     "@react-dnd/invariant" "^2.0.0"
-    "@types/asap" "^2.0.0"
-    asap "^2.0.6"
     redux "^4.0.4"
 
 dns-equal@^1.0.0:
@@ -15408,33 +15407,33 @@ react-dev-utils@^9.0.0:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-dnd-html5-backend@10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-10.0.1.tgz#422c274a3007a86a7a64ddbab4a53e514211a907"
-  integrity sha512-llaw2bvSimBTFYLU479VPLtQgH+cR/kZajXjF6y4f/B9nijJW4IF8DJ2HN6wYXaVZnqaZQWdXBjf8RCOul+ZNQ==
+react-dnd-html5-backend@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-11.1.1.tgz#794f81a53abeccca1bb56f021ec2aca4b34bf3d9"
+  integrity sha512-2cdi5P0HdZwjOq7iuX6cIOVzKukPgVJKNNxRLvZj/fDz5dHwCu/IOHj4e3SypZ+q37jAcd6+BHvCp1hRiGFNOg==
   dependencies:
-    dnd-core "^10.0.1"
+    dnd-core "^11.1.1"
 
-react-dnd-test-backend@10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/react-dnd-test-backend/-/react-dnd-test-backend-10.0.1.tgz#a311d4928657b3f7ab70151843bb6ef74bbbfef4"
-  integrity sha512-n4StfUoSgQlbLwgFSbN6PQtk8Az41D8Ao8pFYkpgaW/ZlTmuy2xM2MvwBKXRm3NiAi3YUWcuj2TIv4p5VhEwCA==
+react-dnd-test-backend@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-test-backend/-/react-dnd-test-backend-11.1.1.tgz#2aae20a15fc2f379cc96a45a276592c98fcefa58"
+  integrity sha512-JrlQ0NXptN+EIhdQatiyahj3EOThs9L3qQ+DA5nUDs2SEkBcHUBfQaOL1YHpn+d81/D/wWkNWy+FHh7b2sgyGw==
   dependencies:
-    dnd-core "^10.0.1"
+    dnd-core "^11.1.1"
 
-react-dnd-test-utils@10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/react-dnd-test-utils/-/react-dnd-test-utils-10.0.1.tgz#1283eeba7037af65c583715cf05cc20150ec2726"
-  integrity sha512-9zS5+Nz9SMWgIMtTHOR3f/kPX/KGEbchbkYvXJR0hvSLyOI47j10hnV7GklJzQe10zS0Y0c1H9SlSRgjdkkGiw==
+react-dnd-test-utils@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-test-utils/-/react-dnd-test-utils-11.1.1.tgz#ba8ba8e7b1fe2f6471f63bb9ef509c14463774bf"
+  integrity sha512-dfWs2MX269ANlDo4ncHYG8bUD0U3cLXyHhLpemGGf6m1J7ru2/W4PKL9ep2hmL5Z5UlJ8nYcuMNip1C6y7Onqg==
 
-react-dnd@10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-10.0.1.tgz#fe9989f3b8aed2f237df090a382a1a309367be76"
-  integrity sha512-9GqK9j2s0+eUQiwIbni2m6/fv6L6Sq2WhPtpJmb5w2Ec+EIUSZLFo4/AZFmG8Nvck9AihavOTz/4nQiDq128DQ==
+react-dnd@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-11.1.1.tgz#eb20db4eee3ab3c48c8147e083248552fcbd9aef"
+  integrity sha512-THjjpXGfSHmZTGI/tT0fLdOGLEVikVEeeTcNuJw7/caUECYvhNnbsle+cz6O0j0/k7Pumy3p8fwBw9m4SbJSzw==
   dependencies:
     "@react-dnd/shallowequal" "^2.0.0"
     "@types/hoist-non-react-statics" "^3.3.1"
-    dnd-core "^10.0.1"
+    dnd-core "^11.1.1"
     hoist-non-react-statics "^3.3.0"
 
 react-docgen@^4.1.0:


### PR DESCRIPTION
Matches the upgrade that we prepared for the Commerce folks on 7.1.x:

- https://github.com/wincent/liferay-portal-ee/pull/9
- https://github.com/wincent/liferay-portal-ee/pull/10

What's going on here:

-  Bump version numbers from 10.0.1 to 11.1.1; there are later versions out now, but they bring nothing of value and given that we've seen 11.1.1 working on 7.1.x, I want to stay in line with that.

-  Adjust `HTML5Backend` imports; this is the breaking change in [the v10 to v11 update](https://github.com/react-dnd/react-dnd/releases/tag/v11.0.0): previously it was a default export but now it is a named export.

-  Configure `frontend-js-react-web` to get `domain` from `frontend-js-node-shims`; this is because `domain` is `require()`-ed [here](https://github.com/react-dnd/asap/blob/b6bebeb7342/src/node/raw.ts#L87), which would cause the loader to throw an error.


-  Configure `frontend-js-react-web` to get `process` from `frontend-js-node-shims`; this is because — the horror 😱 — `@react-dnd/asap` [expects it to be a global](https://github.com/react-dnd/asap/blob/b6bebeb7342/src/node/asap.ts#L24).

   We set up this global in the index of `frontend-js-react-web`, to be sure that it is set by any client that may conceivably need it.

   If we don't do this, drag-and-drop works fine, but when you try to navigate away from a page, we hit the above line and an error is thrown, breaking the transition and spewing out a bunch of red crap into the console.

-  Note that only `frontend-js-react-web` needs these imports configured. Other modules that use `react-dnd` get it from `frontend-js-react-web` and don't need to meddle with the transitive dependencies themselves; at least, in my testing of a couple of places (`segments-web` and `layout-content-page-editor-web`) I didn't see any loader errors.

-  Drop forced resolution of `dnd-core`. Previously, we were doing that in order to avoid running into all the above problems with `domain` and friends. By using an older version of `dnd-core`, we avoided the problematic `@react-dnd/asap` fork of the `asap` package, which [came into react-dnd in v10.0.2](https://github.com/react-dnd/react-dnd/commit/ada65550b75).

   We can no longer use this resolution because resolutions are a very limited tool: they allow us to control what gets installed at build time but they do not influence what happens at runtime. In other words, if a package like `dnd-core` has a dependency with a range like "^3.0.0", and we want to pin to version "3.0.1" or something else compatible, then resolutions work well. But as soon as the range changes to "^4.0.0" we can no longer useful pin to "3.0.1", even if we know it to be compatible: Yarn will install the version we require, but at runtime the loader will blow up because the dependency graph says that `dnd-core` wants "^4.0.0" and we won't have it due to the resolution.

One thought: it would be nice if we could force the various pieces of our module loading system (bundler, loader, registry) to work with react-dnd without these hacks, but that is probably beyond the scope of this task. If you look at [their package.json](https://github.com/react-dnd/asap/blob/b6bebeb7342/package.json#L15-L26), you can see how they've tried to make it work via `"main"` and `"browser"` fields, but I'm not even sure they're doing it right...

Test plan: Test drag and drop in two apps (`segments-web` and `layout-content-page-editor-web`); see it working with no errors in console. Run all JS unit tests in repo.

Mentioning reviewers:

- @julien, who worked on the last react-dnd upgrade and added the resolutions field.
- @izaera, the bundler/loader connoisseur.
- @jbalsas, the person we all turn to when looking for authorization to ship an *egregious hack*.