### PR TITLE
LPS-119377 Update the version of ClayPopover to 3.4.5

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -29,7 +29,7 @@
 		"@clayui/pagination": "3.2.5",
 		"@clayui/pagination-bar": "3.1.9",
 		"@clayui/panel": "3.2.3",
-		"@clayui/popover": "3.4.4",
+		"@clayui/popover": "3.4.5",
 		"@clayui/progress-bar": "3.1.0",
 		"@clayui/shared": "3.2.1",
 		"@clayui/slider": "3.2.0",

--- a/modules/apps/questions/questions-web/package.json
+++ b/modules/apps/questions/questions-web/package.json
@@ -11,7 +11,7 @@
 		"@clayui/loading-indicator": "3.1.0",
 		"@clayui/modal": "3.6.5",
 		"@clayui/navigation-bar": "3.2.3",
-		"@clayui/popover": "3.4.4",
+		"@clayui/popover": "3.4.5",
 		"@clayui/sticker": "3.2.0",
 		"@clayui/tooltip": "3.3.3",
 		"asset-taglib": "*",

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/package.json
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/package.json
@@ -7,7 +7,7 @@
 		"@clayui/icon": "3.0.5",
 		"@clayui/link": "3.2.0",
 		"@clayui/modal": "3.6.5",
-		"@clayui/popover": "3.4.4",
+		"@clayui/popover": "3.4.5",
 		"@clayui/tooltip": "3.3.3",
 		"classnames": "2.2.6",
 		"frontend-js-react-web": "*",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1372,10 +1372,10 @@
     "@clayui/shared" "^3.2.1"
     classnames "^2.2.6"
 
-"@clayui/popover@3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@clayui/popover/-/popover-3.4.4.tgz#b35255e865f02a16ebc5bd8a564d55ab6067ef1c"
-  integrity sha512-EPZgpoKQnFCUJSzOMOnz7O8+SXE8ZrTLKLwfrHtGVmsBAxVl9rwNnPeUOoRrxozFLTxNlwJSMu3n23NSJRbw9w==
+"@clayui/popover@3.4.5":
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/@clayui/popover/-/popover-3.4.5.tgz#d87aaa8f570f057de27b938b2a075492e662c7e0"
+  integrity sha512-O/epC4ebfXLyCGzUYVFZOGdJlVo6XmTaHoA6MMfqN9eWDcD0DsSrXPbZ8cxvfb/8YBvhp3VX9Z1TIoFt8u8c2Q==
   dependencies:
     "@clayui/shared" "^3.2.1"
     classnames "^2.2.6"


### PR DESCRIPTION
This update is only for the `@clayui/popover` package that includes the https://github.com/liferay/clay/issues/3625 fix to unlock the App Builder team with an FP5.