### PR TITLE
LPS-116693 Add support for NPM modules in fragments

### DIFF
--- a/modules/apps/fragment/fragment-impl/build.gradle
+++ b/modules/apps/fragment/fragment-impl/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	compileOnly project(":apps:flags:flags-taglib")
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:fragment:fragment-service")
+	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:item-selector:item-selector-api")

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
@@ -25,16 +25,20 @@ import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
 import com.liferay.fragment.renderer.constants.FragmentRendererConstants;
 import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
+import com.liferay.frontend.js.loader.modules.extender.npm.JSPackage;
+import com.liferay.frontend.js.loader.modules.extender.npm.JSPackageDependency;
+import com.liferay.frontend.js.loader.modules.extender.npm.ModuleNameUtil;
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistry;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.servlet.taglib.util.OutputData;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.servlet.PipingServletResponse;
@@ -42,6 +46,8 @@ import com.liferay.taglib.servlet.PipingServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -224,7 +230,7 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 			sb.append("'); var configuration = ");
 			sb.append(configuration);
 			sb.append(";");
-			sb.append(js);
+			sb.append(_rewriteRequiredModules(fragmentEntryId, js));
 			sb.append(";}());</script>");
 		}
 
@@ -347,6 +353,73 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 		return content;
 	}
 
+	// TODO: this method assumes that the imports information comes in a header
+	// in the JS code (because the bundler has put it there). This is only for
+	// the PoC and should be moved to a more suitable place in the final
+	// version (perhaps the fragment.json file or something like that).
+
+	private String _rewriteRequiredModules(long fragmentEntryId, String js) {
+		if (!js.startsWith("//{imports")) {
+			return js;
+		}
+
+		List<String> modules = new ArrayList<>();
+		List<String> variables = new ArrayList<>();
+
+		String[] lines = js.split(StringPool.NEW_LINE);
+
+		for (int i = 1; i < lines.length; i++) {
+			String line = lines[i];
+
+			if (line.equals("//}imports")) {
+				break;
+			}
+
+			line = line.substring(2);
+
+			String[] parts = line.split("\\|");
+
+			variables.add(parts[0]);
+
+			String moduleName = parts[1];
+
+			String packageName = ModuleNameUtil.getPackageName(moduleName);
+
+			// TODO: this is a bit of a hack because we are passing a null
+			// JSPackage owner to JSPackageDependency, but it can be used in
+			// older versions of the portal if we need to as the NPMRegistry
+			// doesn't use it.
+
+			JSPackage jsPackage = _npmRegistry.resolveJSPackageDependency(
+				new JSPackageDependency(null, packageName, parts[2]));
+
+			if (jsPackage == null) {
+				throw new IllegalStateException(
+					StringBundler.concat(
+						"Unable to resolve package version for module ",
+						moduleName, " in fragment entry ", fragmentEntryId));
+			}
+
+			moduleName = StringUtil.replace(
+				moduleName, packageName, jsPackage.getResolvedId());
+
+			modules.add(
+				StringPool.APOSTROPHE + moduleName + StringPool.APOSTROPHE);
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("Liferay.Loader.require([");
+		sb.append(StringUtil.merge(modules, StringPool.COMMA));
+		sb.append("], function(");
+		sb.append(StringUtil.merge(variables, StringPool.COMMA));
+		sb.append(") {\n");
+		sb.append(js);
+		sb.append("\n});");
+
+		return sb.toString();
+	}
+
 	private String _writePortletPaths(
 			FragmentEntryLink fragmentEntryLink, String html,
 			HttpServletRequest httpServletRequest,
@@ -378,6 +451,9 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 
 	@Reference
 	private MultiVMPool _multiVMPool;
+
+	@Reference
+	private NPMRegistry _npmRegistry;
 
 	@Reference
 	private PortletRegistry _portletRegistry;


### PR DESCRIPTION
> 👀 See [this doc](https://docs.google.com/document/d/1VXXxEyuHC7pGTCRF2vTb3tXu2mPJCG6KHFAKIhs1G7s/edit?usp=sharing) for an explanation of the whole PoC.

This is the server part of LPS-116693. The build time part of the LPS can be found [in this PR](https://github.com/liferay/liferay-js-toolkit/pull/626).

Unfortunately it is impossible to bring support for NPM modules to fragments unless we modify the server. This is because of the way version resolutions work now: we need to execute server code (even if it is minimal) to achieve them. There's no way to do it in pure JavaScript, as the information needed to do it is only available in the server (Java) domain.

This PoC assumes that any fragment may have a header like this:

```javascript
//{imports
//react_dom_0|frontend-js-react-web$react-dom|>=16.8.6
//react_1|frontend-js-react-web$react|>=16.8.6
//}imports
```

When this kind of header is found, the fragment is wrapped inside a `Liferay.Loader.require()` call to fulfill those variables. So, the above header would cause the fragment to be wrapped in a piece of code like this:

```javascript
Liferay.Loader.require([
  'frontend-js-react-web$react-dom@16.12.0', 
  'frontend-js-react-web$react@16.12.0'
], function(react_dom_0, react_1) {
  // ...
});
```

Note that the resolution from `>=16.8.6` to `16.12.0` would be done in the server by the code in this PR's commit.

----

With this simple mechanism, the bundler (or any tool generating fragments) may require any module it needs for the fragment code to execute. In particular, we may request `react` and `react-dom` from `frontend-js-react-web` so that the fragments get react support, but the mechanism is generic enough to use it in any way we like without ever again touching the server.

----

Note, however, that the current format for the imports header is a hack for the PoC. In the final version, we should probably put that information in a better place (perhaps `fragment.json`).
