### PR TITLE
LPS-115768 Drag and drop images into CKEditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -244,17 +244,6 @@ name = HtmlUtil.escapeJS(name);
 
 		var plugins = [];
 
-		<c:if test="<%= Validator.isNotNull(data) && Validator.isNotNull(uploadURL) %>">
-			plugins.push({
-				cfg: {
-					uploadItemReturnType:
-						'<%= editorOptions.getUploadItemReturnType() %>',
-					uploadUrl: '<%= uploadURL %>',
-				},
-				fn: A.Plugin.LiferayEditorImageUploader,
-			});
-		</c:if>
-
 		<c:if test="<%= showSource %>">
 			plugins.push(A.Plugin.LiferayAlloyEditorSource);
 		</c:if>
@@ -301,6 +290,12 @@ name = HtmlUtil.escapeJS(name);
 
 			this.selectRanges([range]);
 		};
+
+		new Liferay.EditorImageUploader({
+			editorName: '<%= name %>',
+			uploadItemReturnType: '<%= editorOptions.getUploadItemReturnType() %>',
+			uploadUrl: '<%= uploadURL %>',
+		});
 
 		<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editor.alloyeditor.web#" + editorName + "#onEditorCreate" %>' />
 

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/config.js
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/config.js
@@ -37,15 +37,6 @@
 							'plugin',
 						],
 					},
-					'liferay-editor-image-uploader': {
-						path: 'editor_image_uploader.js',
-						requires: [
-							'aui-alert',
-							'aui-base',
-							'aui-progressbar',
-							'uploader',
-						],
-					},
 				},
 				root: MODULE_PATH + '/js/',
 			},

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/resources.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/resources.jsp
@@ -53,7 +53,10 @@ String editorName = (String)request.getAttribute(AlloyEditorConstants.ATTRIBUTE_
 				alloyEditorInstances = 0;
 				alloyEditorDisposeResources = false;
 
-				if (window.CKEDITOR && Object.keys(window.CKEDITOR.instances).length === 0) {
+				if (
+					window.CKEDITOR &&
+					Object.keys(window.CKEDITOR.instances).length === 0
+				) {
 					delete window.CKEDITOR;
 				}
 			}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -78,7 +78,8 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			"entities", Boolean.FALSE
 		);
 
