### PR TITLE
COMMERCE-4549 Total items key renamed on DataSetDisplay Api

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/data/set/ClayDataSetDataJSONFactoryImpl.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/data/set/ClayDataSetDataJSONFactoryImpl.java
@@ -114,17 +114,17 @@ public class ClayDataSetDataJSONFactoryImpl
 	private class ClayDataSetResponse {
 
 		public ClayDataSetResponse(
-			List<ClayDataSetDataRow> clayDataSetRows, int total) {
+			List<ClayDataSetDataRow> clayDataSetRows, int totalCount) {
 
 			_clayDataSetRows = clayDataSetRows;
-			_total = total;
+			_totalCount = totalCount;
 		}
 
 		@JsonProperty("items")
 		private final List<ClayDataSetDataRow> _clayDataSetRows;
 
-		@JsonProperty("total")
-		private final int _total;
+		@JsonProperty("totalCount")
+		private final int _totalCount;
 
 	}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -135,7 +135,7 @@ function DataSetDisplay({
 	const formRef = useRef(null);
 
 	function updateDataSetItems(dataSetData) {
-		setTotal(dataSetData.total || 0);
+		setTotal(dataSetData.totalCount);
 		updateItems(dataSetData.items);
 	}
 


### PR DESCRIPTION
DataSetDisplay component works with headless api and custom dataset ones.
The total number of items in our headless api is passed via `totalCount` key and in custom one via `total`.

This created some errors which had been solved by renaming the key in the custom ones.