### PR TITLE
LPS-116884 Fix style of navigation-bar in form-builder

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -46,12 +46,13 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 </div>
 
 <div class="portlet-forms" id="<portlet:namespace />formContainer">
-	<clay:navigation-bar
-		cssClass="forms-navigation-bar"
-		id="formsNavigationBar"
-		inverted="<%= true %>"
-		navigationItems="<%= ddmFormAdminDisplayContext.getFormBuilderNavigationItems() %>"
-	/>
+	<div class="forms-navigation-bar">
+		<clay:navigation-bar
+			id="formsNavigationBar"
+			inverted="<%= true %>"
+			navigationItems="<%= ddmFormAdminDisplayContext.getFormBuilderNavigationItems() %>"
+		/>
+	</div>
 
 	<nav class="hide management-bar management-bar-light navbar navbar-expand-md toolbar-group-field" id="<portlet:namespace />managementToolbar">
 		<clay:container-fluid


### PR DESCRIPTION
The visual bug was introduced by the new `<clay:navigation-bar>` taglib https://issues.liferay.com/browse/LPS-112470. In order to work with React it needs to be wrapped in a `<div>`.

**INPUT**
```jsp
<div>
   <clay:navigation-bar />
</div>
```
**OUTPUT BEFORE THE UPDATE**
```jsp
<div class="navigation-bar ... " >...</div>
```

**OUTPUT AFTER THE UPDATE**
```jsp
<div>
   <div class="navigation-bar ... " >...</div>
</div>
```
The CSS property `position: sticky` needs to be outside the `<div>` to works fine.

The proposed solution is to move [the sticky class](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss#L214) `.forms-navigation-bar` outside the  navigation `<clay:navigation-bar>` taglib

**Result:**
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/46778114/87557767-9daf1280-c6b8-11ea-9aad-7229ee6387f8.gif)
