### PR TITLE
COMMERCE-4550 fetch language header consistent across browsers

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
@@ -16,6 +16,23 @@ import {fetch} from 'frontend-js-web';
 
 import createOdataFilter from './odata';
 
+export function getAcceptLanguageHeaderParam() {
+	const browserLang = navigator.language || navigator.userLanguage;
+	const themeLang = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
+
+	if (browserLang === themeLang) {
+		return browserLang;
+	}
+
+	return `${browserLang}, ${themeLang};q=0.8`;
+}
+
+const fetchHeaders = new Headers({
+	Accept: 'application/json',
+	'Accept-Language': getAcceptLanguageHeaderParam(),
+	'Content-Type': 'application/json',
+});
+
 export function getData(apiURL, query) {
 	const url = new URL(apiURL);
 
@@ -68,6 +85,7 @@ export function getValueFromItem(item, fieldName) {
 
 export function executeAsyncAction(url, method = 'GET') {
 	return fetch(url, {
+		headers: fetchHeaders,
 		method,
 	});
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
@@ -16,22 +16,14 @@ import {fetch} from 'frontend-js-web';
 
 import createOdataFilter from './odata';
 
-export function getAcceptLanguageHeaderParam() {
-	const browserLang = navigator.language || navigator.userLanguage;
+function getAcceptLanguageHeaderParam() {
+	const browserLang = navigator.language ?? navigator.userLanguage;
 	const themeLang = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
 
-	if (browserLang === themeLang) {
-		return browserLang;
-	}
-
-	return `${browserLang}, ${themeLang};q=0.8`;
+	return browserLang === themeLang
+		? browserLang
+		: `${browserLang}, ${themeLang};q=0.8`;
 }
-
-const fetchHeaders = new Headers({
-	Accept: 'application/json',
-	'Accept-Language': getAcceptLanguageHeaderParam(),
-	'Content-Type': 'application/json',
-});
 
 export function getData(apiURL, query) {
 	const url = new URL(apiURL);
@@ -85,7 +77,11 @@ export function getValueFromItem(item, fieldName) {
 
 export function executeAsyncAction(url, method = 'GET') {
 	return fetch(url, {
-		headers: fetchHeaders,
+		headers: {
+			Accept: 'application/json',
+			'Accept-Language': getAcceptLanguageHeaderParam(),
+			'Content-Type': 'application/json',
+		},
 		method,
 	});
 }


### PR DESCRIPTION
The DataSet display fetches data via async request but, in some cases, the headless api doesn't return the same result in Safari.
We identified the issue in the accept-language header which send inconsistent value.

To reproduce the problem initialise a minium site instance then go to control panel -> commerce -> products.
In safari you shouldn't see any item.

---

Note: we are currently migrating all the commerce to master in a specific branch: COMMERCE-4052. Please checkout the branch and deploy all the modules in apps/commerce