### PR TITLE
LPS-117468 Uses moono-lisa skin

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
@@ -83,6 +83,8 @@ public class FragmentEntryLinkEditorConfigContributor
 		).put(
 			"removePlugins", getRemovePluginsLists()
 		).put(
+			"skin", "moono-lisa"
+		).put(
 			"toolbars", JSONFactoryUtil.createJSONObject()
 		);
 	}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
@@ -99,6 +99,8 @@ public class FragmentEntryLinkRichTextEditorConfigContributor
 		).put(
 			"removePlugins", getRemovePluginsLists()
 		).put(
+			"skin", "moono-lisa"
+		).put(
 			"spritemap",
 			themeDisplay.getPathThemeImages() + "/lexicon/icons.svg"
 		).put(


### PR DESCRIPTION
By default, `liferay-ckeditor` now uses the `moono-lexicon` skin that better matches DXP's look and feel. That skin, however, is not meant to be used with `AlloyEditor` and introduces some conflicting styling.

This PR changes the skin used inside PageEditor AlloyEditor instances back to `moono-lisa`.

To test:
- Launch a clean installation of DXP
- Click the **pencil** icon to edit the home page (with the Hello World widget in it)
- Double click on the "Hello World" text to activate AlloyEditor
- Verify that the editor does not have a background

<img width="962" alt="Screen Shot 2020-07-28 at 09 26 12" src="https://user-images.githubusercontent.com/905006/88639194-6840f680-d0b4-11ea-8705-3b92b1b0c294.png">

@p2kmgcl, can you verify this addresses your issue?

PS: This is a followup of https://github.com/liferay-frontend/liferay-portal/pull/157