### PR TITLE
LPS-119211 Adds ApplicationsMenu Application Selector to Portlet Header

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/applications_menu/applications_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/applications_menu/applications_menu.jsp
@@ -22,7 +22,7 @@ ApplicationsMenuDisplayContext applicationsMenuDisplayContext = new Applications
 
 <li class="control-menu-nav-item control-menu-nav-item-separator">
 	<clay:button
-		cssClass="lfr-portal-tooltip"
+		cssClass="btn-menu lfr-portal-tooltip"
 		displayType="unstyled"
 		icon="grid"
 		small="<%= true %>"

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -392,7 +392,7 @@ const ApplicationsMenu = ({
 			)}
 
 			<ClayButtonWithIcon
-				className="dropdown-toggle lfr-portal-tooltip"
+				className="btn-menu dropdown-toggle lfr-portal-tooltip"
 				data-qa-id="applicationsMenu"
 				displayType="unstyled"
 				onClick={handleTriggerButtonClick}

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -84,6 +84,12 @@ a.control-menu-icon,
 		}
 	}
 
+	.btn-menu {
+		border: 1px solid $gray-300;
+		border-radius: $border-radius-lg;
+		box-shadow: 0 4px 8px rgba(39, 38, 52, 0.05);
+	}
+
 	> .container-fluid {
 		padding-bottom: $control-menu-level-1-padding - 1px;
 
@@ -94,6 +100,19 @@ a.control-menu-icon,
 
 	.control-menu-level-1-heading {
 		color: $gray-900;
+		line-height: 1.3;
+	}
+
+	.control-menu-level-3-heading {
+		color: $gray-600;
+		font-size: 0.625rem;
+		line-height: 1.1;
+		text-transform: uppercase;
+	}
+
+	&.control-menu li > .control-menu-nav > .control-menu-nav-item-content {
+		display: inline;
+		margin-left: 16px;
 	}
 
 	.toast-animation {

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/PortletHeaderDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/PortletHeaderDisplayContext.java
@@ -42,6 +42,7 @@ import com.liferay.product.navigation.control.menu.web.internal.constants.Produc
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -66,8 +67,8 @@ public class PortletHeaderDisplayContext {
 			WebKeys.THEME_DISPLAY);
 	}
 
-	public List<Map<String, String>> getApps() throws PortalException {
-		List<Map<String, String>> apps = new ArrayList<>();
+	public List<Map<String, Object>> getApps() throws PortalException {
+		List<Map<String, Object>> apps = new ArrayList<>();
 
 		List<PanelApp> panelApps = getPanelApps();
 
@@ -76,7 +77,10 @@ public class PortletHeaderDisplayContext {
 				_themeDisplay.getCompanyId(), panelApp.getPortletId());
 
 			apps.add(
-				HashMapBuilder.put(
+				HashMapBuilder.<String, Object>put(
+					"active",
+					Objects.equals(panelApp.getPortletId(), getPortletId())
+				).put(
 					"href",
 					String.valueOf(panelApp.getPortletURL(_httpServletRequest))
 				).put(

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/PortletHeaderDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/PortletHeaderDisplayContext.java
@@ -70,12 +70,7 @@ public class PortletHeaderDisplayContext {
 	public List<Map<String, Object>> getApps() throws PortalException {
 		List<Map<String, Object>> apps = new ArrayList<>();
 
-		List<PanelApp> panelApps = getPanelApps();
-
-		for (PanelApp panelApp : panelApps) {
-			Portlet portlet = PortletLocalServiceUtil.getPortletById(
-				_themeDisplay.getCompanyId(), panelApp.getPortletId());
-
+		for (PanelApp panelApp : getPanelApps()) {
 			apps.add(
 				HashMapBuilder.<String, Object>put(
 					"active",
@@ -85,8 +80,15 @@ public class PortletHeaderDisplayContext {
 					String.valueOf(panelApp.getPortletURL(_httpServletRequest))
 				).put(
 					"label",
-					PortalUtil.getPortletTitle(
-						portlet, _themeDisplay.getLocale())
+					() -> {
+						Portlet portlet =
+							PortletLocalServiceUtil.getPortletById(
+								_themeDisplay.getCompanyId(),
+								panelApp.getPortletId());
+
+						return PortalUtil.getPortletTitle(
+							portlet, _themeDisplay.getLocale());
+					}
 				).build());
 		}
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/PortletHeaderDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/PortletHeaderDisplayContext.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.product.navigation.control.menu.web.internal.display.context;
+
+import com.liferay.application.list.PanelApp;
+import com.liferay.application.list.PanelAppRegistry;
+import com.liferay.application.list.PanelCategory;
+import com.liferay.application.list.PanelCategoryRegistry;
+import com.liferay.application.list.constants.ApplicationListWebKeys;
+import com.liferay.application.list.constants.PanelCategoryKeys;
+import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil;
+import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.product.navigation.applications.menu.configuration.ApplicationsMenuInstanceConfiguration;
+import com.liferay.product.navigation.control.menu.web.internal.constants.ProductNavigationControlMenuWebKeys;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class PortletHeaderDisplayContext {
+
+	public PortletHeaderDisplayContext(HttpServletRequest httpServletRequest) {
+		_httpServletRequest = httpServletRequest;
+
+		_panelAppRegistry = (PanelAppRegistry)_httpServletRequest.getAttribute(
+			ApplicationListWebKeys.PANEL_APP_REGISTRY);
+		_panelCategoryRegistry =
+			(PanelCategoryRegistry)_httpServletRequest.getAttribute(
+				ApplicationListWebKeys.PANEL_CATEGORY_REGISTRY);
+
+		_panelCategoryHelper = new PanelCategoryHelper(
+			_panelAppRegistry, _panelCategoryRegistry);
+
+		_themeDisplay = (ThemeDisplay)_httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	public List<Map<String, String>> getApps() throws PortalException {
+		List<Map<String, String>> apps = new ArrayList<>();
+
+		List<PanelApp> panelApps = getPanelApps();
+
+		for (PanelApp panelApp : panelApps) {
+			Portlet portlet = PortletLocalServiceUtil.getPortletById(
+				_themeDisplay.getCompanyId(), panelApp.getPortletId());
+
+			apps.add(
+				HashMapBuilder.put(
+					"href",
+					String.valueOf(panelApp.getPortletURL(_httpServletRequest))
+				).put(
+					"label",
+					PortalUtil.getPortletTitle(
+						portlet, _themeDisplay.getLocale())
+				).build());
+		}
+
+		return apps;
+	}
+
+	public PanelCategory getCurPanelCategory() {
+		if (_curPanelCategory != null) {
+			return _curPanelCategory;
+		}
+
+		String rootPanelCategoryKey = PanelCategoryKeys.CONTROL_PANEL;
+
+		if (_panelCategoryHelper.containsPortlet(
+				getPortletId(),
+				PanelCategoryKeys.APPLICATIONS_MENU_APPLICATIONS)) {
+
+			rootPanelCategoryKey =
+				PanelCategoryKeys.APPLICATIONS_MENU_APPLICATIONS;
+		}
+
+		List<PanelCategory> panelCategories =
+			_panelCategoryRegistry.getChildPanelCategories(
+				rootPanelCategoryKey);
+
+		for (PanelCategory panelCategory : panelCategories) {
+			if (_panelCategoryHelper.containsPortlet(
+					getPortletId(), panelCategory.getKey())) {
+
+				_curPanelCategory = panelCategory;
+
+				return _curPanelCategory;
+			}
+		}
+
+		return null;
+	}
+
+	public List<PanelApp> getPanelApps() {
+		if (_panelApps != null) {
+			return _panelApps;
+		}
+
+		PanelCategory curPanelCategory = getCurPanelCategory();
+
+		_panelApps = _panelCategoryHelper.getAllPanelApps(
+			curPanelCategory.getKey());
+
+		return _panelApps;
+	}
+
+	public String getPortletId() {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		return portletDisplay.getRootPortletId();
+	}
+
+	public String getPortletTitle() {
+		return (String)_httpServletRequest.getAttribute(
+			ProductNavigationControlMenuWebKeys.PORTLET_TITLE);
+	}
+
+	public Map<String, Object> getProps() throws PortalException {
+		return HashMapBuilder.<String, Object>put(
+			"apps", getApps()
+		).put(
+			"category",
+			() -> {
+				PanelCategory curPanelCategory = getCurPanelCategory();
+
+				return curPanelCategory.getLabel(_themeDisplay.getLocale());
+			}
+		).put(
+			"title", HtmlUtil.escape(getPortletTitle())
+		).build();
+	}
+
+	public boolean isShowApplicationsMenuAppSelector() {
+		if (_showApplicationsMenuAppSelector != null) {
+			return _showApplicationsMenuAppSelector;
+		}
+
+		_showApplicationsMenuAppSelector =
+			_isEnableApplicationsMenu() && _isApplicationsMenuApp();
+
+		return _showApplicationsMenuAppSelector;
+	}
+
+	private boolean _isApplicationsMenuApp() {
+		if (Validator.isNull(_themeDisplay.getPpid())) {
+			return false;
+		}
+
+		if (!_panelCategoryHelper.isApplicationsMenuApp(
+				_themeDisplay.getPpid())) {
+
+			return false;
+		}
+
+		Layout layout = _themeDisplay.getLayout();
+
+		if ((layout != null) && !layout.isTypeControlPanel()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private boolean _isEnableApplicationsMenu() {
+		try {
+			ApplicationsMenuInstanceConfiguration
+				applicationsMenuInstanceConfiguration =
+					ConfigurationProviderUtil.getCompanyConfiguration(
+						ApplicationsMenuInstanceConfiguration.class,
+						_themeDisplay.getCompanyId());
+
+			return applicationsMenuInstanceConfiguration.
+				enableApplicationsMenu();
+		}
+		catch (ConfigurationException configurationException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to get applications menu instance configuration",
+					configurationException);
+			}
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortletHeaderDisplayContext.class);
+
+	private PanelCategory _curPanelCategory;
+	private final HttpServletRequest _httpServletRequest;
+	private final PanelAppRegistry _panelAppRegistry;
+	private List<PanelApp> _panelApps;
+	private final PanelCategoryHelper _panelCategoryHelper;
+	private final PanelCategoryRegistry _panelCategoryRegistry;
+	private Boolean _showApplicationsMenuAppSelector;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_header.jsp
@@ -17,9 +17,40 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String portletTitle = (String)request.getAttribute(ProductNavigationControlMenuWebKeys.PORTLET_TITLE);
+PortletHeaderDisplayContext portletHeaderDisplayContext = new PortletHeaderDisplayContext(request);
 %>
 
 <li class="control-menu-nav-item control-menu-nav-item-content">
-	<span class="control-menu-level-1-heading text-truncate" data-qa-id="headerTitle"><%= HtmlUtil.escape(portletTitle) %></span>
+	<c:choose>
+		<c:when test="<%= portletHeaderDisplayContext.isShowApplicationsMenuAppSelector() %>">
+
+			<%
+			PanelCategory curPanelCategory = portletHeaderDisplayContext.getCurPanelCategory();
+
+			List<PanelApp> panelApps = portletHeaderDisplayContext.getPanelApps();
+			%>
+
+			<div class="control-menu-level-3-heading"><%= curPanelCategory.getLabel(locale) %></div>
+
+			<div class="control-menu-level-1-heading">
+				<span class="inline-item inline-item-before text-truncate" data-qa-id="headerTitle"><%= HtmlUtil.escape(portletHeaderDisplayContext.getPortletTitle()) %></span>
+
+				<c:if test="<%= panelApps.size() > 1 %>">
+					<clay:icon
+						symbol="caret-double-l"
+					/>
+				</c:if>
+			</div>
+
+			<c:if test="<%= panelApps.size() > 1 %>">
+				<react:component
+					module="js/PortletHeader"
+					props="<%= portletHeaderDisplayContext.getProps() %>"
+				/>
+			</c:if>
+		</c:when>
+		<c:otherwise>
+			<span class="control-menu-level-1-heading text-truncate" data-qa-id="headerTitle"><%= HtmlUtil.escape(portletHeaderDisplayContext.getPortletTitle()) %></span>
+		</c:otherwise>
+	</c:choose>
 </li>

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/product-navigation" prefix="liferay-product-navigation" %><%@
@@ -27,7 +28,9 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil" %><%@
+<%@ page import="com.liferay.application.list.PanelApp" %><%@
+page import="com.liferay.application.list.PanelCategory" %><%@
+page import="com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil" %><%@
 page import="com.liferay.asset.kernel.model.AssetRenderer" %><%@
 page import="com.liferay.asset.kernel.model.AssetRendererFactory" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
@@ -44,11 +47,12 @@ page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
 page import="com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuPortletKeys" %><%@
-page import="com.liferay.product.navigation.control.menu.web.internal.constants.ProductNavigationControlMenuWebKeys" %><%@
 page import="com.liferay.product.navigation.control.menu.web.internal.display.context.AddContentPanelDisplayContext" %><%@
+page import="com.liferay.product.navigation.control.menu.web.internal.display.context.PortletHeaderDisplayContext" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %>
 
 <%@ page import="java.util.HashMap" %><%@
+page import="java.util.List" %><%@
 page import="java.util.Map" %><%@
 page import="java.util.Objects" %>
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/PortletHeader.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/PortletHeader.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ClayDropDownWithItems} from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
+import React from 'react';
+
+const PortletHeader = ({apps, category, title}) => {
+	return (
+		<>
+			<ClayDropDownWithItems
+				items={apps}
+				trigger={
+					<div>
+						<span className="small">{category}</span>
+						<div>
+							<span
+								className="control-menu-level-1-heading inline-item inline-item-before text-truncate"
+								data-qa-id="headerTitle"
+							>
+								{title}
+							</span>
+
+							<ClayIcon symbol="caret-double-l" />
+						</div>
+					</div>
+				}
+			/>
+		</>
+	);
+};
+
+export default PortletHeader;

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/PortletHeader.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/PortletHeader.js
@@ -23,10 +23,12 @@ const PortletHeader = ({apps, category, title}) => {
 				items={apps}
 				trigger={
 					<div>
-						<span className="small">{category}</span>
-						<div>
+						<div className="control-menu-level-3-heading">
+							{category}
+						</div>
+						<div className="control-menu-level-1-heading">
 							<span
-								className="control-menu-level-1-heading inline-item inline-item-before text-truncate"
+								className="inline-item inline-item-before text-truncate"
 								data-qa-id="headerTitle"
 							>
 								{title}


### PR DESCRIPTION
This is a slight revamp of https://github.com/liferay-echo/liferay-portal/pull/1959 and the second part of the split of https://github.com/liferay-frontend/liferay-portal/pull/289 which covers the first [UX Refinement for Applications Menu](https://issues.liferay.com/browse/LPS-117782)
- [Show Application Section in Control Menu](https://issues.liferay.com/browse/LPS-119209)
- [Show Related Applications Dropdown in Control Menu](https://issues.liferay.com/browse/LPS-119211)

I tried to reduce the amount of checks we do from the previous version and testing it again I don't perceive a noticeable regression. Since the `portlet_header` is only included in admin apps, there should be no impact on performance tests either.

If we want to further improve server-side performance, we can do something similar to the `ProductsMenu` component that rather than the list of Apps gets an endpoint to retrieve it asynchronously. I didn't do it this way because we need to know in advance if we have 1 or more apps in a section in order to show a dropdown, so there's no easy way to avoid the calculation.

![90763509-1f611400-e2e7-11ea-939d-8b314868759a](https://user-images.githubusercontent.com/905006/90880688-2c463c00-e3a9-11ea-9d8a-46d420173281.png)

![90763494-14a67f00-e2e7-11ea-9a99-6512ab53c240](https://user-images.githubusercontent.com/905006/90880691-2d776900-e3a9-11ea-94cc-fe2a2b15f1f6.png)