### PR TITLE
LPS-80871 Add spacingBox to image2 plugin dialog box

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
@@ -53,5 +53,94 @@ CKEDITOR.on('dialogDefinition', (event) => {
 		};
 
 		Liferay.once('destroyPortlet', clearEventHandler);
+
+		if (dialog.getName() === 'image2') {
+			var infoTab = dialogDefinition.getContents('info');
+
+			var spacingBox = {
+				children: [
+					{
+						children: [
+							{
+								commit(widget) {
+									widget.setData('hspace', this.getValue());
+
+									var hspace = widget.data.hspace;
+
+									var imageElement = widget.parts.image;
+									if (imageElement) {
+										if (hspace) {
+											imageElement.setStyle(
+												'margin-left',
+												`${hspace}px`
+											);
+											imageElement.setStyle(
+												'margin-right',
+												`${hspace}px`
+											);
+										}
+									}
+								},
+								id: 'hspace',
+								label: 'HSpace',
+								requiredContent:
+									'img{margin-left,margin-right}',
+								setup(widget) {
+									this.setValue(widget.data.hspace);
+								},
+								type: 'text',
+
+								validate: CKEDITOR.dialog.validate.integer(
+									'Error! HSpace must be a whole number.'
+								),
+							},
+						],
+						type: 'hbox',
+					},
+					{
+						children: [
+							{
+								commit(widget) {
+									widget.setData('vspace', this.getValue());
+
+									var vspace = widget.data.vspace;
+
+									var imageElement = widget.parts.image;
+									if (imageElement) {
+										if (vspace) {
+											imageElement.setStyle(
+												'margin-bottom',
+												`${vspace}px`
+											);
+											imageElement.setStyle(
+												'margin-top',
+												`${vspace}px`
+											);
+										}
+									}
+								},
+								id: 'vspace',
+								label: 'VSpace',
+								requiredContent:
+									'img{margin-top,margin-bottom}',
+								setup(widget) {
+									this.setValue(widget.data.vspace);
+								},
+								type: 'text',
+
+								validate: CKEDITOR.dialog.validate.integer(
+									'Error! VSpace must be a whole number.'
+								),
+							},
+						],
+						type: 'hbox',
+					},
+				],
+				id: 'spacingBox',
+				type: 'hbox',
+			};
+
+			infoTab.add(spacingBox);
+		}
 	}
 });


### PR DESCRIPTION
This PR is a follow up on discussion in https://github.com/liferay/liferay-ckeditor/pull/116

The purpose of these changes is to add possibility to user to add horizontal and vertical space to the image element in editor.
I achieved this by adding 2 additional input fields in `image2` plugin dialog box.
Setting `hspace` value adds horizontal margin, `margin-left` and `margin-right` to image element selected in editor.
Setting `vspace` value adds vertical margin, `margin-left` and `margin-right` to image element selected in editor.

This solves the issue when editing the text next to image, where there was previously no space and allows the user possibility to add custom space.

To test these changes, you can add image to any CKeditor instance in the portal:

For example
Go to
- Content and Data
- Web Content
- New Basic Web Content
- Upload Image to main editor
- Double click image to open dialog box with `Image properties`
- Add preferred `hspace` or `vspace` values


1. Add 12 hspace value
<img width="1229" alt="1" src="https://user-images.githubusercontent.com/25637907/91321750-3e681600-e7bf-11ea-871f-503aed747042.png">


2. Image with text on the right without horizontal space
<img width="1161" alt="2-without hspace" src="https://user-images.githubusercontent.com/25637907/91321458-edf0b880-e7be-11ea-8550-860171d702e0.png">


3. Image with text on the right with applied `hspace` value
<img width="1135" alt="3" src="https://user-images.githubusercontent.com/25637907/91321759-4031d980-e7bf-11ea-82a2-d73dc9ecdae3.png">