### PR TITLE
LPS-119036 Image placeholder and pagination arrows are wrong in RTL languages

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_vertical_card.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_vertical_card.scss
@@ -49,3 +49,9 @@
 .taglib-vertical-card-footer {
 	min-height: 5.6em;
 }
+
+.rtl {
+	.card .aspect-ratio-item-center-middle {
+		transform: translate(50%, -50%);
+	}
+}

--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -129,7 +129,7 @@ if (forcePost && (portletURL != null)) {
 			<li class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
 				<a class="page-link" href="<%= (cur > 1) ? _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) : "javascript:;" %>" onclick="<%= ((cur > 1) && forcePost) ? _getOnClick(namespace, curParam, cur -1) : "" %>">
 					<liferay-ui:icon
-						icon="angle-left"
+						icon='<%= PortalUtil.isRightToLeft(request) ? "angle-right" : "angle-left" %>'
 						markupView="lexicon"
 						message="previous-page"
 					/>
@@ -325,7 +325,7 @@ if (forcePost && (portletURL != null)) {
 			<li class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
 				<a class="page-link" href="<%= (cur < pages) ? _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) : "javascript:;" %>" onclick="<%= ((cur < pages) && forcePost) ? _getOnClick(namespace, curParam, cur + 1) : "" %>">
 					<liferay-ui:icon
-						icon="angle-right"
+						icon='<%= PortalUtil.isRightToLeft(request) ? "angle-left" : "angle-right" %>'
 						markupView="lexicon"
 						message="next-page"
 					/>


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

There are two issue to resolve here when we change to RTL view:

1. Image placeholders are not centered.
2. Pagination arrows are pointing inwards instead of outwards.

You can find more information about how to reproduce the issue in [LPS-119036](https://issues.liferay.com/browse/LPS-119036). 

1. The solution for the first issue is just based on applying current styles to image placeholder but considering rtl languages. 
2. The solution for the second case is based in what we are already doing ([here](https://github.com/liferay/liferay-portal/blob/master/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp#L271)) even in the same taglib to consider these languages.

Thanks.

Regards.

/cc @NemethNorbert