### PR TITLE
LPS-119530 Action menus not visible on Headless DataSet Display + small JS error fixes

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/DefaultRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/DefaultRenderer.js
@@ -20,11 +20,13 @@ import {logError} from '../utilities/logError';
 import TooltipTextRenderer from './TooltipTextRenderer';
 
 function DefaultRenderer({value}) {
-	if (typeof value === 'number') {
-		return <>{value}</>;
-	}
-	else if (typeof value === 'string' || value === undefined) {
-		return <>{value || ''}</>;
+	if (
+		typeof value === 'number' ||
+		typeof value === 'string' ||
+		value === undefined ||
+		value === null
+	) {
+		return <>{value ?? ''}</>;
 	}
 	else if (value.icon) {
 		return <ClayIcon symbol={value.icon} />;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FilterResume.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FilterResume.js
@@ -19,11 +19,11 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
-import getAppContext from './Context';
+import {useAppState} from './Context';
 import {Filter} from './filters/index';
 
 function FilterResume(props) {
-	const {actions} = getAppContext();
+	const {actions} = useAppState();
 	const [open, setOpen] = useState(false);
 
 	const label = (

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FiltersDropdown.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FiltersDropdown.js
@@ -18,11 +18,11 @@ import ClayPanel from '@clayui/panel';
 import classNames from 'classnames';
 import React, {useEffect, useState} from 'react';
 
-import getAppContext from './Context';
+import {useAppState} from './Context';
 import {Filter} from './filters/index';
 
 function DropdownFilterItem(props) {
-	const {actions} = getAppContext();
+	const {actions} = useAppState();
 
 	return (
 		<ClayPanel
@@ -45,7 +45,7 @@ function DropdownFilterItem(props) {
 function FiltersDropdown() {
 	const [active, setActive] = useState(false);
 	const [query, setQuery] = useState('');
-	const {state} = getAppContext();
+	const {state} = useAppState();
 	const [visibleFilters, setVisibleFilter] = useState(
 		state.filters.filter((filter) => !filter.invisible)
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
@@ -51,7 +51,16 @@ export function getValueFromItem(item, fieldName) {
 		return null;
 	}
 	if (Array.isArray(fieldName)) {
-		return fieldName.reduce((acc, key) => acc[key], item);
+		return fieldName.reduce((acc, key) => {
+			if (key === 'LANG') {
+				return (
+					acc[Liferay.ThemeDisplay.getLanguageId()] ||
+					acc[Liferay.ThemeDisplay.getDefaultLanguageId()]
+				);
+			}
+
+			return acc[key];
+		}, item);
 	}
 
 	return item[fieldName];

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/Table.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/Table.js
@@ -141,7 +141,7 @@ function Table({items, itemsActions, schema, style}) {
 
 	const showActionItems = Boolean(
 		itemsActions?.length ||
-			items.find((element) => element.actionDropdownItems)
+			items.find((item) => item.actions || item.actionDropdownItems)
 	);
 
 	const SelectionComponent =
@@ -207,17 +207,17 @@ function Table({items, itemsActions, schema, style}) {
 										itemsActions
 									)}
 									<ClayTable.Cell className="data-set-item-actions-wrapper">
-										{showActionItems &&
-											item.actionDropdownItems && (
-												<ActionsDropdownRenderer
-													actions={
-														itemsActions ||
-														item.actionDropdownItems
-													}
-													itemData={item}
-													itemId={itemId}
-												/>
-											)}
+										{(showActionItems || item.actions) && (
+											<ActionsDropdownRenderer
+												actions={
+													itemsActions ||
+													item.actions ||
+													item.actionDropdownItems
+												}
+												itemData={item}
+												itemId={itemId}
+											/>
+										)}
 									</ClayTable.Cell>
 								</ClayTable.Row>
 								{nestedItems?.length


### PR DESCRIPTION
Fixes small errors reported by @marco-leo when using `<clay:headless-data-set-display />`. Not reproducible on master yet sine his migration of Commerce to master is not completed yet.