### PR TITLE
LPS-117986 Fixes query selection in CKEditor autocomplete plugin

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/autocomplete/autocomplete.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/autocomplete/autocomplete.js
@@ -183,24 +183,26 @@
 				}
 			});
 
-			// What follows is an algorithm to properly select the query from the
-			// last detected trigger. Because of the HTML structure, it's not as
-			// straightforward as a text search.
+			// What follows is an algorithm to properly select the query
+			// from the last detected trigger. Because of the HTML
+			// structure, it's not as straightforward as a text search.
 			//
-			// If triggerIndex === -1, the trigger is not in the current html node
-			// element. Thus, we walk the DOM tree upwards until we find it,
-			// constructing the query as we visit the nodes in the tree.
+			// If triggerIndex === -1, the trigger is not in the current
+			// HTML node element. Thus, we walk the DOM tree upwards
+			// until we find it, constructing the query as we visit the
+			// nodes in the tree.
 			//
-			// If triggerIndex > 1, we found the trigger in a longer text sequence.
-			// We check if the char to the trigger is a space (' ' or nbsp;) by
-			// checking assserting that trimming the char returns false or a
-			// filler char (\u200b) for webkit-based engines. If that's the case,
-			// we take the substring from triggerPosition forward and discard
-			// the rest of the text sequence.
+			// If triggerIndex > 0, we found the trigger in a longer
+			// text sequence.  We check if the char before the trigger
+			// is a space (' ' or nbsp;) by checking that trimming
+			// the char returns false or a filler char (\u200b) for
+			// WebKit-based engines. If that's the case, we take the
+			// substring from triggerPosition forward and discard the
+			// rest of the text sequence.
 			//
-			// If triggerIndex === 1, the trigger is the first char in the sequence
-			// which means it's already the right query and has no additional
-			// characters.
+			// If triggerIndex === 0, the trigger is the first char in
+			// the sequence which means it's already the right query and
+			// has no additional characters.
 
 			if (triggerIndex === -1) {
 				var triggerWalker = instance._getWalker(triggerContainer);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/autocomplete/autocomplete.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/autocomplete/autocomplete.js
@@ -383,7 +383,8 @@
 
 			if (
 				!replaceContainer ||
-				!replaceContainer.hasClass('lfr-ac-content')
+				!replaceContainer.hasClass('lfr-ac-content') ||
+				prevTriggerPosition.value
 			) {
 				replaceContainer = prevTriggerPosition.container.split(
 					prevTriggerPosition.index

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/autocomplete/autocomplete.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/autocomplete/autocomplete.js
@@ -183,6 +183,25 @@
 				}
 			});
 
+			// What follows is an algorithm to properly select the query from the
+			// last detected trigger. Because of the HTML structure, it's not as
+			// straightforward as a text search.
+			//
+			// If triggerIndex === -1, the trigger is not in the current html node
+			// element. Thus, we walk the DOM tree upwards until we find it,
+			// constructing the query as we visit the nodes in the tree.
+			//
+			// If triggerIndex > 1, we found the trigger in a longer text sequence.
+			// We check if the char to the trigger is a space (' ' or nbsp;) by
+			// checking assserting that trimming the char returns false or a
+			// filler char (\u200b) for webkit-based engines. If that's the case,
+			// we take the substring from triggerPosition forward and discard
+			// the rest of the text sequence.
+			//
+			// If triggerIndex === 1, the trigger is the first char in the sequence
+			// which means it's already the right query and has no additional
+			// characters.
+
 			if (triggerIndex === -1) {
 				var triggerWalker = instance._getWalker(triggerContainer);
 
@@ -230,7 +249,8 @@
 			}
 			else if (
 				triggerIndex > 0 &&
-				query.charAt(triggerIndex - 1) === STR_SPACE
+				(!query.charAt(triggerIndex - 1).trim() ||
+					query.charAt(triggerIndex - 1) === '\u200b')
 			) {
 				query = query.substring(triggerIndex);
 			}


### PR DESCRIPTION
Revamp of https://github.com/liferay-frontend/liferay-portal/pull/204

> I haven't had a lot of time to look into this, but from what I've seen, the issue is related to [#10031 CKEditor injects special character in Chrome](https://dev.ckeditor.com/ticket/10031). This is to be expected on Webkit-based browsers and CKEditor accounts for in its [FILLING_CHAR_SEQUENCE](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_selection.html#property-FILLING_CHAR_SEQUENCE)
>
> What I'm seeing is that in presence of the filler char, our computation is off by as many filler chars as present, making the query fail. Curiously enough, an arrow movement (back) or mouse click make the fillers go away and allow the autocomplete to show again.

As stated in the commit message:

Depending on the scenario, the character before the last trigger can be:
- A space
- An `&nbsp;` entity
- A filler sequence (7 `\u200b` chars in webkit browsers)

This PR simply makes sure that all 3 are detected as limits for the query sequence.

This should fix:
- [LPP-38325 Cannot add 2 consecutive mentions](https://issues.liferay.com/browse/LPP-38325) (positive)
- [LPP-38323 Second mention overwrites the first one](https://issues.liferay.com/browse/LPP-38323) (hopeful)

@antonio-ortega, @holatuwol, @hongvo2308, could you test this solution to see if it works as you'd expect? As I said, I didn't carry over the previous modification since I wasn't sure what was its intended effect. Please, feel free to clarify and work with someone on the team to add it to the PR if indeed necessary!
