### PR TITLE
LPS-115271 Adds IntersectionObserver polyfill for IE

### DIFF
--- a/modules/apps/frontend-compatibility/frontend-compatibility-ie/build.gradle
+++ b/modules/apps/frontend-compatibility/frontend-compatibility-ie/build.gradle
@@ -7,6 +7,7 @@ configurations {
 
 task buildCoreJSBundle(type: Copy)
 task buildFetch(type: Copy)
+task buildIntersectionObserver(type: Copy)
 
 buildCSS {
 	imports = [
@@ -49,9 +50,18 @@ buildFetch {
 	into "classes/META-INF/resources"
 }
 
+buildIntersectionObserver {
+	from new File(npmInstall.nodeModulesDir, "intersection-observer")
+
+	include "intersection-observer.js"
+
+	into "classes/META-INF/resources"
+}
+
 classes {
 	dependsOn buildCoreJSBundle
 	dependsOn buildFetch
+	dependsOn buildIntersectionObserver
 }
 
 dependencies {

--- a/modules/apps/frontend-compatibility/frontend-compatibility-ie/package.json
+++ b/modules/apps/frontend-compatibility/frontend-compatibility-ie/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
-		"@clayui/css": "3.17.0"
+		"@clayui/css": "3.17.0",
+		"intersection-observer": "0.11.0"
 	},
 	"name": "frontend-compatibility-ie",
 	"private": true,

--- a/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
+++ b/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
@@ -95,7 +95,8 @@ public class IETopHeadDynamicInclude extends BaseDynamicInclude {
 
 	private static final String[] _JS_FILE_NAMES = {
 		"closest.js", "control.menu.js", "core-js-bundle.min.js", "fetch.js",
-		"remove.js", "svg.contains.js", "uint16array.slice.js"
+		"intersection-observer.js", "remove.js", "svg.contains.js",
+		"uint16array.slice.js"
 	};
 
 	@Reference

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -10342,6 +10342,11 @@ interpret@^2.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.0.0.tgz#b783ffac0b8371503e9ab39561df223286aa5433"
   integrity sha512-e0/LknJ8wpMMhTiWcjivB+ESwIuvHnBSlBbmP/pSb8CQJldoj1p2qv7xGZ/+BtbTziYRFSz8OsvdbiX45LtYQA==
 
+intersection-observer@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.11.0.tgz#f4ea067070326f68393ee161cc0a2ca4c0040c6f"
+  integrity sha512-KZArj2QVnmdud9zTpKf279m2bbGfG+4/kn16UU0NL3pTVl52ZHiJ9IRNSsnn6jaHrL9EGLFM5eWjTx2fz/+zoQ==
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"


### PR DESCRIPTION
Added the polyfill from https://github.com/w3c/IntersectionObserver/blob/b4bfbbc8e8a62b7e0ad3e4b182b3e35d7eb46afd/polyfill/package.json 

Detailed information can be found at https://github.com/w3c/IntersectionObserver/blob/master/explainer.md

Previous discussions: 
https://issues.liferay.com/browse/FOSS-64
https://issues.liferay.com/browse/LWM-1274
https://github.com/wincent/liferay-portal/pull/319#discussion_r436885019