### PR TITLE
LPS-117488 Consolidate Modal Selection UX

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountOrganizationsManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountOrganizationsManagementToolbarDefaultEventHandler.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {DefaultEventHandler, ItemSelectorDialog} from 'frontend-js-web';
+import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
 
 class AccountOrganizationsManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	removeOrganizations(itemData) {
@@ -38,31 +38,27 @@ class AccountOrganizationsManagementToolbarDefaultEventHandler extends DefaultEv
 	}
 
 	selectAccountOrganizations(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('assign'),
-			eventName: this.ns('assignAccountOrganizations'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const form = this.one('#fm');
+
+					Liferay.Util.postForm(form, {
+						data: {
+							accountOrganizationIds: selectedItem.value,
+						},
+						url: itemData.assignAccountOrganizationsURL,
+					});
+				}
+			},
+			selectEventName: this.ns('assignAccountOrganizations'),
 			title: Liferay.Util.sub(
 				Liferay.Language.get('assign-organizations-to-x'),
 				itemData.accountEntryName
 			),
 			url: itemData.selectAccountOrganizationsURL,
-		});
-
-		itemSelectorDialog.open();
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const form = this.one('#fm');
-
-				Liferay.Util.postForm(form, {
-					data: {
-						accountOrganizationIds: selectedItem.value,
-					},
-					url: itemData.assignAccountOrganizationsURL,
-				});
-			}
 		});
 	}
 }

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarDefaultEventHandler.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {DefaultEventHandler, ItemSelectorDialog} from 'frontend-js-web';
+import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
 import {Config} from 'metal-state';
 
 import {MODAL_STATE_ACCOUNT_USERS} from './SessionStorageKeys.es';
@@ -51,31 +51,27 @@ class AccountUsersManagementToolbarDefaultEventHandler extends DefaultEventHandl
 	}
 
 	selectAccountUsers() {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('assign'),
-			eventName: this.ns('assignAccountUsers'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const form = this.one('#fm');
+
+					Liferay.Util.postForm(form, {
+						data: {
+							accountUserIds: selectedItem.value,
+						},
+						url: this.assignAccountUsersURL,
+					});
+				}
+			},
+			selectEventName: this.ns('assignAccountUsers'),
 			title: Liferay.Util.sub(
 				Liferay.Language.get('assign-users-to-x'),
 				this.accountEntryName
 			),
 			url: this.selectAccountUsersURL,
-		});
-
-		itemSelectorDialog.open();
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const form = this.one('#fm');
-
-				Liferay.Util.postForm(form, {
-					data: {
-						accountUserIds: selectedItem.value,
-					},
-					url: this.assignAccountUsersURL,
-				});
-			}
 		});
 	}
 }

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/PersonAccountEntryEventHandler.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/PersonAccountEntryEventHandler.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {PortletBase, openModal} from 'frontend-js-web';
+import {PortletBase, openSelectionModal} from 'frontend-js-web';
 import * as dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 import {Config} from 'metal-state';
@@ -71,7 +71,7 @@ class PersonAccountEntryEventHandler extends PortletBase {
 	}
 
 	_selectAccountUser() {
-		openModal({
+		openSelectionModal({
 			id: this.ns(this.selectUserEventName),
 			onSelect: this._handleOnSelect.bind(this),
 			selectEventName: this.ns(this.selectUserEventName),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupAccountEntriesManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupAccountEntriesManagementToolbarDefaultEventHandler.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {DefaultEventHandler, ItemSelectorDialog} from 'frontend-js-web';
+import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
 import {Config} from 'metal-state';
 
 class AccountGroupAccountEntriesManagementToolbarDefaultEventHandler extends DefaultEventHandler {
@@ -39,31 +39,27 @@ class AccountGroupAccountEntriesManagementToolbarDefaultEventHandler extends Def
 	}
 
 	selectAccountGroupAccountEntries() {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('assign'),
-			eventName: this.ns('selectAccountEntries'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const form = this.one('#fm');
+
+					Liferay.Util.postForm(form, {
+						data: {
+							accountEntryIds: selectedItem.value,
+						},
+						url: this.assignAccountGroupAccountEntriesURL,
+					});
+				}
+			},
+			selectEventName: this.ns('selectAccountEntries'),
 			title: Liferay.Util.sub(
 				Liferay.Language.get('assign-accounts-to-x'),
 				this.accountGroupName
 			),
 			url: this.selectAccountGroupAccountEntriesURL,
-		});
-
-		itemSelectorDialog.open();
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const form = this.one('#fm');
-
-				Liferay.Util.postForm(form, {
-					data: {
-						accountEntryIds: selectedItem.value,
-					},
-					url: this.assignAccountGroupAccountEntriesURL,
-				});
-			}
 		});
 	}
 }

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
@@ -199,7 +199,7 @@ portletDisplay.setURLBack(backURL);
 				searchContainerData = searchContainerData.split(',');
 			}
 
