### PR TITLE
LPS-116361 Adds Admin portlet for Remote Apps

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/jaxrs/context/provider/ThemeDisplayContextProvider.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/jaxrs/context/provider/ThemeDisplayContextProvider.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.servlet.http.HttpServletRequest;
@@ -80,6 +81,8 @@ public class ThemeDisplayContextProvider
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		themeDisplay.setLocale(_portal.getLocale(httpServletRequest));
+
 		long plid = ParamUtil.getLong(httpServletRequest, "plid");
 
 		if (plid > 0) {
@@ -108,5 +111,8 @@ public class ThemeDisplayContextProvider
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/dataset_display/DatasetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/dataset_display/DatasetDisplay.js
@@ -95,7 +95,7 @@ function DatasetDisplay({
 		...currentViewProps
 	} = activeView;
 
-	const selectable = bulkActions?.length && selectedItemsKey;
+	const selectable = bulkActions?.length > 0 && selectedItemsKey;
 
 	useEffect(() => {
 		if (

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/dataset_display/entry.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/dataset_display/entry.js
@@ -21,7 +21,7 @@ import ViewsContext, {viewsReducer} from './views/ViewsContext';
 
 const App = ({apiURL, appURL, ...props}) => {
 	const {
-		activeViewSettings: {name: activeViewName, ...activeViewSettings},
+		activeViewSettings: {name: activeViewName, visibleFieldNames = {}},
 		portletId,
 		views,
 	} = props;
@@ -30,9 +30,9 @@ const App = ({apiURL, appURL, ...props}) => {
 		: views[0];
 	const [state, dispatch] = useThunk(
 		useReducer(viewsReducer, {
-			...activeViewSettings,
 			activeView,
 			views,
+			visibleFieldNames,
 		})
 	);
 

--- a/modules/apps/remote-app/remote-app-admin-web/bnd.bnd
+++ b/modules/apps/remote-app/remote-app-admin-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Remote App Admin Web
+Bundle-SymbolicName: com.liferay.remote.app.admin.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /remote-app-admin-web

--- a/modules/apps/remote-app/remote-app-admin-web/build.gradle
+++ b/modules/apps/remote-app/remote-app-admin-web/build.gradle
@@ -1,0 +1,19 @@
+dependencies {
+	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-1"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.java", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:remote-app:remote-app-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-lang")
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/RemoteAppPortletRegistrar.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/RemoteAppPortletRegistrar.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal;
+
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.remote.app.admin.web.internal.portlet.RemoteAppPortlet;
+import com.liferay.remote.app.model.RemoteAppEntry;
+import com.liferay.remote.app.service.RemoteAppEntryLocalService;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+@Component(immediate = true, service = RemoteAppPortletRegistrar.class)
+public class RemoteAppPortletRegistrar {
+
+	public void registerPortlet(RemoteAppEntry remoteAppEntry) {
+		_registerPortlet(remoteAppEntry);
+	}
+
+	public void unregisterPortlet(RemoteAppEntry remoteAppEntry) {
+		_unregisterPortlet(remoteAppEntry.getEntryId());
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Starting remote web apps");
+		}
+
+		for (RemoteAppEntry remoteAppEntry :
+				remoteAppEntryLocalService.getRemoteAppEntries(
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+			registerPortlet(remoteAppEntry);
+		}
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		if (_log.isInfoEnabled()) {
+			_log.info("Stopping all remote web apps");
+		}
+
+		Collection<RemoteAppPortlet> remoteAppPortlets;
+
+		synchronized (_remoteAppPortlets) {
+			remoteAppPortlets = _remoteAppPortlets.values();
+
+			_remoteAppPortlets.clear();
+		}
+
+		for (RemoteAppPortlet remoteAppPortlet : remoteAppPortlets) {
+			remoteAppPortlet.unregister();
+		}
+	}
+
+	@Reference
+	protected RemoteAppEntryLocalService remoteAppEntryLocalService;
+
+	private void _registerPortlet(RemoteAppEntry remoteAppEntry) {
+		RemoteAppPortlet remoteAppPortlet = new RemoteAppPortlet(
+			remoteAppEntry);
+
+		long entryId = remoteAppEntry.getEntryId();
+
+		synchronized (_remoteAppPortlets) {
+			if (_remoteAppPortlets.containsKey(entryId)) {
+				throw new IllegalStateException(
+					"Portlet " + entryId + " is already registered");
+			}
+
+			_remoteAppPortlets.put(entryId, remoteAppPortlet);
+
+			remoteAppPortlet.register(_bundleContext);
+		}
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Started remote web app " + remoteAppPortlet.getName());
+		}
+	}
+
+	private void _unregisterPortlet(long id) {
+		RemoteAppPortlet remoteAppPortlet;
+
+		synchronized (_remoteAppPortlets) {
+			remoteAppPortlet = _remoteAppPortlets.remove(id);
+		}
+
+		if (remoteAppPortlet != null) {
+			remoteAppPortlet.unregister();
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Stopped remote web app " + remoteAppPortlet.getName());
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RemoteAppPortletRegistrar.class);
+
+	private BundleContext _bundleContext;
+	private final Map<Long, RemoteAppPortlet> _remoteAppPortlets =
+		new HashMap<>();
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/application/list/RemoteAppAdminPanelApp.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/application/list/RemoteAppAdminPanelApp.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.application.list;
+
+import com.liferay.application.list.BasePanelApp;
+import com.liferay.application.list.PanelApp;
+import com.liferay.application.list.constants.PanelCategoryKeys;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.remote.app.admin.web.internal.constants.RemoteAppAdminPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+@Component(
+	immediate = true,
+	property = {
+		"panel.app.order:Integer=100",
+		"panel.category.key=" + PanelCategoryKeys.APPLICATIONS_MENU_APPLICATIONS_CUSTOM_APPS
+	},
+	service = PanelApp.class
+)
+public class RemoteAppAdminPanelApp extends BasePanelApp {
+
+	@Override
+	public String getPortletId() {
+		return RemoteAppAdminPortletKeys.REMOTE_APP_ADMIN;
+	}
+
+	@Override
+	@Reference(
+		target = "(javax.portlet.name=" + RemoteAppAdminPortletKeys.REMOTE_APP_ADMIN + ")",
+		unbind = "-"
+	)
+	public void setPortlet(Portlet portlet) {
+		super.setPortlet(portlet);
+	}
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/constants/DataSetDisplayConstants.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/constants/DataSetDisplayConstants.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.constants;
+
+/**
+ * @author Bruno Basto
+ */
+public class DataSetDisplayConstants {
+
+	public static final String REMOTE_APP_ENTRY_DATA_SET_DISPLAY =
+		"REMOTE_APP_ENTRY_DATA_SET_DISPLAY";
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/constants/RemoteAppAdminPortletKeys.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/constants/RemoteAppAdminPortletKeys.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.constants;
+
+/**
+ * @author Iván Zaera
+ */
+public class RemoteAppAdminPortletKeys {
+
+	public static final String REMOTE_APP_ADMIN =
+		"com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet";
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/constants/RemoteAppAdminWebKeys.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/constants/RemoteAppAdminWebKeys.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.constants;
+
+/**
+ * @author Bruno Basto
+ */
+public class RemoteAppAdminWebKeys {
+
+	public static final String REMOTE_APP_ENTRY = "REMOTE_APP_ENTRY";
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/data/set/RemoteAppClayDataSetEntry.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/data/set/RemoteAppClayDataSetEntry.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.data.set;
+
+import com.liferay.remote.app.model.RemoteAppEntry;
+
+import java.util.Locale;
+
+/**
+ * @author Bruno Basto
+ */
+public class RemoteAppClayDataSetEntry {
+
+	public RemoteAppClayDataSetEntry(
+		RemoteAppEntry remoteAppEntry, Locale locale) {
+
+		_remoteAppEntry = remoteAppEntry;
+		_locale = locale;
+	}
+
+	public long getEntryId() {
+		return _remoteAppEntry.getEntryId();
+	}
+
+	public String getName() {
+		return _remoteAppEntry.getName(_locale);
+	}
+
+	public String getURL() {
+		return _remoteAppEntry.getUrl();
+	}
+
+	private final Locale _locale;
+	private final RemoteAppEntry _remoteAppEntry;
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/data/set/RemoteAppEntryClayDataSetActionProvider.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/data/set/RemoteAppEntryClayDataSetActionProvider.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.data.set;
+
+import com.liferay.frontend.taglib.clay.data.set.ClayDataSetActionProvider;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.remote.app.admin.web.internal.constants.DataSetDisplayConstants;
+
+import java.util.List;
+import java.util.ResourceBundle;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bruno Basto
+ */
+@Component(
+	immediate = true,
+	property = "clay.data.provider.key=" + DataSetDisplayConstants.REMOTE_APP_ENTRY_DATA_SET_DISPLAY,
+	service = ClayDataSetActionProvider.class
+)
+public class RemoteAppEntryClayDataSetActionProvider
+	implements ClayDataSetActionProvider {
+
+	@Override
+	public List<DropdownItem> getDropdownItems(
+			HttpServletRequest httpServletRequest, long groupId, Object model)
+		throws PortalException {
+
+		RemoteAppClayDataSetEntry remoteAppClayDataSetEntry =
+			(RemoteAppClayDataSetEntry)model;
+
+		return DropdownItemListBuilder.add(
+			dropdownItem -> _buildEditAction(
+				dropdownItem, httpServletRequest, remoteAppClayDataSetEntry)
+		).add(
+			dropdownItem -> _buildDeleteAction(
+				dropdownItem, httpServletRequest, remoteAppClayDataSetEntry)
+		).build();
+	}
+
+	private void _buildDeleteAction(
+		DropdownItem dropdownItem, HttpServletRequest httpServletRequest,
+		RemoteAppClayDataSetEntry remoteAppClayDataSetEntry) {
+
+		PortletURL deleteEntryURL = _getActionURL(httpServletRequest);
+
+		deleteEntryURL.setParameter(ActionRequest.ACTION_NAME, "/delete_entry");
+		deleteEntryURL.setParameter(
+			"entryId", String.valueOf(remoteAppClayDataSetEntry.getEntryId()));
+
+		dropdownItem.setHref(deleteEntryURL.toString());
+
+		dropdownItem.setIcon("times-circle");
+		dropdownItem.setLabel(_getMessage(httpServletRequest, "delete"));
+	}
+
+	private void _buildEditAction(
+		DropdownItem dropdownItem, HttpServletRequest httpServletRequest,
+		RemoteAppClayDataSetEntry remoteAppClayDataSetEntry) {
+
+		PortletURL editEntryURL = _getRenderURL(httpServletRequest);
+
+		editEntryURL.setParameter("mvcRenderCommandName", "/edit_entry");
+		editEntryURL.setParameter(
+			"entryId", String.valueOf(remoteAppClayDataSetEntry.getEntryId()));
+
+		String currentURL = ParamUtil.getString(
+			httpServletRequest, "currentUrl",
+			_portal.getCurrentURL(httpServletRequest));
+
+		editEntryURL.setParameter("redirect", currentURL);
+
+		dropdownItem.setHref(editEntryURL);
+		dropdownItem.setLabel(_getMessage(httpServletRequest, "edit"));
+	}
+
+	private PortletURL _getActionURL(HttpServletRequest httpServletRequest) {
+		String portletId = _getPortletId(httpServletRequest);
+
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory =
+			RequestBackedPortletURLFactoryUtil.create(httpServletRequest);
+
+		return requestBackedPortletURLFactory.createActionURL(portletId);
+	}
+
+	private String _getMessage(
+		HttpServletRequest httpServletRequest, String key) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+			"content.Language", themeDisplay.getLocale(), getClass());
+
+		return LanguageUtil.get(resourceBundle, key);
+	}
+
+	private String _getPortletId(HttpServletRequest httpServletRequest) {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		return portletDisplay.getId();
+	}
+
+	private PortletURL _getRenderURL(HttpServletRequest httpServletRequest) {
+		String portletId = _getPortletId(httpServletRequest);
+
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory =
+			RequestBackedPortletURLFactoryUtil.create(httpServletRequest);
+
+		return requestBackedPortletURLFactory.createRenderURL(portletId);
+	}
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private PortletLocalService _portletLocalService;
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/data/set/RemoteAppEntryClayDataSetDataProvider.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/data/set/RemoteAppEntryClayDataSetDataProvider.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.data.set;
+
+import com.liferay.frontend.taglib.clay.data.Filter;
+import com.liferay.frontend.taglib.clay.data.Pagination;
+import com.liferay.frontend.taglib.clay.data.set.provider.ClayDataSetDataProvider;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.remote.app.admin.web.internal.constants.DataSetDisplayConstants;
+import com.liferay.remote.app.model.RemoteAppEntry;
+import com.liferay.remote.app.service.RemoteAppEntryLocalService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bruno Basto
+ */
+@Component(
+	immediate = true,
+	property = "clay.data.provider.key=" + DataSetDisplayConstants.REMOTE_APP_ENTRY_DATA_SET_DISPLAY,
+	service = ClayDataSetDataProvider.class
+)
+public class RemoteAppEntryClayDataSetDataProvider
+	implements ClayDataSetDataProvider<RemoteAppClayDataSetEntry> {
+
+	@Override
+	public List<RemoteAppClayDataSetEntry> getItems(
+			HttpServletRequest httpServletRequest, Filter filter,
+			Pagination pagination, Sort sort)
+		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		List<RemoteAppEntry> entries =
+			_remoteAppEntryLocalService.getRemoteAppEntries(
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		Stream<RemoteAppEntry> stream = entries.stream();
+
+		return stream.map(
+			entry -> new RemoteAppClayDataSetEntry(
+				entry, themeDisplay.getLocale())
+		).collect(
+			Collectors.toList()
+		);
+	}
+
+	@Override
+	public int getItemsCount(
+			HttpServletRequest httpServletRequest, Filter filter)
+		throws PortalException {
+
+		return _remoteAppEntryLocalService.getRemoteAppEntriesCount();
+	}
+
+	@Reference
+	private RemoteAppEntryLocalService _remoteAppEntryLocalService;
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/data/set/RemoteAppEntryTableClayDataSetDisplayView.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/data/set/RemoteAppEntryTableClayDataSetDisplayView.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.data.set;
+
+import com.liferay.frontend.taglib.clay.data.set.ClayDataSetDisplayView;
+import com.liferay.frontend.taglib.clay.data.set.view.table.BaseTableClayDataSetDisplayView;
+import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchema;
+import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaBuilder;
+import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaBuilderFactory;
+import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaField;
+import com.liferay.remote.app.admin.web.internal.constants.DataSetDisplayConstants;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bruno Basto
+ */
+@Component(
+	immediate = true,
+	property = "clay.data.set.display.name=" + DataSetDisplayConstants.REMOTE_APP_ENTRY_DATA_SET_DISPLAY,
+	service = ClayDataSetDisplayView.class
+)
+public class RemoteAppEntryTableClayDataSetDisplayView
+	extends BaseTableClayDataSetDisplayView {
+
+	@Override
+	public ClayTableSchema getClayTableSchema() {
+		ClayTableSchemaBuilder clayTableSchemaBuilder =
+			_clayTableSchemaBuilderFactory.create();
+
+		_addField(clayTableSchemaBuilder, "name", "name", "actionLink");
+		_addField(clayTableSchemaBuilder, "url", "url");
+
+		return clayTableSchemaBuilder.build();
+	}
+
+	private void _addField(
+		ClayTableSchemaBuilder clayTableSchemaBuilder, String fieldName,
+		String label) {
+
+		_addField(clayTableSchemaBuilder, fieldName, label, null);
+	}
+
+	private void _addField(
+		ClayTableSchemaBuilder clayTableSchemaBuilder, String fieldName,
+		String label, String contentRenderer) {
+
+		ClayTableSchemaField field =
+			clayTableSchemaBuilder.addClayTableSchemaField(fieldName, label);
+
+		if (contentRenderer != null) {
+			field.setContentRenderer(contentRenderer);
+		}
+	}
+
+	@Reference
+	private ClayTableSchemaBuilderFactory _clayTableSchemaBuilderFactory;
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/display/context/RemoteAppAdminDataSetDisplayContext.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/display/context/RemoteAppAdminDataSetDisplayContext.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenuBuilder;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.PortletURLUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.remote.app.service.RemoteAppEntryLocalService;
+
+import javax.portlet.PortletURL;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+public class RemoteAppAdminDataSetDisplayContext {
+
+	public RemoteAppAdminDataSetDisplayContext(
+		RenderRequest renderRequest, RenderResponse renderResponse,
+		RemoteAppEntryLocalService remoteAppEntryLocalService) {
+
+		_renderRequest = renderRequest;
+		_renderResponse = renderResponse;
+	}
+
+	public CreationMenu getCreationMenu() {
+		return CreationMenuBuilder.addDropdownItem(
+			dropdownItem -> {
+				PortletURL addEntryURL = _renderResponse.createRenderURL();
+
+				addEntryURL.setParameter("mvcRenderCommandName", "/edit_entry");
+				addEntryURL.setParameter("redirect", _getRedirect());
+
+				dropdownItem.setHref(addEntryURL);
+
+				dropdownItem.setLabel(_getLabel("add-remote-web-app"));
+			}
+		).build();
+	}
+
+	public PortletURL getCurrentPortletURL() {
+		return PortletURLUtil.getCurrent(_renderRequest, _renderResponse);
+	}
+
+	private HttpServletRequest _getHttpServletRequest() {
+		return PortalUtil.getHttpServletRequest(_renderRequest);
+	}
+
+	private String _getLabel(String label) {
+		return LanguageUtil.get(_getHttpServletRequest(), label);
+	}
+
+	private String _getRedirect() {
+		return PortalUtil.getCurrentURL(_getHttpServletRequest());
+	}
+
+	private final RenderRequest _renderRequest;
+	private final RenderResponse _renderResponse;
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/RemoteAppAdminPortlet.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/RemoteAppAdminPortlet.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.portlet;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.remote.app.admin.web.internal.constants.RemoteAppAdminPortletKeys;
+
+import javax.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Iván Zaera
+ */
+@Component(
+	immediate = true,
+	property = {
+		"com.liferay.portlet.css-class-wrapper=portlet-remote-app-admin",
+		"com.liferay.portlet.display-category=hidden",
+		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.preferences-unique-per-layout=false",
+		"com.liferay.portlet.private-request-attributes=false",
+		"com.liferay.portlet.private-session-attributes=false",
+		"com.liferay.portlet.scopeable=true",
+		"com.liferay.portlet.use-default-template=true",
+		"javax.portlet.display-name=Remote Apps",
+		"javax.portlet.expiration-cache=0",
+		"javax.portlet.init-param.mvc-command-names-default-views=/admin/view",
+		"javax.portlet.init-param.portlet-title-based-navigation=true",
+		"javax.portlet.init-param.template-path=/META-INF/resources/",
+		"javax.portlet.name=" + RemoteAppAdminPortletKeys.REMOTE_APP_ADMIN,
+		"javax.portlet.resource-bundle=content.Language",
+		"javax.portlet.security-role-ref=administrator"
+	},
+	service = Portlet.class
+)
+public class RemoteAppAdminPortlet extends MVCPortlet {
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/RemoteAppPortlet.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/RemoteAppPortlet.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.portlet;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.remote.app.model.RemoteAppEntry;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+import javax.portlet.Portlet;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+public class RemoteAppPortlet extends MVCPortlet {
+
+	public RemoteAppPortlet(RemoteAppEntry remoteAppEntry) {
+		_remoteAppEntry = remoteAppEntry;
+	}
+
+	public String getName() {
+		return _remoteAppEntry.getNameCurrentLanguageId();
+	}
+
+	public String getName(Locale locale) {
+		return _remoteAppEntry.getName(locale);
+	}
+
+	public synchronized void register(BundleContext bundleContext) {
+		if (_serviceRegistration != null) {
+			throw new IllegalStateException("Portlet is already registered");
+		}
+
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		properties.put(
+			"com.liferay.portlet.css-class-wrapper", "portlet-remote-app");
+		properties.put(
+			"com.liferay.portlet.display-category", "category.sample");
+		properties.put(
+			"com.liferay.portlet.header-portlet-css", "/display/css/main.css");
+		properties.put("com.liferay.portlet.instanceable", true);
+		properties.put("javax.portlet.name", _getPortletName());
+		properties.put("javax.portlet.security-role-ref", "power-user,user");
+		properties.put(
+			"javax.portlet.resource-bundle", _getResourceBundleName());
+
+		_serviceRegistration = bundleContext.registerService(
+			Portlet.class, this, properties);
+
+		properties = new Hashtable<>();
+
+		properties.put("resource.bundle.base.name", _getResourceBundleName());
+		properties.put("servlet.context.name", "remote-app-admin-web");
+
+		_resourceBundleLoaderServiceRegistration =
+			bundleContext.registerService(
+				ResourceBundleLoader.class,
+				locale -> _getResourceBundle(locale), properties);
+	}
+
+	@Override
+	public void render(
+		RenderRequest renderRequest, RenderResponse renderResponse) {
+
+		try {
+			PrintWriter printWriter = renderResponse.getWriter();
+
+			printWriter.print(
+				"<iframe src=\"" + _remoteAppEntry.getUrl() + "\"></iframe>");
+
+			printWriter.flush();
+		}
+		catch (IOException ioException) {
+			_log.error("Unable to render HTML output", ioException);
+		}
+	}
+
+	public synchronized void unregister() {
+		if (_serviceRegistration == null) {
+			throw new IllegalStateException("Portlet is not registered");
+		}
+
+		_resourceBundleLoaderServiceRegistration.unregister();
+		_serviceRegistration.unregister();
+
+		_resourceBundleLoaderServiceRegistration = null;
+		_serviceRegistration = null;
+	}
+
+	private String _getPortletName() {
+		return "remote_app_" + _remoteAppEntry.getEntryId();
+	}
+
+	private ResourceBundle _getResourceBundle(Locale locale) {
+
+		// TODO: this ResourceBundle needs to be truly localized (and cached)
+
+		return new ResourceBundle() {
+
+			@Override
+			public Enumeration<String> getKeys() {
+				return Collections.enumeration(_labels.keySet());
+			}
+
+			@Override
+			protected Object handleGetObject(String key) {
+				return _labels.get(key);
+			}
+
+			private final Map<String, String> _labels = HashMapBuilder.put(
+				"javax.portlet.title." + _getPortletName(),
+				_remoteAppEntry.getName(locale)
+			).build();
+
+		};
+	}
+
+	private String _getResourceBundleName() {
+		return _getPortletName() + ".Language";
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RemoteAppPortlet.class);
+
+	private final RemoteAppEntry _remoteAppEntry;
+	private ServiceRegistration<ResourceBundleLoader>
+		_resourceBundleLoaderServiceRegistration;
+	private ServiceRegistration<Portlet> _serviceRegistration;
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/action/DeleteEntryMVCActionCommand.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/action/DeleteEntryMVCActionCommand.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.remote.app.admin.web.internal.RemoteAppPortletRegistrar;
+import com.liferay.remote.app.admin.web.internal.constants.RemoteAppAdminPortletKeys;
+import com.liferay.remote.app.exception.NoSuchEntryException;
+import com.liferay.remote.app.service.RemoteAppEntryLocalService;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bruno Basto
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + RemoteAppAdminPortletKeys.REMOTE_APP_ADMIN,
+		"mvc.command.name=/delete_entry"
+	},
+	service = MVCActionCommand.class
+)
+public class DeleteEntryMVCActionCommand extends BaseMVCActionCommand {
+
+	@Override
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		String redirect = ParamUtil.getString(actionRequest, "redirect");
+
+		long entryId = ParamUtil.getLong(actionRequest, "entryId");
+
+		try {
+			_remoteAppPortletRegistrar.unregisterPortlet(
+				_remoteAppEntryLocalService.getRemoteAppEntry(entryId));
+
+			_remoteAppEntryLocalService.deleteRemoteAppEntry(entryId);
+
+			if (Validator.isNotNull(redirect)) {
+				actionResponse.sendRedirect(redirect);
+			}
+		}
+		catch (Exception exception) {
+			if (exception instanceof NoSuchEntryException ||
+				exception instanceof PrincipalException) {
+
+				SessionErrors.add(actionRequest, exception.getClass());
+			}
+			else {
+				throw exception;
+			}
+		}
+	}
+
+	@Reference
+	private RemoteAppEntryLocalService _remoteAppEntryLocalService;
+
+	@Reference
+	private RemoteAppPortletRegistrar _remoteAppPortletRegistrar;
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/action/EditEntryMVCActionCommand.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/action/EditEntryMVCActionCommand.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.remote.app.admin.web.internal.RemoteAppPortletRegistrar;
+import com.liferay.remote.app.admin.web.internal.constants.RemoteAppAdminPortletKeys;
+import com.liferay.remote.app.exception.DuplicateRemoteAppEntryURLException;
+import com.liferay.remote.app.exception.NoSuchEntryException;
+import com.liferay.remote.app.model.RemoteAppEntry;
+import com.liferay.remote.app.service.RemoteAppEntryLocalService;
+
+import java.util.Locale;
+import java.util.Map;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bruno Basto
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + RemoteAppAdminPortletKeys.REMOTE_APP_ADMIN,
+		"mvc.command.name=/edit_entry"
+	},
+	service = MVCActionCommand.class
+)
+public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
+
+	@Override
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		String cmd = ParamUtil.getString(actionRequest, Constants.CMD);
+		String redirect = ParamUtil.getString(actionRequest, "redirect");
+
+		Map<Locale, String> nameMap = LocalizationUtil.getLocalizationMap(
+			actionRequest, "name");
+		String url = ParamUtil.getString(actionRequest, "url");
+
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			RemoteAppEntry.class.getName(), actionRequest);
+
+		try {
+			if (cmd.equals(Constants.ADD)) {
+				RemoteAppEntry remoteAppEntry =
+					_remoteAppEntryLocalService.addEntry(
+						serviceContext.getUserId(), nameMap, url,
+						serviceContext);
+
+				_remoteAppPortletRegistrar.registerPortlet(remoteAppEntry);
+			}
+			else if (cmd.equals(Constants.UPDATE)) {
+				long entryId = ParamUtil.getLong(actionRequest, "entryId");
+
+				RemoteAppEntry remoteAppEntry =
+					_remoteAppEntryLocalService.updateEntry(
+						entryId, nameMap, url, serviceContext);
+
+				_remoteAppPortletRegistrar.unregisterPortlet(remoteAppEntry);
+
+				_remoteAppPortletRegistrar.registerPortlet(remoteAppEntry);
+			}
+
+			if (Validator.isNotNull(redirect)) {
+				actionResponse.sendRedirect(redirect);
+			}
+		}
+		catch (Exception exception) {
+			if (exception instanceof NoSuchEntryException ||
+				exception instanceof PrincipalException) {
+
+				SessionErrors.add(actionRequest, exception.getClass());
+
+				actionResponse.setRenderParameter(
+					"mvcPath", "/admin/error.jsp");
+			}
+			else if (exception instanceof DuplicateRemoteAppEntryURLException) {
+				SessionErrors.add(actionRequest, exception.getClass());
+			}
+			else {
+				throw exception;
+			}
+		}
+	}
+
+	@Reference
+	private RemoteAppEntryLocalService _remoteAppEntryLocalService;
+
+	@Reference
+	private RemoteAppPortletRegistrar _remoteAppPortletRegistrar;
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/action/EditEntryMVCRenderCommand.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/action/EditEntryMVCRenderCommand.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.remote.app.admin.web.internal.constants.RemoteAppAdminPortletKeys;
+import com.liferay.remote.app.admin.web.internal.constants.RemoteAppAdminWebKeys;
+import com.liferay.remote.app.admin.web.internal.display.context.RemoteAppAdminDataSetDisplayContext;
+import com.liferay.remote.app.exception.NoSuchEntryException;
+import com.liferay.remote.app.service.RemoteAppEntryLocalService;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Iván Zaera
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + RemoteAppAdminPortletKeys.REMOTE_APP_ADMIN,
+		"mvc.command.name=/edit_entry"
+	},
+	service = MVCRenderCommand.class
+)
+public class EditEntryMVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		renderRequest.setAttribute(
+			"remoteAppAdminDataSetDisplayContext",
+			new RemoteAppAdminDataSetDisplayContext(
+				renderRequest, renderResponse, _remoteAppEntryLocalService));
+
+		try {
+			long entryId = ParamUtil.getLong(renderRequest, "entryId");
+
+			if (entryId > 0) {
+				renderRequest.setAttribute(
+					RemoteAppAdminWebKeys.REMOTE_APP_ENTRY,
+					_remoteAppEntryLocalService.getRemoteAppEntry(entryId));
+			}
+		}
+		catch (Exception exception) {
+			if (exception instanceof NoSuchEntryException) {
+				SessionErrors.add(renderRequest, exception.getClass());
+
+				return "/admin/error.jsp";
+			}
+
+			throw new PortletException(exception);
+		}
+
+		return "/admin/edit_entry.jsp";
+	}
+
+	@Reference
+	private RemoteAppEntryLocalService _remoteAppEntryLocalService;
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.admin.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.remote.app.admin.web.internal.constants.RemoteAppAdminPortletKeys;
+import com.liferay.remote.app.admin.web.internal.display.context.RemoteAppAdminDataSetDisplayContext;
+import com.liferay.remote.app.service.RemoteAppEntryLocalService;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Iván Zaera
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + RemoteAppAdminPortletKeys.REMOTE_APP_ADMIN,
+		"mvc.command.name=/"
+	},
+	service = MVCRenderCommand.class
+)
+public class ViewMVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		renderRequest.setAttribute(
+			"remoteAppAdminDataSetDisplayContext",
+			new RemoteAppAdminDataSetDisplayContext(
+				renderRequest, renderResponse, _remoteAppEntryLocalService));
+
+		return "/admin/view.jsp";
+	}
+
+	@Reference
+	private RemoteAppEntryLocalService _remoteAppEntryLocalService;
+
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/admin/edit_entry.jsp
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/admin/edit_entry.jsp
@@ -1,0 +1,75 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/admin/init.jsp" %>
+
+<%
+String redirect = ParamUtil.getString(request, "redirect");
+
+RemoteAppEntry remoteAppEntry = (RemoteAppEntry)request.getAttribute(RemoteAppAdminWebKeys.REMOTE_APP_ENTRY);
+
+long entryId = BeanParamUtil.getLong(remoteAppEntry, request, "entryId");
+
+portletDisplay.setShowBackIcon(true);
+portletDisplay.setURLBack(redirect);
+
+renderResponse.setTitle((remoteAppEntry == null) ? LanguageUtil.get(request, "new-remote-app") : remoteAppEntry.getName(locale));
+%>
+
+<portlet:actionURL name="/edit_entry" var="editEntryURL" />
+
+<clay:container-fluid>
+	<aui:form action="<%= editEntryURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveEntry();" %>'>
+		<aui:input name="<%= Constants.CMD %>" type="hidden" />
+		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
+		<aui:input name="entryId" type="hidden" value="<%= entryId %>" />
+
+		<liferay-ui:error exception="<%= DuplicateRemoteAppEntryURLException.class %>" message="please-enter-an-unique-app-url" />
+
+		<aui:model-context bean="<%= remoteAppEntry %>" model="<%= RemoteAppEntry.class %>" />
+
+		<aui:fieldset-group markupView="lexicon">
+			<aui:fieldset>
+				<aui:field-wrapper label="name">
+					<liferay-ui:input-localized
+						autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>"
+						name="name"
+						xml='<%= BeanPropertiesUtil.getString(remoteAppEntry, "name") %>'
+					/>
+				</aui:field-wrapper>
+
+				<aui:input name="url">
+					<aui:validator name="url" />
+				</aui:input>
+			</aui:fieldset>
+		</aui:fieldset-group>
+
+		<aui:button-row>
+			<aui:button type="submit" />
+
+			<aui:button href="<%= redirect %>" type="cancel" />
+		</aui:button-row>
+	</aui:form>
+</clay:container-fluid>
+
+<aui:script>
+	function <portlet:namespace />saveEntry() {
+		document.<portlet:namespace />fm.<portlet:namespace /><%= Constants.CMD %>.value =
+			'<%= (remoteAppEntry == null) ? Constants.ADD : Constants.UPDATE %>';
+
+		submitForm(document.<portlet:namespace />fm);
+	}
+</aui:script>

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/admin/init.jsp
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/admin/init.jsp
@@ -1,0 +1,32 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%@ page import="com.liferay.portal.kernel.bean.BeanParamUtil" %><%@
+page import="com.liferay.portal.kernel.bean.BeanPropertiesUtil" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
+page import="com.liferay.remote.app.admin.web.internal.constants.DataSetDisplayConstants" %><%@
+page import="com.liferay.remote.app.admin.web.internal.constants.RemoteAppAdminWebKeys" %><%@
+page import="com.liferay.remote.app.admin.web.internal.display.context.RemoteAppAdminDataSetDisplayContext" %><%@
+page import="com.liferay.remote.app.exception.DuplicateRemoteAppEntryURLException" %>
+
+<%
+	RemoteAppAdminDataSetDisplayContext remoteAppAdminDataSetDisplayContext = (RemoteAppAdminDataSetDisplayContext)renderRequest.getAttribute("remoteAppAdminDataSetDisplayContext");
+
+	PortletURL currentPortletURL = remoteAppAdminDataSetDisplayContext.getCurrentPortletURL();
+%>

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -1,0 +1,32 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/admin/init.jsp" %>
+
+<clay:dataset-display
+	actionParameterName="entryId"
+	creationMenu="<%= remoteAppAdminDataSetDisplayContext.getCreationMenu() %>"
+	dataProviderKey="<%= DataSetDisplayConstants.REMOTE_APP_ENTRY_DATA_SET_DISPLAY %>"
+	formId='<%= liferayPortletResponse.getNamespace() + "fm" %>'
+	id="<%= DataSetDisplayConstants.REMOTE_APP_ENTRY_DATA_SET_DISPLAY %>"
+	itemsPerPage="<%= 10 %>"
+	namespace="<%= liferayPortletResponse.getNamespace() %>"
+	pageNumber="<%= 1 %>"
+	portletURL="<%= currentPortletURL %>"
+	selectedItemsKey="entryId"
+	selectionType="multiple"
+	style="fluid"
+/>

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/display/css/main.css
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/display/css/main.css
@@ -1,0 +1,4 @@
+.portlet-remote-app iframe {
+    min-height: 500px;
+    width: 100%;
+}

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,35 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+
+<%@ page import="com.liferay.portal.kernel.util.Constants" %><%@
+page import="com.liferay.remote.app.model.RemoteAppEntry" %>
+
+<%@ page import="javax.portlet.PortletURL" %><%@
+page import="javax.portlet.WindowState" %>
+
+<liferay-frontend:defineObjects />
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language.properties
@@ -1,0 +1,5 @@
+javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps
+new-remote-app=New Remote App
+please-enter-an-unique-app-url=Please enter an unique app url.
+registered-app-urls=Registered Remote App URLs
+remote-app-configuration-name=Remote Apps

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalService.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalService.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.BaseLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
@@ -37,6 +38,8 @@ import com.liferay.remote.app.model.RemoteAppEntry;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -63,6 +66,11 @@ public interface RemoteAppEntryLocalService
 	 *
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.remote.app.service.impl.RemoteAppEntryLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the remote app entry local service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link RemoteAppEntryLocalServiceUtil} if injection and service tracking are not available.
 	 */
+	@Indexable(type = IndexableType.REINDEX)
+	public RemoteAppEntry addEntry(
+			long userId, Map<Locale, String> nameMap, String url,
+			ServiceContext serviceContext)
+		throws PortalException;
 
 	/**
 	 * Adds the remote app entry to the database. Also notifies the appropriate model listeners.
@@ -279,6 +287,11 @@ public interface RemoteAppEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public RemoteAppEntry getRemoteAppEntryByUuidAndCompanyId(
 			String uuid, long companyId)
+		throws PortalException;
+
+	public RemoteAppEntry updateEntry(
+			long entryId, Map<Locale, String> nameMap, String url,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	/**

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceUtil.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceUtil.java
@@ -37,6 +37,14 @@ public class RemoteAppEntryLocalServiceUtil {
 	 *
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.remote.app.service.impl.RemoteAppEntryLocalServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
+	public static com.liferay.remote.app.model.RemoteAppEntry addEntry(
+			long userId, java.util.Map<java.util.Locale, String> nameMap,
+			String url,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addEntry(userId, nameMap, url, serviceContext);
+	}
 
 	/**
 	 * Adds the remote app entry to the database. Also notifies the appropriate model listeners.
@@ -327,6 +335,15 @@ public class RemoteAppEntryLocalServiceUtil {
 
 		return getService().getRemoteAppEntryByUuidAndCompanyId(
 			uuid, companyId);
+	}
+
+	public static com.liferay.remote.app.model.RemoteAppEntry updateEntry(
+			long entryId, java.util.Map<java.util.Locale, String> nameMap,
+			String url,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().updateEntry(entryId, nameMap, url, serviceContext);
 	}
 
 	/**

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceWrapper.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceWrapper.java
@@ -33,6 +33,17 @@ public class RemoteAppEntryLocalServiceWrapper
 		_remoteAppEntryLocalService = remoteAppEntryLocalService;
 	}
 
+	@Override
+	public com.liferay.remote.app.model.RemoteAppEntry addEntry(
+			long userId, java.util.Map<java.util.Locale, String> nameMap,
+			String url,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _remoteAppEntryLocalService.addEntry(
+			userId, nameMap, url, serviceContext);
+	}
+
 	/**
 	 * Adds the remote app entry to the database. Also notifies the appropriate model listeners.
 	 *
@@ -342,6 +353,17 @@ public class RemoteAppEntryLocalServiceWrapper
 
 		return _remoteAppEntryLocalService.getRemoteAppEntryByUuidAndCompanyId(
 			uuid, companyId);
+	}
+
+	@Override
+	public com.liferay.remote.app.model.RemoteAppEntry updateEntry(
+			long entryId, java.util.Map<java.util.Locale, String> nameMap,
+			String url,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _remoteAppEntryLocalService.updateEntry(
+			entryId, nameMap, url, serviceContext);
 	}
 
 	/**

--- a/modules/apps/remote-app/remote-app-service/build.gradle
+++ b/modules/apps/remote-app/remote-app-service/build.gradle
@@ -1,6 +1,6 @@
 buildService {
 	apiDir = "../remote-app-api/src/main/java"
-	//testDir = "../remote-app-test/src/testIntegration/java"
+	testDir = "../remote-app-test/src/testIntegration/java"
 }
 
 dependencies {

--- a/modules/apps/remote-app/remote-app-service/service.xml
+++ b/modules/apps/remote-app/remote-app-service/service.xml
@@ -34,6 +34,10 @@
 			<finder-column name="companyId" />
 			<finder-column name="url" />
 		</finder>
+
+		<!-- References -->
+
+		<reference entity="User" package-path="com.liferay.portal" />
 	</entity>
 	<exceptions>
 		<exception>DuplicateRemoteAppEntryURL</exception>

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/RemoteAppServiceUpgrade.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/RemoteAppServiceUpgrade.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.internal.upgrade;
+
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Iván Zaera
+ */
+@Component(immediate = true, service = UpgradeStepRegistrator.class)
+public class RemoteAppServiceUpgrade implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+	}
+
+}

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/base/RemoteAppEntryLocalServiceBaseImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/base/RemoteAppEntryLocalServiceBaseImpl.java
@@ -533,4 +533,8 @@ public abstract class RemoteAppEntryLocalServiceBaseImpl
 	protected com.liferay.counter.kernel.service.CounterLocalService
 		counterLocalService;
 
+	@Reference
+	protected com.liferay.portal.kernel.service.UserLocalService
+		userLocalService;
+
 }

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
@@ -15,7 +15,22 @@
 package com.liferay.remote.app.service.impl;
 
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Indexable;
+import com.liferay.portal.kernel.search.IndexableType;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.remote.app.exception.DuplicateRemoteAppEntryURLException;
+import com.liferay.remote.app.model.RemoteAppEntry;
 import com.liferay.remote.app.service.base.RemoteAppEntryLocalServiceBaseImpl;
+
+import java.util.Locale;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -28,4 +43,88 @@ import org.osgi.service.component.annotations.Component;
 )
 public class RemoteAppEntryLocalServiceImpl
 	extends RemoteAppEntryLocalServiceBaseImpl {
+
+	@Indexable(type = IndexableType.REINDEX)
+	@Override
+	public RemoteAppEntry addEntry(
+			long userId, Map<Locale, String> nameMap, String url,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		// Entry
+
+		User user = userLocalService.getUser(userId);
+
+		long companyId = user.getCompanyId();
+
+		validate(companyId, 0, url);
+
+		long entryId = counterLocalService.increment();
+
+		RemoteAppEntry remoteAppEntry = remoteAppEntryPersistence.create(
+			entryId);
+
+		remoteAppEntry.setUuid(serviceContext.getUuid());
+		remoteAppEntry.setCompanyId(companyId);
+		remoteAppEntry.setUserId(user.getUserId());
+		remoteAppEntry.setUserName(user.getFullName());
+		remoteAppEntry.setNameMap(nameMap);
+		remoteAppEntry.setUrl(url);
+
+		try {
+			remoteAppEntry = remoteAppEntryPersistence.update(remoteAppEntry);
+		}
+		catch (SystemException systemException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Add failed, fetch {companyId=",
+						String.valueOf(user.getCompanyId()), "url=", url, "}"));
+			}
+
+			remoteAppEntry = remoteAppEntryPersistence.fetchByC_U(
+				user.getCompanyId(), url);
+
+			if (remoteAppEntry == null) {
+				throw systemException;
+			}
+		}
+
+		return remoteAppEntry;
+	}
+
+	@Override
+	public RemoteAppEntry updateEntry(
+			long entryId, Map<Locale, String> nameMap, String url,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		validate(serviceContext.getCompanyId(), entryId, url);
+
+		RemoteAppEntry remoteAppEntry =
+			remoteAppEntryPersistence.findByPrimaryKey(entryId);
+
+		remoteAppEntry.setNameMap(nameMap);
+		remoteAppEntry.setUrl(url);
+
+		return remoteAppEntryPersistence.update(remoteAppEntry);
+	}
+
+	protected void validate(long companyId, long entryId, String url)
+		throws PortalException {
+
+		RemoteAppEntry remoteAppEntry = remoteAppEntryPersistence.fetchByC_U(
+			companyId, StringUtil.trim(url));
+
+		if ((remoteAppEntry != null) &&
+			(remoteAppEntry.getEntryId() != entryId)) {
+
+			throw new DuplicateRemoteAppEntryURLException(
+				"{entryId=" + entryId + "}");
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RemoteAppEntryLocalServiceImpl.class);
+
 }

