### PR TITLE
LPS-113302 Apply classic ckeditor implementation in Message Boards, part 1/2

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,8 @@
 	"dependencies": {
 		"ckeditor4-react": "1.0.1",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.14.1-liferay.2"
+		"liferay-ckeditor": "4.14.1-liferay.2",
+		"prop-types": "15.7.2"
 	},
 	"main": "index.js",
 	"name": "frontend-editor-ckeditor-web",

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorClassicEditor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorClassicEditor.java
@@ -56,7 +56,7 @@ public class CKEditorClassicEditor implements Editor, EditorRenderer {
 
 	@Override
 	public String getResourcesJspPath() {
-		return null;
+		return "/resources.jsp";
 	}
 
 	@Override

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
@@ -19,8 +19,10 @@
 <%
 String contents = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":contents");
 Map<String, Object> editorData = (Map<String, Object>)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":data");
+String editorName = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":editorName");
 String name = namespace + GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":name"));
 String onChangeMethod = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":onChangeMethod");
+String placeholder = GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":placeholder"));
 String toolbarSet = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":toolbarSet");
 
 if (Validator.isNotNull(onChangeMethod)) {
@@ -43,8 +45,14 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 	"name", HtmlUtil.escapeAttribute(name)
 ).put(
 	"onChangeMethodName", HtmlUtil.escapeJS(onChangeMethod)
+).put(
+	"title", LanguageUtil.get(request, placeholder)
 ).build();
 %>
+
+<liferay-editor:resources
+	editorName="<%= editorName %>"
+/>
 
 <div>
 	<react:component

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -14,7 +14,8 @@
 
 import {useEventListener} from 'frontend-js-react-web';
 import {isPhone, isTablet} from 'frontend-js-web';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import PropTypes from 'prop-types';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {Editor} from './Editor';
 
