### PR TITLE
LPS-118975 - Fix max-height in apple devices

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
@@ -37,13 +37,10 @@
 .applications-menu-wrapper {
 	display: flex;
 	flex-direction: column;
-	max-height: -moz-available;
-	max-height: -webkit-fill-available;
-	max-height: stretch;
-
-	@include media-breakpoint-up(sm) {
-		max-height: 100vh;
-	}
+	height: -moz-available;
+	height: -webkit-fill-available;
+	height: stretch;
+	max-height: 100vh;
 }
 
 .applications-menu-bg {

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
@@ -37,7 +37,13 @@
 .applications-menu-wrapper {
 	display: flex;
 	flex-direction: column;
-	max-height: 100vh;
+	max-height: -moz-available;
+	max-height: -webkit-fill-available;
+	max-height: stretch;
+
+	@include media-breakpoint-up(sm) {
+		max-height: 100vh;
+	}
 }
 
 .applications-menu-bg {


### PR DESCRIPTION
This PR fixes a problem with the applications menu height in Apple mobile devices, it also can be reproduced in iPad.

![IMG_3F23AD06AB38-1](https://user-images.githubusercontent.com/7963804/90127646-caad1e80-dd65-11ea-8dec-0bfad17e2d66.jpeg)

About some questions you could have:

- Why I use the `small` breakoint and not `xsmall`?
Because iPad has the same issue

- The lines, 40 and 41:
https://github.com/liferay-frontend/liferay-portal/pull/246/commits/7233c666b239b3681952afec98762a7a98ef279a#diff-a8b960730121fffdaf4e2e25b1826a30R40-R41
There are until we are ready to use `autoprefixer` in this module

- The line 42 has not the same value than prefixers:
https://github.com/liferay-frontend/liferay-portal/pull/246/commits/7233c666b239b3681952afec98762a7a98ef279a#diff-a8b960730121fffdaf4e2e25b1826a30R42
Yes, this because the specification has changed, and the new value is: `stretch`
You can see how it works in autoprefixer by using for example: 
https://autoprefixer.github.io and pasting:
```css
.applications-menu-wrapper {
      max-height: stretch;
}
```
![image](https://user-images.githubusercontent.com/7963804/90128494-3f348d00-dd67-11ea-855f-e5f7aefa141a.png)

--- 

**How to test it**

- Use an apple mobile device or select "iPhone X" in your "BrowserStak"
- Login in portal and open the **applications menu**
- Scroll until the final of the menu