--- a/modules/apps/remote-app/remote-app-test/bnd.bnd
+++ b/modules/apps/remote-app/remote-app-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Remote App Test
+Bundle-SymbolicName: com.liferay.remote.app.test
+Bundle-Version: 1.0.0

--- a/modules/apps/remote-app/remote-app-test/build.gradle
+++ b/modules/apps/remote-app/remote-app-test/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationCompile project(":apps:remote-app:remote-app-api")
+	testIntegrationCompile project(":core:petra:petra-string")
+	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/remote-app/remote-app-test/src/testIntegration/java/com/liferay/remote/app/service/persistence/test/RemoteAppEntryPersistenceTest.java
+++ b/modules/apps/remote-app/remote-app-test/src/testIntegration/java/com/liferay/remote/app/service/persistence/test/RemoteAppEntryPersistenceTest.java
@@ -1,0 +1,501 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.service.persistence.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.util.IntegerWrapper;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PersistenceTestRule;
+import com.liferay.portal.test.rule.TransactionalTestRule;
+import com.liferay.remote.app.exception.NoSuchEntryException;
+import com.liferay.remote.app.model.RemoteAppEntry;
+import com.liferay.remote.app.service.RemoteAppEntryLocalServiceUtil;
+import com.liferay.remote.app.service.persistence.RemoteAppEntryPersistence;
+import com.liferay.remote.app.service.persistence.RemoteAppEntryUtil;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @generated
+ */
+@RunWith(Arquillian.class)
+public class RemoteAppEntryPersistenceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(), PersistenceTestRule.INSTANCE,
+			new TransactionalTestRule(
+				Propagation.REQUIRED, "com.liferay.remote.app.service"));
+
+	@Before
+	public void setUp() {
+		_persistence = RemoteAppEntryUtil.getPersistence();
+
+		Class<?> clazz = _persistence.getClass();
+
+		_dynamicQueryClassLoader = clazz.getClassLoader();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		Iterator<RemoteAppEntry> iterator = _remoteAppEntries.iterator();
+
+		while (iterator.hasNext()) {
+			_persistence.remove(iterator.next());
+
+			iterator.remove();
+		}
+	}
+
+	@Test
+	public void testCreate() throws Exception {
+		long pk = RandomTestUtil.nextLong();
+
+		RemoteAppEntry remoteAppEntry = _persistence.create(pk);
+
+		Assert.assertNotNull(remoteAppEntry);
+
+		Assert.assertEquals(remoteAppEntry.getPrimaryKey(), pk);
+	}
+
+	@Test
+	public void testRemove() throws Exception {
+		RemoteAppEntry newRemoteAppEntry = addRemoteAppEntry();
+
+		_persistence.remove(newRemoteAppEntry);
+
+		RemoteAppEntry existingRemoteAppEntry = _persistence.fetchByPrimaryKey(
+			newRemoteAppEntry.getPrimaryKey());
+
+		Assert.assertNull(existingRemoteAppEntry);
+	}
+
+	@Test
+	public void testUpdateNew() throws Exception {
+		addRemoteAppEntry();
+	}
+
+	@Test
+	public void testUpdateExisting() throws Exception {
+		long pk = RandomTestUtil.nextLong();
+
+		RemoteAppEntry newRemoteAppEntry = _persistence.create(pk);
+
+		newRemoteAppEntry.setMvccVersion(RandomTestUtil.nextLong());
+
+		newRemoteAppEntry.setUuid(RandomTestUtil.randomString());
+
+		newRemoteAppEntry.setCompanyId(RandomTestUtil.nextLong());
+
+		newRemoteAppEntry.setUserId(RandomTestUtil.nextLong());
+
+		newRemoteAppEntry.setUserName(RandomTestUtil.randomString());
+
+		newRemoteAppEntry.setCreateDate(RandomTestUtil.nextDate());
+
+		newRemoteAppEntry.setModifiedDate(RandomTestUtil.nextDate());
+
+		newRemoteAppEntry.setName(RandomTestUtil.randomString());
+
+		newRemoteAppEntry.setUrl(RandomTestUtil.randomString());
+
+		_remoteAppEntries.add(_persistence.update(newRemoteAppEntry));
+
+		RemoteAppEntry existingRemoteAppEntry = _persistence.findByPrimaryKey(
+			newRemoteAppEntry.getPrimaryKey());
+
+		Assert.assertEquals(
+			existingRemoteAppEntry.getMvccVersion(),
+			newRemoteAppEntry.getMvccVersion());
+		Assert.assertEquals(
+			existingRemoteAppEntry.getUuid(), newRemoteAppEntry.getUuid());
+		Assert.assertEquals(
+			existingRemoteAppEntry.getEntryId(),
+			newRemoteAppEntry.getEntryId());
+		Assert.assertEquals(
+			existingRemoteAppEntry.getCompanyId(),
+			newRemoteAppEntry.getCompanyId());
+		Assert.assertEquals(
+			existingRemoteAppEntry.getUserId(), newRemoteAppEntry.getUserId());
+		Assert.assertEquals(
+			existingRemoteAppEntry.getUserName(),
+			newRemoteAppEntry.getUserName());
+		Assert.assertEquals(
+			Time.getShortTimestamp(existingRemoteAppEntry.getCreateDate()),
+			Time.getShortTimestamp(newRemoteAppEntry.getCreateDate()));
+		Assert.assertEquals(
+			Time.getShortTimestamp(existingRemoteAppEntry.getModifiedDate()),
+			Time.getShortTimestamp(newRemoteAppEntry.getModifiedDate()));
+		Assert.assertEquals(
+			existingRemoteAppEntry.getName(), newRemoteAppEntry.getName());
+		Assert.assertEquals(
+			existingRemoteAppEntry.getUrl(), newRemoteAppEntry.getUrl());
+	}
+
+	@Test
+	public void testCountByUuid() throws Exception {
+		_persistence.countByUuid("");
+
+		_persistence.countByUuid("null");
+
+		_persistence.countByUuid((String)null);
+	}
+
+	@Test
+	public void testCountByUuid_C() throws Exception {
+		_persistence.countByUuid_C("", RandomTestUtil.nextLong());
+
+		_persistence.countByUuid_C("null", 0L);
+
+		_persistence.countByUuid_C((String)null, 0L);
+	}
+
+	@Test
+	public void testCountByC_U() throws Exception {
+		_persistence.countByC_U(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByC_U(0L, "null");
+
+		_persistence.countByC_U(0L, (String)null);
+	}
+
+	@Test
+	public void testFindByPrimaryKeyExisting() throws Exception {
+		RemoteAppEntry newRemoteAppEntry = addRemoteAppEntry();
+
+		RemoteAppEntry existingRemoteAppEntry = _persistence.findByPrimaryKey(
+			newRemoteAppEntry.getPrimaryKey());
+
+		Assert.assertEquals(existingRemoteAppEntry, newRemoteAppEntry);
+	}
+
+	@Test(expected = NoSuchEntryException.class)
+	public void testFindByPrimaryKeyMissing() throws Exception {
+		long pk = RandomTestUtil.nextLong();
+
+		_persistence.findByPrimaryKey(pk);
+	}
+
+	@Test
+	public void testFindAll() throws Exception {
+		_persistence.findAll(
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, getOrderByComparator());
+	}
+
+	protected OrderByComparator<RemoteAppEntry> getOrderByComparator() {
+		return OrderByComparatorFactoryUtil.create(
+			"RemoteAppEntry", "mvccVersion", true, "uuid", true, "entryId",
+			true, "companyId", true, "userId", true, "userName", true,
+			"createDate", true, "modifiedDate", true, "name", true, "url",
+			true);
+	}
+
+	@Test
+	public void testFetchByPrimaryKeyExisting() throws Exception {
+		RemoteAppEntry newRemoteAppEntry = addRemoteAppEntry();
+
+		RemoteAppEntry existingRemoteAppEntry = _persistence.fetchByPrimaryKey(
+			newRemoteAppEntry.getPrimaryKey());
+
+		Assert.assertEquals(existingRemoteAppEntry, newRemoteAppEntry);
+	}
+
+	@Test
+	public void testFetchByPrimaryKeyMissing() throws Exception {
+		long pk = RandomTestUtil.nextLong();
+
+		RemoteAppEntry missingRemoteAppEntry = _persistence.fetchByPrimaryKey(
+			pk);
+
+		Assert.assertNull(missingRemoteAppEntry);
+	}
+
+	@Test
+	public void testFetchByPrimaryKeysWithMultiplePrimaryKeysWhereAllPrimaryKeysExist()
+		throws Exception {
+
+		RemoteAppEntry newRemoteAppEntry1 = addRemoteAppEntry();
+		RemoteAppEntry newRemoteAppEntry2 = addRemoteAppEntry();
+
+		Set<Serializable> primaryKeys = new HashSet<Serializable>();
+
+		primaryKeys.add(newRemoteAppEntry1.getPrimaryKey());
+		primaryKeys.add(newRemoteAppEntry2.getPrimaryKey());
+
+		Map<Serializable, RemoteAppEntry> remoteAppEntries =
+			_persistence.fetchByPrimaryKeys(primaryKeys);
+
+		Assert.assertEquals(2, remoteAppEntries.size());
+		Assert.assertEquals(
+			newRemoteAppEntry1,
+			remoteAppEntries.get(newRemoteAppEntry1.getPrimaryKey()));
+		Assert.assertEquals(
+			newRemoteAppEntry2,
+			remoteAppEntries.get(newRemoteAppEntry2.getPrimaryKey()));
+	}
+
+	@Test
+	public void testFetchByPrimaryKeysWithMultiplePrimaryKeysWhereNoPrimaryKeysExist()
+		throws Exception {
+
+		long pk1 = RandomTestUtil.nextLong();
+
+		long pk2 = RandomTestUtil.nextLong();
+
+		Set<Serializable> primaryKeys = new HashSet<Serializable>();
+
+		primaryKeys.add(pk1);
+		primaryKeys.add(pk2);
+
+		Map<Serializable, RemoteAppEntry> remoteAppEntries =
+			_persistence.fetchByPrimaryKeys(primaryKeys);
+
+		Assert.assertTrue(remoteAppEntries.isEmpty());
+	}
+
+	@Test
+	public void testFetchByPrimaryKeysWithMultiplePrimaryKeysWhereSomePrimaryKeysExist()
+		throws Exception {
+
+		RemoteAppEntry newRemoteAppEntry = addRemoteAppEntry();
+
+		long pk = RandomTestUtil.nextLong();
+
+		Set<Serializable> primaryKeys = new HashSet<Serializable>();
+
+		primaryKeys.add(newRemoteAppEntry.getPrimaryKey());
+		primaryKeys.add(pk);
+
+		Map<Serializable, RemoteAppEntry> remoteAppEntries =
+			_persistence.fetchByPrimaryKeys(primaryKeys);
+
+		Assert.assertEquals(1, remoteAppEntries.size());
+		Assert.assertEquals(
+			newRemoteAppEntry,
+			remoteAppEntries.get(newRemoteAppEntry.getPrimaryKey()));
+	}
+
+	@Test
+	public void testFetchByPrimaryKeysWithNoPrimaryKeys() throws Exception {
+		Set<Serializable> primaryKeys = new HashSet<Serializable>();
+
+		Map<Serializable, RemoteAppEntry> remoteAppEntries =
+			_persistence.fetchByPrimaryKeys(primaryKeys);
+
+		Assert.assertTrue(remoteAppEntries.isEmpty());
+	}
+
+	@Test
+	public void testFetchByPrimaryKeysWithOnePrimaryKey() throws Exception {
+		RemoteAppEntry newRemoteAppEntry = addRemoteAppEntry();
+
+		Set<Serializable> primaryKeys = new HashSet<Serializable>();
+
+		primaryKeys.add(newRemoteAppEntry.getPrimaryKey());
+
+		Map<Serializable, RemoteAppEntry> remoteAppEntries =
+			_persistence.fetchByPrimaryKeys(primaryKeys);
+
+		Assert.assertEquals(1, remoteAppEntries.size());
+		Assert.assertEquals(
+			newRemoteAppEntry,
+			remoteAppEntries.get(newRemoteAppEntry.getPrimaryKey()));
+	}
+
+	@Test
+	public void testActionableDynamicQuery() throws Exception {
+		final IntegerWrapper count = new IntegerWrapper();
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			RemoteAppEntryLocalServiceUtil.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setPerformActionMethod(
+			new ActionableDynamicQuery.PerformActionMethod<RemoteAppEntry>() {
+
+				@Override
+				public void performAction(RemoteAppEntry remoteAppEntry) {
+					Assert.assertNotNull(remoteAppEntry);
+
+					count.increment();
+				}
+
+			});
+
+		actionableDynamicQuery.performActions();
+
+		Assert.assertEquals(count.getValue(), _persistence.countAll());
+	}
+
+	@Test
+	public void testDynamicQueryByPrimaryKeyExisting() throws Exception {
+		RemoteAppEntry newRemoteAppEntry = addRemoteAppEntry();
+
+		DynamicQuery dynamicQuery = DynamicQueryFactoryUtil.forClass(
+			RemoteAppEntry.class, _dynamicQueryClassLoader);
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq(
+				"entryId", newRemoteAppEntry.getEntryId()));
+
+		List<RemoteAppEntry> result = _persistence.findWithDynamicQuery(
+			dynamicQuery);
+
+		Assert.assertEquals(1, result.size());
+
+		RemoteAppEntry existingRemoteAppEntry = result.get(0);
+
+		Assert.assertEquals(existingRemoteAppEntry, newRemoteAppEntry);
+	}
+
+	@Test
+	public void testDynamicQueryByPrimaryKeyMissing() throws Exception {
+		DynamicQuery dynamicQuery = DynamicQueryFactoryUtil.forClass(
+			RemoteAppEntry.class, _dynamicQueryClassLoader);
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq("entryId", RandomTestUtil.nextLong()));
+
+		List<RemoteAppEntry> result = _persistence.findWithDynamicQuery(
+			dynamicQuery);
+
+		Assert.assertEquals(0, result.size());
+	}
+
+	@Test
+	public void testDynamicQueryByProjectionExisting() throws Exception {
+		RemoteAppEntry newRemoteAppEntry = addRemoteAppEntry();
+
+		DynamicQuery dynamicQuery = DynamicQueryFactoryUtil.forClass(
+			RemoteAppEntry.class, _dynamicQueryClassLoader);
+
+		dynamicQuery.setProjection(ProjectionFactoryUtil.property("entryId"));
+
+		Object newEntryId = newRemoteAppEntry.getEntryId();
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.in("entryId", new Object[] {newEntryId}));
+
+		List<Object> result = _persistence.findWithDynamicQuery(dynamicQuery);
+
+		Assert.assertEquals(1, result.size());
+
+		Object existingEntryId = result.get(0);
+
+		Assert.assertEquals(existingEntryId, newEntryId);
+	}
+
+	@Test
+	public void testDynamicQueryByProjectionMissing() throws Exception {
+		DynamicQuery dynamicQuery = DynamicQueryFactoryUtil.forClass(
+			RemoteAppEntry.class, _dynamicQueryClassLoader);
+
+		dynamicQuery.setProjection(ProjectionFactoryUtil.property("entryId"));
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.in(
+				"entryId", new Object[] {RandomTestUtil.nextLong()}));
+
+		List<Object> result = _persistence.findWithDynamicQuery(dynamicQuery);
+
+		Assert.assertEquals(0, result.size());
+	}
+
+	@Test
+	public void testResetOriginalValues() throws Exception {
+		RemoteAppEntry newRemoteAppEntry = addRemoteAppEntry();
+
+		_persistence.clearCache();
+
+		RemoteAppEntry existingRemoteAppEntry = _persistence.findByPrimaryKey(
+			newRemoteAppEntry.getPrimaryKey());
+
+		Assert.assertEquals(
+			Long.valueOf(existingRemoteAppEntry.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				existingRemoteAppEntry, "getOriginalCompanyId",
+				new Class<?>[0]));
+		Assert.assertTrue(
+			Objects.equals(
+				existingRemoteAppEntry.getUrl(),
+				ReflectionTestUtil.invoke(
+					existingRemoteAppEntry, "getOriginalUrl",
+					new Class<?>[0])));
+	}
+
+	protected RemoteAppEntry addRemoteAppEntry() throws Exception {
+		long pk = RandomTestUtil.nextLong();
+
+		RemoteAppEntry remoteAppEntry = _persistence.create(pk);
+
+		remoteAppEntry.setMvccVersion(RandomTestUtil.nextLong());
+
+		remoteAppEntry.setUuid(RandomTestUtil.randomString());
+
+		remoteAppEntry.setCompanyId(RandomTestUtil.nextLong());
+
+		remoteAppEntry.setUserId(RandomTestUtil.nextLong());
+
+		remoteAppEntry.setUserName(RandomTestUtil.randomString());
+
+		remoteAppEntry.setCreateDate(RandomTestUtil.nextDate());
+
+		remoteAppEntry.setModifiedDate(RandomTestUtil.nextDate());
+
+		remoteAppEntry.setName(RandomTestUtil.randomString());
+
+		remoteAppEntry.setUrl(RandomTestUtil.randomString());
+
+		_remoteAppEntries.add(_persistence.update(remoteAppEntry));
+
+		return remoteAppEntry;
+	}
+
+	private List<RemoteAppEntry> _remoteAppEntries =
+		new ArrayList<RemoteAppEntry>();
+	private RemoteAppEntryPersistence _persistence;
+	private ClassLoader _dynamicQueryClassLoader;
+
+}


