### PR TITLE
LPS-119207 Allow "Browse Server" for links and images in CKEditor

### DIFF
--- a/modules/apps/app-builder/app-builder-web/package.json
+++ b/modules/apps/app-builder/app-builder-web/package.json
@@ -10,7 +10,7 @@
 		"@clayui/link": "3.2.0",
 		"@clayui/list": "3.3.2",
 		"@clayui/loading-indicator": "3.1.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/multi-step-nav": "3.2.6",
 		"@clayui/navigation-bar": "3.2.3",
 		"@clayui/pagination-bar": "3.1.10",

--- a/modules/apps/data-engine/data-engine-taglib/package.json
+++ b/modules/apps/data-engine/data-engine-taglib/package.json
@@ -10,7 +10,7 @@
 		"@clayui/link": "3.2.0",
 		"@clayui/list": "3.3.2",
 		"@clayui/loading-indicator": "3.1.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/multi-step-nav": "3.2.6",
 		"@clayui/navigation-bar": "3.2.3",
 		"@clayui/pagination-bar": "3.1.10",

--- a/modules/apps/depot/depot-web/package.json
+++ b/modules/apps/depot/depot-web/package.json
@@ -7,7 +7,7 @@
 		"@clayui/icon": "3.0.5",
 		"@clayui/label": "3.3.1",
 		"@clayui/layout": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/table": "3.0.7",
 		"frontend-js-web": "*",
 		"metal-dom": "2.16.8",

--- a/modules/apps/document-library/document-library-web/package.json
+++ b/modules/apps/document-library/document-library-web/package.json
@@ -6,7 +6,7 @@
 		"@clayui/form": "3.10.1",
 		"@clayui/icon": "3.0.5",
 		"@clayui/loading-indicator": "3.1.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"asset-taglib": "*",
 		"clay-button": "2.21.4",
 		"clay-multi-select": "2.21.4",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
@@ -3,7 +3,7 @@
 		"@clayui/button": "3.4.0",
 		"@clayui/form": "3.10.1",
 		"@clayui/layout": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/table": "3.0.7",
 		"classnames": "2.2.6",
 		"clay-button": "2.21.4",

--- a/modules/apps/flags/flags-taglib/package.json
+++ b/modules/apps/flags/flags-taglib/package.json
@@ -3,7 +3,7 @@
 		"@clayui/alert": "3.4.1",
 		"@clayui/button": "3.4.0",
 		"@clayui/icon": "3.0.5",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"clay-button": "2.21.4",
 		"clay-icon": "2.21.4",
 		"frontend-js-web": "*",

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -80,7 +80,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 		);
 
 		String extraPlugins =
-			"addimages,autogrow,itemselector,lfrpopup," +
+			"addimages,autogrow,filebrowser,itemselector,lfrpopup," +
 				"media,stylescombo,videoembed";
 
 		boolean inlineEdit = GetterUtil.getBoolean(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -312,6 +312,7 @@
 				selectEventName: editor.name + 'selectItem',
 				title: Liferay.Language.get('select-item'),
 				url,
+				zIndex: CKEDITOR.getNextZIndex(),
 			});
 		},
 

--- a/modules/apps/frontend-js/frontend-js-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-web/package.json
@@ -3,7 +3,7 @@
 		"@clayui/alert": "3.4.1",
 		"@clayui/form": "3.10.1",
 		"@clayui/icon": "3.0.5",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"clay": "2.18.1",
 		"clay-alert": "2.21.4",
 		"liferay-amd-loader": "4.3.0",

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -113,6 +113,7 @@ const openSelectionModal = ({
 	selectedData,
 	title,
 	url,
+	zIndex,
 }) => {
 	let selectedItem;
 
@@ -186,6 +187,7 @@ const openSelectionModal = ({
 		},
 		title,
 		url,
+		zIndex,
 	});
 };
 
