### PR TITLE
LPS-117468 Fix unexpected background and border in Page Editor editables

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/FragmentContent.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/FragmentContent.scss
@@ -15,6 +15,19 @@
 		display: none;
 	}
 
+	.cke_editable {
+		background-color: unset;
+		padding: 0;
+	}
+
+	.cke_editable:after {
+		border: none;
+	}
+
+	.cke_editable:focus {
+		background-color: unset;
+	}
+
 	.portlet {
 		> .portlet-topper {
 			background-color: rgba(255, 255, 255, 0.95);


### PR DESCRIPTION
This is a bug fix for https://issues.liferay.com/browse/LPS-117468
Reseting border and background styles for `cke_editable` css class in page editor.

Steps to reproduce
1. Edit Hello World page (or create a content page with a heading fragment)
2. Double click on a text editable to start editing.