### PR TITLE
LPS-118500 Liferay unable to load Javascript resources when using a custom root context. | master

### DIFF
--- a/modules/apps/frontend-js/frontend-js-jquery-web/src/main/java/com/liferay/frontend/js/jquery/web/internal/servlet/taglib/JQueryTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-jquery-web/src/main/java/com/liferay/frontend/js/jquery/web/internal/servlet/taglib/JQueryTopHeadDynamicInclude.java
@@ -75,8 +75,7 @@ public class JQueryTopHeadDynamicInclude extends BaseDynamicInclude {
 			sb.append("<script data-senna-track=\"permanent\" src=\"");
 
 			String comboPath = _portal.getStaticResourceURL(
-				httpServletRequest, _portal.getPathContext() + "/combo",
-				"minifierType=js", _lastModified);
+				httpServletRequest, "/combo", "minifierType=js", _lastModified);
 
 			sb.append(
 				absolutePortalURLBuilder.forResource(


### PR DESCRIPTION
**Description**:
- When using a custom root context, combo servlet URL is wrong because the root context is added twice.
- Generated combo servlet URL is related to get JQuery resources (javascript files) when javascript fast load is enabled.
- This has been detected from customer in DXP 7.2. The issue is reproducible in **7.2.x**
- The issue is also reproducible in **master**, but with this environment JQuery library must be enabled (See https://github.com/liferay/liferay-portal/blob/master/readme/BREAKING_CHANGES.markdown#jquery-is-no-longer-included-by-default)

**Steps to reproduce:**

1. Change root context from '/' to another value. For example, changing it to 'myportal' in Tomcat would be:
- Change the ROOT folder name (under LIFERAY_HOME/TOMCAT_HOME/webapps/ROOT) to 'myportal'.
- Change the ROOT.xml file name (under LIFERAY_HOME/TOMCAT_HOME/conf/Catalina/localhost/) to 'myportal.xml'.
- Clear temp and work directories under TOMCAT_HOME.

2.  **On master**: Enable JQuery. Thus, in **osgi/configs/** directory create the file:
   ` com.liferay.frontend.js.jquery.web.internal.configuration.JSJQueryConfiguration.config`
    with following content:
   ` enableJQuery="true"`

3. **On 7.2**: JQuery is enabled by default.

4.  Enter this URL in the browser http://localhost:8080/myportal/web/guest/home?p_p_id=com_liferay_login_web_portlet_LoginPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&saveLastPath=false&_com_liferay_login_web_portlet_LoginPortlet_mvcRenderCommandName=%2Flogin%2Flogin&js_fast_load=1

5. Check in the browser, under developer tools, the request URL generated: 

http://localhost:8080/myportal/myportal/combo?browserId=other&minifierType=js&languageId=es_ES&b=7210&t=1596526812119&/myportal/o/frontend-js-jquery-web/jquery/jquery.min.js&/myportal/o/frontend-js-jquery-web/jquery/bootstrap.bundle.min.js&/myportal/o/frontend-js-jquery-web/jquery/collapsible_search.js&/myportal/o/frontend-js-jquery-web/jquery/fm.js&/myportal/o/frontend-js-jquery-web/jquery/form.js&/myportal/o/frontend-js-jquery-web/jquery/popper.min.js&/myportal/o/frontend-js-jquery-web/jquery/side_navigation.js

Please, note that context '**myportal**' appears twice in the URL. 

**Solution proposed:**
Analysis from debugging shows that in
`modules/apps/frontend-js/frontend-js-jquery-web/src/main/java/com/liferay/frontend/js/jquery/web/internal/servlet/taglib/JQueryTopHeadDynamicInclude.java`, `include() `method, combo servlet URL is built using root context.
But next, `absolutePortalURLBuilder` object appends again root context -> and then we have the double context.

So, I consider the initial combo servlet URL should avoid to add the root context.

Best.
 Sergio.



