### PR TITLE
LPS-119280 The height of the textarea with autosize in blogs title does not initialize

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/autosize/autosize.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/autosize/autosize.es.js
@@ -38,12 +38,11 @@ class AutoSize {
 
 		this.template.innerHTML = inputElement.value + DEFAULT_APPEND_CONTENT;
 
-		const height =
+		inputElement.style.height = `${
 			this.template.scrollHeight < this.minHeight
 				? this.minHeight
-				: this.template.scrollHeight;
-
-		inputElement.style.height = height + 'px';
+				: this.template.scrollHeight
+		}px`;
 	}
 
 	createTemplate(computedStyle) {
@@ -75,9 +74,7 @@ class AutoSize {
 
 	handleInput = (event) => {
 		requestAnimationFrame(() => {
-			const target = event.target;
-
-			this._resizeInput(target);
+			this._resizeInput(event.target);
 		});
 	};
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/autosize/autosize.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/autosize/autosize.es.js
@@ -28,6 +28,22 @@ class AutoSize {
 		document.body.appendChild(this.template);
 
 		this.inputElement.addEventListener('input', this.handleInput);
+		this._resizeInput(this.inputElement);
+	}
+
+	_resizeInput(inputElement) {
+		if (this.template.style.width !== this.computedStyle.width) {
+			this.template.style.width = this.computedStyle.width;
+		}
+
+		this.template.innerHTML = inputElement.value + DEFAULT_APPEND_CONTENT;
+
+		const height =
+			this.template.scrollHeight < this.minHeight
+				? this.minHeight
+				: this.template.scrollHeight;
+
+		inputElement.style.height = height + 'px';
 	}
 
 	createTemplate(computedStyle) {
@@ -60,20 +76,8 @@ class AutoSize {
 	handleInput = (event) => {
 		requestAnimationFrame(() => {
 			const target = event.target;
-			const value = target.value;
 
-			if (this.template.style.width !== this.computedStyle.width) {
-				this.template.style.width = this.computedStyle.width;
-			}
-
-			this.template.innerHTML = value + DEFAULT_APPEND_CONTENT;
-
-			const height =
-				this.template.scrollHeight < this.minHeight
-					? this.minHeight
-					: this.template.scrollHeight;
-
-			target.style.height = height + 'px';
+			this._resizeInput(target);
 		});
 	};
 }


### PR DESCRIPTION
**Steps to reproduce:**

1. Add a blog entry
2. Add a long title (ex: 100 characters)
3. Add some content
4. Publish entry
5. Edit the same entry
 

**Before fix:**
The field has insufficient height until you change anything in the title field.

![image](https://user-images.githubusercontent.com/67901/90609316-26fbbc80-e204-11ea-9d3d-7d50efc841d4.png)

**After fix:**
The title field has the correct height.

![image](https://user-images.githubusercontent.com/67901/90609255-121f2900-e204-11ea-8f93-68df488c1d46.png)


