### PR TITLE
LPS-118487 - Improve semantics and continuous reading order

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -135,6 +135,9 @@ const AppsPanel = ({
 
 	return (
 		<div className="applications-menu-wrapper">
+			<h1 className="sr-only">
+				{Liferay.Language.get('applications-menu')}
+			</h1>
 			<div className="applications-menu-header">
 				<ClayLayout.ContainerFluid>
 					<ClayLayout.Row>

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -201,9 +201,9 @@ const AppsPanel = ({
 													>
 														<ul className="list-unstyled">
 															<li className="c-my-3">
-																<h3 className="applications-menu-nav-header">
+																<h2 className="applications-menu-nav-header">
 																	{label}
-																</h3>
+																</h2>
 															</li>
 
 															{panelApps.map(
@@ -300,21 +300,21 @@ const AppsPanel = ({
 										</ClayLayout.ContentCol>
 
 										<ClayLayout.ContentCol className="c-ml-2">
-											<h1 className="applications-menu-company c-mb-0">
+											<div className="applications-menu-company c-mb-0">
 												{companyName}
-											</h1>
+											</div>
 										</ClayLayout.ContentCol>
 									</ClayLayout.ContentRow>
 								</ClayLayout.ContentCol>
 
 								<ClayLayout.ContentCol expand>
-									<p className="applications-menu-powered c-mb-0">
+									<span className="applications-menu-powered c-mb-0">
 										Powered by
-									</p>
+									</span>
 
-									<p className="applications-menu-copyright c-mb-0 c-mt-n1">
+									<span className="applications-menu-copyright c-mb-0 c-mt-n1">
 										Liferay DXP
-									</p>
+									</span>
 								</ClayLayout.ContentCol>
 							</ClayLayout.ContentRow>
 						</ClayLayout.Col>


### PR DESCRIPTION
This PR fixes some accessibility issues in headers order:

![image](https://user-images.githubusercontent.com/7963804/89284084-7d86c980-d64e-11ea-8ad8-1f6860f2d2f5.png)

And improves some other accessibility parts and reading order

- We add a `<h1 class="sr-only">` with the title "Applications menu" in the same way than others administrator components blocks, it allows move you through admin blocks really quick.
- Change headers `<h3>` to `<h2>`
- Remove the last `<h1>` since it is not useful to identify the block because is almost the last element in the semantic block which we call "Applications menu"
- We remove the `<p>`s in Powered by Liferay DXP in order to not break the reading and read:  `Powered by Liferay DXP` instead of `paragraph` , `Powered by` `paragraph` , `Liferay DXP`

--- 

**How to test it:**

- You can use Axe to certify the error has disappeared
- The rest of the changes are improvements you can check by using screen readers