### PR TITLE
LPS-118797 Bug Wiki ckeditor create table

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/creole_dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/creole_dialog_definition.js
@@ -47,7 +47,6 @@ CKEDITOR.on('dialogDefinition', (event) => {
 			infoTab.remove('cmbWidthType');
 			infoTab.remove('cmbWidthType');
 			infoTab.remove('htmlHeightType');
-			infoTab.remove('txtBorder');
 			infoTab.remove('txtCellPad');
 			infoTab.remove('txtCellSpace');
 			infoTab.remove('txtHeight');


### PR DESCRIPTION
### The bug

Is the same that @julien [commented](https://github.com/liferay-frontend/liferay-portal/pull/213#issuecomment-669929260).

**Steps to Reproduce:**

Navigate to CP > Content and Data > Wiki
Click Main
Click Plus button
Click on Table icon


**Expected Result:**
A table UI pop up and table inserted and renders borders.

**Actual Result:**
There's no pop up on table UI and error is thrown in browser console.


### The problem

In master the problem is the order when I click in the toolbar table button is passing first for creole_dialog_definition ([remove txtBorder](https://github.com/liferay/liferay-portal/blob/86404edebc666ff13b0e3a81e0e7be2f92bff38e/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/creole_dialog_definition.js#L50)) and then the plugin showborders try to [get txtBorder](https://github.com/ckeditor/ckeditor4/blob/eb2d11644a796cd13cd047cd55541430359f9317/plugins/showborders/plugin.js#L131) and crash.

In master with `liferay-ckeditor@4.13.1-liferay.8` before clean plugins https://github.com/liferay/liferay-ckeditor/commit/468d7e4345d9df25cb52ad57f59f120cff1c7078#diff-e9f394f8c7b75652dab866e4d9f42b68L79 the order is other (probably because the plugin is bundled with ckeditor) first the plugin showborders get txtBorder and later creole_dialog_definition remove txtBorder.

### The fix

Don´t remove txtBorder in creole_dialog_definition **but I don't know what can happen.** 

@jbalsas could you imagine the consequences of not deleting that `txtBorder`?  In the creole dialog at a quick glance, I don´t view another option for txtBorder.
