### PR TITLE
LPS-114149 Remove logic that was setting placeholder to BLANK on IE >=10

### DIFF
--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -16,12 +16,6 @@
 
 <%@ include file="/html/taglib/aui/input/init.jsp" %>
 
-<%
-if (type.equals("textarea") && BrowserSnifferUtil.isIe(request) && ((BrowserSnifferUtil.getMajorVersion(request) == 10.0) || (BrowserSnifferUtil.getMajorVersion(request) == 11.0))) {
-	placeholder = StringPool.BLANK;
-}
-%>
-
 <c:if test="<%= Validator.isNotNull(helpMessage) %>">
 	<liferay-util:buffer
 		var="helpMessageContent"


### PR DESCRIPTION
Removing logic that was setting placeholder to BLANK on IE >=10.

IE10 is no longer supported and behavior described in [LPS-73502](https://issues.liferay.com/browse/LPS-73502), where this fix was introduced in the first place, is no longer reproducible in IE11.

Steps to reproduce:

Using IE11
- Go to blogs
- Add new blog
- Title and subtitle placeholders should appear
- If no subtitle is introduced and blog is published, "subtitle" is not saved as this field value