-		String extraPlugins = "a11yhelpbtn,itemselector,lfrpopup,media";
+		String extraPlugins =
+			"a11yhelpbtn,addimages,itemselector,lfrpopup,media";
 
 		boolean inlineEdit = GetterUtil.getBoolean(
 			(String)inputEditorTaglibAttributes.get(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -1,0 +1,240 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+(function () {
+	const isIE = CKEDITOR.env.ie;
+
+	/**
+	 * CKEditor plugin which allows Drag&Drop of images directly into the editable area. The image will be encoded
+	 * as Data URI. An event `beforeImageAdd` will be fired with the list of dropped images. If any of the listeners
+	 * returns `false` or cancels the event, the images won't be added to the content. Otherwise,
+	 * an event `imageAdd` will be fired with the inserted element into the editable area.
+	 *
+	 * @class CKEDITOR.plugins.addimages
+	 */
+
+	/**
+	 * Fired before adding images to the editor.
+	 *
+	 * @event CKEDITOR.plugins.addimages#beforeImageAdd
+	 * @instance
+	 * @memberof CKEDITOR.plugins.addimages
+	 * @param {Array} imageFiles Array of image files
+	 */
+
+	/**
+	 * Fired when an image is being added to the editor successfully.
+	 *
+	 * @event CKEDITOR.plugins.addimages#imageAdd
+	 * @instance
+	 * @memberof CKEDITOR.plugins.addimages
+	 * @param {CKEDITOR.dom.element} el The created image with src as Data URI
+	 * @param {File} file The image file
+	 */
+
+	CKEDITOR.plugins.add('addimages', {
+
+		/**
+		 * Accepts an array of dropped files to the editor. Then, it filters the images and sends them for further
+		 * processing to {{#crossLink "CKEDITOR.plugins.addimages/_processFile:method"}}{{/crossLink}}
+		 *
+		 * @fires CKEDITOR.plugins.addimages#beforeImageAdd
+		 * @instance
+		 * @memberof CKEDITOR.plugins.addimages
+		 * @method _handleFiles
+		 * @param {Array} files Array of dropped files. Only the images from this list will be processed.
+		 * @param {Object} editor The current editor instance
+		 * @protected
+		 */
+		_handleFiles(files, editor) {
+			let file;
+			let i;
+
+			const imageFiles = [];
+
+			for (i = 0; i < files.length; i++) {
+				file = files[i];
+
+				if (file.type.indexOf('image') === 0) {
+					imageFiles.push(file);
+				}
+			}
+
+			const result = editor.fire('beforeImageAdd', {
+				imageFiles,
+			});
+
+			if (result) {
+				for (i = 0; i < imageFiles.length; i++) {
+					file = imageFiles[i];
+
+					this._processFile(file, editor);
+				}
+			}
+
+			return false;
+		},
+
+		/**
+		 * Handles drag drop event. The function will create a selection from the current
+		 * point and will send a list of files to be processed to
+		 * {{#crossLink "CKEDITOR.plugins.addimages/_handleFiles:method"}}{{/crossLink}} method.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.plugins.addimages
+		 * @method _onDragDrop
+		 * @param {CKEDITOR.dom.event} event dragdrop event, as received natively from CKEditor
+		 * @protected
+		 */
+		_onDragDrop(event) {
+			const nativeEvent = event.data.$;
+
+			const transferFiles = nativeEvent.dataTransfer.files;
+
+			if (transferFiles.length > 0) {
+				new CKEDITOR.dom.event(nativeEvent).preventDefault();
+
+				const editor = event.editor;
+
+				this._handleFiles(transferFiles, editor);
+			}
+		},
+
+		/**
+		 * Handles drag enter event. In case of IE, this function will prevent the event.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.plugins.addimages
+		 * @method _onDragEnter
+		 * @param {DOM event} event dragenter event, as received natively from CKEditor
+		 * @protected
+		 */
+		_onDragEnter(event) {
+			if (isIE) {
+				this._preventEvent(event);
+			}
+		},
+
+		/**
+		 * Handles drag over event. In case of IE, this function will prevent the event.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.plugins.addimages
+		 * @method _onDragOver
+		 * @param {DOM event} event dragover event, as received natively from CKEditor
+		 * @protected
+		 */
+		_onDragOver(event) {
+			if (isIE) {
+				this._preventEvent(event);
+			}
+		},
+
+		/**
+		 * Checks if the pasted data is image and passes it to
+		 * {{#crossLink "CKEDITOR.plugins.addimages/_processFile:method"}}{{/crossLink}} for processing.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.plugins.addimages
+		 * @method _onPaste
+		 * @param {CKEDITOR.dom.event} event A `paste` event, as received natively from CKEditor
+		 * @protected
+		 */
+		_onPaste(event) {
+			if (
+				event.data &&
+				event.data.$ &&
+				event.data.$.clipboardData &&
+				event.data.$.clipboardData.items &&
+				event.data.$.clipboardData.items.length > 0
+			) {
+				const pastedData = event.data.$.clipboardData.items[0];
+
+				if (pastedData.type.indexOf('image') === 0) {
+					const imageFile = pastedData.getAsFile();
+
+					this._processFile(imageFile, event.editor);
+				}
+			}
+		},
+
+		/**
+		 * Prevents a native event.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.plugins.addimages
+		 * @method _preventEvent
+		 * @param {DOM event} event The event to be prevented.
+		 * @protected
+		 */
+		_preventEvent(event) {
+			event = new CKEDITOR.dom.event(event.data.$);
+
+			event.preventDefault();
+			event.stopPropagation();
+		},
+
+		/**
+		 * Processes an image file. The function creates an img element and sets as source
+		 * a Data URI, then fires an 'imageAdd' event via CKEditor's event system.
+		 *
+		 * @fires CKEDITOR.plugins.addimages#imageAdd
+		 * @instance
+		 * @memberof CKEDITOR.plugins.addimages
+		 * @method _preventEvent
+		 * @param {DOM event} event The event to be prevented.
+		 * @protected
+		 */
+		_processFile(file, editor) {
+			const reader = new FileReader();
+
+			reader.addEventListener('loadend', () => {
+				const bin = reader.result;
+
+				const el = CKEDITOR.dom.element.createFromHtml(
+					'<img src="' + bin + '">'
+				);
+
+				editor.insertElement(el);
+
+				const imageData = {
+					el,
+					file,
+				};
+
+				editor.fire('imageAdd', imageData);
+			});
+
+			reader.readAsDataURL(file);
+		},
+
+		/**
+		 * Initialization of the plugin, part of CKEditor plugin lifecycle.
+		 * The function registers a 'dragenter', 'dragover', 'drop' and `paste` events on the editing area.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.plugins.addimages
+		 * @method init
+		 * @param {Object} editor The current editor instance
+		 */
+		init(editor) {
+			editor.once('contentDom', () => {
+				editor.on('dragenter', this._onDragEnter.bind(this));
+				editor.on('dragover', this._onDragOver.bind(this));
+				editor.on('drop', this._onDragDrop.bind(this));
+				editor.on('paste', this._onPaste.bind(this));
+			});
+		},
+	});
+})();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -99,6 +99,16 @@ if (inlineEdit && Validator.isNotNull(inlineEditSaveURL)) {
 
 	modules += ",inline-editor-ckeditor";
 }
+
+String uploadURL = StringPool.BLANK;
+
+if (editorOptions != null) {
+	uploadURL = editorOptions.getUploadURL();
+
+	if ((data != null) && Validator.isNotNull(uploadURL)) {
+		modules += ",liferay-editor-image-uploader";
+	}
+}
 %>
 
 <liferay-util:buffer
@@ -624,10 +634,15 @@ name = HtmlUtil.escapeJS(name);
 
 		ckEditor.on('drop', function (event) {
 			var data = event.data.dataTransfer.getData('text/html');
-			var fragment = CKEDITOR.htmlParser.fragment.fromHtml(data);
-			var name = fragment.children[0].name;
-			if (name) {
-				return this.pasteFilter.check(name);
+
+			if (data) {
+				var fragment = CKEDITOR.htmlParser.fragment.fromHtml(data);
+
+				var name = fragment.children[0].name;
+
+				if (name) {
+					return this.pasteFilter.check(name);
+				}
 			}
 		});
 
@@ -683,6 +698,11 @@ name = HtmlUtil.escapeJS(name);
 				}
 			});
 		}
