### PR TITLE
LPS-117760 Missing messageType HTML on `liferay-ui:success` taglib

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -39,7 +39,7 @@ const TPL_ALERT_CONTAINER = `
 
 const Text = ({allowHTML, string = null}) => {
 	if (allowHTML) {
-		return <div dangerouslySetInnerHTML={{__html: string}} />;
+		return <span dangerouslySetInnerHTML={{__html: string}} />;
 	}
 
 	return string;

--- a/modules/apps/trash/trash-taglib/build.gradle
+++ b/modules/apps/trash/trash-taglib/build.gradle
@@ -6,6 +6,8 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":apps:trash:trash-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>

--- a/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/undo/page.jsp
+++ b/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/undo/page.jsp
@@ -90,7 +90,7 @@ int trashedEntriesCount = GetterUtil.getInteger(request.getAttribute("liferay-tr
 		<aui:input name="redirect" type="hidden" value="<%= redirectURL %>" />
 		<aui:input name="restoreTrashEntryIds" type="hidden" value="<%= StringUtil.merge(restoreTrashEntryIds) %>" />
 
-		<aui:button cssClass="alert-link btn-link btn-sm btn-unstyled trash-undo-button" type="submit" value="undo" />
+		<aui:button cssClass="alert-link btn-link btn-sm btn-unstyled trash-undo-button" primary="false" type="submit" value="undo" />
 	</aui:form>
 </liferay-util:buffer>
 

--- a/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/undo/page.jsp
+++ b/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/undo/page.jsp
@@ -90,7 +90,13 @@ int trashedEntriesCount = GetterUtil.getInteger(request.getAttribute("liferay-tr
 		<aui:input name="redirect" type="hidden" value="<%= redirectURL %>" />
 		<aui:input name="restoreTrashEntryIds" type="hidden" value="<%= StringUtil.merge(restoreTrashEntryIds) %>" />
 
-		<aui:button cssClass="alert-link btn-link btn-sm btn-unstyled trash-undo-button" primary="false" type="submit" value="undo" />
+		<clay:button
+			cssClass="alert-link trash-undo-button"
+			label="undo"
+			small="<%= true %>"
+			style="link"
+			type="submit"
+		/>
 	</aui:form>
 </liferay-util:buffer>
 

--- a/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/undo/page.jsp
+++ b/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/undo/page.jsp
@@ -28,7 +28,7 @@ int trashedEntriesCount = GetterUtil.getInteger(request.getAttribute("liferay-tr
 <liferay-util:buffer
 	var="alertMessage"
 >
-	<aui:form action="<%= portletURL %>" cssClass="alert-trash-form" name="undoForm">
+	<aui:form action="<%= portletURL %>" cssClass="alert-trash-form d-inline" name="undoForm">
 		<liferay-util:buffer
 			var="trashLink"
 		>

--- a/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/undo/page.jsp
+++ b/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/undo/page.jsp
@@ -94,4 +94,4 @@ int trashedEntriesCount = GetterUtil.getInteger(request.getAttribute("liferay-tr
 	</aui:form>
 </liferay-util:buffer>
 
-<liferay-ui:success key="<%= portletDisplay.getId() + SessionMessages.KEY_SUFFIX_DELETE_SUCCESS_DATA %>" message="<%= alertMessage %>" />
+<liferay-ui:success key="<%= portletDisplay.getId() + SessionMessages.KEY_SUFFIX_DELETE_SUCCESS_DATA %>" message="<%= alertMessage %>" messageType="html" />

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -3886,7 +3886,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Defines the type of the message to be rendered when not using <![CDATA[<code>embed</code>]]> variation.Possible values are <![CDATA[<code>"html"</code>]]> and <![CDATA[<code>"text"</code>]]>. The default value is <![CDATA[<code>"text"</code>]]>.</description>
+			<description>Defines the type of the message to be rendered when not using <![CDATA[<code>embed</code>]]> variation. Possible values are <![CDATA[<code>"html"</code>]]> and <![CDATA[<code>"text"</code>]]>. The default value is <![CDATA[<code>"text"</code>]]>.</description>
 			<name>messageType</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -3886,6 +3886,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>Defines the type of the message to be rendered when not using <![CDATA[<code>embed</code>]]> variation.Possible values are <![CDATA[<code>"html"</code>]]> and <![CDATA[<code>"text"</code>]]>. The default value is <![CDATA[<code>"text"</code>]]>.</description>
+			<name>messageType</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>targetNode</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/util-taglib/src/com/liferay/taglib/ui/SuccessTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SuccessTag.java
@@ -111,8 +111,6 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 	public int processEndTag() throws Exception {
 		String message = _message;
 
-		String messageType = _messageType;
-
 		String bodyContentString = null;
 
 		Object bodyContent = getBodyContentWrapper();
@@ -138,7 +136,7 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 		}
 
 		Map<String, String> values = HashMapBuilder.put(
-			"messageType", messageType
+			"messageType", _messageType
 		).put(
 			"title", LanguageUtil.get(resourceBundle, "success-colon")
 		).build();

--- a/util-taglib/src/com/liferay/taglib/ui/SuccessTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SuccessTag.java
@@ -87,6 +87,10 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 		return _message;
 	}
 
+	public String getMessageType() {
+		return _messageType;
+	}
+
 	public String getTargetNode() {
 		return _targetNode;
 	}
@@ -106,6 +110,8 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 	@Override
 	public int processEndTag() throws Exception {
 		String message = _message;
+
+		String messageType = _messageType;
 
 		String bodyContentString = null;
 
@@ -132,6 +138,8 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 		}
 
 		Map<String, String> values = HashMapBuilder.put(
+			"messageType", messageType
+		).put(
 			"title", LanguageUtil.get(resourceBundle, "success-colon")
 		).build();
 
@@ -172,6 +180,10 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 		_message = message;
 	}
 
+	public void setMessageType(String messageType) {
+		_messageType = messageType;
+	}
+
 	public void setTargetNode(String targetNode) {
 		_targetNode = targetNode;
 	}
@@ -192,6 +204,7 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 		_hasMessage = false;
 		_key = null;
 		_message = null;
+		_messageType = "text";
 		_targetNode = null;
 		_timeout = 5000;
 		_translateMessage = true;
@@ -230,6 +243,7 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 	private boolean _hasMessage;
 	private String _key;
 	private String _message;
+	private String _messageType = "text";
 	private String _targetNode;
 	private int _timeout = 5000;
 	private boolean _translateMessage = true;

--- a/util-taglib/src/com/liferay/taglib/ui/success/toast.tmpl
+++ b/util-taglib/src/com/liferay/taglib/ui/success/toast.tmpl
@@ -1,5 +1,6 @@
 Liferay.Util.openToast({
    message: '$message$'.replace(/&amp;/g, '&'),
+   messageType: '$messageType$',
    title: '$title$',
    type: 'success'
 });


### PR DESCRIPTION
When using `openToast` on `liferay-ui:success` taglib, the `message` property was `text` for every call. However, there is a usage which a HTML is being passed to the toast.

### Test Case:

1. Go to Content and Data
2. Web Content
3. Create few web contents
4. Click on ellipsis of a web content item\
5. Click on Move to Recycle Bin

Before this fix, you will notice the message of openToast is a big markup. After the fix, this markup was parsed due to `messageType` = `html`.

#### Why Diego touched `util-taglib`? @jbalsas 

If we set `html` by default, when using texts, some weird spaces will appear.