### PR TITLE
LPS-119137 Address uncaught exception raised by invalid selector.

### DIFF
--- a/modules/apps/frontend-js/frontend-js-tabs-support-web/src/main/resources/META-INF/resources/TabsProvider.js
+++ b/modules/apps/frontend-js/frontend-js-tabs-support-web/src/main/resources/META-INF/resources/TabsProvider.js
@@ -121,7 +121,12 @@ class TabsProvider {
 	};
 
 	_getPanel(trigger) {
-		return document.querySelector(trigger.getAttribute('href'));
+		try {
+			return document.querySelector(trigger.getAttribute('href'));
+		}
+		catch (error) {
+			return null;
+		}
 	}
 
 	_getTrigger(panel) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-119137

Basically, this fix addresses the use case in which the `href` attribute has a value with characters that need to be escaped, like `:` and `;` in `javascript:;`.