### PR TITLE
LPS-117116 Use useTimeout hook instead of setTimeout

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
@@ -14,6 +14,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import classNames from 'classnames';
+import {useTimeout} from 'frontend-js-react-web';
 import React, {useContext, useEffect, useState} from 'react';
 
 const SidebarContext = React.createContext();
@@ -56,11 +57,13 @@ const SidebarHeader = ({children, subtitle, title}) => {
 const Sidebar = ({children, onClose = noop, open = true}) => {
 	const [isOpen, setIsOpen] = useState(false);
 
+	const delay = useTimeout();
+
 	// Wait until the component is rendered to show it so animation happens
 
 	useEffect(() => {
 		if (open !== false) {
-			setTimeout(() => setIsOpen(true), 100);
+			delay(() => setIsOpen(true), 100);
 		}
 		else {
 			setIsOpen(false);


### PR DESCRIPTION
Use `useTimeout()` because it is not safe to make state-setting calls inside a `setTimeout()` callback, unless guarded by an `isMounted()` check (which `useTimeout()` includes automatically).

We'll eventually [create a lint](https://github.com/liferay/eslint-config-liferay/issues/116) to catch this kind of thing automatically in the future.

(Noticed this while doing post-hoc review of [liferay-frontend#142](https://github.com/liferay-frontend/liferay-portal/pull/142)).

cc @carloslancha