### PR TITLE
LPS-118505 Wrong ellipsis button style on hover

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownActionsTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownActionsTag.java
@@ -14,6 +14,9 @@
 
 package com.liferay.frontend.taglib.clay.servlet.taglib;
 
+import java.util.Map;
+import java.util.Set;
+
 import javax.servlet.jsp.JspException;
 
 /**
@@ -30,6 +33,20 @@ public class DropdownActionsTag extends DropdownMenuTag {
 		setMonospaced(true);
 
 		return super.doStartTag();
+	}
+
+	@Override
+	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("actionsDropdown", true);
+
+		return super.prepareProps(props);
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		cssClasses.add("component-action");
+
+		return super.processCssClasses(cssClasses);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:dropdown-actions:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -51,8 +51,7 @@ export default function DropdownMenu({
 					<ClayButton className={cssClass} {...otherProps}>
 						{icon && (
 							<span
-								className={classNames({
-									'inline-item': label,
+								className={classNames('inline-item', {
 									'inline-item-before': label,
 								})}
 							>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -20,6 +20,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 export default function DropdownMenu({
+	actionsDropdown = false,
 	componentId: _componentId,
 	cssClass,
 	icon,
@@ -33,6 +34,9 @@ export default function DropdownMenu({
 	return (
 		<>
 			<ClayDropDownWithItems
+				className={classNames({
+					'dropdown-action': actionsDropdown,
+				})}
 				items={items.map(({data, ...rest}) => {
 					const dataAttributes = data
 						? Object.entries(data).reduce((acc, [key, value]) => {
@@ -48,7 +52,12 @@ export default function DropdownMenu({
 					};
 				})}
 				trigger={
-					<ClayButton className={cssClass} {...otherProps}>
+					<ClayButton
+						className={classNames(cssClass, {
+							'component-action': actionsDropdown,
+						})}
+						{...otherProps}
+					>
 						{icon && (
 							<span
 								className={classNames('inline-item', {


### PR DESCRIPTION
**Description**

After a conversation with @susanavr and @drakonux, the ellipsis button should have:

* Size: 32x32px 
* Style on hover: change color and background color

This occurs in the search container dropdown items in two display types: list and table.

**Fix**

* Wrong ellipsis button size and style on hover: https://issues.liferay.com/browse/LPS-118505

**Lexicon definition**

![lexicon-list](https://user-images.githubusercontent.com/15845466/89517573-2c0b4580-d7da-11ea-8b31-91058e039c7f.jpg)

**Before**

* Size: 40x40px
* No changes on hover

<img width="1118" alt="Screenshot 2020-08-06 at 11 33 23" src="https://user-images.githubusercontent.com/15845466/89516490-cb2f3d80-d7d8-11ea-963f-980b3c464494.png"> <img width="1111" alt="Screenshot 2020-08-06 at 11 34 17" src="https://user-images.githubusercontent.com/15845466/89516493-cc606a80-d7d8-11ea-8749-e99f88e35e75.png">

**After**

* Size: 32x32px
* Color and background color change on hover

<img width="1111" alt="Screenshot 2020-08-06 at 11 33 33" src="https://user-images.githubusercontent.com/15845466/89516586-ea2dcf80-d7d8-11ea-9f09-007ebd0bd547.png"> <img width="1116" alt="Screenshot 2020-08-06 at 11 34 03" src="https://user-images.githubusercontent.com/15845466/89516590-eb5efc80-d7d8-11ea-9ebd-6572426c75c1.png">
