### PR TITLE
LPS-113801 Refreshes `export-import` portlet when selection modal is closed 

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ExportImportMVCActionCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ExportImportMVCActionCommand.java
@@ -148,12 +148,6 @@ public class ExportImportMVCActionCommand extends BaseMVCActionCommand {
 					ExportImportHelper.TEMP_FOLDER_NAME +
 						portlet.getPortletId());
 
-				SessionMessages.add(
-					actionRequest,
-					_portal.getPortletId(actionRequest) +
-						SessionMessages.KEY_SUFFIX_CLOSE_REFRESH_PORTLET,
-					portlet.getPortletId());
-
 				sendRedirect(actionRequest, actionResponse);
 			}
 		}

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/configuration/icon/ExportImportPortletConfigurationIcon.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/configuration/icon/ExportImportPortletConfigurationIcon.java
@@ -62,7 +62,7 @@ public class ExportImportPortletConfigurationIcon
 	public String getOnClick(
 		PortletRequest portletRequest, PortletResponse portletResponse) {
 
-		StringBundler sb = new StringBundler(11);
+		StringBundler sb = new StringBundler(13);
 
 		sb.append("Liferay.Portlet.openModal({namespace: '");
 
@@ -79,7 +79,9 @@ public class ExportImportPortletConfigurationIcon
 		sb.append(portletDisplay.getId());
 		sb.append("', title: '");
 		sb.append(LanguageUtil.get(themeDisplay.getLocale(), "export-import"));
-		sb.append("', url: '");
+		sb.append("', onClose: function(){ Liferay.Portlet.refresh('#p_p_id_");
+		sb.append(portletDisplay.getId());
+		sb.append("_')}, url: '");
 		sb.append(HtmlUtil.escapeJS(portletDisplay.getURLExportImport()));
 		sb.append("'}); return false;");
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -44,6 +44,7 @@ const openModal = (props) => {
 
 const openPortletModal = ({
 	iframeBodyCssClass,
+	onClose,
 	portletSelector,
 	subTitle,
 	title,
@@ -80,6 +81,7 @@ const openPortletModal = ({
 		openModal({
 			headerHTML,
 			iframeBodyCssClass,
+			onClose,
 			title,
 			url,
 		});


### PR DESCRIPTION
### Test Case

1. Control Panel > Sites > Site Templates
2. Click the ellipsis button on the right upper corner
3. Import the attached lar file(see Jira's link for the attached lar file)
4. Close the Import dialog

You'll notice we aren't able to see the recently imported lar file on the table view. Users needs to refresh the entire page to see the result.

See https://issues.liferay.com/browse/LPS-113801 for attachments/additional details.

### What I did

I noticed We don't have a handling for closing the opened modal on module's call. So, I added a onClose callback on openModal call and called `Liferay.Portlet.refresh` API for prevent reloading the entire page. (thanks to @brunobasto)

### Questions

JFYI, before, when using an AUI component for opening a modal/window, [this event](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js#L171) was being triggered causing an update on the page.

Does make sense moving this code from onClose callback to the openModal/Window command or fire the `closeWindow` Liferay's event?

**Update:**

See the following `openWindow` example: https://github.com/liferay/liferay-portal/blob/master/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf#L70

```js
refreshWindow: window,
```

Before, We had an attribute called `refreshWindow` that I'm guessing that can be used for it.

Does make sense updating https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js#L95 for using this property?

WDYT folks?