### PR TITLE
LPS-119597 Sets proper value to hide the widget and prevent it being added to layouts

### DIFF
--- a/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/RemoteAppAdminPortlet.java
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/java/com/liferay/remote/app/admin/web/internal/portlet/RemoteAppAdminPortlet.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Component;
 	immediate = true,
 	property = {
 		"com.liferay.portlet.css-class-wrapper=portlet-remote-app-admin",
-		"com.liferay.portlet.display-category=hidden",
+		"com.liferay.portlet.display-category=category.hidden",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.preferences-unique-per-layout=false",
 		"com.liferay.portlet.private-request-attributes=false",


### PR DESCRIPTION
Based on [RTL Localization - Adding a Remote Web app portlet creates a loader side panel](https://issues.liferay.com/browse/LPS-119597), discovered that it was possible to add Remote Apps Admin to a layout. That should not be the case.

**The Fix**
Set the proper `category.hidden` value to the `com.liferay.portlet.display-category` property

**Test Plan**
- Edit a Content Page
- Inside the `Fragments & Widgets` section type "remote` or try to locate the "Remote Apps" widget

**Expectation**
The Remote Apps widget (that shows a list of registered remote apps) should not appear and should not be allowed in a layout.