### PR TITLE
LPS-118524 Fixes CKEditor ImageSelector in Message Boards

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -111,6 +111,12 @@ const ClassicEditor = ({
 					CKEDITOR.dtd.$removeEmpty.i = 0;
 					CKEDITOR.dtd.$removeEmpty.span = 0;
 
+					CKEDITOR.getNextZIndex = function () {
+						return CKEDITOR.dialog._.currentZIndex
+							? CKEDITOR.dialog._.currentZIndex + 10
+							: Liferay.zIndex.WINDOW + 10;
+					};
+
 					CKEDITOR.on('instanceCreated', ({editor}) => {
 						editor.name = name;
 


### PR DESCRIPTION
**Steps to Reproduce:**

- Navigate to message boards
- Add Thread
- Try to add image in ckeditor by clicking image icon or drag and drop

**PS:** Drag & Drop has nothing to do here since it was never supported properly. Clicking on the ImageSelector though should indeed open the selection modal

**The Problem:**
We forgot to define `CKEDITOR.getNextZindex` method in our `<ClassicEditor>` component, which is used by the `ImageSelector` plugin.

**The Fix:**
For now, simply moving over the `getNextZIndex` implementation. Feels like there's room for improvement here to either remove the dependency from the plugins or make this more obvious via plugins or some mechanism that doesn't feel like monkey-patching.

**The Proof:**
![mb](https://user-images.githubusercontent.com/905006/89545986-55d96200-d804-11ea-9359-ef3f13babed0.gif)


