### PR TITLE
LPS-117287 Web Content article Publish button stops working

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resources.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resources.jsp
@@ -59,10 +59,15 @@ String inlineEditSaveURL = GetterUtil.getString((String)request.getAttribute(CKE
 
 		var cleanupCkEditorResources = function () {
 			if (!ckEditorInstances && ckEditorDisposeResources) {
-				delete window.CKEDITOR;
-
 				ckEditorInstances = 0;
 				ckEditorDisposeResources = false;
+
+				if (
+					window.CKEDITOR &&
+					Object.keys(window.CKEDITOR.instances).length === 0
+				) {
+					delete window.CKEDITOR;
+				}
 			}
 		};
 


### PR DESCRIPTION
This is a bugfix, see description in https://issues.liferay.com/browse/LPS-117287

The issue is caused by CKEditor and AlloyEditor(s) on the same page. There is a race condition on navigate (back or Publish), and CKEditor instance may delete `CKEDITOR` global object before AlloyEditor instances are destroyed. This is the same fix as in [React-based Editor](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js#L23) and [AlloyEditor](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/resources.jsp#L56).

---

The race scenario causes Publish button to sporadically stops working, and this PR fixes it. But, the console error in ticket description does not match this scenario. The error that happens is 
```
async.js:26 Uncaught ReferenceError: CKEDITOR is not defined
    at CKEDITOR.dom.document.getWindow (ckeditor.js?browserId=chrome&languageId=en_US&b=7310&t=1595861504326:90)
...
```
The error in ticket description is 
```
ckeditor.js?browserId=other&minifierType=js&languageId=en_US&b=7210&t=1592928320518:972 Uncaught TypeError: Cannot read property 'data' of undefined
    at h (VM179 ckeditor.js:972)
...
```
I sporadically got this error when quickly navigating before page loads, and this PR does not fix it. But, this error looks unrelated to the problem of this ticket:
- It does not break the Publish button or other UI features.
- It is much harder to replicate then the undefined `CKEDITOR`, happens around every 20+ navigations, while undefined happens every 3-4 times and can be reliably provoked
- It happens on page open, a click listener is not initialized correctly, so click fires the error. This seemingly has no other effect besides an error in log. In contrast, the undefined `CKEDITOR` happens once when navigating away from page, and breaks a lot of UI.

I gave up on trying to find the root cause of `data` issue, as it looks to be deep in base CKeditor. I think we can ignore it for now.