### PR TITLE
LPS-118940 Remove extra colon from success alerts

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/ShareFormModal/ShareFormModal.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/ShareFormModal/ShareFormModal.es.js
@@ -134,11 +134,11 @@ class ShareFormModal extends Component {
 		const openToastParams = {message};
 
 		if (error) {
-			openToastParams.title = Liferay.Language.get('error-colon');
+			openToastParams.title = Liferay.Language.get('error');
 			openToastParams.type = 'danger';
 		}
 		else {
-			openToastParams.title = Liferay.Language.get('success-colon');
+			openToastParams.title = Liferay.Language.get('success');
 		}
 
 		parentOpenToast(openToastParams);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -124,6 +124,17 @@ function openToast({
 		}
 	};
 
+	let titleHTML =
+		title === undefined ? DEFAULT_TOAST_TYPE_TITLES[type] : title;
+
+	if (titleHTML) {
+		titleHTML = titleHTML.replace(/:$/, '');
+		titleHTML = `<strong class="lead">${titleHTML}:</strong>`;
+	}
+	else {
+		titleHTML = '';
+	}
+
 	render(
 		<ClayAlert
 			autoClose={autoClose}
@@ -135,14 +146,7 @@ function openToast({
 		>
 			<div
 				dangerouslySetInnerHTML={{
-					__html: `${
-						title ||
-						(title === undefined && DEFAULT_TOAST_TYPE_TITLES[type])
-							? `<strong class="lead">${
-									title || DEFAULT_TOAST_TYPE_TITLES[type]
-							  }:</strong>`
-							: ''
-					}${message}`,
+					__html: `${titleHTML}${message}`,
 				}}
 			/>
 		</ClayAlert>,

--- a/util-taglib/src/com/liferay/taglib/ui/SuccessTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SuccessTag.java
@@ -132,7 +132,7 @@ public class SuccessTag extends IncludeTag implements BodyTag {
 		}
 
 		Map<String, String> values = HashMapBuilder.put(
-			"title", LanguageUtil.get(resourceBundle, "success-colon")
+			"title", LanguageUtil.get(resourceBundle, "success")
 		).build();
 
 		if (_embed) {


### PR DESCRIPTION
This fixes the regression caused by [liferay-frontend#208](https://github.com/liferay-frontend/liferay-portal/pull/208), which started inserting the colon separator between title and message automatically.

In most places, we made the compensating change to remove the now-redundant colon from the call sites, but it looks like we missed this indirect one in util-taglib.

In sweeping through, I found another similar missed example in dynamic-data-mapping-form-web and fixed that too.

Test plan:

1. `ant deploy` in util-taglib.
2. Restart tomcat.
3. Create a blog post; see "Success:" (not "Success::") in toast.
4. Bonus: run all JS unit tests in dynamic-data-mapping modules.

![Screenshot 2020-08-12 -160348-ry2MmSnj@2x](https://user-images.githubusercontent.com/7074/90029422-279fca80-dcbb-11ea-85a9-e984279a6133.png)

Note, there's a second commit in here that adds a "defense in depth" layer on top of the first commit. We don't think there are any call sites which pass in a redundant colon at the end of their `title`, but in case they do, we can gracefully suppress it at pretty low cost.

In doing this, I also rejigged the code here to try to make it easier to read ie.

- One ternary and one `if`, written as statements; instead of:
- Two `||`, one `&&` and a ternary, interpolated inside JSX.

cc @jbalsas @diegonvs