### PR TITLE
LPS-117292 - Modify border overlapping

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
@@ -5,8 +5,8 @@ $lead-font-weight: 400;
 $small-font-size: 0.875rem;
 
 $navigation-bar-size: (
-	active-border-offset-bottom: -0.5625rem,
-	active-border-offset-bottom-mobile: -0.5625rem,
+	active-border-offset-bottom: -0.4375rem,
+	active-border-offset-bottom-mobile: -0.4375rem,
 	border-bottom-width: 0.0625rem,
 );
 

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
@@ -13,8 +13,8 @@ $portlet-decorate-bg: #fff;
 $portlet-decorate-border: 1px solid $light-color;
 
 $navigation-bar-size: (
-	active-border-offset-bottom: -0.5625rem,
-	active-border-offset-bottom-mobile: -0.5625rem,
+	active-border-offset-bottom: -0.4375rem,
+	active-border-offset-bottom-mobile: -0.4375rem,
 	border-bottom-width: 0.0625rem,
 );
 


### PR DESCRIPTION
This PR adds new value for border overlapping:

![NavBorder](https://user-images.githubusercontent.com/7963804/87768031-d1ef1400-c81b-11ea-958f-ecf8ba4ff677.gif)

To test it, you need to go to:

1º - Open `Global menu`
2º - Navigate to `Sync Connector Admin`
3º - Navegatee between `Settings` and `Sites`
4º - Check blue line is always over and not overlapping bottom border

