### PR TITLE
LPS-118112 Fix regression caused by https://github.com/liferay-frontend/liferay-portal/pull/174

### DIFF
--- a/portal-web/docroot/html/taglib/ui/error/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/error/page.jsp
@@ -49,8 +49,8 @@ String rowBreak = (String)request.getAttribute("liferay-ui:error:rowBreak");
 		<aui:script>
 			Liferay.Util.openToast({
 			   message: '<%= HtmlUtil.escapeJS(alertMessage) %>',
-			   title: '<%= alertTitle %>'
-			   type: '<%= alertStyle %>',
+			   title: '<%= alertTitle %>',
+			   type: '<%= alertStyle %>'
 			});
 		</aui:script>
 	</c:otherwise>


### PR DESCRIPTION
This pr fixed a regression caused by https://github.com/liferay-frontend/liferay-portal/pull/174.

Steps to reproduce:

- Add a site template.
- Add a site based on the site template.
- Delete the site template.
- Comfirm the pop up of "Are you sure you want to delete this? It will be deleted immediately."

Expected Result: No js error occurs in the browser console.
Actual Result: Uncaught SyntaxError occurs in the browser console. No respond when clicking on UI except refresh the page.