### PR TITLE
LPS-119452 - Get back portlet topper ccp

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_variables.scss
@@ -151,6 +151,22 @@ $theme-colors-cp: map-deep-merge(
 	--lead-font-size: #{$lead-font-size};
 	--lead-font-weight: #{$lead-font-weight};
 
+	// Portlet
+
+	--portlet-bg: transparent;
+	--portlet-content-border-radius: 0;
+	--portlet-header-margin-bottom: calc(
+		var(--spacer) * #{$portlet-header-margin-bottom}
+	);
+
+	--portlet-topper-bg: var(--primary);
+	--portlet-topper-border: var(--portlet-topper-bg);
+	--portlet-topper-border-radius: var(--border-radius-sm)
+		var(--border-radius-sm) 0 0;
+	--portlet-topper-color: var(--white);
+	--portlet-topper-link-color: var(--portlet-topper-color);
+	--portlet-topper-link-hover-color: var(--portlet-topper-link-color);
+
 	// Separator
 
 	--hr-border-color: #{$hr-border-color};


### PR DESCRIPTION
This PR get back the styles for portlet topper:

![image](https://user-images.githubusercontent.com/7963804/90873477-855ca280-e39e-11ea-99da-a688561d0fcc.png)

---

**How to test it:**

1º Add a widget to the page (widget page).
2º Put your pointer over the widget, or: tab by keyboard until the portlet
3º See the awesome electric blue styles