### PR TITLE
LPS-119073 Fix JavaScript error when opening DataSet Display

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/dataset_display/DatasetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/dataset_display/DatasetDisplay.js
@@ -95,7 +95,7 @@ function DatasetDisplay({
 		...currentViewProps
 	} = activeView;
 
-	const selectable = bulkActions?.length && selectedItemsKey;
+	const selectable = bulkActions?.length > 0 && selectedItemsKey;
 
 	useEffect(() => {
 		if (

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/dataset_display/entry.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/dataset_display/entry.js
@@ -21,7 +21,7 @@ import ViewsContext, {viewsReducer} from './views/ViewsContext';
 
 const App = ({apiURL, appURL, ...props}) => {
 	const {
-		activeViewSettings: {name: activeViewName, ...activeViewSettings},
+		activeViewSettings: {name: activeViewName, visibleFieldNames = {}},
 		portletId,
 		views,
 	} = props;
@@ -30,9 +30,9 @@ const App = ({apiURL, appURL, ...props}) => {
 		: views[0];
 	const [state, dispatch] = useThunk(
 		useReducer(viewsReducer, {
-			...activeViewSettings,
 			activeView,
 			views,
+			visibleFieldNames,
 		})
 	);
 


### PR DESCRIPTION
No easy steps to reproduce because this TagLib is currently not being used anywhere. Error reported by @marco-leo when migrating Commerce to master.