### PR TITLE
LPS-116683 Hide ckeditor toolbar labels if toolbar overflows container

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"ckeditor4-react": "1.0.1",
+		"classnames": "2.2.6",
 		"frontend-js-web": "*",
 		"liferay-ckeditor": "4.14.1-liferay.5",
 		"prop-types": "15.7.2"

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -12,11 +12,13 @@
  * details.
  */
 
+import classNames from 'classnames';
 import {useEventListener} from 'frontend-js-react-web';
 import {debounce, isPhone, isTablet} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
+import './ClassicEditor.scss';
 import {Editor} from './Editor';
 
 const getToolbarSet = (toolbarSet) => {
@@ -39,8 +41,10 @@ const ClassicEditor = ({
 	title,
 }) => {
 	const editorRef = useRef();
+	const labeledToolbarsWidth = useRef();
 
 	const [toolbarSet, setToolbarSet] = useState(initialToolbarSet);
+	const [toolbarLabelsVisible, setToolbarLabelsVisible] = useState(true);
 
 	const getConfig = () => {
 		return {
@@ -64,6 +68,29 @@ const ClassicEditor = ({
 
 		return data;
 	}, [contents]);
+
+	const getToolbarsWidth = () => {
+		const container = editorRef.current.editor.container.$;
+
+		const toolbars = Array.from(container.querySelectorAll('.cke_toolbar'));
+
+		return toolbars.reduce((acc, toolbar) => acc + toolbar.offsetWidth, 0);
+	};
+
+	const isToolbarOverflowing = () => {
+		const toolbarsContainer = editorRef.current.editor.container.$.querySelector(
+			'.cke_top'
+		);
+
+		let toolbarsContainerWidth = Infinity;
+
+		if (toolbarsContainer) {
+			toolbarsContainerWidth =
+				parseInt(getComputedStyle(toolbarsContainer).width, 10) || 0;
+		}
+
+		return labeledToolbarsWidth.current >= toolbarsContainerWidth;
+	};
 
 	const onChangeCallback = () => {
 		if (!onChangeMethodName) {
@@ -94,17 +121,23 @@ const ClassicEditor = ({
 
 	const onResize = debounce(() => {
 		setToolbarSet(getToolbarSet(initialToolbarSet));
+
+		setToolbarLabelsVisible(!isToolbarOverflowing());
 	}, 200);
 
 	useEventListener('resize', onResize, true, window);
 
 	return (
-		<div id={`${name}Container`}>
+		<div
+			className={classNames('classic-editor', {
+				'hide-toolbar-labels': !toolbarLabelsVisible,
+			})}
+			id={`${name}Container`}
+		>
 			<label className="control-label" htmlFor={name}>
 				{title}
 			</label>
 			<Editor
-				className="lfr-editable"
 				config={getConfig()}
 				onBeforeLoad={(CKEDITOR) => {
 					CKEDITOR.disableAutoInline = true;
@@ -116,6 +149,10 @@ const ClassicEditor = ({
 
 						editor.on('instanceReady', () => {
 							editor.setData(contents);
+
+							labeledToolbarsWidth.current = getToolbarsWidth();
+
+							setToolbarLabelsVisible(!isToolbarOverflowing());
 						});
 					});
 				}}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.scss
@@ -1,0 +1,7 @@
+.classic-editor.hide-toolbar-labels {
+	.cke_button__label,
+	.cke_button__source_label,
+	.cke_button__sourcedialog_label {
+		display: none;
+	}
+}


### PR DESCRIPTION
This is a followup on https://github.com/liferay/liferay-ckeditor/pull/92. See discussion in that PR, as well as under https://issues.liferay.com/browse/LPS-116683.

To test, open editor in message boards. Keep an eye on the `Source` label.

Before:
![before](https://user-images.githubusercontent.com/5435511/88817271-978f5a80-d1bd-11ea-9c30-cba74566eb6e.gif)

After:
![after](https://user-images.githubusercontent.com/5435511/88817343-ae35b180-d1bd-11ea-8083-779ed2e3d696.gif)

Notes:
- I opted to make this change specific to `ClassicEditor` implementation. This includes both JS and CSS. I added the styles to new component scss, that makes sense to me as it is linked to the implementation.
- The solution is mostly skin-independent, although in theory some future skin could override label display and mess up this feature.
- I do not see how this feature could be achieved only with CSS. I also did not find anything useful for it in CKEditor API.
- In the solution, we are comparing toolbars size to container size. If toolbars size is higher, we hide labels.
- You can notice some choppiness when reducing size. This is because we are debouncing resize event.
- As a threshold of hiding, we are not actually taking width of toolbars, but width of toolbars with labels visible (`labeledToolbarsWidth`). If we would take simple current toolbars width, we would end up with toggling behavior on each pixel change, in the area where container size is near toolbars size. The additional size of the label itself would trigger hide, the reduction from removal of label hiding would trigger show.
- I removed  `className="lfr-editable"`. It does nothing, it's not a part of [ckeditor-react API](https://github.com/ckeditor/ckeditor4-react/blob/master/src/ckeditor.jsx). For style purposes, we are using new top level `classic-editor` class.

@wincent @julien @jbalsas @mateomustapic @carloslancha 