### PR TITLE
LPS-117288 If I have more than one HTML field on a web content I'm not able to edit on click

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
@@ -44,6 +44,10 @@
 			}
 		}
 
+		&.cke_editable:after {
+			display: none;
+		}
+
 		a {
 			cursor: auto;
 		}

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_editor_html.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_editor_html.scss
@@ -1,36 +1,42 @@
-.html-editor.portlet-message-boards {
-	@include hyphens();
-
-	word-wrap: break-word;
-
-	blockquote {
-		background: #eef0f2 url(../images/message_boards/quoteleft.png)
-			no-repeat 5px 5px;
-		border: 1px solid #777;
-		padding: 5px 45px;
-
-		&:after {
-			background: url(../images/message_boards/quoteright.png) no-repeat
-				50%;
-			content: '';
-			display: block;
-			float: right;
-			height: 24px;
-			margin-right: -35px;
-			margin-top: -25px;
-			width: 31px;
-			z-index: 999;
-		}
-
-		cite {
-			display: block;
-			font-weight: bold;
-		}
+.html-editor {
+	&.cke_editable:after {
+		display: none;
 	}
 
-	pre {
-		background: #f9f9f9;
-		border: 1px solid #777;
-		padding: 0.5em;
+	&.portlet-message-boards {
+		@include hyphens();
+
+		word-wrap: break-word;
+
+		blockquote {
+			background: #eef0f2 url(../images/message_boards/quoteleft.png)
+				no-repeat 5px 5px;
+			border: 1px solid #777;
+			padding: 5px 45px;
+
+			&:after {
+				background: url(../images/message_boards/quoteright.png)
+					no-repeat 50%;
+				content: '';
+				display: block;
+				float: right;
+				height: 24px;
+				margin-right: -35px;
+				margin-top: -25px;
+				width: 31px;
+				z-index: 999;
+			}
+
+			cite {
+				display: block;
+				font-weight: bold;
+			}
+		}
+
+		pre {
+			background: #f9f9f9;
+			border: 1px solid #777;
+			padding: 0.5em;
+		}
 	}
 }


### PR DESCRIPTION
This is a bugfix, see details and how to reproduce in https://issues.liferay.com/browse/LPS-117288

The root cause are these styles from base CKEditor:
```css
.cke_editable:after {
    border: 1px solid #e7e7ed;
    bottom: 0;
    content: '';
    left: 0;
    position: fixed;
    right: 0;
    top: 0
}
``` 
I could not find these in CKEditor repo, I found them in runtime in a generated merged CSS file. Recently we updated base CKEditor, I'm guessing these were added or changed then.

The styles are defining a full page overlay in `:after`. In this PR, we are overriding styles to hide the overlay. I don't know what problem the overlay is solving, but in our context it seems to be a needless appendage.

This PR also fixes the issue of not being able to mouse-drag select parts of text, that I mentioned in https://github.com/liferay-frontend/liferay-portal/pull/107#issue-448333193

I am not completely sure I added these styles in the right places:
- I added `ckeditor` styles in the theme. This is because `ckeditor` is rendered in an `iframe`
- I added `alloyeditor` styles in `frontend-css-web`, which I hope is a preferred place of adding styles.