### PR TITLE
LPS-118745 Adds a test suite to cover common cases of loading a field in Metal+Soy

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/package.json
@@ -21,7 +21,7 @@
 		"build": "liferay-npm-scripts build",
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix",
-		"test": "liferay-npm-scripts test"
+		"test": "metalsoy -s \"test/**/*.soy\" -d \"test\" && liferay-npm-scripts test"
 	},
 	"version": "5.0.26"
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/Field/MetalComponentAdapter.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/Field/MetalComponentAdapter.es.js
@@ -57,12 +57,12 @@ export const MetalComponentAdapter = ({
 					onRemoved: (_, event) =>
 						dispatch({
 							payload: event,
-							type: EVENT_TYPES.REMOVED,
+							type: EVENT_TYPES.FIELD_REMOVED,
 						}),
 					onRepeated: (_, event) =>
 						dispatch({
 							payload: event,
-							type: EVENT_TYPES.REPEATED,
+							type: EVENT_TYPES.FIELD_REPEATED,
 						}),
 					pageIndex,
 					spritemap,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/Field/MetalFieldAdapter.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/Field/MetalFieldAdapter.es.js
@@ -21,7 +21,7 @@ import templates from './MetalFieldAdapter.soy';
 class MetalFieldAdapter extends Component {
 	getChildContext() {
 		return {
-			dispatch: this._handleDispatch,
+			dispatch: this._handleDispatch.bind(this),
 			store: {
 				editingLanguageId: this.editingLanguageId,
 			},
@@ -72,6 +72,8 @@ MetalFieldAdapter.STATE = {
 	onBlur: Config.any(),
 	onChange: Config.any(),
 	onFocus: Config.any(),
+	onRemoved: Config.any(),
+	onRepeated: Config.any(),
 	pageIndex: Config.number(),
 	spritemap: Config.string(),
 	type: Config.string(),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/Field/FieldCompabilityLayer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/Field/FieldCompabilityLayer.es.js
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {waitForElement} from '@testing-library/dom';
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import {EVENT_TYPES} from '../../../src/main/resources/META-INF/resources/js/actions/eventTypes.es';
+import {Field} from '../../../src/main/resources/META-INF/resources/js/components/Field/Field.es';
+import {FormNoopProvider} from '../../../src/main/resources/META-INF/resources/js/hooks/useForm.es';
+import {PageProvider} from '../../../src/main/resources/META-INF/resources/js/hooks/usePage.es';
+import MetalFieldMock from '../__mock__/MetalFieldMock.es';
+
+const fieldTypes = [
+	{
+		javaScriptModule: 'MetalFieldMock.es',
+		name: 'metal_field',
+	},
+];
+
+const fieldProps = {
+	name: 'metal_field_name',
+	type: 'metal_field',
+	value: 'Foo',
+};
+
+const FieldWithProvider = ({field, onBlur, onChange, onEvent, onFocus}) => (
+	<FormNoopProvider onEvent={onEvent}>
+		<PageProvider value={{fieldTypes}}>
+			<Field
+				field={field}
+				onBlur={onBlur}
+				onChange={onChange}
+				onFocus={onFocus}
+			/>
+		</PageProvider>
+	</FormNoopProvider>
+);
+
+describe('FieldCompabilityLayer -> Metal+Soy', () => {
+	const originalLiferayLoader = window.Liferay.Loader;
+
+	beforeAll(() => {
+		window.Liferay = {
+			...window.Liferay,
+			Loader: {
+				require: (modules, resolve) =>
+					resolve({default: MetalFieldMock}),
+			},
+		};
+	});
+
+	afterAll(() => {
+		window.Liferay.Loader = originalLiferayLoader;
+	});
+
+	afterEach(cleanup);
+
+	it('renders the Metal field', async () => {
+		const {container} = render(<FieldWithProvider field={fieldProps} />);
+
+		await waitForElement(() => container.querySelector('input'), {
+			container,
+		});
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('dispatch an onChange event when editing some field value', async () => {
+		const onChange = jest.fn();
+
+		const {container} = render(
+			<FieldWithProvider field={fieldProps} onChange={onChange} />
+		);
+
+		await waitForElement(() => container.querySelector('input'), {
+			container,
+		});
+
+		const input = container.querySelector('input');
+
+		fireEvent.input(input, {
+			target: {
+				value: 'test',
+			},
+		});
+
+		expect(onChange).toHaveBeenCalledWith({
+			fieldInstance: expect.any(Object),
+			originalEvent: expect.any(Object),
+			value: 'test',
+		});
+	});
+
+	it('dispatch the onBlur event', async () => {
+		const onBlur = jest.fn();
+
+		const {container} = render(
+			<FieldWithProvider field={fieldProps} onBlur={onBlur} />
+		);
+
+		await waitForElement(() => container.querySelector('input'), {
+			container,
+		});
+
+		const input = container.querySelector('input');
+
+		fireEvent.blur(input);
+
+		expect(onBlur).toHaveBeenCalledWith(
+			{
+				fieldInstance: expect.any(Object),
+				originalEvent: expect.any(Object),
+				value: undefined,
+			},
+			expect.any(Object)
+		);
+	});
+
+	it('dispatch the onFocus event', async () => {
+		const onFocus = jest.fn();
+
+		const {container} = render(
+			<FieldWithProvider field={fieldProps} onFocus={onFocus} />
+		);
+
+		await waitForElement(() => container.querySelector('input'), {
+			container,
+		});
+
+		const input = container.querySelector('input');
+
+		fireEvent.focus(input);
+
+		expect(onFocus).toHaveBeenCalledWith({
+			fieldInstance: expect.any(Object),
+			originalEvent: expect.any(Object),
+			value: undefined,
+		});
+	});
+
+	it('dispatch the EVENT_TYPES.FIELD_REMOVED event when removing the field repeated', async () => {
+		const onEvent = jest.fn();
+
+		const {container, getByText} = render(
+			<FieldWithProvider field={fieldProps} onEvent={onEvent} />
+		);
+
+		await waitForElement(() => getByText('Remove'), {container});
+
+		const button = getByText('Remove');
+
+		fireEvent.click(button);
+
+		expect(onEvent).toHaveBeenCalledWith(
+			EVENT_TYPES.FIELD_REMOVED,
+			'metal_field_name'
+		);
+	});
+
+	it('dispatch the EVENT_TYPES.FIELD_REPEATED event when repeating the same field', async () => {
+		const onEvent = jest.fn();
+
+		const {container, getByText} = render(
+			<FieldWithProvider field={fieldProps} onEvent={onEvent} />
+		);
+
+		await waitForElement(() => getByText('Duplicate'), {container});
+
+		const button = getByText('Duplicate');
+
+		fireEvent.click(button);
+
+		expect(onEvent).toHaveBeenCalledWith(
+			EVENT_TYPES.FIELD_REPEATED,
+			'metal_field_name'
+		);
+	});
+});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/Field/__snapshots__/FieldCompabilityLayer.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/Field/__snapshots__/FieldCompabilityLayer.es.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FieldCompabilityLayer -> Metal+Soy renders the Metal field 1`] = `
+<div>
+  <div
+    class="ddm-field"
+    style=""
+  >
+    <div>
+      <div>
+        <button
+          class="btn btn-danger"
+          type="button"
+        >
+          Remove
+        </button>
+        <button
+          class="btn btn-primary"
+          type="button"
+        >
+          Duplicate
+        </button>
+        <input
+          class="form-control"
+          value="Foo"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/__mock__/MetalFieldMock.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/__mock__/MetalFieldMock.es.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import './MetalFieldMockRegister.soy';
+
+import Component from 'metal-component';
+import Soy from 'metal-soy';
+import {Config} from 'metal-state';
+
+import templates from './MetalFieldMock.soy';
+
+class MetalFieldMock extends Component {
+	dispatch(...args) {
+		const {dispatch} = this.context;
+
+		(dispatch || this.emit).apply(this, args);
+	}
+
+	_handleDuplicateClick() {
+		this.dispatch('fieldRepeated', this.name);
+	}
+
+	_handleRemoveClick() {
+		this.dispatch('fieldRemoved', this.name);
+	}
+
+	_handleInputBlur(event) {
+		this.emit('fieldBlurred', {
+			fieldInstance: this,
+			originalEvent: event,
+			value: event.target.value,
+		});
+	}
+
+	_handleInputFocus(event) {
+		this.emit('fieldFocused', {
+			fieldInstance: this,
+			originalEvent: event,
+			value: event.target.value,
+		});
+	}
+
+	_handleInputChange(event) {
+		this.emit('fieldEdited', {
+			fieldInstance: this,
+			originalEvent: event,
+			value: event.target.value,
+		});
+	}
+}
+
+MetalFieldMock.STATE = {
+	name: Config.string(),
+};
+
+Soy.register(MetalFieldMock, templates);
+
+export default MetalFieldMock;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/__mock__/MetalFieldMock.soy
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/__mock__/MetalFieldMock.soy
@@ -16,6 +16,7 @@
 		>
 			Remove
 		</button>
+
 		<button
 			class="btn btn-primary"
 			data-onclick="{$_handleDuplicateClick}"
@@ -23,6 +24,7 @@
 		>
 			Duplicate
 		</button>
+
 		<input
 			class="form-control"
 			data-onblur="{$_handleInputBlur}"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/__mock__/MetalFieldMock.soy
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/__mock__/MetalFieldMock.soy
@@ -1,0 +1,34 @@
+{namespace MetalFieldMock}
+
+{template .render}
+	{@param? _handleDuplicateClick: any}
+	{@param? _handleInputBlur: any}
+	{@param? _handleInputChange: any}
+	{@param? _handleInputFocus: any}
+	{@param? _handleRemoveClick: any}
+	{@param? value: string}
+
+	<div>
+		<button
+			class="btn btn-danger"
+			data-onclick="{$_handleRemoveClick}"
+			type="button"
+		>
+			Remove
+		</button>
+		<button
+			class="btn btn-primary"
+			data-onclick="{$_handleDuplicateClick}"
+			type="button"
+		>
+			Duplicate
+		</button>
+		<input
+			class="form-control"
+			data-onblur="{$_handleInputBlur}"
+			data-onfocus="{$_handleInputFocus}"
+			data-oninput="{$_handleInputChange}"
+			value="{$value}"
+		/>
+	</div>
+{/template}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/__mock__/MetalFieldMockRegister.soy
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/__mock__/MetalFieldMockRegister.soy
@@ -1,0 +1,5 @@
+{namespace MetalFieldMockRegister}
+
+{deltemplate PageRenderer.RegisterFieldType variant="'metal_field'"}
+	{call MetalFieldMock.render data="all" /}
+{/deltemplate}


### PR DESCRIPTION
These are just a few tests that cover the main cases of backward compatibility for DDM fields in Metal + Soy, according to the conversation with John and Bruno at https://issues.liferay.com/browse/LPS-117051 about this we decided to create a unit test so that it is not just the manual test. Halfway through I ended up discovering a bug in the Repeated and Remove events, So that was good 🙂.