### PR TITLE
LPS-117796 Fixes JavaScript errors with <clay:headless-data-set-display>

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DataSetDisplayTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DataSetDisplayTag.java
@@ -65,14 +65,6 @@ public class DataSetDisplayTag extends IncludeTag {
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
 		try {
-			if (_creationMenu == null) {
-				_creationMenu = new CreationMenu();
-			}
-
-			_setActiveViewSettingsJSON();
-			_setClayDataSetDisplayViewsContext();
-			_setClayPaginationEntries();
-
 			_appURL =
 				PortalUtil.getPortalURL(request) +
 					"/o/frontend-taglib-clay/app";
@@ -101,12 +93,20 @@ public class DataSetDisplayTag extends IncludeTag {
 
 			_apiURL = sb.toString();
 
+			if (_creationMenu == null) {
+				_creationMenu = new CreationMenu();
+			}
+
 			NPMResolver npmResolver = NPMResolverProvider.getNPMResolver();
 
 			if ((npmResolver != null) && Validator.isNull(_module)) {
 				_module = npmResolver.resolveModuleName(
 					"frontend-taglib-clay/data_set_display/entry");
 			}
+
+			_setActiveViewSettingsJSON();
+			_setClayDataSetDisplayViewsContext();
+			_setClayPaginationEntries();
 		}
 		catch (Exception exception) {
 			_log.error(exception, exception);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HeadlessDataSetDisplayTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HeadlessDataSetDisplayTag.java
@@ -72,7 +72,7 @@ public class HeadlessDataSetDisplayTag extends IncludeTag {
 		return super.doStartTag();
 	}
 
-	public String getAPIURL() {
+	public String getApiURL() {
 		return _apiURL;
 	}
 
@@ -154,7 +154,7 @@ public class HeadlessDataSetDisplayTag extends IncludeTag {
 		return _showSearch;
 	}
 
-	public void setAPIURL(String apiURL) {
+	public void setApiURL(String apiURL) {
 		_apiURL = apiURL;
 	}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -95,7 +95,7 @@ function DataSetDisplay({
 		...currentViewProps
 	} = activeView;
 
-	const selectable = bulkActions?.length > 0 && selectedItemsKey;
+	const selectable = !!(bulkActions?.length && selectedItemsKey);
 
 	useEffect(() => {
 		if (

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -316,7 +316,6 @@ function DataSetDisplay({
 				filters={filters}
 				fluid={style === 'fluid'}
 				onFiltersChange={updateFilters}
-				selectable={selectable}
 				selectAllItems={() =>
 					selectItems(items.map((item) => item[selectedItemsKey]))
 				}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
@@ -108,7 +108,7 @@ export function loadData(
 	page = 1,
 	sorting = []
 ) {
-	const url = new URL(apiURL);
+	const url = new URL(apiURL, themeDisplay.getPortalURL());
 
 	url.searchParams.append('currentUrl', currentUrl);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/Table.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/Table.js
@@ -158,7 +158,6 @@ function Table({items, itemsActions, schema, style}) {
 					selectedItemsValue={selectedItemsValue}
 					selectionType={selectionType}
 					selectItems={selectItems}
-					showActionItems={showActionItems}
 					sorting={sorting}
 					updateSorting={updateSorting}
 					visibleFields={visibleFields}
@@ -207,10 +206,9 @@ function Table({items, itemsActions, schema, style}) {
 										itemId,
 										itemsActions
 									)}
-									{showActionItems && (
-										<ClayTable.Cell className="data-set-item-actions-wrapper">
-											{(itemsActions ||
-												item.actionDropdownItems) && (
+									<ClayTable.Cell className="data-set-item-actions-wrapper">
+										{showActionItems &&
+											item.actionDropdownItems && (
 												<ActionsDropdownRenderer
 													actions={
 														itemsActions ||
@@ -220,8 +218,7 @@ function Table({items, itemsActions, schema, style}) {
 													itemId={itemId}
 												/>
 											)}
-										</ClayTable.Cell>
-									)}
+									</ClayTable.Cell>
 								</ClayTable.Row>
 								{nestedItems?.length
 									? nestedItems.map((nestedItem, i) => (

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableHeadRow.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableHeadRow.js
@@ -189,7 +189,6 @@ function TableHeadRow({
 	selectedItemsKey,
 	selectedItemsValue,
 	selectionType,
-	showActionItems,
 	sorting,
 	updateSorting,
 	visibleFields,
@@ -231,13 +230,9 @@ function TableHeadRow({
 						updateSorting={updateSorting}
 					/>
 				))}
-				{showActionItems ? (
-					<ClayTable.Cell className="text-right" headingCell>
-						<FieldsSelectorDropdown fields={schema.fields} />
-					</ClayTable.Cell>
-				) : (
+				<ClayTable.Cell className="text-right" headingCell>
 					<FieldsSelectorDropdown fields={schema.fields} />
-				)}
+				</ClayTable.Cell>
 			</ClayTable.Row>
 		</ClayTable.Head>
 	);
@@ -264,7 +259,6 @@ TableHeadRow.propTypes = {
 		PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 	),
 	selectionType: PropTypes.oneOf(['single', 'multiple']),
-	showActionItems: PropTypes.bool,
 	sorting: PropTypes.arrayOf(
 		PropTypes.shape({
 			direction: PropTypes.oneOf(['asc', 'desc']).isRequired,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/init.jsp
@@ -24,6 +24,7 @@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem" 
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONSerializer" %><%@
+page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %>
 
@@ -34,11 +35,15 @@ page import="com.liferay.portal.kernel.util.Validator" %>
 <liferay-theme:defineObjects />
 
 <%
+String actionParameterName = (String)request.getAttribute("clay:headless-data-set-display:actionParameterName");
+String activeViewSettingsJSON = GetterUtil.getString(request.getAttribute("clay:headless-data-set-display:activeViewSettingsJSON"), "{}");
 String apiURL = (String)request.getAttribute("clay:headless-data-set-display:apiURL");
+String appURL = (String)request.getAttribute("clay:headless-data-set-display:appURL");
 List<DropdownItem> bulkActionDropdownItems = (List<DropdownItem>)request.getAttribute("clay:headless-data-set-display:bulkActionDropdownItems");
 Object clayDataSetDisplayViewsContext = request.getAttribute("clay:headless-data-set-display:clayDataSetDisplayViewsContext");
 Object clayDataSetFiltersContext = request.getAttribute("clay:headless-data-set-display:clayDataSetFiltersContext");
 List<ClayDataSetActionDropdownItem> clayDataSetActionDropdownItems = (List<ClayDataSetActionDropdownItem>)request.getAttribute("clay:headless-data-set-display:clayDataSetActionDropdownItems");
+List<ClayPaginationEntry> clayPaginationEntries = (List<ClayPaginationEntry>)request.getAttribute("clay:headless-data-set-display:clayPaginationEntries");
 CreationMenu creationMenu = (CreationMenu)request.getAttribute("clay:headless-data-set-display:creationMenu");
 String formId = (String)request.getAttribute("clay:headless-data-set-display:formId");
 String id = (String)request.getAttribute("clay:headless-data-set-display:id");
@@ -48,7 +53,6 @@ String namespace = (String)request.getAttribute("clay:headless-data-set-display:
 String nestedItemsKey = (String)request.getAttribute("clay:headless-data-set-display:nestedItemsKey");
 String nestedItemsReferenceKey = (String)request.getAttribute("clay:headless-data-set-display:nestedItemsReferenceKey");
 int pageNumber = (int)request.getAttribute("clay:headless-data-set-display:pageNumber");
-List<ClayPaginationEntry> paginationEntries = (List<ClayPaginationEntry>)request.getAttribute("clay:headless-data-set-display:paginationEntries");
 PortletURL portletURL = (PortletURL)request.getAttribute("clay:headless-data-set-display:portletURL");
 List<String> selectedItems = (List<String>)request.getAttribute("clay:headless-data-set-display:selectedItems");
 String selectedItemsKey = (String)request.getAttribute("clay:headless-data-set-display:selectedItemsKey");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/page.jsp
@@ -33,7 +33,10 @@ JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
 <aui:script require='<%= module + " as dataSetDisplay" %>'>
 	dataSetDisplay.default(
 		{
-			apiUrl: '<%= apiURL %>',
+			actionParameterName: '<%= actionParameterName %>',
+			activeViewSettings: <%= activeViewSettingsJSON %>,
+			apiURL: '<%= apiURL %>',
+			appURL: '<%= appURL %>',
 			bulkActions: <%= jsonSerializer.serializeDeep(bulkActionDropdownItems) %>,
 			creationMenu: <%= jsonSerializer.serializeDeep(creationMenu) %>,
 			currentUrl: '<%= PortalUtil.getCurrentURL(request) %>',
@@ -62,7 +65,7 @@ JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
 			%>
 
 			pagination: {
-				deltas: <%= jsonSerializer.serializeDeep(paginationEntries) %>,
+				deltas: <%= jsonSerializer.serializeDeep(clayPaginationEntries) %>,
 				initialDelta: <%= itemsPerPage %>,
 				initialPageNumber: <%= pageNumber %>,
 			},


### PR DESCRIPTION
JavaScript errors happen when using `<clay:headless-data-set-display />`. Reason is while this was in review some other stuff got merged and I forgot to apply here before sending the final PR.

Not testable on the UI because no portlet uses this yet.