### PR TITLE
LPS-116592 Upgrade float classes in account-admin-web

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
@@ -88,7 +88,7 @@ List<String> domains = accountEntryDisplay.getDomains();
 			/>
 
 			<liferay-ui:search-container-column-text>
-				<a class="modify-link pull-right" data-rowId="<%= domain %>" href="javascript:;"><%= removeDomainIcon %></a>
+				<a class="float-right modify-link" data-rowId="<%= domain %>" href="javascript:;"><%= removeDomainIcon %></a>
 			</liferay-ui:search-container-column-text>
 		</liferay-ui:search-container-row>
 
@@ -150,7 +150,7 @@ List<String> domains = accountEntryDisplay.getDomains();
 
 									rowColumns.push(Liferay.Util.escape(domain));
 									rowColumns.push(
-										'<a class="modify-link pull-right" data-rowId="' +
+										'<a class="float-right modify-link" data-rowId="' +
 											domain +
 											'" href="javascript:;"><%= UnicodeFormatter.toString(removeDomainIcon) %></a>'
 									);

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/person_account_entry_user.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/person_account_entry_user.jsp
@@ -23,7 +23,7 @@ AccountEntryDisplay accountEntryDisplay = (AccountEntryDisplay)request.getAttrib
 <liferay-util:buffer
 	var="removeUserIcon"
 >
-	<a class="pull-right remove-user-link" href="javascript:;">
+	<a class="float-right remove-user-link" href="javascript:;">
 		<liferay-ui:icon
 			icon="times-circle"
 			markupView="lexicon"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_kaleo_process.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_kaleo_process.jsp
@@ -89,13 +89,13 @@ renderResponse.setTitle(title);
 		var="htmlBottom"
 	>
 		<aui:button-row cssClass="kaleo-process-buttons">
-			<aui:button cssClass='<%= (historyKey.equals("forms") ? StringPool.BLANK : "hide") + " kaleo-process-previous pull-left" %>' icon="icon-circle-arrow-left" value="previous" />
+			<aui:button cssClass='<%= (historyKey.equals("forms") ? StringPool.BLANK : "hide") + " float-left kaleo-process-previous" %>' icon="icon-circle-arrow-left" value="previous" />
 
-			<aui:button cssClass='<%= (historyKey.equals("forms") ? StringPool.BLANK : "hide") + " kaleo-process-submit pull-right" %>' disabled="<%= true %>" primary="<%= true %>" type="submit" />
+			<aui:button cssClass='<%= (historyKey.equals("forms") ? StringPool.BLANK : "hide") + " float-right kaleo-process-submit" %>' disabled="<%= true %>" primary="<%= true %>" type="submit" />
 
-			<aui:button cssClass='<%= (historyKey.equals("forms") ? "hide" : StringPool.BLANK) + " kaleo-process-next pull-right" %>' disabled="<%= true %>" icon="icon-circle-arrow-right" iconAlign="right" primary="<%= true %>" value="next" />
+			<aui:button cssClass='<%= (historyKey.equals("forms") ? "hide" : StringPool.BLANK) + " float-right kaleo-process-next" %>' disabled="<%= true %>" icon="icon-circle-arrow-right" iconAlign="right" primary="<%= true %>" value="next" />
 
-			<aui:button cssClass="kaleo-process-cancel pull-right" href="<%= redirect %>" value="cancel" />
+			<aui:button cssClass="float-right kaleo-process-cancel" href="<%= redirect %>" value="cancel" />
 		</aui:button-row>
 	</liferay-util:buffer>
 


### PR DESCRIPTION
This is similar to https://github.com/liferay-frontend/liferay-portal/pull/185.

I've looked for `.pull-left` and `.pull-right` classes in Portal and I found these 3 cases, I think we can upgrade them

**Result for portal-workflow-kaleo-forms-web:**
<img width="1440" alt="Screenshot 2020-07-30 at 19 02 21" src="https://user-images.githubusercontent.com/46778114/88953758-ac412080-d299-11ea-9586-87c83ca26b96.png">

**Result for account-admin-web:**
I couldn't find the class in the UI but I trust it will work, since originally `.pull-right` extends `.float-right` https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_utilities.scss#L11