-			Util.openModal({
+			Util.openSelectionModal({
 				id: '<portlet:namespace />selectAccountEntry',
 				onSelect: function (selectedItem) {
 					var entityId = selectedItem.entityid;

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/ManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/ManagementToolbarDefaultEventHandler.es.js
@@ -14,7 +14,6 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	createPortletURL,
 	navigate,
 	openSelectionModal,
@@ -95,20 +94,18 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 		accountEntrySelectorURL,
 		callback
 	) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: dialogButtonLabel,
-			eventName: dialogEventName,
+			multiple: true,
+			onSelect(selectedItem) {
+				if (selectedItem) {
+					callback(selectedItem);
+				}
+			},
+			selectEventName: dialogEventName,
 			title: dialogTitle,
 			url: accountEntrySelectorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			if (event.selectedItem) {
-				callback(event.selectedItem);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	_updateAccountUsers(url) {

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/ManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/ManagementToolbarDefaultEventHandler.es.js
@@ -17,7 +17,7 @@ import {
 	ItemSelectorDialog,
 	createPortletURL,
 	navigate,
-	openModal,
+	openSelectionModal,
 } from 'frontend-js-web';
 
 class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
@@ -70,7 +70,7 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	addAccountUser(itemData) {
-		openModal({
+		openSelectionModal({
 			id: this.ns('addAccountUser'),
 			onSelect: (selectedItem) => {
 				var addAccountUserURL = createPortletURL(

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/ManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/ManagementToolbarDefaultEventHandler.es.js
@@ -97,7 +97,7 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 		openSelectionModal({
 			buttonAddLabel: dialogButtonLabel,
 			multiple: true,
-			onSelect(selectedItem) {
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					callback(selectedItem);
 				}

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category_action.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category_action.jsp
@@ -94,49 +94,45 @@ AssetCategory category = (AssetCategory)row.getObject();
 </liferay-ui:icon-menu>
 
 <c:if test="<%= assetCategoriesDisplayContext.hasPermission(category, ActionKeys.UPDATE) %>">
-	<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+	<aui:script sandbox="<%= true %>">
 		var moveCategoryIcon = document.getElementById(
 			'<portlet:namespace /><%= row.getRowId() %>moveCategory'
 		);
 
 		if (moveCategoryIcon) {
 			moveCategoryIcon.addEventListener('click', function (event) {
-				var itemSelectorDialog = new ItemSelectorDialog.default({
-					eventName: '<portlet:namespace />selectCategory',
+				Liferay.Util.openSelectionModal({
+					multiple: true,
+					onSelect: function(selectedItem) {
+						if (selectedItem) {
+							var parentCategoryId = 0;
+							var vocabularyId = 0;
+
+							for (var key in selectedItem) {
+								var item = selectedItem[key];
+
+								if (!item.unchecked) {
+									parentCategoryId = item.categoryId || 0;
+									vocabularyId = item.vocabularyId || 0;
+
+									break;
+								}
+							}
+
+							if (vocabularyId > 0 || parentCategoryId > 0) {
+								document.<portlet:namespace />moveCategoryFm.<portlet:namespace />categoryId.value =
+									'<%= category.getCategoryId() %>';
+								document.<portlet:namespace />moveCategoryFm.<portlet:namespace />parentCategoryId.value = parentCategoryId;
+								document.<portlet:namespace />moveCategoryFm.<portlet:namespace />vocabularyId.value = vocabularyId;
+
+								submitForm(document.<portlet:namespace />moveCategoryFm);
+							}
+						}
+					},
+					selectEventName: '<portlet:namespace />selectCategory',
 					title:
 						'<liferay-ui:message arguments="<%= category.getTitle(locale) %>" key="move-x" />',
 					url: '<%= assetCategoriesDisplayContext.getSelectCategoryURL() %>',
-				});
-
-				itemSelectorDialog.open();
-
-				itemSelectorDialog.on('selectedItemChange', function (event) {
-					var selectedItem = event.selectedItem;
-
-					if (selectedItem) {
-						var parentCategoryId = 0;
-						var vocabularyId = 0;
-
-						for (var key in selectedItem) {
-							var item = selectedItem[key];
-
-							if (!item.unchecked) {
-								parentCategoryId = item.categoryId || 0;
-								vocabularyId = item.vocabularyId || 0;
-
-								break;
-							}
-						}
-
-						if (vocabularyId > 0 || parentCategoryId > 0) {
-							document.<portlet:namespace />moveCategoryFm.<portlet:namespace />categoryId.value =
-								'<%= category.getCategoryId() %>';
-							document.<portlet:namespace />moveCategoryFm.<portlet:namespace />parentCategoryId.value = parentCategoryId;
-							document.<portlet:namespace />moveCategoryFm.<portlet:namespace />vocabularyId.value = vocabularyId;
-
-							submitForm(document.<portlet:namespace />moveCategoryFm);
-						}
-					}
 				});
 			});
 		}

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category_action.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category_action.jsp
@@ -103,7 +103,7 @@ AssetCategory category = (AssetCategory)row.getObject();
 			moveCategoryIcon.addEventListener('click', function (event) {
 				Liferay.Util.openSelectionModal({
 					multiple: true,
-					onSelect: function(selectedItem) {
+					onSelect: function (selectedItem) {
 						if (selectedItem) {
 							var parentCategoryId = 0;
 							var vocabularyId = 0;
@@ -125,7 +125,9 @@ AssetCategory category = (AssetCategory)row.getObject();
 								document.<portlet:namespace />moveCategoryFm.<portlet:namespace />parentCategoryId.value = parentCategoryId;
 								document.<portlet:namespace />moveCategoryFm.<portlet:namespace />vocabularyId.value = vocabularyId;
 
-								submitForm(document.<portlet:namespace />moveCategoryFm);
+								submitForm(
+									document.<portlet:namespace />moveCategoryFm
+								);
 							}
 						}
 					},

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-web';
 
 const ACTIONS = {
 	deleteVocabularies({
@@ -24,34 +24,30 @@ const ACTIONS = {
 
 		vocabulariesForm.setAttribute('method', 'post');
 
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('delete'),
-			eventName: `${portletNamespace}selectVocabularies`,
+			multiple: true,
+			onSelect(selectedItems) {
+				if (selectedItems) {
+					if (
+						confirm(
+							Liferay.Language.get(
+								'are-you-sure-you-want-to-delete-the-selected-entries'
+							)
+						)
+					) {
+						selectedItems.forEach((item) => {
+							vocabulariesForm.appendChild(item.cloneNode(true));
+						});
+
+						submitForm(vocabulariesForm, deleteVocabulariesURL);
+					}
+				}
+			},
+			selectEventName: `${portletNamespace}selectVocabularies`,
 			title: Liferay.Language.get('delete-vocabulary'),
 			url: viewVocabulariesURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItems = event.selectedItem;
-
-			if (selectedItems) {
-				if (
-					confirm(
-						Liferay.Language.get(
-							'are-you-sure-you-want-to-delete-the-selected-entries'
-						)
-					)
-				) {
-					selectedItems.forEach((item) => {
-						vocabulariesForm.appendChild(item.cloneNode(true));
-					});
-
-					submitForm(vocabulariesForm, deleteVocabulariesURL);
-				}
-			}
-		});
-
-		itemSelectorDialog.open();
 	},
 };
 

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -27,7 +27,7 @@ const ACTIONS = {
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('delete'),
 			multiple: true,
-			onSelect(selectedItems) {
+			onSelect: (selectedItems) => {
 				if (selectedItems) {
 					if (
 						confirm(

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/AssetCategoriesManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/AssetCategoriesManagementToolbarDefaultEventHandler.es.js
@@ -33,7 +33,7 @@ class AssetCategoriesManagementToolbarDefaultEventHandler extends DefaultEventHa
 		const namespace = this.namespace;
 
 		openSelectionModal({
-			onSelect(selectedItem) {
+			onSelect: (selectedItem) => {
 				const category = selectedItem
 					? selectedItem[Object.keys(selectedItem)[0]]
 					: null;

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/AssetCategoriesManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/AssetCategoriesManagementToolbarDefaultEventHandler.es.js
@@ -14,8 +14,8 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	addParams,
+	openSelectionModal,
 } from 'frontend-js-web';
 
 class AssetCategoriesManagementToolbarDefaultEventHandler extends DefaultEventHandler {
@@ -32,28 +32,22 @@ class AssetCategoriesManagementToolbarDefaultEventHandler extends DefaultEventHa
 	selectCategory(itemData) {
 		const namespace = this.namespace;
 
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: this.ns('selectCategory'),
-			singleSelect: true,
+		openSelectionModal({
+			onSelect(selectedItem) {
+				const category = selectedItem
+					? selectedItem[Object.keys(selectedItem)[0]]
+					: null;
+
+				if (category) {
+					location.href = addParams(
+						namespace + 'categoryId=' + category.categoryId,
+						itemData.viewCategoriesURL
+					);
+				}
+			},
+			selectEventName: this.ns('selectCategory'),
 			title: Liferay.Language.get('select-category'),
 			url: itemData.categoriesSelectorURL,
-		});
-
-		itemSelectorDialog.open();
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			const category = selectedItem
-				? selectedItem[Object.keys(selectedItem)[0]]
-				: null;
-
-			if (category) {
-				location.href = addParams(
-					namespace + 'categoryId=' + category.categoryId,
-					itemData.viewCategoriesURL
-				);
-			}
 		});
 	}
 }

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
@@ -137,7 +137,7 @@ PortletURL portletURL = editAssetListDisplayContext.getPortletURL();
 		selectManageableGroupIcon.addEventListener('click', function (event) {
 			event.preventDefault();
 
-			Liferay.Util.openModal({
+			Liferay.Util.openSelectionModal({
 				id: '<%= editAssetListDisplayContext.getSelectGroupEventName() %>',
 				onSelect: function (selectedItem) {
 					var entityId = selectedItem.groupid;

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -287,221 +287,221 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 		String className = editAssetListDisplayContext.getClassName(curRendererFactory);
 	%>
 
-			Util.toggleSelectBox(
-				'<portlet:namespace />anyClassType<%= className %>',
-				'false',
-				'<portlet:namespace /><%= className %>Boxes'
-			);
+		Util.toggleSelectBox(
+			'<portlet:namespace />anyClassType<%= className %>',
+			'false',
+			'<portlet:namespace /><%= className %>Boxes'
+		);
 
-			var <%= className %>Options = document.getElementById(
-				'<portlet:namespace /><%= className %>Options'
-			);
+		var <%= className %>Options = document.getElementById(
+			'<portlet:namespace /><%= className %>Options'
+		);
 
-			function <portlet:namespace />toggle<%= className %>(removeOrderBySubtype) {
-				var assetOptions = assetMultipleSelector.options;
+		function <portlet:namespace />toggle<%= className %>(removeOrderBySubtype) {
+			var assetOptions = assetMultipleSelector.options;
 
-				var showOptions =
-					assetSelector.value == '<%= curRendererFactory.getClassNameId() %>' ||
-					(assetSelector.value == 'false' &&
-						assetOptions.length == 1 &&
-						assetOptions[0].value ==
-							'<%= curRendererFactory.getClassNameId() %>');
+			var showOptions =
+				assetSelector.value == '<%= curRendererFactory.getClassNameId() %>' ||
+				(assetSelector.value == 'false' &&
+					assetOptions.length == 1 &&
+					assetOptions[0].value ==
+						'<%= curRendererFactory.getClassNameId() %>');
 
-				if (showOptions) {
-					<%= className %>Options.classList.remove('hide');
-				}
-				else {
-					<%= className %>Options.classList.add('hide');
-				}
-
-				if (orderingPanel && removeOrderBySubtype) {
-					Array.prototype.forEach.call(
-						orderingPanel.querySelectorAll('.order-by-subtype'),
-						function (option) {
-							dom.exitDocument(option);
-						}
-					);
-				}
-
-				<c:if test="<%= editAssetListDisplayContext.isShowSubtypeFieldsFilter() %>">
-					<%= className %>toggleSubclassesFields(true);
-				</c:if>
+			if (showOptions) {
+				<%= className %>Options.classList.remove('hide');
+			}
+			else {
+				<%= className %>Options.classList.add('hide');
 			}
 
-			<%
-			ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
-
-			List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(editAssetListDisplayContext.getReferencedModelsGroupIds(), locale);
-
-			if (assetAvailableClassTypes.isEmpty()) {
-				continue;
-			}
-
-			for (ClassType classType : assetAvailableClassTypes) {
-				List<ClassTypeField> classTypeFields = classType.getClassTypeFields();
-
-				if (classTypeFields.isEmpty()) {
-					continue;
-				}
-			%>
-
-					var optgroupClose = '</optgroup>';
-					var optgroupOpen =
-						'<optgroup class="order-by-subtype" label="<%= HtmlUtil.escape(classType.getName()) %>">';
-
-					var columnBuffer1 = [optgroupOpen];
-					var columnBuffer2 = [optgroupOpen];
-
-					<%
-					String orderByColumn1 = editAssetListDisplayContext.getOrderByColumn1();
-					String orderByColumn2 = editAssetListDisplayContext.getOrderByColumn2();
-
-					for (ClassTypeField classTypeField : classTypeFields) {
-						String value = editAssetListDisplayContext.encodeName(classTypeField.getClassTypeId(), classTypeField.getName(), null);
-						String selectedOrderByColumn1 = StringPool.BLANK;
-						String selectedOrderByColumn2 = StringPool.BLANK;
-
-						if (orderByColumn1.equals(value)) {
-							selectedOrderByColumn1 = "selected";
-						}
-
-						if (orderByColumn2.equals(value)) {
-							selectedOrderByColumn2 = "selected";
-						}
-					%>
-
-							columnBuffer1.push(
-								'<option <%= selectedOrderByColumn1 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
-							);
-							columnBuffer2.push(
-								'<option <%= selectedOrderByColumn2 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
-							);
-
-					<%
+			if (orderingPanel && removeOrderBySubtype) {
+				Array.prototype.forEach.call(
+					orderingPanel.querySelectorAll('.order-by-subtype'),
+					function (option) {
+						dom.exitDocument(option);
 					}
-					%>
-
-					columnBuffer1.push(optgroupClose);
-					columnBuffer2.push(optgroupClose);
-
-					MAP_DDM_STRUCTURES[
-						'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn1'
-					] = columnBuffer1.join('');
-					MAP_DDM_STRUCTURES[
-						'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn2'
-					] = columnBuffer2.join('');
-
-			<%
+				);
 			}
-			%>
-
-			var <%= className %>SubtypeSelector = document.getElementById(
-				'<portlet:namespace />anyClassType<%= className %>'
-			);
 
 			<c:if test="<%= editAssetListDisplayContext.isShowSubtypeFieldsFilter() %>">
-				function <%= className %>toggleSubclassesFields(
-					hideSubtypeFilterEnableWrapper
+				<%= className %>toggleSubclassesFields(true);
+			</c:if>
+		}
+
+		<%
+		ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
+
+		List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(editAssetListDisplayContext.getReferencedModelsGroupIds(), locale);
+
+		if (assetAvailableClassTypes.isEmpty()) {
+			continue;
+		}
+
+		for (ClassType classType : assetAvailableClassTypes) {
+			List<ClassTypeField> classTypeFields = classType.getClassTypeFields();
+
+			if (classTypeFields.isEmpty()) {
+				continue;
+			}
+		%>
+
+			var optgroupClose = '</optgroup>';
+			var optgroupOpen =
+				'<optgroup class="order-by-subtype" label="<%= HtmlUtil.escape(classType.getName()) %>">';
+
+			var columnBuffer1 = [optgroupOpen];
+			var columnBuffer2 = [optgroupOpen];
+
+			<%
+			String orderByColumn1 = editAssetListDisplayContext.getOrderByColumn1();
+			String orderByColumn2 = editAssetListDisplayContext.getOrderByColumn2();
+
+			for (ClassTypeField classTypeField : classTypeFields) {
+				String value = editAssetListDisplayContext.encodeName(classTypeField.getClassTypeId(), classTypeField.getName(), null);
+				String selectedOrderByColumn1 = StringPool.BLANK;
+				String selectedOrderByColumn2 = StringPool.BLANK;
+
+				if (orderByColumn1.equals(value)) {
+					selectedOrderByColumn1 = "selected";
+				}
+
+				if (orderByColumn2.equals(value)) {
+					selectedOrderByColumn2 = "selected";
+				}
+			%>
+
+				columnBuffer1.push(
+					'<option <%= selectedOrderByColumn1 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
+				);
+				columnBuffer2.push(
+					'<option <%= selectedOrderByColumn2 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
+				);
+
+			<%
+			}
+			%>
+
+			columnBuffer1.push(optgroupClose);
+			columnBuffer2.push(optgroupClose);
+
+			MAP_DDM_STRUCTURES[
+				'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn1'
+			] = columnBuffer1.join('');
+			MAP_DDM_STRUCTURES[
+				'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn2'
+			] = columnBuffer2.join('');
+
+		<%
+		}
+		%>
+
+		var <%= className %>SubtypeSelector = document.getElementById(
+			'<portlet:namespace />anyClassType<%= className %>'
+		);
+
+		<c:if test="<%= editAssetListDisplayContext.isShowSubtypeFieldsFilter() %>">
+			function <%= className %>toggleSubclassesFields(
+				hideSubtypeFilterEnableWrapper
+			) {
+				var selectedSubtype = <%= className %>SubtypeSelector.value;
+
+				var structureOptions = document.getElementById(
+					'<portlet:namespace />' + selectedSubtype + '_<%= className %>Options'
+				);
+
+				if (structureOptions) {
+					structureOptions.classList.remove('hide');
+				}
+
+				var subtypeFieldsWrappers = document.querySelectorAll(
+					'#<portlet:namespace /><%= className %>subtypeFieldsWrapper, #<portlet:namespace /><%= className %>subtypeFieldsFilterEnableWrapper'
+				);
+
+				Array.prototype.forEach.call(subtypeFieldsWrappers, function (
+					subtypeFieldsWrapper
 				) {
-					var selectedSubtype = <%= className %>SubtypeSelector.value;
-
-					var structureOptions = document.getElementById(
-						'<portlet:namespace />' + selectedSubtype + '_<%= className %>Options'
-					);
-
-					if (structureOptions) {
-						structureOptions.classList.remove('hide');
-					}
-
-					var subtypeFieldsWrappers = document.querySelectorAll(
-						'#<portlet:namespace /><%= className %>subtypeFieldsWrapper, #<portlet:namespace /><%= className %>subtypeFieldsFilterEnableWrapper'
-					);
-
-					Array.prototype.forEach.call(subtypeFieldsWrappers, function (
-						subtypeFieldsWrapper
-					) {
-						if (selectedSubtype != 'false' && selectedSubtype != 'true') {
-							if (orderingPanel) {
-								Array.prototype.forEach.call(
-									orderingPanel.querySelectorAll('.order-by-subtype'),
-									function (option) {
-										dom.exitDocument(option);
-									}
-								);
-
-								var optTextOrderByColumn1 =
-									MAP_DDM_STRUCTURES[
-										'<%= className %>_' +
-											selectedSubtype +
-											'_optTextOrderByColumn1'
-									];
-
-								if (optTextOrderByColumn1) {
-									dom.append(orderByColumn1, optTextOrderByColumn1);
+					if (selectedSubtype != 'false' && selectedSubtype != 'true') {
+						if (orderingPanel) {
+							Array.prototype.forEach.call(
+								orderingPanel.querySelectorAll('.order-by-subtype'),
+								function (option) {
+									dom.exitDocument(option);
 								}
+							);
 
-								var optTextOrderByColumn2 =
-									MAP_DDM_STRUCTURES[
-										'<%= className %>_' +
-											selectedSubtype +
-											'_optTextOrderByColumn2'
-									];
+							var optTextOrderByColumn1 =
+								MAP_DDM_STRUCTURES[
+									'<%= className %>_' +
+										selectedSubtype +
+										'_optTextOrderByColumn1'
+								];
 
-								if (optTextOrderByColumn2) {
-									dom.append(orderByColumn2, optTextOrderByColumn2);
-								}
+							if (optTextOrderByColumn1) {
+								dom.append(orderByColumn1, optTextOrderByColumn1);
 							}
 
-							if (structureOptions) {
-								subtypeFieldsWrapper.classList.remove('hide');
+							var optTextOrderByColumn2 =
+								MAP_DDM_STRUCTURES[
+									'<%= className %>_' +
+										selectedSubtype +
+										'_optTextOrderByColumn2'
+								];
+
+							if (optTextOrderByColumn2) {
+								dom.append(orderByColumn2, optTextOrderByColumn2);
 							}
-							else if (hideSubtypeFilterEnableWrapper) {
-								subtypeFieldsWrapper.classList.add('hide');
-							}
+						}
+
+						if (structureOptions) {
+							subtypeFieldsWrapper.classList.remove('hide');
 						}
 						else if (hideSubtypeFilterEnableWrapper) {
 							subtypeFieldsWrapper.classList.add('hide');
 						}
-					});
+					}
+					else if (hideSubtypeFilterEnableWrapper) {
+						subtypeFieldsWrapper.classList.add('hide');
+					}
+				});
+			}
+
+			<%= className %>toggleSubclassesFields(false);
+
+			<%= className %>SubtypeSelector.addEventListener('change', function (event) {
+				setDDMFields('<%= className %>', '', '', '', '');
+
+				var saveButton = document.getElementById('<portlet:namespace />saveButton');
+
+				if (<%= className %>SubtypeSelector.value === '') {
+					saveButton.classList.add('disabled');
+					saveButton.disabled = true;
+				}
+				else {
+					saveButton.classList.remove('disabled');
+					saveButton.disabled = false;
 				}
 
-				<%= className %>toggleSubclassesFields(false);
+				var subtypeFieldsFilterEnabledCheckbox = document.getElementById(
+					'<portlet:namespace />subtypeFieldsFilterEnabled<%= className %>'
+				);
 
-				<%= className %>SubtypeSelector.addEventListener('change', function (event) {
-					setDDMFields('<%= className %>', '', '', '', '');
+				if (subtypeFieldsFilterEnabledCheckbox) {
+					subtypeFieldsFilterEnabledCheckbox.checked = false;
+				}
 
-					var saveButton = document.getElementById('<portlet:namespace />saveButton');
+				var assetSubtypeFields = sourcePanel.querySelectorAll(
+					'.asset-subtypefields'
+				);
 
-					if (<%= className %>SubtypeSelector.value === '') {
-						saveButton.classList.add('disabled');
-						saveButton.disabled = true;
-					}
-					else {
-						saveButton.classList.remove('disabled');
-						saveButton.disabled = false;
-					}
-
-					var subtypeFieldsFilterEnabledCheckbox = document.getElementById(
-						'<portlet:namespace />subtypeFieldsFilterEnabled<%= className %>'
-					);
-
-					if (subtypeFieldsFilterEnabledCheckbox) {
-						subtypeFieldsFilterEnabledCheckbox.checked = false;
-					}
-
-					var assetSubtypeFields = sourcePanel.querySelectorAll(
-						'.asset-subtypefields'
-					);
-
-					Array.prototype.forEach.call(assetSubtypeFields, function (
-						assetSubtypeField
-					) {
-						assetSubtypeField.classList.add('hide');
-					});
-
-					<%= className %>toggleSubclassesFields(true);
+				Array.prototype.forEach.call(assetSubtypeFields, function (
+					assetSubtypeField
+				) {
+					assetSubtypeField.classList.add('hide');
 				});
-			</c:if>
+
+				<%= className %>toggleSubclassesFields(true);
+			});
+		</c:if>
 
 	<%
 	}
@@ -514,7 +514,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 			String className = editAssetListDisplayContext.getClassName(curRendererFactory);
 		%>
 
-				<portlet:namespace />toggle<%= className %>(removeOrderBySubtype);
+			<portlet:namespace />toggle<%= className %>(removeOrderBySubtype);
 
 		<%
 		}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -610,7 +610,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 			url
 		);
 
-		Util.openModal({
+		Util.openSelectionModal({
 			id: '<portlet:namespace />selectDDMStructure' + delegateTarget.id,
 			onSelect: function (selectedItem) {
 				setDDMFields(

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -287,221 +287,221 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 		String className = editAssetListDisplayContext.getClassName(curRendererFactory);
 	%>
 
-		Util.toggleSelectBox(
-			'<portlet:namespace />anyClassType<%= className %>',
-			'false',
-			'<portlet:namespace /><%= className %>Boxes'
-		);
+			Util.toggleSelectBox(
+				'<portlet:namespace />anyClassType<%= className %>',
+				'false',
+				'<portlet:namespace /><%= className %>Boxes'
+			);
 
-		var <%= className %>Options = document.getElementById(
-			'<portlet:namespace /><%= className %>Options'
-		);
+			var <%= className %>Options = document.getElementById(
+				'<portlet:namespace /><%= className %>Options'
+			);
 
-		function <portlet:namespace />toggle<%= className %>(removeOrderBySubtype) {
-			var assetOptions = assetMultipleSelector.options;
+			function <portlet:namespace />toggle<%= className %>(removeOrderBySubtype) {
+				var assetOptions = assetMultipleSelector.options;
 
-			var showOptions =
-				assetSelector.value == '<%= curRendererFactory.getClassNameId() %>' ||
-				(assetSelector.value == 'false' &&
-					assetOptions.length == 1 &&
-					assetOptions[0].value ==
-						'<%= curRendererFactory.getClassNameId() %>');
+				var showOptions =
+					assetSelector.value == '<%= curRendererFactory.getClassNameId() %>' ||
+					(assetSelector.value == 'false' &&
+						assetOptions.length == 1 &&
+						assetOptions[0].value ==
+							'<%= curRendererFactory.getClassNameId() %>');
 
-			if (showOptions) {
-				<%= className %>Options.classList.remove('hide');
+				if (showOptions) {
+					<%= className %>Options.classList.remove('hide');
+				}
+				else {
+					<%= className %>Options.classList.add('hide');
+				}
+
+				if (orderingPanel && removeOrderBySubtype) {
+					Array.prototype.forEach.call(
+						orderingPanel.querySelectorAll('.order-by-subtype'),
+						function (option) {
+							dom.exitDocument(option);
+						}
+					);
+				}
+
+				<c:if test="<%= editAssetListDisplayContext.isShowSubtypeFieldsFilter() %>">
+					<%= className %>toggleSubclassesFields(true);
+				</c:if>
 			}
-			else {
-				<%= className %>Options.classList.add('hide');
-			}
 
-			if (orderingPanel && removeOrderBySubtype) {
-				Array.prototype.forEach.call(
-					orderingPanel.querySelectorAll('.order-by-subtype'),
-					function (option) {
-						dom.exitDocument(option);
-					}
-				);
-			}
+			<%
+			ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
 
-			<c:if test="<%= editAssetListDisplayContext.isShowSubtypeFieldsFilter() %>">
-				<%= className %>toggleSubclassesFields(true);
-			</c:if>
-		}
+			List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(editAssetListDisplayContext.getReferencedModelsGroupIds(), locale);
 
-		<%
-		ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
-
-		List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(editAssetListDisplayContext.getReferencedModelsGroupIds(), locale);
-
-		if (assetAvailableClassTypes.isEmpty()) {
-			continue;
-		}
-
-		for (ClassType classType : assetAvailableClassTypes) {
-			List<ClassTypeField> classTypeFields = classType.getClassTypeFields();
-
-			if (classTypeFields.isEmpty()) {
+			if (assetAvailableClassTypes.isEmpty()) {
 				continue;
 			}
-		%>
 
-			var optgroupClose = '</optgroup>';
-			var optgroupOpen =
-				'<optgroup class="order-by-subtype" label="<%= HtmlUtil.escape(classType.getName()) %>">';
+			for (ClassType classType : assetAvailableClassTypes) {
+				List<ClassTypeField> classTypeFields = classType.getClassTypeFields();
 
-			var columnBuffer1 = [optgroupOpen];
-			var columnBuffer2 = [optgroupOpen];
-
-			<%
-			String orderByColumn1 = editAssetListDisplayContext.getOrderByColumn1();
-			String orderByColumn2 = editAssetListDisplayContext.getOrderByColumn2();
-
-			for (ClassTypeField classTypeField : classTypeFields) {
-				String value = editAssetListDisplayContext.encodeName(classTypeField.getClassTypeId(), classTypeField.getName(), null);
-				String selectedOrderByColumn1 = StringPool.BLANK;
-				String selectedOrderByColumn2 = StringPool.BLANK;
-
-				if (orderByColumn1.equals(value)) {
-					selectedOrderByColumn1 = "selected";
-				}
-
-				if (orderByColumn2.equals(value)) {
-					selectedOrderByColumn2 = "selected";
+				if (classTypeFields.isEmpty()) {
+					continue;
 				}
 			%>
 
-				columnBuffer1.push(
-					'<option <%= selectedOrderByColumn1 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
-				);
-				columnBuffer2.push(
-					'<option <%= selectedOrderByColumn2 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
-				);
+					var optgroupClose = '</optgroup>';
+					var optgroupOpen =
+						'<optgroup class="order-by-subtype" label="<%= HtmlUtil.escape(classType.getName()) %>">';
+
+					var columnBuffer1 = [optgroupOpen];
+					var columnBuffer2 = [optgroupOpen];
+
+					<%
+					String orderByColumn1 = editAssetListDisplayContext.getOrderByColumn1();
+					String orderByColumn2 = editAssetListDisplayContext.getOrderByColumn2();
+
+					for (ClassTypeField classTypeField : classTypeFields) {
+						String value = editAssetListDisplayContext.encodeName(classTypeField.getClassTypeId(), classTypeField.getName(), null);
+						String selectedOrderByColumn1 = StringPool.BLANK;
+						String selectedOrderByColumn2 = StringPool.BLANK;
+
+						if (orderByColumn1.equals(value)) {
+							selectedOrderByColumn1 = "selected";
+						}
+
+						if (orderByColumn2.equals(value)) {
+							selectedOrderByColumn2 = "selected";
+						}
+					%>
+
+							columnBuffer1.push(
+								'<option <%= selectedOrderByColumn1 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
+							);
+							columnBuffer2.push(
+								'<option <%= selectedOrderByColumn2 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
+							);
+
+					<%
+					}
+					%>
+
+					columnBuffer1.push(optgroupClose);
+					columnBuffer2.push(optgroupClose);
+
+					MAP_DDM_STRUCTURES[
+						'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn1'
+					] = columnBuffer1.join('');
+					MAP_DDM_STRUCTURES[
+						'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn2'
+					] = columnBuffer2.join('');
 
 			<%
 			}
 			%>
 
-			columnBuffer1.push(optgroupClose);
-			columnBuffer2.push(optgroupClose);
+			var <%= className %>SubtypeSelector = document.getElementById(
+				'<portlet:namespace />anyClassType<%= className %>'
+			);
 
-			MAP_DDM_STRUCTURES[
-				'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn1'
-			] = columnBuffer1.join('');
-			MAP_DDM_STRUCTURES[
-				'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn2'
-			] = columnBuffer2.join('');
-
-		<%
-		}
-		%>
-
-		var <%= className %>SubtypeSelector = document.getElementById(
-			'<portlet:namespace />anyClassType<%= className %>'
-		);
-
-		<c:if test="<%= editAssetListDisplayContext.isShowSubtypeFieldsFilter() %>">
-			function <%= className %>toggleSubclassesFields(
-				hideSubtypeFilterEnableWrapper
-			) {
-				var selectedSubtype = <%= className %>SubtypeSelector.value;
-
-				var structureOptions = document.getElementById(
-					'<portlet:namespace />' + selectedSubtype + '_<%= className %>Options'
-				);
-
-				if (structureOptions) {
-					structureOptions.classList.remove('hide');
-				}
-
-				var subtypeFieldsWrappers = document.querySelectorAll(
-					'#<portlet:namespace /><%= className %>subtypeFieldsWrapper, #<portlet:namespace /><%= className %>subtypeFieldsFilterEnableWrapper'
-				);
-
-				Array.prototype.forEach.call(subtypeFieldsWrappers, function (
-					subtypeFieldsWrapper
+			<c:if test="<%= editAssetListDisplayContext.isShowSubtypeFieldsFilter() %>">
+				function <%= className %>toggleSubclassesFields(
+					hideSubtypeFilterEnableWrapper
 				) {
-					if (selectedSubtype != 'false' && selectedSubtype != 'true') {
-						if (orderingPanel) {
-							Array.prototype.forEach.call(
-								orderingPanel.querySelectorAll('.order-by-subtype'),
-								function (option) {
-									dom.exitDocument(option);
+					var selectedSubtype = <%= className %>SubtypeSelector.value;
+
+					var structureOptions = document.getElementById(
+						'<portlet:namespace />' + selectedSubtype + '_<%= className %>Options'
+					);
+
+					if (structureOptions) {
+						structureOptions.classList.remove('hide');
+					}
+
+					var subtypeFieldsWrappers = document.querySelectorAll(
+						'#<portlet:namespace /><%= className %>subtypeFieldsWrapper, #<portlet:namespace /><%= className %>subtypeFieldsFilterEnableWrapper'
+					);
+
+					Array.prototype.forEach.call(subtypeFieldsWrappers, function (
+						subtypeFieldsWrapper
+					) {
+						if (selectedSubtype != 'false' && selectedSubtype != 'true') {
+							if (orderingPanel) {
+								Array.prototype.forEach.call(
+									orderingPanel.querySelectorAll('.order-by-subtype'),
+									function (option) {
+										dom.exitDocument(option);
+									}
+								);
+
+								var optTextOrderByColumn1 =
+									MAP_DDM_STRUCTURES[
+										'<%= className %>_' +
+											selectedSubtype +
+											'_optTextOrderByColumn1'
+									];
+
+								if (optTextOrderByColumn1) {
+									dom.append(orderByColumn1, optTextOrderByColumn1);
 								}
-							);
 
-							var optTextOrderByColumn1 =
-								MAP_DDM_STRUCTURES[
-									'<%= className %>_' +
-										selectedSubtype +
-										'_optTextOrderByColumn1'
-								];
+								var optTextOrderByColumn2 =
+									MAP_DDM_STRUCTURES[
+										'<%= className %>_' +
+											selectedSubtype +
+											'_optTextOrderByColumn2'
+									];
 
-							if (optTextOrderByColumn1) {
-								dom.append(orderByColumn1, optTextOrderByColumn1);
+								if (optTextOrderByColumn2) {
+									dom.append(orderByColumn2, optTextOrderByColumn2);
+								}
 							}
 
-							var optTextOrderByColumn2 =
-								MAP_DDM_STRUCTURES[
-									'<%= className %>_' +
-										selectedSubtype +
-										'_optTextOrderByColumn2'
-								];
-
-							if (optTextOrderByColumn2) {
-								dom.append(orderByColumn2, optTextOrderByColumn2);
+							if (structureOptions) {
+								subtypeFieldsWrapper.classList.remove('hide');
 							}
-						}
-
-						if (structureOptions) {
-							subtypeFieldsWrapper.classList.remove('hide');
+							else if (hideSubtypeFilterEnableWrapper) {
+								subtypeFieldsWrapper.classList.add('hide');
+							}
 						}
 						else if (hideSubtypeFilterEnableWrapper) {
 							subtypeFieldsWrapper.classList.add('hide');
 						}
+					});
+				}
+
+				<%= className %>toggleSubclassesFields(false);
+
+				<%= className %>SubtypeSelector.addEventListener('change', function (event) {
+					setDDMFields('<%= className %>', '', '', '', '');
+
+					var saveButton = document.getElementById('<portlet:namespace />saveButton');
+
+					if (<%= className %>SubtypeSelector.value === '') {
+						saveButton.classList.add('disabled');
+						saveButton.disabled = true;
 					}
-					else if (hideSubtypeFilterEnableWrapper) {
-						subtypeFieldsWrapper.classList.add('hide');
+					else {
+						saveButton.classList.remove('disabled');
+						saveButton.disabled = false;
 					}
+
+					var subtypeFieldsFilterEnabledCheckbox = document.getElementById(
+						'<portlet:namespace />subtypeFieldsFilterEnabled<%= className %>'
+					);
+
+					if (subtypeFieldsFilterEnabledCheckbox) {
+						subtypeFieldsFilterEnabledCheckbox.checked = false;
+					}
+
+					var assetSubtypeFields = sourcePanel.querySelectorAll(
+						'.asset-subtypefields'
+					);
+
+					Array.prototype.forEach.call(assetSubtypeFields, function (
+						assetSubtypeField
+					) {
+						assetSubtypeField.classList.add('hide');
+					});
+
+					<%= className %>toggleSubclassesFields(true);
 				});
-			}
-
-			<%= className %>toggleSubclassesFields(false);
-
-			<%= className %>SubtypeSelector.addEventListener('change', function (event) {
-				setDDMFields('<%= className %>', '', '', '', '');
-
-				var saveButton = document.getElementById('<portlet:namespace />saveButton');
-
-				if (<%= className %>SubtypeSelector.value === '') {
-					saveButton.classList.add('disabled');
-					saveButton.disabled = true;
-				}
-				else {
-					saveButton.classList.remove('disabled');
-					saveButton.disabled = false;
-				}
-
-				var subtypeFieldsFilterEnabledCheckbox = document.getElementById(
-					'<portlet:namespace />subtypeFieldsFilterEnabled<%= className %>'
-				);
-
-				if (subtypeFieldsFilterEnabledCheckbox) {
-					subtypeFieldsFilterEnabledCheckbox.checked = false;
-				}
-
-				var assetSubtypeFields = sourcePanel.querySelectorAll(
-					'.asset-subtypefields'
-				);
-
-				Array.prototype.forEach.call(assetSubtypeFields, function (
-					assetSubtypeField
-				) {
-					assetSubtypeField.classList.add('hide');
-				});
-
-				<%= className %>toggleSubclassesFields(true);
-			});
-		</c:if>
+			</c:if>
 
 	<%
 	}
@@ -514,7 +514,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 			String className = editAssetListDisplayContext.getClassName(curRendererFactory);
 		%>
 
-			<portlet:namespace />toggle<%= className %>(removeOrderBySubtype);
+				<portlet:namespace />toggle<%= className %>(removeOrderBySubtype);
 
 		<%
 		}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -153,7 +153,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 	</portlet:actionURL>
 
 	function <portlet:namespace />openSelectSegmentsEntryDialog() {
-		Liferay.Util.openModal({
+		Liferay.Util.openSelectionModal({
 			id: '<portlet:namespace />selectEntity',
 			onSelect: function (selectedItem) {
 				Liferay.Util.postForm(document.<portlet:namespace />fm, {

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -188,14 +188,14 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 			String className = assetListDisplayContext.getClassName(assetRendererFactory);
 		%>
 
-			Liferay.Util.setFormValues(form, {
-				classTypeIds<%= className %>: Liferay.Util.listSelect(
-					Liferay.Util.getFormElement(
-						form,
-						'<%= className %>currentClassTypeIds'
-					)
-				),
-			});
+				Liferay.Util.setFormValues(form, {
+					classTypeIds<%= className %>: Liferay.Util.listSelect(
+						Liferay.Util.getFormElement(
+							form,
+							'<%= className %>currentClassTypeIds'
+						)
+					),
+				});
 
 		<%
 		}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -188,14 +188,14 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 			String className = assetListDisplayContext.getClassName(assetRendererFactory);
 		%>
 
-				Liferay.Util.setFormValues(form, {
-					classTypeIds<%= className %>: Liferay.Util.listSelect(
-						Liferay.Util.getFormElement(
-							form,
-							'<%= className %>currentClassTypeIds'
-						)
-					),
-				});
+			Liferay.Util.setFormValues(form, {
+				classTypeIds<%= className %>: Liferay.Util.listSelect(
+					Liferay.Util.getFormElement(
+						form,
+						'<%= className %>currentClassTypeIds'
+					)
+				),
+			});
 
 		<%
 		}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
@@ -211,7 +211,7 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 	</c:otherwise>
 </c:choose>
 
-<aui:script require="metal-dom/src/dom as dom, frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script require="metal-dom/src/dom as dom">
 	var delegateHandler = dom.delegate(
 		document.body,
 		'click',
@@ -221,32 +221,28 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 
 			var delegateTarget = event.delegateTarget;
 
-			var itemSelectorDialog = new ItemSelectorDialog.default({
-				eventName: '<portlet:namespace />selectAsset',
+			Liferay.Util.openSelectionModal({
+				multiple: true,
+				onSelect: function(selectedItems) {
+					if (selectedItems) {
+						var assetEntryIds = [];
+
+						Array.prototype.forEach.call(selectedItems, function (
+							assetEntry
+						) {
+							assetEntryIds.push(assetEntry.entityid);
+						});
+
+						Liferay.Util.postForm(document.<portlet:namespace />fm, {
+							data: {
+								assetEntryIds: assetEntryIds.join(','),
+							},
+						});
+					}
+				},
+				selectEventName: '<portlet:namespace />selectAsset',
 				title: delegateTarget.dataset.title,
 				url: delegateTarget.dataset.href,
-			});
-
-			itemSelectorDialog.open();
-
-			itemSelectorDialog.on('selectedItemChange', function (event) {
-				var selectedItems = event.selectedItem;
-
-				if (selectedItems) {
-					var assetEntryIds = [];
-
-					Array.prototype.forEach.call(selectedItems, function (
-						assetEntry
-					) {
-						assetEntryIds.push(assetEntry.entityid);
-					});
-
-					Liferay.Util.postForm(document.<portlet:namespace />fm, {
-						data: {
-							assetEntryIds: assetEntryIds.join(','),
-						},
-					});
-				}
 			});
 		}
 	);

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
@@ -223,7 +223,7 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 
 			Liferay.Util.openSelectionModal({
 				multiple: true,
-				onSelect: function(selectedItems) {
+				onSelect: function (selectedItems) {
 					if (selectedItems) {
 						var assetEntryIds = [];
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
@@ -259,7 +259,7 @@ for (long groupId : groupIds) {
 
 			Liferay.Util.openSelectionModal({
 				multiple: true,
-				onSelect: function(selectedItems) {
+				onSelect: function (selectedItems) {
 					if (selectedItems) {
 						selectAssets(selectedItems);
 					}

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
@@ -227,7 +227,7 @@ for (long groupId : groupIds) {
 	}
 </script>
 
-<aui:script require="metal-dom/src/dom as dom, frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script require="metal-dom/src/dom as dom">
 	function selectAssets(assetEntryList) {
 		var assetClassName = '';
 		var assetEntryIds = [];
@@ -257,20 +257,16 @@ for (long groupId : groupIds) {
 
 			var delegateTarget = event.delegateTarget;
 
-			var itemSelectorDialog = new ItemSelectorDialog.default({
-				eventName: '<%= eventName %>',
+			Liferay.Util.openSelectionModal({
+				multiple: true,
+				onSelect: function(selectedItems) {
+					if (selectedItems) {
+						selectAssets(selectedItems);
+					}
+				},
+				selectEventName: '<%= eventName %>',
 				title: delegateTarget.dataset.title,
 				url: delegateTarget.dataset.href,
-			});
-
-			itemSelectorDialog.open();
-
-			itemSelectorDialog.on('selectedItemChange', function (event) {
-				var selectedItems = event.selectedItem;
-
-				if (selectedItems) {
-					selectAssets(selectedItems);
-				}
 			});
 		}
 	);

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_list.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_list.jsp
@@ -39,7 +39,7 @@ AssetListEntry assetListEntry = assetPublisherDisplayContext.fetchAssetListEntry
 	<aui:button name="clearAssetListButton" value="clear" />
 </div>
 
-<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script sandbox="<%= true %>">
 	var assetListEntryId = document.getElementById(
 		'<portlet:namespace />assetListEntryId'
 	);

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_list.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_list.jsp
@@ -52,27 +52,23 @@ AssetListEntry assetListEntry = assetPublisherDisplayContext.fetchAssetListEntry
 	);
 
 	if (selectAssetListButton) {
-		selectAssetListButton.addEventListener('click', function (event) {
-			var itemSelectorDialog = new ItemSelectorDialog.default({
-				eventName:
+		selectAssetListButton.addEventListener('click', function () {
+			Liferay.Util.openSelectionModal({
+				onSelect: function (selectedItem) {
+					if (selectedItem) {
+						var itemValue = JSON.parse(selectedItem.value);
+
+						assetListEntryId.value = itemValue.classPK;
+
+						assetListTitle.innerHTML = itemValue.title;
+					}
+				},
+				selectEventName:
 					'<%= assetPublisherDisplayContext.getSelectAssetListEventName() %>',
-				singleSelect: true,
 				title: '<liferay-ui:message key="select-collection" />',
 				url:
 					'<%= assetPublisherDisplayContext.getAssetListSelectorURL() %>',
 			});
-
-			itemSelectorDialog.on('selectedItemChange', function (event) {
-				if (event.selectedItem) {
-					var itemValue = JSON.parse(event.selectedItem.value);
-
-					assetListEntryId.value = itemValue.classPK;
-
-					assetListTitle.innerHTML = itemValue.title;
-				}
-			});
-
-			itemSelectorDialog.open();
 		});
 	}
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/scope.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/scope.jsp
@@ -160,7 +160,7 @@ itemSelectorURL.setParameter("portletResource", assetPublisherDisplayContext.get
 
 			var opener = Liferay.Util.getOpener();
 
-			opener.Liferay.Util.openModal({
+			opener.Liferay.Util.openSelectionModal({
 				id: '<%= eventName %>' + event.currentTarget.id,
 				onSelect: function (event) {
 					Liferay.Util.postForm(form, {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -248,208 +248,208 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		String className = assetPublisherWebHelper.getClassName(curRendererFactory);
 	%>
 
-			Util.toggleSelectBox(
-				'<portlet:namespace />anyClassType<%= className %>',
-				'false',
-				'<portlet:namespace /><%= className %>Boxes'
-			);
+		Util.toggleSelectBox(
+			'<portlet:namespace />anyClassType<%= className %>',
+			'false',
+			'<portlet:namespace /><%= className %>Boxes'
+		);
 
-			var <%= className %>Options = document.getElementById(
-				'<portlet:namespace /><%= className %>Options'
-			);
+		var <%= className %>Options = document.getElementById(
+			'<portlet:namespace /><%= className %>Options'
+		);
 
-			function <portlet:namespace />toggle<%= className %>(removeOrderBySubtype) {
-				var assetOptions = assetMultipleSelector.options;
+		function <portlet:namespace />toggle<%= className %>(removeOrderBySubtype) {
+			var assetOptions = assetMultipleSelector.options;
 
-				var showOptions =
-					assetSelector.value == '<%= curRendererFactory.getClassNameId() %>' ||
-					(assetSelector.value == 'false' &&
-						assetOptions.length == 1 &&
-						assetOptions[0].value ==
-							'<%= curRendererFactory.getClassNameId() %>');
+			var showOptions =
+				assetSelector.value == '<%= curRendererFactory.getClassNameId() %>' ||
+				(assetSelector.value == 'false' &&
+					assetOptions.length == 1 &&
+					assetOptions[0].value ==
+						'<%= curRendererFactory.getClassNameId() %>');
 
-				if (showOptions) {
-					<%= className %>Options.classList.remove('hide');
-				}
-				else {
-					<%= className %>Options.classList.add('hide');
-				}
-
-				if (removeOrderBySubtype) {
-					Array.prototype.forEach.call(
-						orderingPanel.querySelectorAll('.order-by-subtype'),
-						function (option) {
-							dom.exitDocument(option);
-						}
-					);
-				}
-
-				<c:if test="<%= assetPublisherDisplayContext.isShowSubtypeFieldsFilter() %>">
-					<%= className %>toggleSubclassesFields(true);
-				</c:if>
+			if (showOptions) {
+				<%= className %>Options.classList.remove('hide');
+			}
+			else {
+				<%= className %>Options.classList.add('hide');
 			}
 
-			<%
-			ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
-
-			List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(assetPublisherDisplayContext.getReferencedModelsGroupIds(), locale);
-
-			if (assetAvailableClassTypes.isEmpty()) {
-				continue;
-			}
-
-			for (ClassType classType : assetAvailableClassTypes) {
-				List<ClassTypeField> classTypeFields = classType.getClassTypeFields();
-
-				if (classTypeFields.isEmpty()) {
-					continue;
-				}
-			%>
-
-					var optgroupClose = '</optgroup>';
-					var optgroupOpen =
-						'<optgroup class="order-by-subtype" label="<%= HtmlUtil.escape(classType.getName()) %>">';
-
-					var columnBuffer1 = [optgroupOpen];
-					var columnBuffer2 = [optgroupOpen];
-
-					<%
-					String orderByColumn1 = assetPublisherDisplayContext.getOrderByColumn1();
-					String orderByColumn2 = assetPublisherDisplayContext.getOrderByColumn2();
-
-					for (ClassTypeField classTypeField : classTypeFields) {
-						String value = assetPublisherWebHelper.encodeName(classTypeField.getClassTypeId(), classTypeField.getName(), null);
-						String selectedOrderByColumn1 = StringPool.BLANK;
-						String selectedOrderByColumn2 = StringPool.BLANK;
-
-						if (orderByColumn1.equals(value)) {
-							selectedOrderByColumn1 = "selected";
-						}
-
-						if (orderByColumn2.equals(value)) {
-							selectedOrderByColumn2 = "selected";
-						}
-					%>
-
-							columnBuffer1.push(
-								'<option <%= selectedOrderByColumn1 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
-							);
-							columnBuffer2.push(
-								'<option <%= selectedOrderByColumn2 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
-							);
-
-					<%
+			if (removeOrderBySubtype) {
+				Array.prototype.forEach.call(
+					orderingPanel.querySelectorAll('.order-by-subtype'),
+					function (option) {
+						dom.exitDocument(option);
 					}
-					%>
-
-					columnBuffer1.push(optgroupClose);
-					columnBuffer2.push(optgroupClose);
-
-					MAP_DDM_STRUCTURES[
-						'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn1'
-					] = columnBuffer1.join('');
-					MAP_DDM_STRUCTURES[
-						'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn2'
-					] = columnBuffer2.join('');
-
-			<%
+				);
 			}
-			%>
-
-			var <%= className %>SubtypeSelector = document.getElementById(
-				'<portlet:namespace />anyClassType<%= className %>'
-			);
 
 			<c:if test="<%= assetPublisherDisplayContext.isShowSubtypeFieldsFilter() %>">
-				function <%= className %>toggleSubclassesFields(
-					hideSubtypeFilterEnableWrapper
+				<%= className %>toggleSubclassesFields(true);
+			</c:if>
+		}
+
+		<%
+		ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
+
+		List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(assetPublisherDisplayContext.getReferencedModelsGroupIds(), locale);
+
+		if (assetAvailableClassTypes.isEmpty()) {
+			continue;
+		}
+
+		for (ClassType classType : assetAvailableClassTypes) {
+			List<ClassTypeField> classTypeFields = classType.getClassTypeFields();
+
+			if (classTypeFields.isEmpty()) {
+				continue;
+			}
+		%>
+
+			var optgroupClose = '</optgroup>';
+			var optgroupOpen =
+				'<optgroup class="order-by-subtype" label="<%= HtmlUtil.escape(classType.getName()) %>">';
+
+			var columnBuffer1 = [optgroupOpen];
+			var columnBuffer2 = [optgroupOpen];
+
+			<%
+			String orderByColumn1 = assetPublisherDisplayContext.getOrderByColumn1();
+			String orderByColumn2 = assetPublisherDisplayContext.getOrderByColumn2();
+
+			for (ClassTypeField classTypeField : classTypeFields) {
+				String value = assetPublisherWebHelper.encodeName(classTypeField.getClassTypeId(), classTypeField.getName(), null);
+				String selectedOrderByColumn1 = StringPool.BLANK;
+				String selectedOrderByColumn2 = StringPool.BLANK;
+
+				if (orderByColumn1.equals(value)) {
+					selectedOrderByColumn1 = "selected";
+				}
+
+				if (orderByColumn2.equals(value)) {
+					selectedOrderByColumn2 = "selected";
+				}
+			%>
+
+				columnBuffer1.push(
+					'<option <%= selectedOrderByColumn1 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
+				);
+				columnBuffer2.push(
+					'<option <%= selectedOrderByColumn2 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
+				);
+
+			<%
+			}
+			%>
+
+			columnBuffer1.push(optgroupClose);
+			columnBuffer2.push(optgroupClose);
+
+			MAP_DDM_STRUCTURES[
+				'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn1'
+			] = columnBuffer1.join('');
+			MAP_DDM_STRUCTURES[
+				'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn2'
+			] = columnBuffer2.join('');
+
+		<%
+		}
+		%>
+
+		var <%= className %>SubtypeSelector = document.getElementById(
+			'<portlet:namespace />anyClassType<%= className %>'
+		);
+
+		<c:if test="<%= assetPublisherDisplayContext.isShowSubtypeFieldsFilter() %>">
+			function <%= className %>toggleSubclassesFields(
+				hideSubtypeFilterEnableWrapper
+			) {
+				var selectedSubtype = <%= className %>SubtypeSelector.value;
+
+				var structureOptions = document.getElementById(
+					'<portlet:namespace />' + selectedSubtype + '_<%= className %>Options'
+				);
+
+				if (structureOptions) {
+					structureOptions.classList.remove('hide');
+				}
+
+				var subtypeFieldsWrappers = document.querySelectorAll(
+					'#<portlet:namespace /><%= className %>subtypeFieldsWrapper, #<portlet:namespace /><%= className %>subtypeFieldsFilterEnableWrapper'
+				);
+
+				Array.prototype.forEach.call(subtypeFieldsWrappers, function (
+					subtypeFieldsWrapper
 				) {
-					var selectedSubtype = <%= className %>SubtypeSelector.value;
-
-					var structureOptions = document.getElementById(
-						'<portlet:namespace />' + selectedSubtype + '_<%= className %>Options'
-					);
-
-					if (structureOptions) {
-						structureOptions.classList.remove('hide');
-					}
-
-					var subtypeFieldsWrappers = document.querySelectorAll(
-						'#<portlet:namespace /><%= className %>subtypeFieldsWrapper, #<portlet:namespace /><%= className %>subtypeFieldsFilterEnableWrapper'
-					);
-
-					Array.prototype.forEach.call(subtypeFieldsWrappers, function (
-						subtypeFieldsWrapper
-					) {
-						if (selectedSubtype != 'false' && selectedSubtype != 'true') {
-							Array.prototype.forEach.call(
-								orderingPanel.querySelectorAll('.order-by-subtype'),
-								function (option) {
-									dom.exitDocument(option);
-								}
-							);
-
-							var optTextOrderByColumn1 =
-								MAP_DDM_STRUCTURES[
-									'<%= className %>_' +
-										selectedSubtype +
-										'_optTextOrderByColumn1'
-								];
-
-							if (optTextOrderByColumn1) {
-								dom.append(orderByColumn1, optTextOrderByColumn1);
+					if (selectedSubtype != 'false' && selectedSubtype != 'true') {
+						Array.prototype.forEach.call(
+							orderingPanel.querySelectorAll('.order-by-subtype'),
+							function (option) {
+								dom.exitDocument(option);
 							}
+						);
 
-							var optTextOrderByColumn2 =
-								MAP_DDM_STRUCTURES[
-									'<%= className %>_' +
-										selectedSubtype +
-										'_optTextOrderByColumn2'
-								];
+						var optTextOrderByColumn1 =
+							MAP_DDM_STRUCTURES[
+								'<%= className %>_' +
+									selectedSubtype +
+									'_optTextOrderByColumn1'
+							];
 
-							if (optTextOrderByColumn2) {
-								dom.append(orderByColumn2, optTextOrderByColumn2);
-							}
+						if (optTextOrderByColumn1) {
+							dom.append(orderByColumn1, optTextOrderByColumn1);
+						}
 
-							if (structureOptions) {
-								subtypeFieldsWrapper.classList.remove('hide');
-							}
-							else if (hideSubtypeFilterEnableWrapper) {
-								subtypeFieldsWrapper.classList.add('hide');
-							}
+						var optTextOrderByColumn2 =
+							MAP_DDM_STRUCTURES[
+								'<%= className %>_' +
+									selectedSubtype +
+									'_optTextOrderByColumn2'
+							];
+
+						if (optTextOrderByColumn2) {
+							dom.append(orderByColumn2, optTextOrderByColumn2);
+						}
+
+						if (structureOptions) {
+							subtypeFieldsWrapper.classList.remove('hide');
 						}
 						else if (hideSubtypeFilterEnableWrapper) {
 							subtypeFieldsWrapper.classList.add('hide');
 						}
-					});
+					}
+					else if (hideSubtypeFilterEnableWrapper) {
+						subtypeFieldsWrapper.classList.add('hide');
+					}
+				});
+			}
+
+			<%= className %>toggleSubclassesFields(false);
+
+			<%= className %>SubtypeSelector.addEventListener('change', function (event) {
+				setDDMFields('<%= className %>', '', '', '', '');
+
+				var subtypeFieldsFilterEnabledCheckbox = document.getElementById(
+					'<portlet:namespace />subtypeFieldsFilterEnabled<%= className %>'
+				);
+
+				if (subtypeFieldsFilterEnabledCheckbox) {
+					subtypeFieldsFilterEnabledCheckbox.checked = false;
 				}
 
-				<%= className %>toggleSubclassesFields(false);
+				var assetSubtypeFields = sourcePanel.querySelectorAll(
+					'.asset-subtypefields'
+				);
 
-				<%= className %>SubtypeSelector.addEventListener('change', function (event) {
-					setDDMFields('<%= className %>', '', '', '', '');
-
-					var subtypeFieldsFilterEnabledCheckbox = document.getElementById(
-						'<portlet:namespace />subtypeFieldsFilterEnabled<%= className %>'
-					);
-
-					if (subtypeFieldsFilterEnabledCheckbox) {
-						subtypeFieldsFilterEnabledCheckbox.checked = false;
-					}
-
-					var assetSubtypeFields = sourcePanel.querySelectorAll(
-						'.asset-subtypefields'
-					);
-
-					Array.prototype.forEach.call(assetSubtypeFields, function (
-						assetSubtypeField
-					) {
-						assetSubtypeField.classList.add('hide');
-					});
-
-					<%= className %>toggleSubclassesFields(true);
+				Array.prototype.forEach.call(assetSubtypeFields, function (
+					assetSubtypeField
+				) {
+					assetSubtypeField.classList.add('hide');
 				});
-			</c:if>
+
+				<%= className %>toggleSubclassesFields(true);
+			});
+		</c:if>
 
 	<%
 	}
@@ -462,7 +462,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 			String className = assetPublisherWebHelper.getClassName(curRendererFactory);
 		%>
 
-				<portlet:namespace />toggle<%= className %>(removeOrderBySubtype);
+			<portlet:namespace />toggle<%= className %>(removeOrderBySubtype);
 
 		<%
 		}

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -248,208 +248,208 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		String className = assetPublisherWebHelper.getClassName(curRendererFactory);
 	%>
 
-		Util.toggleSelectBox(
-			'<portlet:namespace />anyClassType<%= className %>',
-			'false',
-			'<portlet:namespace /><%= className %>Boxes'
-		);
+			Util.toggleSelectBox(
+				'<portlet:namespace />anyClassType<%= className %>',
+				'false',
+				'<portlet:namespace /><%= className %>Boxes'
+			);
 
-		var <%= className %>Options = document.getElementById(
-			'<portlet:namespace /><%= className %>Options'
-		);
+			var <%= className %>Options = document.getElementById(
+				'<portlet:namespace /><%= className %>Options'
+			);
 
-		function <portlet:namespace />toggle<%= className %>(removeOrderBySubtype) {
-			var assetOptions = assetMultipleSelector.options;
+			function <portlet:namespace />toggle<%= className %>(removeOrderBySubtype) {
+				var assetOptions = assetMultipleSelector.options;
 
-			var showOptions =
-				assetSelector.value == '<%= curRendererFactory.getClassNameId() %>' ||
-				(assetSelector.value == 'false' &&
-					assetOptions.length == 1 &&
-					assetOptions[0].value ==
-						'<%= curRendererFactory.getClassNameId() %>');
+				var showOptions =
+					assetSelector.value == '<%= curRendererFactory.getClassNameId() %>' ||
+					(assetSelector.value == 'false' &&
+						assetOptions.length == 1 &&
+						assetOptions[0].value ==
+							'<%= curRendererFactory.getClassNameId() %>');
 
-			if (showOptions) {
-				<%= className %>Options.classList.remove('hide');
+				if (showOptions) {
+					<%= className %>Options.classList.remove('hide');
+				}
+				else {
+					<%= className %>Options.classList.add('hide');
+				}
+
+				if (removeOrderBySubtype) {
+					Array.prototype.forEach.call(
+						orderingPanel.querySelectorAll('.order-by-subtype'),
+						function (option) {
+							dom.exitDocument(option);
+						}
+					);
+				}
+
+				<c:if test="<%= assetPublisherDisplayContext.isShowSubtypeFieldsFilter() %>">
+					<%= className %>toggleSubclassesFields(true);
+				</c:if>
 			}
-			else {
-				<%= className %>Options.classList.add('hide');
-			}
 
-			if (removeOrderBySubtype) {
-				Array.prototype.forEach.call(
-					orderingPanel.querySelectorAll('.order-by-subtype'),
-					function (option) {
-						dom.exitDocument(option);
-					}
-				);
-			}
+			<%
+			ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
 
-			<c:if test="<%= assetPublisherDisplayContext.isShowSubtypeFieldsFilter() %>">
-				<%= className %>toggleSubclassesFields(true);
-			</c:if>
-		}
+			List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(assetPublisherDisplayContext.getReferencedModelsGroupIds(), locale);
 
-		<%
-		ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
-
-		List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(assetPublisherDisplayContext.getReferencedModelsGroupIds(), locale);
-
-		if (assetAvailableClassTypes.isEmpty()) {
-			continue;
-		}
-
-		for (ClassType classType : assetAvailableClassTypes) {
-			List<ClassTypeField> classTypeFields = classType.getClassTypeFields();
-
-			if (classTypeFields.isEmpty()) {
+			if (assetAvailableClassTypes.isEmpty()) {
 				continue;
 			}
-		%>
 
-			var optgroupClose = '</optgroup>';
-			var optgroupOpen =
-				'<optgroup class="order-by-subtype" label="<%= HtmlUtil.escape(classType.getName()) %>">';
+			for (ClassType classType : assetAvailableClassTypes) {
+				List<ClassTypeField> classTypeFields = classType.getClassTypeFields();
 
-			var columnBuffer1 = [optgroupOpen];
-			var columnBuffer2 = [optgroupOpen];
-
-			<%
-			String orderByColumn1 = assetPublisherDisplayContext.getOrderByColumn1();
-			String orderByColumn2 = assetPublisherDisplayContext.getOrderByColumn2();
-
-			for (ClassTypeField classTypeField : classTypeFields) {
-				String value = assetPublisherWebHelper.encodeName(classTypeField.getClassTypeId(), classTypeField.getName(), null);
-				String selectedOrderByColumn1 = StringPool.BLANK;
-				String selectedOrderByColumn2 = StringPool.BLANK;
-
-				if (orderByColumn1.equals(value)) {
-					selectedOrderByColumn1 = "selected";
-				}
-
-				if (orderByColumn2.equals(value)) {
-					selectedOrderByColumn2 = "selected";
+				if (classTypeFields.isEmpty()) {
+					continue;
 				}
 			%>
 
-				columnBuffer1.push(
-					'<option <%= selectedOrderByColumn1 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
-				);
-				columnBuffer2.push(
-					'<option <%= selectedOrderByColumn2 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
-				);
+					var optgroupClose = '</optgroup>';
+					var optgroupOpen =
+						'<optgroup class="order-by-subtype" label="<%= HtmlUtil.escape(classType.getName()) %>">';
+
+					var columnBuffer1 = [optgroupOpen];
+					var columnBuffer2 = [optgroupOpen];
+
+					<%
+					String orderByColumn1 = assetPublisherDisplayContext.getOrderByColumn1();
+					String orderByColumn2 = assetPublisherDisplayContext.getOrderByColumn2();
+
+					for (ClassTypeField classTypeField : classTypeFields) {
+						String value = assetPublisherWebHelper.encodeName(classTypeField.getClassTypeId(), classTypeField.getName(), null);
+						String selectedOrderByColumn1 = StringPool.BLANK;
+						String selectedOrderByColumn2 = StringPool.BLANK;
+
+						if (orderByColumn1.equals(value)) {
+							selectedOrderByColumn1 = "selected";
+						}
+
+						if (orderByColumn2.equals(value)) {
+							selectedOrderByColumn2 = "selected";
+						}
+					%>
+
+							columnBuffer1.push(
+								'<option <%= selectedOrderByColumn1 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
+							);
+							columnBuffer2.push(
+								'<option <%= selectedOrderByColumn2 %> value="<%= value %>"><%= HtmlUtil.escapeJS(classTypeField.getLabel()) %></option>'
+							);
+
+					<%
+					}
+					%>
+
+					columnBuffer1.push(optgroupClose);
+					columnBuffer2.push(optgroupClose);
+
+					MAP_DDM_STRUCTURES[
+						'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn1'
+					] = columnBuffer1.join('');
+					MAP_DDM_STRUCTURES[
+						'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn2'
+					] = columnBuffer2.join('');
 
 			<%
 			}
 			%>
 
-			columnBuffer1.push(optgroupClose);
-			columnBuffer2.push(optgroupClose);
+			var <%= className %>SubtypeSelector = document.getElementById(
+				'<portlet:namespace />anyClassType<%= className %>'
+			);
 
-			MAP_DDM_STRUCTURES[
-				'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn1'
-			] = columnBuffer1.join('');
-			MAP_DDM_STRUCTURES[
-				'<%= className %>_<%= classType.getClassTypeId() %>_optTextOrderByColumn2'
-			] = columnBuffer2.join('');
-
-		<%
-		}
-		%>
-
-		var <%= className %>SubtypeSelector = document.getElementById(
-			'<portlet:namespace />anyClassType<%= className %>'
-		);
-
-		<c:if test="<%= assetPublisherDisplayContext.isShowSubtypeFieldsFilter() %>">
-			function <%= className %>toggleSubclassesFields(
-				hideSubtypeFilterEnableWrapper
-			) {
-				var selectedSubtype = <%= className %>SubtypeSelector.value;
-
-				var structureOptions = document.getElementById(
-					'<portlet:namespace />' + selectedSubtype + '_<%= className %>Options'
-				);
-
-				if (structureOptions) {
-					structureOptions.classList.remove('hide');
-				}
-
-				var subtypeFieldsWrappers = document.querySelectorAll(
-					'#<portlet:namespace /><%= className %>subtypeFieldsWrapper, #<portlet:namespace /><%= className %>subtypeFieldsFilterEnableWrapper'
-				);
-
-				Array.prototype.forEach.call(subtypeFieldsWrappers, function (
-					subtypeFieldsWrapper
+			<c:if test="<%= assetPublisherDisplayContext.isShowSubtypeFieldsFilter() %>">
+				function <%= className %>toggleSubclassesFields(
+					hideSubtypeFilterEnableWrapper
 				) {
-					if (selectedSubtype != 'false' && selectedSubtype != 'true') {
-						Array.prototype.forEach.call(
-							orderingPanel.querySelectorAll('.order-by-subtype'),
-							function (option) {
-								dom.exitDocument(option);
+					var selectedSubtype = <%= className %>SubtypeSelector.value;
+
+					var structureOptions = document.getElementById(
+						'<portlet:namespace />' + selectedSubtype + '_<%= className %>Options'
+					);
+
+					if (structureOptions) {
+						structureOptions.classList.remove('hide');
+					}
+
+					var subtypeFieldsWrappers = document.querySelectorAll(
+						'#<portlet:namespace /><%= className %>subtypeFieldsWrapper, #<portlet:namespace /><%= className %>subtypeFieldsFilterEnableWrapper'
+					);
+
+					Array.prototype.forEach.call(subtypeFieldsWrappers, function (
+						subtypeFieldsWrapper
+					) {
+						if (selectedSubtype != 'false' && selectedSubtype != 'true') {
+							Array.prototype.forEach.call(
+								orderingPanel.querySelectorAll('.order-by-subtype'),
+								function (option) {
+									dom.exitDocument(option);
+								}
+							);
+
+							var optTextOrderByColumn1 =
+								MAP_DDM_STRUCTURES[
+									'<%= className %>_' +
+										selectedSubtype +
+										'_optTextOrderByColumn1'
+								];
+
+							if (optTextOrderByColumn1) {
+								dom.append(orderByColumn1, optTextOrderByColumn1);
 							}
-						);
 
-						var optTextOrderByColumn1 =
-							MAP_DDM_STRUCTURES[
-								'<%= className %>_' +
-									selectedSubtype +
-									'_optTextOrderByColumn1'
-							];
+							var optTextOrderByColumn2 =
+								MAP_DDM_STRUCTURES[
+									'<%= className %>_' +
+										selectedSubtype +
+										'_optTextOrderByColumn2'
+								];
 
-						if (optTextOrderByColumn1) {
-							dom.append(orderByColumn1, optTextOrderByColumn1);
-						}
+							if (optTextOrderByColumn2) {
+								dom.append(orderByColumn2, optTextOrderByColumn2);
+							}
 
-						var optTextOrderByColumn2 =
-							MAP_DDM_STRUCTURES[
-								'<%= className %>_' +
-									selectedSubtype +
-									'_optTextOrderByColumn2'
-							];
-
-						if (optTextOrderByColumn2) {
-							dom.append(orderByColumn2, optTextOrderByColumn2);
-						}
-
-						if (structureOptions) {
-							subtypeFieldsWrapper.classList.remove('hide');
+							if (structureOptions) {
+								subtypeFieldsWrapper.classList.remove('hide');
+							}
+							else if (hideSubtypeFilterEnableWrapper) {
+								subtypeFieldsWrapper.classList.add('hide');
+							}
 						}
 						else if (hideSubtypeFilterEnableWrapper) {
 							subtypeFieldsWrapper.classList.add('hide');
 						}
-					}
-					else if (hideSubtypeFilterEnableWrapper) {
-						subtypeFieldsWrapper.classList.add('hide');
-					}
-				});
-			}
-
-			<%= className %>toggleSubclassesFields(false);
-
-			<%= className %>SubtypeSelector.addEventListener('change', function (event) {
-				setDDMFields('<%= className %>', '', '', '', '');
-
-				var subtypeFieldsFilterEnabledCheckbox = document.getElementById(
-					'<portlet:namespace />subtypeFieldsFilterEnabled<%= className %>'
-				);
-
-				if (subtypeFieldsFilterEnabledCheckbox) {
-					subtypeFieldsFilterEnabledCheckbox.checked = false;
+					});
 				}
 
-				var assetSubtypeFields = sourcePanel.querySelectorAll(
-					'.asset-subtypefields'
-				);
+				<%= className %>toggleSubclassesFields(false);
 
-				Array.prototype.forEach.call(assetSubtypeFields, function (
-					assetSubtypeField
-				) {
-					assetSubtypeField.classList.add('hide');
+				<%= className %>SubtypeSelector.addEventListener('change', function (event) {
+					setDDMFields('<%= className %>', '', '', '', '');
+
+					var subtypeFieldsFilterEnabledCheckbox = document.getElementById(
+						'<portlet:namespace />subtypeFieldsFilterEnabled<%= className %>'
+					);
+
+					if (subtypeFieldsFilterEnabledCheckbox) {
+						subtypeFieldsFilterEnabledCheckbox.checked = false;
+					}
+
+					var assetSubtypeFields = sourcePanel.querySelectorAll(
+						'.asset-subtypefields'
+					);
+
+					Array.prototype.forEach.call(assetSubtypeFields, function (
+						assetSubtypeField
+					) {
+						assetSubtypeField.classList.add('hide');
+					});
+
+					<%= className %>toggleSubclassesFields(true);
 				});
-
-				<%= className %>toggleSubclassesFields(true);
-			});
-		</c:if>
+			</c:if>
 
 	<%
 	}
@@ -462,7 +462,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 			String className = assetPublisherWebHelper.getClassName(curRendererFactory);
 		%>
 
-			<portlet:namespace />toggle<%= className %>(removeOrderBySubtype);
+				<portlet:namespace />toggle<%= className %>(removeOrderBySubtype);
 
 		<%
 		}

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -559,6 +559,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		);
 
 		Util.openSelectionModal({
+			customSelectEvent: true,
 			id: '<portlet:namespace />selectDDMStructure' + delegateTarget.id,
 			onSelect: function (selectedItem) {
 				setDDMFields(

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -558,7 +558,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 			url
 		);
 
-		Util.openModal({
+		Util.openSelectionModal({
 			id: '<portlet:namespace />selectDDMStructure' + delegateTarget.id,
 			onSelect: function (selectedItem) {
 				setDDMFields(

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -19,7 +19,7 @@ import ClayIcon from '@clayui/icon';
 import ClayMultiSelect from '@clayui/multi-select';
 import classNames from 'classnames';
 import {usePrevious} from 'frontend-js-react-web';
-import {openSelectionModal} from 'frontend-js-web';
+import {ItemSelectorDialog} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -108,7 +108,8 @@ function AssetVocabulariesCategoriesSelector({
 				)
 			) {
 				validAddedItems.push(item);
-			} else {
+			}
+			else {
 				invalidAddedItems.push(item);
 			}
 		});
@@ -139,35 +140,39 @@ function AssetVocabulariesCategoriesSelector({
 			vocabularyIds: sourceItemsVocabularyIds.concat(),
 		});
 
-		openSelectionModal({
+		const itemSelectorDialog = new ItemSelectorDialog({
 			buttonAddLabel: Liferay.Language.get('done'),
-			multiple: true,
-			onSelect(dialogSelectedItems) {
-				if (dialogSelectedItems) {
-					const newValues = Object.keys(dialogSelectedItems).reduce(
-						(acc, itemKey) => {
-							const item = dialogSelectedItems[itemKey];
-							if (!item.unchecked) {
-								acc.push({
-									label: item.value,
-									value: item.categoryId,
-								});
-							}
-
-							return acc;
-						},
-						[]
-					);
-
-					onSelectedItemsChange(newValues);
-				}
-			},
-			selectEventName: eventName,
-			size: 'lg',
+			dialogClasses: 'modal-lg',
+			eventName,
 			title: label
 				? Liferay.Util.sub(Liferay.Language.get('select-x'), label)
 				: Liferay.Language.get('select-categories'),
 			url,
+		});
+
+		itemSelectorDialog.open();
+
+		itemSelectorDialog.on('selectedItemChange', (event) => {
+			const dialogSelectedItems = event.selectedItem;
+
+			if (dialogSelectedItems) {
+				const newValues = Object.keys(dialogSelectedItems).reduce(
+					(acc, itemKey) => {
+						const item = dialogSelectedItems[itemKey];
+						if (!item.unchecked) {
+							acc.push({
+								label: item.value,
+								value: item.categoryId,
+							});
+						}
+
+						return acc;
+					},
+					[]
+				);
+
+				onSelectedItemsChange(newValues);
+			}
 		});
 	};
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -19,7 +19,7 @@ import ClayIcon from '@clayui/icon';
 import ClayMultiSelect from '@clayui/multi-select';
 import classNames from 'classnames';
 import {usePrevious} from 'frontend-js-react-web';
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -108,8 +108,7 @@ function AssetVocabulariesCategoriesSelector({
 				)
 			) {
 				validAddedItems.push(item);
-			}
-			else {
+			} else {
 				invalidAddedItems.push(item);
 			}
 		});
@@ -140,39 +139,35 @@ function AssetVocabulariesCategoriesSelector({
 			vocabularyIds: sourceItemsVocabularyIds.concat(),
 		});
 
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
-			dialogClasses: 'modal-lg',
-			eventName,
+			multiple: true,
+			onSelect(dialogSelectedItems) {
+				if (dialogSelectedItems) {
+					const newValues = Object.keys(dialogSelectedItems).reduce(
+						(acc, itemKey) => {
+							const item = dialogSelectedItems[itemKey];
+							if (!item.unchecked) {
+								acc.push({
+									label: item.value,
+									value: item.categoryId,
+								});
+							}
+
+							return acc;
+						},
+						[]
+					);
+
+					onSelectedItemsChange(newValues);
+				}
+			},
+			selectEventName: eventName,
+			size: 'lg',
 			title: label
 				? Liferay.Util.sub(Liferay.Language.get('select-x'), label)
 				: Liferay.Language.get('select-categories'),
 			url,
-		});
-
-		itemSelectorDialog.open();
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const dialogSelectedItems = event.selectedItem;
-
-			if (dialogSelectedItems) {
-				const newValues = Object.keys(dialogSelectedItems).reduce(
-					(acc, itemKey) => {
-						const item = dialogSelectedItems[itemKey];
-						if (!item.unchecked) {
-							acc.push({
-								label: item.value,
-								value: item.categoryId,
-							});
-						}
-
-						return acc;
-					},
-					[]
-				);
-
-				onSelectedItemsChange(newValues);
-			}
 		});
 	};
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
@@ -17,7 +17,7 @@ import {useResource} from '@clayui/data-provider';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayMultiSelect from '@clayui/multi-select';
 import {usePrevious} from 'frontend-js-react-web';
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect} from 'react';
 
@@ -128,53 +128,50 @@ function AssetTagsSelector({
 			selectedTagNames: selectedItems.map((item) => item.value).join(),
 		});
 
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
-			eventName,
+			multiple: true,
+			onSelect(dialogSelectedItems) {
+				if (dialogSelectedItems && dialogSelectedItems.items.length) {
+					const newValues = dialogSelectedItems.items
+						.split(',')
+						.map((value) => {
+							return {
+								label: value,
+								value,
+							};
+						});
+
+					const addedItems = newValues.filter(
+						(newValue) =>
+							!selectedItems.find(
+								(selectedItem) =>
+									selectedItem.label === newValue.label
+							)
+					);
+
+					const removedItems = selectedItems.filter(
+						(selectedItem) =>
+							!newValues.find(
+								(newValue) =>
+									newValue.label === selectedItem.label
+							)
+					);
+
+					onSelectedItemsChange(newValues);
+
+					addedItems.forEach((item) =>
+						callGlobalCallback(addCallback, item)
+					);
+
+					removedItems.forEach((item) =>
+						callGlobalCallback(removeCallback, item)
+					);
+				}
+			},
+			selectEventName: eventName,
 			title: Liferay.Language.get('tags'),
 			url,
-		});
-
-		itemSelectorDialog.open();
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const dialogSelectedItems = event.selectedItem;
-
-			if (dialogSelectedItems && dialogSelectedItems.items.length) {
-				const newValues = dialogSelectedItems.items
-					.split(',')
-					.map((value) => {
-						return {
-							label: value,
-							value,
-						};
-					});
-
-				const addedItems = newValues.filter(
-					(newValue) =>
-						!selectedItems.find(
-							(selectedItem) =>
-								selectedItem.label === newValue.label
-						)
-				);
-
-				const removedItems = selectedItems.filter(
-					(selectedItem) =>
-						!newValues.find(
-							(newValue) => newValue.label === selectedItem.label
-						)
-				);
-
-				onSelectedItemsChange(newValues);
-
-				addedItems.forEach((item) =>
-					callGlobalCallback(addCallback, item)
-				);
-
-				removedItems.forEach((item) =>
-					callGlobalCallback(removeCallback, item)
-				);
-			}
 		});
 	};
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
@@ -131,7 +131,7 @@ function AssetTagsSelector({
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
 			multiple: true,
-			onSelect(dialogSelectedItems) {
+			onSelect: (dialogSelectedItems) => {
 				if (dialogSelectedItems && dialogSelectedItems.items.length) {
 					const newValues = dialogSelectedItems.items
 						.split(',')

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
@@ -134,7 +134,7 @@
 			Liferay.Util.openSelectionModal({
 				buttonAddLabel: '<liferay-ui:message key="done" />',
 				multiple: true,
-				onSelect: function(assetEntryIds) {
+				onSelect: function (assetEntryIds) {
 					if (assetEntryIds) {
 						Array.prototype.forEach.call(assetEntryIds, function (
 							assetEntry
@@ -149,13 +149,9 @@
 
 								var entryHtml =
 									'<h4 class="list-group-title">' +
-									Liferay.Util.escapeHTML(
-										assetEntry.assettitle
-									) +
+									Liferay.Util.escapeHTML(assetEntry.assettitle) +
 									'</h4><p class="list-group-subtitle">' +
-									Liferay.Util.escapeHTML(
-										assetEntry.assettype
-									) +
+									Liferay.Util.escapeHTML(assetEntry.assettype) +
 									'</p><p class="list-group-subtitle">' +
 									Liferay.Util.escapeHTML(
 										assetEntry.groupdescriptivename

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
@@ -131,61 +131,52 @@
 				searchContainerData = [];
 			}
 
-			Liferay.Loader.require(
-				'frontend-js-web/liferay/ItemSelectorDialog.es',
-				function (ItemSelectorDialog) {
-					var itemSelectorDialog = new ItemSelectorDialog.default({
-						buttonAddLabel: '<liferay-ui:message key="done" />',
-						eventName:
-							'<%= inputAssetLinksDisplayContext.getEventName() %>',
-						title: event.currentTarget.attr('data-title'),
-						url: event.currentTarget.attr('data-href'),
-					});
+			Liferay.Util.openSelectionModal({
+				buttonAddLabel: '<liferay-ui:message key="done" />',
+				multiple: true,
+				onSelect: function(assetEntryIds) {
+					if (assetEntryIds) {
+						Array.prototype.forEach.call(assetEntryIds, function (
+							assetEntry
+						) {
+							var entityId = assetEntry.entityid;
 
-					itemSelectorDialog.open();
+							if (searchContainerData.indexOf(entityId) == -1) {
+								var entryLink =
+									'<div class="text-right"><a class="modify-link" data-rowId="' +
+									entityId +
+									'" href="javascript:;"><%= UnicodeFormatter.toString(removeLinkIcon) %></a></div>';
 
-					itemSelectorDialog.on('selectedItemChange', function (event) {
-						var assetEntryIds = event.selectedItem;
+								var entryHtml =
+									'<h4 class="list-group-title">' +
+									Liferay.Util.escapeHTML(
+										assetEntry.assettitle
+									) +
+									'</h4><p class="list-group-subtitle">' +
+									Liferay.Util.escapeHTML(
+										assetEntry.assettype
+									) +
+									'</p><p class="list-group-subtitle">' +
+									Liferay.Util.escapeHTML(
+										assetEntry.groupdescriptivename
+									) +
+									'</p>';
 
-						if (assetEntryIds) {
-							Array.prototype.forEach.call(assetEntryIds, function (
-								assetEntry
-							) {
-								var entityId = assetEntry.entityid;
+								searchContainer.addRow(
+									[entryHtml, entryLink],
+									entityId
+								);
 
-								if (searchContainerData.indexOf(entityId) == -1) {
-									var entryLink =
-										'<div class="text-right"><a class="modify-link" data-rowId="' +
-										entityId +
-										'" href="javascript:;"><%= UnicodeFormatter.toString(removeLinkIcon) %></a></div>';
-
-									var entryHtml =
-										'<h4 class="list-group-title">' +
-										Liferay.Util.escapeHTML(
-											assetEntry.assettitle
-										) +
-										'</h4><p class="list-group-subtitle">' +
-										Liferay.Util.escapeHTML(
-											assetEntry.assettype
-										) +
-										'</p><p class="list-group-subtitle">' +
-										Liferay.Util.escapeHTML(
-											assetEntry.groupdescriptivename
-										) +
-										'</p>';
-
-									searchContainer.addRow(
-										[entryHtml, entryLink],
-										entityId
-									);
-
-									searchContainer.updateDataStore();
-								}
-							});
-						}
-					});
-				}
-			);
+								searchContainer.updateDataStore();
+							}
+						});
+					}
+				},
+				selectEventName:
+					'<%= inputAssetLinksDisplayContext.getEventName() %>',
+				title: event.currentTarget.attr('data-title'),
+				url: event.currentTarget.attr('data-href'),
+			});
 		},
 		'.asset-selector a'
 	);

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
@@ -93,7 +93,7 @@
 
 	chooseSpecificDisplayPage.addEventListener('click', function (event) {
 		Liferay.Util.openSelectionModal({
-			onSelect: function(selectedItem) {
+			onSelect: function (selectedItem) {
 				assetDisplayPageIdInput.value = '';
 
 				pagesContainerInput.value = '';
@@ -113,7 +113,8 @@
 					}
 				}
 			},
-			selectEventName: '<%= selectAssetDisplayPageDisplayContext.getEventName() %>',
+			selectEventName:
+				'<%= selectAssetDisplayPageDisplayContext.getEventName() %>',
 			title: '<liferay-ui:message key="select-page" />',
 			url:
 				'<%= selectAssetDisplayPageDisplayContext.getAssetDisplayPageItemSelectorURL() %>',

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
@@ -74,7 +74,7 @@
 	</div>
 </div>
 
-<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script sandbox="<%= true %>">
 	var assetDisplayPageIdInput = document.getElementById(
 		'<portlet:namespace />assetDisplayPageIdInput'
 	);

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
@@ -92,37 +92,31 @@
 	);
 
 	chooseSpecificDisplayPage.addEventListener('click', function (event) {
-		var itemSelectorDialog = new ItemSelectorDialog.default({
-			eventName: '<%= selectAssetDisplayPageDisplayContext.getEventName() %>',
-			singleSelect: true,
+		Liferay.Util.openSelectionModal({
+			onSelect: function(selectedItem) {
+				assetDisplayPageIdInput.value = '';
+
+				pagesContainerInput.value = '';
+
+				if (selectedItem) {
+					if (selectedItem.type === 'asset-display-page') {
+						assetDisplayPageIdInput.value = selectedItem.id;
+					}
+					else {
+						pagesContainerInput.value = selectedItem.id;
+					}
+
+					specificDisplayPageNameInput.value = selectedItem.name;
+
+					if (previewSpecificDisplayPageButton) {
+						previewSpecificDisplayPageButton.parentNode.remove();
+					}
+				}
+			},
+			selectEventName: '<%= selectAssetDisplayPageDisplayContext.getEventName() %>',
 			title: '<liferay-ui:message key="select-page" />',
 			url:
 				'<%= selectAssetDisplayPageDisplayContext.getAssetDisplayPageItemSelectorURL() %>',
-		});
-
-		itemSelectorDialog.open();
-
-		itemSelectorDialog.on('selectedItemChange', function (event) {
-			var selectedItem = event.selectedItem;
-
-			assetDisplayPageIdInput.value = '';
-
-			pagesContainerInput.value = '';
-
-			if (selectedItem) {
-				if (selectedItem.type === 'asset-display-page') {
-					assetDisplayPageIdInput.value = selectedItem.id;
-				}
-				else {
-					pagesContainerInput.value = selectedItem.id;
-				}
-
-				specificDisplayPageNameInput.value = selectedItem.name;
-
-				if (previewSpecificDisplayPageButton) {
-					previewSpecificDisplayPageButton.parentNode.remove();
-				}
-			}
 		});
 	});
 

--- a/modules/apps/blogs/blogs-recent-bloggers-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/blogs/blogs-recent-bloggers-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -65,73 +65,59 @@ if (organizationId > 0) {
 					'<portlet:namespace />selectOrganizationButton'
 				);
 
-				if (<portlet:namespace />selectOrganizationButton) {
-					<portlet:namespace />selectOrganizationButton.addEventListener(
-						'click',
-						function (event) {
-							Liferay.Util.selectEntity(
-								{
-									dialog: {
-										constrain: true,
-										destroyOnHide: true,
-										modal: true,
-									},
+				<portlet:namespace />selectOrganizationButton.addEventListener(
+					'click',
+					function (event) {
+						Liferay.Util.openSelectionModal({
+							onSelect: function (event) {
+								var form = document.getElementById('<portlet:namespace />fm');
 
-									<%
-									String portletId = PortletProviderUtil.getPortletId(User.class.getName(), PortletProvider.Action.VIEW);
-									%>
-
-									id:
-										'<%= PortalUtil.getPortletNamespace(portletId) %>selectOrganization',
-									title:
-										'<liferay-ui:message arguments="organization" key="select-x" />',
-
-									<%
-									PortletURL selectOrganizationURL = PortletProviderUtil.getPortletURL(request, Organization.class.getName(), PortletProvider.Action.BROWSE);
-
-									selectOrganizationURL.setWindowState(LiferayWindowState.POP_UP);
-									%>
-
-									uri: '<%= selectOrganizationURL.toString() %>',
-								},
-								function (event) {
-									var form = document.getElementById(
-										'<portlet:namespace />fm'
+								if (form) {
+									var organizationId = form.querySelector(
+										'#<portlet:namespace />organizationId'
 									);
 
-									if (form) {
-										var organizationId = form.querySelector(
-											'#<portlet:namespace />organizationId'
-										);
+									if (organizationId) {
+										organizationId.setAttribute('value', event.entityid);
+									}
 
-										if (organizationId) {
-											organizationId.setAttribute(
-												'value',
-												event.entityid
-											);
-										}
+									var organizationName = form.querySelector(
+										'#<portlet:namespace />organizationName'
+									);
 
-										var organizationName = form.querySelector(
-											'#<portlet:namespace />organizationName'
-										);
-
-										if (organizationName) {
-											organizationName.setAttribute(
-												'value',
-												event.entityname
-											);
-										}
-
-										Liferay.Util.toggleDisabled(
-											'#<portlet:namespace />removeOrganizationButton',
-											false
+									if (organizationName) {
+										organizationName.setAttribute(
+											'value',
+											event.entityname
 										);
 									}
+
+									Liferay.Util.toggleDisabled(
+										'#<portlet:namespace />removeOrganizationButton',
+										false
+									);
 								}
-							);
-						}
-					);
-				}
+							},
+
+							<%
+							String portletId = PortletProviderUtil.getPortletId(User.class.getName(), PortletProvider.Action.VIEW);
+							%>
+
+							selectEventName:
+								'<%= PortalUtil.getPortletNamespace(portletId) %>selectOrganization',
+							title:
+								'<liferay-ui:message arguments="organization" key="select-x" />',
+
+							<%
+							PortletURL selectOrganizationURL = PortletProviderUtil.getPortletURL(request, Organization.class.getName(), PortletProvider.Action.BROWSE);
+
+							selectOrganizationURL.setWindowState(LiferayWindowState.POP_UP);
+							%>
+
+							url: '<%= selectOrganizationURL.toString() %>',
+						});
+					}
+				);
 
 				Liferay.Util.toggleSelectBox(
 					'<portlet:namespace />selectionMethod',

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
@@ -61,79 +61,66 @@ if (organizationId > 0) {
 					<aui:button name="removeOrganizationButton" onClick="<%= taglibRemoveFolder %>" value="remove" />
 				</div>
 
-				<aui:script>
+				<aui:script sandbox="<%= true %>">
 					var <portlet:namespace />selectOrganizationButton = document.getElementById(
 						'<portlet:namespace />selectOrganizationButton'
 					);
 
-					if (<portlet:namespace />selectOrganizationButton) {
-						<portlet:namespace />selectOrganizationButton.addEventListener(
-							'click',
-							function (event) {
-								Liferay.Util.selectEntity(
-									{
-										dialog: {
-											constrain: true,
-											destroyOnHide: true,
-											modal: true,
-										},
+					<portlet:namespace />selectOrganizationButton.addEventListener(
+						'click',
+						function (event) {
+							Liferay.Util.openSelectionModal({
+								onSelect: function (event) {
+									var form = document.getElementById('<portlet:namespace />fm');
 
-										<%
-										String portletId = PortletProviderUtil.getPortletId(User.class.getName(), PortletProvider.Action.VIEW);
-										%>
-
-										id:
-											'<%= PortalUtil.getPortletNamespace(portletId) %>selectOrganization',
-										title:
-											'<liferay-ui:message arguments="organization" key="select-x" />',
-
-										<%
-										PortletURL selectOrganizationURL = PortletProviderUtil.getPortletURL(request, Organization.class.getName(), PortletProvider.Action.BROWSE);
-
-										selectOrganizationURL.setParameter("tabs1", "organizations");
-										selectOrganizationURL.setWindowState(LiferayWindowState.POP_UP);
-										%>
-
-										uri: '<%= selectOrganizationURL.toString() %>',
-									},
-									function (event) {
-										var form = document.getElementById(
-											'<portlet:namespace />fm'
+									if (form) {
+										var organizationId = form.querySelector(
+											'#<portlet:namespace />organizationId'
 										);
 
-										if (form) {
-											var organizationId = form.querySelector(
-												'#<portlet:namespace />organizationId'
-											);
-
-											if (organizationId) {
-												organizationId.setAttribute(
-													'value',
-													event.entityid
-												);
-											}
-
-											var organizationName = form.querySelector(
-												'#<portlet:namespace />organizationName'
-											);
-
-											if (organizationName) {
-												organizationName.setAttribute(
-													'value',
-													event.entityname
-												);
-											}
+										if (organizationId) {
+											organizationId.setAttribute('value', event.entityid);
 										}
 
-										Liferay.Util.toggleDisabled(
-											'#<portlet:namespace />removeOrganizationButton',
-											false
+										var organizationName = form.querySelector(
+											'#<portlet:namespace />organizationName'
 										);
+
+										if (organizationName) {
+											organizationName.setAttribute(
+												'value',
+												event.entityname
+											);
+										}
 									}
-								);
-							}
-						);
-					}
+
+									Liferay.Util.toggleDisabled(
+										'#<portlet:namespace />removeOrganizationButton',
+										false
+									);
+								},
+
+								<%
+								String portletId = PortletProviderUtil.getPortletId(User.class.getName(), PortletProvider.Action.VIEW);
+								%>
+
+								selectEventName:
+									'<%= PortalUtil.getPortletNamespace(portletId) %>selectOrganization',
+
+								title:
+									'<liferay-ui:message arguments="organization" key="select-x" />',
+
+								<%
+								PortletURL selectOrganizationURL = PortletProviderUtil.getPortletURL(request, Organization.class.getName(), PortletProvider.Action.BROWSE);
+
+								selectOrganizationURL.setParameter("tabs1", "organizations");
+								selectOrganizationURL.setWindowState(LiferayWindowState.POP_UP);
+								%>
+
+								url: '<%= selectOrganizationURL.toString() %>',
+							});
+						}
+					);
 				</aui:script>
 
 				<aui:script require="metal-dom/src/dom">

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
@@ -107,21 +107,8 @@ renderResponse.setTitle(headerTitle);
 									<portlet:namespace />selectFolderButton.addEventListener('click', function (
 										event
 									) {
-										Liferay.Util.selectEntity(
-											{
-												dialog: {
-													constrain: true,
-													destroyOnHide: true,
-													modal: true,
-													width: 680,
-												},
-												id: '<portlet:namespace />selectFolder',
-												title:
-													'<liferay-ui:message arguments="folder" key="select-x" />',
-												uri:
-													'<liferay-portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
-											},
-											function (event) {
+										Liferay.Util.openSelectionModal({
+											onSelect: function (event) {
 												var folderData = {
 													idString: 'folderId',
 													idValue: event.entityid,
@@ -130,8 +117,12 @@ renderResponse.setTitle(headerTitle);
 												};
 
 												Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
-											}
-										);
+											},
+											selectEventName: '<portlet:namespace />selectFolder',
+											title: '<liferay-ui:message arguments="folder" key="select-x" />',
+											url:
+												'<liferay-portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
+										});
 									});
 								}
 							</aui:script>

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
@@ -115,21 +115,8 @@ renderResponse.setTitle(headerTitle);
 								<portlet:namespace />selectFolderButton.addEventListener('click', function (
 									event
 								) {
-									Liferay.Util.selectEntity(
-										{
-											dialog: {
-												constrain: true,
-												destroyOnHide: true,
-												modal: true,
-												width: 680,
-											},
-											id: '<portlet:namespace />selectFolder',
-											title:
-												'<liferay-ui:message arguments="folder" key="select-x" />',
-											uri:
-												'<liferay-portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
-										},
-										function (event) {
+									Liferay.Util.openSelectionModal({
+										onSelect: function (event) {
 											var folderData = {
 												idString: 'parentFolderId',
 												idValue: event.entityid,
@@ -138,8 +125,12 @@ renderResponse.setTitle(headerTitle);
 											};
 
 											Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
-										}
-									);
+										},
+										selectEventName: '<portlet:namespace />selectFolder',
+										title: '<liferay-ui:message arguments="folder" key="select-x" />',
+										url:
+											'<liferay-portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
+									});
 								});
 							}
 						</aui:script>

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/move_entries.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/move_entries.jsp
@@ -292,27 +292,8 @@ if (portletTitleBasedNavigation) {
 			);
 
 			if (folderName) {
-				Liferay.Util.selectEntity(
-					{
-						dialog: {
-							constrain: true,
-							destroyOnHide: true,
-							modal: true,
-							width: 680,
-						},
-						id: '<portlet:namespace />selectFolder',
-						selectedData: [folderName.value],
-						title:
-							'<liferay-ui:message arguments="folder" key="select-x" />',
-
-						<portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-							<portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" />
-							<portlet:param name="folderId" value="<%= String.valueOf(newFolderId) %>" />
-						</portlet:renderURL>
-
-						uri: '<%= selectFolderURL.toString() %>',
-					},
-					function (event) {
+				Liferay.Util.openSelectionModal({
+					onSelect: function (event) {
 						var folderData = {
 							idString: 'newFolderId',
 							idValue: event.entityid,
@@ -324,8 +305,19 @@ if (portletTitleBasedNavigation) {
 							folderData,
 							'<portlet:namespace />'
 						);
-					}
-				);
+					},
+					selectedData: [folderName.value],
+					selectEventName: '<portlet:namespace />selectFolder',
+					title:
+						'<liferay-ui:message arguments="folder" key="select-x" />',
+
+					<portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+						<portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" />
+						<portlet:param name="folderId" value="<%= String.valueOf(newFolderId) %>" />
+					</portlet:renderURL>
+
+					url: '<%= selectFolderURL.toString() %>',
+				});
 			}
 		});
 	}

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration.jsp
@@ -187,22 +187,8 @@ catch (NoSuchFolderException nsfe) {
 						<portlet:namespace />selectFolderButton.addEventListener('click', function (
 							event
 						) {
-							Liferay.Util.selectEntity(
-								{
-									dialog: {
-										constrain: true,
-										destroyOnHide: true,
-										modal: true,
-										width: 830,
-									},
-									id:
-										'<%= HtmlUtil.escapeJS(PortalUtil.getPortletNamespace(portletResource)) %>selectFolder',
-									title:
-										'<liferay-ui:message arguments="folder" key="select-x" />',
-									uri:
-										'<liferay-portlet:renderURL portletName="<%= portletResource %>" windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
-								},
-								function (event) {
+							Liferay.Util.openSelectionModal({
+								onSelect: function (event) {
 									var folderData = {
 										idString: 'rootFolderId',
 										idValue: event.entityid,
@@ -211,8 +197,13 @@ catch (NoSuchFolderException nsfe) {
 									};
 
 									Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
-								}
-							);
+								},
+								selectEventName:
+									'<%= HtmlUtil.escapeJS(PortalUtil.getPortletNamespace(portletResource)) %>selectFolder',
+								title: '<liferay-ui:message arguments="folder" key="select-x" />',
+								url:
+									'<liferay-portlet:renderURL portletName="<%= portletResource %>" windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
+							});
 						});
 					}
 				</aui:script>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/dynamic_include/ChangeTrackingIndicator.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/dynamic_include/ChangeTrackingIndicator.js
@@ -14,7 +14,7 @@
 
 import {Align, ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import {createPortletURL} from 'frontend-js-web';
+import {createPortletURL, navigate, openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -35,25 +35,18 @@ const Component = ({
 	Liferay.on('destroyPortlet', onDestroyPortlet);
 
 	const onSelectChangeList = function () {
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					modal: true,
-					width: 900,
-				},
-				id: namespace + 'selectChangeList',
-				title: Liferay.Language.get('select-a-publication'),
-				uri: selectURL,
-			},
-			(event) => {
+		openSelectionModal({
+			onSelect: (event) => {
 				const portletURL = createPortletURL(checkoutURL, {
 					ctCollectionId: event.ctcollectionid,
 				});
 
-				Liferay.Util.navigate(portletURL.toString());
-			}
-		);
+				navigate(portletURL.toString());
+			},
+			selectEventName: namespace + 'selectChangeList',
+			title: Liferay.Language.get('select-a-publication'),
+			url: selectURL,
+		});
 	};
 
 	Liferay.on(namespace + 'openDialog', onSelectChangeList);

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarDefaultEventHandler.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarDefaultEventHandler.js
@@ -17,7 +17,7 @@ import {
 	ItemSelectorDialog,
 	addParams,
 	navigate,
-	openModal,
+	openSelectionModal,
 } from 'frontend-js-web';
 
 class ContentDashboardManagementToolbarDefaultEventHandler extends DefaultEventHandler {
@@ -144,7 +144,7 @@ class ContentDashboardManagementToolbarDefaultEventHandler extends DefaultEventH
 	}
 
 	selectScope(itemData) {
-		openModal({
+		openSelectionModal({
 			id: this.ns('selectedScopeIdItem'),
 			onSelect: (selectedItem) => {
 				navigate(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarDefaultEventHandler.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarDefaultEventHandler.js
@@ -14,7 +14,6 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	addParams,
 	navigate,
 	openSelectionModal,
@@ -22,125 +21,109 @@ import {
 
 class ContentDashboardManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	selectAuthor(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('select'),
-			eventName: this.ns('selectedAuthorItem'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					var redirectURL = itemData.redirectURL;
+
+					selectedItem.forEach((item) => {
+						redirectURL = addParams(
+							this.namespace + 'authorIds=' + item.id,
+							redirectURL
+						);
+					});
+
+					navigate(redirectURL);
+				}
+			},
+			selectEventName: this.ns('selectedAuthorItem'),
 			title: itemData.dialogTitle,
 			url: itemData.selectAuthorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				var redirectURL = itemData.redirectURL;
-
-				selectedItem.forEach((item) => {
-					redirectURL = addParams(
-						this.namespace + 'authorIds=' + item.id,
-						redirectURL
-					);
-				});
-
-				navigate(redirectURL);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	selectAssetCategory(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('select'),
-			eventName: this.ns('selectedAssetCategory'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const assetCategories = Object.keys(selectedItem).filter(
+						(key) => !selectedItem[key].unchecked
+					);
+
+					var redirectURL = itemData.redirectURL;
+
+					assetCategories.forEach((assetCategory) => {
+						redirectURL = addParams(
+							this.namespace +
+								'assetCategoryId=' +
+								selectedItem[assetCategory].categoryId,
+							redirectURL
+						);
+					});
+
+					navigate(redirectURL);
+				}
+			},
+			selectEventName: this.ns('selectedAssetCategory'),
 			title: itemData.dialogTitle,
 			url: itemData.selectAssetCategoryURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const assetCategories = Object.keys(selectedItem).filter(
-					(key) => !selectedItem[key].unchecked
-				);
-
-				var redirectURL = itemData.redirectURL;
-
-				assetCategories.forEach((assetCategory) => {
-					redirectURL = addParams(
-						this.namespace +
-							'assetCategoryId=' +
-							selectedItem[assetCategory].categoryId,
-						redirectURL
-					);
-				});
-
-				navigate(redirectURL);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	selectAssetTag(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('select'),
-			eventName: this.ns('selectedAssetTag'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const assetTags = selectedItem['items'].split(',');
+
+					var redirectURL = itemData.redirectURL;
+
+					assetTags.forEach((assetTag) => {
+						redirectURL = addParams(
+							this.namespace + 'assetTagId=' + assetTag,
+							redirectURL
+						);
+					});
+
+					navigate(redirectURL);
+				}
+			},
+			selectEventName: this.ns('selectedAssetTag'),
 			title: itemData.dialogTitle,
 			url: itemData.selectTagURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const assetTags = selectedItem['items'].split(',');
-
-				var redirectURL = itemData.redirectURL;
-
-				assetTags.forEach((assetTag) => {
-					redirectURL = addParams(
-						this.namespace + 'assetTagId=' + assetTag,
-						redirectURL
-					);
-				});
-
-				navigate(redirectURL);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	selectContentDashboardItemType(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('select'),
-			eventName: this.ns('selectedContentDashboardItemTypeItem'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					var redirectURL = itemData.redirectURL;
+
+					selectedItem.forEach((item) => {
+						redirectURL = addParams(
+							this.namespace +
+								'contentDashboardItemTypePayload=' +
+								JSON.stringify(item),
+							redirectURL
+						);
+					});
+
+					navigate(redirectURL);
+				}
+			},
+			selectEventName: this.ns('selectedContentDashboardItemTypeItem'),
 			title: itemData.dialogTitle,
 			url: itemData.selectContentDashboardItemTypeURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				var redirectURL = itemData.redirectURL;
-
-				selectedItem.forEach((item) => {
-					redirectURL = addParams(
-						this.namespace +
-							'contentDashboardItemTypePayload=' +
-							JSON.stringify(item),
-						redirectURL
-					);
-				});
-
-				navigate(redirectURL);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	selectScope(itemData) {

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/memberships/depot_groups.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/memberships/depot_groups.jsp
@@ -116,121 +116,112 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 </liferay-ui:search-container>
 
 <c:if test="<%= depotAdminMembershipsDisplayContext.isSelectable() %>">
-	<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
-		AUI().use('liferay-search-container', function (A) {
-			var AArray = A.Array;
+	<aui:script use="liferay-search-container">
+		var AArray = A.Array;
 
-			var addDepotGroupIds = [];
-			var deleteDepotGroupIds = [];
+		var addDepotGroupIds = [];
+		var deleteDepotGroupIds = [];
 
-			var searchContainer = Liferay.SearchContainer.get(
-				'<portlet:namespace />depotGroupsSearchContainer'
-			);
+		var searchContainer = Liferay.SearchContainer.get(
+			'<portlet:namespace />depotGroupsSearchContainer'
+		);
 
-			var searchContainerContentBox = searchContainer.get('contentBox');
+		var searchContainerContentBox = searchContainer.get('contentBox');
 
-			var itemSelectorDialog = new ItemSelectorDialog.default({
-				eventName:
+		var selectDepotGroupLink = document.getElementById(
+			'<portlet:namespace />selectDepotGroupLink'
+		);
+
+		selectDepotGroupLink.addEventListener('click', function (event) {
+			Liferay.Util.openSelectionModal({
+				onSelect: function (selectedItem) {
+					if (selectedItem) {
+						var itemValue = JSON.parse(selectedItem.value);
+
+						var rowColumns = [];
+
+						rowColumns.push(itemValue.title);
+						rowColumns.push('');
+						rowColumns.push(
+							'<a class="modify-link" data-rowId="' +
+								itemValue.classPK +
+								'" href="javascript:;"><%= UnicodeFormatter.toString(removeDepotGroupIcon) %></a>'
+						);
+
+						var searchContainerData = searchContainer.getData();
+
+						var itemsValues = searchContainerData.split(',');
+
+						if (!itemsValues.includes(itemValue.classPK)) {
+							searchContainer.addRow(rowColumns, itemValue.classPK);
+
+							searchContainer.updateDataStore();
+						}
+
+						addDepotGroupIds.push(itemValue.classPK);
+
+						AArray.removeItem(deleteDepotGroupIds, itemValue.classPK);
+
+						document.<portlet:namespace />fm.<portlet:namespace />addDepotGroupIds.value = addDepotGroupIds.join(
+							','
+						);
+						document.<portlet:namespace />fm.<portlet:namespace />deleteDepotGroupIds.value = deleteDepotGroupIds.join(
+							','
+						);
+					}
+				},
+				selectEventName:
 					'<%= depotAdminMembershipsDisplayContext.getItemSelectorEventName() %>',
-				singleSelect: true,
 				title:
 					'<liferay-ui:message arguments="asset-library" key="select-x" />',
 				url: '<%= depotAdminMembershipsDisplayContext.getItemSelectorURL() %>',
 			});
-
-			itemSelectorDialog.on('selectedItemChange', function (event) {
-				var selectedItem = event.selectedItem;
-
-				if (selectedItem) {
-					var itemValue = JSON.parse(selectedItem.value);
-
-					var rowColumns = [];
-
-					rowColumns.push(itemValue.title);
-					rowColumns.push('');
-					rowColumns.push(
-						'<a class="modify-link" data-rowId="' +
-							itemValue.classPK +
-							'" href="javascript:;"><%= UnicodeFormatter.toString(removeDepotGroupIcon) %></a>'
-					);
-
-					var searchContainerData = searchContainer.getData();
-
-					var itemsValues = searchContainerData.split(',');
-
-					if (!itemsValues.includes(itemValue.classPK)) {
-						searchContainer.addRow(rowColumns, itemValue.classPK);
-
-						searchContainer.updateDataStore();
-					}
-
-					addDepotGroupIds.push(itemValue.classPK);
-
-					AArray.removeItem(deleteDepotGroupIds, itemValue.classPK);
-
-					document.<portlet:namespace />fm.<portlet:namespace />addDepotGroupIds.value = addDepotGroupIds.join(
-						','
-					);
-					document.<portlet:namespace />fm.<portlet:namespace />deleteDepotGroupIds.value = deleteDepotGroupIds.join(
-						','
-					);
-				}
-			});
-
-			var selectDepotGroupLink = document.getElementById(
-				'<portlet:namespace />selectDepotGroupLink'
-			);
-
-			selectDepotGroupLink.addEventListener('click', function (event) {
-				event.preventDefault();
-				itemSelectorDialog.open();
-			});
-
-			var handleOnModifyLink = searchContainerContentBox.delegate(
-				'click',
-				function (event) {
-					var link = event.currentTarget;
-
-					var rowId = link.attr('data-rowId');
-					var tr = link.ancestor('tr');
-
-					var selectGroup = Liferay.Util.getWindow(
-						'<portlet:namespace />selectGroup'
-					);
-
-					if (selectGroup) {
-						var selectButton = selectGroup.iframe.node
-							.get('contentWindow.document')
-							.one('.selector-button[data-entityid="' + rowId + '"]');
-
-						Liferay.Util.toggleDisabled(selectButton, false);
-					}
-
-					searchContainer.deleteRow(tr, rowId);
-
-					AArray.removeItem(addDepotGroupIds, event.rowId);
-
-					deleteDepotGroupIds.push(rowId);
-
-					document.<portlet:namespace />fm.<portlet:namespace />addDepotGroupIds.value = addDepotGroupIds.join(
-						','
-					);
-					document.<portlet:namespace />fm.<portlet:namespace />deleteDepotGroupIds.value = deleteDepotGroupIds.join(
-						','
-					);
-				},
-				'.modify-link'
-			);
-
-			var onDestroyPortlet = function (event) {
-				if (event.portletId === '<%= portletDisplay.getId() %>') {
-					Liferay.detach(handleOnModifyLink);
-
-					Liferay.detach('destroyPortlet', onDestroyPortlet);
-				}
-			};
-
-			Liferay.on('destroyPortlet', onDestroyPortlet);
 		});
+
+		var handleOnModifyLink = searchContainerContentBox.delegate(
+			'click',
+			function (event) {
+				var link = event.currentTarget;
+
+				var rowId = link.attr('data-rowId');
+				var tr = link.ancestor('tr');
+
+				var selectGroup = Liferay.Util.getWindow(
+					'<portlet:namespace />selectGroup'
+				);
+
+				if (selectGroup) {
+					var selectButton = selectGroup.iframe.node
+						.get('contentWindow.document')
+						.one('.selector-button[data-entityid="' + rowId + '"]');
+
+					Liferay.Util.toggleDisabled(selectButton, false);
+				}
+
+				searchContainer.deleteRow(tr, rowId);
+
+				AArray.removeItem(addDepotGroupIds, event.rowId);
+
+				deleteDepotGroupIds.push(rowId);
+
+				document.<portlet:namespace />fm.<portlet:namespace />addDepotGroupIds.value = addDepotGroupIds.join(
+					','
+				);
+				document.<portlet:namespace />fm.<portlet:namespace />deleteDepotGroupIds.value = deleteDepotGroupIds.join(
+					','
+				);
+			},
+			'.modify-link'
+		);
+
+		var onDestroyPortlet = function (event) {
+			if (event.portletId === '<%= portletDisplay.getId() %>') {
+				Liferay.detach(handleOnModifyLink);
+
+				Liferay.detach('destroyPortlet', onDestroyPortlet);
+			}
+		};
+
+		Liferay.on('destroyPortlet', onDestroyPortlet);
 	</aui:script>
 </c:if>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/roles/depot_roles.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/roles/depot_roles.jsp
@@ -212,21 +212,8 @@ DepotAdminRolesDisplayContext depotAdminRolesDisplayContext = (DepotAdminRolesDi
 		A.one('#<portlet:namespace />selectDepotRoleLink').on('click', function (
 			event
 		) {
-			Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						modal: true,
-					},
-
-					id:
-						'<%= depotAdminRolesDisplayContext.getSelectDepotRolesEventName() %>',
-					selectedData: searchContainer.getData(true),
-					title: '<liferay-ui:message arguments="role" key="select-x" />',
-					uri:
-						'<%= depotAdminRolesDisplayContext.getSelectDepotRolesURL() %>',
-				},
-				function (event) {
+			Util.openSelectionModal({
+				onSelect: function (event) {
 					var A = AUI();
 					var LString = A.Lang.String;
 
@@ -294,8 +281,13 @@ DepotAdminRolesDisplayContext depotAdminRolesDisplayContext = (DepotAdminRolesDi
 					searchContainer.addRow(rowColumns, id);
 
 					searchContainer.updateDataStore();
-				}
-			);
+				},
+				selectedData: searchContainer.getData(true),
+				selectEventName:
+					'<%= depotAdminRolesDisplayContext.getSelectDepotRolesEventName() %>',
+				title: '<liferay-ui:message arguments="role" key="select-x" />',
+				url: '<%= depotAdminRolesDisplayContext.getSelectDepotRolesURL() %>',
+			});
 		});
 	</aui:script>
 </c:if>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
@@ -113,21 +113,8 @@ List<DepotEntryGroupRel> depotEntryGroupRels = depotAdminSitesDisplayContext.get
 		);
 
 		addConnectedSiteButton.addEventListener('click', function (event) {
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						modal: true,
-					},
-					eventName:
-						'<%= liferayPortletResponse.getNamespace() + "selectSite" %>',
-					id: '<portlet:namespace />selectSite',
-					title: '<liferay-ui:message key="select-site" />',
-					uri:
-						'<%= String.valueOf(depotAdminSitesDisplayContext.getItemSelectorURL()) %>',
-				},
-				function (event) {
+			Liferay.Util.openSelectionModal({
+				onSelect: function (event) {
 					var toGroupIdInput = document.querySelector(
 						'#<portlet:namespace />toGroupId'
 					);
@@ -141,8 +128,13 @@ List<DepotEntryGroupRel> depotEntryGroupRels = depotAdminSitesDisplayContext.get
 					redirectInput.value = '<%= currentURL %>';
 
 					submitForm(toGroupIdInput.form);
-				}
-			);
+				},
+				selectEventName:
+					'<%= liferayPortletResponse.getNamespace() + "selectSite" %>',
+				title: '<liferay-ui:message key="select-site" />',
+				url:
+					'<%= String.valueOf(depotAdminSitesDisplayContext.getItemSelectorURL()) %>',
+			});
 		});
 	</aui:script>
 </clay:sheet-section>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -134,7 +134,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 				if (selectFolderButton) {
 					selectFolderButton.addEventListener('click', function (event) {
-						Liferay.Util.getOpener().Liferay.Util.openModal({
+						Liferay.Util.getOpener().Liferay.Util.openSelectionModal({
 							id:
 								'_<%= HtmlUtil.escapeJS(dlRequestHelper.getPortletResource()) %>_selectFolder',
 							onSelect: function (selectedItem) {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/additional_metadata_fields.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/additional_metadata_fields.jsp
@@ -72,7 +72,7 @@ DLFileEntryAdditionalMetadataSetsDisplayContext dlFileEntryAdditionalMetadataSet
 
 <aui:script>
 	function <portlet:namespace />openDDMStructureSelector() {
-		Liferay.Util.openModal({
+		Liferay.Util.openSelectionModal({
 			id: '<portlet:namespace />selectDDMStructure',
 			onSelect: function (selectedItem) {
 				var searchContainer = Liferay.SearchContainer.get(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure_form_builder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure_form_builder.jsp
@@ -195,7 +195,7 @@ renderResponse.setTitle(title);
 
 <aui:script>
 	function <portlet:namespace />openParentDDMStructureSelector() {
-		Liferay.Util.openModal({
+		Liferay.Util.openSelectionModal({
 			id: '<portlet:namespace />selectDDMStructure',
 			onSelect: function (selectedItem) {
 				var form = document.<portlet:namespace />fm;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/select_ddm_structure.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/select_ddm_structure.jsp
@@ -86,10 +86,3 @@ SearchContainer<com.liferay.dynamic.data.mapping.model.DDMStructure> ddmStructur
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectDDMStructureFm',
-		'<%= HtmlUtil.escapeJS(dlSelectDDMStructureDisplayContext.getEventName()) %>'
-	);
-</aui:script>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -282,7 +282,7 @@ renderResponse.setTitle(headerTitle);
 
 								if (selectFolderButton) {
 									selectFolderButton.addEventListener('click', function (event) {
-										Liferay.Util.openModal({
+										Liferay.Util.openSelectionModal({
 											id: '<portlet:namespace />selectFolder',
 											onSelect: function (selectedItem) {
 												var folderData = {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
@@ -65,7 +65,7 @@ renderResponse.setTitle(dlEditFileShortcutDisplayContext.getTitle());
 	</aui:form>
 </clay:container-fluid>
 
-<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script sandbox="<%= true %>">
 	var selectToFileEntryButton = document.getElementById(
 		'<portlet:namespace />selectToFileEntryButton'
 	);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
@@ -70,41 +70,32 @@ renderResponse.setTitle(dlEditFileShortcutDisplayContext.getTitle());
 		'<portlet:namespace />selectToFileEntryButton'
 	);
 
-	if (selectToFileEntryButton) {
-		var itemSelectorDialog = new ItemSelectorDialog.default({
-			eventName: '<portlet:namespace />toFileEntrySelectedItem',
-			singleSelect: true,
+	selectToFileEntryButton.addEventListener('click', function (event) {
+		Liferay.Util.openSelectionModal({
+			onSelect: function (selectedItem) {
+				if (selectedItem) {
+					var itemValue = JSON.parse(selectedItem.value);
+
+					var toFileEntryId = document.getElementById(
+						'<portlet:namespace />toFileEntryId'
+					);
+
+					if (toFileEntryId) {
+						toFileEntryId.value = itemValue.fileEntryId;
+					}
+
+					var toFileEntryTitle = document.getElementById(
+						'<portlet:namespace />toFileEntryTitle'
+					);
+
+					if (toFileEntryTitle) {
+						toFileEntryTitle.value = itemValue.title;
+					}
+				}
+			},
+			selectEventName: '<portlet:namespace />toFileEntrySelectedItem',
 			title: '<liferay-ui:message arguments="file" key="select-x" />',
 			url: '<%= dlEditFileShortcutDisplayContext.getItemSelectorURL() %>',
 		});
-
-		itemSelectorDialog.on('selectedItemChange', function (event) {
-			var selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				var itemValue = JSON.parse(selectedItem.value);
-
-				var toFileEntryId = document.getElementById(
-					'<portlet:namespace />toFileEntryId'
-				);
-
-				if (toFileEntryId) {
-					toFileEntryId.value = itemValue.fileEntryId;
-				}
-
-				var toFileEntryTitle = document.getElementById(
-					'<portlet:namespace />toFileEntryTitle'
-				);
-
-				if (toFileEntryTitle) {
-					toFileEntryTitle.value = itemValue.title;
-				}
-			}
-		});
-
-		selectToFileEntryButton.addEventListener('click', function (event) {
-			event.preventDefault();
-			itemSelectorDialog.open();
-		});
-	}
+	});
 </aui:script>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
@@ -463,7 +463,7 @@ renderResponse.setTitle(headerTitle);
 				searchContainerData = searchContainerData.split(',');
 			}
 
-			Liferay.Util.openModal({
+			Liferay.Util.openSelectionModal({
 				id: '<portlet:namespace />fileEntryTypeSelector',
 				onSelect: function (selectedItem) {
 					selectFileEntryType(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
@@ -400,49 +400,26 @@ AUI.add(
 					var itemData = event.data.item.data;
 
 					if (itemData.action === 'openDocumentTypesSelector') {
-						Liferay.Loader.require(
-							'frontend-js-web/liferay/ItemSelectorDialog.es',
-							(ItemSelectorDialog) => {
-								var itemSelectorDialog = new ItemSelectorDialog.default(
-									{
-										eventName: instance.ns(
-											'selectFileEntryType'
-										),
-										singleSelect: true,
-										title: Liferay.Language.get(
-											'select-document-type'
-										),
-										url: instance.get(
-											'selectFileEntryTypeURL'
-										),
-									}
-								);
+						Liferay.Util.openSelectionModal({
+							onSelect: (selectedItem) => {
+								if (selectedItem) {
+									var uri = instance.get(
+										'viewFileEntryTypeURL'
+									);
 
-								itemSelectorDialog.open();
+									uri = Liferay.Util.addParams(
+										instance.ns('fileEntryTypeId=') +
+											selectedItem.value,
+										uri
+									);
 
-								itemSelectorDialog.on(
-									'selectedItemChange',
-									(event) => {
-										var selectedItem = event.selectedItem;
-
-										if (selectedItem) {
-											var uri = instance.get(
-												'viewFileEntryTypeURL'
-											);
-
-											uri = Liferay.Util.addParams(
-												instance.ns(
-													'fileEntryTypeId='
-												) + selectedItem.value,
-												uri
-											);
-
-											location.href = uri;
-										}
-									}
-								);
-							}
-						);
+									Liferay.Util.navigate(uri);
+								}
+							},
+							selectEventName: instance.ns('selectFileEntryType'),
+							title: Liferay.Language.get('select-document-type'),
+							url: instance.get('selectFileEntryTypeURL'),
+						});
 					}
 				},
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
@@ -533,7 +533,7 @@ AUI.add(
 						);
 					}
 
-					Liferay.Util.openModal({
+					Liferay.Util.openSelectionModal({
 						id: namespace + 'selectFolder',
 						onSelect: (selectedItem) => {
 							if (parameterName && parameterValue) {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
@@ -21,8 +21,6 @@ Folder folder = (Folder)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FOLDER);
 
 long folderId = BeanParamUtil.getLong(folder, request, "folderId", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectFolder");
-
 long repositoryId = scopeGroupId;
 String folderName = LanguageUtil.get(request, "home");
 
@@ -177,10 +175,3 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectFolderFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_group.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_group.jsp
@@ -17,8 +17,6 @@
 <%@ include file="/document_library/init.jsp" %>
 
 <%
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectGroup");
-
 PortletURL portletURL = renderResponse.createRenderURL();
 
 portletURL.setParameter("mvcPath", "/document_library/select_group.jsp");
@@ -143,10 +141,3 @@ portletURL.setParameter("mvcPath", "/document_library/select_group.jsp");
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectGroupFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -249,7 +249,7 @@ if (portletTitleBasedNavigation) {
 	) {
 		var namespace = '<portlet:namespace />';
 
-		Liferay.Util.openModal({
+		Liferay.Util.openSelectionModal({
 			id: namespace + 'selectFolder',
 			onSelect: function (selectedItem) {
 				var form = document.getElementById(namespace + 'fm');

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
@@ -105,7 +105,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 	if (openFolderSelectorButton) {
 		openFolderSelectorButton.addEventListener('click', function (event) {
-			Liferay.Util.getOpener().Liferay.Util.openModal({
+			Liferay.Util.getOpener().Liferay.Util.openSelectionModal({
 				id:
 					'_<%= HtmlUtil.escapeJS(igRequestHelper.getPortletResource()) %>_selectFolder',
 				onSelect: function (selectedItem) {

--- a/modules/apps/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/display/context/dependencies/compare_to_js.ftl
+++ b/modules/apps/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/display/context/dependencies/compare_to_js.ftl
@@ -1,5 +1,5 @@
 function ${jsNamespace}compareVersionDialog(eventUri) {
-	Liferay.Util.openModal({
+	Liferay.Util.openSelectionModal({
 		id: '${jsNamespace}compareFileVersions',
 		onSelect: function(selectedItem) {
 			var uri = '${compareVersionURL}';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
@@ -18,9 +18,9 @@ import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import {usePage} from 'dynamic-data-mapping-form-renderer';
 import {
+	ItemSelectorDialog,
 	createActionURL,
 	createPortletURL,
-	openSelectionModal,
 } from 'frontend-js-web';
 import React, {useMemo, useState} from 'react';
 
@@ -232,20 +232,33 @@ const Main = ({
 		return errorMessages.join(' ');
 	};
 
+	const handleVisibleChange = (event) => {
+		if (event.selectedItem) {
+			onFocus({}, event);
+		}
+		else {
+			onBlur({}, event);
+		}
+	};
+
 	const handleSelectButtonClicked = ({
 		itemSelectorAuthToken,
 		portletNamespace,
 	}) => {
-		openSelectionModal({
-			onSelect: handleFieldChanged,
-			selectEventName: `${portletNamespace}selectDocumentLibrary`,
-			title: 'select-file',
+		const itemSelectorDialog = new ItemSelectorDialog({
+			eventName: `${portletNamespace}selectDocumentLibrary`,
+			singleSelect: true,
 			url: getDocumentLibrarySelectorURL({
 				groupId,
 				itemSelectorAuthToken,
 				portletNamespace,
 			}),
 		});
+
+		itemSelectorDialog.on('selectedItemChange', handleFieldChanged);
+		itemSelectorDialog.on('visibleChange', handleVisibleChange);
+
+		itemSelectorDialog.open();
 	};
 
 	const handleFieldChanged = (event) => {
@@ -257,11 +270,6 @@ const Main = ({
 			setCurrentValue(value);
 
 			onChange(event, value);
-
-			onFocus({}, event);
-		}
-		else {
-			onBlur({}, event);
 		}
 	};
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
@@ -18,9 +18,9 @@ import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import {usePage} from 'dynamic-data-mapping-form-renderer';
 import {
-	ItemSelectorDialog,
 	createActionURL,
 	createPortletURL,
+	openSelectionModal,
 } from 'frontend-js-web';
 import React, {useMemo, useState} from 'react';
 
@@ -232,33 +232,20 @@ const Main = ({
 		return errorMessages.join(' ');
 	};
 
-	const handleVisibleChange = (event) => {
-		if (event.selectedItem) {
-			onFocus({}, event);
-		}
-		else {
-			onBlur({}, event);
-		}
-	};
-
 	const handleSelectButtonClicked = ({
 		itemSelectorAuthToken,
 		portletNamespace,
 	}) => {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: `${portletNamespace}selectDocumentLibrary`,
-			singleSelect: true,
+		openSelectionModal({
+			onSelect: handleFieldChanged,
+			selectEventName: `${portletNamespace}selectDocumentLibrary`,
+			title: 'select-file',
 			url: getDocumentLibrarySelectorURL({
 				groupId,
 				itemSelectorAuthToken,
 				portletNamespace,
 			}),
 		});
-
-		itemSelectorDialog.on('selectedItemChange', handleFieldChanged);
-		itemSelectorDialog.on('visibleChange', handleVisibleChange);
-
-		itemSelectorDialog.open();
 	};
 
 	const handleFieldChanged = (event) => {
@@ -270,6 +257,11 @@ const Main = ({
 			setCurrentValue(value);
 
 			onChange(event, value);
+
+			onFocus({}, event);
+		}
+		else {
+			onBlur({}, event);
 		}
 	};
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -15,7 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
-import {openSelectionModal} from 'frontend-js-web';
+import {ItemSelectorDialog} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
@@ -86,12 +86,15 @@ const ImagePicker = ({
 	const handleItemSelectorTriggerClick = (event) => {
 		event.preventDefault();
 
-		openSelectionModal({
-			onSelect: handleFieldChanged,
-			selectEventName: `${portletNamespace}selectDocumentLibrary`,
-			title: Liferay.Language.get('select-file'),
+		const itemSelectorDialog = new ItemSelectorDialog({
+			eventName: `${portletNamespace}selectDocumentLibrary`,
+			singleSelect: true,
 			url: itemSelectorURL,
 		});
+
+		itemSelectorDialog.on('selectedItemChange', handleFieldChanged);
+
+		itemSelectorDialog.open();
 	};
 
 	const placeholder = readOnly

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -15,7 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
@@ -86,15 +86,12 @@ const ImagePicker = ({
 	const handleItemSelectorTriggerClick = (event) => {
 		event.preventDefault();
 
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: `${portletNamespace}selectDocumentLibrary`,
-			singleSelect: true,
+		openSelectionModal({
+			onSelect: handleFieldChanged,
+			selectEventName: `${portletNamespace}selectDocumentLibrary`,
+			title: Liferay.Language.get('select-file'),
 			url: itemSelectorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', handleFieldChanged);
-
-		itemSelectorDialog.open();
 	};
 
 	const placeholder = readOnly

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/browser/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/browser/view.jsp
@@ -88,10 +88,3 @@
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectDDMFormFm',
-		'<%= HtmlUtil.escapeJS(ddmFormBrowserDisplayContext.getEventName()) %>'
-	);
-</aui:script>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -402,7 +402,7 @@ AUI.add(
 					var portletNamespace = instance.get('portletNamespace');
 
 					Liferay.Util.openSelectionModal({
-						onSelect(selectedItem) {
+						onSelect: (selectedItem) => {
 							if (selectedItem) {
 								var itemValue = JSON.parse(selectedItem.value);
 
@@ -611,7 +611,7 @@ AUI.add(
 					var portletNamespace = instance.get('portletNamespace');
 
 					Liferay.Util.openSelectionModal({
-						onSelect(selectedItem) {
+						onSelect: (selectedItem) => {
 							if (selectedItem) {
 								var itemValue = JSON.parse(selectedItem.value);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -401,41 +401,23 @@ AUI.add(
 
 					var portletNamespace = instance.get('portletNamespace');
 
-					Liferay.Loader.require(
-						'frontend-js-web/liferay/ItemSelectorDialog.es',
-						(ItemSelectorDialog) => {
-							var itemSelectorDialog = new ItemSelectorDialog.default(
-								{
-									eventName:
-										portletNamespace +
-										'selectDocumentLibrary',
-									singleSelect: true,
-									url: instance._getDocumentLibrarySelectorURL(),
-								}
-							);
+					Liferay.Util.openSelectionModal({
+						onSelect(selectedItem) {
+							if (selectedItem) {
+								var itemValue = JSON.parse(selectedItem.value);
 
-							itemSelectorDialog.on(
-								'selectedItemChange',
-								(event) => {
-									var selectedItem = event.selectedItem;
-
-									if (selectedItem) {
-										var itemValue = JSON.parse(
-											selectedItem.value
-										);
-
-										instance._selectFileEntry(
-											itemValue.groupId,
-											itemValue.title,
-											itemValue.uuid
-										);
-									}
-								}
-							);
-
-							itemSelectorDialog.open();
-						}
-					);
+								instance._selectFileEntry(
+									itemValue.groupId,
+									itemValue.title,
+									itemValue.uuid
+								);
+							}
+						},
+						selectEventName:
+							portletNamespace + 'selectDocumentLibrary',
+						title: Liferay.Language.get('select-file'),
+						url: instance._getDocumentLibrarySelectorURL(),
+					});
 				},
 
 				_onClickClear() {
@@ -628,43 +610,23 @@ AUI.add(
 
 					var portletNamespace = instance.get('portletNamespace');
 
-					Liferay.Loader.require(
-						'frontend-js-web/liferay/ItemSelectorDialog.es',
-						(ItemSelectorDialog) => {
-							var itemSelectorDialog = new ItemSelectorDialog.default(
-								{
-									eventName:
-										portletNamespace + 'selectContent',
-									singleSelect: true,
-									title: Liferay.Language.get(
-										'journal-article'
-									),
-									url: instance._getWebContentSelectorURL(),
-								}
-							);
+					Liferay.Util.openSelectionModal({
+						onSelect(selectedItem) {
+							if (selectedItem) {
+								var itemValue = JSON.parse(selectedItem.value);
 
-							itemSelectorDialog.on(
-								'selectedItemChange',
-								(event) => {
-									var selectedItem = event.selectedItem;
-
-									if (selectedItem) {
-										var itemValue = JSON.parse(
-											selectedItem.value
-										);
-
-										instance.setValue({
-											className: itemValue.className,
-											classPK: itemValue.classPK,
-											title: itemValue.title,
-										});
-									}
-								}
-							);
-
-							itemSelectorDialog.open();
-						}
-					);
+								instance.setValue({
+									className: itemValue.className,
+									classPK: itemValue.classPK,
+									title: itemValue.title,
+								});
+							}
+						},
+						selectEventName:
+							portletNamespace + 'selectDocumentLibrary',
+						title: Liferay.Language.get('journal-article'),
+						url: instance._getWebContentSelectorURL(),
+					});
 				},
 
 				_onClickClear() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1441,7 +1441,7 @@ AUI.add(
 					var portletNamespace = instance.get('portletNamespace');
 
 					Liferay.Util.openSelectionModal({
-						onSelect(selectedItem) {
+						onSelect: (selectedItem) => {
 							if (selectedItem) {
 								var itemValue = JSON.parse(selectedItem.value);
 
@@ -1739,7 +1739,7 @@ AUI.add(
 					var portletNamespace = instance.get('portletNamespace');
 
 					Liferay.Util.openSelectionModal({
-						onSelect(selectedItem) {
+						onSelect: (selectedItem) => {
 							if (selectedItem) {
 								var itemValue = JSON.parse(selectedItem.value);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1440,43 +1440,25 @@ AUI.add(
 
 					var portletNamespace = instance.get('portletNamespace');
 
-					Liferay.Loader.require(
-						'frontend-js-web/liferay/ItemSelectorDialog.es',
-						(ItemSelectorDialog) => {
-							var itemSelectorDialog = new ItemSelectorDialog.default(
-								{
-									eventName:
-										portletNamespace +
-										'selectDocumentLibrary',
-									singleSelect: true,
-									url: instance.getDocumentLibrarySelectorURL(),
-								}
-							);
+					Liferay.Util.openSelectionModal({
+						onSelect(selectedItem) {
+							if (selectedItem) {
+								var itemValue = JSON.parse(selectedItem.value);
 
-							itemSelectorDialog.on(
-								'selectedItemChange',
-								(event) => {
-									var selectedItem = event.selectedItem;
-
-									if (selectedItem) {
-										var itemValue = JSON.parse(
-											selectedItem.value
-										);
-
-										instance.setValue({
-											classPK: itemValue.fileEntryId,
-											groupId: itemValue.groupId,
-											title: itemValue.title,
-											type: itemValue.type,
-											uuid: itemValue.uuid,
-										});
-									}
-								}
-							);
-
-							itemSelectorDialog.open();
-						}
-					);
+								instance.setValue({
+									classPK: itemValue.fileEntryId,
+									groupId: itemValue.groupId,
+									title: itemValue.title,
+									type: itemValue.type,
+									uuid: itemValue.uuid,
+								});
+							}
+						},
+						selectEventName:
+							portletNamespace + 'selectDocumentLibrary',
+						title: Liferay.Language.get('select-file'),
+						url: instance.getDocumentLibrarySelectorURL(),
+					});
 				},
 
 				_validateField(fieldNode) {
@@ -1756,45 +1738,24 @@ AUI.add(
 
 					var portletNamespace = instance.get('portletNamespace');
 
-					Liferay.Loader.require(
-						'frontend-js-web/liferay/ItemSelectorDialog.es',
-						(ItemSelectorDialog) => {
-							var itemSelectorDialog = new ItemSelectorDialog.default(
-								{
-									eventName:
-										portletNamespace + 'selectWebContent',
-									singleSelect: true,
-									title: Liferay.Language.get(
-										'journal-article'
-									),
-									url: instance._getWebContentSelectorURL(),
-								}
-							);
+					Liferay.Util.openSelectionModal({
+						onSelect(selectedItem) {
+							if (selectedItem) {
+								var itemValue = JSON.parse(selectedItem.value);
 
-							itemSelectorDialog.on(
-								'selectedItemChange',
-								(event) => {
-									var selectedItem = event.selectedItem;
+								instance.setValue({
+									className: itemValue.className,
+									classPK: itemValue.classPK,
+									title: itemValue.title || '',
+								});
 
-									if (selectedItem) {
-										var itemValue = JSON.parse(
-											selectedItem.value
-										);
-
-										instance.setValue({
-											className: itemValue.className,
-											classPK: itemValue.classPK,
-											title: itemValue.title || '',
-										});
-
-										instance._hideMessage();
-									}
-								}
-							);
-
-							itemSelectorDialog.open();
-						}
-					);
+								instance._hideMessage();
+							}
+						},
+						selectEventName: portletNamespace + 'selectWebContent',
+						title: Liferay.Language.get('journal-article'),
+						url: instance._getWebContentSelectorURL(),
+					});
 				},
 
 				_hideMessage() {

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionResourcesManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionResourcesManagementToolbarDefaultEventHandler.es.js
@@ -12,29 +12,23 @@
  * details.
  */
 
-import {DefaultEventHandler, ItemSelectorDialog} from 'frontend-js-web';
+import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
 
 class FragmentCollectionResourcesManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	addFragmentCollectionResource(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: this.ns('uploadFragmentCollectionResource'),
-			singleSelect: true,
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const itemValue = JSON.parse(selectedItem.value);
+
+					this.one('#fileEntryId').value = itemValue.fileEntryId;
+
+					submitForm(this.one('#fragmentCollectionResourceFm'));
+				}
+			},
+			selectEventName: this.ns('uploadFragmentCollectionResource'),
 			title: Liferay.Language.get('upload-fragment-collection-resource'),
 			url: itemData.itemSelectorURL,
-		});
-
-		itemSelectorDialog.open();
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const itemValue = JSON.parse(selectedItem.value);
-
-				this.one('#fileEntryId').value = itemValue.fileEntryId;
-
-				submitForm(this.one('#fragmentCollectionResourceFm'));
-			}
 		});
 	}
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionsViewDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionsViewDefaultEventHandler.es.js
@@ -23,6 +23,7 @@ import {Config} from 'metal-state';
  * @class FragmentCollectionsViewDefaultEventHandler
  */
 class FragmentCollectionsViewDefaultEventHandler extends DefaultEventHandler {
+
 	/**
 	 * Opens an item selector to remove selected collections
 	 * @private
@@ -106,7 +107,7 @@ class FragmentCollectionsViewDefaultEventHandler extends DefaultEventHandler {
 		openSelectionModal({
 			buttonAddLabel: dialogButtonLabel,
 			multiple: true,
-			onSelect(selectedItem) {
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					callback(selectedItem);
 				}
@@ -146,6 +147,7 @@ class FragmentCollectionsViewDefaultEventHandler extends DefaultEventHandler {
 }
 
 FragmentCollectionsViewDefaultEventHandler.STATE = {
+
 	/**
 	 * @default undefined
 	 * @instance

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionsViewDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionsViewDefaultEventHandler.es.js
@@ -14,8 +14,8 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	openModal,
+	openSelectionModal,
 } from 'frontend-js-web';
 import {Config} from 'metal-state';
 
@@ -23,7 +23,6 @@ import {Config} from 'metal-state';
  * @class FragmentCollectionsViewDefaultEventHandler
  */
 class FragmentCollectionsViewDefaultEventHandler extends DefaultEventHandler {
-
 	/**
 	 * Opens an item selector to remove selected collections
 	 * @private
@@ -104,20 +103,18 @@ class FragmentCollectionsViewDefaultEventHandler extends DefaultEventHandler {
 		dialogURL,
 		callback
 	) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: dialogButtonLabel,
-			eventName: this.ns('selectCollections'),
+			multiple: true,
+			onSelect(selectedItem) {
+				if (selectedItem) {
+					callback(selectedItem);
+				}
+			},
+			selectedEventName: this.ns('selectCollections'),
 			title: dialogTitle,
 			url: dialogURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			if (event.selectedItem) {
-				callback(event.selectedItem);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	/**
@@ -149,7 +146,6 @@ class FragmentCollectionsViewDefaultEventHandler extends DefaultEventHandler {
 }
 
 FragmentCollectionsViewDefaultEventHandler.STATE = {
-
 	/**
 	 * @default undefined
 	 * @instance

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCompositionDropdownDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCompositionDropdownDefaultEventHandler.es.js
@@ -14,7 +14,6 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	openSelectionModal,
 	openSimpleInputModal,
 } from 'frontend-js-web';
@@ -58,28 +57,22 @@ class FragmentCompositionDropdownDefaultEventHandler extends DefaultEventHandler
 	}
 
 	updateFragmentCompositionPreview(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: this.ns('changePreview'),
-			singleSelect: true,
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const itemValue = JSON.parse(selectedItem.value);
+
+					this.one('#fragmentCompositionId').value =
+						itemData.fragmentCompositionId;
+					this.one('#fragmentCompositionFileEntryId').value =
+						itemValue.fileEntryId;
+
+					submitForm(this.one('#fragmentCompositionPreviewFm'));
+				}
+			},
+			selectEventName: this.ns('changePreview'),
 			title: Liferay.Language.get('fragment-thumbnail'),
 			url: itemData.itemSelectorURL,
-		});
-
-		itemSelectorDialog.open();
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const itemValue = JSON.parse(selectedItem.value);
-
-				this.one('#fragmentCompositionId').value =
-					itemData.fragmentCompositionId;
-				this.one('#fragmentCompositionFileEntryId').value =
-					itemValue.fileEntryId;
-
-				submitForm(this.one('#fragmentCompositionPreviewFm'));
-			}
 		});
 	}
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCompositionDropdownDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCompositionDropdownDefaultEventHandler.es.js
@@ -15,6 +15,7 @@
 import {
 	DefaultEventHandler,
 	ItemSelectorDialog,
+	openSelectionModal,
 	openSimpleInputModal,
 } from 'frontend-js-web';
 
@@ -87,7 +88,7 @@ class FragmentCompositionDropdownDefaultEventHandler extends DefaultEventHandler
 		selectFragmentCollectionURL,
 		targetFragmentCompositionURL
 	) {
-		Liferay.Util.openModal({
+		openSelectionModal({
 			id: this.ns('selectFragmentCollection'),
 			onSelect: (selectedItem) => {
 				if (selectedItem) {

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEntryDropdownDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEntryDropdownDefaultEventHandler.es.js
@@ -15,6 +15,7 @@
 import {
 	DefaultEventHandler,
 	ItemSelectorDialog,
+	openSelectionModal,
 	openSimpleInputModal,
 } from 'frontend-js-web';
 import {Config} from 'metal-state';
@@ -28,7 +29,7 @@ class FragmentEntryDropdownDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	copyToContributedFragmentEntry(itemData) {
-		Liferay.Util.openModal({
+		openSelectionModal({
 			id: this.ns('selectFragmentCollection'),
 			onSelect: (selectedItem) => {
 				if (selectedItem) {
@@ -132,7 +133,7 @@ class FragmentEntryDropdownDefaultEventHandler extends DefaultEventHandler {
 		selectFragmentCollectionURL,
 		targetFragmentEntryURL
 	) {
-		Liferay.Util.openModal({
+		openSelectionModal({
 			id: this.ns('selectFragmentCollection'),
 			onSelect: (selectedItem) => {
 				if (selectedItem) {

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEntryDropdownDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEntryDropdownDefaultEventHandler.es.js
@@ -14,7 +14,6 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	openSelectionModal,
 	openSimpleInputModal,
 } from 'frontend-js-web';
@@ -105,26 +104,21 @@ class FragmentEntryDropdownDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	updateFragmentEntryPreview(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: this.ns('changePreview'),
-			singleSelect: true,
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const itemValue = JSON.parse(selectedItem.value);
+
+					this.one('#fragmentEntryId').value =
+						itemData.fragmentEntryId;
+					this.one('#fileEntryId').value = itemValue.fileEntryId;
+
+					submitForm(this.one('#fragmentEntryPreviewFm'));
+				}
+			},
+			selectEventName: this.ns('changePreview'),
 			title: Liferay.Language.get('fragment-thumbnail'),
 			url: itemData.itemSelectorURL,
-		});
-
-		itemSelectorDialog.open();
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const itemValue = JSON.parse(selectedItem.value);
-
-				this.one('#fragmentEntryId').value = itemData.fragmentEntryId;
-				this.one('#fileEntryId').value = itemValue.fileEntryId;
-
-				submitForm(this.one('#fragmentEntryPreviewFm'));
-			}
 		});
 	}
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultEventHandler.es.js
@@ -12,7 +12,11 @@
  * details.
  */
 
-import {DefaultEventHandler, openSimpleInputModal} from 'frontend-js-web';
+import {
+	DefaultEventHandler,
+	openSelectionModal,
+	openSimpleInputModal,
+} from 'frontend-js-web';
 import {Config} from 'metal-state';
 
 class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
@@ -50,7 +54,7 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 			this.ns('allRowIds')
 		);
 
-		Liferay.Util.openModal({
+		openSelectionModal({
 			id: this.ns('selectFragmentCollection'),
 			onSelect: (selectedItem) => {
 				if (selectedItem) {
@@ -108,7 +112,7 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 			this.ns('rowIdsFragmentEntry')
 		);
 
-		Liferay.Util.openModal({
+		openSelectionModal({
 			id: this.ns('selectFragmentCollection'),
 			onSelect: (selectedItem) => {
 				if (selectedItem) {

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -145,27 +145,16 @@ name = HtmlUtil.escapeJS(name);
 	var alloyEditor;
 
 	var documentBrowseLinkCallback = function (editor, linkHref, callback) {
-		Liferay.Loader.require(
-			'frontend-js-web/liferay/ItemSelectorDialog.es',
-			function (ItemSelectorDialog) {
-				var itemSelectorDialog = new ItemSelectorDialog.default({
-					eventName: editor.name + 'selectDocument',
-					singleSelect: true,
-					title: '<liferay-ui:message key="select-item" />',
-					url: linkHref,
-				});
-
-				itemSelectorDialog.open();
-
-				itemSelectorDialog.on('selectedItemChange', function (event) {
-					var selectedItem = event.selectedItem;
-
-					if (selectedItem) {
-						callback(selectedItem);
-					}
-				});
-			}
-		);
+		Liferay.Util.openSelectionModal({
+			onSelect: function (selectedItem) {
+				if (selectedItem) {
+					callback(selectedItem);
+				}
+			},
+			selectEventName: editor.name + 'selectDocument',
+			title: '<liferay-ui:message key="select-item" />',
+			url: linkHref,
+		});
 	};
 
 	var getInitialContent = function () {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -42,7 +42,7 @@ export {default as PortletBase} from './liferay/PortletBase.es';
 
 // Modal API
 
-export {openModal} from './liferay/modal/Modal';
+export {openModal, openSelectionModal} from './liferay/modal/Modal';
 
 export {default as openSimpleInputModal} from './liferay/modal/commands/OpenSimpleInputModal.es';
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -250,6 +250,15 @@ Liferay.Util.openModal = (...args) => {
 	);
 };
 
+Liferay.Util.openSelectionModal = (...args) => {
+	Liferay.Loader.require(
+		'frontend-js-web/liferay/modal/Modal',
+		(commands) => {
+			commands.openSelectionModal(...args);
+		}
+	);
+};
+
 Liferay.Util.openToast = (...args) => {
 	Liferay.Loader.require(
 		'frontend-js-web/liferay/toast/commands/OpenToast.es',

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -122,14 +122,11 @@ const openSelectionModal = ({
 			eventHandlers.splice(0, eventHandlers.length);
 		},
 		onOpen: ({container, processClose}) => {
-			const selectEventHandler = Liferay.on(
-				selectEventName,
-				(selectedItem) => {
-					onSelect(selectedItem);
+			const selectEventHandler = Liferay.on(selectEventName, (event) => {
+				onSelect(event.data || event);
 
-					processClose();
-				}
-			);
+				processClose();
+			});
 
 			eventHandlers.push(selectEventHandler);
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -103,16 +103,39 @@ const openPortletWindow = ({bodyCssClass, portlet, uri, ...otherProps}) => {
 };
 
 const openSelectionModal = ({
+	buttonAddLabel = Liferay.Language.get('add'),
+	buttonCancelLabel = Liferay.Language.get('cancel'),
 	id,
+	multiple = false,
 	onSelect,
 	selectEventName,
 	selectedData,
 	title,
 	url,
 }) => {
+	let selectedItem;
+
 	const eventHandlers = [];
+	const select = ({processClose}) => {
+		onSelect(selectedItem);
+
+		processClose();
+	};
 
 	openModal({
+		buttons: multiple
+			? [
+					{
+						displayType: 'secondary',
+						label: buttonCancelLabel,
+						type: 'cancel',
+					},
+					{
+						label: buttonAddLabel,
+						onClick: select,
+					},
+			  ]
+			: null,
 		id,
 		onClose: () => {
 			eventHandlers.forEach((eventHandler) => {
@@ -123,9 +146,11 @@ const openSelectionModal = ({
 		},
 		onOpen: ({container, processClose}) => {
 			const selectEventHandler = Liferay.on(selectEventName, (event) => {
-				onSelect(event.data || event);
+				selectedItem = event.data || event;
 
-				processClose();
+				if (!multiple) {
+					select({processClose});
+				}
 			});
 
 			eventHandlers.push(selectEventHandler);
@@ -210,7 +235,7 @@ const Modal = ({
 		}
 
 		if (onClick) {
-			onClick();
+			onClick({processClose});
 		}
 	};
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -171,10 +171,13 @@ const openSelectionModal = ({
 				});
 			}
 
-			itemElements.forEach((itemElement) => {
-				itemElement.addEventListener('click', (event) => {
-					Liferay.fire(selectEventName, event.currentTarget.dataset);
-				});
+			container.addEventListener('click', (event) => {
+				const delegateTarget =
+					event.target && event.target.closest('.selector-button');
+
+				if (delegateTarget) {
+					Liferay.fire(selectEventName, delegateTarget.dataset);
+				}
 			});
 		},
 		title,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -155,12 +155,10 @@ const openSelectionModal = ({
 
 			eventHandlers.push(selectEventHandler);
 
+			const itemElements = container.querySelectorAll('.selector-button');
+
 			if (selectedData) {
 				const selectedDataSet = new Set(selectedData);
-
-				const itemElements = container.querySelectorAll(
-					'.selector-button'
-				);
 
 				itemElements.forEach((itemElement) => {
 					const itemId =
@@ -172,6 +170,12 @@ const openSelectionModal = ({
 					}
 				});
 			}
+
+			itemElements.forEach((itemElement) => {
+				itemElement.addEventListener('click', (event) => {
+					Liferay.fire(selectEventName, event.currentTarget.dataset);
+				});
+			});
 		},
 		title,
 		url,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -105,6 +105,7 @@ const openPortletWindow = ({bodyCssClass, portlet, uri, ...otherProps}) => {
 const openSelectionModal = ({
 	buttonAddLabel = Liferay.Language.get('add'),
 	buttonCancelLabel = Liferay.Language.get('cancel'),
+	customSelectEvent = false,
 	id,
 	multiple = false,
 	onSelect,
@@ -171,14 +172,17 @@ const openSelectionModal = ({
 				});
 			}
 
-			container.addEventListener('click', (event) => {
-				const delegateTarget =
-					event.target && event.target.closest('.selector-button');
+			if (!customSelectEvent) {
+				container.addEventListener('click', (event) => {
+					const delegateTarget =
+						event.target &&
+						event.target.closest('.selector-button');
 
-				if (delegateTarget) {
-					Liferay.fire(selectEventName, delegateTarget.dataset);
-				}
-			});
+					if (delegateTarget) {
+						Liferay.fire(selectEventName, delegateTarget.dataset);
+					}
+				});
+			}
 		},
 		title,
 		url,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -136,7 +136,7 @@ const openSelectionModal = ({
 					},
 			  ]
 			: null,
-		id,
+		id: id || selectEventName,
 		onClose: () => {
 			eventHandlers.forEach((eventHandler) => {
 				eventHandler.detach();

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/image_selector.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/image_selector.js
@@ -232,7 +232,7 @@ AUI.add(
 					var instance = this;
 
 					Liferay.Util.openSelectionModal({
-						onSelect(selectedItem) {
+						onSelect: (selectedItem) => {
 							if (selectedItem) {
 								instance._updateImageData(
 									JSON.parse(selectedItem.value)
@@ -354,7 +354,8 @@ AUI.add(
 						instance.fire(STR_IMAGE_DATA, {
 							imageData: image,
 						});
-					} else {
+					}
+					else {
 						instance.fire(STR_ERROR_MESSAGE, {
 							error: data.error,
 						});
@@ -480,7 +481,8 @@ AUI.add(
 						errorType === STATUS_CODE.SC_FILE_CUSTOM_EXCEPTION
 					) {
 						message = error.message;
-					} else if (
+					}
+					else if (
 						errorType === STATUS_CODE.SC_FILE_EXTENSION_EXCEPTION
 					) {
 						if (instance.get('validExtensions')) {
@@ -490,20 +492,23 @@ AUI.add(
 								),
 								[instance.get('validExtensions')]
 							);
-						} else {
+						}
+						else {
 							message = Lang.sub(
 								Liferay.Language.get(
 									'please-enter-a-file-with-a-valid-file-type'
 								)
 							);
 						}
-					} else if (
+					}
+					else if (
 						errorType === STATUS_CODE.SC_FILE_NAME_EXCEPTION
 					) {
 						message = Liferay.Language.get(
 							'please-enter-a-file-with-a-valid-file-name'
 						);
-					} else if (
+					}
+					else if (
 						errorType === STATUS_CODE.SC_FILE_SIZE_EXCEPTION
 					) {
 						message = Lang.sub(
@@ -516,7 +521,8 @@ AUI.add(
 								),
 							]
 						);
-					} else if (
+					}
+					else if (
 						errorType ===
 						STATUS_CODE.SC_UPLOAD_REQUEST_SIZE_EXCEPTION
 					) {

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/image_selector.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/image_selector.js
@@ -231,37 +231,20 @@ AUI.add(
 				_onBrowseClick() {
 					var instance = this;
 
-					Liferay.Loader.require(
-						'frontend-js-web/liferay/ItemSelectorDialog.es',
-						(ItemSelectorDialog) => {
-							var itemSelectorDialog = new ItemSelectorDialog.default(
-								{
-									eventName: instance.get(
-										'itemSelectorEventName'
-									),
-									singleSelect: true,
-									url: instance.get('itemSelectorURL'),
-								}
-							);
+					Liferay.Util.openSelectionModal({
+						onSelect(selectedItem) {
+							if (selectedItem) {
+								instance._updateImageData(
+									JSON.parse(selectedItem.value)
+								);
 
-							itemSelectorDialog.open();
-
-							itemSelectorDialog.on(
-								'selectedItemChange',
-								(event) => {
-									var selectedItem = event.selectedItem;
-
-									if (selectedItem) {
-										instance._updateImageData(
-											JSON.parse(selectedItem.value)
-										);
-
-										Liferay.fire(STR_IMAGE_SELECTED);
-									}
-								}
-							);
-						}
-					);
+								Liferay.fire(STR_IMAGE_SELECTED);
+							}
+						},
+						selectEventName: instance.get('itemSelectorEventName'),
+						title: Liferay.Language.get('select-file'),
+						url: instance.get('itemSelectorURL'),
+					});
 
 					instance._cancelTimer();
 				},
@@ -371,8 +354,7 @@ AUI.add(
 						instance.fire(STR_IMAGE_DATA, {
 							imageData: image,
 						});
-					}
-					else {
+					} else {
 						instance.fire(STR_ERROR_MESSAGE, {
 							error: data.error,
 						});
@@ -498,8 +480,7 @@ AUI.add(
 						errorType === STATUS_CODE.SC_FILE_CUSTOM_EXCEPTION
 					) {
 						message = error.message;
-					}
-					else if (
+					} else if (
 						errorType === STATUS_CODE.SC_FILE_EXTENSION_EXCEPTION
 					) {
 						if (instance.get('validExtensions')) {
@@ -509,23 +490,20 @@ AUI.add(
 								),
 								[instance.get('validExtensions')]
 							);
-						}
-						else {
+						} else {
 							message = Lang.sub(
 								Liferay.Language.get(
 									'please-enter-a-file-with-a-valid-file-type'
 								)
 							);
 						}
-					}
-					else if (
+					} else if (
 						errorType === STATUS_CODE.SC_FILE_NAME_EXCEPTION
 					) {
 						message = Liferay.Language.get(
 							'please-enter-a-file-with-a-valid-file-name'
 						);
-					}
-					else if (
+					} else if (
 						errorType === STATUS_CODE.SC_FILE_SIZE_EXCEPTION
 					) {
 						message = Lang.sub(
@@ -538,8 +516,7 @@ AUI.add(
 								),
 							]
 						);
-					}
-					else if (
+					} else if (
 						errorType ===
 						STATUS_CODE.SC_UPLOAD_REQUEST_SIZE_EXCEPTION
 					) {

--- a/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/JournalArticleSelector.js
+++ b/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/JournalArticleSelector.js
@@ -15,7 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import {ReactFieldBase} from 'dynamic-data-mapping-form-field-type';
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 const JournalArticleSelector = ({
@@ -51,16 +51,12 @@ const JournalArticleSelector = ({
 	const handleItemSelectorTriggerClick = (event) => {
 		event.preventDefault();
 
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: `${portletNamespace}selectJournalArticle`,
-			singleSelect: true,
+		openSelectionModal({
+			onSelect: handleFieldChanged,
+			selectEventName: `${portletNamespace}selectJournalArticle`,
 			title: Liferay.Language.get('journal-article'),
 			url: itemSelectorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', handleFieldChanged);
-
-		itemSelectorDialog.open();
 	};
 
 	return (

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -54,7 +54,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 	</liferay-frontend:edit-form-footer>
 </liferay-frontend:edit-form>
 
-<aui:script require="metal-dom/src/all/dom as dom, frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script require="metal-dom/src/all/dom as dom">
 	var articlePreview = document.getElementById(
 		'<portlet:namespace />articlePreview'
 	);
@@ -62,28 +62,21 @@ String redirect = ParamUtil.getString(request, "redirect");
 		'<portlet:namespace />assetEntryId'
 	);
 
-	var itemSelectorDialog = new ItemSelectorDialog.default({
-		eventName: '<portlet:namespace />selectedItem',
-		singleSelect: true,
-		title: '<liferay-ui:message key="select-web-content" />',
-		url: '<%= journalContentDisplayContext.getItemSelectorURL() %>',
-	});
-
-	itemSelectorDialog.on('selectedItemChange', function (event) {
-		var selectedItem = event.selectedItem;
-
-		if (!selectedItem) {
-			return;
-		}
-
-		retrieveWebContent(selectedItem.assetclasspk);
-	});
-
 	dom.delegate(articlePreview, 'click', '.web-content-selector', function (
 		event
 	) {
 		event.preventDefault();
-		itemSelectorDialog.open();
+
+		Liferay.Util.openSelectionModal({
+			onSelect: function (selectedItem) {
+				if (selectedItem) {
+					retrieveWebContent(selectedItem.assetclasspk);
+				}
+			},
+			selectEventName: '<portlet:namespace />selectedItem',
+			title: '<liferay-ui:message key="select-web-content" />',
+			url: '<%= journalContentDisplayContext.getItemSelectorURL() %>',
+		});
 	});
 
 	dom.delegate(articlePreview, 'click', '.selector-button', function (event) {

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_template.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_template.jsp
@@ -100,7 +100,7 @@ AssetRenderer<JournalArticle> assetRenderer = assetRendererFactory.getAssetRende
 
 			var instance = this;
 
-			Liferay.Util.openModal({
+			Liferay.Util.openSelectionModal({
 				onSelect: function (selectedItem) {
 					templateKeyInput.setAttribute(
 						'value',

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
@@ -125,7 +125,7 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 					url
 				);
 
-				Liferay.Util.openModal({
+				Liferay.Util.openSelectionModal({
 					onSelect: function (selectedItem) {
 						changeDDMTemplate(selectedItem);
 					},
@@ -195,7 +195,7 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 
 	if (selectDDMTemplateButton) {
 		selectDDMTemplateButton.addEventListener('click', function (event) {
-			Liferay.Util.openModal({
+			Liferay.Util.openSelectionModal({
 				onSelect: function (selectedItem) {
 					changeDDMTemplate(selectedItem);
 				},

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template/basic_info.jsp
@@ -91,7 +91,7 @@ DDMStructure ddmStructure = journalEditDDMTemplateDisplayContext.getDDMStructure
 
 		if (selectDDMStructure) {
 			selectDDMStructure.addEventListener('click', function (event) {
-				Liferay.Util.openModal({
+				Liferay.Util.openSelectionModal({
 					onSelect: function (selectedItem) {
 						if (
 							document.<portlet:namespace />fm

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
@@ -195,7 +195,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 
 <aui:script>
 	function <portlet:namespace />openParentDDMStructureSelector() {
-		Liferay.Util.openModal({
+		Liferay.Util.openSelectionModal({
 			onSelect: function (selectedItem) {
 				var form = document.<portlet:namespace />fm;
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
@@ -341,7 +341,7 @@ renderResponse.setTitle((feed == null) ? LanguageUtil.get(request, "new-feed") :
 
 <aui:script>
 	function <portlet:namespace />openDDMStructureSelector() {
-		Liferay.Util.openModal({
+		Liferay.Util.openSelectionModal({
 			onSelect: function (selectedItem) {
 				if (
 					document.<portlet:namespace />fm

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -149,34 +149,14 @@ renderResponse.setTitle(title);
 
 						<aui:button name="selectFolderButton" value="select" />
 
-						<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+						<aui:script sandbox="<%= true %>">
 							var selectFolderButton = document.getElementById(
 								'<portlet:namespace />selectFolderButton'
 							);
 
-							if (selectFolderButton) {
-								selectFolderButton.addEventListener('click', function (event) {
-									event.preventDefault();
-
-									var itemSelectorDialog = new ItemSelectorDialog.default({
-										eventName: '<portlet:namespace />selectFolder',
-										singleSelect: true,
-										title: '<liferay-ui:message arguments="folder" key="select-x" />',
-
-										<portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-											<portlet:param name="mvcPath" value="/select_folder.jsp" />
-											<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
-											<portlet:param name="parentFolderId" value="<%= String.valueOf(parentFolderId) %>" />
-										</portlet:renderURL>
-
-										url: '<%= selectFolderURL.toString() %>',
-									});
-
-									itemSelectorDialog.open();
-
-									itemSelectorDialog.on('selectedItemChange', function (event) {
-										var selectedItem = event.selectedItem;
-
+							selectFolderButton.addEventListener('click', function (event) {
+								Liferay.Util.openSelectionModal({
+									onSelect: function (selectedItem) {
 										if (selectedItem) {
 											var folderData = {
 												idString: 'parentFolderId',
@@ -187,9 +167,19 @@ renderResponse.setTitle(title);
 
 											Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
 										}
-									});
+									},
+									selectEventName: '<portlet:namespace />selectFolder',
+									title: '<liferay-ui:message arguments="folder" key="select-x" />',
+
+									<portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+										<portlet:param name="mvcPath" value="/select_folder.jsp" />
+										<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
+										<portlet:param name="parentFolderId" value="<%= String.valueOf(parentFolderId) %>" />
+									</portlet:renderURL>
+
+									url: '<%= selectFolderURL.toString() %>',
 								});
-							}
+							});
 						</aui:script>
 
 						<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -393,7 +393,7 @@ renderResponse.setTitle(title);
 
 	if (selectDDMStructureButton) {
 		selectDDMStructureButton.addEventListener('click', function (event) {
-			Liferay.Util.openModal({
+			Liferay.Util.openSelectionModal({
 				onSelect: function (selectedItem) {
 					var ddmStructureLink =
 						'<a class="modify-link" data-rowId="' +

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultEventHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultEventHandler.es.js
@@ -17,6 +17,7 @@ import {
 	ItemSelectorDialog,
 	addParams,
 	openModal,
+	openSelectionModal,
 } from 'frontend-js-web';
 import {Config} from 'metal-state';
 
@@ -24,7 +25,7 @@ class ElementsDefaultEventHandler extends DefaultEventHandler {
 	compareVersions(itemData) {
 		const namespace = this.namespace;
 
-		openModal({
+		openSelectionModal({
 			onSelect: (selectedItem) => {
 				let url = itemData.redirectURL;
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultEventHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultEventHandler.es.js
@@ -168,7 +168,7 @@ class ElementsDefaultEventHandler extends DefaultEventHandler {
 		openSelectionModal({
 			buttonAddLabel: dialogButtonLabel,
 			multiple: true,
-			onSelect(selectedItem) {
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					callback(selectedItem);
 				}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultEventHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultEventHandler.es.js
@@ -14,7 +14,6 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	addParams,
 	openModal,
 	openSelectionModal,
@@ -166,20 +165,18 @@ class ElementsDefaultEventHandler extends DefaultEventHandler {
 		selectArticleTranslationsURL,
 		callback
 	) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: dialogButtonLabel,
-			eventName: this.ns('selectTranslations'),
+			multiple: true,
+			onSelect(selectedItem) {
+				if (selectedItem) {
+					callback(selectedItem);
+				}
+			},
+			selectEventName: this.ns('selectTranslations'),
 			title: dialogTitle,
 			url: selectArticleTranslationsURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			if (event.selectedItem) {
-				callback(event.selectedItem);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	_send(url) {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultEventHandler.es.js
@@ -16,7 +16,7 @@ import {
 	DefaultEventHandler,
 	addParams,
 	navigate,
-	openModal,
+	openSelectionModal,
 } from 'frontend-js-web';
 import {Config} from 'metal-state';
 
@@ -50,7 +50,7 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	handleCreationMenuMoreButtonClicked(event) {
 		event.preventDefault();
 
-		openModal({
+		openSelectionModal({
 			onSelect: (selectedItem) => {
 				navigate(
 					addParams(
@@ -91,7 +91,7 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	openDDMStructuresSelector() {
-		openModal({
+		openSelectionModal({
 			onSelect: (selectedItem) => {
 				Liferay.Util.navigate(
 					addParams(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/MoveEntries.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/MoveEntries.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {ItemSelectorDialog, PortletBase} from 'frontend-js-web';
+import {PortletBase, openSelectionModal} from 'frontend-js-web';
 import {Config} from 'metal-state';
 
 /**
@@ -66,32 +66,26 @@ class MoveEntries extends PortletBase {
 	 * @review
 	 */
 	_handleSelectFolderButtonClick() {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: this.ns('selectFolder'),
-			singleSelect: true,
+		openSelectionModal({
+			onSelect(selectedItem) {
+				if (selectedItem) {
+					var folderData = {
+						idString: 'newFolderId',
+						idValue: selectedItem.folderId,
+						nameString: 'folderName',
+						nameValue: selectedItem.folderName,
+					};
+
+					Liferay.Util.selectFolder(
+						folderData,
+						this.namespace || this.portletNamespace
+					);
+				}
+			},
+			selectEventName: this.ns('selectFolder'),
 			title: Liferay.Language.get('select-folder'),
 			url: this.selectFolderURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				var folderData = {
-					idString: 'newFolderId',
-					idValue: selectedItem.folderId,
-					nameString: 'folderName',
-					nameValue: selectedItem.folderName,
-				};
-
-				Liferay.Util.selectFolder(
-					folderData,
-					this.namespace || this.portletNamespace
-				);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 }
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/MoveEntries.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/MoveEntries.es.js
@@ -67,7 +67,7 @@ class MoveEntries extends PortletBase {
 	 */
 	_handleSelectFolderButtonClick() {
 		openSelectionModal({
-			onSelect(selectedItem) {
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					var folderData = {
 						idString: 'newFolderId',

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/article_history.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/article_history.jsp
@@ -119,19 +119,8 @@ List<KBArticle> kbArticles = KBArticleServiceUtil.getKBArticleVersions(scopeGrou
 	dom.delegate(document.body, 'click', '.compare-to-link > a', function (event) {
 		var currentTarget = event.delegateTarget;
 
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					destroyOnHide: true,
-					modal: true,
-				},
-				eventName: '<portlet:namespace />selectVersionFm',
-				id: '<portlet:namespace />compareVersions' + currentTarget.id,
-				title: '<liferay-ui:message key="compare-versions" />',
-				uri: currentTarget.dataset.uri,
-			},
-			function (event) {
+		Liferay.Util.openSelectionModal({
+			onSelect: function (event) {
 				var uri = '<%= HtmlUtil.escapeJS(compareVersionURL) %>';
 
 				uri = Liferay.Util.addParams(
@@ -143,8 +132,11 @@ List<KBArticle> kbArticles = KBArticleServiceUtil.getKBArticleVersions(scopeGrou
 					uri
 				);
 
-				location.href = uri;
-			}
-		);
+				Liferay.Util.navigate(uri);
+			},
+			selectEventName: '<portlet:namespace />selectVersionFm',
+			title: '<liferay-ui:message key="compare-versions" />',
+			url: currentTarget.dataset.uri,
+		});
 	});
 </aui:script>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/move_object.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/move_object.jsp
@@ -116,32 +116,8 @@ if (portletTitleBasedNavigation) {
 
 	if (selectKBObjectButton) {
 		selectKBObjectButton.addEventListener('click', function (event) {
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						modal: true,
-						width: 680,
-					},
-					id: '<portlet:namespace />selectKBObject',
-					title: '<liferay-ui:message key="select-parent" />',
-
-					<liferay-portlet:renderURL var="selectKBObjectURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-						<portlet:param name="mvcPath" value='<%= templatePath + "select_parent.jsp" %>' />
-						<portlet:param name="resourceClassNameId" value="<%= String.valueOf(resourceClassNameId) %>" />
-						<portlet:param name="resourcePrimKey" value="<%= String.valueOf(resourcePrimKey) %>" />
-						<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(parentResourceClassNameId) %>" />
-						<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(parentResourcePrimKey) %>" />
-						<portlet:param name="originalParentResourcePrimKey" value="<%= String.valueOf(parentResourcePrimKey) %>" />
-						<portlet:param name="priority" value="<%= String.valueOf(priority) %>" />
-						<portlet:param name="status" value="<%= String.valueOf(status) %>" />
-						<portlet:param name="targetStatus" value="<%= String.valueOf(targetStatus) %>" />
-					</liferay-portlet:renderURL>
-
-					uri: '<%= HtmlUtil.escapeJS(selectKBObjectURL) %>',
-				},
-				function (event) {
+			Liferay.Util.openSelectionModal({
+				onSelect: function (event) {
 					Liferay.Util.setFormValues(document.<portlet:namespace />fm, {
 						parentPriority: event.priority,
 						parentResourceClassNameId: event.resourceclassnameid,
@@ -155,8 +131,24 @@ if (portletTitleBasedNavigation) {
 					};
 
 					Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
-				}
-			);
+				},
+				selectEventName: '<portlet:namespace />selectKBObject',
+				title: '<liferay-ui:message key="select-parent" />',
+
+				<liferay-portlet:renderURL var="selectKBObjectURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+					<portlet:param name="mvcPath" value='<%= templatePath + "select_parent.jsp" %>' />
+					<portlet:param name="resourceClassNameId" value="<%= String.valueOf(resourceClassNameId) %>" />
+					<portlet:param name="resourcePrimKey" value="<%= String.valueOf(resourcePrimKey) %>" />
+					<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(parentResourceClassNameId) %>" />
+					<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(parentResourcePrimKey) %>" />
+					<portlet:param name="originalParentResourcePrimKey" value="<%= String.valueOf(parentResourcePrimKey) %>" />
+					<portlet:param name="priority" value="<%= String.valueOf(priority) %>" />
+					<portlet:param name="status" value="<%= String.valueOf(status) %>" />
+					<portlet:param name="targetStatus" value="<%= String.valueOf(targetStatus) %>" />
+				</liferay-portlet:renderURL>
+
+				url: '<%= HtmlUtil.escapeJS(selectKBObjectURL) %>',
+			});
 		});
 	}
 </aui:script>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/configuration.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/configuration.jsp
@@ -111,29 +111,8 @@ kbArticlePortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBArtic
 		document
 			.getElementById('<portlet:namespace />selectKBArticleButton')
 			.addEventListener('click', function (event) {
-				Liferay.Util.selectEntity(
-					{
-						dialog: {
-							constrain: true,
-							destroyOnHide: true,
-							modal: true,
-							width: 600,
-						},
-						id: '<portlet:namespace />selectKBObject',
-						title: '<liferay-ui:message key="select-article" />',
-
-						<liferay-portlet:renderURL portletName="<%= portletResource %>" var="selectKBObjectURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-							<portlet:param name="mvcPath" value="/article/select_parent.jsp" />
-							<portlet:param name="eventName" value='<%= liferayPortletResponse.getNamespace() + "selectKBObject" %>' />
-							<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(PortalUtil.getClassNameId(KBArticleConstants.getClassName())) %>" />
-							<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(kbArticlePortletInstanceConfiguration.resourcePrimKey()) %>" />
-							<portlet:param name="originalParentResourcePrimKey" value="<%= String.valueOf(kbArticlePortletInstanceConfiguration.resourcePrimKey()) %>" />
-							<portlet:param name="selectableClassNameIds" value="<%= String.valueOf(PortalUtil.getClassNameId(KBArticleConstants.getClassName())) %>" />
-						</liferay-portlet:renderURL>
-
-						uri: '<%= HtmlUtil.escapeJS(selectKBObjectURL) %>',
-					},
-					function (event) {
+				Liferay.Util.openSelectionModal({
+					onSelect: function (event) {
 						var kbArticleData = {
 							idString: 'resourcePrimKey',
 							idValue: event.resourceprimkey,
@@ -145,8 +124,21 @@ kbArticlePortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBArtic
 							kbArticleData,
 							'<portlet:namespace />'
 						);
-					}
-				);
+					},
+					selectEventName: '<portlet:namespace />selectKBObject',
+					title: '<liferay-ui:message key="select-article" />',
+
+					<liferay-portlet:renderURL portletName="<%= portletResource %>" var="selectKBObjectURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+						<portlet:param name="mvcPath" value="/article/select_parent.jsp" />
+						<portlet:param name="eventName" value='<%= liferayPortletResponse.getNamespace() + "selectKBObject" %>' />
+						<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(PortalUtil.getClassNameId(KBArticleConstants.getClassName())) %>" />
+						<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(kbArticlePortletInstanceConfiguration.resourcePrimKey()) %>" />
+						<portlet:param name="originalParentResourcePrimKey" value="<%= String.valueOf(kbArticlePortletInstanceConfiguration.resourcePrimKey()) %>" />
+						<portlet:param name="selectableClassNameIds" value="<%= String.valueOf(PortalUtil.getClassNameId(KBArticleConstants.getClassName())) %>" />
+					</liferay-portlet:renderURL>
+
+					url: '<%= HtmlUtil.escapeJS(selectKBObjectURL) %>',
+				});
 			});
 	}
 </aui:script>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/configuration.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/configuration.jsp
@@ -137,28 +137,8 @@ kbDisplayPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBDispl
 		document
 			.getElementById('<portlet:namespace />selectKBObjectButton')
 			.addEventListener('click', function (event) {
-				Liferay.Util.selectEntity(
-					{
-						dialog: {
-							constrain: true,
-							destroyOnHide: true,
-							modal: true,
-							width: 600,
-						},
-						id: '<portlet:namespace />selectKBObject',
-						title: '<liferay-ui:message key="select-entry" />',
-
-						<liferay-portlet:renderURL portletName="<%= portletResource %>" var="selectKBObjectURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-							<portlet:param name="mvcPath" value="/display/select_parent.jsp" />
-							<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(resourceClassNameId) %>" />
-							<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(kbDisplayPortletInstanceConfiguration.resourcePrimKey()) %>" />
-							<portlet:param name="originalParentResourcePrimKey" value="<%= String.valueOf(kbDisplayPortletInstanceConfiguration.resourcePrimKey()) %>" />
-							<portlet:param name="eventName" value='<%= liferayPortletResponse.getNamespace() + "selectKBObject" %>' />
-						</liferay-portlet:renderURL>
-
-						uri: '<%= HtmlUtil.escapeJS(selectKBObjectURL) %>',
-					},
-					function (event) {
+				Liferay.Util.openSelectionModal({
+					onSelect: function (event) {
 						document.getElementById(
 							'<portlet:namespace />resourceClassNameId'
 						).value = event.resourceclassnameid;
@@ -174,8 +154,20 @@ kbDisplayPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBDispl
 							kbObjectData,
 							'<portlet:namespace />'
 						);
-					}
-				);
+					},
+					selectEventName: '<portlet:namespace />selectKBObject',
+					title: '<liferay-ui:message key="select-entry" />',
+
+					<liferay-portlet:renderURL portletName="<%= portletResource %>" var="selectKBObjectURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+						<portlet:param name="mvcPath" value="/display/select_parent.jsp" />
+						<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(resourceClassNameId) %>" />
+						<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(kbDisplayPortletInstanceConfiguration.resourcePrimKey()) %>" />
+						<portlet:param name="originalParentResourcePrimKey" value="<%= String.valueOf(kbDisplayPortletInstanceConfiguration.resourcePrimKey()) %>" />
+						<portlet:param name="eventName" value='<%= liferayPortletResponse.getNamespace() + "selectKBObject" %>' />
+					</liferay-portlet:renderURL>
+
+					url: '<%= HtmlUtil.escapeJS(selectKBObjectURL) %>',
+				});
 			});
 	}
 </aui:script>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
@@ -247,7 +247,7 @@ else {
 				Liferay.Util.openSelectionModal({
 					buttonAddLabel: '<liferay-ui:message key="done" />',
 					multiple: true,
-					onSelect: function(selectedItem) {
+					onSelect: function (selectedItem) {
 						if (selectedItem) {
 							var masterLayoutName = document.getElementById(
 								'<portlet:namespace />masterLayoutName'
@@ -315,7 +315,7 @@ else {
 			Liferay.Util.openSelectionModal({
 				buttonAddLabel: '<liferay-ui:message key="done" />',
 				multiple: true,
-				onSelect: function(selectedItem) {
+				onSelect: function (selectedItem) {
 					if (selectedItem) {
 						var styleBookName = document.getElementById(
 							'<portlet:namespace />styleBookName'

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
@@ -222,7 +222,7 @@ else {
 </c:if>
 
 <c:if test="<%= editableMasterLayout %>">
-	<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+	<aui:script sandbox="<%= true %>">
 		var changeMasterLayoutButton = document.getElementById(
 			'<portlet:namespace />changeMasterLayoutButton'
 		);
@@ -244,45 +244,41 @@ else {
 		var changeMasterLayoutButtonEventListener = changeMasterLayoutButton.addEventListener(
 			'click',
 			function (event) {
-				var itemSelectorDialog = new ItemSelectorDialog.default({
+				Liferay.Util.openSelectionModal({
 					buttonAddLabel: '<liferay-ui:message key="done" />',
-					eventName: '<portlet:namespace />selectMasterLayout',
+					multiple: true,
+					onSelect: function(selectedItem) {
+						if (selectedItem) {
+							var masterLayoutName = document.getElementById(
+								'<portlet:namespace />masterLayoutName'
+							);
+
+							masterLayoutName.innerHTML = selectedItem.name;
+
+							masterLayoutPlid.value = selectedItem.plid;
+
+							if (masterLayoutPlid.value == 0) {
+								themeContainer.classList.remove('hide');
+							}
+							else {
+								themeContainer.classList.add('hide');
+							}
+
+							if (
+								masterLayoutPlid.value == oldMasterLayoutPlid &&
+								masterLayoutPlid.value != 0
+							) {
+								editMasterLayoutButton.classList.remove('hide');
+							}
+							else {
+								editMasterLayoutButton.classList.add('hide');
+							}
+						}
+					},
+					selectEventName: '<portlet:namespace />selectMasterLayout',
 					title: '<liferay-ui:message key="select-master" />',
 					url:
 						'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_master_layout.jsp" /></portlet:renderURL>',
-				});
-
-				itemSelectorDialog.open();
-
-				itemSelectorDialog.on('selectedItemChange', function (event) {
-					var selectedItem = event.selectedItem;
-
-					if (selectedItem) {
-						var masterLayoutName = document.getElementById(
-							'<portlet:namespace />masterLayoutName'
-						);
-
-						masterLayoutName.innerHTML = selectedItem.name;
-
-						masterLayoutPlid.value = selectedItem.plid;
-
-						if (masterLayoutPlid.value == 0) {
-							themeContainer.classList.remove('hide');
-						}
-						else {
-							themeContainer.classList.add('hide');
-						}
-
-						if (
-							masterLayoutPlid.value == oldMasterLayoutPlid &&
-							masterLayoutPlid.value != 0
-						) {
-							editMasterLayoutButton.classList.remove('hide');
-						}
-						else {
-							editMasterLayoutButton.classList.add('hide');
-						}
-					}
 				});
 			}
 		);
@@ -308,7 +304,7 @@ else {
 	</aui:script>
 </c:if>
 
-<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script sandbox="<%= true %>">
 	var changeStyleBookButton = document.getElementById(
 		'<portlet:namespace />changeStyleBookButton'
 	);
@@ -316,32 +312,28 @@ else {
 	var changeStyleBookButtonEventListener = changeStyleBookButton.addEventListener(
 		'click',
 		function (event) {
-			var itemSelectorDialog = new ItemSelectorDialog.default({
+			Liferay.Util.openSelectionModal({
 				buttonAddLabel: '<liferay-ui:message key="done" />',
-				eventName: '<portlet:namespace />selectStyleBook',
+				multiple: true,
+				onSelect: function(selectedItem) {
+					if (selectedItem) {
+						var styleBookName = document.getElementById(
+							'<portlet:namespace />styleBookName'
+						);
+
+						styleBookName.innerHTML = selectedItem.name;
+
+						var styleBookEntryId = document.getElementById(
+							'<portlet:namespace />styleBookEntryId'
+						);
+
+						styleBookEntryId.value = selectedItem.stylebookentryid;
+					}
+				},
+				selectEventName: '<portlet:namespace />selectStyleBook',
 				title: '<liferay-ui:message key="select-style-book" />',
 				url:
 					'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_style_book.jsp" /><portlet:param name="selPlid" value="<%= String.valueOf(selLayout.getPlid()) %>" /><portlet:param name="editableMasterLayout" value="<%= String.valueOf(editableMasterLayout) %>" /></portlet:renderURL>',
-			});
-
-			itemSelectorDialog.open();
-
-			itemSelectorDialog.on('selectedItemChange', function (event) {
-				var selectedItem = event.selectedItem;
-
-				if (selectedItem) {
-					var styleBookName = document.getElementById(
-						'<portlet:namespace />styleBookName'
-					);
-
-					styleBookName.innerHTML = selectedItem.name;
-
-					var styleBookEntryId = document.getElementById(
-						'<portlet:namespace />styleBookEntryId'
-					);
-
-					styleBookEntryId.value = selectedItem.stylebookentryid;
-				}
 			});
 		}
 	);

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_edit.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_edit.jsp
@@ -59,7 +59,7 @@ else {
 	A.one('#<portlet:namespace />changeTheme').on('click', function (event) {
 		event.preventDefault();
 
-		Util.openModal({
+		Util.openSelectionModal({
 			onSelect: function (selectedItem) {
 				var themeId = selectedItem.themeid;
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_theme.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_theme.jsp
@@ -121,10 +121,3 @@ SelectThemeDisplayContext selectThemeDisplayContext = new SelectThemeDisplayCont
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectThemeFm',
-		'<%= HtmlUtil.escapeJS(selectThemeDisplayContext.getEventName()) %>'
-	);
-</aui:script>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {ItemSelectorDialog, debounce} from 'frontend-js-web';
+import {debounce, openSelectionModal} from 'frontend-js-web';
 
 import {config} from '../config/index';
 
@@ -83,21 +83,15 @@ export default function getAlloyEditorProcessor(
 					url,
 					changeLinkCallback
 				) => {
-					const itemSelectorDialog = new ItemSelectorDialog({
-						eventName: editor.title + 'selectItem',
-						singleSelect: true,
+					openSelectionModal({
+						onSelect(selectedItem) {
+							if (selectedItem) {
+								changeLinkCallback(selectedItem);
+							}
+						},
+						selectEventName: editor.title + 'selectItem',
 						title: Liferay.Language.get('select-item'),
 						url,
-					});
-
-					itemSelectorDialog.open();
-
-					itemSelectorDialog.on('selectedItemChange', (event) => {
-						const selectedItem = event.selectedItem;
-
-						if (selectedItem) {
-							changeLinkCallback(selectedItem);
-						}
 					});
 				},
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
@@ -84,7 +84,7 @@ export default function getAlloyEditorProcessor(
 					changeLinkCallback
 				) => {
 					openSelectionModal({
-						onSelect(selectedItem) {
+						onSelect: (selectedItem) => {
 							if (selectedItem) {
 								changeLinkCallback(selectedItem);
 							}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/openImageSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/openImageSelector.js
@@ -19,7 +19,7 @@ import {config} from '../app/config/index';
 export function openImageSelector(callback, destroyedCallback = null) {
 	openSelectionModal({
 		onClose: destroyedCallback,
-		onSelect(selectedItem) {
+		onSelect: (selectedItem) => {
 			if (selectedItem) {
 				const {returnType, value} = selectedItem;
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/openImageSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/openImageSelector.js
@@ -12,51 +12,40 @@
  * details.
  */
 
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-web';
 
 import {config} from '../app/config/index';
 
 export function openImageSelector(callback, destroyedCallback = null) {
-	const itemSelectorDialog = new ItemSelectorDialog({
-		eventName: `${config.portletNamespace}selectImage`,
-		singleSelect: true,
+	openSelectionModal({
+		onClose: destroyedCallback,
+		onSelect(selectedItem) {
+			if (selectedItem) {
+				const {returnType, value} = selectedItem;
+
+				const selectedImage = {};
+
+				if (returnType === 'URL') {
+					selectedImage.title = '';
+					selectedImage.url = value;
+				}
+				else {
+					const fileEntry = JSON.parse(value);
+
+					selectedImage.title = fileEntry.title;
+					selectedImage.url = fileEntry.url;
+				}
+
+				callback(selectedImage);
+			}
+			else {
+				if (destroyedCallback) {
+					destroyedCallback();
+				}
+			}
+		},
+		selectEventName: `${config.portletNamespace}selectImage`,
 		title: Liferay.Language.get('select'),
 		url: config.imageSelectorURL,
 	});
-
-	itemSelectorDialog.on('selectedItemChange', (event) => {
-		const selectedItem = event.selectedItem || {};
-
-		const {returnType, value} = selectedItem;
-
-		if (returnType) {
-			const selectedImage = {};
-
-			if (returnType === 'URL') {
-				selectedImage.title = '';
-				selectedImage.url = value;
-			}
-			else {
-				const fileEntry = JSON.parse(value);
-
-				selectedImage.title = fileEntry.title;
-				selectedImage.url = fileEntry.url;
-			}
-
-			callback(selectedImage);
-		}
-		else {
-			if (destroyedCallback) {
-				destroyedCallback();
-			}
-		}
-	});
-
-	itemSelectorDialog.on('visibleChange', () => {
-		if (destroyedCallback) {
-			destroyedCallback();
-		}
-	});
-
-	itemSelectorDialog.open();
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/openInfoItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/openInfoItemSelector.js
@@ -22,7 +22,7 @@ export function openInfoItemSelector(
 ) {
 	openSelectionModal({
 		onClose: destroyedCallback,
-		onSelect(selectedItem) {
+		onSelect: (selectedItem) => {
 			if (selectedItem && selectedItem.value) {
 				const infoItem = {
 					...JSON.parse(selectedItem.value),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/openInfoItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/openInfoItemSelector.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-web';
 
 export function openInfoItemSelector(
 	callback,
@@ -20,35 +20,20 @@ export function openInfoItemSelector(
 	itemSelectorURL,
 	destroyedCallback = null
 ) {
-	const itemSelectorDialog = new ItemSelectorDialog({
-		eventName,
-		singleSelect: true,
+	openSelectionModal({
+		onClose: destroyedCallback,
+		onSelect(selectedItem) {
+			if (selectedItem && selectedItem.value) {
+				const infoItem = {
+					...JSON.parse(selectedItem.value),
+					type: selectedItem.returnType,
+				};
+
+				callback(infoItem);
+			}
+		},
+		selectEventName: eventName,
 		title: Liferay.Language.get('select'),
 		url: itemSelectorURL,
 	});
-
-	itemSelectorDialog.on('selectedItemChange', (event) => {
-		const selectedItem = event.selectedItem;
-
-		if (selectedItem && selectedItem.value) {
-			const infoItem = {
-				...JSON.parse(selectedItem.value),
-				type: selectedItem.returnType,
-			};
-
-			callback(infoItem);
-		}
-	});
-
-	itemSelectorDialog.on('visibleChange', (event) => {
-		if (
-			!event.newVal &&
-			destroyedCallback &&
-			typeof destroyedCallback === 'function'
-		) {
-			destroyedCallback();
-		}
-	});
-
-	itemSelectorDialog.open();
 }

--- a/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/LayoutSelector.js
+++ b/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/LayoutSelector.js
@@ -15,7 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import {ReactFieldBase} from 'dynamic-data-mapping-form-field-type';
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {openSelectionDialog} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 const LayoutSelector = ({
@@ -49,16 +49,12 @@ const LayoutSelector = ({
 	const handleItemSelectorTriggerClick = (event) => {
 		event.preventDefault();
 
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: `${portletNamespace}selectLayout`,
-			singleSelect: true,
+		openSelectionDialog({
+			onSelect: handleFieldChanged,
+			selectEventName: `${portletNamespace}selectLayout`,
 			title: Liferay.Language.get('page'),
 			url: itemSelectorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', handleFieldChanged);
-
-		itemSelectorDialog.open();
 	};
 
 	return (

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -29,7 +29,7 @@ const ACTIONS = {
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('delete'),
 			multiple: true,
-			onSelect(selectedItems) {
+			onSelect: (selectedItems) => {
 				if (selectedItems) {
 					if (
 						confirm(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-web';
 
 const ACTIONS = {
 	deleteCollections({
@@ -26,39 +26,35 @@ const ACTIONS = {
 
 		layoutPageTemplateCollectionsForm.setAttribute('method', 'post');
 
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('delete'),
-			eventName: `${portletNamespace}selectCollections`,
+			multiple: true,
+			onSelect(selectedItems) {
+				if (selectedItems) {
+					if (
+						confirm(
+							Liferay.Language.get(
+								'are-you-sure-you-want-to-delete-the-selected-entries'
+							)
+						)
+					) {
+						selectedItems.forEach((item) => {
+							layoutPageTemplateCollectionsForm.appendChild(
+								item.cloneNode(true)
+							);
+						});
+
+						submitForm(
+							layoutPageTemplateCollectionsForm,
+							deleteLayoutPageTemplateCollectionURL
+						);
+					}
+				}
+			},
+			selectEventName: `${portletNamespace}selectCollections`,
 			title: Liferay.Language.get('delete-collection'),
 			url: viewLayoutPageTemplateCollectionURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			var selectedItems = event.selectedItem;
-
-			if (selectedItems) {
-				if (
-					confirm(
-						Liferay.Language.get(
-							'are-you-sure-you-want-to-delete-the-selected-entries'
-						)
-					)
-				) {
-					selectedItems.forEach((item) => {
-						layoutPageTemplateCollectionsForm.appendChild(
-							item.cloneNode(true)
-						);
-					});
-
-					submitForm(
-						layoutPageTemplateCollectionsForm,
-						deleteLayoutPageTemplateCollectionURL
-					);
-				}
-			}
-		});
-
-		itemSelectorDialog.open();
 	},
 };
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/DisplayPageDropdownDefaultEventHandler.es.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/DisplayPageDropdownDefaultEventHandler.es.js
@@ -14,8 +14,8 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	openModal,
+	openSelectionModal,
 	openSimpleInputModal,
 } from 'frontend-js-web';
 import {Config} from 'metal-state';
@@ -87,28 +87,22 @@ class DisplayPageDropdownDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	updateLayoutPageTemplateEntryPreview(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: this.ns('changePreview'),
-			singleSelect: true,
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const itemValue = JSON.parse(selectedItem.value);
+
+					this.one('#layoutPageTemplateEntryId').value =
+						itemData.layoutPageTemplateEntryId;
+					this.one('#fileEntryId').value = itemValue.fileEntryId;
+
+					submitForm(this.one('#layoutPageTemplateEntryPreviewFm'));
+				}
+			},
+			selectEventName: this.ns('changePreview'),
 			title: Liferay.Language.get('page-template-thumbnail'),
 			url: itemData.itemSelectorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const itemValue = JSON.parse(selectedItem.value);
-
-				this.one('#layoutPageTemplateEntryId').value =
-					itemData.layoutPageTemplateEntryId;
-				this.one('#fileEntryId').value = itemValue.fileEntryId;
-
-				submitForm(this.one('#layoutPageTemplateEntryPreviewFm'));
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	_send(url) {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateEntryDropdownDefaultEventHandler.es.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateEntryDropdownDefaultEventHandler.es.js
@@ -14,8 +14,8 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	openModal,
+	openSelectionModal,
 	openSimpleInputModal,
 } from 'frontend-js-web';
 import {Config} from 'metal-state';
@@ -70,28 +70,22 @@ class LayoutPageTemplateEntryDropdownDefaultEventHandler extends DefaultEventHan
 	}
 
 	updateLayoutPageTemplateEntryPreview(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: this.ns('changePreview'),
-			singleSelect: true,
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const itemValue = JSON.parse(selectedItem.value);
+
+					this.one('#layoutPageTemplateEntryId').value =
+						itemData.layoutPageTemplateEntryId;
+					this.one('#fileEntryId').value = itemValue.fileEntryId;
+
+					submitForm(this.one('#layoutPageTemplateEntryPreviewFm'));
+				}
+			},
+			selectEventName: this.ns('changePreview'),
 			title: Liferay.Language.get('page-template-thumbnail'),
 			url: itemData.itemSelectorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const itemValue = JSON.parse(selectedItem.value);
-
-				this.one('#layoutPageTemplateEntryId').value =
-					itemData.layoutPageTemplateEntryId;
-				this.one('#fileEntryId').value = itemValue.fileEntryId;
-
-				submitForm(this.one('#layoutPageTemplateEntryPreviewFm'));
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	_send(url) {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/MasterLayoutDropdownDefaultEventHandler.es.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/MasterLayoutDropdownDefaultEventHandler.es.js
@@ -14,8 +14,8 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	openModal,
+	openSelectionModal,
 	openSimpleInputModal,
 } from 'frontend-js-web';
 import {Config} from 'metal-state';
@@ -85,28 +85,22 @@ class MasterLayoutDropdownDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	updateMasterLayoutPreview(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: this.ns('changePreview'),
-			singleSelect: true,
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const itemValue = JSON.parse(selectedItem.value);
+
+					this.one('#layoutPageTemplateEntryId').value =
+						itemData.layoutPageTemplateEntryId;
+					this.one('#fileEntryId').value = itemValue.fileEntryId;
+
+					submitForm(this.one('#masterLayoutPreviewFm'));
+				}
+			},
+			selectEventName: this.ns('changePreview'),
 			title: Liferay.Language.get('master-page-thumbnail'),
 			url: itemData.itemSelectorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const itemValue = JSON.parse(selectedItem.value);
-
-				this.one('#layoutPageTemplateEntryId').value =
-					itemData.layoutPageTemplateEntryId;
-				this.one('#fileEntryId').value = itemValue.fileEntryId;
-
-				submitForm(this.one('#masterLayoutPreviewFm'));
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	_send(url) {

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraph.es.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraph.es.js
@@ -41,7 +41,7 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 
 	openGraphImageButton.addEventListener('click', () => {
 		openSelectionModal({
-			onSelect(selectedItem) {
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					const itemValue = JSON.parse(selectedItem.value);
 

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraph.es.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraph.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {ItemSelectorDialog, toggleDisabled} from 'frontend-js-web';
+import {openSelectionModal, toggleDisabled} from 'frontend-js-web';
 
 import {previewSeoFireChange} from './PreviewSeoEvents.es';
 
@@ -20,13 +20,6 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 	const openGraphImageButton = document.getElementById(
 		`${namespace}openGraphImageButton`
 	);
-
-	const itemSelectorDialog = new ItemSelectorDialog({
-		eventName: `${namespace}openGraphImageSelectedItem`,
-		singleSelect: true,
-		title: Liferay.Language.get('open-graph-image'),
-		url: uploadOpenGraphImageURL,
-	});
 
 	const openGraphImageFileEntryId = document.getElementById(
 		`${namespace}openGraphImageFileEntryId`
@@ -46,28 +39,29 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 		`[for="${namespace}openGraphImageAlt"`
 	);
 
-	itemSelectorDialog.on('selectedItemChange', (event) => {
-		const selectedItem = event.selectedItem;
-
-		if (selectedItem) {
-			const itemValue = JSON.parse(selectedItem.value);
-
-			openGraphImageFileEntryId.value = itemValue.fileEntryId;
-			openGraphImageTitle.value = itemValue.title;
-
-			toggleDisabled(openGraphImageAltField, false);
-			toggleDisabled(openGraphImageAltFieldDefaultLocale, false);
-			toggleDisabled(openGraphImageAltLabel, false);
-
-			previewSeoFireChange(namespace, {
-				type: 'imgUrl',
-				value: itemValue.url,
-			});
-		}
-	});
-
 	openGraphImageButton.addEventListener('click', () => {
-		itemSelectorDialog.open();
+		openSelectionModal({
+			onSelect(selectedItem) {
+				if (selectedItem) {
+					const itemValue = JSON.parse(selectedItem.value);
+
+					openGraphImageFileEntryId.value = itemValue.fileEntryId;
+					openGraphImageTitle.value = itemValue.title;
+
+					toggleDisabled(openGraphImageAltField, false);
+					toggleDisabled(openGraphImageAltFieldDefaultLocale, false);
+					toggleDisabled(openGraphImageAltLabel, false);
+
+					previewSeoFireChange(namespace, {
+						type: 'imgUrl',
+						value: itemValue.url,
+					});
+				}
+			},
+			selectEventName: `${namespace}openGraphImageSelectedItem`,
+			title: Liferay.Language.get('open-graph-image'),
+			url: uploadOpenGraphImageURL,
+		});
 	});
 
 	const openGraphClearImageButton = document.getElementById(

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraphSettings.es.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraphSettings.es.js
@@ -44,7 +44,7 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
-			onSelect(selectedItem) {
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					const itemValue = JSON.parse(selectedItem.value);
 

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraphSettings.es.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraphSettings.es.js
@@ -12,20 +12,12 @@
  * details.
  */
 
-import {ItemSelectorDialog, toggleDisabled} from 'frontend-js-web';
+import {openSelectionModal, toggleDisabled} from 'frontend-js-web';
 
 export default function ({namespace, uploadOpenGraphImageURL}) {
 	const openGraphImageButton = document.getElementById(
 		`${namespace}openGraphImageButton`
 	);
-
-	const itemSelectorDialog = new ItemSelectorDialog({
-		buttonAddLabel: Liferay.Language.get('done'),
-		eventName: `${namespace}openGraphImageSelectedItem`,
-		singleSelect: true,
-		title: Liferay.Language.get('open-graph-image'),
-		url: uploadOpenGraphImageURL,
-	});
 
 	const openGraphImageFileEntryId = document.getElementById(
 		`${namespace}openGraphImageFileEntryId`
@@ -47,27 +39,30 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 		`[for="${namespace}openGraphImageAlt"]`
 	);
 
-	itemSelectorDialog.on('selectedItemChange', (event) => {
-		const selectedItem = event.selectedItem;
-
-		if (selectedItem) {
-			const itemValue = JSON.parse(selectedItem.value);
-
-			openGraphImageFileEntryId.value = itemValue.fileEntryId;
-			openGraphImageTitle.value = itemValue.title;
-			openGraphPreviewImage.src = itemValue.url;
-
-			toggleDisabled(openGraphImageAltField, false);
-			toggleDisabled(openGraphImageAltFieldDefaultLocale, false);
-			toggleDisabled(openGraphImageAltLabel, false);
-
-			openGraphPreviewImage.classList.remove('hide');
-		}
-	});
-
 	openGraphImageButton.addEventListener('click', (event) => {
 		event.preventDefault();
-		itemSelectorDialog.open();
+
+		openSelectionModal({
+			buttonAddLabel: Liferay.Language.get('done'),
+			onSelect(selectedItem) {
+				if (selectedItem) {
+					const itemValue = JSON.parse(selectedItem.value);
+
+					openGraphImageFileEntryId.value = itemValue.fileEntryId;
+					openGraphImageTitle.value = itemValue.title;
+					openGraphPreviewImage.src = itemValue.url;
+
+					toggleDisabled(openGraphImageAltField, false);
+					toggleDisabled(openGraphImageAltFieldDefaultLocale, false);
+					toggleDisabled(openGraphImageAltLabel, false);
+
+					openGraphPreviewImage.classList.remove('hide');
+				}
+			},
+			selectEventName: `${namespace}openGraphImageSelectedItem`,
+			title: Liferay.Language.get('open-graph-image'),
+			url: uploadOpenGraphImageURL,
+		});
 	});
 
 	const openGraphClearImageButton = document.getElementById(

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/resources/META-INF/resources/layout/edit/link_to_layout.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/resources/META-INF/resources/layout/edit/link_to_layout.jsp
@@ -34,7 +34,7 @@
 				event.preventDefault();
 
 				Liferay.Util.openSelectionModal({
-					onSelect(selectedItem) {
+					onSelect: function(selectedItem) {
 						const linkToLayoutName = document.getElementById('<portlet:namespace />linkToLayoutName');
 						const linkToLayoutUuid = document.getElementById('<portlet:namespace />linkToLayoutUuid');
 

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/resources/META-INF/resources/layout/edit/link_to_layout.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/resources/META-INF/resources/layout/edit/link_to_layout.jsp
@@ -25,25 +25,16 @@
 
 	<aui:button name="selectLayoutButton" value="select" />
 
-	<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+	<aui:script sandbox="<%= true %>">
 		var selectLayoutButton = document.getElementById('<portlet:namespace />selectLayoutButton');
 
-		if (selectLayoutButton) {
-			selectLayoutButton.addEventListener(
-				'click',
-				function(event) {
-					event.preventDefault();
+		selectLayoutButton.addEventListener(
+			'click',
+			function(event) {
+				event.preventDefault();
 
-					const itemSelectorDialog = new ItemSelectorDialog.default({
-						eventName: '<%= linkToPageLayoutTypeControllerDisplayContext.getEventName() %>',
-						singleSelect: true,
-						title: '<liferay-ui:message key="select-layout" />',
-						url: '<%= linkToPageLayoutTypeControllerDisplayContext.getItemSelectorURL() %>'
-					});
-
-					itemSelectorDialog.on('selectedItemChange', function(event) {
-						const selectedItem = event.selectedItem;
-
+				Liferay.Util.openSelectionModal({
+					onSelect(selectedItem) {
 						const linkToLayoutName = document.getElementById('<portlet:namespace />linkToLayoutName');
 						const linkToLayoutUuid = document.getElementById('<portlet:namespace />linkToLayoutUuid');
 
@@ -51,11 +42,12 @@
 							linkToLayoutName.value = selectedItem.name;
 							linkToLayoutUuid.value = selectedItem.id;
 						}
-					});
-
-					itemSelectorDialog.open();
-				}
-			);
-		}
+					},
+					selectEventName: '<%= linkToPageLayoutTypeControllerDisplayContext.getEventName() %>',
+					title: '<liferay-ui:message key="select-layout" />',
+					url: '<%= linkToPageLayoutTypeControllerDisplayContext.getItemSelectorURL() %>'
+				});
+			}
+		);
 	</aui:script>
 </div>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_category.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_category.jsp
@@ -103,26 +103,8 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "move"),
 
 	if (selectCategoryButton) {
 		selectCategoryButton.addEventListener('click', function (event) {
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						modal: true,
-						width: 680,
-					},
-					id: '<portlet:namespace />selectCategory',
-					title:
-						'<liferay-ui:message arguments="category" key="select-x" />',
-
-					<portlet:renderURL var="selectCategoryURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-						<portlet:param name="mvcRenderCommandName" value="/message_boards/select_category" />
-						<portlet:param name="mbCategoryId" value="<%= String.valueOf((category == null) ? MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID : category.getParentCategoryId()) %>" />
-						<portlet:param name="excludedMBCategoryId" value="<%= String.valueOf(categoryId) %>" />
-					</portlet:renderURL>
-
-					uri: '<%= selectCategoryURL %>',
-				},
-				function (event) {
+			Liferay.Util.openSelectionModal({
+				onSelect: function (event) {
 					var form = document.<portlet:namespace />fm;
 
 					Liferay.Util.setFormValues(form, {
@@ -137,8 +119,18 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "move"),
 					if (removeCategoryButton) {
 						Liferay.Util.toggleDisabled(removeCategoryButton, false);
 					}
-				}
-			);
+				},
+				selectEventName: '<portlet:namespace />selectCategory',
+				title: '<liferay-ui:message arguments="category" key="select-x" />',
+
+				<portlet:renderURL var="selectCategoryURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+					<portlet:param name="mvcRenderCommandName" value="/message_boards/select_category" />
+					<portlet:param name="mbCategoryId" value="<%= String.valueOf((category == null) ? MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID : category.getParentCategoryId()) %>" />
+					<portlet:param name="excludedMBCategoryId" value="<%= String.valueOf(categoryId) %>" />
+				</portlet:renderURL>
+
+				url: '<%= selectCategoryURL %>',
+			});
 		});
 	}
 </script>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_thread.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_thread.jsp
@@ -146,31 +146,23 @@ if (portletTitleBasedNavigation) {
 
 	if (selectCategoryButton) {
 		selectCategoryButton.addEventListener('click', function (event) {
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						modal: true,
-						width: 680,
-					},
-					id: '<portlet:namespace />selectCategory',
-					title:
-						'<liferay-ui:message arguments="category" key="select-x" />',
-
-					<portlet:renderURL var="selectCategoryURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-						<portlet:param name="mvcRenderCommandName" value="/message_boards/select_category" />
-						<portlet:param name="mbCategoryId" value="<%= String.valueOf(category.getParentCategoryId()) %>" />
-					</portlet:renderURL>
-
-					uri: '<%= selectCategoryURL %>',
-				},
-				function (event) {
+			Liferay.Util.openSelectionModal({
+				onSelect: function (event) {
 					Liferay.Util.setFormValues(form, {
 						categoryName: Liferay.Util.unescape(event.name),
 						mbCategoryId: event.categoryid,
 					});
-				}
-			);
+				},
+				selectEventName: '<portlet:namespace />selectCategory',
+				title: '<liferay-ui:message arguments="category" key="select-x" />',
+
+				<portlet:renderURL var="selectCategoryURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+					<portlet:param name="mvcRenderCommandName" value="/message_boards/select_category" />
+					<portlet:param name="mbCategoryId" value="<%= String.valueOf(category.getParentCategoryId()) %>" />
+				</portlet:renderURL>
+
+				url: '<%= selectCategoryURL %>',
+			});
 		});
 	}
 </script>

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules_toolbar.jspf
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules_toolbar.jspf
@@ -103,34 +103,27 @@
 
 	if (saveInstanceButton) {
 		saveInstanceButton.addEventListener('click', function (event) {
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						modal: true,
-					},
-					id: '<portlet:namespace />selectRuleGroup',
-					title:
-						'<%= UnicodeLanguageUtil.get(resourceBundle, "device-families") %>',
-
-					<liferay-portlet:renderURL portletName="<%= MDRPortletKeys.MOBILE_DEVICE_RULES %>" varImpl="selectRuleGroupURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-						<portlet:param name="mvcRenderCommandName" value="/mobile_device_rules/select_rule_group" />
-						<portlet:param name="groupId" value="<%= String.valueOf(groupId) %>" />
-						<portlet:param name="className" value="<%= className %>" />
-						<portlet:param name="classPK" value="<%= String.valueOf(classPK) %>" />
-						<portlet:param name="eventName" value='<%= liferayPortletResponse.getNamespace() + "selectRuleGroup" %>' />
-					</liferay-portlet:renderURL>
-
-					uri: '<%= selectRuleGroupURL %>',
-				},
-				function (event) {
+			Liferay.Util.openSelectionModal({
+				onSelect: function (event) {
 					<portlet:namespace />saveRuleGroupInstance(
 						event.rulegroupid,
 						event.rulegroupname
 					);
-				}
-			);
+				},
+				selectEventName: '<portlet:namespace />selectRuleGroup',
+				title:
+					'<%= UnicodeLanguageUtil.get(resourceBundle, "device-families") %>',
+
+				<liferay-portlet:renderURL portletName="<%= MDRPortletKeys.MOBILE_DEVICE_RULES %>" varImpl="selectRuleGroupURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+					<portlet:param name="mvcRenderCommandName" value="/mobile_device_rules/select_rule_group" />
+					<portlet:param name="groupId" value="<%= String.valueOf(groupId) %>" />
+					<portlet:param name="className" value="<%= className %>" />
+					<portlet:param name="classPK" value="<%= String.valueOf(classPK) %>" />
+					<portlet:param name="eventName" value='<%= liferayPortletResponse.getNamespace() + "selectRuleGroup" %>' />
+				</liferay-portlet:renderURL>
+
+				url: '<%= selectRuleGroupURL %>',
+			});
 		});
 	}
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/select_rule_group.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/select_rule_group.jsp
@@ -175,10 +175,3 @@ ruleGroupSearch.setResults(mdrRuleGroups);
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectRuleGroupFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
@@ -201,35 +201,26 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 
 					if (selectUserButton) {
 						selectUserButton.addEventListener('click', function (event) {
-							Liferay.Util.selectEntity(
-								{
-									dialog: {
-										modal: true,
-										destroyOnHide: true,
-									},
-
-									<%
-									SelectUsersDisplayContext selectUsersDisplayContext = new SelectUsersDisplayContext(request, renderRequest, renderResponse);
-									%>
-
-									eventName:
-										'<%= HtmlUtil.escapeJS(selectUsersDisplayContext.getEventName()) %>',
-									id:
-										'<%= HtmlUtil.escapeJS(selectUsersDisplayContext.getEventName()) %>',
-
-									title: '<liferay-ui:message key="users" />',
-									uri:
-										'<%= HtmlUtil.escapeJS(String.valueOf(selectUsersDisplayContext.getPortletURL())) %>',
-								},
-								function (event) {
+							Liferay.Util.openSelectionModal({
+								onSelect: function (event) {
 									A.one('#<portlet:namespace />clientCredentialUserId').val(
 										event.userid
 									);
 									A.one('#<portlet:namespace />clientCredentialUserName').val(
 										event.screenname
 									);
-								}
-							);
+								},
+
+								<%
+								SelectUsersDisplayContext selectUsersDisplayContext = new SelectUsersDisplayContext(request, renderRequest, renderResponse);
+								%>
+
+								selectEventName:
+									'<%= HtmlUtil.escapeJS(selectUsersDisplayContext.getEventName()) %>',
+								title: '<liferay-ui:message key="users" />',
+								url:
+									'<%= HtmlUtil.escapeJS(String.valueOf(selectUsersDisplayContext.getPortletURL())) %>',
+							});
 						});
 					}
 				</aui:script>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/select_users.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/select_users.jsp
@@ -70,10 +70,3 @@ SelectUsersDisplayContext selectUsersDisplayContext = new SelectUsersDisplayCont
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectUser',
-		'<%= HtmlUtil.escapeJS(selectUsersDisplayContext.getEventName()) %>'
-	);
-</aui:script>

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/edit_password_policy_assignments.jsp
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/edit_password_policy_assignments.jsp
@@ -119,7 +119,7 @@ SearchContainer<?> searchContainer = editPasswordPolicyAssignmentsManagementTool
 	</liferay-ui:search-container>
 </aui:form>
 
-<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script sandbox="<%= true %>">
 	<portlet:renderURL var="selectMembersURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 		<portlet:param name="mvcPath" value="/select_members.jsp" />
 		<portlet:param name="tabs1" value="<%= tabs1 %>" />
@@ -128,48 +128,44 @@ SearchContainer<?> searchContainer = editPasswordPolicyAssignmentsManagementTool
 	</portlet:renderURL>
 
 	var addAssignees = function (event) {
-		var itemSelectorDialog = new ItemSelectorDialog.default({
-			eventName: '<portlet:namespace />selectMember',
+		Liferay.Util.openSelectionModal({
+			multiple: true,
+			onSelect: function(result) {
+				if (result && result.item) {
+					var form = document.getElementById('<portlet:namespace />fm');
+
+					if (form) {
+						if (result.memberType == 'users') {
+							var addUserIdsInput = form.querySelector(
+								'#<portlet:namespace />addUserIds'
+							);
+
+							if (addUserIdsInput) {
+								addUserIdsInput.setAttribute('value', result.item);
+							}
+						}
+						else if (result.memberType == 'organizations') {
+							var addOrganizationIdsInput = form.querySelector(
+								'#<portlet:namespace />addOrganizationIds'
+							);
+
+							if (addOrganizationIdsInput) {
+								addOrganizationIdsInput.setAttribute(
+									'value',
+									result.item
+								);
+							}
+						}
+
+						submitForm(form);
+					}
+				}
+			},
+			selectEventName: '<portlet:namespace />selectMember',
 			title:
 				'<liferay-ui:message arguments="<%= HtmlUtil.escape(passwordPolicy.getName()) %>" key="add-assignees-to-x" />',
 			url: '<%= selectMembersURL %>',
 		});
-
-		itemSelectorDialog.on('selectedItemChange', function (event) {
-			var result = event.selectedItem;
-
-			if (result && result.item) {
-				var form = document.getElementById('<portlet:namespace />fm');
-
-				if (form) {
-					if (result.memberType == 'users') {
-						var addUserIdsInput = form.querySelector(
-							'#<portlet:namespace />addUserIds'
-						);
-
-						if (addUserIdsInput) {
-							addUserIdsInput.setAttribute('value', result.item);
-						}
-					}
-					else if (result.memberType == 'organizations') {
-						var addOrganizationIdsInput = form.querySelector(
-							'#<portlet:namespace />addOrganizationIds'
-						);
-
-						if (addOrganizationIdsInput) {
-							addOrganizationIdsInput.setAttribute(
-								'value',
-								result.item
-							);
-						}
-					}
-
-					submitForm(form);
-				}
-			}
-		});
-
-		itemSelectorDialog.open();
 	};
 
 	Liferay.componentReady('editPasswordPolicyAssignmentsManagementToolbar').then(

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/edit_password_policy_assignments.jsp
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/edit_password_policy_assignments.jsp
@@ -130,7 +130,7 @@ SearchContainer<?> searchContainer = editPasswordPolicyAssignmentsManagementTool
 	var addAssignees = function (event) {
 		Liferay.Util.openSelectionModal({
 			multiple: true,
-			onSelect: function(result) {
+			onSelect: function (result) {
 				if (result && result.item) {
 					var form = document.getElementById('<portlet:namespace />fm');
 

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -22,7 +22,7 @@ import '../css/ApplicationsMenu.scss';
 import ClayLabel from '@clayui/label';
 import ClaySticker from '@clayui/sticker';
 import ClayTabs from '@clayui/tabs';
-import {fetch} from 'frontend-js-web';
+import {fetch, navigate, openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
 
@@ -89,10 +89,10 @@ const SitesPanel = ({mySites, portletNamespace, recentSites, viewAllURL}) => {
 						className="applications-menu-btn btn-unstyled c-mb-0 c-mt-3"
 						displayType="link"
 						onClick={() => {
-							Liferay.Util.openModal({
+							openSelectionModal({
 								id: `${portletNamespace}selectSite`,
 								onSelect: (selectedItem) => {
-									Liferay.Util.navigate(selectedItem.url);
+									navigate(selectedItem.url);
 								},
 								selectEventName: `${portletNamespace}selectSite`,
 								title: Liferay.Language.get(

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
@@ -87,7 +87,7 @@ public class MySitesPersonalMenuEntry implements PersonalMenuEntry {
 
 		StringBuilder sb = new StringBuilder(11);
 
-		sb.append("javascript:Liferay.Util.openModal({id: '");
+		sb.append("javascript:Liferay.Util.openSelectionModal({id: '");
 		sb.append(namespace);
 		sb.append("selectSite', onSelect: function(selectedItem) ");
 		sb.append("{Liferay.Util.navigate(selectedItem.url);}");

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_icon_sites.jspf
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_icon_sites.jspf
@@ -47,7 +47,7 @@ PortletURL itemSelectorURL = itemSelector.getItemSelectorURL(RequestBackedPortle
 
 		if (manageSitesLink) {
 			manageSitesLink.addEventListener('click', function (event) {
-				Liferay.Util.openModal({
+				Liferay.Util.openSelectionModal({
 					id: '<portlet:namespace />selectSite',
 					onSelect: function (selectedItem) {
 						Liferay.Util.navigate(selectedItem.url);

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_assignments.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_assignments.jsp
@@ -118,7 +118,7 @@ renderResponse.setTitle(role.getTitle(locale));
 	var addAssignees = function (event) {
 		Liferay.Util.openSelectionModal({
 			multiple: true,
-			onSelect: function(selectedItem) {
+			onSelect: function (selectedItem) {
 				if (selectedItem) {
 					var assignmentsRedirect = Liferay.Util.PortletURL.createPortletURL(
 						'<%= portletURL.toString() %>',

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_assignments.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_assignments.jsp
@@ -112,12 +112,42 @@ renderResponse.setTitle(role.getTitle(locale));
 	<portlet:param name="tabs1" value="assignees" />
 </portlet:actionURL>
 
-<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script sandbox="<%= true %>">
 	var form = document.<portlet:namespace />fm;
 
 	var addAssignees = function (event) {
-		var itemSelectorDialog = new ItemSelectorDialog.default({
-			eventName: '<portlet:namespace />selectAssignees',
+		Liferay.Util.openSelectionModal({
+			multiple: true,
+			onSelect: function(selectedItem) {
+				if (selectedItem) {
+					var assignmentsRedirect = Liferay.Util.PortletURL.createPortletURL(
+						'<%= portletURL.toString() %>',
+						{
+							tabs2: selectedItem.type,
+						}
+					);
+
+					var data = {
+						redirect: assignmentsRedirect.toString(),
+					};
+
+					if (selectedItem.type == 'segments') {
+						data.addSegmentsEntryIds = selectedItem.value;
+					}
+					else if (selectedItem.type === 'users') {
+						data.addUserIds = selectedItem.value;
+					}
+					else {
+						data.addGroupIds = selectedItem.value;
+					}
+
+					Liferay.Util.postForm(form, {
+						data: data,
+						url: '<%= editRoleAssignmentsURL %>',
+					});
+				}
+			},
+			selectEventName: '<portlet:namespace />selectAssignees',
 			title:
 				'<liferay-ui:message arguments="<%= HtmlUtil.escape(role.getName()) %>" key="add-assignees-to-x" />',
 
@@ -132,40 +162,6 @@ renderResponse.setTitle(role.getTitle(locale));
 
 			url: '<%= selectAssigneesURL %>',
 		});
-
-		itemSelectorDialog.on('selectedItemChange', function (event) {
-			var selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				var assignmentsRedirect = Liferay.Util.PortletURL.createPortletURL(
-					'<%= portletURL.toString() %>',
-					{
-						tabs2: selectedItem.type,
-					}
-				);
-
-				var data = {
-					redirect: assignmentsRedirect.toString(),
-				};
-
-				if (selectedItem.type == 'segments') {
-					data.addSegmentsEntryIds = selectedItem.value;
-				}
-				else if (selectedItem.type === 'users') {
-					data.addUserIds = selectedItem.value;
-				}
-				else {
-					data.addGroupIds = selectedItem.value;
-				}
-
-				Liferay.Util.postForm(form, {
-					data: data,
-					url: '<%= editRoleAssignmentsURL %>',
-				});
-			}
-		});
-
-		itemSelectorDialog.open();
 	};
 
 	<portlet:namespace />unsetRoleAssignments = function () {

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/GroupLabels.es.js
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/GroupLabels.es.js
@@ -15,6 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
+import {openSelectionModal} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 export default function GroupLabels({
@@ -40,30 +41,6 @@ export default function GroupLabels({
 				.split('@@')
 				.filter((name) => !!name)
 		);
-	}, [portletNamespace, target]);
-
-	useEffect(() => {
-		const selectGroupHandle = Liferay.on(
-			`${portletNamespace}selectGroup`,
-			(event) => {
-				if (event.grouptarget === target) {
-					setGroupIds((groupIds) =>
-						groupIds.indexOf(event.groupid) == -1
-							? [...groupIds, event.groupid]
-							: groupIds
-					);
-					setGroupNames((groupNames) =>
-						groupNames.indexOf(event.groupdescriptivename) == -1
-							? [...groupNames, event.groupdescriptivename]
-							: groupNames
-					);
-				}
-			}
-		);
-
-		return () => {
-			Liferay.detach(selectGroupHandle);
-		};
 	}, [portletNamespace, target]);
 
 	useEffect(() => {
@@ -111,19 +88,33 @@ export default function GroupLabels({
 			<ClayButton
 				displayType="unstyled"
 				onClick={() => {
-					Liferay.Util.selectEntity({
-						dialog: {
-							constrain: true,
-							modal: true,
-							width: 600,
+					openSelectionModal({
+						onSelect: (event) => {
+							if (event.grouptarget === target) {
+								setGroupIds((groupIds) =>
+									groupIds.indexOf(event.groupid) == -1
+										? [...groupIds, event.groupid]
+										: groupIds
+								);
+								setGroupNames((groupNames) =>
+									groupNames.indexOf(
+										event.groupdescriptivename
+									) == -1
+										? [
+												...groupNames,
+												event.groupdescriptivename,
+										  ]
+										: groupNames
+								);
+							}
 						},
-						id: `${portletNamespace}selectGroup${target}`,
+						selectEventName: `${portletNamespace}selectGroup${target}`,
 						selectedData: groupIds,
 						title: Liferay.Util.sub(
 							Liferay.Language.get('select-x'),
 							Liferay.Language.get('site')
 						),
-						uri: itemSelectorURL,
+						url: itemSelectorURL,
 					});
 				}}
 			>

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
@@ -260,10 +260,3 @@ else {
 		</c:when>
 	</c:choose>
 </aui:form>
-
-<aui:script use="aui-base">
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectOrganizationRoleFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/inputs/SelectEntityInput.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/inputs/SelectEntityInput.es.js
@@ -46,7 +46,7 @@ class SelectEntityInput extends React.Component {
 			openSelectionModal({
 				buttonAddLabel: Liferay.Language.get('select'),
 				multiple: true,
-				onSelect(selectedItems) {
+				onSelect: (selectedItems) => {
 					if (selectedItems) {
 						const selectedValues = selectedItems.map((item) => ({
 							displayValue: item.name,
@@ -60,40 +60,19 @@ class SelectEntityInput extends React.Component {
 				title,
 				url: uri,
 			});
-
-			itemSelectorDialog.open();
-
-			itemSelectorDialog.on('selectedItemChange', (event) => {
-				const selectedItems = event.selectedItem;
-
-				if (selectedItems) {
-					const selectedValues = selectedItems.map((item) => ({
-						displayValue: item.name,
-						value: item.id,
-					}));
-
-					onChange(selectedValues);
-				}
-			});
-		} else {
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						modal: true,
-					},
-					id,
-					title,
-					uri,
-				},
-				(event) => {
+		}
+		else {
+			openSelectionModal({
+				onSelect: (event) => {
 					onChange({
 						displayValue: event.entityname,
 						value: event.entityid,
 					});
-				}
-			);
+				},
+				selectEventName: id,
+				title,
+				url: uri,
+			});
 		}
 	};
 

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/inputs/SelectEntityInput.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/inputs/SelectEntityInput.es.js
@@ -13,7 +13,7 @@
  */
 
 import ClayButton from '@clayui/button';
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-web';
 import propTypes from 'prop-types';
 import React from 'react';
 
@@ -43,9 +43,20 @@ class SelectEntityInput extends React.Component {
 		} = this.props;
 
 		if (multiple) {
-			const itemSelectorDialog = new ItemSelectorDialog({
+			openSelectionModal({
 				buttonAddLabel: Liferay.Language.get('select'),
-				eventName: id,
+				multiple: true,
+				onSelect(selectedItems) {
+					if (selectedItems) {
+						const selectedValues = selectedItems.map((item) => ({
+							displayValue: item.name,
+							value: item.id,
+						}));
+
+						onChange(selectedValues);
+					}
+				},
+				selectEventName: id,
 				title,
 				url: uri,
 			});
@@ -64,8 +75,7 @@ class SelectEntityInput extends React.Component {
 					onChange(selectedValues);
 				}
 			});
-		}
-		else {
+		} else {
 			Liferay.Util.selectEntity(
 				{
 					dialog: {

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -172,7 +172,7 @@ request.setAttribute("view.jsp-eventName", eventName);
 	<aui:input name="siteRoleIds" type="hidden" />
 </aui:form>
 
-<aui:script require="metal-dom/src/all/dom as dom, frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script require="metal-dom/src/all/dom as dom">
 	var form = document.getElementById(
 		'<portlet:namespace/>updateSegmentsEntrySiteRolesFm'
 	);
@@ -183,25 +183,21 @@ request.setAttribute("view.jsp-eventName", eventName);
 		var itemSelectorURL = link.dataset.itemselectorurl;
 		var segmentsEntryId = link.dataset.segmentsentryid;
 
-		var itemSelectorDialog = new ItemSelectorDialog.default({
+		Liferay.Util.openSelectionModal({
 			eventName: '<%= eventName %>',
+			multiple: true,
+			onSelect: function(selectedItem) {
+				if (selectedItem) {
+					var data = {
+						segmentsEntryId: segmentsEntryId,
+						siteRoleIds: selectedItem.value,
+					};
+
+					Liferay.Util.postForm(form, {data: data});
+				}
+			},
 			title: '<liferay-ui:message key="assign-site-roles" />',
 			url: itemSelectorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', function (event) {
-			var selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				var data = {
-					segmentsEntryId: segmentsEntryId,
-					siteRoleIds: selectedItem.value,
-				};
-
-				Liferay.Util.postForm(form, {data: data});
-			}
-		});
-
-		itemSelectorDialog.open();
 	});
 </aui:script>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -186,7 +186,7 @@ request.setAttribute("view.jsp-eventName", eventName);
 		Liferay.Util.openSelectionModal({
 			eventName: '<%= eventName %>',
 			multiple: true,
-			onSelect: function(selectedItem) {
+			onSelect: function (selectedItem) {
 				if (selectedItem) {
 					var data = {
 						segmentsEntryId: segmentsEntryId,

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/SharedAssets.es.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/SharedAssets.es.js
@@ -40,7 +40,7 @@ class SharedAssets extends PortletBase {
 
 		if (itemData && itemData.action === 'openAssetTypesSelector') {
 			openSelectionModal({
-				onSelect(selectedItem) {
+				onSelect: (selectedItem) => {
 					if (selectedItem) {
 						let uri = viewAssetTypeURL;
 

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/SharedAssets.es.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/SharedAssets.es.js
@@ -12,7 +12,12 @@
  * details.
  */
 
-import {ItemSelectorDialog, PortletBase, addParams} from 'frontend-js-web';
+import {
+	PortletBase,
+	addParams,
+	navigate,
+	openSelectionModal,
+} from 'frontend-js-web';
 
 class SharedAssets extends PortletBase {
 	constructor(config, ...args) {
@@ -33,29 +38,23 @@ class SharedAssets extends PortletBase {
 		const namespace = this.namespace;
 		const viewAssetTypeURL = this._viewAssetTypeURL;
 
-		if (itemData.action === 'openAssetTypesSelector') {
-			const itemSelectorDialog = new ItemSelectorDialog({
-				eventName: namespace + 'selectAssetType',
-				singleSelect: true,
+		if (itemData && itemData.action === 'openAssetTypesSelector') {
+			openSelectionModal({
+				onSelect(selectedItem) {
+					if (selectedItem) {
+						let uri = viewAssetTypeURL;
+
+						uri = addParams(
+							namespace + 'className=' + selectedItem.value,
+							uri
+						);
+
+						navigate(uri);
+					}
+				},
+				selectEventName: namespace + 'selectAssetType',
 				title: Liferay.Language.get('select-asset-type'),
 				url: this._selectAssetTypeURL,
-			});
-
-			itemSelectorDialog.open();
-
-			itemSelectorDialog.on('selectedItemChange', (event) => {
-				const selectedItem = event.selectedItem;
-
-				if (selectedItem) {
-					let uri = viewAssetTypeURL;
-
-					uri = addParams(
-						namespace + 'className=' + selectedItem.value,
-						uri
-					);
-
-					location.href = uri;
-				}
 			});
 		}
 	}

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
@@ -90,7 +90,7 @@ if (selLayout != null) {
 
 	A.one('#<portlet:namespace />chooseLayout').on('click', function (event) {
 		Liferay.Util.openSelectionModal({
-			onSelect: function(selectedItem) {
+			onSelect: function (selectedItem) {
 				if (selectedItem) {
 					groupId.val(selectedItem.groupId);
 

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
@@ -89,35 +89,26 @@ if (selLayout != null) {
 	var privateLayout = A.one('#<portlet:namespace />privateLayout');
 
 	A.one('#<portlet:namespace />chooseLayout').on('click', function (event) {
-		Liferay.Loader.require(
-			'frontend-js-web/liferay/ItemSelectorDialog.es',
-			function (ItemSelectorDialog) {
-				var itemSelectorDialog = new ItemSelectorDialog.default({
-					eventName: '<%= eventName %>',
-					title: '<liferay-ui:message key="select-layout" />',
-					url: '<%= itemSelectorURL.toString() %>',
-				});
+		Liferay.Util.openSelectionModal({
+			onSelect: function(selectedItem) {
+				if (selectedItem) {
+					groupId.val(selectedItem.groupId);
 
-				itemSelectorDialog.on('selectedItemChange', function (event) {
-					var selectedItem = event.selectedItem;
+					layoutUuid.val(selectedItem.id);
 
-					if (selectedItem) {
-						groupId.val(selectedItem.groupId);
+					privateLayout.val(selectedItem.privateLayout);
 
-						layoutUuid.val(selectedItem.id);
+					layoutNameInput.html(selectedItem.name);
+					layoutNameInput.simulate('change');
 
-						privateLayout.val(selectedItem.privateLayout);
-
-						layoutNameInput.html(selectedItem.name);
-						layoutNameInput.simulate('change');
-
-						layoutItemRemove.removeClass('hide');
-					}
-				});
-
-				itemSelectorDialog.open();
-			}
-		);
+					layoutItemRemove.removeClass('hide');
+				}
+			},
+			multiple: true,
+			selectEventName: '<%= eventName %>',
+			title: '<liferay-ui:message key="select-layout" />',
+			url: '<%= itemSelectorURL.toString() %>',
+		});
 	});
 
 	layoutItemRemove.on('click', function (event) {

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -250,7 +250,7 @@ else {
 	</liferay-frontend:edit-form-footer>
 </liferay-frontend:edit-form>
 
-<aui:script require="metal-dom/src/dom as dom, frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script require="metal-dom/src/dom as dom">
 	var form = document.<portlet:namespace />fm;
 
 	form.addEventListener('change', <portlet:namespace/>resetPreview);
@@ -356,29 +356,23 @@ else {
 				uri
 			);
 
-			var itemSelectorDialog = new ItemSelectorDialog.default({
-				eventName:
+			Liferay.Util.openSelectionModal({
+				onSelect: function (selectedItem) {
+					if (selectedItem) {
+						rootMenuItemIdInput.value =
+							selectedItem.selectSiteNavigationMenuItemId;
+						rootMenuItemNameSpan.innerText =
+							selectedItem.selectSiteNavigationMenuItemName;
+
+						<portlet:namespace/>resetPreview();
+					}
+				},
+				selectEventName:
 					'<%= siteNavigationMenuDisplayContext.getRootMenuItemEventName() %>',
-				singleSelect: true,
 				title:
 					'<liferay-ui:message key="select-site-navigation-menu-item" />',
 				url: uri,
 			});
-
-			itemSelectorDialog.on('selectedItemChange', function (event) {
-				var selectedItem = event.selectedItem;
-
-				if (selectedItem) {
-					rootMenuItemIdInput.value =
-						selectedItem.selectSiteNavigationMenuItemId;
-					rootMenuItemNameSpan.innerText =
-						selectedItem.selectSiteNavigationMenuItemName;
-
-					<portlet:namespace/>resetPreview();
-				}
-			});
-
-			itemSelectorDialog.open();
 		});
 	}
 
@@ -401,22 +395,9 @@ else {
 		siteNavigationMenuIdInput
 	) {
 		chooseSiteNavigationMenuButton.addEventListener('click', function (event) {
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						modal: true,
-					},
-					eventName:
-						'<%= siteNavigationMenuDisplayContext.getSiteNavigationMenuEventName() %>',
-					id: '<portlet:namespace />selectSiteNavigationMenu',
-					title:
-						'<liferay-ui:message key="select-site-navigation-menu" />',
-					uri:
-						'<%= siteNavigationMenuDisplayContext.getSiteNavigationMenuItemSelectorURL() %>',
-				},
-				function (selectedItem) {
+			Liferay.Util.openSelectionModal({
+				id: '<portlet:namespace />selectSiteNavigationMenu',
+				onSelect: function(selectedItem) {
 					if (selectedItem) {
 						navigationMenuName.innerText = selectedItem.name;
 						rootMenuItemIdInput.value = '0';
@@ -427,8 +408,14 @@ else {
 
 						<portlet:namespace/>resetPreview();
 					}
-				}
-			);
+				},
+				selectEventName:
+					'<%= siteNavigationMenuDisplayContext.getSiteNavigationMenuEventName() %>',
+				title:
+					'<liferay-ui:message key="select-site-navigation-menu" />',
+				url:
+					'<%= siteNavigationMenuDisplayContext.getSiteNavigationMenuItemSelectorURL() %>',
+			});
 		});
 	}
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -397,7 +397,7 @@ else {
 		chooseSiteNavigationMenuButton.addEventListener('click', function (event) {
 			Liferay.Util.openSelectionModal({
 				id: '<portlet:namespace />selectSiteNavigationMenu',
-				onSelect: function(selectedItem) {
+				onSelect: function (selectedItem) {
 					if (selectedItem) {
 						navigationMenuName.innerText = selectedItem.name;
 						rootMenuItemIdInput.value = '0';
@@ -411,8 +411,7 @@ else {
 				},
 				selectEventName:
 					'<%= siteNavigationMenuDisplayContext.getSiteNavigationMenuEventName() %>',
-				title:
-					'<liferay-ui:message key="select-site-navigation-menu" />',
+				title: '<liferay-ui:message key="select-site-navigation-menu" />',
 				url:
 					'<%= siteNavigationMenuDisplayContext.getSiteNavigationMenuItemSelectorURL() %>',
 			});

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/default_user_associations.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/default_user_associations.jsp
@@ -183,19 +183,8 @@ for (long defaultTeamId : defaultTeamIds) {
 				config.uri
 			);
 
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						modal: true,
-					},
-					id: config.id,
-					selectedData: searchContainerData,
-					title: config.title,
-					uri: uri,
-				},
-				function (event) {
+			Liferay.Util.openSelectionModal({
+				onSelect: function (event) {
 					var entityId = event.entityid;
 
 					var rowColumns = [
@@ -208,8 +197,12 @@ for (long defaultTeamId : defaultTeamIds) {
 					searchContainer.addRow(rowColumns, entityId);
 
 					searchContainer.updateDataStore();
-				}
-			);
+				},
+				selectEventName: config.id,
+				selectedData: searchContainerData,
+				title: config.title,
+				url: uri,
+			});
 		});
 	};
 

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/details.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/details.jsp
@@ -210,27 +210,8 @@ else {
 		A.one('#<portlet:namespace />selectParentSiteLink').on('click', function (
 			event
 		) {
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						modal: true,
-					},
-					id: '<portlet:namespace />selectGroup',
-					title: '<liferay-ui:message arguments="site" key="select-x" />',
-
-					<%
-					PortletURL groupSelectorURL = PortletProviderUtil.getPortletURL(request, Group.class.getName(), PortletProvider.Action.BROWSE);
-
-					groupSelectorURL.setParameter("includeCurrentGroup", Boolean.FALSE.toString());
-					groupSelectorURL.setParameter("groupId", String.valueOf(group.getGroupId()));
-					groupSelectorURL.setParameter("eventName", liferayPortletResponse.getNamespace() + "selectGroup");
-					groupSelectorURL.setWindowState(LiferayWindowState.POP_UP);
-					%>
-
-					uri: '<%= groupSelectorURL.toString() %>',
-				},
-				function (event) {
+			Liferay.Util.openSelectionModal({
+				onSelect: function (event) {
 					var searchContainer = Liferay.SearchContainer.get(
 						'<portlet:namespace />parentGroupSearchContainer'
 					);
@@ -256,8 +237,21 @@ else {
 					A.one(
 						'#<portlet:namespace />membershipRestrictionContainer'
 					).show();
-				}
-			);
+				},
+				selectEventName: '<portlet:namespace />selectGroup',
+				title: '<liferay-ui:message arguments="site" key="select-x" />',
+
+				<%
+				PortletURL groupSelectorURL = PortletProviderUtil.getPortletURL(request, Group.class.getName(), PortletProvider.Action.BROWSE);
+
+				groupSelectorURL.setParameter("includeCurrentGroup", Boolean.FALSE.toString());
+				groupSelectorURL.setParameter("groupId", String.valueOf(group.getGroupId()));
+				groupSelectorURL.setParameter("eventName", liferayPortletResponse.getNamespace() + "selectGroup");
+				groupSelectorURL.setWindowState(LiferayWindowState.POP_UP);
+				%>
+
+				url: '<%= groupSelectorURL.toString() %>',
+			});
 		});
 
 		var searchContainer = Liferay.SearchContainer.get(

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationsManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationsManagementToolbarDefaultEventHandler.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {DefaultEventHandler, ItemSelectorDialog} from 'frontend-js-web';
+import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
 import dom from 'metal-dom';
 
 class OrganizationsManagementToolbarDefaultEventHandler extends DefaultEventHandler {
@@ -27,33 +27,29 @@ class OrganizationsManagementToolbarDefaultEventHandler extends DefaultEventHand
 	}
 
 	selectOrganizations(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
-			eventName: this.ns('selectOrganizations'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const addGroupOrganizationsFm = this.one(
+						'#addGroupOrganizationsFm'
+					);
+
+					selectedItem.forEach((item) => {
+						dom.append(addGroupOrganizationsFm, item);
+					});
+
+					submitForm(addGroupOrganizationsFm);
+				}
+			},
+			selectEventName: this.ns('selectOrganizations'),
 			title: Liferay.Util.sub(
 				Liferay.Language.get('assign-organizations-to-this-x'),
 				itemData.groupTypeLabel
 			),
 			url: itemData.selectOrganizationsURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const addGroupOrganizationsFm = this.one(
-					'#addGroupOrganizationsFm'
-				);
-
-				selectedItem.forEach((item) => {
-					dom.append(addGroupOrganizationsFm, item);
-				});
-
-				submitForm(addGroupOrganizationsFm);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 }
 

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserDropdownDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserDropdownDefaultEventHandler.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {DefaultEventHandler, ItemSelectorDialog} from 'frontend-js-web';
+import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
 import dom from 'metal-dom';
 
 class UserDropdownDefaultEventHandler extends DefaultEventHandler {
@@ -27,28 +27,29 @@ class UserDropdownDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	assignRoles(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
-			eventName: this.ns('selectUsersRoles'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const editUserGroupRoleFm = this.one(
+						'#editUserGroupRoleFm'
+					);
+
+					selectedItem.forEach((item) => {
+						dom.append(editUserGroupRoleFm, item);
+					});
+
+					submitForm(
+						editUserGroupRoleFm,
+						itemData.editUserGroupRoleURL
+					);
+				}
+			},
+			selectEventName: this.ns('selectUsersRoles'),
 			title: Liferay.Language.get('assign-roles'),
 			url: itemData.assignRolesURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const editUserGroupRoleFm = this.one('#editUserGroupRoleFm');
-
-				selectedItem.forEach((item) => {
-					dom.append(editUserGroupRoleFm, item);
-				});
-
-				submitForm(editUserGroupRoleFm, itemData.editUserGroupRoleURL);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 }
 

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarDefaultEventHandler.es.js
@@ -14,8 +14,8 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	addParams,
+	openSelectionModal,
 } from 'frontend-js-web';
 import dom from 'metal-dom';
 
@@ -58,56 +58,50 @@ class UserGroupsManagementToolbarDefaultEventHandler extends DefaultEventHandler
 	}
 
 	selectRole(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
-			eventName: this.ns('selectRole'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const fm = this.one('#fm');
+
+					selectedItem.forEach((item) => {
+						dom.append(fm, item);
+					});
+
+					submitForm(fm, itemData.editUserGroupsRolesURL);
+				}
+			},
+			selectEventName: this.ns('selectRole'),
 			title: Liferay.Language.get('assign-roles'),
 			url: itemData.selectRoleURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const fm = this.one('#fm');
-
-				selectedItem.forEach((item) => {
-					dom.append(fm, item);
-				});
-
-				submitForm(fm, itemData.editUserGroupsRolesURL);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	selectUserGroups(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
-			eventName: this.ns('selectUserGroups'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const addGroupUserGroupsFm = this.one(
+						'#addGroupUserGroupsFm'
+					);
+
+					selectedItem.forEach((item) => {
+						dom.append(addGroupUserGroupsFm, item);
+					});
+
+					submitForm(addGroupUserGroupsFm);
+				}
+			},
+			selectEventName: this.ns('selectUserGroups'),
 			title: Liferay.Util.sub(
 				Liferay.Language.get('assign-user-groups-to-this-x'),
 				itemData.groupTypeLabel
 			),
 			url: itemData.selectUserGroupsURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const addGroupUserGroupsFm = this.one('#addGroupUserGroupsFm');
-
-				selectedItem.forEach((item) => {
-					dom.append(addGroupUserGroupsFm, item);
-				});
-
-				submitForm(addGroupUserGroupsFm);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 }
 

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarDefaultEventHandler.es.js
@@ -37,24 +37,17 @@ class UserGroupsManagementToolbarDefaultEventHandler extends DefaultEventHandler
 	}
 
 	selectRoles(itemData) {
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					destroyOnHide: true,
-					modal: true,
-				},
-				eventName: this.ns('selectRole'),
-				title: Liferay.Language.get('select-role'),
-				uri: itemData.selectRolesURL,
-			},
-			(event) => {
+		openSelectionModal({
+			onSelect: (event) => {
 				location.href = addParams(
 					`${this.ns('roleId')}=${event.id}`,
 					itemData.viewRoleURL
 				);
-			}
-		);
+			},
+			selectEventName: this.ns('selectRole'),
+			title: Liferay.Language.get('select-role'),
+			url: itemData.selectRolesURL,
+		});
 	}
 
 	selectRole(itemData) {

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UsersManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UsersManagementToolbarDefaultEventHandler.es.js
@@ -38,24 +38,17 @@ class UsersManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	selectRoles(itemData) {
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					destroyOnHide: true,
-					modal: true,
-				},
-				eventName: this.ns('selectRole'),
-				title: Liferay.Language.get('select-role'),
-				uri: itemData.selectRolesURL,
-			},
-			(event) => {
+		openSelectionModal({
+			onSelect: (event) => {
 				location.href = addParams(
 					`${this.ns('roleId')}=${event.id}`,
 					itemData.viewRoleURL
 				);
-			}
-		);
+			},
+			selectEventName: this.ns('selectRole'),
+			title: Liferay.Language.get('select-role'),
+			url: itemData.selectRolesURL,
+		});
 	}
 
 	selectRole(itemData) {
@@ -83,7 +76,7 @@ class UsersManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
 			multiple: true,
-			onSelect(selectedItem) {
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					const addGroupUsersFm = this.one('#addGroupUsersFm');
 

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UsersManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UsersManagementToolbarDefaultEventHandler.es.js
@@ -14,9 +14,9 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
 	addParams,
 	getPortletId,
+	openSelectionModal,
 } from 'frontend-js-web';
 import dom from 'metal-dom';
 
@@ -59,34 +59,42 @@ class UsersManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	selectRole(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
-			eventName: this.ns('selectRole'),
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const fm = this.one('#fm');
+
+					selectedItem.forEach((item) => {
+						dom.append(fm, item);
+					});
+
+					submitForm(fm, itemData.editUsersRolesURL);
+				}
+			},
+			selectEventName: this.ns('selectRole'),
 			title: Liferay.Language.get('assign-roles'),
 			url: itemData.selectRoleURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const fm = this.one('#fm');
-
-				selectedItem.forEach((item) => {
-					dom.append(fm, item);
-				});
-
-				submitForm(fm, itemData.editUsersRolesURL);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	selectUsers(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
-			eventName: this.ns('selectUsers'),
+			multiple: true,
+			onSelect(selectedItem) {
+				if (selectedItem) {
+					const addGroupUsersFm = this.one('#addGroupUsersFm');
+
+					selectedItem.forEach((item) => {
+						dom.append(addGroupUsersFm, item);
+					});
+
+					submitForm(addGroupUsersFm);
+				}
+			},
+			selectEventName: this.ns('selectUsers'),
 			title: Liferay.Util.sub(
 				Liferay.Language.get('assign-users-to-this-x'),
 				itemData.groupTypeLabel
@@ -96,22 +104,6 @@ class UsersManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 				itemData.selectUsersURL
 			),
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const addGroupUsersFm = this.one('#addGroupUsersFm');
-
-				selectedItem.forEach((item) => {
-					dom.append(addGroupUsersFm, item);
-				});
-
-				submitForm(addGroupUsersFm);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 }
 

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_group_action.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_group_action.jsp
@@ -86,7 +86,7 @@ UserGroup userGroup = (UserGroup)row.getObject();
 	</c:if>
 </liferay-ui:icon-menu>
 
-<aui:script require="metal-dom/src/dom as dom, frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script require="metal-dom/src/dom as dom">
 	var assignRolesLink = document.getElementById(
 		'<portlet:namespace /><%= row.getRowId() %>assignRoles'
 	);
@@ -108,29 +108,25 @@ UserGroup userGroup = (UserGroup)row.getObject();
 				userGroupId: target.dataset.usergroupid,
 			});
 
-			var itemSelectorDialog = new ItemSelectorDialog.default({
+			Liferay.Util.openSelectionModal({
 				buttonAddLabel: '<liferay-ui:message key="done" />',
-				eventName: '<portlet:namespace />selectUserGroupsRoles',
+				multiple: true,
+				onSelect: function (selectedItems) {
+					if (selectedItems) {
+						Array.prototype.forEach.call(selectedItems, function (
+							selectedItem,
+							index
+						) {
+							dom.append(addUserGroupGroupRoleFm, selectedItem);
+						});
+
+						submitForm(addUserGroupGroupRoleFm);
+					}
+				},
+				selectEventName: '<portlet:namespace />selectUserGroupsRoles',
 				title: '<liferay-ui:message key="assign-roles" />',
 				url: target.dataset.href,
 			});
-
-			itemSelectorDialog.on('selectedItemChange', function (event) {
-				var selectedItems = event.selectedItem;
-
-				if (selectedItems) {
-					Array.prototype.forEach.call(selectedItems, function (
-						selectedItem,
-						index
-					) {
-						dom.append(addUserGroupGroupRoleFm, selectedItem);
-					});
-
-					submitForm(addUserGroupGroupRoleFm);
-				}
-			});
-
-			itemSelectorDialog.open();
 		});
 	}
 
@@ -155,29 +151,25 @@ UserGroup userGroup = (UserGroup)row.getObject();
 				userGroupId: target.dataset.usergroupid,
 			});
 
-			var itemSelectorDialog = new ItemSelectorDialog.default({
+			Liferay.Util.openSelectionModal({
 				buttonAddLabel: '<liferay-ui:message key="done" />',
-				eventName: '<portlet:namespace />selectUserGroupsRoles',
+				multiple: true,
+				onSelect: function (selectedItems) {
+					if (selectedItems) {
+						Array.prototype.forEach.call(selectedItems, function (
+							selectedItem,
+							index
+						) {
+							dom.append(unassignUserGroupGroupRoleFm, selectedItem);
+						});
+
+						submitForm(unassignUserGroupGroupRoleFm);
+					}
+				},
+				selectEventName: '<portlet:namespace />selectUserGroupsRoles',
 				title: '<liferay-ui:message key="unassign-roles" />',
 				url: target.dataset.href,
 			});
-
-			itemSelectorDialog.on('selectedItemChange', function (event) {
-				var selectedItems = event.selectedItem;
-
-				if (selectedItems) {
-					Array.prototype.forEach.call(selectedItems, function (
-						selectedItem,
-						index
-					) {
-						dom.append(unassignUserGroupGroupRoleFm, selectedItem);
-					});
-
-					submitForm(unassignUserGroupGroupRoleFm);
-				}
-			});
-
-			itemSelectorDialog.open();
 		});
 	}
 </aui:script>

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUserGroupsManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUserGroupsManagementToolbarDefaultEventHandler.es.js
@@ -12,32 +12,30 @@
  * details.
  */
 
-import {DefaultEventHandler, ItemSelectorDialog} from 'frontend-js-web';
+import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
 import dom from 'metal-dom';
 
 class EditTeamAssignmentsUserGroupsManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	selectUserGroup(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: this.ns('selectUserGroup'),
+		openSelectionModal({
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const addTeamUserGroupsFm = this.one(
+						'#addTeamUserGroupsFm'
+					);
+
+					selectedItem.forEach((item) => {
+						dom.append(addTeamUserGroupsFm, item);
+					});
+
+					submitForm(addTeamUserGroupsFm);
+				}
+			},
+			selectEventName: this.ns('selectUserGroup'),
 			title: itemData.title,
 			url: itemData.selectUserGroupURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const addTeamUserGroupsFm = this.one('#addTeamUserGroupsFm');
-
-				selectedItem.forEach((item) => {
-					dom.append(addTeamUserGroupsFm, item);
-				});
-
-				submitForm(addTeamUserGroupsFm);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	deleteUserGroups() {

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUsersManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUsersManagementToolbarDefaultEventHandler.es.js
@@ -12,32 +12,28 @@
  * details.
  */
 
-import {DefaultEventHandler, ItemSelectorDialog} from 'frontend-js-web';
+import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
 import dom from 'metal-dom';
 
 class EditTeamAssignmentsUsersManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	selectUser(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: this.ns('selectUser'),
+		openSelectionModal({
+			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const addTeamUsersFm = this.one('#addTeamUsersFm');
+
+					selectedItem.forEach((item) => {
+						dom.append(addTeamUsersFm, item);
+					});
+
+					submitForm(addTeamUsersFm);
+				}
+			},
+			selectEventName: this.ns('selectUser'),
 			title: itemData.title,
 			url: itemData.selectUserURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const addTeamUsersFm = this.one('#addTeamUsersFm');
-
-				selectedItem.forEach((item) => {
-					dom.append(addTeamUsersFm, item);
-				});
-
-				submitForm(addTeamUsersFm);
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	deleteUsers() {

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_team.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_team.jsp
@@ -115,10 +115,3 @@ SelectTeamDisplayContext selectTeamDisplayContext = new SelectTeamDisplayContext
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectTeamFm',
-		'<%= HtmlUtil.escapeJS(selectTeamDisplayContext.getEventName()) %>'
-	);
-</aui:script>

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/StyleBookEntryDropdownDefaultEventHandler.es.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/StyleBookEntryDropdownDefaultEventHandler.es.js
@@ -14,7 +14,7 @@
 
 import {
 	DefaultEventHandler,
-	ItemSelectorDialog,
+	openSelectionModal,
 	openSimpleInputModal,
 } from 'frontend-js-web';
 import {Config} from 'metal-state';
@@ -75,27 +75,22 @@ class StyleBookEntryDropdownDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	updateStyleBookEntryPreview(itemData) {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: this.ns('changePreview'),
-			singleSelect: true,
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const itemValue = JSON.parse(selectedItem.value);
+
+					this.one('#styleBookEntryId').value =
+						itemData.styleBookEntryId;
+					this.one('#fileEntryId').value = itemValue.fileEntryId;
+
+					submitForm(this.one('#styleBookEntryPreviewFm'));
+				}
+			},
+			selectEventName: this.ns('changePreview'),
 			title: Liferay.Language.get('style-book-thumbnail'),
 			url: itemData.itemSelectorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				const itemValue = JSON.parse(selectedItem.value);
-
-				this.one('#styleBookEntryId').value = itemData.styleBookEntryId;
-				this.one('#fileEntryId').value = itemValue.fileEntryId;
-
-				submitForm(this.one('#styleBookEntryPreviewFm'));
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	_send(url) {

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites.jsp
@@ -263,7 +263,7 @@ portletURL.setParameter("delta", String.valueOf(delta));
 					}
 				);
 
-				Liferay.Util.openModal({
+				Liferay.Util.openSelectionModal({
 					id: '<portlet:namespace />editDefaultFilePermissionsDialog',
 					onSelect: function (selectedItem) {
 						Liferay.Util.fetch(selectedItem.uri, {method: 'POST'})

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites_action.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites_action.jsp
@@ -88,7 +88,7 @@ String groupId = String.valueOf(group.getGroupId());
 			}
 		);
 
-		Liferay.Util.openModal({
+		Liferay.Util.openSelectionModal({
 			id: '<portlet:namespace />editDefaultFilePermissionsDialog',
 			onSelect: function (selectedItem) {
 				Liferay.Util.fetch(selectedItem.uri, {method: 'POST'})

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/js/EntriesDefaultEventHandler.es.js
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/js/EntriesDefaultEventHandler.es.js
@@ -12,26 +12,14 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
+import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
 
 class EntriesDefaultEventHandler extends DefaultEventHandler {
 	moveEntry(itemData) {
 		const instance = this;
 
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					destroyOnHide: true,
-					modal: true,
-					width: 1024,
-				},
-				eventName: this.ns('selectContainer'),
-				id: this.ns('selectContainer'),
-				title: Liferay.Language.get('warning'),
-				uri: itemData.moveEntryURL,
-			},
-			(event) => {
+		openSelectionModal({
+			onSelect: (event) => {
 				const selectContainerForm = document.getElementById(
 					`${instance.namespace}selectContainerForm`
 				);
@@ -74,8 +62,11 @@ class EntriesDefaultEventHandler extends DefaultEventHandler {
 
 					submitForm(selectContainerForm);
 				}
-			}
-		);
+			},
+			selectEventName: this.ns('selectContainer'),
+			title: Liferay.Language.get('warning'),
+			url: itemData.moveEntryURL,
+		});
 	}
 
 	restoreEntry(itemData) {

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group_assignments.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group_assignments.jsp
@@ -135,13 +135,14 @@ PortletURL portletURL = editUserGroupAssignmentsManagementToolbarDisplayContext.
 
 	function <portlet:namespace />addUsers(event) {
 		Liferay.Util.openSelectionModal({
-			onSelect: function(selectedItem) {
+			onSelect: function (selectedItem) {
 				if (selectedItem) {
 					Liferay.Util.postForm(form, {
 						data: {
 							addUserIds: selectedItem,
 						},
-						url: '<portlet:actionURL name="editUserGroupAssignments" />',
+						url:
+							'<portlet:actionURL name="editUserGroupAssignments" />',
 					});
 				}
 			},

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group_assignments.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group_assignments.jsp
@@ -125,7 +125,7 @@ PortletURL portletURL = editUserGroupAssignmentsManagementToolbarDisplayContext.
 	</liferay-ui:search-container>
 </aui:form>
 
-<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
+<aui:script sandbox="<%= true %>">
 	var form = document.<portlet:namespace />fm;
 
 	<portlet:renderURL var="selectUsersURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
@@ -134,27 +134,23 @@ PortletURL portletURL = editUserGroupAssignmentsManagementToolbarDisplayContext.
 	</portlet:renderURL>
 
 	function <portlet:namespace />addUsers(event) {
-		var itemSelectorDialog = new ItemSelectorDialog.default({
-			eventName: '<portlet:namespace />selectUsers',
+		Liferay.Util.openSelectionModal({
+			onSelect: function(selectedItem) {
+				if (selectedItem) {
+					Liferay.Util.postForm(form, {
+						data: {
+							addUserIds: selectedItem,
+						},
+						url: '<portlet:actionURL name="editUserGroupAssignments" />',
+					});
+				}
+			},
+			multiple: true,
+			selectEventName: '<portlet:namespace />selectUsers',
 			title:
 				'<liferay-ui:message arguments="<%= HtmlUtil.escape(userGroup.getName()) %>" key="add-users-to-x" />',
 			url: '<%= selectUsersURL %>',
 		});
-
-		itemSelectorDialog.on('selectedItemChange', function (event) {
-			var selectedItem = event.selectedItem;
-
-			if (selectedItem) {
-				Liferay.Util.postForm(form, {
-					data: {
-						addUserIds: selectedItem,
-					},
-					url: '<portlet:actionURL name="editUserGroupAssignments" />',
-				});
-			}
-		});
-
-		itemSelectorDialog.open();
 	}
 
 	function <portlet:namespace />removeUsers() {

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/select_user_group.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/select_user_group.jsp
@@ -17,8 +17,6 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectUserGroup");
-
 User selUser = PortalUtil.getSelectedUser(request);
 
 SelectUserGroupManagementToolbarDisplayContext selectUserGroupManagementToolbarDisplayContext = new SelectUserGroupManagementToolbarDisplayContext(request, renderRequest, renderResponse);
@@ -95,10 +93,3 @@ renderResponse.setTitle(LanguageUtil.get(request, "user-groups"));
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="aui-base">
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectUserGroupFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/parent_organization.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/parent_organization.jsp
@@ -227,19 +227,8 @@ if (parentOrganization != null) {
 		selectOrganizationLink.on('click', function (event) {
 			var searchContainerData = searchContainer.getData();
 
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						modal: true,
-					},
-					id: '<portlet:namespace />selectOrganization',
-					selectedData: [searchContainerData],
-					title:
-						'<liferay-ui:message arguments="parent-organization" key="select-x" />',
-					uri: '<%= selectOrganizationRenderURL %>',
-				},
-				function (event) {
+			Liferay.Util.openSelectionModal({
+				onSelect: function (event) {
 					var rowColumns = [];
 
 					var href =
@@ -265,8 +254,13 @@ if (parentOrganization != null) {
 					selectOrganizationLinkText.text(
 						'<liferay-ui:message key="change" />'
 					);
-				}
-			);
+				},
+				selectEventName: '<portlet:namespace />selectOrganization',
+				selectedData: [searchContainerData],
+				title:
+					'<liferay-ui:message arguments="parent-organization" key="select-x" />',
+				url: '<%= selectOrganizationRenderURL %>',
+			});
 		});
 	}
 </aui:script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -144,33 +144,8 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 					var searchContainer = Liferay.SearchContainer.get(searchContainerName);
 
-					Liferay.Util.selectEntity(
-						{
-							dialog: {
-								constrain: true,
-								modal: true,
-							},
-
-							<%
-							String regularRoleEventName = liferayPortletResponse.getNamespace() + "selectRegularRole";
-							%>
-
-							id: '<%= regularRoleEventName %>',
-							selectedData: searchContainer.getData(true),
-							title:
-								'<liferay-ui:message arguments="regular-role" key="select-x" />',
-
-							<%
-							PortletURL selectRegularRoleURL = PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE);
-
-							selectRegularRoleURL.setParameter("p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId()));
-							selectRegularRoleURL.setParameter("eventName", regularRoleEventName);
-							selectRegularRoleURL.setWindowState(LiferayWindowState.POP_UP);
-							%>
-
-							uri: '<%= selectRegularRoleURL.toString() %>',
-						},
-						function (event) {
+					Liferay.Util.openSelectionModal({
+						onSelect: function (event) {
 							<portlet:namespace />selectRole(
 								event.entityid,
 								event.entityname,
@@ -179,8 +154,27 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 								event.groupid,
 								event.iconcssclass
 							);
-						}
-					);
+						},
+
+						<%
+						String regularRoleEventName = liferayPortletResponse.getNamespace() + "selectRegularRole";
+						%>
+
+						selectEventName: '<%= regularRoleEventName %>',
+						selectedData: searchContainer.getData(true),
+						title:
+							'<liferay-ui:message arguments="regular-role" key="select-x" />',
+
+						<%
+						PortletURL selectRegularRoleURL = PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE);
+
+						selectRegularRoleURL.setParameter("p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId()));
+						selectRegularRoleURL.setParameter("eventName", regularRoleEventName);
+						selectRegularRoleURL.setWindowState(LiferayWindowState.POP_UP);
+						%>
+
+						url: '<%= selectRegularRoleURL.toString() %>',
+					});
 				});
 			}
 		</aui:script>
@@ -396,36 +390,8 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 					var searchContainer = Liferay.SearchContainer.get(searchContainerName);
 
-					Liferay.Util.selectEntity(
-						{
-							dialog: {
-								constrain: true,
-								modal: true,
-							},
-
-							<%
-							String organizationRoleEventName = liferayPortletResponse.getNamespace() + "selectOrganizationRole";
-							%>
-
-							id: '<%= organizationRoleEventName %>',
-							selectedData: searchContainer.getData(true),
-							title:
-								'<liferay-ui:message arguments="organization-role" key="select-x" />',
-
-							<%
-							PortletURL selectOrganizationRoleURL = PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE);
-
-							selectOrganizationRoleURL.setParameter("p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId()));
-							selectOrganizationRoleURL.setParameter("step", "1");
-							selectOrganizationRoleURL.setParameter("roleType", String.valueOf(RoleConstants.TYPE_ORGANIZATION));
-							selectOrganizationRoleURL.setParameter("organizationIds", StringUtil.merge(organizationIds));
-							selectOrganizationRoleURL.setParameter("eventName", organizationRoleEventName);
-							selectOrganizationRoleURL.setWindowState(LiferayWindowState.POP_UP);
-							%>
-
-							uri: '<%= selectOrganizationRoleURL.toString() %>',
-						},
-						function (event) {
+					Liferay.Util.openSelectionModal({
+						onSelect: function (event) {
 							<portlet:namespace />selectRole(
 								event.entityid,
 								event.entityname,
@@ -434,8 +400,30 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 								event.groupid,
 								event.iconcssclass
 							);
-						}
-					);
+						},
+
+						<%
+						String organizationRoleEventName = liferayPortletResponse.getNamespace() + "selectOrganizationRole";
+						%>
+
+						selectEventName: '<%= organizationRoleEventName %>',
+						selectedData: searchContainer.getData(true),
+						title:
+							'<liferay-ui:message arguments="organization-role" key="select-x" />',
+
+						<%
+						PortletURL selectOrganizationRoleURL = PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE);
+
+						selectOrganizationRoleURL.setParameter("p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId()));
+						selectOrganizationRoleURL.setParameter("step", "1");
+						selectOrganizationRoleURL.setParameter("roleType", String.valueOf(RoleConstants.TYPE_ORGANIZATION));
+						selectOrganizationRoleURL.setParameter("organizationIds", StringUtil.merge(organizationIds));
+						selectOrganizationRoleURL.setParameter("eventName", organizationRoleEventName);
+						selectOrganizationRoleURL.setWindowState(LiferayWindowState.POP_UP);
+						%>
+
+						url: '<%= selectOrganizationRoleURL.toString() %>',
+					});
 				});
 			}
 		</aui:script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -307,53 +307,44 @@ else {
 			}
 		);
 
-		Liferay.Loader.require(
-			'frontend-js-web/liferay/ItemSelectorDialog.es',
-			function (ItemSelectorDialog) {
-				var itemSelectorDialog = new ItemSelectorDialog.default({
-					buttonAddLabel: '<liferay-ui:message key="done" />',
-					eventName: '<portlet:namespace />selectUsers',
-					title: '<liferay-ui:message key="assign-users" />',
-					url: selectUsersURL.toString(),
-				});
+		Liferay.Util.openSelectionModal({
+			buttonAddLabel: '<liferay-ui:message key="done" />',
+			multiple: true,
+			onSelect: function(data) {
+				if (data) {
+					<portlet:renderURL var="assignmentsURL">
+						<portlet:param name="mvcRenderCommandName" value="/users_admin/view" />
+						<portlet:param name="toolbarItem" value="view-all-organizations" />
+						<portlet:param name="usersListView" value="<%= UserConstants.LIST_VIEW_TREE %>" />
+					</portlet:renderURL>
 
-				itemSelectorDialog.on('selectedItemChange', function (event) {
-					var data = event.selectedItem;
-
-					if (data) {
-						<portlet:renderURL var="assignmentsURL">
-							<portlet:param name="mvcRenderCommandName" value="/users_admin/view" />
-							<portlet:param name="toolbarItem" value="view-all-organizations" />
-							<portlet:param name="usersListView" value="<%= UserConstants.LIST_VIEW_TREE %>" />
-						</portlet:renderURL>
-
-						var assignmentsRedirectURL = Liferay.Util.PortletURL.createPortletURL(
-							'<%= assignmentsURL.toString() %>',
-							{
-								organizationId: organizationId,
-							}
-						);
-
-						var editAssignmentParameters = {
-							addUserIds: data.value,
-							assignmentsRedirect: assignmentsRedirectURL.toString(),
+					var assignmentsRedirectURL = Liferay.Util.PortletURL.createPortletURL(
+						'<%= assignmentsURL.toString() %>',
+						{
 							organizationId: organizationId,
-						};
+						}
+					);
 
-						var editAssignmentURL = Liferay.Util.PortletURL.createPortletURL(
-							'<portlet:actionURL name="/users_admin/edit_organization_assignments" />',
-							editAssignmentParameters
-						);
+					var editAssignmentParameters = {
+						addUserIds: data.value,
+						assignmentsRedirect: assignmentsRedirectURL.toString(),
+						organizationId: organizationId,
+					};
 
-						submitForm(
-							document.<portlet:namespace />fm,
-							editAssignmentURL.toString()
-						);
-					}
-				});
+					var editAssignmentURL = Liferay.Util.PortletURL.createPortletURL(
+						'<portlet:actionURL name="/users_admin/edit_organization_assignments" />',
+						editAssignmentParameters
+					);
 
-				itemSelectorDialog.open();
-			}
-		);
+					submitForm(
+						document.<portlet:namespace />fm,
+						editAssignmentURL.toString()
+					);
+				}
+			},
+			selectEventName: '<portlet:namespace />selectUsers',
+			title: '<liferay-ui:message key="assign-users" />',
+			url: selectUsersURL.toString(),
+		});
 	};
 </aui:script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -310,7 +310,7 @@ else {
 		Liferay.Util.openSelectionModal({
 			buttonAddLabel: '<liferay-ui:message key="done" />',
 			multiple: true,
-			onSelect: function(data) {
+			onSelect: function (data) {
 				if (data) {
 					<portlet:renderURL var="assignmentsURL">
 						<portlet:param name="mvcRenderCommandName" value="/users_admin/view" />

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/compare_versions_pop_up.jspf
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/compare_versions_pop_up.jspf
@@ -18,19 +18,8 @@
 	dom.delegate(document.body, 'click', '.compare-to-link > a', function (event) {
 		var currentTarget = event.delegateTarget;
 
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					destroyOnHide: true,
-					modal: true,
-				},
-				eventName: '<portlet:namespace />selectVersionFm',
-				id: '<portlet:namespace />compareVersions' + currentTarget.id,
-				title: '<liferay-ui:message key="compare-versions" />',
-				uri: currentTarget.dataset.uri,
-			},
-			function (event) {
+		Liferay.Util.openSelectionModal({
+			onSelect: function (event) {
 				<portlet:renderURL var="compareVersionURL">
 					<portlet:param name="mvcRenderCommandName" value="/wiki/compare_versions" />
 					<portlet:param name="backURL" value="<%= currentURL %>" />
@@ -51,7 +40,10 @@
 				);
 
 				location.href = uri;
-			}
-		);
+			},
+			selectEventName: '<portlet:namespace />selectVersionFm',
+			title: '<liferay-ui:message key="compare-versions" />',
+			url: currentTarget.dataset.uri,
+		});
 	});
 </aui:script>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/select_version.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/select_version.jsp
@@ -20,7 +20,6 @@
 WikiPage wikiPage = (WikiPage)request.getAttribute(WikiWebKeys.WIKI_PAGE);
 
 double sourceVersion = ParamUtil.getDouble(request, "sourceVersion");
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectVersionFm");
 
 PortletURL portletURL = renderResponse.createRenderURL();
 
@@ -96,10 +95,3 @@ portletURL.setParameter("sourceVersion", String.valueOf(sourceVersion));
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectVersionFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>

--- a/portal-web/test/functional/com/liferay/portalweb/functions/Click.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/Click.function
@@ -194,7 +194,7 @@ definition {
 		);
 
 		if (selenium.isElementPresent("//iframe[not(contains(@class,'hidden'))]")) {
-			selenium.selectFrame("//iframe");
+			selenium.selectFrame("//iframe[not(contains(@class,'hidden'))]");
 		}
 
 		selenium.pause("3000");

--- a/portal-web/test/functional/com/liferay/portalweb/functions/Click.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/Click.function
@@ -193,8 +193,8 @@ definition {
 			"//script[contains(@src,'/o/frontend-js-aui-web/liferay/menu_toggle.js')]"
 		);
 
-		if (selenium.isElementPresent("//iframe[not(contains(@class,'hidden'))]")) {
-			selenium.selectFrame("//iframe[not(contains(@class,'hidden'))]");
+		if (selenium.isElementPresent("//*[contains(@class,'modal-body')]/iframe[not(contains(@class,'hidden'))]")) {
+			selenium.selectFrame("//*[contains(@class,'modal-body')]/iframe[not(contains(@class,'hidden'))]");
 		}
 
 		selenium.pause("3000");

--- a/portal-web/test/functional/com/liferay/portalweb/functions/SelectFrame.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/SelectFrame.function
@@ -54,10 +54,7 @@ definition {
 
 	function selectSecondFrame {
 		if (contains("${locator1}", "/iframe")) {
-			WaitForLiferayEvent(
-				attributeName = "src",
-				attributeValue = "dialog-iframe-popup",
-				eventName = "modalIframeLoaded");
+			selenium.waitForVisible();
 
 			selenium.mouseOver();
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -412,7 +412,7 @@ definition {
 		SelectFrame(value1 = "relative=top");
 
 		if (isSet(kbFolderName)) {
-			SelectFrame(locator1 = "KnowledgeBaseSelectParent#SELECT_PARENT_DISPLAY_IFRAME");
+			Modal.selectFrameSpecific(modalTitle = "Select Entry");
 
 			AssertClick(
 				key_kbFolderName = "${kbFolderName}",
@@ -422,7 +422,7 @@ definition {
 			SelectFrame(value1 = "relative=top");
 		}
 
-		SelectFrame(locator1 = "KnowledgeBaseSelectParent#SELECT_PARENT_DISPLAY_IFRAME");
+		Modal.selectFrameSpecific(modalTitle = "Select Entry");
 
 		Click(
 			key_kbArticleTitle = "${kbArticleTitle}",
@@ -487,7 +487,7 @@ definition {
 
 		SelectFrame(value1 = "relative=top");
 
-		SelectFrame(locator1 = "KnowledgeBaseSelectParent#SELECT_PARENT_DISPLAY_IFRAME");
+		Modal.selectFrameSpecific(modalTitle = "Select Entry");
 
 		AssertClick(
 			key_kbFolderName = "${kbFolderName}",
@@ -970,7 +970,7 @@ definition {
 
 		SelectFrame(value1 = "relative=top");
 
-		SelectFrame(locator1 = "KnowledgeBaseSelectParent#SELECT_PARENT_DISPLAY_IFRAME");
+		Modal.selectFrameSpecific(modalTitle = "Select Entry");
 
 		AssertClick(
 			key_kbArticleTitle = "${kbArticleTitle}",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -409,10 +409,8 @@ definition {
 			locator1 = "Button#SELECT",
 			value1 = "Select");
 
-		SelectFrame(value1 = "relative=top");
-
 		if (isSet(kbFolderName)) {
-			Modal.selectFrameSpecific(modalTitle = "Select Entry");
+			SelectFrame.selectFrameNoLoading(locator1 = "IFrame#MODAL_BODY");
 
 			AssertClick(
 				key_kbFolderName = "${kbFolderName}",
@@ -422,7 +420,7 @@ definition {
 			SelectFrame(value1 = "relative=top");
 		}
 
-		Modal.selectFrameSpecific(modalTitle = "Select Entry");
+		SelectFrame.selectFrameNoLoading(locator1 = "IFrame#MODAL_BODY");
 
 		Click(
 			key_kbArticleTitle = "${kbArticleTitle}",
@@ -485,9 +483,7 @@ definition {
 			locator1 = "Button#SELECT",
 			value1 = "Select");
 
-		SelectFrame(value1 = "relative=top");
-
-		Modal.selectFrameSpecific(modalTitle = "Select Entry");
+		SelectFrame.selectFrameNoLoading(locator1 = "IFrame#MODAL_BODY");
 
 		AssertClick(
 			key_kbFolderName = "${kbFolderName}",
@@ -968,9 +964,7 @@ definition {
 			locator1 = "Button#SELECT",
 			value1 = "Select");
 
-		SelectFrame(value1 = "relative=top");
-
-		Modal.selectFrameSpecific(modalTitle = "Select Entry");
+		SelectFrame.selectFrameNoLoading(locator1 = "IFrame#MODAL_BODY");
 
 		AssertClick(
 			key_kbArticleTitle = "${kbArticleTitle}",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Modal.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Modal.macro
@@ -6,4 +6,10 @@ definition {
 		Alert.viewSuccessMessage();
 	}
 
+	macro selectFrameSpecific {
+		SelectFrame(
+			locator1 = "IFrame#MODAL_ANY"
+			key_title = "${modalTitle}"
+		);
+	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Modal.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Modal.macro
@@ -8,8 +8,8 @@ definition {
 
 	macro selectFrameSpecific {
 		SelectFrame(
-			locator1 = "IFrame#MODAL_ANY"
-			key_title = "${modalTitle}"
-		);
+			key_title = "${modalTitle}",
+			locator1 = "IFrame#MODAL_ANY");
 	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/asset/assetpublisher/AssetPublisherPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/asset/assetpublisher/AssetPublisherPortlet.macro
@@ -380,11 +380,9 @@ definition {
 				locator1 = "APConfiguration#ASSET_SELECTION_MANUAL_ASSET_ENTRIES_ASSET",
 				value1 = "${assetType}");
 
-			SelectFrameTop();
-
 			WaitForElementPresent(locator1 = "APConfigurationManual#ASSET_SELECTION_MANUAL_SELECT_ASSET_ENTRIES_DIALOG");
 
-			SelectFrame(locator1 = "IFrame#MODAL_BODY");
+			SelectFrame.selectFrameNoLoading(locator1 = "IFrame#MODAL_BODY");
 
 			var key_assetTitle = "${assetTitle}";
 
@@ -394,9 +392,9 @@ definition {
 
 			SelectFrameTop();
 
-			Button.clickAdd();
+			SelectFrame(locator1 = "IFrame#CONFIGURATION");
 
-			SelectFrame(locator1 = "IFrame#MODAL_BODY");
+			Button.clickAdd();
 		}
 
 		Alert.viewSuccessMessage();
@@ -847,9 +845,7 @@ definition {
 
 		Button.clickSelect();
 
-		SelectFrameTop();
-
-		SelectFrame(locator1 = "IFrame#ASSET_LIST_DIALOG");
+		SelectFrame.selectFrameNoLoading(locator1 = "IFrame#ASSET_LIST_DIALOG");
 
 		if (isSet(depotName)) {
 			AssertClick(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/webcontentdisplay/WebContentDisplayPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/webcontentdisplay/WebContentDisplayPortlet.macro
@@ -288,11 +288,9 @@ definition {
 			locator1 = "WCDConfiguration#SELECT_WEB_CONTENT_BUTTON",
 			value1 = "Select");
 
-		SelectFrame(value1 = "relative=top");
-
 		WaitForElementPresent(locator1 = "IFrame#MODAL_BODY");
 
-		SelectFrame(locator1 = "IFrame#MODAL_BODY");
+		SelectFrame.selectFrameNoLoading(locator1 = "IFrame#MODAL_BODY");
 
 		Click(
 			key_breadcrumbName = "Sites",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/webcontentdisplay/WebContentDisplayPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/webcontentdisplay/WebContentDisplayPortlet.macro
@@ -337,11 +337,9 @@ definition {
 			locator1 = "WCDConfiguration#SELECT_WEB_CONTENT_BUTTON",
 			value1 = "Select");
 
-		SelectFrame(value1 = "relative=top");
-
 		WaitForElementPresent(locator1 = "IFrame#MODAL_BODY");
 
-		SelectFrame(locator1 = "IFrame#MODAL_BODY");
+		SelectFrame.selectFrameNoLoading(locator1 = "IFrame#MODAL_BODY");
 
 		if (isSet(depotName)) {
 			var key_rowEntry = "${webContentTitle}";

--- a/portal-web/test/functional/com/liferay/portalweb/macros/sitenavigation/sitenavigationmenu/NavigationMenusWidget.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/sitenavigation/sitenavigationmenu/NavigationMenusWidget.macro
@@ -5,8 +5,6 @@ definition {
 
 		Click.pauseClickAt(locator1 = "Button#SELECT");
 
-		SelectFrame(value1 = "relative=top");
-
 		SelectFrame.selectSecondFrame(locator1 = "IFrame#MODAL_BODY");
 
 		Click(

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/IFrame.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/IFrame.path
@@ -124,6 +124,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>MODAL_ANY</td>
+	<td>//*[contains(@class,'modal-dialog') and contains(.,'${key_title}')]//iframe</td>
+	<td></td>
+</tr>
+<tr>
 	<td>PAGE_VARIATION_IFRAME</td>
 	<td>//iframe[contains(@id,'pagesVariationsDialog_iframe_')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/IFrame.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/IFrame.path
@@ -50,7 +50,7 @@
 </tr>
 <tr>
 	<td>ASSET_LIST_DIALOG</td>
-	<td>//iframe[contains(@class,'dialog-iframe-node') and contains(@id,'selectAssetList_iframe')]</td>
+	<td>//iframe[contains(@id,'selectAssetList_iframe')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavBar.path
@@ -60,7 +60,7 @@
 </tr>
 <tr>
 	<td>MY_SITES</td>
-	<td>//*[contains(@class,'nav-link') and contains(.,'My Sites')]</td>
+	<td>//*[contains(@class,'navbar')]//a[normalize-space()='My Sites']</td>
 	<td></td>
 </tr>
 <tr>
@@ -80,7 +80,7 @@
 </tr>
 <tr>
 	<td>RECENT</td>
-	<td>//button[contains(@class,'navbar-toggler')]/span[contains(.,'Recent')]</td>
+	<td>//*[contains(@class,'navbar')]//a[normalize-space()='Recent']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfigurationManual.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfigurationManual.path
@@ -20,7 +20,7 @@
 </tr>
 <tr>
 	<td>ASSET_SELECTION_MANUAL_SELECT_ASSET_ENTRIES_DIALOG</td>
-	<td>//div[contains(@id,'selectAsset') and contains(@class,'dialog-iframe-modal')]</td>
+	<td>//*[contains(@id,'selectAsset')]//*[contains(@class,'modal-dialog')]</td>
 	<td></td>
 </tr>
 </tbody>


### PR DESCRIPTION
Okay... so this is maybe an over-reach to fix [Flickering styles in modals](https://issues.liferay.com/browse/LPS-117488). I had this cooking for a while on the side... I'm just sad @markocikos isn't around to greenlight this 😢 

**This PR:**
- Creates a new `openSelectionModal` utility on top of our current `openModal` to simplify and consolidate item selection
    - As a first step, this simplifies `openModal` and decouples it from the `selection` logic
- Replaces existing usages of `openModal` + `selectEventName` (since the selection logic lives now up in the chain)
- Replaces usages of `ItemSelectorDialog` with `openSelectionModal` (both single and multiple selection)
    - As a side-effect, we remove completely the `ItemSelectorDialog` component and the weird 3-step invocation pattern
- Replaces usages of `Liferay.Util.selectEntity` with `openSelectionModal`
    - As a side effect, this should allow us to also deprecate this API

**Benefits:**
- Consistent item selection throughout DXP. This was a key item in `7.2` that we're in risk of regressing in `7.3`, which is what really pushed me to try to get it in.
- Reduced number of patterns to do the same thing (easier to document and enforce in the future)

**How to test it:**
After this change, this can be tested almost everywhere we "select" things, though the ones in the issue report should be enough to see the changes:

- Go to Global Menu > Content Dashboard
- Filter by Author or Subtype

- Go to Web Content
- Create a Web Content
- Select a display page template

After the change, the selection would be achieved through a Clay Modal (animation and everything) and styles won't flicker since all the css classes are in place and content is not shown until the iframe is done loading.

Going to mention some teams here today and personally tomorrow so we can validate this, but ideally we should push this asap to have enough time to stabilize.
- Hey @liferay-lima, hope you're okay with us removing the `ItemSelectorDialog` component. I know we discussed in the past where this should live, so maybe this makes sense to you? We're still using all the `ItemSelector` infra, just opening them through other means.
- Hey @bryceosterhaus, it was here where I "noticed" the iframe performance regression I mentioned at [Improve Iframe loading perceived performance](https://issues.liferay.com/browse/LPS-118805). This could be just subjective, but while I was changing modals and checking they worked, they felt slower to me. Could you maybe identify some modals here and try before and after to get a feeling for yourself?
- Hey @john-co, @PablitoBonito, I ran a couple of test suites at https://github.com/jbalsas/liferay-portal/pull/2226#issuecomment-674895777. Most of the failures are apparently just iframe locators. Could we prioritize this in a way that we can get this **merged asap**?

Thanks everyone! 🤞 

/cc @matuzalemsteles, @diegonvs, @brunobasto, could you give this a try, check test failures and see how safe this feels? :)