### PR TITLE
LPS-117833 apply markup changes to components

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/package.json
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/package.json
@@ -3,6 +3,7 @@
 		"@clayui/button": "3.3.1",
 		"@clayui/drop-down": "3.4.6",
 		"@clayui/icon": "3.0.5",
+		"@clayui/label": "3.3.1",
 		"@clayui/layout": "3.1.1",
 		"@clayui/sticker": "3.1.1",
 		"frontend-js-web": "*",

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuMVCResourceCommand.java
@@ -246,6 +246,9 @@ public class ApplicationsMenuMVCResourceCommand extends BaseMVCResourceCommand {
 		for (Group group : groups) {
 			recentSitesJSONArray.put(
 				JSONUtil.put(
+					"current",
+					group.getGroupId() == themeDisplay.getScopeGroupId()
+				).put(
 					"key", group.getGroupKey()
 				).put(
 					"label", group.getDescriptiveName(themeDisplay.getLocale())

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
@@ -1,40 +1,6 @@
 @import 'atlas-variables';
 
-$control-menu-height: 56px;
-$tab-header-height: 38px;
-
 .applications-menu-modal {
-	.applications-menu-header {
-		.autofit-row {
-			@include media-breakpoint-down(xs) {
-				flex-wrap: wrap;
-			}
-		}
-
-		.applications-menu-tabs {
-			@include media-breakpoint-down(xs) {
-				order: 1;
-				width: 100%;
-			}
-		}
-
-		.control-menu-level-1-heading {
-			@include media-breakpoint-down(xs) {
-				flex-grow: 1;
-				flex-shrink: 1;
-				min-height: 3.25rem;
-			}
-		}
-
-		.nav-link {
-			line-height: 1.6rem;
-
-			@include media-breakpoint-up(sm) {
-				line-height: 2.15rem;
-			}
-		}
-	}
-
 	.modal-full {
 		margin-top: 0;
 		width: 100%;
@@ -53,90 +19,148 @@ $tab-header-height: 38px;
 		}
 	}
 
-	.tab-pane {
-		max-height: calc(100vh - #{$control-menu-height + $tab-header-height});
-		overflow-y: auto;
+	.modal-info .btn-monospaced {
+		color: $secondary;
 	}
 }
 
-.applications-menu-nav {
-	margin: 0;
-	padding: 0.2rem;
+.applications-menu-header .nav-link {
+	color: $secondary;
+	padding-bottom: 1rem;
+	padding-top: 1rem;
 
-	@include media-breakpoint-down(xs) {
-		@at-root {
-			.mobile #{&} {
-				padding-bottom: 7rem;
-			}
+	&.active {
+		color: $dark;
+	}
+}
+
+.applications-menu-wrapper {
+	display: flex;
+	flex-direction: column;
+	max-height: 100vh;
+}
+
+.applications-menu-bg {
+	@include media-breakpoint-up(md) {
+		background: linear-gradient(
+			to right,
+			$white 0%,
+			$white 50%,
+			$light 51%,
+			$light 100%
+		);
+
+		.container-fluid {
+			background-color: $white;
 		}
 	}
+}
+
+.applications-menu-border-top {
+	border-top: 1px solid $light;
+}
+
+.applications-menu-nav-columns {
+	column-count: 1;
+	margin-left: -$grid-gutter-width / 2;
+	margin-right: -$grid-gutter-width / 2;
+	orphans: 1;
+	widows: 1;
 
 	@include media-breakpoint-up(sm) {
-		padding: 1.5rem 2.5rem 1.5rem 1.75rem;
+		column-count: 2;
 	}
 
-	.applications-menu-nav-header {
-		color: $secondary;
-		font-size: 0.875rem;
-		font-weight: 700;
-		line-height: 3rem;
-		text-transform: uppercase;
+	@include media-breakpoint-up(md) {
+		column-count: 3;
 	}
 
-	.applications-menu-nav-subheader {
-		color: $secondary;
-		font-size: 0.75rem;
-		font-weight: 600;
-		margin-bottom: 0.25rem;
-		text-transform: uppercase;
+	@include media-breakpoint-up(lg) {
+		column-count: 4;
 	}
 
-	.applications-menu-nav-item {
-		margin-bottom: 0.5rem;
+	.col-md {
+		display: inline-block;
 	}
+}
 
-	.applications-menu-nav-link {
+.applications-menu-nav-header {
+	color: $secondary;
+	font-size: 0.875rem;
+	font-weight: 700;
+	text-transform: uppercase;
+}
+
+.applications-menu-nav-link {
+	color: $dark;
+
+	&:hover {
 		color: $dark;
-		line-height: 1.5rem;
-
-		&.active {
-			font-weight: 600;
-		}
+		text-decoration: none;
 	}
 
-	.applications-menu-nav-columns {
-		column-count: 1;
-		orphans: 1;
-		widows: 1;
+	&.active {
+		font-weight: 600;
+	}
 
-		@include media-breakpoint-up(sm) {
-			column-count: 2;
-		}
+	.sticker-sm {
+		height: 1.25rem;
+		width: 1.25rem;
+	}
+}
 
-		@include media-breakpoint-up(md) {
-			column-count: 3;
-		}
+.applications-menu-sites-label {
+	background-color: $light;
+	color: $secondary;
+	font-size: 0.875rem;
+	font-weight: 600;
+	margin-bottom: 0;
+	text-transform: uppercase;
 
-		@include media-breakpoint-up(lg) {
-			column-count: 4;
-		}
-
-		.col-md {
-			display: inline-block;
-		}
+	@include media-breakpoint-up(md) {
+		bottom: 100%;
+		left: 0.5rem;
+		padding: 1.375rem 1.5rem;
+		position: absolute;
 	}
 }
 
 .applications-menu-sites {
-	margin-bottom: 0;
-	width: 100%;
+	background-color: $light;
+	height: 100%;
+}
 
-	@include media-breakpoint-up(md) {
-		width: 270px;
-	}
+.applications-menu-shrink {
+	flex-shrink: 1;
+	min-width: 0;
+}
 
-	> ul {
-		margin-bottom: 0;
-		padding: 0 1.5rem 1rem;
-	}
+.applications-menu-btn {
+	font-size: 0.875rem;
+	font-weight: 600;
+	text-decoration: none;
+}
+
+.applications-menu-nav-divider {
+	border-top: 1px solid $secondary;
+	width: 1.25rem;
+}
+
+.applications-menu-company {
+	font-size: 1rem;
+	font-weight: 600;
+}
+
+.applications-menu-powered {
+	color: $secondary;
+	font-size: 0.625rem;
+	text-align: right;
+	text-transform: uppercase;
+}
+
+.applications-menu-copyright {
+	color: $secondary;
+	font-size: 0.875rem;
+	font-weight: 600;
+	text-align: right;
 }

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
@@ -46,8 +46,8 @@
 			to right,
 			$white 0%,
 			$white 50%,
-			$light 51%,
-			$light 100%
+			$light-l1 51%,
+			$light-l1 100%
 		);
 
 		.container-fluid {
@@ -110,7 +110,7 @@
 }
 
 .applications-menu-sites-label {
-	background-color: $light;
+	background-color: $light-l1;
 	color: $secondary;
 	font-size: 0.875rem;
 	font-weight: 600;
@@ -126,7 +126,7 @@
 }
 
 .applications-menu-sites {
-	background-color: $light;
+	background-color: $light-l1;
 	height: 100%;
 }
 

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -26,7 +26,7 @@ import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
 
-const Site = ({label, logoURL, url}) => {
+const Site = ({current, label, logoURL, url}) => {
 	return (
 		<li className="c-mt-3">
 			<a className="applications-menu-nav-link" href={url}>
@@ -41,7 +41,7 @@ const Site = ({label, logoURL, url}) => {
 						<span className="text-truncate">{label}</span>
 					</ClayLayout.ContentCol>
 
-					{!url && (
+					{current && (
 						<ClayLayout.ContentCol className="c-ml-2">
 							<ClayLabel displayType="info">
 								{Liferay.Language.get('current')}
@@ -58,8 +58,14 @@ const SitesPanel = ({mySites, portletNamespace, recentSites, viewAllURL}) => {
 	return (
 		<>
 			{recentSites?.length > 0 &&
-				recentSites.map(({key, label, logoURL, url}) => (
-					<Site key={key} label={label} logoURL={logoURL} url={url} />
+				recentSites.map(({current, key, label, logoURL, url}) => (
+					<Site
+						current={current}
+						key={key}
+						label={label}
+						logoURL={logoURL}
+						url={url}
+					/>
 				))}
 
 			{recentSites?.length > 0 && mySites?.length > 0 && (
@@ -67,8 +73,14 @@ const SitesPanel = ({mySites, portletNamespace, recentSites, viewAllURL}) => {
 			)}
 
 			{mySites?.length > 0 &&
-				mySites.map(({key, label, logoURL, url}) => (
-					<Site key={key} label={label} logoURL={logoURL} url={url} />
+				mySites.map(({current, key, label, logoURL, url}) => (
+					<Site
+						current={current}
+						key={key}
+						label={label}
+						logoURL={logoURL}
+						url={url}
+					/>
 				))}
 
 			{viewAllURL && (

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -19,35 +19,220 @@ import classNames from 'classnames';
 
 import '../css/ApplicationsMenu.scss';
 
+import ClayLabel from '@clayui/label';
 import ClaySticker from '@clayui/sticker';
 import ClayTabs from '@clayui/tabs';
 import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
 
-const Sites = ({label, sites}) => {
+// remove PlaceholderSites when Sites is dynamic
+
+const PlaceholderSites = () => {
 	return (
 		<>
-			<li className="applications-menu-nav-subheader">{label}</li>
+			<li className="c-mt-3">
+				<a className="applications-menu-nav-link" href="#">
+					<ClayLayout.ContentRow verticalAlign="center">
+						<ClayLayout.ContentCol>
+							<ClaySticker size="sm">
+								<img
+									alt=""
+									height="20px"
+									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
+								/>
+							</ClaySticker>
+						</ClayLayout.ContentCol>
 
-			{sites.map(({key, label, logoURL, url}) => (
-				<li className="applications-menu-nav-item" key={key}>
-					<a className="applications-menu-nav-link" href={url}>
-						<ClaySticker
-							className="inline-item-before"
-							inline={true}
-							size="sm"
-						>
-							<img className="sticker-img" src={logoURL} />
-						</ClaySticker>
+						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
+							<span className="text-truncate">
+								CyRay Cycles Very Long Name To Insert For You
+							</span>
+						</ClayLayout.ContentCol>
 
-						{label}
-					</a>
-				</li>
-			))}
+						<ClayLayout.ContentCol className="c-ml-2">
+							<ClayLabel displayType="info">
+								{'current'}
+							</ClayLabel>
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
+				</a>
+			</li>
+
+			<li className="c-mt-3">
+				<a className="applications-menu-nav-link" href="#">
+					<ClayLayout.ContentRow verticalAlign="center">
+						<ClayLayout.ContentCol>
+							<ClaySticker size="sm">
+								<img
+									alt=""
+									height="20px"
+									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
+								/>
+							</ClaySticker>
+						</ClayLayout.ContentCol>
+
+						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
+							<span className="text-truncate">
+								CyRay Cycles Intranet
+							</span>
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
+				</a>
+			</li>
+
+			<li className="c-mt-3">
+				<a className="applications-menu-nav-link" href="#">
+					<ClayLayout.ContentRow verticalAlign="center">
+						<ClayLayout.ContentCol>
+							<ClaySticker size="sm">
+								<img
+									alt=""
+									height="20px"
+									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
+								/>
+							</ClaySticker>
+						</ClayLayout.ContentCol>
+
+						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
+							<span className="text-truncate">Front Store</span>
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
+				</a>
+			</li>
+
+			<li className="applications-menu-nav-divider c-mt-3"></li>
+
+			<li className="c-mt-3">
+				<a className="applications-menu-nav-link" href="#">
+					<ClayLayout.ContentRow verticalAlign="center">
+						<ClayLayout.ContentCol>
+							<ClaySticker size="sm">
+								<img
+									alt=""
+									height="20px"
+									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
+								/>
+							</ClaySticker>
+						</ClayLayout.ContentCol>
+
+						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
+							<span className="text-truncate">Front Store</span>
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
+				</a>
+			</li>
+
+			<li className="c-mt-3">
+				<a className="applications-menu-nav-link" href="#">
+					<ClayLayout.ContentRow verticalAlign="center">
+						<ClayLayout.ContentCol>
+							<ClaySticker size="sm">
+								<img
+									alt=""
+									height="20px"
+									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
+								/>
+							</ClaySticker>
+						</ClayLayout.ContentCol>
+
+						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
+							<span className="text-truncate">
+								CyRay Magazine
+							</span>
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
+				</a>
+			</li>
+
+			<li className="c-mt-3">
+				<a className="applications-menu-nav-link" href="#">
+					<ClayLayout.ContentRow verticalAlign="center">
+						<ClayLayout.ContentCol>
+							<ClaySticker size="sm">
+								<img
+									alt=""
+									height="20px"
+									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
+								/>
+							</ClaySticker>
+						</ClayLayout.ContentCol>
+
+						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
+							<span className="text-truncate">
+								CyRay Foundation
+							</span>
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
+				</a>
+			</li>
+
+			<li className="c-mt-3">
+				<a className="applications-menu-nav-link" href="#">
+					<ClayLayout.ContentRow verticalAlign="center">
+						<ClayLayout.ContentCol>
+							<ClaySticker size="sm">
+								<img
+									alt=""
+									height="20px"
+									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
+								/>
+							</ClaySticker>
+						</ClayLayout.ContentCol>
+
+						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
+							<span className="text-truncate">
+								CyRay Partners
+							</span>
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
+				</a>
+			</li>
+
+			<li className="c-mt-3">
+				<ClayButton
+					className="applications-menu-btn btn-unstyled c-mb-0 c-mt-3"
+					displayType="link"
+					onClick={() => alert('Placeholder')}
+				>
+					{Liferay.Language.get('view-all')}
+				</ClayButton>
+			</li>
 		</>
 	);
 };
+
+// const Sites = ({label, sites}) => {
+// 	return (
+// 		<>
+// 			{sites.map(({key, label, logoURL, url}) => (
+// 				<li className="c-mt-3" key={key}>
+// 					<a className="applications-menu-nav-link" href={url}>
+// 						<ClayLayout.ContentRow verticalAlign="center">
+// 							<ClayLayout.ContentCol>
+// 								<ClaySticker size="sm">
+// 									<img alt="" height="20px" src={logoURL} />
+// 								</ClaySticker>
+// 							</ClayLayout.ContentCol>
+
+// 							<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
+// 								<span className="text-truncate">{label}</span>
+// 							</ClayLayout.ContentCol>
+
+// 							{!url && (
+// 								<ClayLayout.ContentCol className="c-ml-2">
+// 									<ClayLabel displayType="info">
+// 										{'current'}
+// 									</ClayLabel>
+// 								</ClayLayout.ContentCol>
+// 							)}
+// 						</ClayLayout.ContentRow>
+// 					</a>
+// 				</li>
+// 			))}
+// 		</>
+// 	);
+// };
 
 const AppsPanel = ({
 	categories = [],
@@ -73,137 +258,147 @@ const AppsPanel = ({
 	const [activeTab, setActiveTab] = useState(index);
 
 	return (
-		<>
-			<div className="border-bottom applications-menu-header">
+		<div className="applications-menu-wrapper">
+			<div className="applications-menu-header">
 				<ClayLayout.ContainerFluid>
-					<ClayLayout.ContentRow verticalAlign="center">
-						<ClayLayout.ContentCol>
-							<ClaySticker>
-								<img alt="" height="32px" src={logoURL} />
-							</ClaySticker>
-						</ClayLayout.ContentCol>
-						<ClayLayout.ContentCol className="c-mr-3 c-pl-1 c-pr-3 control-menu-level-1-heading">
-							{companyName}
-						</ClayLayout.ContentCol>
-						<ClayLayout.ContentCol
-							className="applications-menu-tabs"
-							expand
-						>
-							<ClayTabs modern>
-								{categories.map(({key, label}, index) => (
-									<ClayTabs.Item
-										active={activeTab === index}
-										id={`${portletNamespace}tab_${index}`}
-										key={key}
-										onClick={() => setActiveTab(index)}
-									>
-										<span className="c-inner" tabIndex="-1">
-											{label}
-										</span>
-									</ClayTabs.Item>
-								))}
-							</ClayTabs>
-						</ClayLayout.ContentCol>
+					<ClayLayout.Row>
+						<ClayLayout.Col>
+							<ClayLayout.ContentRow verticalAlign="center">
+								<ClayLayout.ContentCol expand>
+									<ClayTabs modern>
+										{categories.map(
+											({key, label}, index) => (
+												<ClayTabs.Item
+													active={activeTab === index}
+													id={`${portletNamespace}tab_${index}`}
+													key={key}
+													onClick={() =>
+														setActiveTab(index)
+													}
+												>
+													<span
+														className="c-inner"
+														tabIndex="-1"
+													>
+														{label}
+													</span>
+												</ClayTabs.Item>
+											)
+										)}
+									</ClayTabs>
+								</ClayLayout.ContentCol>
 
-						<ClayLayout.ContentCol>
-							<ClayButtonWithIcon
-								className="text-secondary"
-								displayType="unstyled"
-								onClick={handleCloseButtonClick}
-								small
-								symbol="times"
-								title={Liferay.Language.get('close')}
-							/>
-						</ClayLayout.ContentCol>
-					</ClayLayout.ContentRow>
+								<ClayLayout.ContentCol>
+									<ClayButtonWithIcon
+										displayType="unstyled"
+										onClick={handleCloseButtonClick}
+										small
+										symbol="times"
+										title={Liferay.Language.get('close')}
+									/>
+								</ClayLayout.ContentCol>
+							</ClayLayout.ContentRow>
+						</ClayLayout.Col>
+					</ClayLayout.Row>
 				</ClayLayout.ContainerFluid>
 			</div>
 
-			<ClayTabs.Content activeIndex={activeTab}>
-				{categories.map(({childCategories}, index) => (
-					<ClayTabs.TabPane
-						aria-labelledby={`${portletNamespace}tab_${index}`}
-						key={`tabPane-${index}`}
-					>
-						<ClayLayout.Row className="applications-menu-nav">
-							<ClayLayout.Col className="c-p-0" md>
-								<div className="applications-menu-nav-columns">
-									{childCategories.map(
-										({key, label, panelApps}) => (
-											<ClayLayout.Col key={key} md>
-												<ul className="list-unstyled">
-													<li className="applications-menu-nav-header">
-														{label}
-													</li>
-
-													{panelApps.map(
-														({
-															label,
-															portletId,
-															url,
-														}) => (
-															<li
-																className="applications-menu-nav-item"
-																key={portletId}
-															>
-																<a
-																	className={classNames(
-																		'component-link applications-menu-nav-link',
-																		{
-																			active:
-																				portletId ===
-																				selectedPortletId,
-																		}
-																	)}
-																	href={url}
-																>
-																	<span
-																		className="c-inner"
-																		tabIndex="-1"
-																	>
-																		{label}
-																	</span>
-																</a>
+			<div className="applications-menu-bg applications-menu-border-top applications-menu-content">
+				<ClayLayout.ContainerFluid>
+					<ClayLayout.Row>
+						<ClayLayout.Col lg="9" md="8">
+							<ClayTabs.Content activeIndex={activeTab}>
+								{categories.map(({childCategories}, index) => (
+									<ClayTabs.TabPane
+										aria-labelledby={`${portletNamespace}tab_${index}`}
+										key={`tabPane-${index}`}
+									>
+										<div className="applications-menu-nav-columns c-mt-md-3 c-my-2">
+											{childCategories.map(
+												({key, label, panelApps}) => (
+													<ClayLayout.Col
+														key={key}
+														md
+													>
+														<ul className="list-unstyled">
+															<li className="c-my-3">
+																<h3 className="applications-menu-nav-header">
+																	{label}
+																</h3>
 															</li>
-														)
-													)}
-												</ul>
-											</ClayLayout.Col>
-										)
+
+															{panelApps.map(
+																({
+																	label,
+																	portletId,
+																	url,
+																}) => (
+																	<li
+																		className="c-mt-2"
+																		key={
+																			portletId
+																		}
+																	>
+																		<a
+																			className={classNames(
+																				'component-link applications-menu-nav-link',
+																				{
+																					active:
+																						portletId ===
+																						selectedPortletId,
+																				}
+																			)}
+																			href={
+																				url
+																			}
+																		>
+																			<span
+																				className="c-inner"
+																				tabIndex="-1"
+																			>
+																				{
+																					label
+																				}
+																			</span>
+																		</a>
+																	</li>
+																)
+															)}
+														</ul>
+													</ClayLayout.Col>
+												)
+											)}
+										</div>
+									</ClayTabs.TabPane>
+								))}
+							</ClayTabs.Content>
+						</ClayLayout.Col>
+
+						<ClayLayout.Col
+							className="c-pl-md-2 c-px-0"
+							lg="3"
+							md="4"
+						>
+							<div className="applications-menu-sites c-p-3 c-px-md-4">
+								<h2 className="applications-menu-sites-label c-mt-2 c-mt-md-0">
+									Sites
+								</h2>
+
+								<ul className="c-mb-2 list-unstyled">
+									<PlaceholderSites />
+									{/* {sites.mySites && sites.mySites.length > 0 && (
+										<Sites
+											label={Liferay.Language.get(
+												'my-sites'
+											)}
+											sites={sites.mySites}
+										/>
 									)}
-								</div>
-							</ClayLayout.Col>
-
-							<div className="applications-menu-sites">
-								<ul className="bg-light list-unstyled rounded">
-									<li className="applications-menu-nav-header">
-										{Liferay.Language.get('sites')}
-									</li>
-
-									{sites.recentSites &&
-										sites.recentSites.length > 0 && (
-											<Sites
-												label={Liferay.Language.get(
-													'recently-visited'
-												)}
-												sites={sites.recentSites}
-											/>
-										)}
-
-									{sites.mySites &&
-										sites.mySites.length > 0 && (
-											<Sites
-												label={Liferay.Language.get(
-													'my-sites'
-												)}
-												sites={sites.mySites}
-											/>
-										)}
 
 									{sites.viewAllURL && (
-										<li>
+										<li className="c-mt-3">
 											<ClayButton
-												className="c-pl-0"
+												className="applications-menu-btn btn-unstyled c-mb-0 c-mt-3"
 												displayType="link"
 												onClick={() => {
 													Liferay.Util.openModal({
@@ -222,21 +417,71 @@ const AppsPanel = ({
 														url: sites.viewAllURL,
 													});
 												}}
-												small
 											>
 												{Liferay.Language.get(
 													'view-all'
 												)}
 											</ClayButton>
 										</li>
-									)}
+									)} */}
 								</ul>
 							</div>
-						</ClayLayout.Row>
-					</ClayTabs.TabPane>
-				))}
-			</ClayTabs.Content>
-		</>
+						</ClayLayout.Col>
+					</ClayLayout.Row>
+				</ClayLayout.ContainerFluid>
+			</div>
+
+			<div className="applications-menu-bg applications-menu-footer">
+				<ClayLayout.ContainerFluid>
+					<ClayLayout.Row>
+						<ClayLayout.Col lg="9" md="8">
+							<ClayLayout.ContentRow
+								className="applications-menu-border-top c-py-3"
+								verticalAlign="center"
+							>
+								<ClayLayout.ContentCol expand>
+									<ClayLayout.ContentRow verticalAlign="center">
+										<ClayLayout.ContentCol>
+											<ClaySticker>
+												<img
+													alt=""
+													height="32px"
+													src={logoURL}
+												/>
+											</ClaySticker>
+										</ClayLayout.ContentCol>
+
+										<ClayLayout.ContentCol className="c-ml-2">
+											<h1 className="applications-menu-company c-mb-0">
+												{companyName}
+											</h1>
+										</ClayLayout.ContentCol>
+									</ClayLayout.ContentRow>
+								</ClayLayout.ContentCol>
+
+								<ClayLayout.ContentCol expand>
+									<p className="applications-menu-powered c-mb-0">
+										Powered by
+									</p>
+
+									<p className="applications-menu-copyright c-mb-0 c-mt-n1">
+										Liferay DXP
+									</p>
+								</ClayLayout.ContentCol>
+							</ClayLayout.ContentRow>
+						</ClayLayout.Col>
+
+						<ClayLayout.Col
+							className="c-pl-md-2 c-px-0 d-md-block d-none"
+							lg="3"
+							md="4"
+						>
+							<div className="applications-menu-sites"></div>
+						</ClayLayout.Col>
+					</ClayLayout.Row>
+				</ClayLayout.ContainerFluid>
+			</div>
+		</div>
 	);
 };
 

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -26,213 +26,77 @@ import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
 
-// remove PlaceholderSites when Sites is dynamic
-
-const PlaceholderSites = () => {
+const Site = ({label, logoURL, url}) => {
 	return (
-		<>
-			<li className="c-mt-3">
-				<a className="applications-menu-nav-link" href="#">
-					<ClayLayout.ContentRow verticalAlign="center">
-						<ClayLayout.ContentCol>
-							<ClaySticker size="sm">
-								<img
-									alt=""
-									height="20px"
-									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
-								/>
-							</ClaySticker>
-						</ClayLayout.ContentCol>
+		<li className="c-mt-3">
+			<a className="applications-menu-nav-link" href={url}>
+				<ClayLayout.ContentRow verticalAlign="center">
+					<ClayLayout.ContentCol>
+						<ClaySticker size="sm">
+							<img alt="" height="20px" src={logoURL} />
+						</ClaySticker>
+					</ClayLayout.ContentCol>
 
-						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
-							<span className="text-truncate">
-								CyRay Cycles Very Long Name To Insert For You
-							</span>
-						</ClayLayout.ContentCol>
+					<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
+						<span className="text-truncate">{label}</span>
+					</ClayLayout.ContentCol>
 
+					{!url && (
 						<ClayLayout.ContentCol className="c-ml-2">
 							<ClayLabel displayType="info">
-								{'current'}
+								{Liferay.Language.get('current')}
 							</ClayLabel>
 						</ClayLayout.ContentCol>
-					</ClayLayout.ContentRow>
-				</a>
-			</li>
-
-			<li className="c-mt-3">
-				<a className="applications-menu-nav-link" href="#">
-					<ClayLayout.ContentRow verticalAlign="center">
-						<ClayLayout.ContentCol>
-							<ClaySticker size="sm">
-								<img
-									alt=""
-									height="20px"
-									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
-								/>
-							</ClaySticker>
-						</ClayLayout.ContentCol>
-
-						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
-							<span className="text-truncate">
-								CyRay Cycles Intranet
-							</span>
-						</ClayLayout.ContentCol>
-					</ClayLayout.ContentRow>
-				</a>
-			</li>
-
-			<li className="c-mt-3">
-				<a className="applications-menu-nav-link" href="#">
-					<ClayLayout.ContentRow verticalAlign="center">
-						<ClayLayout.ContentCol>
-							<ClaySticker size="sm">
-								<img
-									alt=""
-									height="20px"
-									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
-								/>
-							</ClaySticker>
-						</ClayLayout.ContentCol>
-
-						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
-							<span className="text-truncate">Front Store</span>
-						</ClayLayout.ContentCol>
-					</ClayLayout.ContentRow>
-				</a>
-			</li>
-
-			<li className="applications-menu-nav-divider c-mt-3"></li>
-
-			<li className="c-mt-3">
-				<a className="applications-menu-nav-link" href="#">
-					<ClayLayout.ContentRow verticalAlign="center">
-						<ClayLayout.ContentCol>
-							<ClaySticker size="sm">
-								<img
-									alt=""
-									height="20px"
-									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
-								/>
-							</ClaySticker>
-						</ClayLayout.ContentCol>
-
-						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
-							<span className="text-truncate">Front Store</span>
-						</ClayLayout.ContentCol>
-					</ClayLayout.ContentRow>
-				</a>
-			</li>
-
-			<li className="c-mt-3">
-				<a className="applications-menu-nav-link" href="#">
-					<ClayLayout.ContentRow verticalAlign="center">
-						<ClayLayout.ContentCol>
-							<ClaySticker size="sm">
-								<img
-									alt=""
-									height="20px"
-									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
-								/>
-							</ClaySticker>
-						</ClayLayout.ContentCol>
-
-						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
-							<span className="text-truncate">
-								CyRay Magazine
-							</span>
-						</ClayLayout.ContentCol>
-					</ClayLayout.ContentRow>
-				</a>
-			</li>
-
-			<li className="c-mt-3">
-				<a className="applications-menu-nav-link" href="#">
-					<ClayLayout.ContentRow verticalAlign="center">
-						<ClayLayout.ContentCol>
-							<ClaySticker size="sm">
-								<img
-									alt=""
-									height="20px"
-									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
-								/>
-							</ClaySticker>
-						</ClayLayout.ContentCol>
-
-						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
-							<span className="text-truncate">
-								CyRay Foundation
-							</span>
-						</ClayLayout.ContentCol>
-					</ClayLayout.ContentRow>
-				</a>
-			</li>
-
-			<li className="c-mt-3">
-				<a className="applications-menu-nav-link" href="#">
-					<ClayLayout.ContentRow verticalAlign="center">
-						<ClayLayout.ContentCol>
-							<ClaySticker size="sm">
-								<img
-									alt=""
-									height="20px"
-									src="http://localhost:8080/image/company_logo?img_id=0&t=1595865907262"
-								/>
-							</ClaySticker>
-						</ClayLayout.ContentCol>
-
-						<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
-							<span className="text-truncate">
-								CyRay Partners
-							</span>
-						</ClayLayout.ContentCol>
-					</ClayLayout.ContentRow>
-				</a>
-			</li>
-
-			<li className="c-mt-3">
-				<ClayButton
-					className="applications-menu-btn btn-unstyled c-mb-0 c-mt-3"
-					displayType="link"
-					onClick={() => alert('Placeholder')}
-				>
-					{Liferay.Language.get('view-all')}
-				</ClayButton>
-			</li>
-		</>
+					)}
+				</ClayLayout.ContentRow>
+			</a>
+		</li>
 	);
 };
 
-// const Sites = ({label, sites}) => {
-// 	return (
-// 		<>
-// 			{sites.map(({key, label, logoURL, url}) => (
-// 				<li className="c-mt-3" key={key}>
-// 					<a className="applications-menu-nav-link" href={url}>
-// 						<ClayLayout.ContentRow verticalAlign="center">
-// 							<ClayLayout.ContentCol>
-// 								<ClaySticker size="sm">
-// 									<img alt="" height="20px" src={logoURL} />
-// 								</ClaySticker>
-// 							</ClayLayout.ContentCol>
+const SitesPanel = ({mySites, portletNamespace, recentSites, viewAllURL}) => {
+	return (
+		<>
+			{recentSites?.length > 0 &&
+				recentSites.map(({key, label, logoURL, url}) => (
+					<Site key={key} label={label} logoURL={logoURL} url={url} />
+				))}
 
-// 							<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
-// 								<span className="text-truncate">{label}</span>
-// 							</ClayLayout.ContentCol>
+			{recentSites?.length > 0 && mySites?.length > 0 && (
+				<li className="applications-menu-nav-divider c-mt-3"></li>
+			)}
 
-// 							{!url && (
-// 								<ClayLayout.ContentCol className="c-ml-2">
-// 									<ClayLabel displayType="info">
-// 										{'current'}
-// 									</ClayLabel>
-// 								</ClayLayout.ContentCol>
-// 							)}
-// 						</ClayLayout.ContentRow>
-// 					</a>
-// 				</li>
-// 			))}
-// 		</>
-// 	);
-// };
+			{mySites?.length > 0 &&
+				mySites.map(({key, label, logoURL, url}) => (
+					<Site key={key} label={label} logoURL={logoURL} url={url} />
+				))}
+
+			{viewAllURL && (
+				<li className="c-mt-3">
+					<ClayButton
+						className="applications-menu-btn btn-unstyled c-mb-0 c-mt-3"
+						displayType="link"
+						onClick={() => {
+							Liferay.Util.openModal({
+								id: `${portletNamespace}selectSite`,
+								onSelect: (selectedItem) => {
+									Liferay.Util.navigate(selectedItem.url);
+								},
+								selectEventName: `${portletNamespace}selectSite`,
+								title: Liferay.Language.get(
+									'select-site-or-asset-library'
+								),
+								url: viewAllURL,
+							});
+						}}
+					>
+						{Liferay.Language.get('view-all')}
+					</ClayButton>
+				</li>
+			)}
+		</>
+	);
+};
 
 const AppsPanel = ({
 	categories = [],
@@ -381,49 +245,18 @@ const AppsPanel = ({
 						>
 							<div className="applications-menu-sites c-p-3 c-px-md-4">
 								<h2 className="applications-menu-sites-label c-mt-2 c-mt-md-0">
-									Sites
+									{Liferay.Language.get('sites')}
 								</h2>
 
 								<ul className="c-mb-2 list-unstyled">
-									<PlaceholderSites />
-									{/* {sites.mySites && sites.mySites.length > 0 && (
-										<Sites
-											label={Liferay.Language.get(
-												'my-sites'
-											)}
-											sites={sites.mySites}
+									{sites && (
+										<SitesPanel
+											mySites={sites.mySites}
+											portletNamespace={portletNamespace}
+											recentSites={sites.recentSites}
+											viewAllURL={sites.viewAllURL}
 										/>
 									)}
-
-									{sites.viewAllURL && (
-										<li className="c-mt-3">
-											<ClayButton
-												className="applications-menu-btn btn-unstyled c-mb-0 c-mt-3"
-												displayType="link"
-												onClick={() => {
-													Liferay.Util.openModal({
-														id: `${portletNamespace}selectSite`,
-														onSelect: (
-															selectedItem
-														) => {
-															Liferay.Util.navigate(
-																selectedItem.url
-															);
-														},
-														selectEventName: `${portletNamespace}selectSite`,
-														title: Liferay.Language.get(
-															'select-site-or-asset-library'
-														),
-														url: sites.viewAllURL,
-													});
-												}}
-											>
-												{Liferay.Language.get(
-													'view-all'
-												)}
-											</ClayButton>
-										</li>
-									)} */}
 								</ul>
 							</div>
 						</ClayLayout.Col>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
@@ -15,7 +15,7 @@
 </tr>
 <tr>
 	<td>CATEGORY</td>
-	<td>//ul[contains(@class,'list') and not(contains(@class,'rounded'))]//li[contains(@class,'dropdown-subheader') and contains(.,'${key_category}')]</td>
+	<td>//div[contains(@class,'applications-menu-nav-columns')]//li[contains(.,'${key_category}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -30,12 +30,12 @@
 </tr>
 <tr>
 	<td>PORTLET</td>
-	<td>//li[contains(@class,'applications-menu-nav-header') and contains(.,'${key_category}')]/following-sibling::li//span[normalize-space(text())='${key_portlet}']</td>
+	<td>//div[contains(@class,'applications-menu-nav-columns')]//li[contains(.,'${key_category}')]/following-sibling::li//span[normalize-space(text())='${key_portlet}']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>SITE_LINK</td>
-	<td>//div[contains(@aria-labelledby,'ApplicationsMenuPortlet') and contains(@class,'active')]//a[span][normalize-space(text())='${key_site}']</td>
+	<td>//div[contains(@class,'applications-menu-sites')]//span[normalize-space(text())='${key_site}']</td>
 	<td></td>
 </tr>
 <tr>
@@ -45,7 +45,7 @@
 </tr>
 <tr>
 	<td>VIEW_ALL_LINK</td>
-	<td>//div[contains(@aria-labelledby,'ApplicationsMenuPortlet') and contains(@class,'active')]//button[contains(@class,'btn-link') and contains(.,'View All')]</td>
+	<td>//div[contains(@class,'applications-menu-sites')]//button[contains(@class,'btn-link') and contains(.,'View All')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
This is a massive structure change necessary for the required restyle.

I've removed all the extra classes and the `!important utility classes`

I've created a temporary `<PlaceholderSites>` "component" to work on the style but we'll need it make the original `<Sites>` dynamic following  the [Figma file](https://www.figma.com/file/IWV8DgAZdoyzfHAGLGY5JN/Applications-Menu-Visual-changes-7.3-release?node-id=115%3A4410) specifications

@carloslancha can you help me?

edit: and perhaps divide the whole in sections `<ApplicationsMenuHeader>`, `<ApplicationsMenuFooter>`, etc

---

**Current result:**

<img width="1440" alt="Screenshot 2020-07-27 at 18 55 26" src="https://user-images.githubusercontent.com/46778114/88570675-c29e7080-d03c-11ea-83dc-98e521478d69.png">
<img width="1440" alt="Screenshot 2020-07-27 at 18 56 23" src="https://user-images.githubusercontent.com/46778114/88570683-c6ca8e00-d03c-11ea-8aa8-97c8dc7fbd26.png">

/cc @jbalsas @marcoscv-work @victorvalle
