### PR TITLE
LPS-118289 Show row as active on hover and when the sidebar is open showing row's element content

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
@@ -20,6 +20,10 @@
 }
 
 .lfr-search-container-wrapper {
+	.quick-action-menu {
+		padding-left: 20px;
+	}
+
 	.taglib-search-iterator-page-iterator-bottom {
 		margin-top: 24px;
 	}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/SidebarPanel.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/SidebarPanel.js
@@ -136,13 +136,13 @@ const SidebarPanel = React.forwardRef(
 		}, [View]);
 
 		useImperativeHandle(ref, () => ({
-			close: () => dispatch({type: 'CLOSE_SIDEBAR'}),
+			close: () => safeDispatch({type: 'CLOSE_SIDEBAR'}),
 			open: (fetchURL, View) => {
 				CurrentView.current = View;
 
 				getData(fetchURL);
 
-				dispatch({type: 'OPEN_SIDEBAR'});
+				safeDispatch({type: 'OPEN_SIDEBAR'});
 			},
 		}));
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
@@ -19,16 +19,42 @@ import SidebarPanelInfoView from '../components/SidebarPanelInfoView';
 import SidebarPanelMetricsView from '../components/SidebarPanelMetricsView';
 
 const actions = {
-	showInfo(fetchURL, portletNamespace) {
-		showSidebar({View: SidebarPanelInfoView, fetchURL, portletNamespace});
+	showInfo({fetchURL, portletNamespace, rowId}) {
+		selectRow(portletNamespace, rowId);
+		showSidebar({
+			View: SidebarPanelInfoView,
+			fetchURL,
+			portletNamespace,
+		});
 	},
-	showMetrics(fetchURL, portletNamespace) {
+	showMetrics({fetchURL, portletNamespace, rowId}) {
+		selectRow(portletNamespace, rowId);
 		showSidebar({
 			View: SidebarPanelMetricsView,
 			fetchURL,
 			portletNamespace,
 		});
 	},
+};
+
+const deselectAllRows = (portletNamespace) => {
+	const activeRows = document.querySelectorAll(
+		`[data-searchcontainerid="${portletNamespace}content"] tr.active`
+	);
+
+	activeRows.forEach((row) => row.classList.remove('active'));
+};
+
+const getRow = (portletNamespace, rowId) =>
+	document.querySelector(
+		`[data-searchcontainerid="${portletNamespace}content"] [data-rowid="${rowId}"]`
+	);
+
+const selectRow = (portletNamespace, rowId) => {
+	deselectAllRows(portletNamespace);
+
+	const currentRow = getRow(portletNamespace, rowId);
+	currentRow.classList.add('active');
 };
 
 const showSidebar = ({View, fetchURL, portletNamespace}) => {
@@ -45,6 +71,11 @@ const showSidebar = ({View, fetchURL, portletNamespace}) => {
 			SidebarPanel,
 			{
 				fetchURL,
+				onClose: () => {
+					Liferay.component(id).close();
+
+					deselectAllRows(portletNamespace);
+				},
 				ref: (element) => {
 					Liferay.component(id, element);
 				},
@@ -74,7 +105,11 @@ export default function propsTransformer({
 					if (action) {
 						event.preventDefault();
 
-						actions[action](item.data.fetchURL, portletNamespace);
+						actions[action]({
+							fetchURL: item.data.fetchURL,
+							portletNamespace,
+							rowId: item.data.classPK,
+						});
 					}
 				},
 			};

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -62,6 +62,7 @@ ContentDashboardAdminManagementToolbarDisplayContext contentDashboardAdminManage
 
 				<div class="sheet-section">
 					<liferay-ui:search-container
+						cssClass="table-hover"
 						id="content"
 						searchContainer="<%= contentDashboardAdminDisplayContext.getSearchContainer() %>"
 					>
@@ -69,7 +70,15 @@ ContentDashboardAdminManagementToolbarDisplayContext contentDashboardAdminManage
 							className="com.liferay.content.dashboard.web.internal.item.ContentDashboardItem"
 							keyProperty="id"
 							modelVar="contentDashboardItem"
+							rowIdProperty="classPK"
 						>
+
+							<%
+							row.setData(HashMapBuilder.<String, Object>put(
+								"rowId", row.getRowId()
+							).build());
+							%>
+
 							<liferay-ui:search-container-column-text
 								cssClass="table-cell-expand table-title"
 								name="title"


### PR DESCRIPTION
Show row as active on hover and when the sidebar is open showing row's element content.

Steps to reproduce:

- Create a Web Content
- Go to Content Dashboard
- Row should be shown as active on hover
- Click on info quick action button or "Show Infor" item in the Web Content row dropdown menu
- Row should be shown as active 

![image](https://user-images.githubusercontent.com/5803434/89013672-915fc200-d314-11ea-81d9-9b111a142bf6.png)