### PR DESCRIPTION
Originally https://github.com/liferay-frontend/liferay-portal/pull/200
And then broken down as requested: https://github.com/brianchandotcom/liferay-portal/pull/92278#issuecomment-669475551
Part 1: https://github.com/liferay-frontend/liferay-portal/pull/217
Part 2: This PR

To test it:
1. Go to `Remote Apps ` under `Custom Apps` in the `Applications Menu`
![Screen Shot 2020-08-11 at 09 08 20](https://user-images.githubusercontent.com/156388/89895692-9ba27b80-dbb2-11ea-9e53-85a0e32d5cd0.png)

2. Click the plus button and add a new Remote App
![Screen Shot 2020-08-11 at 09 08 59](https://user-images.githubusercontent.com/156388/89895715-a8bf6a80-dbb2-11ea-9280-476a61b3ddbf.png)

![Screen Shot 2020-08-11 at 09 08 34](https://user-images.githubusercontent.com/156388/89895761-bbd23a80-dbb2-11ea-8808-ab48211a451a.png)

3. The newly created app should now be available as a widget to be added on a page
![Screen Shot 2020-08-11 at 09 09 42](https://user-images.githubusercontent.com/156388/89895824-d1dffb00-dbb2-11ea-8b52-26955ba13af2.png)

4. When added, an iframe pointing to the app url should be rendered
![Screen Shot 2020-08-11 at 09 13 30](https://user-images.githubusercontent.com/156388/89895911-f2a85080-dbb2-11ea-8fb0-3375f350ba8c.png)
