### PR TITLE
LPS-116194 Add style-editor frontend-token-definition

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
@@ -1,0 +1,680 @@
+{
+	"frontendTokenCategories": [
+		{
+			"label": "Color System",
+			"name": "colorSystem",
+			"tokenSets": [
+				{
+					"frontendTokens": [
+						{
+							"editorType": "ColorPicker",
+							"label": "white",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "white"
+								}
+							],
+							"name": "whiteColor",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "gray-100",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "gray-100"
+								}
+							],
+							"name": "gray100Color",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "gray-200",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "gray-200"
+								}
+							],
+							"name": "gray200Color",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "gray-300",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "gray-300"
+								}
+							],
+							"name": "gray300Color",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "gray-400",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "gray-400"
+								}
+							],
+							"name": "gray400Color",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "gray-500",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "gray-500"
+								}
+							],
+							"name": "gray500Color",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "gray-600",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "gray-600"
+								}
+							],
+							"name": "gray600Color",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "gray-700",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "gray-700"
+								}
+							],
+							"name": "gray700Color",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "gray-800",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "gray-800"
+								}
+							],
+							"name": "gray800Color",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "gray-900",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "gray-900"
+								}
+							],
+							"name": "gray900Color",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "black",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "black"
+								}
+							],
+							"name": "blackColor",
+							"type": "String"
+						}
+					],
+					"label": "Grays",
+					"name": "grays"
+				},
+				{
+					"frontendTokens": [
+						{
+							"editorType": "ColorPicker",
+							"label": "primary",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "primary"
+								}
+							],
+							"name": "primaryColor",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "secondary",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "secondary"
+								}
+							],
+							"name": "secondaryColor",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "success",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "success"
+								}
+							],
+							"name": "successColor",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "info",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "info"
+								}
+							],
+							"name": "infoColor",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "warning",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "warning"
+								}
+							],
+							"name": "warningColor",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "danger",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "danger"
+								}
+							],
+							"name": "dangerColor",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "dark",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "dark"
+								}
+							],
+							"name": "darkColor",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "light",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "light"
+								}
+							],
+							"name": "lightColor",
+							"type": "String"
+						}
+					],
+					"label": "Theme Colors",
+					"name": "themeColors"
+				}
+			]
+		},
+		{
+			"label": "Spacing",
+			"name": "spacing",
+			"tokenSets": [
+				{
+					"frontendTokens": [
+						{
+							"label": "spacer",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "spacer"
+								}
+							],
+							"name": "spacer",
+							"type": "Number"
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Global",
+			"name": "global",
+			"tokenSets": [
+				{
+					"frontendTokens": [
+						{
+							"editorType": "ColorPicker",
+							"label": "body-bg",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "body-bg"
+								}
+							],
+							"name": "bodyBgColor",
+							"type": "String"
+						},
+						{
+							"editorType": "ColorPicker",
+							"label": "body-color",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "body-color"
+								}
+							],
+							"name": "bodyColor",
+							"type": "String"
+						}
+					],
+					"label": "Body",
+					"name": "body"
+				},
+				{
+					"frontendTokens": [
+						{
+							"label": "border-radius",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "border-radius"
+								}
+							],
+							"name": "borderRadius",
+							"type": "Number"
+						},
+						{
+							"label": "border-radius-sm",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "border-radius-sm"
+								}
+							],
+							"name": "borderRadiusSm",
+							"type": "Number"
+						},
+						{
+							"label": "border-radius-lg",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "border-radius-lg"
+								}
+							],
+							"name": "borderRadiusLg",
+							"type": "Number"
+						},
+						{
+							"label": "border-radius-circle",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "border-radius-circle"
+								}
+							],
+							"name": "borderRadiusCircle",
+							"type": "Number"
+						},
+						{
+							"label": "rounded-pill",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "rounded-pill"
+								}
+							],
+							"name": "roundedPill",
+							"type": "Number"
+						}
+					],
+					"label": "Borders",
+					"name": "borders"
+				},
+				{
+					"frontendTokens": [
+						{
+							"label": "box-shadow",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "box-shadow"
+								}
+							],
+							"name": "boxShadow",
+							"type": "String"
+						},
+						{
+							"label": "box-shadow-sm",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "box-shadow-sm"
+								}
+							],
+							"name": "boxShadowSm",
+							"type": "String"
+						},
+						{
+							"label": "box-shadow-lg",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "box-shadow-lg"
+								}
+							],
+							"name": "boxShadowLg",
+							"type": "String"
+						}
+					],
+					"label": "Box Shadows",
+					"name": "boxShadows"
+				}
+			]
+		},
+		{
+			"label": "Layout",
+			"name": "layout",
+			"tokenSets": [
+				{
+					"frontendTokens": [
+						{
+							"label": "container-max",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "container-max"
+								}
+							],
+							"name": "containerMax",
+							"type": "Number"
+						}
+					],
+					"label": "Grid Containers",
+					"name": "gridContainers"
+				}
+			]
+		},
+		{
+			"label": "Typography",
+			"name": "typography",
+			"tokenSets": [
+				{
+					"frontendTokens": [
+						{
+							"label": "font-family-sans-serif",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-family-sans-serif"
+								}
+							],
+							"name": "fontFamilySansSerif",
+							"type": "String"
+						},
+						{
+							"label": "font-family-monospace",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-family-monospace"
+								}
+							],
+							"name": "fontFamilyMonospace",
+							"type": "String"
+						},
+						{
+							"label": "font-family-base",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-family-base"
+								}
+							],
+							"name": "fontFamilyBase",
+							"type": "String"
+						}
+					],
+					"label": "Font Family",
+					"name": "fontFamily"
+				},
+				{
+					"frontendTokens": [
+						{
+							"label": "font-size-sm",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-size-sm"
+								}
+							],
+							"name": "fontSizeSm",
+							"type": "Number"
+						},
+						{
+							"label": "font-size-base",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-size-base"
+								}
+							],
+							"name": "fontSizeBase",
+							"type": "Number"
+						},
+						{
+							"label": "font-size-lg",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-size-lg"
+								}
+							],
+							"name": "fontSizeLg",
+							"type": "Number"
+						},
+						{
+							"label": "font-size-sm",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-size-sm"
+								}
+							],
+							"name": "fontSizeSm",
+							"type": "Number"
+						},
+						{
+							"label": "font-size-base",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-size-base"
+								}
+							],
+							"name": "fontSizeBase",
+							"type": "Number"
+						},
+						{
+							"label": "font-size-lg",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-size-lg"
+								}
+							],
+							"name": "fontSizeLg",
+							"type": "Number"
+						}
+					],
+					"label": "Font Size",
+					"name": "fontSize"
+				},
+				{
+					"frontendTokens": [
+						{
+							"label": "font-weight-lighter",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-weight-lighter"
+								}
+							],
+							"name": "fontWeightLighter",
+							"type": "String"
+						},
+						{
+							"label": "font-weight-light",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-weight-light"
+								}
+							],
+							"name": "fontWeightLight",
+							"type": "String"
+						},
+						{
+							"label": "font-weight-normal",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-weight-normal"
+								}
+							],
+							"name": "fontWeightNormal",
+							"type": "String"
+						},
+						{
+							"label": "font-weight-bold",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-weight-bold"
+								}
+							],
+							"name": "fontWeightBold",
+							"type": "String"
+						},
+						{
+							"label": "font-weight-bolder",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "font-weight-bolder"
+								}
+							],
+							"name": "fontWeightBolder",
+							"type": "String"
+						}
+					],
+					"label": "Font Weight",
+					"name": "fontWeight"
+				},
+				{
+					"frontendTokens": [
+						{
+							"label": "h1-font-size",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "h1-font-size"
+								}
+							],
+							"name": "h1FontSize",
+							"type": "Number"
+						},
+						{
+							"label": "h2-font-size",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "h2-font-size"
+								}
+							],
+							"name": "h2FontSize",
+							"type": "Number"
+						},
+						{
+							"label": "h3-font-size",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "h3-font-size"
+								}
+							],
+							"name": "h3FontSize",
+							"type": "Number"
+						},
+						{
+							"label": "h4-font-size",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "h4-font-size"
+								}
+							],
+							"name": "h4FontSize",
+							"type": "Number"
+						},
+						{
+							"label": "h5-font-size",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "h5-font-size"
+								}
+							],
+							"name": "h5FontSize",
+							"type": "Number"
+						},
+						{
+							"label": "h6-font-size",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "h6-font-size"
+								}
+							],
+							"name": "h6FontSize",
+							"type": "Number"
+						}
+					],
+					"label": "Headings",
+					"name": "headings"
+				}
+			]
+		}
+	]
+}

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
@@ -7,6 +7,7 @@
 				{
 					"frontendTokens": [
 						{
+							"defaultValue": "#FFF",
 							"editorType": "ColorPicker",
 							"label": "white",
 							"mappings": [
@@ -19,6 +20,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#f7f8f9",
 							"editorType": "ColorPicker",
 							"label": "gray-100",
 							"mappings": [
@@ -31,6 +33,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#f1f2f5",
 							"editorType": "ColorPicker",
 							"label": "gray-200",
 							"mappings": [
@@ -43,6 +46,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#e7e7ed",
 							"editorType": "ColorPicker",
 							"label": "gray-300",
 							"mappings": [
@@ -55,6 +59,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#cdced9",
 							"editorType": "ColorPicker",
 							"label": "gray-400",
 							"mappings": [
@@ -67,6 +72,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#a7a9bc",
 							"editorType": "ColorPicker",
 							"label": "gray-500",
 							"mappings": [
@@ -79,6 +85,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#6b6c7e",
 							"editorType": "ColorPicker",
 							"label": "gray-600",
 							"mappings": [
@@ -91,6 +98,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#495057",
 							"editorType": "ColorPicker",
 							"label": "gray-700",
 							"mappings": [
@@ -103,6 +111,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#393a4a",
 							"editorType": "ColorPicker",
 							"label": "gray-800",
 							"mappings": [
@@ -115,6 +124,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#272833",
 							"editorType": "ColorPicker",
 							"label": "gray-900",
 							"mappings": [
@@ -127,6 +137,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#000",
 							"editorType": "ColorPicker",
 							"label": "black",
 							"mappings": [
@@ -145,6 +156,7 @@
 				{
 					"frontendTokens": [
 						{
+							"defaultValue": "#0b5fff",
 							"editorType": "ColorPicker",
 							"label": "primary",
 							"mappings": [
@@ -157,6 +169,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#6b6c7e",
 							"editorType": "ColorPicker",
 							"label": "secondary",
 							"mappings": [
@@ -169,6 +182,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#287d3c",
 							"editorType": "ColorPicker",
 							"label": "success",
 							"mappings": [
@@ -181,6 +195,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#2e5aac",
 							"editorType": "ColorPicker",
 							"label": "info",
 							"mappings": [
@@ -193,6 +208,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#b95000",
 							"editorType": "ColorPicker",
 							"label": "warning",
 							"mappings": [
@@ -205,6 +221,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#da1414",
 							"editorType": "ColorPicker",
 							"label": "danger",
 							"mappings": [
@@ -217,6 +234,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#272833",
 							"editorType": "ColorPicker",
 							"label": "dark",
 							"mappings": [
@@ -229,6 +247,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#f1f2f5",
 							"editorType": "ColorPicker",
 							"label": "light",
 							"mappings": [
@@ -253,6 +272,7 @@
 				{
 					"frontendTokens": [
 						{
+							"defaultValue": "1rem",
 							"label": "spacer",
 							"mappings": [
 								{
@@ -274,6 +294,7 @@
 				{
 					"frontendTokens": [
 						{
+							"defaultValue": "#f1f2f5",
 							"editorType": "ColorPicker",
 							"label": "body-bg",
 							"mappings": [
@@ -286,6 +307,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#272833",
 							"editorType": "ColorPicker",
 							"label": "body-color",
 							"mappings": [
@@ -304,6 +326,7 @@
 				{
 					"frontendTokens": [
 						{
+							"defaultValue": "0.25rem",
 							"label": "border-radius",
 							"mappings": [
 								{
@@ -315,6 +338,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "0.1875rem",
 							"label": "border-radius-sm",
 							"mappings": [
 								{
@@ -326,6 +350,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "0.375rem",
 							"label": "border-radius-lg",
 							"mappings": [
 								{
@@ -337,6 +362,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "50%",
 							"label": "border-radius-circle",
 							"mappings": [
 								{
@@ -348,6 +374,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "50rem",
 							"label": "rounded-pill",
 							"mappings": [
 								{
@@ -365,6 +392,7 @@
 				{
 					"frontendTokens": [
 						{
+							"defaultValue": "0 .5rem 1rem rgba(#000, .15)",
 							"label": "box-shadow",
 							"mappings": [
 								{
@@ -376,6 +404,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "0 .125rem .25rem rgba(#000, .075)",
 							"label": "box-shadow-sm",
 							"mappings": [
 								{
@@ -387,6 +416,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "0 1rem 3rem rgba(#000, .175)",
 							"label": "box-shadow-lg",
 							"mappings": [
 								{
@@ -410,6 +440,7 @@
 				{
 					"frontendTokens": [
 						{
+							"defaultValue": "576px",
 							"label": "container-max-sm",
 							"mappings": [
 								{
@@ -421,6 +452,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "768px",
 							"label": "container-max-md",
 							"mappings": [
 								{
@@ -432,6 +464,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "992px",
 							"label": "container-max-lg",
 							"mappings": [
 								{
@@ -443,6 +476,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "1280px",
 							"label": "container-max-xl",
 							"mappings": [
 								{
@@ -466,6 +500,7 @@
 				{
 					"frontendTokens": [
 						{
+							"defaultValue": "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
 							"label": "font-family-sans-serif",
 							"mappings": [
 								{
@@ -477,6 +512,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
 							"label": "font-family-monospace",
 							"mappings": [
 								{
@@ -488,6 +524,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
 							"label": "font-family-base",
 							"mappings": [
 								{
@@ -505,6 +542,7 @@
 				{
 					"frontendTokens": [
 						{
+							"defaultValue": "0.875rem",
 							"label": "font-size-sm",
 							"mappings": [
 								{
@@ -516,6 +554,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "0.875rem",
 							"label": "font-size-base",
 							"mappings": [
 								{
@@ -527,7 +566,7 @@
 							"type": "Number"
 						},
 						{
-						{
+							"defaultValue": "1.125rem",
 							"label": "font-size-lg",
 							"mappings": [
 								{
@@ -545,6 +584,7 @@
 				{
 					"frontendTokens": [
 						{
+							"defaultValue": "lighter",
 							"label": "font-weight-lighter",
 							"mappings": [
 								{
@@ -556,6 +596,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "300",
 							"label": "font-weight-light",
 							"mappings": [
 								{
@@ -567,6 +608,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "400",
 							"label": "font-weight-normal",
 							"mappings": [
 								{
@@ -578,6 +620,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "700",
 							"label": "font-weight-bold",
 							"mappings": [
 								{
@@ -589,6 +632,7 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "900",
 							"label": "font-weight-bolder",
 							"mappings": [
 								{
@@ -606,6 +650,7 @@
 				{
 					"frontendTokens": [
 						{
+							"defaultValue": "1.625rem",
 							"label": "h1-font-size",
 							"mappings": [
 								{
@@ -617,6 +662,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "1.375rem",
 							"label": "h2-font-size",
 							"mappings": [
 								{
@@ -628,6 +674,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "1.1875rem",
 							"label": "h3-font-size",
 							"mappings": [
 								{
@@ -639,6 +686,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "1rem",
 							"label": "h4-font-size",
 							"mappings": [
 								{
@@ -650,6 +698,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "0.875rem",
 							"label": "h5-font-size",
 							"mappings": [
 								{
@@ -661,6 +710,7 @@
 							"type": "Number"
 						},
 						{
+							"defaultValue": "0.8125rem",
 							"label": "h6-font-size",
 							"mappings": [
 								{

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
@@ -410,14 +410,47 @@
 				{
 					"frontendTokens": [
 						{
-							"label": "container-max",
+							"label": "container-max-sm",
 							"mappings": [
 								{
 									"type": "cssVariable",
-									"value": "container-max"
+									"value": "container-max-sm"
 								}
 							],
-							"name": "containerMax",
+							"name": "containerMaxSm",
+							"type": "Number"
+						},
+						{
+							"label": "container-max-md",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "container-max-md"
+								}
+							],
+							"name": "containerMaxMd",
+							"type": "Number"
+						},
+						{
+							"label": "container-max-lg",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "container-max-lg"
+								}
+							],
+							"name": "containerMaxLg",
+							"type": "Number"
+						},
+						{
+							"label": "container-max-xl",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "container-max-xl"
+								}
+							],
+							"name": "containerMaxXl",
 							"type": "Number"
 						}
 					],
@@ -494,38 +527,6 @@
 							"type": "Number"
 						},
 						{
-							"label": "font-size-lg",
-							"mappings": [
-								{
-									"type": "cssVariable",
-									"value": "font-size-lg"
-								}
-							],
-							"name": "fontSizeLg",
-							"type": "Number"
-						},
-						{
-							"label": "font-size-sm",
-							"mappings": [
-								{
-									"type": "cssVariable",
-									"value": "font-size-sm"
-								}
-							],
-							"name": "fontSizeSm",
-							"type": "Number"
-						},
-						{
-							"label": "font-size-base",
-							"mappings": [
-								{
-									"type": "cssVariable",
-									"value": "font-size-base"
-								}
-							],
-							"name": "fontSizeBase",
-							"type": "Number"
-						},
 						{
 							"label": "font-size-lg",
 							"mappings": [


### PR DESCRIPTION
New version of the frontend-token-definition

from https://github.com/liferay-frontend/liferay-portal/pull/135
with changes from https://github.com/brianchandotcom/liferay-portal/pull/91544#issuecomment-661223466

---

We noticed that the `tokenSets` have preserved its name in the [schema](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-token/frontend-token-definition-api/src/main/resources/com/liferay/frontend/token/definition/frontend-token-definition.schema.json#L107). Eventually we'd like to change it to `frontendTokenSets` to keep the consistency of the names