### PR TITLE
LPS-117363 - Add new two spacers to custom properties

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_variables.scss
@@ -12,6 +12,8 @@ $spacers-cp: map-deep-merge(
 		6: var(--spacer-6),
 		7: var(--spacer-7),
 		8: var(--spacer-8),
+		9: var(--spacer-9),
+		10: var(--spacer-10),
 	),
 	$spacers-cp
 );


### PR DESCRIPTION
This PR adds new two spacers:

It is related to:
https://github.com/liferay/clay/issues/3521

***and It cannot be merged until this first PR in Clay be ready in portal (next version).***

---

To test it:
Use any spacer class: for example: `mt-10` or `p-10` and check the class make its changes