### PR TITLE
LPS-119691 Removes common markup ids to avoid them being styled as if this was inside a popup (which it is not)

### DIFF
--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -16,7 +16,7 @@
 
 <%@ include file="/html/portal/init.jsp" %>
 
-<div class="pt-0" id="wrapper">
+<div id="wrapper">
 	<header class="mb-4" id="banner">
 		<div class="mb-4 navbar navbar-classic navbar-top py-3">
 			<div class="container">
@@ -37,7 +37,7 @@
 	</header>
 
 	<div class="container" id="content">
-		<div class="sheet sheet-lg" id="main-content">
+		<div class="sheet sheet-lg">
 			<h2 class="sheet-title" title="<liferay-ui:message key="basic-configuration" />">
 				<liferay-ui:message key="basic-configuration" />
 			</h2>


### PR DESCRIPTION
This was caused by https://github.com/liferay-frontend/liferay-portal/pull/294, making the Setup Wizard look off.

![SetupWizard-Chrome84](https://user-images.githubusercontent.com/905006/91148244-a9c7c000-e6b9-11ea-9450-7d8de57f2e7b.PNG)

**The problem**
- We're styling `.portal-popup:not(.article-preview) #main-content` with `position:absolute` and other niceties. 
- Setup Wizard renders in "popup" mode but outside a dialog

**The fix**
- Smallest possible fix is to simply remove the `main-content` id. 
- Other options would be to restyle the the content, or add another exception to the `.portal-popup` rule.

<img width="1203" alt="Screen Shot 2020-08-25 at 09 50 03" src="https://user-images.githubusercontent.com/905006/91148606-2e1a4300-e6ba-11ea-9394-479b18295550.png">

I'm trying the first one here to see if tests would need to be adjusted and we can simply get away with that minimal fix.

