### PR TITLE
LPS-115764 Add support for pasting embed images in html documents

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -227,45 +227,47 @@
 
 				fragment.forEach((element) => {
 					if (
-						element.type === CKEDITOR.NODE_ELEMENT &&
-						element.name === 'img'
+						element.type !== CKEDITOR.NODE_ELEMENT ||
+						element.name !== 'img'
 					) {
-						const base64Regex = /^data:image\/(.*);base64,/;
-						const match = element.attributes.src.match(base64Regex);
+						return;
+					}
 
-						if (element.attributes.src && match) {
-							const src = element.attributes.src;
-							const extension = match[1];
-							const name = `${Date.now().toString()}.${extension}`;
+					const base64Regex = /^data:image\/(.*);base64,/;
+					const match = element.attributes.src.match(base64Regex);
 
-							// Mark this "src" attribute as something we want to replace
+					if (element.attributes.src && match) {
+						const src = element.attributes.src;
+						const extension = match[1];
+						const name = `${Date.now().toString()}.${extension}`;
 
-							this._imageSrcToReplace.push(src);
+						// Mark this "src" attribute as something we want to replace
 
-							this._fetchBlob(src)
-								.then((blob) => {
-									const file = new File([blob], name, {
-										type: blob.type,
-									});
+						this._imageSrcToReplace.push(src);
 
-									const element = CKEDITOR.dom.element.createFromHtml(
-										`<img src="${src}">`
-									);
-
-									editor.fire('imageAdd', {
-										el: element,
-										file,
-									});
-								})
-								.catch(() => {
-									Liferay.Util.openToast({
-										message: Liferay.Language.get(
-											'an-unexpected-error-occurred-while-uploading-your-file'
-										),
-										type: 'danger',
-									});
+						this._fetchBlob(src)
+							.then((blob) => {
+								const file = new File([blob], name, {
+									type: blob.type,
 								});
-						}
+
+								const element = CKEDITOR.dom.element.createFromHtml(
+									`<img src="${src}">`
+								);
+
+								editor.fire('imageAdd', {
+									el: element,
+									file,
+								});
+							})
+							.catch(() => {
+								Liferay.Util.openToast({
+									message: Liferay.Language.get(
+										'an-unexpected-error-occurred-while-uploading-your-file'
+									),
+									type: 'danger',
+								});
+							});
 					}
 				});
 			}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -56,8 +56,8 @@
 		 * @instance
 		 * @memberof CKEDITOR.plugins.addimages
 		 * @method _handleFiles
-		 * @param {Array} files Array of dropped files. Only the images from this list will be processed.
-		 * @param {Object} editor The current editor instance
+		 * @param {Array.<File>} files Array of dropped files. Only the images from this list will be processed
+		 * @param {CKEDITOR.editor} editor The current editor instance
 		 * @protected
 		 */
 		_handleFiles(files, editor) {
@@ -90,14 +90,14 @@
 		},
 
 		/**
-		 * Handles drag drop event. The function will create a selection from the current
+		 * Handles drop event. The function will create a selection from the current
 		 * point and will send a list of files to be processed to
 		 * {{#crossLink "CKEDITOR.plugins.addimages/_handleFiles:method"}}{{/crossLink}} method.
 		 *
 		 * @instance
 		 * @memberof CKEDITOR.plugins.addimages
 		 * @method _onDragDrop
-		 * @param {CKEDITOR.dom.event} event dragdrop event, as received natively from CKEditor
+		 * @param {CKEDITOR.eventInfo} Facade for the native `drop` event
 		 * @protected
 		 */
 		_onDragDrop(event) {
@@ -115,12 +115,12 @@
 		},
 
 		/**
-		 * Handles drag enter event. In case of IE, this function will prevent the event.
+		 * Handles dragenter event. In case of IE, this function will prevent the event.
 		 *
 		 * @instance
 		 * @memberof CKEDITOR.plugins.addimages
 		 * @method _onDragEnter
-		 * @param {DOM event} event dragenter event, as received natively from CKEditor
+		 * @param {CKEDITOR.eventInfo} Facade for the native `dragenter` event
 		 * @protected
 		 */
 		_onDragEnter(event) {
@@ -130,12 +130,12 @@
 		},
 
 		/**
-		 * Handles drag over event. In case of IE, this function will prevent the event.
+		 * Handles dragover event. In case of IE, this function will prevent the event.
 		 *
 		 * @instance
 		 * @memberof CKEDITOR.plugins.addimages
 		 * @method _onDragOver
-		 * @param {DOM event} event dragover event, as received natively from CKEditor
+		 * @param {CKEDITOR.eventInfo} event Facade for the native `dragover` event
 		 * @protected
 		 */
 		_onDragOver(event) {
@@ -182,14 +182,14 @@
 		},
 
 		/**
-		 * Checks if the pasted data is image or html.
+		 * Checks if the pasted data is a dropped image or html.
 		 * In the case of images, it passes it to
 		 * {{#crossLink "CKEDITOR.plugins.addimages/_processFile:method"}}{{/crossLink}} for processing.
 		 *
 		 * @instance
 		 * @memberof CKEDITOR.plugins.addimages
 		 * @method _onPaste
-		 * @param {CKEDITOR.dom.event} event A `paste` event, as received natively from CKEditor
+		 * @param {CKEDITOR.eventInfo} event Facade for the native `paste` event
 		 * @protected
 		 */
 		_onPaste(event) {
@@ -264,7 +264,7 @@
 		 * @instance
 		 * @memberof CKEDITOR.plugins.addimages
 		 * @method _preventEvent
-		 * @param {DOM event} event The event to be prevented.
+		 * @param {CKEDITOR.eventInfo} event Facade for the native event to be prevented
 		 * @protected
 		 */
 		_preventEvent(event) {
@@ -281,8 +281,9 @@
 		 * @fires CKEDITOR.plugins.addimages#imageAdd
 		 * @instance
 		 * @memberof CKEDITOR.plugins.addimages
-		 * @method _preventEvent
-		 * @param {DOM event} event The event to be prevented.
+		 * @method _processFile
+		 * @param {File} file The file to be processed
+		 * @param {CKEDITOR.editor} editor The current editor instance
 		 * @protected
 		 */
 		_processFile(file, editor) {
@@ -315,7 +316,7 @@
 		 * @instance
 		 * @memberof CKEDITOR.plugins.addimages
 		 * @method init
-		 * @param {Object} editor The current editor instance
+		 * @param {CKEDITOR.editor} editor The current editor instance
 		 */
 		init(editor) {
 			editor.once('contentDom', () => {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -150,13 +150,12 @@
 		 * @instance
 		 * @memberof CKEDITOR.plugins.addimages
 		 * @method _onImageUploaded
-		 * @param {Object} event Event data
+		 * @param {Image} image The image that was uploaded
+		 * @param {CKEDITOR.editor} editor The current editor instance
 		 * @protected
 		 */
-		_onImageUploaded(event) {
+		_onImageUploaded(image, editor) {
 			const instance = this;
-
-			const {editor, el} = event;
 
 			const fragment = CKEDITOR.htmlParser.fragment.fromHtml(
 				editor.getData()
@@ -165,8 +164,8 @@
 			const filter = new CKEDITOR.htmlParser.filter({
 				elements: {
 					img(element) {
-						if (el.src === instance._tempImage.src) {
-							element.attributes.src = el.src;
+						if (image.src === instance._tempImage.src) {
+							element.attributes.src = image.src;
 						}
 					},
 				},
@@ -429,16 +428,32 @@
 
 							imageContainer.remove();
 
-							const eventInfo = {
+							editor.fire('imageUploaded', {
 								editor,
 								el: image,
 								fileEntryId: data.file.fileEntryId,
 								uploadImageReturnType: '',
-							};
+							});
 
-							editor.fire('imageUploaded', eventInfo);
+							const fragment = CKEDITOR.htmlParser.fragment.fromHtml(
+								editor.getData()
+							);
 
-							this._onImageUploaded(eventInfo);
+							let imageFound = false;
+
+							fragment.forEach((element) => {
+								if (
+									element.type === CKEDITOR.NODE_ELEMENT &&
+									element.attributes['data-image-id'] ===
+										image.dataset.imageId
+								) {
+									imageFound = true;
+								}
+							});
+
+							if (!imageFound) {
+								this._onImageUploaded(image, editor);
+							}
 						}
 					}
 					else {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -335,8 +335,8 @@
 				editor.on('dragenter', this._onDragEnter.bind(this));
 				editor.on('dragover', this._onDragOver.bind(this));
 				editor.on('drop', this._onDragDrop.bind(this));
-				editor.on('paste', this._onPaste.bind(this));
 				editor.on('imageUploaded', this._onImageUploaded.bind(this));
+				editor.on('paste', this._onPaste.bind(this));
 			});
 
 			AUI().use('aui-progressbar,uploader', (A) => {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -252,12 +252,10 @@
 										`<img src="${src}">`
 									);
 
-									const imageData = {
+									editor.fire('imageAdd', {
 										el: element,
 										file,
-									};
-
-									editor.fire('imageAdd', imageData);
+									});
 								})
 								.catch(() => {
 									Liferay.Util.openToast({

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -248,12 +248,12 @@
 										type: blob.type,
 									});
 
-									const el = CKEDITOR.dom.element.createFromHtml(
+									const element = CKEDITOR.dom.element.createFromHtml(
 										`<img src="${src}">`
 									);
 
 									const imageData = {
-										el,
+										el: element,
 										file,
 									};
 


### PR DESCRIPTION
The `addimages` plugin will now upload image using data urls
in their `src` attribute.

**Before**:

![Before](https://user-images.githubusercontent.com/5572/89782064-d5bd4000-db14-11ea-81a1-bb1cbc05e716.gif)


**After**:

![After](https://user-images.githubusercontent.com/5572/89782086-e077d500-db14-11ea-9271-8a91f52a138c.gif)

