### PR TITLE
LPS-113302 Apply classic ckeditor implementation in Message Boards, part 1/2

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/resources.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/resources.jsp
@@ -54,7 +54,7 @@ String editorName = (String)request.getAttribute(AlloyEditorConstants.ATTRIBUTE_
 				alloyEditorDisposeResources = false;
 
 				if (CKEDITOR && Object.keys(CKEDITOR.instances).length === 0) {
-					window.CKEDITOR = undefined;
+					delete window.CKEDITOR;
 				}
 			}
 		};

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/resources.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/resources.jsp
@@ -53,7 +53,7 @@ String editorName = (String)request.getAttribute(AlloyEditorConstants.ATTRIBUTE_
 				alloyEditorInstances = 0;
 				alloyEditorDisposeResources = false;
 
-				if (CKEDITOR && Object.keys(CKEDITOR.instances).length === 0) {
+				if (window.CKEDITOR && Object.keys(window.CKEDITOR.instances).length === 0) {
 					delete window.CKEDITOR;
 				}
 			}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,8 @@
 	"dependencies": {
 		"ckeditor4-react": "1.0.1",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.14.1-liferay.3"
+		"liferay-ckeditor": "4.14.1-liferay.3",
+		"prop-types": "15.7.2"
 	},
 	"main": "index.js",
 	"name": "frontend-editor-ckeditor-web",

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
@@ -21,6 +21,7 @@ String contents = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMES
 Map<String, Object> editorData = (Map<String, Object>)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":data");
 String name = namespace + GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":name"));
 String onChangeMethod = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":onChangeMethod");
+String placeholder = GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":placeholder"));
 String toolbarSet = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":toolbarSet");
 
 if (Validator.isNotNull(onChangeMethod)) {
@@ -43,6 +44,8 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 	"name", HtmlUtil.escapeAttribute(name)
 ).put(
 	"onChangeMethodName", HtmlUtil.escapeJS(onChangeMethod)
+).put(
+	"title", LanguageUtil.get(request, placeholder)
 ).build();
 %>
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
@@ -13,11 +13,22 @@
  */
 
 import CKEditor from 'ckeditor4-react';
-import React from 'react';
+import React, {useEffect} from 'react';
 
 const BASEPATH = '/o/frontend-editor-ckeditor-web/ckeditor/';
 
 const Editor = React.forwardRef((props, ref) => {
+	useEffect(() => {
+		Liferay.once('beforeScreenFlip', () => {
+			if (
+				window.CKEDITOR &&
+				Object.keys(window.CKEDITOR.instances).length === 0
+			) {
+				delete window.CKEDITOR;
+			}
+		});
+	}, []);
+
 	return <CKEditor ref={ref} {...props} />;
 });
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.js
@@ -12,5 +12,6 @@
  * details.
  */
 
+export {ClassicEditor} from './editor/ClassicEditor';
 export {Editor} from './editor/Editor';
 export {InlineEditor} from './editor/InlineEditor';

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/init.jsp
@@ -31,6 +31,7 @@ page import="com.liferay.petra.string.StringBundler" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.editor.configuration.EditorOptions" %><%@
 page import="com.liferay.portal.kernel.json.JSONObject" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.PortalWebResourceConstants" %><%@
 page import="com.liferay.portal.kernel.servlet.PortalWebResourcesUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resources.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resources.jsp
@@ -59,7 +59,7 @@ String inlineEditSaveURL = GetterUtil.getString((String)request.getAttribute(CKE
 
 		var cleanupCkEditorResources = function () {
 			if (!ckEditorInstances && ckEditorDisposeResources) {
-				window.CKEDITOR = undefined;
+				delete window.CKEDITOR;
 
 				ckEditorInstances = 0;
 				ckEditorDisposeResources = false;

--- a/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBAttachmentHTMLEditorConfigContributor.java
+++ b/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBAttachmentHTMLEditorConfigContributor.java
@@ -43,6 +43,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"editor.name=ckeditor", "editor.name=ckeditor_bbcode",
+		"editor.name=ckeditor_classic",
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS,
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS_ADMIN
 	},

--- a/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBEditorOptionsContributor.java
+++ b/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBEditorOptionsContributor.java
@@ -35,6 +35,7 @@ import org.osgi.service.component.annotations.Component;
 @Component(
 	property = {
 		"editor.name=ckeditor", "editor.name=ckeditor_bbcode",
+		"editor.name=ckeditor_classic",
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS,
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS_ADMIN
 	},

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/util/MBUtil.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/util/MBUtil.java
@@ -115,7 +115,7 @@ public class MBUtil {
 			return "ckeditor_bbcode";
 		}
 
-		return "ckeditor";
+		return "ckeditor_classic";
 	}
 
 	public static String getHtmlQuoteBody(

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/html_editor.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/html_editor.jspf
@@ -24,7 +24,7 @@ if (Validator.isNull(body)) {
 	}
 }
 
-Editor editor = InputEditorTag.getEditor(request, "ckeditor");
+Editor editor = InputEditorTag.getEditor(request, "ckeditor_classic");
 %>
 
 <liferay-editor:editor


### PR DESCRIPTION
Task history:
1. https://github.com/jbalsas/liferay-portal/pull/2221
2. https://github.com/liferay-frontend/liferay-portal/pull/107
3. https://github.com/liferay-frontend/liferay-portal/pull/121

Changes from https://github.com/liferay-frontend/liferay-portal/pull/121:
- Removed the ugly manual script loading. Instead, we are fixing the default `ckeditor4-react` loading, by deleting `CKEDITOR` property instead of assigning `undefined`. 
- Simplified `beforeScreenFlip` event handling, by using `Liferay.once`, instead of `on` and `detach`.

There is a `window.CKEDITOR = undefined` in [test of the CKEditor's jquery adapter](https://github.com/ckeditor/ckeditor4/blob/eb2d11644a796cd13cd047cd55541430359f9317/tests/adapters/jquery/manual/nockeditor.html), revealing that we are not supporting IE8 with this change. I sincerely hope that is not a problem :smile: 