### PR TITLE
LPS-118964 - Fix floatElements uses

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
@@ -221,7 +221,7 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 
 				<clay:content-row
 					cssClass="asset-details"
-					floatElements="true"
+					floatElements=""
 					verticalAlign="center"
 				>
 					<c:if test="<%= assetPublisherDisplayContext.isEnableRatings() && assetRenderer.isRatable() %>">
@@ -319,7 +319,7 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 
 				<clay:content-row
 					cssClass="asset-details"
-					floatElements="true"
+					floatElements=""
 					verticalAlign="center"
 				>
 					<c:if test="<%= assetPublisherDisplayContext.isShowAvailableLocales() && assetRenderer.isLocalizable() %>">

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -244,7 +244,7 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 
 		<clay:content-row
 			cssClass="asset-details"
-			floatElements="true"
+			floatElements=""
 			verticalAlign="center"
 		>
 			<c:if test="<%= showContextLink %>">
@@ -372,7 +372,7 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 
 		<clay:content-row
 			cssClass="asset-details"
-			floatElements="true"
+			floatElements=""
 			verticalAlign="center"
 		>
 			<c:if test="<%= showLocalization %>">

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
@@ -203,7 +203,7 @@ if (journalContentDisplayContext.isShowArticle()) {
 
 		<clay:content-row
 			cssClass="mb-4 user-tool-asset-addon-entries"
-			floatElements="true"
+			floatElements=""
 			verticalAlign="center"
 		>
 			<c:if test="<%= ratingsContentMetadataAssetAddonEntry != null %>">


### PR DESCRIPTION
This PR fixes the use of `floatElements`
Where we needed an `autofit-float` class we were getting `autofit-float-true`.
Now it is fixed

---

How to test the PR:

- Add to the homepage an **Asset Publisher widget**
- Configure it to show all icons of sharing, print, etc
- Save and refresh the page to see the correct class `autoflit-row` applied