### PR TITLE
LPS-118183 Wrong padding in sidebar-body when displaying alerts

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/package.json
+++ b/modules/apps/content-dashboard/content-dashboard-web/package.json
@@ -10,6 +10,7 @@
 		"@clayui/loading-indicator": "3.1.0",
 		"@clayui/sticker": "3.1.1",
 		"@clayui/tabs": "3.2.2",
+		"classnames": "2.2.6",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
@@ -14,6 +14,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayLayout from '@clayui/layout';
+import classNames from 'classnames';
 import {useTimeout} from 'frontend-js-react-web';
 import React, {useContext, useEffect, useState} from 'react';
 
@@ -21,8 +22,10 @@ const SidebarContext = React.createContext();
 
 const noop = () => {};
 
-const SidebarBody = ({children}) => {
-	return <div className="sidebar-body">{children}</div>;
+const SidebarBody = ({children, className}) => {
+	return (
+		<div className={classNames('sidebar-body', className)}>{children}</div>
+	);
 };
 
 const SidebarHeader = ({children, subtitle, title}) => {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelMetricsView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelMetricsView.js
@@ -33,7 +33,7 @@ const SidebarPanelMetricsView = ({html}) => {
 				title={Liferay.Language.get('content-performance')}
 			/>
 
-			<Sidebar.Body>
+			<Sidebar.Body className="c-p-0">
 				<div ref={elementRef}></div>
 			</Sidebar.Body>
 		</>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/css/main.scss
@@ -27,7 +27,6 @@
 	.sidebar-body {
 		bottom: 0;
 		left: 0;
-		padding: 1rem;
 		position: absolute;
 		right: 0;
 		top: 56px;

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
@@ -32,7 +32,7 @@ export default function Main({
 	trafficSources,
 }) {
 	return (
-		<>
+		<div className="c-p-3">
 			<BasicInformation
 				authorName={authorName}
 				languageTag={languageTag}
@@ -81,7 +81,7 @@ export default function Main({
 					trafficSources={trafficSources}
 				/>
 			)}
-		</>
+		</div>
 	);
 }
 


### PR DESCRIPTION
**Description**

Fix padding when displaying alerts in the Content Performance panel. Padding was added in `sidebar-body` but the alerts should not take any padding to take all the width of the sidebar.

**Type**

Bug

**Screenshots**

Before and after

<img width="319" alt="LPS-118183" src="https://user-images.githubusercontent.com/15845466/88909276-33bb6f00-d25b-11ea-866a-7f1682a273b0.png">  <img width="317" alt="Screenshot 2020-07-30 at 11 55 32" src="https://user-images.githubusercontent.com/15845466/88909582-990f6000-d25b-11ea-9ec5-0a8d4e22d409.png">
