### PR TITLE
LPS-116752 Social bookmarks share button styles

### DIFF
--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
@@ -77,10 +77,10 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_social
 					displayType="secondary"
 					dropdownItems="<%= SocialBookmarksTagUtil.getDropdownItems(request.getLocale(), remainingTypes, className, classPK, title, url) %>"
 					icon="share"
-					label="share"
 					monospaced="<%= true %>"
 					propsTransformer="bookmarks/SocialBookmarksDropdownPropsTransformer"
 					small="<%= true %>"
+					title="share"
 				/>
 
 			<%

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
@@ -35,7 +35,6 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_social
 				dropdownItems="<%= SocialBookmarksTagUtil.getDropdownItems(request.getLocale(), types, className, classPK, title, url) %>"
 				icon="share"
 				label='<%= BrowserSnifferUtil.isMobile(request) ? null : "share" %>'
-				monospaced="<%= true %>"
 				propsTransformer="bookmarks/SocialBookmarksDropdownPropsTransformer"
 				small="<%= true %>"
 			/>


### PR DESCRIPTION
We have two problems with share button

**Steps to reproduce:**

- Add a new widget page with the KB display widget
- Go to KB to add a basic article
- Go the page 
- View the share button 

**Expected Result:**

The share button can be displayed normally as below

![image](https://user-images.githubusercontent.com/67901/87523220-f49bf400-c686-11ea-9f5c-28bfb5fb7b56.png)


**Actual Result:**

The share button can not be displayed normally as below

![image](https://user-images.githubusercontent.com/67901/87523294-109f9580-c687-11ea-9f73-83a955bbf5e0.png)

---

**Steps to reproduce:**

- Add a blog entry
- Add a blog widget in a page

**Expected results:**

The social bookmarks dropdown doesn't have a text and has a title.

![image](https://user-images.githubusercontent.com/67901/87523764-a1767100-c687-11ea-8968-242f37336536.png)


**Actual results:**

The social bookmarks dropdown has a cut text and doesn't have a title.

![image](https://user-images.githubusercontent.com/67901/87523655-8277df00-c687-11ea-90f2-922c9e78ca0f.png)



