### PR TITLE
LPS-115016 Fixes CI

### DIFF
--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/package.json
@@ -13,5 +13,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "1.0.18"
+	"version": "3.0.0"
 }


### PR DESCRIPTION
ci:test:relevant is failing after https://github.com/liferay/liferay-portal/commit/50dbb25b7ea93a49ff1097d342544ffe3b5ac1a7#diff-093858e4a67d6c82a58a07fd25a0a6a6 because the version in package.json for frontend-js-tooltip-support-web is now different than the one on the bnd.

This PR fixes that.