### PR TITLE
LPS-118539 The table borders are missing in wiki

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorCreoleConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorCreoleConfigContributor.java
@@ -72,7 +72,8 @@ public class CKEditorCreoleConfigContributor
 		).put(
 			"disableObjectResizing", Boolean.TRUE
 		).put(
-			"extraPlugins", "a11yhelpbtn,creole,itemselector,lfrpopup,wikilink"
+			"extraPlugins",
+			"a11yhelpbtn,creole,itemselector,lfrpopup,showborders,wikilink"
 		).put(
 			"filebrowserWindowFeatures",
 			"title=" + LanguageUtil.get(themeDisplay.getLocale(), "browse")


### PR DESCRIPTION
The table borders don't show when the user is editing a wiki entry.

**Before**

![image](https://user-images.githubusercontent.com/67901/89521638-27499000-d7e0-11ea-9539-9adee8433f24.png)

**After**
![image](https://user-images.githubusercontent.com/67901/89521736-58c25b80-d7e0-11ea-9364-77037fd459fb.png)

