### PR TITLE
LPS-114429 Update AlloyEditor to v2.11.10

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"alloyeditor": "2.11.9"
+		"alloyeditor": "2.11.10"
 	},
 	"name": "frontend-editor-alloyeditor-web",
 	"scripts": {

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -3463,10 +3463,10 @@ alloy-ui@^3.1.0-deprecated.40:
   resolved "https://registry.yarnpkg.com/alloy-ui/-/alloy-ui-3.1.0.tgz#95842e4c793abbfe84aa8abfc5a637cd36dda823"
   integrity sha1-lYQuTHk6u/6Eqoq/xaY3zTbdqCM=
 
-alloyeditor@2.11.9:
-  version "2.11.9"
-  resolved "https://registry.yarnpkg.com/alloyeditor/-/alloyeditor-2.11.9.tgz#b69ca73387865b7a20d0220311815fb05f3b1015"
-  integrity sha512-lq0P9wNTNainOwWo2AK4xwVTmTV9E1eKjeJ4IHdB8kRO/F5nlbDrH6GxeUnH3nXXYoGc9FlHjqBwgn4RKJXW1Q==
+alloyeditor@2.11.10:
+  version "2.11.10"
+  resolved "https://registry.yarnpkg.com/alloyeditor/-/alloyeditor-2.11.10.tgz#86f8d612c2f7c6b8fe7f8ffacec8d5966e56cc72"
+  integrity sha512-9+7mNwHWgE0vo8de1kKRh3IaL6p5+9MlCknaiSX4OUuNU1I6gY/8FOkB2DLBualFhvBfUVLUEutmArstT3b+WQ==
   dependencies:
     clay-css "^2.11.1"
     prop-types "^15.6.2"


### PR DESCRIPTION
Specifically fixes problems resizing table cells via drag as described in [LPS-114429](https://issues.liferay.com/browse/LPS-114429), but [full release notes](https://github.com/liferay/alloy-editor/releases/tag/v2.11.10) are:

- fix: set width and height attributes for firefox and chrome
- fix: unbreak table drag-resizing by using fixed table layout
- fix: avoid JS error computing selection position

cc @diegonvs @holatuwol