### PR TITLE
LPS-116970 Avoids resolving sourcemap annotations

### DIFF
--- a/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/frontend/js/minifier/GoogleJavaScriptMinifier.java
+++ b/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/frontend/js/minifier/GoogleJavaScriptMinifier.java
@@ -64,6 +64,7 @@ public class GoogleJavaScriptMinifier implements JavaScriptMinifier {
 			compilerOptions.setEmitUseStrict(false);
 			compilerOptions.setLanguageIn(
 				CompilerOptions.LanguageMode.ECMASCRIPT_NEXT);
+			compilerOptions.setResolveSourceMapAnnotations(false);
 
 			compiler.compile(
 				SourceFile.fromCode("extern", StringPool.BLANK), sourceFile,


### PR DESCRIPTION
This PR attempts to blindly fix [Cannot add Web Content on Windows Environment if StripFilter is enabled](https://issues.liferay.com/browse/LPS-116970) since I haven't been able to even run the scenario with the infrastructure we have.

**Steps to Reproduce** (theoretical, I haven't been able to run Portal in this scenario)
- Compile portal on linux/mac machine
- Enable StripFilter in portal-ext.properties `com.liferay.portal.servlet.filters.strip.StripFilter=true`
- Start Portal on Windows machine
- Login to Portal
- Create Web Content
- Attempt to Edit Web Content Fields

**Current Result**
Java StackTrace exception probably causing errors in the client code delivery.

```
ERROR [http-nio-8080-exec-6][StripFilter:62] java.nio.file.InvalidPathException: Illegal char <:> at index 4: http://localhost:8080/group/guest/~/control_panel/manage
java.nio.file.InvalidPathException: Illegal char <:> at index 4: http://localhost:8080/group/guest/~/control_panel/manage
        at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
        at sun.nio.fs.WindowsPath.parse(WindowsPath.java:94)
        at sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:255)
        at com.google.javascript.jscomp.SourceMapResolver.getRelativePath(SourceMapResolver.java:73)
        at com.google.javascript.jscomp.SourceMapResolver.extractSourceMap(SourceMapResolver.java:53)
        [...]
```

**Rationale of the fix**
Just by [blind inspection of Closure Compiler code](https://github.com/google/closure-compiler/blob/246ab429f96bff062941a4da8b8f2af01ef5eb0d/src/com/google/javascript/jscomp/JsAst.java#L165):

```java
if (result.sourceMapURL != null && compiler.getOptions().resolveSourceMapAnnotations) {
    boolean parseInline = compiler.getOptions().parseInlineSourceMaps;
    SourceFile sourceMapSourceFile =
        SourceMapResolver.extractSourceMap(sourceFile, result.sourceMapURL, parseInline);
    if (sourceMapSourceFile != null) {
        compiler.addInputSourceMap(sourceFile.getName(), new SourceMapInput(sourceMapSourceFile));
    }
}
```

So, assuming that setting `resolveSourceMapAnnotations` to false would simply skip this and save the day 🙏 