### PR TITLE
LPS-113302 Apply classic ckeditor implementation in Message Boards, part 1/2

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,8 @@
 	"dependencies": {
 		"ckeditor4-react": "1.0.1",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.14.1-liferay.3"
+		"liferay-ckeditor": "4.14.1-liferay.3",
+		"prop-types": "15.7.2"
 	},
 	"main": "index.js",
 	"name": "frontend-editor-ckeditor-web",

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
@@ -21,6 +21,7 @@ String contents = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMES
 Map<String, Object> editorData = (Map<String, Object>)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":data");
 String name = namespace + GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":name"));
 String onChangeMethod = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":onChangeMethod");
+String placeholder = GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":placeholder"));
 String toolbarSet = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":toolbarSet");
 
 if (Validator.isNotNull(onChangeMethod)) {
@@ -43,6 +44,8 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 	"name", HtmlUtil.escapeAttribute(name)
 ).put(
 	"onChangeMethodName", HtmlUtil.escapeJS(onChangeMethod)
+).put(
+	"title", LanguageUtil.get(request, placeholder)
 ).build();
 %>
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
@@ -13,15 +13,54 @@
  */
 
 import CKEditor from 'ckeditor4-react';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
-const BASEPATH = '/o/frontend-editor-ckeditor-web/ckeditor/';
+const CKEDITOR_BASEPATH = '/o/frontend-editor-ckeditor-web/ckeditor/';
+const CKEDITOR_PATH = `${CKEDITOR_BASEPATH}ckeditor.js`;
 
 const Editor = React.forwardRef((props, ref) => {
-	return <CKEditor ref={ref} {...props} />;
+	const [initialized, setInitialized] = useState(!!window.CKEDITOR);
+
+	useEffect(() => {
+		let script;
+
+		const destroyGlobalCkEditor = () => {
+			if (
+				window.CKEDITOR &&
+				Object.keys(window.CKEDITOR.instances).length === 0
+			) {
+				window.CKEDITOR = undefined;
+
+				Liferay.detach('beforeScreenFlip', destroyGlobalCkEditor);
+			}
+		};
+
+		if (!initialized) {
+			script = document.createElement('script');
+
+			script.setAttribute('data-senna-track', 'temporary');
+			script.src = CKEDITOR_PATH;
+
+			script.onload = () => {
+				setInitialized(true);
+			};
+
+			document.head.appendChild(script);
+
+			Liferay.on('beforeScreenFlip', destroyGlobalCkEditor);
+		}
+
+		return () => {
+			if (script) {
+				document.head.removeChild(script);
+			}
+		};
+	}, [initialized]);
+
+	return initialized && <CKEditor ref={ref} {...props} />;
 });
 
-CKEditor.editorUrl = `${BASEPATH}ckeditor.js`;
-window.CKEDITOR_BASEPATH = BASEPATH;
+CKEditor.editorUrl = CKEDITOR_PATH;
+window.CKEDITOR_BASEPATH = CKEDITOR_BASEPATH;
 
 export {Editor};

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.js
@@ -12,5 +12,6 @@
  * details.
  */
 
+export {ClassicEditor} from './editor/ClassicEditor';
 export {Editor} from './editor/Editor';
 export {InlineEditor} from './editor/InlineEditor';

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/init.jsp
@@ -31,6 +31,7 @@ page import="com.liferay.petra.string.StringBundler" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.editor.configuration.EditorOptions" %><%@
 page import="com.liferay.portal.kernel.json.JSONObject" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.PortalWebResourceConstants" %><%@
 page import="com.liferay.portal.kernel.servlet.PortalWebResourcesUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@

--- a/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBAttachmentHTMLEditorConfigContributor.java
+++ b/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBAttachmentHTMLEditorConfigContributor.java
@@ -43,6 +43,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"editor.name=ckeditor", "editor.name=ckeditor_bbcode",
+		"editor.name=ckeditor_classic",
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS,
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS_ADMIN
 	},

--- a/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBEditorOptionsContributor.java
+++ b/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBEditorOptionsContributor.java
@@ -35,6 +35,7 @@ import org.osgi.service.component.annotations.Component;
 @Component(
 	property = {
 		"editor.name=ckeditor", "editor.name=ckeditor_bbcode",
+		"editor.name=ckeditor_classic",
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS,
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS_ADMIN
 	},

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/util/MBUtil.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/util/MBUtil.java
@@ -115,7 +115,7 @@ public class MBUtil {
 			return "ckeditor_bbcode";
 		}
 
-		return "ckeditor";
+		return "ckeditor_classic";
 	}
 
 	public static String getHtmlQuoteBody(

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/html_editor.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/html_editor.jspf
@@ -24,7 +24,7 @@ if (Validator.isNull(body)) {
 	}
 }
 
-Editor editor = InputEditorTag.getEditor(request, "ckeditor");
+Editor editor = InputEditorTag.getEditor(request, "ckeditor_classic");
 %>
 
 <liferay-editor:editor


### PR DESCRIPTION
This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/107

Changes:
- Removed dependency on `resources.jsp`. To achieve this:
  - [the ugly one] Added manual `ckeditor` script loading, to ensure `CKEDITOR` global object will be available.
  - Added cleanup of `CKEDITOR` global object when navigating away from a page with editor. I did not migrate manual tracking of instances count, `addInstance`, `removeInstance`, `ckEditorInstances` etc. We can see that out-of the-box in `CKEDITOR.instances` array. I am not sure if there is some point to it that I'm not seeing. It does not help with race condition on cleanup that I mentioned in https://github.com/liferay-frontend/liferay-portal/pull/107.
- Added debouncing on resize.
- `ckeditor` remains as component property.

Now, why the ugly loading change? Steps of the problem:
1. On page-1 load (reload), editor works normally.
1. Navigate to page-2 with ckeditor.
1. Navigate to page-1. Navigating away from page-2 deletes `CKEDITOR` object.

If we are using `resources.jsp`, this is not a problem, because we [reload `ckeditor.js` manually](https://github.com/liferay/liferay-portal/blob/e67026449a8a6dae28fc7a7da27e3ff6a3f780b6/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resources.jsp#L38).

In the new component, we rely on `ckeditor4-react` for loading. [This is the code](https://github.com/ckeditor/ckeditor4-react/blob/master/src/getEditorNamespace.js), and looking at it, it should work fine. If `CKEDITOR` is not defined, we run `loadScript` and re-initialize it. The Promise then resolves with sparkling `CKEDITOR` object.

But, what happens, promise returns with `CKEDITOR` = undefined and editor breaks on the next line, when we [invoke `onBeforeLoad`](https://github.com/ckeditor/ckeditor4-react/blob/470e9ba60aac1df5ae9f54016b906b06d496eade/src/ckeditor.jsx#L61).

This is quite an awesome bug, see the console below:
![screen](https://user-images.githubusercontent.com/5435511/87543882-ce398100-c6a5-11ea-9d78-1423c4926e36.png)

It looks like window is not treated like a normal object:
```js
undefined in window // true
undefined in {} // false
```
JavaScript is awesome?  ¯\\_(ツ)_/¯