@@ -203,6 +205,7 @@ const Modal = ({
 	size,
 	title,
 	url,
+	zIndex,
 }) => {
 	const [loading, setLoading] = useState(true);
 	const [visible, setVisible] = useState(true);
@@ -337,6 +340,7 @@ const Modal = ({
 					id={id}
 					observer={observer}
 					size={url && !size ? 'full-screen' : size}
+					zIndex={zIndex}
 				>
 					<ClayModal.Header>
 						{headerHTML ? (

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -21,7 +21,7 @@
 		"@clayui/list": "3.3.2",
 		"@clayui/loading-indicator": "3.1.0",
 		"@clayui/management-toolbar": "3.2.3",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/multi-select": "3.6.3",
 		"@clayui/multi-step-nav": "3.2.6",
 		"@clayui/nav": "3.2.2",

--- a/modules/apps/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib/package.json
@@ -7,7 +7,7 @@
 		"@clayui/form": "3.10.1",
 		"@clayui/icon": "3.0.5",
 		"@clayui/list": "3.3.2",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/tabs": "3.2.3",
 		"frontend-js-react-web": "*",
 		"frontend-js-web": "*",

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
@@ -8,7 +8,7 @@
 		"@clayui/icon": "3.0.5",
 		"@clayui/layout": "3.2.0",
 		"@clayui/link": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/navigation-bar": "3.2.3",
 		"@clayui/panel": "3.2.3",
 		"@clayui/tabs": "3.2.3",

--- a/modules/apps/layout/layout-admin-web/package.json
+++ b/modules/apps/layout/layout-admin-web/package.json
@@ -9,7 +9,7 @@
 		"@clayui/layout": "3.2.0",
 		"@clayui/link": "3.2.0",
 		"@clayui/list": "3.3.2",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"classnames": "2.2.6",
 		"clay-badge": "2.21.4",
 		"clay-checkbox": "2.21.4",

--- a/modules/apps/questions/questions-web/package.json
+++ b/modules/apps/questions/questions-web/package.json
@@ -9,7 +9,7 @@
 		"@clayui/label": "3.3.1",
 		"@clayui/link": "3.2.0",
 		"@clayui/loading-indicator": "3.1.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/navigation-bar": "3.2.3",
 		"@clayui/popover": "3.4.5",
 		"@clayui/sticker": "3.2.0",

--- a/modules/apps/sharing/sharing-web/package.json
+++ b/modules/apps/sharing/sharing-web/package.json
@@ -8,7 +8,7 @@
 		"@clayui/form": "3.10.1",
 		"@clayui/icon": "3.0.5",
 		"@clayui/layout": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/multi-select": "3.6.3",
 		"@clayui/sticker": "3.2.0",
 		"frontend-js-react-web": "*",

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/package.json
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/package.json
@@ -6,7 +6,7 @@
 		"@clayui/form": "3.10.1",
 		"@clayui/icon": "3.0.5",
 		"@clayui/link": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/popover": "3.4.5",
 		"@clayui/tooltip": "3.3.3",
 		"classnames": "2.2.6",

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
@@ -9,7 +9,7 @@
 		"@clayui/link": "3.2.0",
 		"@clayui/loading-indicator": "3.1.0",
 		"@clayui/management-toolbar": "3.2.3",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/multi-select": "3.6.3",
 		"@clayui/pagination-bar": "3.1.10",
 		"@clayui/tabs": "3.2.3",

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
@@ -10,7 +10,7 @@
 		"@clayui/layout": "3.2.0",
 		"@clayui/list": "3.3.2",
 		"@clayui/management-toolbar": "3.2.3",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/navigation-bar": "3.2.3",
 		"@clayui/panel": "3.2.3",
 		"@clayui/progress-bar": "3.1.0",

--- a/modules/dxp/apps/segments/segments-experiment-web/package.json
+++ b/modules/dxp/apps/segments/segments-experiment-web/package.json
@@ -7,7 +7,7 @@
 		"@clayui/icon": "3.0.5",
 		"@clayui/layout": "3.2.0",
 		"@clayui/link": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/tabs": "3.2.3",
 		"@clayui/tooltip": "3.3.3",
 		"classnames": "2.2.6",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1289,10 +1289,10 @@
     "@clayui/layout" "^3.2.0"
     classnames "^2.2.6"
 
-"@clayui/modal@3.6.5":
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/@clayui/modal/-/modal-3.6.5.tgz#10cce5c10a479995590af4955e8773ce0cad3a97"
-  integrity sha512-TBBRfcMrxlX5GGKt+TjZAryY+mmyL/7LUKV8gWezAmoSFM4Ukej6hCUcadgKgQkV5Up9HotFcxzDQ7rzVVujmg==
+"@clayui/modal@3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@clayui/modal/-/modal-3.7.0.tgz#f67ac09f681ffe73f54dfb1297f8855d73ab2302"
+  integrity sha512-LgYKgGuCkJ7H0VpzxXLKqQ+Pv9dzDVakSMaws+kL1qnNeBbQBOMwIYL0Ehl4FRrsAiNhPyVU0eDW4fh0F2UFow==
   dependencies:
     "@clayui/button" "^3.4.0"
     "@clayui/icon" "^3.0.5"


### PR DESCRIPTION
This PR enables the `Browse Server` button in different CKEditor dialogs so things like Document Library Assets or Liferay Pages can be selected and linked when editing content.

**The PR:**
- Updates to a new `ClayModal` version that includes support for `zIndex`
- Adds a `zIndex` param to our existing `openModal` and `openSelectionModal` APIs
- Loads the `filebrowser` plugin by default making sure that dialogs stack on top of each other.

**The Result:**
![links](https://user-images.githubusercontent.com/905006/91070463-0df57000-e637-11ea-962e-2d5678414c16.gif)