### PR TITLE
LPS-117503 Fixes invalid date error

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -190,7 +190,7 @@ const DatePicker = ({
 					}
 
 					if (moment(value).isValid()) {
-						onChange(moment(value).format(dateMask));
+						onChange(moment(value).format(dateMask.toUpperCase()));
 					}
 				}}
 				ref={inputRef}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
@@ -163,4 +163,35 @@ describe('DatePicker', () => {
 
 		expect(handleFieldEdited).toHaveBeenCalled();
 	});
+
+	it('call the onChange callback with a valid date', async () => {
+		const onChange = jest.fn();
+
+		const {container, getAllByDisplayValue, getByLabelText} = render(
+			<DatePickerWithProvider
+				{...defaultDatePickerConfig}
+				onChange={onChange}
+			/>
+		);
+
+		userEvent.click(
+			container.querySelector('.date-picker-dropdown-toggle')
+		);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		userEvent.click(getByLabelText('Select current date'));
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		const date = moment().format('MM/DD/YYYY');
+
+		await wait(() => expect(getAllByDisplayValue(date)).toBeTruthy());
+
+		expect(onChange).toHaveBeenCalledWith({}, date);
+	});
 });


### PR DESCRIPTION
Just a small fix that was breaking the Forms DatePicker with "Invalid Date" still uses `moment` in some parts maybe it is an improvement to change it later, I didn’t change it because I may lose some case that date-fns doesn’t cover or the behavior is different compared to the moment in the date checks and does not make this ticket too big.