### PR TITLE
LPS-118717 Create a deep copy of icon in case it already exists

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor_source.js
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor_source.js
@@ -91,15 +91,15 @@ AUI.add(
 
 					var currentState = MAP_TOGGLE_STATE[instance._isVisible];
 
-					if (!currentState.icon) {
+					if (currentState.icon) {
+						icon = currentState.icon.cloneNode(true);
+					}
+					else {
 						icon = Liferay.Util.getLexiconIcon(
 							currentState.iconCssClass
 						);
 
 						currentState.icon = icon;
-					}
-					else {
-						icon = currentState.icon.cloneNode(true);
 					}
 
 					return icon;

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor_source.js
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor_source.js
@@ -87,16 +87,19 @@ AUI.add(
 				_getEditorStateLexiconIcon() {
 					var instance = this;
 
+					var icon;
+
 					var currentState = MAP_TOGGLE_STATE[instance._isVisible];
 
-					var icon = currentState.icon;
-
-					if (!icon) {
+					if (!currentState.icon) {
 						icon = Liferay.Util.getLexiconIcon(
 							currentState.iconCssClass
 						);
 
 						currentState.icon = icon;
+					}
+					else {
+						icon = currentState.icon.cloneNode(true);
 					}
 
 					return icon;


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

Thanks!

**Steps to reproduce**

1. Start Liferay
2. Create a new Web Content Structure with two HTML Fields
3. Create a new Web Content from that structure
4. Click in the first HTML input field and switch to source format (the button with the label "</>")
5. Before doing anything else, go to the second HTML field and click the same "</>" button

**Expected behavior**
The source icon in the first field remains the same.

**Actual behavior**
The source icon in the first field has disappeared.

**Root cause**
We are reusing the same SVG icon that was already available in the DOM and we are using [replace](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor_source.js#L310) function to do it. According to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Node/replaceChild) this takes in (newNode, oldNode) parameters, and if newNode already exists in the DOM it will be removed.

**Proposed solution**
To rewrite __getEditorStateLexiconIcon_() method inside alloyeditor_source.js to create a "clear copy" of it instead of reusing it

Original information [here](https://issues.liferay.com/browse/LPS-118717?focusedCommentId=2220181&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2220181).

/cc @NemethNorbert