### PR TITLE
LPS-116950 Fix YUI Modals Resizing Behaviour

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
@@ -36,6 +36,10 @@
 	&.modal-dialog-sm {
 		max-width: $modal-md;
 	}
+
+	.yui3-resize-handles-wrapper {
+		pointer-events: all;
+	}
 }
 
 .modal-hidden {


### PR DESCRIPTION
This is basically a workaround/hack to allow pointer events in YUI resize handles

We currently apply `pointer-events: none` to the `modal-dialog` CSS class selector, which prevents the resize handles from receiving events.

This simply overrides that for the specific handles which seems like the minimal possible fix, considering most modals are being migrated to Clay which does not present this issue.

**Test Plan:**
- Navigate to CP > People > Memberships
- Click Add button
- Assert stripes on bottom right corner of modal

**Expected:** The bottom-right handle responds to user interaction and can be dragged to change the size of the modal

By default YUI modals are configured to be resizable with a bottom-right handle, so this can be observed in almost every legacy modal. In this case, this goes through the `selectEntity` API, which maybe we can update soon-ish anyways :)

**The Proof:**
![resize](https://user-images.githubusercontent.com/905006/89375020-19ffa900-d6ed-11ea-97fd-a40e3937421d.gif)