+
+		new Liferay.EditorImageUploader({
+			editorName: '<%= name %>',
+			uploadUrl: '<%= uploadURL %>',
+		});
 	};
 
 	<%

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/editor_image_uploader.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/editor_image_uploader.js
@@ -19,11 +19,7 @@ AUI.add(
 
 		var CSS_UPLOADING_IMAGE = 'uploading-image';
 
-		var NAME = 'editorimageupload';
-
 		var STR_BLANK = '';
-
-		var STR_HOST = 'host';
 
 		var TPL_IMAGE_CONTAINER =
 			'<div class="uploading-image-container"></div>';
@@ -32,6 +28,11 @@ AUI.add(
 
 		var EditorImageUploader = A.Component.create({
 			ATTRS: {
+				editorName: {
+					validator: Lang.isString,
+					value: STR_BLANK,
+				},
+
 				strings: {
 					validator: Lang.isObject,
 					value: {
@@ -57,11 +58,9 @@ AUI.add(
 				},
 			},
 
-			EXTENDS: A.Plugin.Base,
+			NAME: 'editorimageupload',
 
-			NAME,
-
-			NS: NAME,
+			NS: 'editorimageupload',
 
 			prototype: {
 				_createProgressBar(image) {
@@ -128,6 +127,8 @@ AUI.add(
 
 					image.addClass(CSS_UPLOADING_IMAGE);
 
+					instance._tempImage = image;
+
 					var uploader = eventData.uploader;
 
 					if (uploader) {
@@ -170,9 +171,7 @@ AUI.add(
 					var data = JSON.parse(event.data);
 
 					if (data.success) {
-						var image = A.one(instance._editor.element.$).one(
-							'[data-random-id="' + data.file.randomId + '"]'
-						);
+						var image = instance._tempImage;
 
 						if (image) {
 							image.removeAttribute('data-random-id');
@@ -215,8 +214,6 @@ AUI.add(
 				_onUploadError(event) {
 					var instance = this;
 
-					event.target.cancelUpload();
-
 					instance._removeTempImage(event);
 				},
 
@@ -234,24 +231,21 @@ AUI.add(
 					}
 				},
 
-				_removeTempImage(imageData) {
+				_removeTempImage() {
 					var instance = this;
 
-					if (imageData && imageData.randomId) {
-						var imageId = imageData.randomId;
+					var image = instance._tempImage;
 
-						var image = A.one(instance._editor.element.$).one(
-							'[data-random-id="' + imageId + '"]'
-						);
-
+					if (image) {
 						image.ancestor().remove();
 					}
 
 					var strings = instance.get('strings');
 
-					var alert = instance._getAlert();
-
-					alert.set('bodyContent', strings.uploadingFileError).show();
+					Liferay.Util.openToast({
+						message: strings.uploadingFileError,
+						type: 'danger',
+					});
 				},
 
 				_uploadImage(file, randomId) {
@@ -288,9 +282,7 @@ AUI.add(
 				initializer() {
 					var instance = this;
 
-					var host = instance.get(STR_HOST);
-
-					var editor = host.getNativeEditor();
+					var editor = CKEDITOR.instances[instance.get('editorName')];
 
 					editor.on('imageAdd', instance._onImageAdd, instance);
 
@@ -319,8 +311,7 @@ AUI.add(
 			},
 		});
 
-		A.Plugin.LiferayBlogsUploader = EditorImageUploader;
-		A.Plugin.LiferayEditorImageUploader = EditorImageUploader;
+		Liferay.EditorImageUploader = EditorImageUploader;
 	},
 	'',
 	{

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
@@ -208,6 +208,15 @@
 						path: 'dynamic_select.js',
 						requires: ['aui-base'],
 					},
+					'liferay-editor-image-uploader': {
+						path: 'editor_image_uploader.js',
+						requires: [
+							'aui-alert',
+							'aui-base',
+							'aui-progressbar',
+							'uploader',
+						],
+					},
 					'liferay-form': {
 						path: 'form.js',
 						requires: ['aui-base', 'aui-form-validator'],


### PR DESCRIPTION
We currently support drag & drop images into Blogs Alloy Editor. In this PR, we are adding support for Blogs CKEditor.

To test, add to `portal-ext.properties`
```
editor.wysiwyg.portal-web.docroot.html.portlet.blogs.edit_entry.jsp=ckeditor
```
![after](https://user-images.githubusercontent.com/5435511/89319435-619c1b80-d680-11ea-8025-4b360e63eda5.gif)

Notes:
- Drag & drop images feature requires backend support in modules, it cannot be ootb editor feature. We are applying this to Blogs, it is the only module currently supporting it.
- I needed to convert `EditorImageUploader` from plugin to standalone module because `CKEditor` is not an AUI module, so it cannot be plugged.
- The original `ae_addimages` plugin is [here](https://github.com/liferay/alloy-editor/blob/master/src/plugins/addimages.js), I converted it to ckeditor plugin using neighboring plugin patterns. Notably I removed the [`createSelectionFromPoint` part](https://github.com/liferay/alloy-editor/blob/70b9faf5dfa8d2cc153ab362aa6f27e27a5ca6f1/src/plugins/addimages.js#L155), that simply did not exist in CKEditor.
- There is a bug in this PR: progress bar for upload does not appear below image but on top of the page. This is because `A.ProgressBar` does not like when `boundingBox` node is in `iframe`. It often does not show at all, for unknown reasons. I cannot currently think of a fix, other then to rewrite the progress bar, and we can do that in a followup.
- The upload error handling does not work in master. `cancelUpload` function does not exist on `Uploader` object, so I removed it. I replaced AUI alert, that is invisible on page, with `Liferay.Util.openToast`.