### PR TITLE
LPS-107947 Adds missing `navbar` related classes on the preview for matching the same styles of the site-navigation when previewing the navigation menu

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -235,10 +235,12 @@ else {
 			<clay:col
 				md="6"
 			>
-				<liferay-portlet:preview
-					portletName="<%= portletResource %>"
-					showBorders="<%= true %>"
-				/>
+				<div class="navbar navbar-classic navbar-expand-md navbar-light pb-3">
+					<liferay-portlet:preview
+						portletName="<%= portletResource %>"
+						showBorders="<%= true %>"
+					/>
+				</div>
 			</clay:col>
 		</clay:row>
 	</liferay-frontend:edit-form-body>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -235,12 +235,12 @@ else {
 			<clay:col
 				md="6"
 			>
-				<div class="navbar navbar-classic navbar-expand-md navbar-light pb-3">
+				<nav class="navbar navbar-classic navbar-expand-md navbar-light pb-3">
 					<liferay-portlet:preview
 						portletName="<%= portletResource %>"
 						showBorders="<%= true %>"
 					/>
-				</div>
+				</nav>
 			</clay:col>
 		</clay:row>
 	</liferay-frontend:edit-form-body>


### PR DESCRIPTION
…matching the same styles of the site-navigation when previewing the navigation menu

### Test Case

1. Create some pages (Site Builder -> Pages -> Create a new Page -> Edit -> Publish)
2. Go back the home page
3. Hover site navigation widget
4. Click on the ellipsis and then on Configuration
5. Note the preview doesn't look like the main page navigation menu

### Before

<img width="369" alt="Screen Shot 2020-08-21 at 19 35 09" src="https://user-images.githubusercontent.com/7663513/90940513-6e8d6e80-e3e5-11ea-82db-0a9a6ea84a23.png">

### After

<img width="370" alt="Screen Shot 2020-08-21 at 19 36 29" src="https://user-images.githubusercontent.com/7663513/90940572-9da3e000-e3e5-11ea-8da5-b1d73de7f7bc.png">

### What I did

I noticed the styles from `navbar-light` were missing on the preview. It was being added outside the configuration iframe scope. So, I decided to add these missing styles on the preview configuration jsp. 

### Questions

When grepping the preview taglib, I found three usages:

```log
modules/apps/site-navigation/site-navigation-breadcrumb-web/src/main/resources/META-INF/resources/configuration.jsp:                            <liferay-portlet:preview
modules/apps/site-navigation/site-navigation-directory-web/src/main/resources/META-INF/resources/configuration.jsp:                             <liferay-portlet:preview
modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp:                                  <liferay-portlet:preview
```

However, I'm not sure if these classes were needed on breadcrumb-web and on directory-web. 