@@ -32,21 +33,22 @@ const getToolbarSet = (toolbarSet) => {
 const ClassicEditor = ({
 	contents = '',
 	cssClass,
-	editorConfig = {},
+	editorConfig,
 	initialToolbarSet,
 	name,
 	onChangeMethodName,
+	title,
 }) => {
 	const editorRef = useRef();
 
 	const [toolbarSet, setToolbarSet] = useState(initialToolbarSet);
 
-	const config = useMemo(() => {
+	const getConfig = () => {
 		return {
 			toolbar: toolbarSet,
 			...editorConfig,
 		};
-	}, [editorConfig, toolbarSet]);
+	};
 
 	const getHTML = useCallback(() => {
 		let data = contents;
@@ -65,6 +67,10 @@ const ClassicEditor = ({
 	}, [contents]);
 
 	const onChangeCallback = () => {
+		if (!onChangeMethodName) {
+			return;
+		}
+
 		const editor = editorRef.current.editor;
 
 		if (editor.checkDirty()) {
@@ -96,9 +102,12 @@ const ClassicEditor = ({
 
 	return (
 		<div className={cssClass} id={`${name}Container`}>
+			<label className="control-label" htmlFor={name}>
+				{title}
+			</label>
 			<Editor
 				className="lfr-editable"
-				config={config}
+				config={getConfig()}
 				data={contents}
 				key={toolbarSet}
 				onBeforeLoad={(CKEDITOR) => {
@@ -115,6 +124,16 @@ const ClassicEditor = ({
 			/>
 		</div>
 	);
+};
+
+ClassicEditor.propTypes = {
+	contents: PropTypes.string,
+	cssClass: PropTypes.string,
+	editorConfig: PropTypes.object,
+	initialToolbarSet: PropTypes.string,
+	name: PropTypes.string,
+	onChangeMethodName: PropTypes.string,
+	title: PropTypes.string,
 };
 
 export default ClassicEditor;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.js
@@ -12,5 +12,6 @@
  * details.
  */
 
+export {ClassicEditor} from './editor/ClassicEditor';
 export {Editor} from './editor/Editor';
 export {InlineEditor} from './editor/InlineEditor';

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/init.jsp
@@ -31,6 +31,7 @@ page import="com.liferay.petra.string.StringBundler" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.editor.configuration.EditorOptions" %><%@
 page import="com.liferay.portal.kernel.json.JSONObject" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.PortalWebResourceConstants" %><%@
 page import="com.liferay.portal.kernel.servlet.PortalWebResourcesUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resources.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resources.jsp
@@ -59,10 +59,12 @@ String inlineEditSaveURL = GetterUtil.getString((String)request.getAttribute(CKE
 
 		var cleanupCkEditorResources = function () {
 			if (!ckEditorInstances && ckEditorDisposeResources) {
-				window.CKEDITOR = undefined;
-
 				ckEditorInstances = 0;
 				ckEditorDisposeResources = false;
+
+				if (CKEDITOR && Object.keys(CKEDITOR.instances).length === 0) {
+					window.CKEDITOR = undefined;
+				}
 			}
 		};
 

--- a/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBAttachmentHTMLEditorConfigContributor.java
+++ b/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBAttachmentHTMLEditorConfigContributor.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"editor.name=ckeditor", "editor.name=ckeditor_bbcode",
+		"editor.name=ckeditor_bbcode", "editor.name=ckeditor_classic",
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS,
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS_ADMIN
 	},

--- a/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBEditorOptionsContributor.java
+++ b/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBEditorOptionsContributor.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"editor.name=ckeditor", "editor.name=ckeditor_bbcode",
+		"editor.name=ckeditor_bbcode", "editor.name=ckeditor_classic",
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS,
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS_ADMIN
 	},

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/util/MBUtil.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/util/MBUtil.java
@@ -115,7 +115,7 @@ public class MBUtil {
 			return "ckeditor_bbcode";
 		}
 
-		return "ckeditor";
+		return "ckeditor_classic";
 	}
 
 	public static String getHtmlQuoteBody(

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/html_editor.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/html_editor.jspf
@@ -24,7 +24,7 @@ if (Validator.isNull(body)) {
 	}
 }
 
-Editor editor = InputEditorTag.getEditor(request, "ckeditor");
+Editor editor = InputEditorTag.getEditor(request, "ckeditor_classic");
 %>
 
 <liferay-editor:editor


### PR DESCRIPTION
@jbalsas @carloslancha @julien @wincent 

This is a followup on https://github.com/jbalsas/liferay-portal/pull/2221. We are putting the support of rendering opinionated component from React context on hold. In this PR, the goal is to iron out `ClassicEditor` component, by updating a `<liferay-editor:editor>` usage in `message-boards`. We are updating the HTML editor use, part 2/2 will be update of bbcode editor.

To test:
1. Site Administatration > Content & Data > Message Boards > options on top right > Configuration
1. Set format to HTML
1. Place the Message Boards App on a page
1. New Thread > Make a sample post. Add some sample formatting, like bolding.
1. On the view page, there is also a ckeditor, showing the post in read-only mode. Formatting should apply.
1. Edit post.
1. Cancel.

Notes:
1. The main purpose of adding resources.jsp is to ensure [ckeditor initialization on SPA navigation](https://github.com/liferay/liferay-portal/blob/fcffc8af664fd67a6f1fd01a460824265f35349a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resources.jsp#L38). Without this, `CKEDITOR` global object is undefined when navigating away and back to page. Secondary purpose is cleanup of no longer necessary global object.
1. With the addition of above resources, there is a race condition when leaving the page. Leaving triggers ckeditor's on destroy event listeners, as well as [`destroyGlobalCkEditor`](https://github.com/liferay/liferay-portal/blob/fcffc8af664fd67a6f1fd01a460824265f35349a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resources.jsp#L88) in resources.jsp. ckeditor's on destroy event listeners use `CKEDITOR`, but sometimes we destroy it in `destroyGlobalCkEditor` before they have the chance. To prevent breakage, we have [this workaround](https://github.com/liferay-frontend/liferay-portal/commit/22e47844138760c2716b7d6fabe44f893be59263). It means that sometimes we will not clean up the `CKEDITOR` object when leaving the page, but that is much better than sometimes everything breaks. This is a duplicate of the same workaround we did in `alloyeditor`.
1. I removed `useMemo` in config override to simplify, I don't think there is any reason for it.
1. I [re-branded](https://github.com/liferay-frontend/liferay-portal/compare/master...markocikos:LPS-113302?expand=1#diff-3459d79ed5cbe6ecd820dca89fd68683R49) `placeholder` from backend configuration to `title`... because it's a title, not a placeholder.
1. TIL, `onChange={onChangeMethodName && onChangeCallback}`  like I tried [here](https://github.com/jbalsas/liferay-portal/pull/2221/commits/60638bbb52eb3e3921085f8cafdcde84778ab024#diff-d56c6936fe2bae8620add307fceb521bR144) does not work. I rewrote it to [simple `if`](https://github.com/liferay-frontend/liferay-portal/compare/master...markocikos:LPS-113302?expand=1#diff-60128641efe40efd4a4df0325f6e6070R70-R73).
1. [Bug in master] We cannot drag-select text in editor with mouse, it's a bit annoying. I'm not sure if this is a bug or a much-needed improvement, but it's something that we should definitely look into. For testing, I selected text with shift+arrows.