### PR TITLE
LPS-115812 - Remove "lexicon" path in favor of "clay" path for icons

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/create_asset_list.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/create_asset_list.jsp
@@ -39,7 +39,7 @@ String portletResource = ParamUtil.getString(request, "portletResource");
 			mainFieldPlaceholder: '<liferay-ui:message key="title" />',
 			namespace:
 				'<%= PortalUtil.getPortletNamespace(HtmlUtil.escape(portletResource)) %>',
-			spritemap: '<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg',
+			spritemap: '<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg',
 		});
 	}
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -309,8 +309,7 @@ public class ViewChangesDisplayContext {
 				return rootDisplayClassesJSONArray;
 			}
 		).put(
-			"spritemap",
-			_themeDisplay.getPathThemeImages() + "/lexicon/icons.svg"
+			"spritemap", _themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 		).put(
 			"typeNames",
 			DisplayContextUtil.getTypeNamesJSONObject(

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewDiscardDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewDiscardDisplayContext.java
@@ -121,8 +121,7 @@ public class ViewDiscardDisplayContext {
 				return renderURL.toString();
 			}
 		).put(
-			"spritemap",
-			_themeDisplay.getPathThemeImages() + "/lexicon/icons.svg"
+			"spritemap", _themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 		).put(
 			"typeNames",
 			DisplayContextUtil.getTypeNamesJSONObject(

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -168,7 +168,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 											<div class="alert alert-info">
 												<span class="alert-indicator">
 													<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
-														<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#info-circle" />
+														<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#info-circle" />
 													</svg>
 												</span>
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/end.jsp
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/end.jsp
@@ -48,7 +48,7 @@ Map<String, Object> props = HashMapBuilder.<String, Object>put(
 ).put(
 	"sidebarPanels", sidebarPanels
 ).put(
-	"spritemap", themeDisplay.getPathThemeImages() + "/lexicon/icons.svg"
+	"spritemap", themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 ).build();
 %>
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/AppContext.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/AppContext.es.js
@@ -78,7 +78,7 @@ const initialState = {
 	hoveredField: {},
 	sidebarOpen: true,
 	sidebarPanelId: 'fields',
-	spritemap: `${Liferay.ThemeDisplay.getPathThemeImages()}/lexicon/icons.svg`,
+	spritemap: `${Liferay.ThemeDisplay.getPathThemeImages()}/clay/icons.svg`,
 };
 
 const addCustomObjectField = ({

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/item/selector/application_disabled.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/item/selector/application_disabled.jsp
@@ -26,7 +26,7 @@ DepotApplicationDisplayContext depotApplicationDisplayContext = (DepotApplicatio
 	<div class="alert alert-info">
 		<span class="alert-indicator">
 			<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
-				<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#info-circle" />
+				<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#info-circle" />
 			</svg>
 		</span>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_abstract.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_abstract.jsp
@@ -53,7 +53,7 @@ FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIB
 					<div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
 						<div class="text-secondary">
 							<svg aria-hidden="true" class="lexicon-icon reference-mark user-icon-xl">
-								<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#<%= assetRenderer.getIconCssClass() %>" />
+								<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#<%= assetRenderer.getIconCssClass() %>" />
 							</svg>
 						</div>
 					</div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/folder_abstract.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/folder_abstract.jsp
@@ -27,7 +27,7 @@ Folder folder = (Folder)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FOLDER);
 		<div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
 			<div class="text-secondary">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder reference-mark user-icon-xl">
-					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#folder" />
+					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#folder" />
 				</svg>
 			</div>
 		</div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/folder_full_content.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/folder_full_content.jsp
@@ -25,7 +25,7 @@ Folder folder = (Folder)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FOLDER);
 		<div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
 			<div class="text-secondary">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder reference-mark user-icon-xl">
-					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#folder" />
+					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#folder" />
 				</svg>
 			</div>
 		</div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/edit_data_provider.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/edit_data_provider.jsp
@@ -60,7 +60,7 @@ renderResponse.setTitle((ddmDataProviderInstance == null) ? LanguageUtil.get(req
 					<span class="hide-accessible"><liferay-ui:message key="required" />&nbsp;</span>
 
 					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-asterisk reference-mark">
-						<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#asterisk" />
+						<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#asterisk" />
 					</svg>
 				</liferay-util:buffer>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/test/resources/com/liferay/dynamic/data/mapping/form/builder/internal/context/dependencies/ddm-form-values.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/test/resources/com/liferay/dynamic/data/mapping/form/builder/internal/context/dependencies/ddm-form-values.json
@@ -128,7 +128,7 @@
 	"portletNamespace": "_com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormPortlet_",
 	"readOnly": false,
 	"requiredFieldsWarningMessageHTML": {
-		"content": "<label class=\"required-warning\">Todos os campos marcados com <svg aria-hidden=\"true\" class=\"lexicon-icon lexicon-icon-asterisk reference-mark\"><use xlink:href=\"http://localhost:8080/o/classic-theme/images/lexicon/icons.svg#asterisk\" /></svg> são obrigatórios.</label>",
+		"content": "<label class=\"required-warning\">Todos os campos marcados com <svg aria-hidden=\"true\" class=\"lexicon-icon lexicon-icon-asterisk reference-mark\"><use xlink:href=\"http://localhost:8080/o/classic-theme/images/clay/icons.svg#asterisk\" /></svg> são obrigatórios.</label>",
 		"contentDirection": null,
 		"contentKind": "HTML"
 	},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
@@ -217,7 +217,7 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 		StringBundler sb = new StringBundler(3);
 
 		sb.append(themeDisplay.getPathThemeImages());
-		sb.append("/lexicon/icons.svg");
+		sb.append("/clay/icons.svg");
 		sb.append(StringPool.POUND);
 
 		return sb.toString();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/jest-setup-after-env.config.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/jest-setup-after-env.config.js
@@ -16,7 +16,7 @@ Liferay.DDM = {
 	FormSettings: {
 		restrictedFormURL: 'http://localhost:8080/group/forms/shared/-/form/',
 		sharedFormURL: 'http://localhost:8080/web/forms/shared/-/form/',
-		spritemap: '/lexicon/icons.svg',
+		spritemap: '/clay/icons.svg',
 	},
 };
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
@@ -724,7 +724,7 @@ public class DDMFormAdminDisplayContext {
 		StringBundler sb = new StringBundler(3);
 
 		sb.append(themeDisplay.getPathThemeImages());
-		sb.append("/lexicon/icons.svg");
+		sb.append("/clay/icons.svg");
 		sb.append(StringPool.POUND);
 
 		return sb.toString();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
@@ -128,7 +128,7 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 	Liferay.namespace('DDM').FormSettings = {
 		portletNamespace: '<portlet:namespace />',
 		showPagination: false,
-		spritemap: '<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg',
+		spritemap: '<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg',
 	};
 
 	Liferay.Forms.App = {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -186,7 +186,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 			'<%= ddmFormAdminDisplayContext.getRestrictedFormURL() %>',
 		sharedFormURL: '<%= ddmFormAdminDisplayContext.getSharedFormURL() %>',
 		showPagination: true,
-		spritemap: '<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg',
+		spritemap: '<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg',
 	};
 
 	Liferay.Forms.App = {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance.jsp
@@ -123,7 +123,7 @@ FormInstancePermissionCheckerHelper formInstancePermissionCheckerHelper = ddmFor
 </clay:container-fluid>
 
 <aui:script require='<%= "metal-dom/src/all/dom as dom, " + mainRequire + "/admin/js/components/ShareFormModal/ShareFormModal.es as ShareFormModal" %>'>
-	var spritemap = themeDisplay.getPathThemeImages() + '/lexicon/icons.svg';
+	var spritemap = themeDisplay.getPathThemeImages() + '/clay/icons.svg';
 
 	var afterOpenShareFormModal = function (data) {
 		Liferay.namespace('DDM').FormSettings = {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/resources/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/dependencies/ddm-form-values.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/resources/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/dependencies/ddm-form-values.json
@@ -128,7 +128,7 @@
 	"portletNamespace": "_com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormPortlet_",
 	"readOnly": false,
 	"requiredFieldsWarningMessageHTML": {
-		"content": "<label class=\"required-warning\">Todos os campos marcados com <svg aria-hidden=\"true\" class=\"lexicon-icon lexicon-icon-asterisk reference-mark\"><use xlink:href=\"http://localhost:8080/o/classic-theme/images/lexicon/icons.svg#asterisk\" /></svg> são obrigatórios.</label>",
+		"content": "<label class=\"required-warning\">Todos os campos marcados com <svg aria-hidden=\"true\" class=\"lexicon-icon lexicon-icon-asterisk reference-mark\"><use xlink:href=\"http://localhost:8080/o/classic-theme/images/clay/icons.svg#asterisk\" /></svg> são obrigatórios.</label>",
 		"contentDirection": null,
 		"contentKind": "HTML"
 	},

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/soy/Flags.soy
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/soy/Flags.soy
@@ -36,7 +36,7 @@
 		id="{$id}"
 	{/let}
 
-	{let $spritemap: $pathThemeImages + '/lexicon/icons.svg' /}
+	{let $spritemap: $pathThemeImages + '/clay/icons.svg' /}
 
 	<div {$containerAttributes}>
 		{call .flagIcon}
@@ -234,7 +234,7 @@
 				<label class="control-label" for="{$portletNamespace}reporterEmailAddress">{msg desc=""}email-address{/msg}
 					<span class="reference-mark text-warning">
 						<svg class="lexicon-icon">
-							<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#asterisk"></use>
+							<use xlink:href="{$pathThemeImages}/clay/icons.svg#asterisk"></use>
 						</svg>
 					</span>
 				</label>

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
@@ -435,8 +435,7 @@ public class EditFragmentEntryDisplayContext {
 				return resources;
 			}
 		).put(
-			"spritemap",
-			_themeDisplay.getPathThemeImages() + "/lexicon/icons.svg"
+			"spritemap", _themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 		).put(
 			"status",
 			() -> {

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -225,7 +225,7 @@ name = HtmlUtil.escapeJS(name);
 			{
 				documentBrowseLinkCallback: documentBrowseLinkCallback,
 				htmlEncodeOutput: true,
-				spritemap: themeDisplay.getPathThemeImages() + '/lexicon/icons.svg',
+				spritemap: themeDisplay.getPathThemeImages() + '/clay/icons.svg',
 				title: false,
 				uiNode: uiNode,
 			},

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/BrightnessComponent.soy
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/BrightnessComponent.soy
@@ -10,7 +10,7 @@
 {template .render}
 	<div id="{$ref}">
 		<svg class="d-none d-sm-block lexicon-icon min-value">
-			<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#sun"></use>
+			<use xlink:href="{$pathThemeImages}/clay/icons.svg#sun"></use>
 		</svg>
 
 		<div class="centered">
@@ -24,7 +24,7 @@
 		</div>
 
 		<svg class="d-none d-sm-block lexicon-icon max-value">
-			<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#sun"></use>
+			<use xlink:href="{$pathThemeImages}/clay/icons.svg#sun"></use>
 		</svg>
 	</div>
 {/template}

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ContrastComponent.soy
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ContrastComponent.soy
@@ -10,7 +10,7 @@
 {template .render}
 	<div id="{$ref}">
 		<svg class="d-none d-sm-block lexicon-icon min-value">
-			<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#adjust"></use>
+			<use xlink:href="{$pathThemeImages}/clay/icons.svg#adjust"></use>
 		</svg>
 
 		<div class="centered">
@@ -26,7 +26,7 @@
 		</div>
 
 		<svg class="d-none d-sm-block lexicon-icon max-value">
-			<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#adjust"></use>
+			<use xlink:href="{$pathThemeImages}/clay/icons.svg#adjust"></use>
 		</svg>
 	</div>
 {/template}

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/EffectsComponent.soy
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/EffectsComponent.soy
@@ -15,7 +15,7 @@
 		<div class="carousel-left-arrow">
 			<a class="btn btn-link icon-monospaced" data-onclick="scrollLeft" href="javascript:;">
 				<svg class="lexicon-icon">
-					<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#angle-left"></use>
+					<use xlink:href="{$pathThemeImages}/clay/icons.svg#angle-left"></use>
 				</svg>
 			</a>
 		</div>
@@ -63,7 +63,7 @@
 		<div class="carousel-right-arrow">
 			<a class="btn btn-link icon-monospaced" data-onclick="scrollRight" href="javascript:;">
 				<svg class="lexicon-icon">
-					<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#angle-right"></use>
+					<use xlink:href="{$pathThemeImages}/clay/icons.svg#angle-right"></use>
 				</svg>
 			</a>
 		</div>

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.soy
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.soy
@@ -46,19 +46,19 @@
 				<div class="btn-group" role="group">
 					<a class="btn btn-link btn-monospaced {$history and $history.canUndo ? '' : 'disabled'}" data-onclick="undo" href="javascript:;" title="{msg desc=""}undo{/msg}">
 						<svg class="lexicon-icon">
-							<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#angle-left"></use>
+							<use xlink:href="{$pathThemeImages}/clay/icons.svg#angle-left"></use>
 						</svg>
 					</a>
 
 					<a class="btn btn-link btn-monospaced {$history and $history.canReset ? '' : 'disabled'}" data-onclick="reset" href="javascript:;" title="{msg desc=""}restore{/msg}">
 						<svg class="lexicon-icon">
-							<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#restore"></use>
+							<use xlink:href="{$pathThemeImages}/clay/icons.svg#restore"></use>
 						</svg>
 					</a>
 
 					<a class="btn btn-link btn-monospaced {$history and $history.canRedo ? '' : 'disabled'}" data-onclick="redo" href="javascript:;" title="{msg desc=""}redo{/msg}">
 						<svg class="lexicon-icon">
-							<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#angle-right"></use>
+							<use xlink:href="{$pathThemeImages}/clay/icons.svg#angle-right"></use>
 						</svg>
 					</a>
 				</div>
@@ -128,7 +128,7 @@
 
 		<a class="btn btn-monospaced" data-control="{$control.variant}" data-onclick="requestImageEditorEditFilters" data-tool="tool-{$toolIndex}" href="javascript:;" title="{$tool.title}">
 			<svg class="lexicon-icon">
-				<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#{$tool.icon}"></use>
+				<use xlink:href="{$pathThemeImages}/clay/icons.svg#{$tool.icon}"></use>
 			</svg>
 		</a>
 
@@ -158,7 +158,7 @@
 		{param icon: $tool.icon /}
 		{param items: $tool.controls /}
 		{param preferredAlign: 'TopCenter' /}
-		{param spritemap: $pathThemeImages + '/lexicon/icons.svg' /}
+		{param spritemap: $pathThemeImages + '/clay/icons.svg' /}
 		{param style: 'link' /}
 		{param triggerTitle: $tool.title/}
 		{param triggerClasses: 'btn btn-monospaced' /}
@@ -186,7 +186,7 @@
 				<span class="d-none d-sm-block">{msg desc=""}apply{/msg}</span>
 
 				<svg class="d-sm-none lexicon-icon">
-					<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#check"></use>
+					<use xlink:href="{$pathThemeImages}/clay/icons.svg#check"></use>
 				</svg>
 			</button>
 		</div>
@@ -205,7 +205,7 @@
 				<span class="d-none d-sm-block">{msg desc=""}cancel{/msg}</span>
 
 				<svg class="d-sm-none lexicon-icon">
-					<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#times"></use>
+					<use xlink:href="{$pathThemeImages}/clay/icons.svg#times"></use>
 				</svg>
 			</button>
 		</div>

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ResizeComponent.soy
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ResizeComponent.soy
@@ -16,7 +16,7 @@
 
 			<a class="btn btn-link" data-onclick="toggleLockProportions" href="javascript:;">
 				<svg class="lexicon-icon" style="width: 14px;">
-					<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#{$lockProportions ? 'lock' : 'unlock'}"></use>
+					<use xlink:href="{$pathThemeImages}/clay/icons.svg#{$lockProportions ? 'lock' : 'unlock'}"></use>
 				</svg>
 			</a>
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/RotateComponent.soy
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/RotateComponent.soy
@@ -10,13 +10,13 @@
 	<div id="{$ref}">
 		<a class="btn btn-link btn-monospaced" data-onclick="rotateLeft" href="javascript:;">
 			<svg class="lexicon-icon">
-				<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#reply"></use>
+				<use xlink:href="{$pathThemeImages}/clay/icons.svg#reply"></use>
 			</svg>
 		</a>
 
 		<a class="btn btn-link btn-monospaced" data-onclick="rotateRight" href="javascript:;">
 			<svg class="lexicon-icon" style="transform: scaleX(-1);">
-				<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#reply"></use>
+				<use xlink:href="{$pathThemeImages}/clay/icons.svg#reply"></use>
 			</svg>
 		</a>
 	</div>

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/SaturationComponent.soy
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/SaturationComponent.soy
@@ -10,7 +10,7 @@
 {template .render}
 	<div id="{$ref}">
 		<svg class="d-none d-sm-block lexicon-icon min-value">
-			<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#radio-button"></use>
+			<use xlink:href="{$pathThemeImages}/clay/icons.svg#radio-button"></use>
 		</svg>
 
 		<div class="centered">
@@ -26,7 +26,7 @@
 		</div>
 
 		<svg class="d-none d-sm-block lexicon-icon max-value">
-			<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#radio-button"></use>
+			<use xlink:href="{$pathThemeImages}/clay/icons.svg#radio-button"></use>
 		</svg>
 	</div>
 {/template}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/alert.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/alert.js
@@ -257,7 +257,7 @@ AUI.add(
 				TPL_ALERTS_CONTAINER: '<div class="lfr-alert-container"></div>',
 
 				TPL_CONTENT:
-					'<strong class="lead"><svg class="lexicon-icon" focusable="false"><use href="{pathThemeImages}/lexicon/icons.svg#{icon}" /><title>{title}</title></svg> {title}</strong>{message}',
+					'<strong class="lead"><svg class="lexicon-icon" focusable="false"><use href="{pathThemeImages}/clay/icons.svg#{icon}" /><title>{title}</title></svg> {title}</strong>{message}',
 
 				bindUI() {
 					var instance = this;

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/fullscreen_source_editor.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/fullscreen_source_editor.js
@@ -22,7 +22,7 @@ AUI.add(
 			'<div class="col-6">' +
 			'<button class="btn btn-secondary btn-sm float-right lfr-portal-tooltip" data-title="{iconMoonTooltip}" id="switchTheme" type="button">' +
 			'<svg class="lexicon-icon lexicon-icon-moon" focusable="false" role="img">' +
-			'<use href="{pathThemeImages}/lexicon/icons.svg#moon" />' +
+			'<use href="{pathThemeImages}/clay/icons.svg#moon" />' +
 			'</svg>' +
 			'</button>' +
 			'</div>' +
@@ -30,17 +30,17 @@ AUI.add(
 			'<div class="btn-group" role="group">' +
 			'<button class="btn btn-secondary btn-sm" data-layout="vertical">' +
 			'<svg class="lexicon-icon lexicon-icon-columns" focusable="false" role="img">' +
-			'<use href="{pathThemeImages}/lexicon/icons.svg#columns" />' +
+			'<use href="{pathThemeImages}/clay/icons.svg#columns" />' +
 			'</svg>' +
 			'</button>' +
 			'<button class="btn btn-secondary btn-sm" data-layout="horizontal">' +
 			'<svg class="lexicon-icon lexicon-icon-cards" focusable="false" role="img">' +
-			'<use href="{pathThemeImages}/lexicon/icons.svg#cards" />' +
+			'<use href="{pathThemeImages}/clay/icons.svg#cards" />' +
 			'</svg>' +
 			'</button>' +
 			'<button class="btn btn-secondary btn-sm" data-layout="simple">' +
 			'<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="img">' +
-			'<use href="{pathThemeImages}/lexicon/icons.svg#expand" />' +
+			'<use href="{pathThemeImages}/clay/icons.svg#expand" />' +
 			'</svg>' +
 			'</button>' +
 			'</div>' +

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -46,7 +46,7 @@
 		'<svg class="lexicon-icon lexicon-icon-{0} {1}" focusable="false" role="image">' +
 		'<use href="' +
 		themeDisplay.getPathThemeImages() +
-		'/lexicon/icons.svg#{0}" />' +
+		'/clay/icons.svg#{0}" />' +
 		'</svg>';
 
 	var Window = {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -69,7 +69,7 @@ AUI.add(
 									labelHTML:
 										'<svg class="lexicon-icon" focusable="false"><use href="' +
 										Liferay.ThemeDisplay.getPathThemeImages() +
-										'/lexicon/icons.svg#times" /><title>' +
+										'/clay/icons.svg#times" /><title>' +
 										Liferay.Language.get('close') +
 										'</title></svg>',
 									on: {

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
@@ -39,7 +39,7 @@ export default function render(renderable, renderData, container) {
 	if (!Liferay.SPA || Liferay.SPA.app) {
 		const {portletId} = renderData;
 		const spritemap =
-			Liferay.ThemeDisplay.getPathThemeImages() + '/lexicon/icons.svg';
+			Liferay.ThemeDisplay.getPathThemeImages() + '/clay/icons.svg';
 
 		let {componentId} = renderData;
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTag.java
@@ -211,7 +211,7 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 					"namespace", portletDisplay.getNamespace()
 				).put(
 					"spritemap",
-					themeDisplay.getPathThemeImages() + "/lexicon/icons.svg"
+					themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 				).build()));
 
 		String containerId = getContainerId();

--- a/modules/apps/frontend-taglib/frontend-taglib/src/test/resources/com/liferay/frontend/taglib/servlet/taglib/dependencies/component_tag.html
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/test/resources/com/liferay/frontend/taglib/servlet/taglib/dependencies/component_tag.html
@@ -4,7 +4,7 @@ Liferay.Loader.require('null/module', function(nullModule) {
 try {
 (function() {
 var module = nullModule;
-Liferay.component('componentId', new module.default({"name":"value","namespace":"namespace","spritemap":"\/lexicon\/icons.svg"}), { destroyOnNavigate: true, portletId: ''});
+Liferay.component('componentId', new module.default({"name":"value","namespace":"namespace","spritemap":"\/clay\/icons.svg"}), { destroyOnNavigate: true, portletId: ''});
 })();
 } catch (err) {
 	console.error(err);

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
@@ -19,7 +19,7 @@ export const spritemap =
 	window.location.protocol +
 	'//' +
 	window.location.host +
-	'/o/classic-theme/images/lexicon/icons.svg';
+	'/o/classic-theme/images/clay/icons.svg';
 
 const Icon = (props) => {
 	const {symbol, ...otherProps} = props;

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -414,7 +414,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 				message,
 				spritemap:
 					Liferay.ThemeDisplay.getPathThemeImages() +
-					'/lexicon/icons.svg',
+					'/clay/icons.svg',
 				style: 'danger',
 				title: '',
 				visible: true,

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/folder_full_content.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/folder_full_content.jsp
@@ -27,7 +27,7 @@ JournalFolder folder = journalDisplayContext.getFolder();
 		<div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
 			<div class="text-secondary">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder reference-mark user-icon-xl">
-					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#folder" />
+					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#folder" />
 				</svg>
 			</div>
 		</div>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
@@ -101,8 +101,7 @@ public class FragmentEntryLinkRichTextEditorConfigContributor
 		).put(
 			"skin", "moono-lisa"
 		).put(
-			"spritemap",
-			themeDisplay.getPathThemeImages() + "/lexicon/icons.svg"
+			"spritemap", themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 		).put(
 			"toolbars", getToolbarsJSONObject(themeDisplay.getLocale())
 		);

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_display_page_master_layout.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_display_page_master_layout.jsp
@@ -76,7 +76,7 @@ sb.append("/js/modal/openDisplayPageModal.es as openDisplayPageModal");
 				),
 				namespace: '<portlet:namespace />',
 				spritemap:
-					'<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg',
+					'<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg',
 				title: '<liferay-ui:message key="add-display-page-template" />',
 			});
 		}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry_master_layout.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry_master_layout.jsp
@@ -78,7 +78,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 				mainFieldPlaceholder: '<liferay-ui:message key="name" />',
 				namespace: '<portlet:namespace />',
 				spritemap:
-					'<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg',
+					'<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg',
 			});
 		}
 	);

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/js/main.js
@@ -243,7 +243,7 @@ AUI.add(
 									labelHTML:
 										'<svg class="lexicon-icon" focusable="false"><use href="' +
 										Liferay.ThemeDisplay.getPathThemeImages() +
-										'/lexicon/icons.svg#times" /><title>' +
+										'/clay/icons.svg#times" /><title>' +
 										Liferay.Language.get('close') +
 										'</title></svg>',
 									on: {
@@ -303,7 +303,7 @@ AUI.add(
 									labelHTML:
 										'<svg class="lexicon-icon" focusable="false"><use href="' +
 										Liferay.ThemeDisplay.getPathThemeImages() +
-										'/lexicon/icons.svg#times" /><title>' +
+										'/clay/icons.svg#times" /><title>' +
 										Liferay.Language.get('close') +
 										'</title></svg>',
 									on: {
@@ -357,7 +357,7 @@ AUI.add(
 									labelHTML:
 										'<svg class="lexicon-icon" focusable="false"><use href="' +
 										Liferay.ThemeDisplay.getPathThemeImages() +
-										'/lexicon/icons.svg#times" /><title>' +
+										'/clay/icons.svg#times" /><title>' +
 										Liferay.Language.get('close') +
 										'</title></svg>',
 									on: {

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
@@ -245,8 +245,7 @@ public class LayoutsTreeDisplayContext {
 		).put(
 			"namespace", getNamespace()
 		).put(
-			"spritemap",
-			_themeDisplay.getPathThemeImages() + "/lexicon/icons.svg"
+			"spritemap", _themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 		).build();
 	}
 

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -170,7 +170,7 @@ SiteNavigationAdminManagementToolbarDisplayContext siteNavigationAdminManagement
 				mainFieldValue: data.mainFieldValue,
 				namespace: '<portlet:namespace />',
 				spritemap:
-					'<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg',
+					'<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg',
 			});
 		}
 	);

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
@@ -78,7 +78,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-site-template"));
 					mainFieldLabel: '<liferay-ui:message key="name" />',
 					namespace: '<portlet:namespace />',
 					spritemap:
-						'<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg',
+						'<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg',
 				});
 			}
 		);

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/last_publication_date_message.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/last_publication_date_message.jsp
@@ -92,7 +92,7 @@ if (Validator.isNull(publisherName)) {
 			<div class="alert alert-info" role="alert">
 				<span class="alert-indicator">
 					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-info-circle">
-						<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#info-circle" />
+						<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#info-circle" />
 					</svg>
 				</span>
 				<span class="last-publication-branch">
@@ -124,7 +124,7 @@ if (Validator.isNull(publisherName)) {
 		<div class="alert alert-info" role="alert">
 			<span class="alert-indicator">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-info-circle">
-					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#info-circle" />
+					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#info-circle" />
 				</svg>
 			</span>
 

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -232,7 +232,7 @@ if (liveLayout != null) {
 								<div class="container-fluid container-fluid-max-xl staging-alert-container">
 									<span class="alert-indicator">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-info-circle">
-											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#info-circle" />
+											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#info-circle" />
 										</svg>
 									</span>
 

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_status.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_status.jsp
@@ -29,7 +29,7 @@ if ((layoutRevision == null) && (layout != null)) {
 		<div class="staging-alert-container">
 			<span class="alert-indicator">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-info-circle">
-					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#info-circle" />
+					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#info-circle" />
 				</svg>
 			</span>
 

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/alert/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/alert/page.jsp
@@ -22,14 +22,14 @@
 	<c:choose>
 		<c:when test="<%= type == AlertType.ERROR.getAlertCode() %>">
 			<svg aria-hidden="true" class="lexicon-icon lexicon-icon-exclamation-full">
-				<use xlink:href="<%= themeDisplayPath %>/lexicon/icons.svg#exclamation-full" />
+				<use xlink:href="<%= themeDisplayPath %>/clay/icons.svg#exclamation-full" />
 			</svg>
 
 			<strong class="lead"><%= LanguageUtil.get(request, "alert-helper-error") %>: </strong>
 		</c:when>
 		<c:when test="<%= type == AlertType.INFO.getAlertCode() %>">
 			<svg aria-hidden="true" class="lexicon-icon lexicon-icon-info-circle">
-				<use xlink:href="<%= themeDisplayPath %>/lexicon/icons.svg#info-circle" />
+				<use xlink:href="<%= themeDisplayPath %>/clay/icons.svg#info-circle" />
 			</svg>
 
 			<strong class="lead"><%= LanguageUtil.get(request, "alert-helper-info") %>: </strong>
@@ -57,7 +57,7 @@
 
 		<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" data-dismiss="liferay-alert" type="button">
 			<svg aria-hidden="true" class="icon-monospaced lexicon-icon lexicon-icon-times">
-				<use xlink:href="<%= themeDisplayPath %>/lexicon/icons.svg#times" />
+				<use xlink:href="<%= themeDisplayPath %>/clay/icons.svg#times" />
 			</svg>
 
 			<span class="sr-only"><%= LanguageUtil.get(request, "close") %></span>

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/js/DocumentLibraryOpener.es.js
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/js/DocumentLibraryOpener.es.js
@@ -127,8 +127,7 @@ class DocumentLibraryOpener {
 				}
 			},
 			spritemap:
-				Liferay.ThemeDisplay.getPathThemeImages() +
-				'/lexicon/icons.svg',
+				Liferay.ThemeDisplay.getPathThemeImages() + '/clay/icons.svg',
 		});
 	}
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/EditRankingDisplayBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/EditRankingDisplayBuilder.java
@@ -89,8 +89,7 @@ public class EditRankingDisplayBuilder {
 		).put(
 			"namespace", _renderResponse.getNamespace()
 		).put(
-			"spritemap",
-			_themeDisplay.getPathThemeImages() + "/lexicon/icons.svg"
+			"spritemap", _themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 		).build();
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/dialogs.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/dialogs.js
@@ -87,7 +87,7 @@ AUI.add(
 									labelHTML:
 										'<svg class="lexicon-icon" focusable="false"><use href="' +
 										Liferay.ThemeDisplay.getPathThemeImages() +
-										'/lexicon/icons.svg#times" /><title>' +
+										'/clay/icons.svg#times" /><title>' +
 										Liferay.Language.get('close') +
 										'</title></svg>',
 									on: {
@@ -148,7 +148,7 @@ AUI.add(
 								labelHTML:
 									'<svg class="lexicon-icon" focusable="false"><use href="' +
 									Liferay.ThemeDisplay.getPathThemeImages() +
-									'/lexicon/icons.svg#times" /><title>' +
+									'/clay/icons.svg#times" /><title>' +
 									Liferay.Language.get('close') +
 									'</title></svg>',
 								on: {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/utils.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/utils.js
@@ -201,7 +201,7 @@ AUI.add(
 								labelHTML:
 									'<svg class="lexicon-icon" focusable="false"><use href="' +
 									Liferay.ThemeDisplay.getPathThemeImages() +
-									'/lexicon/icons.svg#times" /><title>' +
+									'/clay/icons.svg#times" /><title>' +
 									Liferay.Language.get('close') +
 									'</title></svg>',
 								on: {

--- a/modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/src/main/resources/META-INF/resources/__artifactId__.soy
+++ b/modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/src/main/resources/META-INF/resources/__artifactId__.soy
@@ -70,7 +70,7 @@
 
 				{if $required}
 					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-asterisk reference-mark">
-						<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#asterisk" />
+						<use xlink:href="{$pathThemeImages}/clay/icons.svg#asterisk" />
 					</svg>
 				{/if}
 			</label>

--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -342,7 +342,7 @@
 						);
 
 						var updateMessage = function(message) {
-							connectionMessages.html('<div class="alert alert-danger"><span class="alert-indicator"><svg aria-hidden="true" class="lexicon-icon lexicon-icon-exclamation-full"><use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#exclamation-full"></use></svg></span><strong class="lead"><liferay-ui:message key="error-colon" /></strong>' + message + '</div>');
+							connectionMessages.html('<div class="alert alert-danger"><span class="alert-indicator"><svg aria-hidden="true" class="lexicon-icon lexicon-icon-exclamation-full"><use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#exclamation-full"></use></svg></span><strong class="lead"><liferay-ui:message key="error-colon" /></strong>' + message + '</div>');
 						};
 
 						var startInstall = function() {
@@ -416,7 +416,7 @@
 							<div class="alert alert-success">
 								<span class="alert-indicator">
 									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check-circle-full">
-										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#check-circle-full"></use>
+										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#check-circle-full"></use>
 									</svg>
 								</span>
 
@@ -445,7 +445,7 @@
 							<div class="alert alert-info">
 								<span class="alert-indicator">
 									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-info-circle">
-										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#info-circle"></use>
+										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#info-circle"></use>
 									</svg>
 								</span>
 
@@ -457,7 +457,7 @@
 								<div class="alert alert-warning">
 									<span class="alert-indicator">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-warning-full">
-											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#warning-full"></use>
+											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#warning-full"></use>
 										</svg>
 									</span>
 

--- a/portal-web/docroot/html/taglib/ui/error/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/error/page.jsp
@@ -36,7 +36,7 @@ String rowBreak = (String)request.getAttribute("liferay-ui:error:rowBreak");
 
 			<span class="alert-indicator">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-<%= alertIcon %>">
-					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#<%= alertIcon %>"></use>
+					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#<%= alertIcon %>"></use>
 				</svg>
 			</span>
 

--- a/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/steps.jspf
+++ b/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/steps.jspf
@@ -149,7 +149,7 @@
 
 							<div class="divider">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-<%= sectionIcon %>">
-									<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#<%= sectionIcon %>"></use>
+									<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#<%= sectionIcon %>"></use>
 								</svg>
 							</div>
 

--- a/portal-web/docroot/html/taglib/ui/ratings/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/ratings/page.jsp
@@ -110,11 +110,11 @@ if (!inTrash) {
 
 							<span class="rating-element <%= (i <= averageIndex) ? "icon-star-on" : "icon-star-off" %>" title="<%= message %>">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-star" role="img">
-									<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#star" />
+									<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#star" />
 								</svg>
 
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-star-o" role="img">
-									<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#star-o" />
+									<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#star-o" />
 								</svg>
 							</span>
 
@@ -144,11 +144,11 @@ if (!inTrash) {
 
 								<a class="btn btn-unstyled rating-element <%= (i <= yourScoreStars) ? "icon-star-on" : "icon-star-off" %>" href="javascript:;">
 									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-star" role="img">
-										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#star" />
+										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#star" />
 									</svg>
 
 									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-star-o" role="img">
-										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#star-o" />
+										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#star-o" />
 									</svg>
 								</a>
 
@@ -184,11 +184,11 @@ if (!inTrash) {
 
 								<a class="btn btn-unstyled rating-element <%= (i <= yourScoreStars) ? "icon-star-on" : "icon-star-off" %>" href="javascript:;">
 									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-star" role="img">
-										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#star" />
+										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#star" />
 									</svg>
 
 									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-star-o" role="img">
-										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#star-o" />
+										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#star-o" />
 									</svg>
 								</a>
 
@@ -234,11 +234,11 @@ if (!inTrash) {
 
 							<span class="rating-element <%= (i <= averageIndex) ? "icon-star-on" : "icon-star-off" %>" title="<%= message %>">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-star" role="img">
-									<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#star" />
+									<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#star" />
 								</svg>
 
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-star-o" role="img">
-									<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#star-o" />
+									<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#star-o" />
 								</svg>
 							</span>
 
@@ -290,7 +290,7 @@ if (!inTrash) {
 								<span class="btn-sm rating-element rating-thumb-up rating-<%= thumbUp ? "on" : "off" %>" title="<%= thumbsTitle %>">
 									<span class="inline-item inline-item-before">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-thumbs-up" role="img">
-											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#thumbs-up" />
+											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#thumbs-up" />
 										</svg>
 									</span>
 
@@ -301,7 +301,7 @@ if (!inTrash) {
 									<span class="btn-sm rating-element rating-thumb-down rating-<%= thumbDown ? "on" : "off" %>" title="<%= thumbsTitle %>">
 										<span class="inline-item inline-item-before">
 											<svg aria-hidden="true" class="lexicon-icon lexicon-icon-thumbs-down" role="img">
-												<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#thumbs-down" />
+												<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#thumbs-down" />
 											</svg>
 										</span>
 
@@ -325,7 +325,7 @@ if (!inTrash) {
 								<a class="btn btn-outline-borderless btn-outline-secondary btn-sm rating-element rating-thumb-up rating-<%= thumbUp ? "on" : "off" %>" href="javascript:;" title="<liferay-ui:message key="<%= positiveRatingMessage %>" />">
 									<span class="inline-item inline-item-before">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-thumbs-up" role="img">
-											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#thumbs-up" />
+											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#thumbs-up" />
 										</svg>
 									</span>
 									<span class="votes"><%= positiveVotes %></span>
@@ -335,7 +335,7 @@ if (!inTrash) {
 									<a class="btn btn-outline-borderless btn-outline-secondary btn-sm rating-element rating-thumb-down rating-<%= thumbDown ? "on" : "off" %>" href="javascript:;" title="<liferay-ui:message key='<%= thumbDown ? "you-have-rated-this-as-bad" : "rate-this-as-bad" %>' />">
 										<span class="inline-item inline-item-before">
 											<svg aria-hidden="true" class="lexicon-icon lexicon-icon-thumbs-down" role="img">
-												<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#thumbs-down" />
+												<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#thumbs-down" />
 											</svg>
 										</span>
 										<span class="votes"><%= negativeVotes %></span>

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -842,3 +842,25 @@ This change was made to enable image drag and drop handling in CKEditor, and
 have a common solution for both Alloy Editor and CKEditor.
 
 ---------------------------------------
+
+### Moving lexicon icons path
+- **Date:** 2020-Aug-17
+- **JIRA Ticket:** [LPS-115812](https://issues.liferay.com/browse/LPS-115812)
+
+### What changed?
+
+The path for the lexicon icons has been changed from `themeDisplay.getPathThemeImages() + "/lexicon/icons.svg` to `themeDisplay.getPathThemeImages() + "/clay/icons.svg`
+
+### Who is affected
+
+This affects custom solutions that use this path directly. The gradle task for building the icons on the `lexicon` path will be removed.
+
+### How should I update my code?
+
+Update the path to reference `clay` instead of `lexicon`
+
+#### Why was this change made?
+
+This change was made to unify references to the icon spritemap.
+
+---------------------------------------

--- a/util-taglib/src/com/liferay/taglib/aui/ATag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/ATag.java
@@ -62,7 +62,7 @@ public class ATag extends BaseATag {
 				jspWriter.write("lexicon-icon-shortcut\" focusable=\"false\" ");
 				jspWriter.write("role=\"img\"><use href=\"");
 				jspWriter.write(themeDisplay.getPathThemeImages());
-				jspWriter.write("/lexicon/icons.svg#shortcut\" /><span ");
+				jspWriter.write("/clay/icons.svg#shortcut\" /><span ");
 				jspWriter.write("class=\"sr-only\">");
 
 				String opensNewWindowLabel = LanguageUtil.get(

--- a/util-taglib/src/com/liferay/taglib/aui/IconTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/IconTag.java
@@ -141,9 +141,7 @@ public class IconTag extends BaseIconTag {
 						(ThemeDisplay)httpServletRequest.getAttribute(
 							WebKeys.THEME_DISPLAY);
 
-					src =
-						themeDisplay.getPathThemeImages() +
-							"/lexicon/icons.svg";
+					src = themeDisplay.getPathThemeImages() + "/clay/icons.svg";
 				}
 
 				jspWriter.write(src);

--- a/util-taglib/src/com/liferay/taglib/ui/UserPortraitTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/UserPortraitTag.java
@@ -61,7 +61,7 @@ public class UserPortraitTag extends IncludeTag {
 			sb.append("<svg class=\"lexicon-icon\">");
 			sb.append("<use href=\"");
 			sb.append(themeDisplay.getPathThemeImages());
-			sb.append("/lexicon/icons.svg#user\" /></svg>");
+			sb.append("/clay/icons.svg#user\" /></svg>");
 			sb.append("</span></span>");
 
 			return sb.toString();

--- a/util-taglib/src/com/liferay/taglib/ui/success/embed.tmpl
+++ b/util-taglib/src/com/liferay/taglib/ui/success/embed.tmpl
@@ -1,7 +1,7 @@
 <div class="alert alert-success" role="alert">
     <span class="alert-indicator">
         <svg aria-hidden="true" class="lexicon-icon lexicon-icon-check-circle-full">
-            <use xlink:href="$pathThemeImages$/lexicon/icons.svg#check-circle-full"></use>
+            <use xlink:href="$pathThemeImages$/clay/icons.svg#check-circle-full"></use>
         </svg>
     </span>
     <strong class="lead">$title$</strong>$message$


### PR DESCRIPTION
Aimed to unify calls to icons.svg. This is just a step in the right direction, ideally we have a dedicated module for icons rather than pull from themes. Right now we still run into issues with calls to both `admin-theme` and `classic-theme` for icons.