### PR TITLE
LPS-115577 Add a new method to obtain localized JSON for token definitions

### DIFF
--- a/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinition.java
+++ b/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinition.java
@@ -14,11 +14,13 @@
 
 package com.liferay.frontend.token.definition;
 
+import java.util.Locale;
+
 /**
  * @author Iván Zaera
  */
 public interface FrontendTokenDefinition {
 
-	public String getJSON();
+	public String getJSON(Locale locale);
 
 }

--- a/modules/apps/frontend-token/frontend-token-definition-impl/build.gradle
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:frontend-token:frontend-token-definition-api")
+	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-string")
 
 	testCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/frontend-token/frontend-token-definition-impl/source-formatter-suppressions.xml
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/source-formatter-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<source-check>
+		<suppress checks="ResourceBundleCheck" files="src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImplTest\.java" />
+	</source-check>
+</suppressions>

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Arrays;
@@ -91,17 +92,22 @@ public class FrontendTokenDefinitionImpl implements FrontendTokenDefinition {
 		JSONObject jsonObject, ResourceBundle resourceBundle) {
 
 		for (String key : jsonObject.keySet()) {
-			if (_LOCALIZABLE_KEYS.contains(key)) {
+			if (_localizableKeys.contains(key)) {
 				String value = jsonObject.getString(key);
 
 				if (Validator.isNotNull(value)) {
 					try {
-						jsonObject.put(key, resourceBundle.getString(value));
+						jsonObject.put(
+							key,
+							ResourceBundleUtil.getString(
+								resourceBundle, value));
 					}
 					catch (MissingResourceException missingResourceException) {
-						_log.warn(
-							"Unable to find key " + key,
-							missingResourceException);
+						if (_log.isWarnEnabled()) {
+							_log.warn(
+								"Unable to find key " + key,
+								missingResourceException);
+						}
 					}
 				}
 			}
@@ -127,11 +133,11 @@ public class FrontendTokenDefinitionImpl implements FrontendTokenDefinition {
 		}
 	}
 
-	private static final Set<String> _LOCALIZABLE_KEYS = new HashSet<>(
-		Arrays.asList("label"));
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		FrontendTokenDefinitionImpl.class);
+
+	private static final Set<String> _localizableKeys = new HashSet<>(
+		Arrays.asList("label"));
 
 	private final String _json;
 	private final JSONFactory _jsonFactory;

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImpl.java
@@ -15,27 +15,128 @@
 package com.liferay.frontend.token.definition.internal;
 
 import com.liferay.frontend.token.definition.FrontendTokenDefinition;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Iván Zaera
  */
 public class FrontendTokenDefinitionImpl implements FrontendTokenDefinition {
 
-	public FrontendTokenDefinitionImpl(String json, String themeId) {
+	public FrontendTokenDefinitionImpl(
+		String json, JSONFactory jsonFactory,
+		ResourceBundleLoader resourceBundleLoader, String themeId) {
+
 		_json = json;
+		_jsonFactory = jsonFactory;
+		_resourceBundleLoader = resourceBundleLoader;
 		_themeId = themeId;
 	}
 
 	@Override
-	public String getJSON() {
-		return _json;
+	public String getJSON(Locale locale) {
+		String json = _jsons.get(locale);
+
+		if (json == null) {
+			json = translateJSON(locale);
+
+			_jsons.put(locale, json);
+		}
+
+		return json;
 	}
 
 	public String getThemeId() {
 		return _themeId;
 	}
 
+	protected String translateJSON(Locale locale) {
+		if (_resourceBundleLoader == null) {
+			return _json;
+		}
+
+		try {
+			JSONObject jsonObject = _jsonFactory.createJSONObject(_json);
+
+			translateJSONObject(
+				jsonObject, _resourceBundleLoader.loadResourceBundle(locale));
+
+			return _jsonFactory.looseSerializeDeep(jsonObject);
+		}
+		catch (JSONException jsonException) {
+			_log.error(
+				"Unable to parse token-definitions.json of theme " + _themeId,
+				jsonException);
+		}
+
+		return _json;
+	}
+
+	protected void translateJSONObject(
+		JSONObject jsonObject, ResourceBundle resourceBundle) {
+
+		for (String key : jsonObject.keySet()) {
+			if (_LOCALIZABLE_KEYS.contains(key)) {
+				String value = jsonObject.getString(key);
+
+				if (Validator.isNotNull(value)) {
+					try {
+						jsonObject.put(key, resourceBundle.getString(value));
+					}
+					catch (MissingResourceException missingResourceException) {
+						_log.warn(
+							"Unable to find key " + key,
+							missingResourceException);
+					}
+				}
+			}
+			else {
+				Object object = jsonObject.get(key);
+
+				if (object instanceof JSONObject) {
+					translateJSONObject((JSONObject)object, resourceBundle);
+				}
+				else if (object instanceof JSONArray) {
+					JSONArray jsonArray = (JSONArray)object;
+
+					for (int i = 0; i < jsonArray.length(); i++) {
+						Object childObject = jsonArray.get(i);
+
+						if (childObject instanceof JSONObject) {
+							translateJSONObject(
+								(JSONObject)childObject, resourceBundle);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static final Set<String> _LOCALIZABLE_KEYS = new HashSet<>(
+		Arrays.asList("label"));
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FrontendTokenDefinitionImpl.class);
+
 	private final String _json;
+	private final JSONFactory _jsonFactory;
+	private final Map<Locale, String> _jsons = new ConcurrentHashMap<>();
+	private final ResourceBundleLoader _resourceBundleLoader;
 	private final String _themeId;
 
 }

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
@@ -68,7 +68,7 @@ public class FrontendTokenDefinitionRegistryImpl
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		resourceBundleLoaders = ServiceTrackerMapFactory.openSingleValueMap(
-				bundleContext, ResourceBundleLoader.class, "bundle.symbolic.name");
+			bundleContext, ResourceBundleLoader.class, "bundle.symbolic.name");
 
 		bundleTracker = new BundleTracker<>(
 			bundleContext, Bundle.ACTIVE, _bundleTrackerCustomizer);
@@ -192,7 +192,7 @@ public class FrontendTokenDefinitionRegistryImpl
 	private static final Pattern _themeIdPattern = Pattern.compile(
 		".*<theme id=\"([^\"]*)\"[^>]*>.*");
 
-	private BundleTrackerCustomizer _bundleTrackerCustomizer =
+	private BundleTrackerCustomizer<Bundle> _bundleTrackerCustomizer =
 		new BundleTrackerCustomizer<Bundle>() {
 
 			@Override

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImplTest.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImplTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.token.definition.internal;
+
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.net.URL;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Iván Zaera
+ */
+public class FrontendTokenDefinitionImplTest {
+
+	@Test
+	public void testTranslateJSON() {
+		ResourceBundleLoader resourceBundleLoader = Mockito.mock(
+			ResourceBundleLoader.class);
+
+		Package aPackage = FrontendTokenDefinitionImplTest.class.getPackage();
+
+		Mockito.when(
+			resourceBundleLoader.loadResourceBundle(Locale.ENGLISH)
+		).thenReturn(
+			ResourceBundle.getBundle(
+				aPackage.getName() + ".dependencies.Language", Locale.ENGLISH)
+		);
+
+		FrontendTokenDefinitionImpl frontendTokenDefinitionImpl =
+			new FrontendTokenDefinitionImpl(
+				_frontendTokenDefinitionJSON, new JSONFactoryImpl(),
+				resourceBundleLoader, "theme_id");
+
+		String json = frontendTokenDefinitionImpl.translateJSON(Locale.ENGLISH);
+
+		Assert.assertEquals(_translatedFrontendTokenDefinitionJSON, json);
+	}
+
+	private static final String _frontendTokenDefinitionJSON;
+	private static final String _translatedFrontendTokenDefinitionJSON;
+
+	static {
+		URL url = FrontendTokenDefinitionRegistryImplTest.class.getResource(
+			"dependencies/frontend-token-definition.json");
+
+		try (InputStream inputStream = url.openStream()) {
+			_frontendTokenDefinitionJSON = StringUtil.read(inputStream);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+
+		url = FrontendTokenDefinitionRegistryImplTest.class.getResource(
+			"dependencies/translated-frontend-token-definition.json");
+
+		try (InputStream inputStream = url.openStream()) {
+			JSONFactory jsonFactory = new JSONFactoryImpl();
+
+			_translatedFrontendTokenDefinitionJSON =
+				jsonFactory.looseSerializeDeep(
+					jsonFactory.createJSONObject(StringUtil.read(inputStream)));
+		}
+		catch (IOException | JSONException exception) {
+			throw new RuntimeException(exception);
+		}
+	}
+
+}

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImplTest.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImplTest.java
@@ -17,6 +17,7 @@ package com.liferay.frontend.token.definition.internal;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -25,7 +26,6 @@ import java.io.InputStream;
 
 import java.net.URL;
 
-import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.junit.Assert;
@@ -46,31 +46,34 @@ public class FrontendTokenDefinitionImplTest {
 		Package aPackage = FrontendTokenDefinitionImplTest.class.getPackage();
 
 		Mockito.when(
-			resourceBundleLoader.loadResourceBundle(Locale.ENGLISH)
+			resourceBundleLoader.loadResourceBundle(LocaleUtil.ENGLISH)
 		).thenReturn(
 			ResourceBundle.getBundle(
-				aPackage.getName() + ".dependencies.Language", Locale.ENGLISH)
+				aPackage.getName() + ".dependencies.Language",
+				LocaleUtil.ENGLISH)
 		);
 
 		FrontendTokenDefinitionImpl frontendTokenDefinitionImpl =
 			new FrontendTokenDefinitionImpl(
-				_frontendTokenDefinitionJSON, new JSONFactoryImpl(),
+				_FRONTEND_TOKEN_DEFINITION_JSON, new JSONFactoryImpl(),
 				resourceBundleLoader, "theme_id");
 
-		String json = frontendTokenDefinitionImpl.translateJSON(Locale.ENGLISH);
+		String json = frontendTokenDefinitionImpl.translateJSON(
+			LocaleUtil.ENGLISH);
 
-		Assert.assertEquals(_translatedFrontendTokenDefinitionJSON, json);
+		Assert.assertEquals(_TRANSLATED_FRONTEND_TOKEN_DEFINITION_JSON, json);
 	}
 
-	private static final String _frontendTokenDefinitionJSON;
-	private static final String _translatedFrontendTokenDefinitionJSON;
+	private static final String _FRONTEND_TOKEN_DEFINITION_JSON;
+
+	private static final String _TRANSLATED_FRONTEND_TOKEN_DEFINITION_JSON;
 
 	static {
 		URL url = FrontendTokenDefinitionRegistryImplTest.class.getResource(
 			"dependencies/frontend-token-definition.json");
 
 		try (InputStream inputStream = url.openStream()) {
-			_frontendTokenDefinitionJSON = StringUtil.read(inputStream);
+			_FRONTEND_TOKEN_DEFINITION_JSON = StringUtil.read(inputStream);
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
@@ -82,7 +85,7 @@ public class FrontendTokenDefinitionImplTest {
 		try (InputStream inputStream = url.openStream()) {
 			JSONFactory jsonFactory = new JSONFactoryImpl();
 
-			_translatedFrontendTokenDefinitionJSON =
+			_TRANSLATED_FRONTEND_TOKEN_DEFINITION_JSON =
 				jsonFactory.looseSerializeDeep(
 					jsonFactory.createJSONObject(StringUtil.read(inputStream)));
 		}

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImplTest.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImplTest.java
@@ -17,6 +17,7 @@ package com.liferay.frontend.token.definition.internal;
 import com.liferay.frontend.token.definition.FrontendTokenDefinition;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PortalImpl;
 
@@ -26,7 +27,6 @@ import java.io.InputStream;
 import java.net.URL;
 
 import java.util.Dictionary;
-import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -72,7 +72,7 @@ public class FrontendTokenDefinitionRegistryImplTest {
 
 			Assert.assertEquals(
 				StringUtil.read(inputStream),
-				frontendTokenDefinition.getJSON(Locale.ENGLISH));
+				frontendTokenDefinition.getJSON(LocaleUtil.ENGLISH));
 		}
 	}
 

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImplTest.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImplTest.java
@@ -15,6 +15,7 @@
 package com.liferay.frontend.token.definition.internal;
 
 import com.liferay.frontend.token.definition.FrontendTokenDefinition;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PortalImpl;
@@ -25,6 +26,7 @@ import java.io.InputStream;
 import java.net.URL;
 
 import java.util.Dictionary;
+import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,6 +45,9 @@ public class FrontendTokenDefinitionRegistryImplTest {
 		FrontendTokenDefinitionRegistryImpl
 			frontendTokenDefinitionRegistryImpl =
 				new FrontendTokenDefinitionRegistryImpl();
+
+		frontendTokenDefinitionRegistryImpl.resourceBundleLoaders =
+			Mockito.mock(ServiceTrackerMap.class);
 
 		Bundle bundle = Mockito.mock(Bundle.class);
 
@@ -67,7 +72,7 @@ public class FrontendTokenDefinitionRegistryImplTest {
 
 			Assert.assertEquals(
 				StringUtil.read(inputStream),
-				frontendTokenDefinition.getJSON());
+				frontendTokenDefinition.getJSON(Locale.ENGLISH));
 		}
 	}
 

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/test/resources/com/liferay/frontend/token/definition/internal/dependencies/Language.properties
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/test/resources/com/liferay/frontend/token/definition/internal/dependencies/Language.properties
@@ -1,0 +1,3 @@
+color-system=Color System
+white=White
+grays=Gray Tones

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/test/resources/com/liferay/frontend/token/definition/internal/dependencies/translated-frontend-token-definition.json
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/test/resources/com/liferay/frontend/token/definition/internal/dependencies/translated-frontend-token-definition.json
@@ -1,14 +1,14 @@
 {
 	"frontendTokenCategories": [
 		{
-			"label": "color-system",
+			"label": "Color System",
 			"name": "colorSystem",
 			"tokenSets": [
 				{
 					"frontendTokens": [
 						{
 							"editorType": "ColorPicker",
-							"label": "white",
+							"label": "White",
 							"mappings": [
 								{
 									"type": "cssVariable",
@@ -19,7 +19,7 @@
 							"type": "String"
 						}
 					],
-					"label": "grays",
+					"label": "Gray Tones",
 					"name": "grays"
 				}
 			]


### PR DESCRIPTION
Simply store one version of the JSON per locale and return it on request.

I have added tests for the feature and have then checked it manually by adding the necessary files to Classic Theme. Unfortunately if I send those files in this PR it will conflict, so we will pass this first and add the necessary files later on a follow up PR.