### PR TITLE
LPS-119479 Adds Video and Audio Selector Buttons when Xuggler is enabled

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.xuggler.XugglerUtil;
 
 import java.util.Locale;
 import java.util.Map;
@@ -206,6 +207,10 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			toJSONArray("['NumberedList', 'BulletedList']"),
 			toJSONArray("['Link', Unlink]"),
 			toJSONArray("['Table', 'ImageSelector', 'VideoEmbed']"));
+
+		if (XugglerUtil.isEnabled()) {
+			jsonArray.put(toJSONArray("['AudioSelector', 'VideoSelector']"));
+		}
 
 		if (isShowSource(inputEditorTaglibAttributes)) {
 			jsonArray.put(toJSONArray("['Source']"));


### PR DESCRIPTION
Adding this by default in the simple setup so that it matches the expectations of admins enabling Xuggler in their system.

Product will revisit the whole audio/video integration since Xuggler is not meant to generate production quality media and is being misused for that matter. In the meantime, we add the buttons unconditionally for a more consistent support.

**Test Plan:**
- Add the following property to `portal-ext.properties` file: `xuggler.enabled=true`
- Application Menus > Control Panel > Server Administration > External Services
- Install in Enabling Xuggler provides video conversion functionality.
- Restart the server
- Product Menu > Site Builder > Content & Data > Web Content > Web Content tab
- Click the plus icon > Basic Web Content
- Assert the CKEditor in content field
- Assert Video and Audio buttons that allow selecting video and audio files from Document Library and direct URLs

<img width="776" alt="Screen Shot 2020-08-20 at 15 03 04" src="https://user-images.githubusercontent.com/905006/90780596-4d018980-e2f6-11ea-9c3b-545de0360f10.png">
