### PR TITLE
LPS-118101 center dialog relative to the window

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
@@ -31,26 +31,10 @@ CKEDITOR.on('dialogDefinition', (event) => {
 		};
 
 		var centerDialog = function () {
-			var editorElement = dialog.getParentEditor().container;
-
-			var documentPosition = editorElement
-				.getLast()
-				.getDocumentPosition();
-
 			var dialogSize = dialog.getSize();
 
-			var x =
-				documentPosition.x +
-				((editorElement.getLast().getSize('width', true) -
-					dialogSize.width) /
-					2 -
-					window.scrollX);
-			var y =
-				documentPosition.y +
-				((editorElement.getLast().getSize('height', true) -
-					dialogSize.height) /
-					2 -
-					window.scrollY);
+			var x = window.innerWidth / 2 - dialogSize.width / 2;
+			var y = window.innerHeight / 2 - dialogSize.height / 2;
 
 			dialog.move(x, y, false);
 		};


### PR DESCRIPTION
Hi guys,

Could you review this pull request, please?

You can find more information in LPS-118101 and PTR-1850.

The main goal of the change is to show CKEditor modals center relative to the window (including scroll) instead of to the editor.

Thanks.

Regards.