### PR TITLE
LPS-117963 Fix portal-workflow-web classes

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/edit_workflow_definition_link.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/edit_workflow_definition_link.jsp
@@ -31,7 +31,7 @@ String resource = workflowDefinitionLinkSearchEntry.getResource();
 	<portlet:param name="redirect" value="<%= currentURL %>" />
 </portlet:actionURL>
 
-<div hidden="true" id="<%= randomNamespace %>formContainer">
+<div class="d-none" id="<%= randomNamespace %>formContainer">
 	<aui:form action="<%= updateWorkflowDefinitionLinkURL %>" cssClass="workflow-definition-form" method="post">
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 		<aui:input name="namespace" type="hidden" value="<%= randomNamespace %>" />

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/workflow_definition_link_action.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/workflow_definition_link_action.jsp
@@ -22,7 +22,7 @@ ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_
 String randomNamespace = (String)row.getParameter("randomNamespace");
 %>
 
-<div class="btn-group btn-group-nowrap" hidden="true" id="<%= randomNamespace %>saveCancelGroup">
+<div class="btn-group btn-group-nowrap d-none" id="<%= randomNamespace %>saveCancelGroup">
 	<div class="btn-group-item">
 		<button class="btn btn-primary btn-sm" id="<%= randomNamespace %>saveButton" type="button")><%= LanguageUtil.get(request, "save") %></button>
 	</div>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/js/main.js
@@ -163,13 +163,11 @@ AUI.add(
 				for (var index in elementsList) {
 					var element = elementsList[parseInt(index, 10)];
 
-					var hidden = element.getAttribute('hidden');
-
-					if (hidden) {
-						element.removeAttribute('hidden');
+					if (element.classList.contains('d-none')) {
+						element.classList.remove('d-none');
 					}
 					else {
-						element.setAttribute('hidden', true);
+						element.classList.add('d-none');
 					}
 				}
 			},


### PR DESCRIPTION
Originally this part was using the property `hidden="true"` but since this property seems to not be available in Clay/DXP anymore I prefered to upgrade it with a simple `d-none` class

**Result:**

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/46778114/88829609-2061c280-d1cd-11ea-8cd3-af6dbccda240.gif)
