### PR TITLE
LPS-118801 Properly cleanup CKEditor and AlloyEditor resources on navigation

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -241,6 +241,10 @@ name = HtmlUtil.escapeJS(name);
 		alloyEditor = new A.LiferayAlloyEditor({
 			contents: '<%= HtmlUtil.escapeJS(contents) %>',
 			editorConfig: editorConfig,
+			editorPaths: [
+				'<%= PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR) %>',
+				'<%= PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_ALLOYEDITOR) %>',
+			],
 			namespace: '<%= name %>',
 
 			<c:if test="<%= Validator.isNotNull(onBlurMethod) %>">

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
@@ -36,6 +36,11 @@ AUI.add(
 					value: {},
 				},
 
+				editorPaths: {
+					validator: Lang.isArray,
+					value: [],
+				},
+
 				onBlurMethod: {
 					getter: '_getEditorMethod',
 					validator: '_validateEditorMethod',
@@ -325,6 +330,21 @@ AUI.add(
 
 						doc.designMode = 'off';
 					}
+
+					// LPS-118801
+
+					instance.get('editorPaths').forEach((editorPath) => {
+						document
+							.querySelectorAll(
+								`link[href*="${editorPath}"],script[src*="${editorPath}"]`
+							)
+							.forEach((tag) => {
+								tag.setAttribute(
+									'data-senna-track',
+									'temporary'
+								);
+							});
+					});
 				},
 
 				_onKey(event) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -513,6 +513,23 @@ name = HtmlUtil.escapeJS(name);
 				if (instanceReady) {
 					initData();
 				}
+
+				// LPS-118801
+
+				var editorPath =
+					'<%= HtmlUtil.escapeJS(PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR)) %>';
+
+				document
+					.querySelectorAll(
+						'link[href*="' +
+							editorPath +
+							'"],script[src*="' +
+							editorPath +
+							'"]'
+					)
+					.forEach(function (tag) {
+						tag.setAttribute('data-senna-track', 'temporary');
+					});
 			});
 		</c:if>
 


### PR DESCRIPTION
Pretty self explanatory (I think) fix for [CKEditor - toolbar icons shake while hovering mouse over them - [inconsistent in CP admin pages]](https://issues.liferay.com/browse/LPS-118801). 

**The issue**
- When navigating from one page to another, dynamically loaded CKEditor or AlloyEditor resources are not cleaned up.
- This caused style conflicts between CKEditor's `moono-lexicon` skin and AlloyEditor's `moono-lisa`.

**The solution**
Mark all resources added to the page as `data-senna-track="temporary"` so they're disposed on navigation.