### PR TITLE
LPS-118809: Line breaks disappear when selecting a user from mention.

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/autocomplete/autocomplete.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/autocomplete/autocomplete.js
@@ -376,7 +376,15 @@
 
 			newElement.replace(replaceContainer);
 
-			var nextElement = newElement.getNext();
+			var nextElement = newElement.getNext(function () {
+				return (
+					this.type !== CKEDITOR.NODE_TEXT || this.getText().trim()
+				);
+			});
+
+			if (nextElement && nextElement.$.nodeName === 'BR') {
+				nextElement = null;
+			}
 
 			if (nextElement) {
 				var containerAscendant = instance._getContainerAscendant(


### PR DESCRIPTION
From: @dinh-thai

> This issue relate to the changed of ticket https://issues.liferay.com/browse/LPS-47033.
> The current logic code is after autocomplete, it will remove next node if that node not include white space.