### PR TITLE
LPS-117287 Multiple clicks on links mess up SPA navigation

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
@@ -15,7 +15,7 @@
 'use strict';
 
 import {async} from 'metal';
-import {match} from 'metal-dom';
+import {delegate, match} from 'metal-dom';
 import {utils, version} from 'senna';
 import globals from 'senna/lib/globals/globals';
 
@@ -123,6 +123,14 @@ const initSPA = function () {
 			}
 		});
 	};
+
+	delegate(document, 'click', 'a', (event) => {
+		const url = event.delegateTarget.href;
+
+		if (app.canNavigate(url)) {
+			app.navigate(url);
+		}
+	});
 
 	Liferay.initComponentCache();
 


### PR DESCRIPTION
This is a bugfix, see description and discussion in https://issues.liferay.com/browse/LPS-117287. This ticket exposes several unrelated bugs, one of which we previously fixed in https://github.com/liferay-frontend/liferay-portal/pull/171.

To reproduce, double(+)click on an edit link in journal. I added few console logs for gifs, as it is not clear when I click.

Before:
![before](https://user-images.githubusercontent.com/5435511/89909410-53ee1500-dbef-11ea-8ecc-cfa05fdc2d8f.gif)

After:
![after](https://user-images.githubusercontent.com/5435511/89909311-3751dd00-dbef-11ea-9b48-aa31d24c3066.gif)

Notes:
- This issue is not only in Journal, it is all over the place. It is most noticeable when opening pages with editors, such as journal or blogs, but weird things can happen on any page. For example, management toolbar may render below page content. I was not brave enough to make the change on all links on the portal, or on all `<aui:a>` links. What would be the ideal scope for this kind of change?
- Alternative to prevention is to handle the breakage on opening. I tried this, or example detecting if the editor already exist before creating it and destroying it, but nothing worked on a satisfactory level.
