### PR TITLE
LPS-117114 show content performance in content dashboard sidebar

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/servlet/taglib/util/ContentDashboardDropdownItemsProvider.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/servlet/taglib/util/ContentDashboardDropdownItemsProvider.java
@@ -97,17 +97,6 @@ public class ContentDashboardDropdownItemsProvider {
 				return dropdownItem;
 			},
 			() -> {
-				DropdownItem dropdownItem = new DropdownItem();
-
-				dropdownItem.setData(
-					HashMapBuilder.<String, Object>put(
-						"action", "showInfo"
-					).put(
-						"className", contentDashboardItem.getClassName()
-					).put(
-						"classPK", contentDashboardItem.getClassPK()
-					).build());
-
 				ResourceURL resourceURL =
 					_liferayPortletResponse.createResourceURL();
 
@@ -119,7 +108,18 @@ public class ContentDashboardDropdownItemsProvider {
 				resourceURL.setResourceID(
 					"/content_dashboard/get_content_dashboard_item_info");
 
-				dropdownItem.setHref(String.valueOf(resourceURL));
+				DropdownItem dropdownItem = new DropdownItem();
+
+				dropdownItem.setData(
+					HashMapBuilder.<String, Object>put(
+						"action", "showInfo"
+					).put(
+						"className", contentDashboardItem.getClassName()
+					).put(
+						"classPK", contentDashboardItem.getClassPK()
+					).put(
+						"fetchURL", String.valueOf(resourceURL)
+					).build());
 
 				dropdownItem.setLabel(_language.get(locale, "info"));
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,3 +1,7 @@
+.audit-graph {
+	position: relative;
+}
+
 .content-dashboard-management-toolbar {
 	.navbar-expand-md .container-fluid {
 		padding: 0;
@@ -60,6 +64,9 @@
 
 .sidebar {
 	.sidebar-header {
+		padding-bottom: 5px;
+		padding-top: 10px;
+
 		.component-subtitle {
 			font-size: 0.875rem;
 		}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
@@ -68,10 +68,4 @@
 			font-size: 1rem;
 		}
 	}
-
-	.sidebar-body {
-		.sidebar-section p {
-			font-size: 0.875rem;
-		}
-	}
 }

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/SidebarPanel.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/SidebarPanel.js
@@ -16,13 +16,7 @@ import ClayAlert from '@clayui/alert';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {useTimeout} from 'frontend-js-react-web';
 import {fetch} from 'frontend-js-web';
-import React, {
-	useCallback,
-	useEffect,
-	useImperativeHandle,
-	useRef,
-	useState,
-} from 'react';
+import React, {useEffect, useImperativeHandle, useRef, useState} from 'react';
 
 import Sidebar from './components/Sidebar';
 
@@ -37,51 +31,46 @@ const SidebarPanel = React.forwardRef(
 
 		const delay = useTimeout();
 
-		const getData = useCallback(
-			(fetchURL) => {
-				setIsLoading(true);
-				setResourceData(null);
+		const getData = (fetchURL) => {
+			setIsLoading(true);
+			setResourceData(null);
 
-				fetch(fetchURL, {
-					method: 'GET',
-				})
-					.then((response) =>
-						response.headers.get('content-type').includes('json')
-							? response
-									.json()
-									.then((data) => setData(data, data?.error))
-							: response.text().then((html) => setData({html}))
-					)
-					.catch(() => {
-						setData(
-							null,
-							Liferay.Language.get('an-unexpected-error-occurred')
-						);
-					});
-			},
-			[setData]
-		);
+			fetch(fetchURL, {
+				method: 'GET',
+			})
+				.then((response) =>
+					response.headers.get('content-type').includes('json')
+						? response
+								.json()
+								.then((data) => setData(data, data?.error))
+						: response.text().then((html) => setData({html}))
+				)
+				.catch(() => {
+					setData(
+						null,
+						Liferay.Language.get('an-unexpected-error-occurred')
+					);
+				});
+		};
 
 		const onCloseHandle = () => (onClose ? onClose() : setIsOpen(false));
 
-		const setData = useCallback(
-			(data, error) => {
+		const setData = (data, error) => {
 
-				// Force 300 ms of waiting to render the response so loading
-				// looks more natural.
+			// Force 300 ms of waiting to render the response so loading
+			// looks more natural.
 
-				delay(() => {
-					setIsLoading(false);
-					setError(error);
-					setResourceData(data);
-				}, 300);
-			},
-			[delay]
-		);
+			delay(() => {
+				setIsLoading(false);
+				setError(error);
+				setResourceData(data);
+			}, 300);
+		};
 
 		useEffect(() => {
 			getData(fetchURL);
-		}, [fetchURL, getData]);
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [fetchURL]);
 
 		useEffect(() => {
 			CurrentView.current = View;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/SidebarPanel.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/SidebarPanel.js
@@ -41,10 +41,13 @@ const SidebarPanel = React.forwardRef(
 			fetch(fetchURL, {
 				method: 'GET',
 			})
-				.then((response) => response.json())
-				.then((data) => {
-					setData(data, data?.error);
-				})
+				.then((response) =>
+					response.headers.get('content-type').includes('json')
+						? response
+								.json()
+								.then((data) => setData(data, data?.error))
+						: response.text().then((html) => setData({html}))
+				)
 				.catch(() => {
 					setData(
 						null,

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/SidebarPanel.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/SidebarPanel.js
@@ -14,6 +14,7 @@
 
 import ClayAlert from '@clayui/alert';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {useTimeout} from 'frontend-js-react-web';
 import {fetch} from 'frontend-js-web';
 import React, {
 	useCallback,
@@ -34,41 +35,49 @@ const SidebarPanel = React.forwardRef(
 		const [isOpen, setIsOpen] = useState(true);
 		const [resourceData, setResourceData] = useState();
 
-		const getData = useCallback((fetchURL) => {
-			setIsLoading(true);
-			setResourceData(null);
+		const delay = useTimeout();
 
-			fetch(fetchURL, {
-				method: 'GET',
-			})
-				.then((response) =>
-					response.headers.get('content-type').includes('json')
-						? response
-								.json()
-								.then((data) => setData(data, data?.error))
-						: response.text().then((html) => setData({html}))
-				)
-				.catch(() => {
-					setData(
-						null,
-						Liferay.Language.get('an-unexpected-error-occurred')
-					);
-				});
-		}, []);
+		const getData = useCallback(
+			(fetchURL) => {
+				setIsLoading(true);
+				setResourceData(null);
+
+				fetch(fetchURL, {
+					method: 'GET',
+				})
+					.then((response) =>
+						response.headers.get('content-type').includes('json')
+							? response
+									.json()
+									.then((data) => setData(data, data?.error))
+							: response.text().then((html) => setData({html}))
+					)
+					.catch(() => {
+						setData(
+							null,
+							Liferay.Language.get('an-unexpected-error-occurred')
+						);
+					});
+			},
+			[setData]
+		);
 
 		const onCloseHandle = () => (onClose ? onClose() : setIsOpen(false));
 
-		const setData = (data, error) => {
+		const setData = useCallback(
+			(data, error) => {
 
-			// Force 300 ms of waiting to render the response so loading
-			// looks more natural.
+				// Force 300 ms of waiting to render the response so loading
+				// looks more natural.
 
-			setTimeout(() => {
-				setIsLoading(false);
-				setError(error);
-				setResourceData(data);
-			}, 300);
-		};
+				delay(() => {
+					setIsLoading(false);
+					setError(error);
+					setResourceData(data);
+				}, 300);
+			},
+			[delay]
+		);
 
 		useEffect(() => {
 			getData(fetchURL);

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
@@ -86,4 +86,5 @@ const Sidebar = ({children, onClose = noop, open = true}) => {
 Sidebar.Body = SidebarBody;
 Sidebar.Header = SidebarHeader;
 
+export {SidebarContext, Sidebar};
 export default Sidebar;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
@@ -15,6 +15,7 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayLayout from '@clayui/layout';
 import classNames from 'classnames';
+import {useTimeout} from 'frontend-js-react-web';
 import React, {useContext, useEffect, useState} from 'react';
 
 const SidebarContext = React.createContext();
@@ -57,16 +58,18 @@ const SidebarHeader = ({children, subtitle, title}) => {
 const Sidebar = ({children, onClose = noop, open = true}) => {
 	const [isOpen, setIsOpen] = useState(false);
 
+	const delay = useTimeout();
+
 	// Wait until the component is rendered to show it so animation happens
 
 	useEffect(() => {
 		if (open !== false) {
-			setTimeout(() => setIsOpen(true), 100);
+			delay(() => setIsOpen(true), 100);
 		}
 		else {
 			setIsOpen(false);
 		}
-	}, [open]);
+	}, [delay, open]);
 
 	return (
 		<div

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
@@ -74,7 +74,7 @@ const Sidebar = ({children, onClose = noop, open = true}) => {
 				open: isOpen,
 			})}
 		>
-			<div className="sidebar sidebar-light">
+			<div className="sidebar sidebar-light sidebar-sm">
 				<SidebarContext.Provider value={{onClose}}>
 					{children}
 				</SidebarContext.Provider>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView.js
@@ -80,23 +80,31 @@ const SidebarPanelInfoView = ({
 
 	return (
 		<>
-			<Sidebar.Header subtitle={subType} title={title}>
-				{versions.map((version) => (
-					<div key={version}>
-						<ClayLabel displayType="info">
-							{`${Liferay.Language.get('version')} ${
-								version.version
-							}`}
-						</ClayLabel>
-
-						<ClayLabel displayType={version.statusStyle}>
-							{version.statusLabel}
-						</ClayLabel>
-					</div>
-				))}
-			</Sidebar.Header>
+			<Sidebar.Header title="Content Info" />
 
 			<Sidebar.Body>
+				<div className="mb-4 sidebar-dl sidebar-section">
+					<div className="component-title text-truncate-inline">
+						<span className="text-truncate">{title}</span>
+					</div>
+
+					<p className="component-subtitle">{subType}</p>
+
+					{versions.map((version) => (
+						<div key={version}>
+							<ClayLabel displayType="info">
+								{`${Liferay.Language.get('version')} ${
+									version.version
+								}`}
+							</ClayLabel>
+
+							<ClayLabel displayType={version.statusStyle}>
+								{version.statusLabel}
+							</ClayLabel>
+						</div>
+					))}
+				</div>
+
 				<ClayTabs modern>
 					<ClayTabs.Item
 						active={activeTabKeyValue === 0}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView.js
@@ -93,9 +93,8 @@ const SidebarPanelInfoView = ({
 					{versions.map((version) => (
 						<div key={version}>
 							<ClayLabel displayType="info">
-								{`${Liferay.Language.get('version')} ${
-									version.version
-								}`}
+								{Liferay.Language.get('version')}{' '}
+								{version.version}
 							</ClayLabel>
 
 							<ClayLabel displayType={version.statusStyle}>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView.js
@@ -80,7 +80,7 @@ const SidebarPanelInfoView = ({
 
 	return (
 		<>
-			<Sidebar.Header title="Content Info" />
+			<Sidebar.Header title={Liferay.Language.get('content-info')} />
 
 			<Sidebar.Body>
 				<div className="mb-4 sidebar-dl sidebar-section">

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelMetricsView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelMetricsView.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React, {useEffect, useRef} from 'react';
+
+import Sidebar from './Sidebar';
+
+const SidebarPanelMetricsView = ({html}) => {
+	const elementRef = useRef();
+
+	useEffect(() => {
+		const fragment = document.createRange().createContextualFragment(html);
+
+		elementRef.current.innerHTML = '';
+
+		elementRef.current.appendChild(fragment);
+	}, [html]);
+
+	return (
+		<>
+			<Sidebar.Header title="Content Performance" />
+
+			<Sidebar.Body>
+				<div ref={elementRef}></div>
+			</Sidebar.Body>
+		</>
+	);
+};
+
+export default SidebarPanelMetricsView;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelMetricsView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelMetricsView.js
@@ -29,7 +29,9 @@ const SidebarPanelMetricsView = ({html}) => {
 
 	return (
 		<>
-			<Sidebar.Header title="Content Performance" />
+			<Sidebar.Header
+				title={Liferay.Language.get('content-performance')}
+			/>
 
 			<Sidebar.Body>
 				<div ref={elementRef}></div>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
@@ -71,7 +71,7 @@ export default function propsTransformer({
 					if (action) {
 						event.preventDefault();
 
-						actions[action](item.href);
+						actions[action](item.data.fetchURL);
 					}
 				},
 			};

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
@@ -16,6 +16,7 @@ import {render} from 'frontend-js-react-web';
 
 import SidebarPanel from '../SidebarPanel';
 import SidebarPanelInfoView from '../components/SidebarPanelInfoView';
+import SidebarPanelMetricsView from '../components/SidebarPanelMetricsView';
 
 export default function propsTransformer({
 	items,
@@ -27,8 +28,8 @@ export default function propsTransformer({
 		showInfo(fetchURL) {
 			showSidebar(fetchURL, SidebarPanelInfoView);
 		},
-		showMetrics() {
-			showSidebar();
+		showMetrics(fetchURL) {
+			showSidebar(fetchURL, SidebarPanelMetricsView);
 		},
 	};
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -32,7 +32,7 @@ ContentDashboardAdminManagementToolbarDisplayContext contentDashboardAdminManage
 					<%= contentDashboardAdminDisplayContext.getAuditGraphTitle() %>
 				</h2>
 
-				<div id="audit-graph">
+				<div class="audit-graph">
 					<div class="inline-item my-5 p-5 w-100">
 						<span aria-hidden="true" class="loading-animation"></span>
 					</div>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language.properties
@@ -1,6 +1,8 @@
 add-marketing-categories=Add Marketing Categories
 audience=Audience
 content-dashboard=Content Dashboard
+content-info=Content Info
+content-performance=Content Performance
 content-per-x=Content per {0}
 content-per-x-and-x=Content per {0} and {1}
 content-x=Content ({0})

--- a/modules/dxp/apps/analytics/analytics-reports-web/build.gradle
+++ b/modules/dxp/apps/analytics/analytics-reports-web/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")

--- a/modules/dxp/apps/analytics/analytics-reports-web/package.json
+++ b/modules/dxp/apps/analytics/analytics-reports-web/package.json
@@ -4,6 +4,7 @@
 		"@clayui/drop-down": "3.4.6",
 		"@clayui/form": "3.9.0",
 		"@clayui/icon": "3.0.5",
+		"@clayui/layout": "3.1.1",
 		"@clayui/loading-indicator": "3.1.0",
 		"@clayui/sticker": "3.1.1",
 		"@clayui/tooltip": "3.3.2",

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/product/navigation/control/menu/AnalyticsReportsProductNavigationControlMenuEntry.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/product/navigation/control/menu/AnalyticsReportsProductNavigationControlMenuEntry.java
@@ -359,7 +359,7 @@ public class AnalyticsReportsProductNavigationControlMenuEntry
 
 			jspWriter.write("analyticsReportsPanelId\">");
 			jspWriter.write(
-				"<div class=\"sidebar sidebar-default sidenav-menu " +
+				"<div class=\"sidebar sidebar-light sidenav-menu " +
 					"sidebar-sm\">");
 
 			RuntimeTag runtimeTag = new RuntimeTag();

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/analytics_reports_panel.jsp
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/analytics_reports_panel.jsp
@@ -35,7 +35,7 @@ AnalyticsReportsDisplayContext analyticsReportsDisplayContext = (AnalyticsReport
 	</c:when>
 	<c:otherwise>
 		<div id="<portlet:namespace />-analytics-reports-root">
-			<div class="p-3 pt-5 text-center">
+			<div class="pt-5 text-center">
 				<liferay-ui:icon
 					alt="connect-to-liferay-analytics-cloud"
 					src='<%= PortalUtil.getPathContext(request) + "/assets/ac-icon.svg" %>'

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/css/analytics-reports-app.scss
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/css/analytics-reports-app.scss
@@ -1,0 +1,133 @@
+.analytics-reports-app {
+	.component-title {
+		font-weight: 600;
+	}
+
+	.custom-circle {
+		border-radius: 50%;
+		display: inline-block;
+		height: 8px;
+		width: 8px;
+	}
+
+	.custom-square {
+		display: inline-block;
+		height: 8px;
+		width: 8px;
+	}
+
+	.custom-tooltip {
+		background-color: #fff;
+		border: 1px solid #ccc;
+		margin: 0;
+		opacity: 0.9;
+		padding: 0.25rem;
+		white-space: nowrap;
+	}
+
+	.interval-selector-wrapper {
+		display: flex;
+	}
+
+	.line-chart-wrapper {
+		opacity: 1;
+		position: relative;
+
+		&.line-chart-wrapper--loading {
+			.line-chart {
+				opacity: 0.6;
+				pointer-events: none;
+
+				.recharts-cartesian-axis .recharts-cartesian-axis-ticks {
+					opacity: 0;
+				}
+			}
+		}
+
+		.recharts-cartesian-axis .recharts-cartesian-axis-ticks {
+			opacity: 1;
+			transition: opacity 0.15s ease-in-out;
+			will-change: opacity;
+		}
+	}
+
+	.list-group-keywords-list {
+		li {
+			border-width: 0;
+		}
+
+		li > div.autofit-col {
+			padding-left: 0;
+		}
+	}
+
+	.loading-animation {
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: 40%;
+	}
+
+	.pie-chart-wrapper {
+		display: flex;
+		justify-content: space-between;
+
+		.pie-chart-wrapper--legend--title {
+			font-weight: 600;
+		}
+
+		.pie-chart-wrapper--legend {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+
+			.pie-chart-wrapper--legend--dot {
+				border-radius: 50%;
+				display: inline-block;
+				height: 8px;
+				margin-right: 8px;
+				width: 8px;
+			}
+		}
+
+		.pie-chart-wrapper--chart {
+			.dim {
+				opacity: 0.4;
+			}
+		}
+
+		.custom-tooltip {
+			transform: translateX(-50%);
+		}
+	}
+
+	.recharts-legend-item {
+		padding-bottom: 8px;
+
+		&:last-child {
+			padding-bottom: 16px;
+		}
+	}
+
+	.recharts-tooltip-label {
+		font-weight: bold;
+	}
+
+	.recharts-wrapper {
+		.recharts-cartesian-grid-vertical line:not(:last-child),
+		.recharts-cartesian-grid-horizontal
+			line:not(:last-child):not(:first-child) {
+			stroke-opacity: 0;
+		}
+	}
+
+	.traffic-source-detail {
+		thead > tr {
+			height: 40px;
+		}
+
+		tbody > tr {
+			height: 30px;
+		}
+	}
+}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,169 +1,42 @@
-@import 'atlas-variables';
-@import 'mixins';
-
 .lfr-analytics-reports-panel {
 	&.open-admin-panel.sidenav-menu-slider {
 		visibility: visible;
-		width: 320px;
+		width: 330px;
 	}
 
-	.sidebar-body {
-		background-color: #fff;
-		border-left-color: #e7e7ed;
-		border-left-style: solid;
-		border-left-width: 1px;
-	}
-}
-
-.lfr-analytics-reports-panel {
-	.sidebar .sidebar-header {
-		padding-bottom: 0.75rem;
-		padding-top: 0.75rem;
-	}
-
-	@media only screen and (min-width: 768px) {
-		.sidebar-header {
-			padding-bottom: 12px;
-			padding-left: 24px;
-			padding-top: 12px;
-		}
+	.sidebar-header,
+	.sidebar-header .sidenav-close {
+		color: #d5d6e1;
 	}
 
 	.sidebar-header {
 		background-color: #272833;
-		color: #d5d6e1;
-		display: flex;
-		justify-content: space-between;
 		line-height: 32px;
 		padding-bottom: 8px;
 		padding-right: 9px;
 		padding-top: 8px;
 	}
 
-	.sidebar-body {
-		bottom: 0;
-		left: 0;
-		padding: 0;
-		position: absolute;
-		right: 0;
-		top: 56px;
-	}
-
-	@media only screen and (min-width: 768px) {
+	@media only screen and (min-width: 576px) {
 		.sidebar-header {
 			padding-bottom: 12px;
-			padding-left: 24px;
 			padding-top: 12px;
 		}
 	}
 
-	.recharts-tooltip-label {
-		font-weight: bold;
-	}
-
-	.recharts-legend-item {
-		padding-bottom: 8px;
-	}
-
-	.recharts-legend-item:last-child {
-		padding-bottom: 16px;
-	}
-
-	.custom-circle {
-		border-radius: 50%;
-		display: inline-block;
-		height: 8px;
-		width: 8px;
-	}
-
-	.custom-square {
-		display: inline-block;
-		height: 8px;
-		width: 8px;
-	}
-
-	.custom-tooltip {
-		background-color: #fff;
-		border: 1px solid #ccc;
-		margin: 0;
-		opacity: 0.9;
-		padding: 0.25rem;
-		white-space: nowrap;
-	}
-
-	.line-chart-wrapper {
-		opacity: 1;
-		position: relative;
-
-		&.line-chart-wrapper--loading {
-			.line-chart {
-				opacity: 0.6;
-				pointer-events: none;
-				.recharts-cartesian-axis .recharts-cartesian-axis-ticks {
-					opacity: 0;
-				}
-			}
-		}
-		.recharts-cartesian-axis .recharts-cartesian-axis-ticks {
-			opacity: 1;
-			transition: opacity 0.15s ease-in-out;
-			will-change: opacity;
-		}
-	}
-
-	.loading-animation {
+	.sidebar-body {
+		bottom: 0;
 		left: 0;
+		padding: 1rem;
 		position: absolute;
 		right: 0;
-		top: 40%;
-	}
+		top: 56px;
 
-	.interval-selector-wrapper {
-		display: flex;
-	}
-
-	.pie-chart-wrapper {
-		display: flex;
-		justify-content: space-between;
-		.pie-chart-wrapper--legend--title {
-			font-weight: 600;
-		}
-		.pie-chart-wrapper--legend {
-			list-style: none;
-			margin: 0;
-			padding: 0;
-			.pie-chart-wrapper--legend--dot {
-				border-radius: 50%;
-				display: inline-block;
-				height: 8px;
-				margin-right: 8px;
-				width: 8px;
-			}
-		}
-		.pie-chart-wrapper--chart {
-			.dim {
-				opacity: 0.4;
-			}
-		}
-		.custom-tooltip {
-			transform: translateX(-50%);
-		}
-	}
-	.traffic-source-detail {
-		thead > tr {
-			height: 40px;
-		}
-		tbody > tr {
-			height: 30px;
-		}
-	}
-
-	.list-group-keywords-list {
-		li {
-			border-width: 0;
-		}
-		li > div.autofit-col {
-			padding-left: 0;
+		.loading-animation {
+			left: 0;
+			position: absolute;
+			right: 0;
+			top: 40%;
 		}
 	}
 }

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/AnalyticsReportsApp.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/AnalyticsReportsApp.js
@@ -16,6 +16,8 @@ import ConnectionContext from './context/ConnectionContext';
 import {StoreContextProvider} from './context/store';
 import APIService from './utils/APIService';
 
+import '../css/analytics-reports-app.scss';
+
 export default function ({context, props}) {
 	const {languageTag, namespace, page} = context;
 	const {defaultTimeRange, defaultTimeSpanKey, timeSpans} = context;
@@ -52,17 +54,19 @@ export default function ({context, props}) {
 			}}
 		>
 			<StoreContextProvider value={{publishedToday}}>
-				<Navigation
-					api={api}
-					authorName={authorName}
-					defaultTimeRange={defaultTimeRange}
-					defaultTimeSpanKey={defaultTimeSpanKey}
-					languageTag={languageTag}
-					pagePublishDate={publishDate}
-					pageTitle={title}
-					timeSpanOptions={timeSpans}
-					trafficSources={trafficSources}
-				/>
+				<div className="analytics-reports-app">
+					<Navigation
+						api={api}
+						authorName={authorName}
+						defaultTimeRange={defaultTimeRange}
+						defaultTimeSpanKey={defaultTimeSpanKey}
+						languageTag={languageTag}
+						pagePublishDate={publishDate}
+						pageTitle={title}
+						timeSpanOptions={timeSpans}
+						trafficSources={trafficSources}
+					/>
+				</div>
 			</StoreContextProvider>
 		</ConnectionContext.Provider>
 	);

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -10,6 +10,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import ClaySticker from '@clayui/sticker';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -40,16 +41,22 @@ function BasicInformation({authorName, languageTag, publishDate, title}) {
 	}).format(publishDate);
 
 	return (
-		<div>
-			<h4 className="mb-2">{title}</h4>
-			<span className="text-secondary">
-				{Liferay.Util.sub(
-					Liferay.Language.get('published-on-x'),
-					formattedPublishDate
-				)}
-			</span>
-			<Author authorName={authorName} />
-		</div>
+		<ClayLayout.ContentRow className="sidebar-section">
+			<ClayLayout.ContentCol expand>
+				<div className="component-title text-truncate-inline">
+					<span className="text-truncate">{title}</span>
+				</div>
+
+				<p className="text-secondary">
+					{Liferay.Util.sub(
+						Liferay.Language.get('published-on-x'),
+						formattedPublishDate
+					)}
+				</p>
+
+				<Author authorName={authorName} />
+			</ClayLayout.ContentCol>
+		</ClayLayout.ContentRow>
 	);
 }
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
@@ -9,7 +9,8 @@
  * distribution rights of the Software.
  */
 
-import {ClayButtonWithIcon} from '@clayui/button';
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
 import {Align} from 'metal-position';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -26,25 +27,24 @@ export default function Detail({
 }) {
 	return (
 		<>
-			<div className="d-flex p-2">
-				<ClayButtonWithIcon
-					className="text-secondary"
+			<div className="d-flex pb-3 pt-1">
+				<ClayButton
 					displayType="unstyled"
 					onClick={() => {
 						onCurrentPageChange({view: 'main'});
 						onTrafficSourceNameChange('');
 					}}
-					small="true"
-					symbol="angle-left"
-				/>
+					small={true}
+				>
+					<ClayIcon symbol="angle-left-small" />
+				</ClayButton>
+
 				<div className="align-self-center flex-grow-1 mx-2">
-					{currentPage.data.title}
+					<strong>{currentPage.data.title}</strong>
 				</div>
 			</div>
 
-			<hr className="my-0" />
-
-			<div className="p-3 traffic-source-detail">
+			<div className="traffic-source-detail">
 				<TotalCount
 					className="mb-2"
 					dataProvider={trafficVolumeDataProvider}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -131,7 +131,7 @@ export default function Navigation({
 				)}
 
 			{currentPage.view === 'main' && (
-				<div className="p-3">
+				<div>
 					<Main
 						authorName={authorName}
 						chartDataProviders={[

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/view.jsp
@@ -22,11 +22,26 @@ String analyticsReportsPanelState = SessionClicks.get(request, "com.liferay.anal
 
 <div class="lfr-analytics-reports-sidebar" id="analyticsReportsSidebar">
 	<div class="sidebar-header">
-		<h1 class="sr-only"><liferay-ui:message key="content-performance-panel" /></h1>
+		<clay:content-row
+			cssClass="sidebar-section"
+		>
+			<clay:content-col
+				expand="<%= true %>"
+			>
+				<h1 class="sr-only"><liferay-ui:message key="content-performance-panel" /></h1>
 
-		<span><liferay-ui:message key="content-performance" /></span>
+				<span><liferay-ui:message key="content-performance" /></span>
+			</clay:content-col>
 
-		<aui:icon cssClass="icon-monospaced sidenav-close" image="times" markupView="lexicon" url="javascript:;" />
+			<clay:content-col>
+				<clay:button
+					cssClass="sidenav-close"
+					displayType="unstyled"
+					icon="times-small"
+					monospaced="<%= true %>"
+				/>
+			</clay:content-col>
+		</clay:content-row>
 	</div>
 
 	<div class="sidebar-body">


### PR DESCRIPTION
Rebase from https://github.com/liferay-frontend/liferay-portal/pull/156

All LPS-116826 commits are already merged but not synchronized with master,  you can ignore them.

LPS-117114-show-content-performance-metrics

Following https://github.com/liferay-frontend/liferay-portal/pull/120

**Steps to reproduce**

There's some work that needs to be done from backend, so until that is done the steps are...

- Add this [configs files](https://github.com/liferay-tango/liferay-portal/files/4948229/configs.zip) to your portal
- [Connect to AC](https://docs.google.com/document/d/1azuZZHFaceEHCBWcJ0ZbIPC7sKnqrcwY9oB36QkUSmY/edit?usp=sharing)
- Create a display page template and mark it as default
- Create a categorized Basic Web Content with an Audience and Stage
- Create a new page, add to it an asset publisher widget and publish
- Go to the page and click in the web content title
- Inspect the Content Performance button and copy the `data-url`
![image](https://user-images.githubusercontent.com/5803434/88297110-d2961780-ccff-11ea-9eb4-11dc1d042471.png)
- Go to `modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/servlet/taglib/util/ContentDashboardDropdownItemsProvider.java` and add
```
dropdownItem.putData("fetchURL", "the url you just copied");
```
in line `139` , just before `dropdownItem.setLabel(_language.get(locale, "metrics"));`
- Deploy the module
- Go to Global Menu > Content Dashboard
- Click on the actions menu of the web content and click metrics

![image](https://user-images.githubusercontent.com/5803434/88297503-446e6100-cd00-11ea-9d96-b113ecd575cf.png)