### PR TITLE
LPS-119755 Show or hide ApplicationsMenu modal when pressing Meta + Shift + 'M' keys

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -22,6 +22,7 @@ import '../css/ApplicationsMenu.scss';
 import ClayLabel from '@clayui/label';
 import ClaySticker from '@clayui/sticker';
 import ClayTabs from '@clayui/tabs';
+import {useEventListener} from 'frontend-js-react-web';
 import {fetch, navigate, openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
@@ -345,6 +346,22 @@ const ApplicationsMenu = ({
 	const {observer, onClose} = useModal({
 		onClose: () => setVisible(false),
 	});
+
+	useEventListener(
+		'keydown',
+		(event) => {
+			event.preventDefault();
+
+			if (event.metaKey && event.shiftKey && event.key === 'm') {
+				if (!visible) {
+					fetchCategories();
+				}
+				setVisible(!visible);
+			}
+		},
+		true,
+		window
+	);
 
 	const fetchCategoriesPromiseRef = useRef();
 


### PR DESCRIPTION
…hift + 'M' keys

### Test Case

1. Open DXP main page
2. Press Win/Command key + shift + m
3. You will see the ApplicationsMenu modal open

### Questions

During the tests, I noticed sometimes this hotkey opens the Profile information of Chrome and sometimes a weird yellow terminal on Firefox. I'm not able to reproduce it anymore but it can happen.