### PR TITLE
LPS-117120 - Fix global menu height in mobile

### DIFF
--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
@@ -63,6 +63,14 @@ $tab-header-height: 38px;
 	margin: 0;
 	padding: 0.2rem;
 
+	@include media-breakpoint-down(xs) {
+		@at-root {
+			.mobile #{&} {
+				padding-bottom: 7rem;
+			}
+		}
+	}
+
 	@include media-breakpoint-up(sm) {
 		padding: 1.5rem 2.5rem 1.5rem 1.75rem;
 	}


### PR DESCRIPTION
This PR fixes a problem in mobiles (issue for iPhone7) to get to see all the global menu vertical space.

---

To test the PR you only need to open your portal in your mobile by using your Mac/PC local IP.

![iphone7](https://user-images.githubusercontent.com/7963804/87559767-00a1a900-c6bb-11ea-93dd-1efa76f605a6.gif)
