### PR TITLE
LPS-115866 Disables AUI Preload Setting by default

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/configuration/AUIConfiguration.java
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/configuration/AUIConfiguration.java
@@ -38,7 +38,7 @@ public interface AUIConfiguration {
 	 * @review
 	 */
 	@Meta.AD(
-		deflt = "true", description = "enable-aui-preload-description",
+		deflt = "false", description = "enable-aui-preload-description",
 		name = "enable-aui-preload", required = false
 	)
 	public boolean enableAUIPreload();


### PR DESCRIPTION
This could technically be a Breaking Change for code not properly declaring their dependencies, so I added a note about it.

This PR basically just flips the switch on some AUI modules being loaded by default in every page. Below are some performance metrics (values not to be taken literally but as a mere indicator of progress).

| Device | Before | After |
| --- | --- | --- |
| Phone | <img width="772" alt="Screen Shot 2020-08-20 at 10 11 10" src="https://user-images.githubusercontent.com/905006/90753545-a9ea4900-e2d0-11ea-8110-bcd8c30c1ef5.png"> | <img width="764" alt="Screen Shot 2020-08-20 at 10 14 13" src="https://user-images.githubusercontent.com/905006/90753562-ace53980-e2d0-11ea-9ba7-d481a1e4ce88.png"> |
| Desktop | <img width="792" alt="Screen Shot 2020-08-20 at 10 10 44" src="https://user-images.githubusercontent.com/905006/90753602-b79fce80-e2d0-11ea-831c-bfade864ec73.png"> | <img width="764" alt="Screen Shot 2020-08-20 at 10 15 02" src="https://user-images.githubusercontent.com/905006/90753625-be2e4600-e2d0-11ea-80e2-6360678dec6f.png"> |

Just for reference, we were waiting to flip the switch to avoid issues backporting... but let's look at this carefully just in case :)