### PR TITLE
LPS-113302 Apply classic ckeditor in Message Boards, part 2/2

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorBBCodeEditor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorBBCodeEditor.java
@@ -46,7 +46,7 @@ public class CKEditorBBCodeEditor implements Editor, EditorRenderer {
 
 	@Override
 	public String getJspPath() {
-		return "/ckeditor.jsp";
+		return "/ckeditor_classic.jsp";
 	}
 
 	@Override
@@ -56,7 +56,7 @@ public class CKEditorBBCodeEditor implements Editor, EditorRenderer {
 
 	@Override
 	public String getResourcesJspPath() {
-		return "/resources.jsp";
+		return null;
 	}
 
 	@Override

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -32,7 +32,6 @@ const getToolbarSet = (toolbarSet) => {
 
 const ClassicEditor = ({
 	contents = '',
-	cssClass,
 	editorConfig,
 	initialToolbarSet,
 	name,
@@ -100,15 +99,13 @@ const ClassicEditor = ({
 	useEventListener('resize', onResize, true, window);
 
 	return (
-		<div className={cssClass} id={`${name}Container`}>
+		<div id={`${name}Container`}>
 			<label className="control-label" htmlFor={name}>
 				{title}
 			</label>
 			<Editor
 				className="lfr-editable"
 				config={getConfig()}
-				data={contents}
-				key={toolbarSet}
 				onBeforeLoad={(CKEDITOR) => {
 					CKEDITOR.disableAutoInline = true;
 					CKEDITOR.dtd.$removeEmpty.i = 0;
@@ -116,6 +113,10 @@ const ClassicEditor = ({
 
 					CKEDITOR.on('instanceCreated', ({editor}) => {
 						editor.name = name;
+
+						editor.on('instanceReady', () => {
+							editor.setData(contents);
+						});
 					});
 				}}
 				onChange={onChangeCallback}
@@ -127,7 +128,6 @@ const ClassicEditor = ({
 
 ClassicEditor.propTypes = {
 	contents: PropTypes.string,
-	cssClass: PropTypes.string,
 	editorConfig: PropTypes.object,
 	initialToolbarSet: PropTypes.string,
 	name: PropTypes.string,

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
@@ -99,14 +99,6 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 					return response.text();
 				})
 				.then(function (response) {
-					var editorName =
-						'<portlet:namespace />replyMessageBody' + messageId;
-
-					if (window[editorName]) {
-						window[editorName].dispose();
-						Liferay.destroyComponent(editorName);
-					}
-
 					addQuickReplyContainer.innerHTML = response;
 
 					domAll.globalEval.runScriptsInElement(addQuickReplyContainer);
@@ -121,6 +113,9 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 					if (parentMessageIdInput) {
 						parentMessageIdInput.value = messageId;
 					}
+
+					var editorName =
+						'<portlet:namespace />replyMessageBody' + messageId;
 
 					Liferay.componentReady(editorName).then(function (editor) {
 						editor.focus();
@@ -147,12 +142,6 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 
 		if (addQuickReplyContainer) {
 			addQuickReplyContainer.classList.add('hide');
-		}
-
-		var editorName = '<portlet:namespace />replyMessageBody' + messageId;
-
-		if (window[editorName]) {
-			window[editorName].dispose();
 		}
 
 		Liferay.Util.toggleDisabled(


### PR DESCRIPTION
@jbalsas @wincent @carloslancha 

In this PR, we are updating bbcode editor in message boards, fixing a regression bug and cleaning up the `ClassicEditor` a bit.

To test:

1. Site Administatration > Content & Data > Message Boards > options on top right > Configuration
1. Set format to BBCode
1. Place the Message Boards App on a page
1. New Thread > Make a sample post. Add some sample formatting, like bolding. Publish.
1. Edit post.
1. Cancel.
1. Reply.
1. Cancel reply.
1. Reply.
1. Post reply.

Notes:
1. We are not building a new editor for bbcode encoding. Instead, we are using `ckeditor_classic`, just with different CKEditor configuration. This is not a scary change, since the only use of bbcode encoding is in message boards. There is a mention in `mentions-web`, but no `<liferay-editor:editor>`, so not sure if or how it applies.
1. Instead of setting editor content with `data` prop, we are setting data on `instanceReady`. This way plugins are applied before setting data, including encoding plugin `bbcode`. Without this change, editor shows bbcode source code when it should show executed HTML. Alternative would be to reformat data before passing it editor, like we are doing on [view message page](https://github.com/liferay/liferay-portal/blob/74e300f3f9a09543a8c6521c1c9e05d7e9a2d8e0/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp#L403), but in my opinion it's better to use editor's own API. We end up using it anyways, for example on switching to Source and back.
1. I removed `cssClass` prop as we are not using it. There is the `cssClasses` attribute [floating around backend configuration](https://github.com/liferay/liferay-portal/blob/74e300f3f9a09543a8c6521c1c9e05d7e9a2d8e0/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorClassicConfigContributor.java#L69), but it is added to editor config object.
1. I removed the `key` prop, as far as I can tell it is unnecessary.
1. The regression bug is on opening a reply post and canceling it. It happens because we didn't migrate `window[editorName].dispose` to `ClassicEditor`. This is the only use of `dispose`. Instead of migrating it now, in this PR I opted to remove the usage. Now, when we hide the reply post, editor is just hidden with it. Replying again re-initializes editor with no problem.

---

In the legacy editor, as well as partially migrated to the new component, there is this rather ugly pattern of defining utility methods in the `window[editorName]`. The mentioned `dispose` is one example, but `getHTML` is used a lot more:
```js
useEffect(() => {
	window[name] = {
		getHTML,
		getText() {
			return contents;
		},
	};
}, [contents, getHTML, name]);
```
To replace it, we could make a new utility, something like `Liferay.CKEditor.getData(name)`, that would serve the same purpose. The content of the utility would be basically
```js
data = editor.getData();

if (CKEDITOR.env.gecko && CKEDITOR.tools.trim(data) === '<br />') {
    return '';
}

return data;
```
What do you think?