### PR TITLE
LPS-107476 Adds a missing `selectedLanguageId` on input_localized AUI component

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -106,7 +106,9 @@ AUI.add(
 
 						var itemsError = instance.get(STR_ITEMS_ERROR);
 
-						var itemIndex = instance.get('defaultLanguageId');
+						var itemIndex =
+							instance.get('selectedLanguageId') ||
+							instance.get('defaultLanguageId');
 
 						if (itemsError.length) {
 							itemIndex = itemsError[0];
@@ -114,6 +116,10 @@ AUI.add(
 
 						return instance.get(STR_ITEMS).indexOf(itemIndex);
 					},
+				},
+
+				selectedLanguageId: {
+					validator: Lang.isString,
 				},
 
 				translatedLanguages: {
@@ -472,7 +478,9 @@ AUI.add(
 					var items = instance.get(STR_ITEMS);
 					var selected = instance.get(STR_SELECTED);
 
-					return items[selected];
+					return (
+						items[selected] || instance.get('selectedLanguageId')
+					);
 				},
 
 				getValue(languageId) {

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -303,6 +303,7 @@
 					lazy: <%= !type.equals("editor") %>,
 					name: '<%= HtmlUtil.escapeJS(name) %>',
 					namespace: '<%= namespace %>',
+					selectedLanguageId: '<%= selectedLanguageId %>',
 					toggleSelection: false,
 					translatedLanguages: '<%= StringUtil.merge(languageIds) %>'
 				}


### PR DESCRIPTION
### Test Case:

1. Create a basic web content for the default language (say, en_US) with title "bwcenglish".
2. Edit the web content and click on the upper-most flag icon to select another language, for example, Spanish (es_ES).
3. Change the title to "bwcspanish".
4. Save as Draft.
5. Click on the same flag icon and try to change back to the default language.

✅  Expected: The language can be changed.
❌  Observed: The language remains as Spanish.

Taking as a basis Pavel's comment on https://issues.liferay.com/browse/LPS-107476?focusedCommentId=2153486&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2153486, I added the selectedLanguageId and updated the behaviour on AUI component when it decides which languageId will be settled by default.

You may ask about the differences between `selectedLanguageId` and `defaultLanguageId`:
The difference between those tags is because `defaultLanguageId` is defined by the system and `selectedLanguageId` can be dynamic depending on the context.