### PR TITLE
LPS-119175 Diff version compartor has not enough space/paddings

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_diff_version_comparator.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_diff_version_comparator.scss
@@ -16,6 +16,17 @@
 
 	.diff-target-selector {
 		border-left: 1px solid transparent;
+		padding-left: 30px;
+	}
+
+	.diff-container-column {
+		.diff-container {
+			min-height: 400px;
+		}
+
+		.legend-item {
+			margin-right: 15px;
+		}
 	}
 
 	.divider {

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/components/Diff.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/components/Diff.js
@@ -20,7 +20,7 @@ export default function Diff({diff, onClose, version}) {
 	return (
 		<ClayCard className="diff-container-column">
 			{version && (
-				<ClayCard.Row className="card-row-padded diff-version-filter">
+				<ClayCard.Row className="card-body diff-version-filter">
 					<div className="autofit-row">
 						<div className="autofit-col autofit-col-expand">
 							<ClayCard.Description displayType="title">
@@ -43,14 +43,14 @@ export default function Diff({diff, onClose, version}) {
 				</ClayCard.Row>
 			)}
 
-			<ClayCard.Row className="card-row-padded diff-container">
+			<ClayCard.Row className="card-body diff-container">
 				<div
 					className="taglib-diff-html"
 					dangerouslySetInnerHTML={{__html: diff}}
 				/>
 			</ClayCard.Row>
 
-			<ClayCard.Row className="card-row-padded taglib-diff-html">
+			<ClayCard.Row className="card-body taglib-diff-html">
 				<span className="diff-html-added legend-item">
 					{Liferay.Language.get('added')}
 				</span>


### PR DESCRIPTION
**Steps to reproduce:**

1. Add a wiki page
2. Edit to page to create another version
3. Navigate to page info > Versions > Compare
4. Compare to 1.1 to 1.0
5. View comparison table that appears

**Before the fix:**

No padding in the card, nor the legends. 
![wiki comparison actual](https://user-images.githubusercontent.com/8373764/90627972-10ae2a80-e21d-11ea-9f6e-71ab4a58cf14.PNG)


**After the fix:** 
The legend text is spaced properly. The diff section has more height and padding (similar in 7.1 version)

<img width="1125" alt="Screenshot 2020-08-19 at 13 09 24" src="https://user-images.githubusercontent.com/8373764/90628063-3affe800-e21d-11ea-8c7a-c8d0094bc286.png">
