### PR TITLE
LPS-110689 Adds Numpad keys to validInputKeyCodes list

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/EditAdaptiveMediaConfig.es.js
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/EditAdaptiveMediaConfig.es.js
@@ -17,13 +17,6 @@ import core from 'metal';
 import dom from 'metal-dom';
 
 const VALID_INPUT_KEYS = new Set([
-	'Backspace',
-	'Tab',
-	'Enter',
-	'ArrowUp',
-	'Up',
-	'ArrowDown',
-	'Down',
 	'0',
 	'1',
 	'2',
@@ -34,6 +27,13 @@ const VALID_INPUT_KEYS = new Set([
 	'7',
 	'8',
 	'9',
+	'ArrowDown',
+	'ArrowUp',
+	'Backspace',
+	'Down',
+	'Enter',
+	'Tab',
+	'Up',
 ]);
 
 /**

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/EditAdaptiveMediaConfig.es.js
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/EditAdaptiveMediaConfig.es.js
@@ -16,6 +16,26 @@ import {PortletBase, normalizeFriendlyURL} from 'frontend-js-web';
 import core from 'metal';
 import dom from 'metal-dom';
 
+const VALID_INPUT_KEYS = new Set([
+	'Backspace',
+	'Tab',
+	'Enter',
+	'ArrowUp',
+	'Up',
+	'ArrowDown',
+	'Down',
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9',
+]);
+
 /**
  * EditAdaptiveMediaConfig
  *
@@ -24,29 +44,6 @@ import dom from 'metal-dom';
  */
 
 class EditAdaptiveMediaConfig extends PortletBase {
-
-	/**
-	 * @inheritDoc
-	 */
-	created() {
-		this.validInputKeyCodes_ = [
-			8,
-			9,
-			13,
-			38,
-			40,
-			48,
-			49,
-			50,
-			51,
-			52,
-			53,
-			54,
-			55,
-			56,
-			57,
-		];
-	}
 
 	/**
 	 * @inheritDoc
@@ -129,9 +126,7 @@ class EditAdaptiveMediaConfig extends PortletBase {
 	 * @param {KeyboardEvent} event The keyboard event.
 	 */
 	handleKeyDown_(event) {
-		const code = event.keyCode || event.charCode;
-
-		if (this.validInputKeyCodes_.indexOf(code) == -1) {
+		if (!VALID_INPUT_KEYS.has(event.key)) {
 			event.preventDefault();
 		}
 	}


### PR DESCRIPTION
### Test Case

1. Global Menu Icon
2. Control Panel -> Configurations -> Adaptive Media
3. Add a new adaptive media(?) clicking on the plus button

Try to enter the width and height values by hitting the numbers above the letters on your keyboard: Works ✅ 
Try to enter the width and height values by hitting the numbers on the numberpad (num-lock on, of course): Doesn't work. ❌ 

Test Case additional considerations:

I wasn't unable to install a Linux distro to test it and It wasn't reproduced on Mac. However, running a Windows alongside a VM and using a Microsoft Numpad keyboard on a Firefox I was able to reproduce it.

-----

One interesting thing is because when using `key` instead of `keyCode` We don't need to care about Numpad different key codes :) (See https://github.com/liferay-frontend/liferay-portal/pull/153/commits/3bf070c9d322206ad601c907ec095004ce400e85)

See:
![Screen Shot 2020-07-22 at 16 13 30](https://user-images.githubusercontent.com/7663513/88218344-4b30a180-cc36-11ea-9a7a-d682587fee07.png)
From: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values