### PR TITLE
LPS-116752 Social bookmarks share button styles

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
@@ -49,6 +49,7 @@ FileVersion fileVersion = (FileVersion)request.getAttribute("file_entry_upper_tb
 				<li class="tbar-item">
 					<clay:button
 						borderless="<%= true %>"
+						data-qa-id="infoButton"
 						displayType="secondary"
 						icon="info-circle-open"
 						id='<%= liferayPortletResponse.getNamespace() + "OpenContextualSidebar" %>'

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -259,6 +259,8 @@ public class BaseContainerTag extends AttributesTagSupport {
 			props.putAll(_additionalProps);
 		}
 
+		props.putAll(getDynamicAttributes());
+
 		return props;
 	}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -290,7 +290,9 @@ public class ButtonTag extends BaseContainerTag {
 			cssClasses.add("btn-block");
 		}
 
-		if (Validator.isNotNull(_icon) || _monospaced) {
+		if ((Validator.isNotNull(_icon) && Validator.isNull(_label)) ||
+			_monospaced) {
+
 			cssClasses.add("btn-monospaced");
 		}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -322,7 +322,13 @@ public class ButtonTag extends BaseContainerTag {
 			JspWriter jspWriter = pageContext.getOut();
 
 			if (Validator.isNotNull(_icon)) {
-				jspWriter.write("<svg class=\"lexicon-icon lexicon-icon-");
+				jspWriter.write("<span class=\"inline-item");
+
+				if (Validator.isNotNull(_label)) {
+					jspWriter.write(" inline-item-before");
+				}
+
+				jspWriter.write("\"><svg class=\"lexicon-icon lexicon-icon-");
 				jspWriter.write(_icon);
 				jspWriter.write("\" role=\"presentation\" viewBox=\"0 0 512 ");
 				jspWriter.write("512\"><use xlink:href=\"");
@@ -338,7 +344,7 @@ public class ButtonTag extends BaseContainerTag {
 
 				jspWriter.write("#");
 				jspWriter.write(_icon);
-				jspWriter.write("\" /></svg>");
+				jspWriter.write("\" /></svg></span>");
 			}
 
 			if (Validator.isNotNull(_label)) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -24,6 +24,7 @@ export default function DropdownMenu({
 	icon,
 	items,
 	label,
+	locale: _locale,
 	portletId: _portletId,
 	portletNamespace: _portletNamespace,
 	...otherProps

--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
@@ -262,7 +262,6 @@
 
 			.lexicon-icon {
 				height: 14px;
-				margin-right: 0.65rem;
 				width: 14px;
 			}
 		}

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
@@ -77,10 +77,10 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_social
 					displayType="secondary"
 					dropdownItems="<%= SocialBookmarksTagUtil.getDropdownItems(request.getLocale(), remainingTypes, className, classPK, title, url) %>"
 					icon="share"
-					label="share"
 					monospaced="<%= true %>"
 					propsTransformer="bookmarks/SocialBookmarksDropdownPropsTransformer"
 					small="<%= true %>"
+					title="share"
 				/>
 
 			<%

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
@@ -35,7 +35,6 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_social
 				dropdownItems="<%= SocialBookmarksTagUtil.getDropdownItems(request.getLocale(), types, className, classPK, title, url) %>"
 				icon="share"
 				label='<%= BrowserSnifferUtil.isMobile(request) ? null : "share" %>'
-				monospaced="<%= true %>"
 				propsTransformer="bookmarks/SocialBookmarksDropdownPropsTransformer"
 				small="<%= true %>"
 			/>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Button.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Button.macro
@@ -7,7 +7,7 @@ definition {
 	}
 
 	macro clickAdd {
-		Button.click(button = "Add");
+		Click(locator1 = "Button#ADD");
 	}
 
 	macro clickAddRow {


### PR DESCRIPTION
From https://github.com/liferay-frontend/liferay-portal/pull/118, because I don't have write access in @boton's repo:

So, what we do here:
- Pass `title` attribute to `clay:dropdown-menu`
- Make sure `dynamicAttributes` are passed as props
- Exclude `locale` from `otherProps` so it won't pollute the final markup
- Remove `btn-monospace` by default server-side from all buttons that have icons (this caused fouc because it makes the label break and it's not actually present client-side)

--- 

We have two problems with share button

**Steps to reproduce:**

- Add a new widget page with the KB display widget
- Go to KB to add a basic article
- Go the page 
- View the share button 

**Expected Result:**

The share button can be displayed normally as below

![image](https://user-images.githubusercontent.com/67901/87523220-f49bf400-c686-11ea-9f5c-28bfb5fb7b56.png)


**Actual Result:**

The share button can not be displayed normally as below

![image](https://user-images.githubusercontent.com/67901/87523294-109f9580-c687-11ea-9f73-83a955bbf5e0.png)

---

**Steps to reproduce:**

- Add a blog entry
- Add a blog widget in a page

**Expected results:**

The social bookmarks dropdown doesn't have a text and has a title.

![image](https://user-images.githubusercontent.com/67901/87523764-a1767100-c687-11ea-8968-242f37336536.png)


**Actual results:**

The social bookmarks dropdown has a cut text and doesn't have a title.

![image](https://user-images.githubusercontent.com/67901/87523655-8277df00-c687-11ea-90f2-922c9e78ca0f.png)

Additional context from @boton:

> I pass the title to the clay dropdown here https://github.com/liferay-frontend/liferay-portal/pull/118/files#diff-f53cecdf213bf0d35836806f14a74211R83, but not render in the final HTML.
> 
> ![image](https://user-images.githubusercontent.com/67901/87524867-04b4d300-c689-11ea-8195-d8dae557b89a.png)
>
> Maybe we need to filter locale to provide clean HTML.



