### PR TITLE
LPS-118651 Adds custom request param to identify routed requests

### DIFF
--- a/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/java/com/liferay/portal/portlet/bridge/soy/internal/SoyPortlet.java
+++ b/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/java/com/liferay/portal/portlet/bridge/soy/internal/SoyPortlet.java
@@ -359,6 +359,8 @@ public class SoyPortlet extends MVCPortlet {
 			portletNamespace + "pjax", "true");
 
 		redirect = HttpUtil.setParameter(redirect, "p_p_lifecycle", "2");
+		redirect = HttpUtil.setParameter(
+			redirect, portletNamespace + "soy_route", true);
 
 		httpServletResponse.sendRedirect(redirect);
 	}
@@ -518,8 +520,7 @@ public class SoyPortlet extends MVCPortlet {
 	}
 
 	private boolean _isRoutedRequest(PortletRequest portletRequest) {
-		return Validator.isNotNull(
-			portletRequest.getParameter("original_p_p_lifecycle"));
+		return Validator.isNotNull(portletRequest.getParameter("soy_route"));
 	}
 
 	private void _prepareSessionMessages(

--- a/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/resources/META-INF/resources/router/SoyPortletRouter.js
+++ b/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/resources/META-INF/resources/router/SoyPortletRouter.js
@@ -123,6 +123,9 @@ class SoyPortletRouter extends State {
 				const uri = new URL(redirect, window.location.origin);
 				uri.searchParams.delete('p_p_lifecycle');
 				uri.searchParams.delete(`${instance.portletNamespace}pjax`);
+				uri.searchParams.delete(
+					`${instance.portletNamespace}soy_route`
+				);
 
 				if (
 					uri.searchParams.has(
@@ -230,10 +233,11 @@ class SoyPortletRouter extends State {
 
 		uri.searchParams.set('p_p_lifecycle', '2');
 		uri.searchParams.set(`${this.portletNamespace}pjax`, true);
+		uri.searchParams.set(`${this.portletNamespace}soy_route`, true);
 
 		if (!uri.searchParams.has('p_p_id')) {
-			uri.searchParams.add('p_p_id', this.portletId);
-			uri.searchParams.add(`${this.portletNamespace}no_p_p_id`, true);
+			uri.searchParams.append('p_p_id', this.portletId);
+			uri.searchParams.append(`${this.portletNamespace}no_p_p_id`, true);
 		}
 
 		return uri.toString();


### PR DESCRIPTION
This is a possible fix for [Hello Soy Portlet uncaught type errors](https://issues.liferay.com/browse/LPS-118651)

Even if the report is specific to the Hello Soy Portlet which is not present in `master`, the truth is that this is caused in the underlying infrastructure which it still is.

**The Problem:**
This was likely caused by the solution applied to [Serving a MVCResourceCommand in a SoyPortlet triggers unnecessary rendering](https://issues.liferay.com/browse/LPS-91062) which makes any requests without `p_p_lifecycle` in their URL fail to be properly routed and return an empty `serveResource` body instead.

**The fix:**
Add an additional parameter `soy_route` (be my guest and find a better name for it) so there's no overlap with other features. If the param is there, it's a routed request, if not, it isn't (or so I hope). 

**Test plan:**
I tested this on `7.2.x` (haven't tested in `master`, so I might've messed up in translation)

#### LPS-118651
- Add the Hello Soy Portlet to a page

Assert that navigation and submission works in the portlet

#### LPS-91062
- Go to Content -> Documents and Media.
- Create a Basic Document.
- Click on the document's action menu and click Share.
- Type something in the autocomplete.

Assert that no errors are being thrown in the console (I previously checked that making `isRoutedRequest` always return `true` makes this reproducible.