### PR TITLE
Disable svg4everybody unless its IE or cross-origin

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-web/.npmbundlerrc
@@ -12,6 +12,7 @@
 		"**/liferay/workflow.js",
 		"**/loader/config.js",
 		"**/misc/swfobject.js",
-		"**/misc/xp_progress.js"
+		"**/misc/xp_progress.js",
+		"**/misc/svg4everybody.es.js"
 	]
 }

--- a/modules/apps/frontend-js/frontend-js-web/bnd.bnd
+++ b/modules/apps/frontend-js/frontend-js-web/bnd.bnd
@@ -5,7 +5,7 @@ Liferay-JS-Resources-Top-Head:\
 	/loader/config.js,\
 	/loader/loader.js,\
 	\
-	/misc/svg4everybody.js,\
+	/misc/svg4everybody.es.js,\
 	\
 	/liferay/dom_task_runner.js,\
 	/liferay/events.js,\

--- a/modules/apps/frontend-js/frontend-js-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-web/build.gradle
@@ -3,7 +3,6 @@ import com.liferay.gradle.util.copy.StripPathSegmentsAction
 task buildClay(type: Copy)
 task buildLiferayAMDLoader(type: Copy)
 task buildLodash(type: Copy)
-task buildSvg4everybody(type: Copy)
 
 File jsDestinationDir = file("tmp/META-INF/resources")
 
@@ -36,26 +35,9 @@ buildLiferayAMDLoader {
 	into new File(jsDestinationDir, "loader")
 }
 
-buildSvg4everybody {
-	dependsOn npmInstall
-	eachFile new StripPathSegmentsAction(2)
-
-	filter {
-		String line ->
-
-		line.replace "\"function\" == typeof define", "false && \"function\" == typeof define"
-	}
-
-	from npmInstall.nodeModulesDir
-	include "svg4everybody/dist/svg4everybody.js"
-	includeEmptyDirs = false
-	into new File(jsDestinationDir, "misc")
-}
-
 classes {
 	dependsOn buildClay
 	dependsOn buildLiferayAMDLoader
-	dependsOn buildSvg4everybody
 }
 
 clean {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/misc/svg4everybody.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/misc/svg4everybody.es.js
@@ -1,0 +1,53 @@
+if (Liferay.Browser.isIe()) {
+	require('svg4everybody');
+} else {
+	const queue = [];
+
+	window.svg4everybody = (args) => {
+		queue.push(args);
+	};
+
+	const requestAnimationFrame = window.requestAnimationFrame || setTimeout;
+
+	let useNodesBypassed = 0;
+
+	const uses = document.getElementsByTagName('use');
+
+	function oninterval() {
+		if (useNodesBypassed && uses.length - useNodesBypassed <= 0) {
+			return void requestAnimationFrame(oninterval, 67);
+		}
+
+		useNodesBypassed = 0;
+
+		for (let index = 0; index < uses.length; index++) {
+			const useNode = uses[index];
+
+			const src =
+				useNode.getAttribute('xlink:href') ||
+				useNode.getAttribute('href');
+
+			if (!src && useNode.hasAttribute('data-href')) {
+				useNode.setAttribute('href', useNode.getAttribute('data-href'));
+			}
+
+			if (src && !src.match(location.origin)) {
+				require('svg4everybody');
+
+				for (let i = 0; i < queue.length; i++) {
+					const args = queue[i];
+
+					svg4everybody(args);
+				}
+
+				return;
+			}
+
+			++useNodesBypassed;
+		}
+
+		requestAnimationFrame(oninterval, 67);
+	}
+
+	oninterval();
+}


### PR DESCRIPTION
I am working on https://issues.liferay.com/browse/LPS-115810 and I am hitting a wall with how to load `svg4everybody` dynamically in the JS. I tested this code out by copying and pasting the svy4everybody file directly in here, but ideally I would be able to grab it from the node_modules.

Here is how this works...

1. If the browser is IE, we use svg4everybody and don't worry about custom logic.
2. If the browser is not IE, we use similar logic as svg4everybody and iterate through all `<use>` tags and replace `data-href` with `href`.
    - If the href is cross origin, we skip our custom logic and opt for svg4everybody.

Any thoughts on how to conditionally load svg4everybody in this file? The `require()` statements do not work. I am also open to other suggestions on how to go about this.