### PR TITLE
COMMERCE-4536 deprecated property name updated on DataSetDisplay

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/emails_list/EmailsList.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/emails_list/EmailsList.js
@@ -22,7 +22,7 @@ import React, {useContext} from 'react';
 import ActionsDropdownRenderer from '../../data_renderers/ActionsDropdownRenderer';
 
 function Email({
-	actionItems,
+	actionDropdownItems,
 	author,
 	borderBottom,
 	dataSetDisplayContext,
@@ -102,9 +102,11 @@ function Email({
 						</div>
 					</div>
 				</div>
-				{actionItems.length ? (
+				{actionDropdownItems.length ? (
 					<div className="col-auto d-flex flex-column justify-content-center">
-						<ActionsDropdownRenderer actions={actionItems} />
+						<ActionsDropdownRenderer
+							actions={actionDropdownItems}
+						/>
 					</div>
 				) : null}
 			</div>
@@ -113,7 +115,7 @@ function Email({
 }
 
 Email.propTypes = {
-	actionItems: PropTypes.array,
+	actionDropdownItems: PropTypes.array,
 	author: PropTypes.shape({
 		avatarSrc: PropTypes.string,
 		email: PropTypes.string.isRequired,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/Table.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/Table.js
@@ -89,7 +89,7 @@ function CustomTableCell({
 
 function getItemFields(item, fields, itemId, itemsActions) {
 	return fields.map((field, i) => {
-		const {actionItems, comments} = item;
+		const {actionDropdownItems, comments} = item;
 		const rawValue = getValueFromItem(item, field.fieldName);
 		const formattedValue = field.mapData
 			? field.mapData(rawValue)
@@ -98,7 +98,7 @@ function getItemFields(item, fields, itemId, itemsActions) {
 
 		return (
 			<CustomTableCell
-				actions={itemsActions || actionItems}
+				actions={itemsActions || actionDropdownItems}
 				comment={comment}
 				itemData={item}
 				itemId={itemId}


### PR DESCRIPTION
Due to the dataset display migration to master, some renaming was made among the entire component.

After some tests we realised that action were not working due to an incomplete renaming that would be completed with this fix.

To reproduce the problem initialise a minium site instance then go to control panel -> commerce -> channels.
At the moment the first table column does not contain links. After the fix the channels names would be navigable items.

--- 

Note: we are currently migrating all the commerce to master in a specific branch: COMMERCE-4052. Please checkout the branch and deploy the modules in apps/commerce