### PR TITLE
LPS-117987 Fix the style of the error message

### DIFF
--- a/portal-web/docroot/html/taglib/ui/error/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/error/page.jsp
@@ -48,9 +48,9 @@ String rowBreak = (String)request.getAttribute("liferay-ui:error:rowBreak");
 	<c:otherwise>
 		<aui:script>
 			Liferay.Util.openToast({
-			   displayType: '<%= alertStyle %>',
 			   message: '<%= HtmlUtil.escapeJS(alertMessage) %>',
 			   title: '<%= alertTitle %>'
+			   type: '<%= alertStyle %>',
 			});
 		</aui:script>
 	</c:otherwise>

--- a/util-taglib/src/com/liferay/taglib/ui/success/toast.tmpl
+++ b/util-taglib/src/com/liferay/taglib/ui/success/toast.tmpl
@@ -1,5 +1,5 @@
 Liferay.Util.openToast({
-   displayType: 'success',
    message: '$message$'.replace(/&amp;/g, '&'),
-   title: '$title$'
+   title: '$title$',
+   type: 'success'
 });


### PR DESCRIPTION
This pr fixes a bug where error messages appeared on the screen with success styles. This was caused for using the wrong property to define the style when calling the openToast function.


Steps to reproduce (one of many ways):

- Go to applications menu
- Go to Content dashboard
- Click on the kebab menu and select configuration
- Leave the right box empty
- Save


