### PR TITLE
LPS-119114 Fix space to make the product-menu closable

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_add_panel.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_add_panel.scss
@@ -16,6 +16,12 @@
 	width: $admin-panel-width;
 }
 
+.lfr-product-menu-panel.sidenav-fixed.sidenav-menu-slider {
+	@include media-breakpoint-down(xs) {
+		top: 3rem;
+	}
+}
+
 .lfr-admin-panel {
 	&.sidenav-menu-slider {
 		z-index: $admin-panel-zindex;

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -24,10 +24,10 @@ ApplicationsMenuInstanceConfiguration applicationsMenuInstanceConfiguration = Co
 %>
 
 <div class="lfr-product-menu-sidebar <%= applicationsMenuInstanceConfiguration.enableApplicationsMenu() ? "lfr-applications-menu" : "" %>" id="productMenuSidebar">
+	<h1 class="sr-only"><liferay-ui:message key="product-admin-menu" /></h1>
+
 	<c:if test="<%= !applicationsMenuInstanceConfiguration.enableApplicationsMenu() %>">
 		<div class="sidebar-header">
-			<h1 class="sr-only"><liferay-ui:message key="product-admin-menu" /></h1>
-
 			<clay:content-row>
 				<clay:content-col
 					expand="<%= true %>"


### PR DESCRIPTION
The first solution I tried, was to move the condition and re-enable the close button

![image](https://user-images.githubusercontent.com/46778114/90254736-855f1e80-de43-11ea-8dac-1c63f2eadd34.png)

But, as you can see, it's pretty ugly 😁.

So I decided to slightly change the layout of the current Product-Menu

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/46778114/90255130-21892580-de44-11ea-98a8-9586d037ef00.gif)


