### PR TITLE
LPS-119754 Update ApplicationMenu trigger to show a tooltip with the new keyboard hotkey

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -28,7 +28,7 @@ import React, {useRef, useState} from 'react';
 
 const OPEN_MENU_TITLE_TPL = `<div>${Liferay.Language.get(
 	'open-menu'
-)}</div><kbd class="c-kbd c-kbd-dark"><kbd class="c-kbd">⌘</kbd><span class="c-kbd-separator">+</span><kbd class="c-kbd">M</kbd></kbd>`;
+)}</div><kbd class="c-kbd c-kbd-dark"><kbd class="c-kbd">⌘</kbd><span class="c-kbd-separator">+</span><kbd class="c-kbd">⇧</kbd><span class="c-kbd-separator">+</span><kbd class="c-kbd">M</kbd></kbd>`;
 
 const Site = ({current, label, logoURL, url}) => {
 	return (

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -22,6 +22,7 @@ import '../css/ApplicationsMenu.scss';
 import ClayLabel from '@clayui/label';
 import ClaySticker from '@clayui/sticker';
 import ClayTabs from '@clayui/tabs';
+import {useEventListener} from 'frontend-js-react-web';
 import {fetch, navigate, openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
@@ -349,6 +350,22 @@ const ApplicationsMenu = ({
 	const {observer, onClose} = useModal({
 		onClose: () => setVisible(false),
 	});
+
+	useEventListener(
+		'keydown',
+		(event) => {
+			event.preventDefault();
+
+			if (event.metaKey && event.shiftKey && event.key === 'm') {
+				if (!visible) {
+					fetchCategories();
+				}
+				setVisible(!visible);
+			}
+		},
+		true,
+		window
+	);
 
 	const fetchCategoriesPromiseRef = useRef();
 

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -366,6 +366,7 @@ const ApplicationsMenu = ({
 				if (!visible) {
 					fetchCategories();
 				}
+
 				setVisible(!visible);
 			}
 		},

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -26,16 +26,9 @@ import {fetch, navigate, openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
 
-const OPEN_MENU_TITLE_TPL = `
-	<div>
-		${Liferay.Language.get('open-menu')}
-	</div>
-	<kbd class="c-kbd c-kbd-dark">
-		<kbd class="c-kbd">⌘</kbd>
-		<span class="c-kbd-separator">+</span>
-		<kbd class="c-kbd">M</kbd>
-	</kbd>
-`;
+const OPEN_MENU_TITLE_TPL = `<div>${Liferay.Language.get(
+	'open-menu'
+)}</div><kbd class="c-kbd c-kbd-dark"><kbd class="c-kbd">⌘</kbd><span class="c-kbd-separator">+</span><kbd class="c-kbd">M</kbd></kbd>`;
 
 const Site = ({current, label, logoURL, url}) => {
 	return (

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -354,7 +354,9 @@ const ApplicationsMenu = ({
 	useEventListener(
 		'keydown',
 		(event) => {
-			const isCMDPressed = event.metaKey || event.ctrlKey;
+			const isCMDPressed = Liferay.Browser.isMac()
+				? event.metaKey
+				: event.ctrlKey;
 
 			if (
 				isCMDPressed &&

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -371,11 +371,7 @@ const ApplicationsMenu = ({
 			) {
 				event.preventDefault();
 
-				if (!visible) {
-					fetchCategories();
-				}
-
-				setVisible(!visible);
+				handleTriggerButtonClick();
 			}
 		},
 		true,
@@ -404,7 +400,7 @@ const ApplicationsMenu = ({
 
 	const handleTriggerButtonClick = () => {
 		fetchCategories();
-		setVisible(true);
+		setVisible(!visible);
 	};
 
 	return (

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -27,9 +27,15 @@ import {fetch, navigate, openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
 
-const OPEN_MENU_TITLE_TPL = `<div>${Liferay.Language.get(
-	'open-menu'
-)}</div><kbd class="c-kbd c-kbd-dark"><kbd class="c-kbd">⌘</kbd><span class="c-kbd-separator">+</span><kbd class="c-kbd">⇧</kbd><span class="c-kbd-separator">+</span><kbd class="c-kbd">M</kbd></kbd>`;
+const OPEN_MENU_TITLE_TPL =
+	`<div>${Liferay.Language.get('open-menu')}</div>` +
+	'<kbd class="c-kbd c-kbd-dark">' +
+	'<kbd class="c-kbd">⌘</kbd>' +
+	'<span class="c-kbd-separator">+</span>' +
+	'<kbd class="c-kbd">⇧</kbd>' +
+	'<span class="c-kbd-separator">+</span>' +
+	'<kbd class="c-kbd">M</kbd>' +
+	'</kbd>';
 
 const Site = ({current, label, logoURL, url}) => {
 	return (

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -26,6 +26,17 @@ import {fetch, navigate, openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
 
+const OPEN_MENU_TITLE_TPL = `
+	<div>
+		${Liferay.Language.get('open-menu')}
+	</div>
+	<kbd class="c-kbd c-kbd-dark">
+		<kbd class="c-kbd">⌘</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd">M</kbd>
+	</kbd>
+`;
+
 const Site = ({current, label, logoURL, url}) => {
 	return (
 		<li className="c-mt-3">
@@ -392,6 +403,7 @@ const ApplicationsMenu = ({
 			)}
 
 			<ClayButtonWithIcon
+				aria-label={Liferay.Language.get('open-menu')}
 				className="dropdown-toggle lfr-portal-tooltip"
 				data-qa-id="applicationsMenu"
 				displayType="unstyled"
@@ -400,7 +412,7 @@ const ApplicationsMenu = ({
 				onMouseOver={fetchCategories}
 				small
 				symbol="grid"
-				title={Liferay.Language.get('applications-menu')}
+				title={OPEN_MENU_TITLE_TPL}
 			/>
 		</>
 	);

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -354,9 +354,15 @@ const ApplicationsMenu = ({
 	useEventListener(
 		'keydown',
 		(event) => {
-			event.preventDefault();
+			const isCMDPressed = event.metaKey || event.ctrlKey;
 
-			if (event.metaKey && event.shiftKey && event.key === 'm') {
+			if (
+				isCMDPressed &&
+				event.shiftKey &&
+				event.key.toLowerCase() === 'm'
+			) {
+				event.preventDefault();
+
 				if (!visible) {
 					fetchCategories();
 				}

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu
 recently-visited=Recently Visited
+open-menu=Open menu

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language.properties
@@ -1,4 +1,4 @@
 applications-menu=Applications Menu
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu
-recently-visited=Recently Visited
 open-menu=Open menu
+recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ar.properties
@@ -1,3 +1,4 @@
 applications-menu=قائمة التطبيقات
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=قائمة عمومية
+open-menu=Open menu (Automatic Copy)
 recently-visited=تمت زيارته مؤخرًا

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_bg.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ca.properties
@@ -1,3 +1,4 @@
 applications-menu=Menú d'aplicacions
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Menú global
+open-menu=Open menu (Automatic Copy)
 recently-visited=Visitats recentment

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_cs.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_da.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_de.properties
@@ -1,3 +1,4 @@
 applications-menu=Globales Menü
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Globales Menü
+open-menu=Open menu (Automatic Copy)
 recently-visited=Kürzlich besucht

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_el.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu
+open-menu=Open menu
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en_AU.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en_GB.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_es.properties
@@ -1,3 +1,4 @@
 applications-menu=Menú de aplicaciones
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Menú global
+open-menu=Open menu (Automatic Copy)
 recently-visited=Visitadas recientemente

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_et.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_eu.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fa.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fi.properties
@@ -1,3 +1,4 @@
 applications-menu=Sovellusvalikko
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Globaali Valikko
+open-menu=Open menu (Automatic Copy)
 recently-visited=Äskettäin Vierailtu

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fr.properties
@@ -1,3 +1,4 @@
 applications-menu=Menu des applications
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Menu global
+open-menu=Open menu (Automatic Copy)
 recently-visited=Récemment visitée

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fr_CA.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_gl.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hr.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hu.properties
@@ -1,3 +1,4 @@
 applications-menu=Alkalmazások menü
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Globális menü
+open-menu=Open menu (Automatic Copy)
 recently-visited=Nemrég meglátogatva

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_in.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_it.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Menu Globale
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_iw.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ja.properties
@@ -1,3 +1,4 @@
 applications-menu=アプリケーションメニュー
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=グローバルメニュー
+open-menu=Open menu (Automatic Copy)
 recently-visited=最近アクセス

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_kk.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ko.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_lo.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_lt.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nb.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nl.properties
@@ -1,3 +1,4 @@
 applications-menu=Applicatiemenu
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Algemeen menu
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recent bezocht

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pl.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,3 +1,4 @@
 applications-menu=Menu de aplicativos
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Menu global
+open-menu=Open menu (Automatic Copy)
 recently-visited=Visitado recentemente

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ro.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ru.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sk.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sl.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sv.properties
@@ -1,3 +1,4 @@
 applications-menu=Programmeny
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Global meny
+open-menu=Open menu (Automatic Copy)
 recently-visited=Nyligen besökt

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ta_IN.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_th.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_tr.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_uk.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_vi.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,3 +1,4 @@
 applications-menu=应用程序菜单
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=全局菜单
+open-menu=Open menu (Automatic Copy)
 recently-visited=最近​​访问

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited


### PR DESCRIPTION
…new keyboard hotkey

### Context

This PR is a part of https://issues.liferay.com/browse/LPS-119736 -> https://issues.liferay.com/browse/LPS-119754.

### Test Case

1. Click on Applications Menu button(the button with grid symbol on the top-right of DXP toolbar)
2. Click on Workflow -> Process Builder
3. Hover the Applications Menu button

### Consequences:

Updates the Grid button(applications menu button) title from `Applications Menu` to `Open Menu (CMD + M)` using kbd elements(https://clayui.com/docs/css/content/c-kbd.html#nested-c-kbd)

### Questions:

#### Question 1

When using the DXP tooltip pattern using tooltip-support utility, I notice when passing a markup it can’t be accessible(See [1]). However, when adding a `aria-label` attribute on the button it will override the screen reader speech.

##### Sub Question #1:
(Should I update the `aria-label` from `Open Menu` to `Open Menu Press (⌘ + M)`?)

I added the following piece of code to be a title[1]:

```js
const OPEN_MENU_TITLE_TPL = `
	<div>
		${Liferay.Language.get('open-menu')}
	</div>
	<kbd class="c-kbd c-kbd-dark">
		<kbd class="c-kbd">⌘</kbd>
		<span class="c-kbd-separator">+</span>
		<kbd class="c-kbd">M</kbd>
	</kbd>
`;
```

I’m not a fan by using TPLs strings with React, but I didn’t found other way to inject html on our tooltips provided by tooltip support.

For settling the inner tooltip content using `kbd` things but it won’t show properly as specified by Figma, there isn’t a broken line between the Open menu message and the kbd hotkeys. For solving it, I had a conversation with Patrick and We found a bug on Clay styles here: https://github.com/liferay/clay/issues/3652. Once this issue will be fixed, the styles will be automatically corrected.

###### See the following images:

Current:

<img width="148" alt="Screen Shot 2020-08-25 at 19 00 22" src="https://user-images.githubusercontent.com/7663513/91232659-e7523a80-e705-11ea-8b60-03b31a91cd47.png">

<img width="384" alt="Screen Shot 2020-08-25 at 17 24 19" src="https://user-images.githubusercontent.com/7663513/91232674-f1743900-e705-11ea-9689-69730da5fa3b.png">


With the https://github.com/liferay/clay/issues/3652 fix:

<img width="119" alt="Screen Shot 2020-08-25 at 19 08 39" src="https://user-images.githubusercontent.com/7663513/91232878-65164600-e706-11ea-8987-f2b502cd3770.png">

<img width="554" alt="Screen Shot 2020-08-25 at 19 00 39" src="https://user-images.githubusercontent.com/7663513/91232729-05b83600-e706-11ea-89c9-59e1b09f9cb9.png">

###### Already Implemented on this PR?

YES

#### Question 2

* Tooltip-support doesn’t support showing the tooltip when focusing(the focusing behaviour was mentioned on the ticket as “*Given that*: The user hovers with the mouse over the product menu trigger or focuses on it” from: https://issues.liferay.com/browse/LPS-119736

**Should we modify this focus behaviour on tooltip-support implementation?**

###### Already Implemented on this PR?

NO

-----

From: https://github.com/liferay-frontend/liferay-portal/pull/310
### LPS-119755 Show or hide ApplicationsMenu modal when pressing Meta + Shift + 'M' keys

##### Test Case

1. Open DXP main page
2. Press Win/Command key + shift + m
3. You will see the ApplicationsMenu modal open

##### Questions

During the tests, I noticed sometimes this hotkey opens the Profile information of Chrome and sometimes a weird yellow terminal on Firefox. I'm not able to reproduce it anymore but it can happen.