### PR TITLE
LPS-118797 Avoid removing txtBorder field from info tab

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/creole_dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/creole_dialog_definition.js
@@ -47,7 +47,6 @@ CKEDITOR.on('dialogDefinition', (event) => {
 			infoTab.remove('cmbWidthType');
 			infoTab.remove('cmbWidthType');
 			infoTab.remove('htmlHeightType');
-			infoTab.remove('txtBorder');
 			infoTab.remove('txtCellPad');
 			infoTab.remove('txtCellSpace');
 			infoTab.remove('txtHeight');

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/creole_dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/creole_dialog_definition.js
@@ -12,53 +12,63 @@
  * details.
  */
 
-CKEDITOR.on('dialogDefinition', (event) => {
-	if (event.editor === ckEditor) {
-		var dialogName = event.data.name;
+CKEDITOR.on(
+	'dialogDefinition',
+	(event) => {
+		if (event.editor === ckEditor) {
+			var dialogName = event.data.name;
 
-		var dialogDefinition = event.data.definition;
+			var dialogDefinition = event.data.definition;
 
-		var infoTab;
+			var infoTab;
 
-		if (dialogName === 'cellProperties') {
-			infoTab = dialogDefinition.getContents('info');
+			if (dialogName === 'cellProperties') {
+				infoTab = dialogDefinition.getContents('info');
 
-			infoTab.remove('bgColor');
-			infoTab.remove('bgColorChoose');
-			infoTab.remove('borderColor');
-			infoTab.remove('borderColorChoose');
-			infoTab.remove('colSpan');
-			infoTab.remove('hAlign');
-			infoTab.remove('height');
-			infoTab.remove('htmlHeightType');
-			infoTab.remove('rowSpan');
-			infoTab.remove('vAlign');
-			infoTab.remove('width');
-			infoTab.remove('widthType');
-			infoTab.remove('wordWrap');
+				infoTab.remove('bgColor');
+				infoTab.remove('bgColorChoose');
+				infoTab.remove('borderColor');
+				infoTab.remove('borderColorChoose');
+				infoTab.remove('colSpan');
+				infoTab.remove('hAlign');
+				infoTab.remove('height');
+				infoTab.remove('htmlHeightType');
+				infoTab.remove('rowSpan');
+				infoTab.remove('vAlign');
+				infoTab.remove('width');
+				infoTab.remove('widthType');
+				infoTab.remove('wordWrap');
 
-			dialogDefinition.minHeight = 40;
-			dialogDefinition.minWidth = 210;
+				dialogDefinition.minHeight = 40;
+				dialogDefinition.minWidth = 210;
+			}
+			else if (
+				dialogName === 'table' ||
+				dialogName === 'tableProperties'
+			) {
+				infoTab = dialogDefinition.getContents('info');
+
+				infoTab.remove('cmbAlign');
+				infoTab.remove('cmbWidthType');
+				infoTab.remove('cmbWidthType');
+				infoTab.remove('htmlHeightType');
+				infoTab.remove('txtBorder');
+				infoTab.remove('txtCellPad');
+				infoTab.remove('txtCellSpace');
+				infoTab.remove('txtHeight');
+				infoTab.remove('txtSummary');
+				infoTab.remove('txtWidth');
+
+				dialogDefinition.minHeight = 180;
+				dialogDefinition.minWidth = 210;
+			}
+			else if (dialogName === 'image') {
+				dialogDefinition.removeContents('Link');
+				dialogDefinition.removeContents('advanced');
+			}
 		}
-		else if (dialogName === 'table' || dialogName === 'tableProperties') {
-			infoTab = dialogDefinition.getContents('info');
-
-			infoTab.remove('cmbAlign');
-			infoTab.remove('cmbWidthType');
-			infoTab.remove('cmbWidthType');
-			infoTab.remove('htmlHeightType');
-			infoTab.remove('txtCellPad');
-			infoTab.remove('txtCellSpace');
-			infoTab.remove('txtHeight');
-			infoTab.remove('txtSummary');
-			infoTab.remove('txtWidth');
-
-			dialogDefinition.minHeight = 180;
-			dialogDefinition.minWidth = 210;
-		}
-		else if (dialogName === 'image') {
-			dialogDefinition.removeContents('Link');
-			dialogDefinition.removeContents('advanced');
-		}
-	}
-});
+	},
+	null,
+	null,
+	100
+);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/creole_dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/creole_dialog_definition.js
@@ -16,9 +16,49 @@ CKEDITOR.on(
 	'dialogDefinition',
 	(event) => {
 		if (event.editor === ckEditor) {
+			var boundingWindow = event.editor.window;
+
 			var dialogName = event.data.name;
 
 			var dialogDefinition = event.data.definition;
+
+			var dialog = event.data.dialog;
+
+			var onShow = dialogDefinition.onShow;
+
+			dialogDefinition.onShow = function () {
+				if (typeof onShow === 'function') {
+					onShow.apply(this, arguments);
+				}
+
+				centerDialog();
+			};
+
+			var centerDialog = function () {
+				var dialogSize = dialog.getSize();
+
+				var x = window.innerWidth / 2 - dialogSize.width / 2;
+				var y = window.innerHeight / 2 - dialogSize.height / 2;
+
+				dialog.move(x, y, false);
+			};
+
+			var debounce = function (fn, delay) {
+				return function debounced() {
+					var args = arguments;
+					clearTimeout(debounced.id);
+					debounced.id = setTimeout(() => {
+						fn.apply(null, args);
+					}, delay);
+				};
+			};
+
+			boundingWindow.on(
+				'resize',
+				debounce(() => {
+					centerDialog();
+				}, 250)
+			);
 
 			var infoTab;
 


### PR DESCRIPTION
Re-sent from [https://github.com/liferay-frontend/liferay-portal/pull/234](https://github.com/liferay-frontend/liferay-portal/pull/234):

> Steps to Reproduce:

> Navigate to CP > Content and Data > Wiki
> Click Main
> Click Plus button
> Click on Table icon
> 
> Expected Result:
> A table UI pop up and table inserted and renders borders.
> 
> Actual Result:
> There's no pop up on table UI and error is thrown in browser console.
> 
> The problem
> In master the problem is the order when I click in the toolbar table button is passing first for creole_dialog_definition (remove txtBorder) and then the plugin showborders try to get txtBorder and crash.
> 
> In master with liferay-ckeditor@4.13.1-liferay.8 before clean plugins liferay/liferay-ckeditor@468d7e4#diff-e9f394f8c7b75652dab866e4d9f42b68L79 the order is other (probably because the plugin is bundled with ckeditor) first the plugin showborders get txtBorder and later creole_dialog_definition remove txtBorder.
> 
> The fix
> Don´t remove txtBorder in creole_dialog_definition but I don't know what can happen.

/cc @ambrinchaudhary

