### PR TITLE
LPS-119819 [Content Dashboard] Fix bug

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
@@ -75,16 +75,17 @@
 	height: auto;
 	left: 100%;
 	position: fixed;
+	transition: transform 0.5s ease;
 	width: $sidebarWidth;
 	z-index: $zindex-dropdown - 1;
-}
 
-.sidebar-body {
-	padding-top: 0;
-}
+	.sidebar-body {
+		padding-top: 0;
 
-.sidebar-body > .sidebar-section {
-	margin-bottom: 16px;
+		& > .sidebar-section {
+			margin-bottom: 16px;
+		}
+	}
 }
 
 .sidebar-open {
@@ -100,10 +101,6 @@
 
 .sidebar-wrapper {
 	transition: padding-right 0.5s ease;
-}
-
-.content-dashboard.sidebar {
-	transition: transform 0.5s ease;
 }
 
 .text-truncate-reverse {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
@@ -61,7 +61,7 @@
 		height: calc(100% - #{$controlMenuHeight});
 	}
 
-	.sidebar {
+	.content-dashboard.sidebar {
 		top: $controlMenuHeight;
 	}
 }
@@ -70,7 +70,7 @@
 	height: 100%;
 }
 
-.sidebar {
+.content-dashboard.sidebar {
 	bottom: 0;
 	height: auto;
 	left: 100%;
@@ -88,7 +88,7 @@
 }
 
 .sidebar-open {
-	.sidebar {
+	.content-dashboard.sidebar {
 		transform: translateX(-100%);
 		will-change: transform;
 	}
@@ -102,7 +102,7 @@
 	transition: padding-right 0.5s ease;
 }
 
-.sidebar {
+.content-dashboard.sidebar {
 	transition: transform 0.5s ease;
 }
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
@@ -82,7 +82,7 @@ const Sidebar = ({children, onClose = noop, open = true}) => {
 	}, [isOpen]);
 
 	return (
-		<div className="sidebar sidebar-light sidebar-sm">
+		<div className="content-dashboard sidebar sidebar-light sidebar-sm">
 			<SidebarContext.Provider value={{onClose}}>
 				{children}
 			</SidebarContext.Provider>

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/__snapshots__/Sidebar.js.snap
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/__snapshots__/Sidebar.js.snap
@@ -3,7 +3,7 @@
 exports[`Sidebar renders a closed sidebar 1`] = `
 <div>
   <div
-    class="sidebar sidebar-light sidebar-sm"
+    class="content-dashboard sidebar sidebar-light sidebar-sm"
   />
 </div>
 `;
@@ -11,7 +11,7 @@ exports[`Sidebar renders a closed sidebar 1`] = `
 exports[`Sidebar renders a sidebar with a header with title and subtitle 1`] = `
 <div>
   <div
-    class="sidebar sidebar-light sidebar-sm"
+    class="content-dashboard sidebar sidebar-light sidebar-sm"
   >
     <div
       class="sidebar-header"
@@ -58,7 +58,7 @@ exports[`Sidebar renders a sidebar with a header with title and subtitle 1`] = `
 exports[`Sidebar renders a sidebar with body with custom content 1`] = `
 <div>
   <div
-    class="sidebar sidebar-light sidebar-sm"
+    class="content-dashboard sidebar sidebar-light sidebar-sm"
   >
     <div
       class="sidebar-body"
@@ -74,7 +74,7 @@ exports[`Sidebar renders a sidebar with body with custom content 1`] = `
 exports[`Sidebar renders an open sidebar 1`] = `
 <div>
   <div
-    class="sidebar sidebar-light sidebar-sm"
+    class="content-dashboard sidebar sidebar-light sidebar-sm"
   />
 </div>
 `;

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/__snapshots__/SidebarPanelInfoView.js.snap
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/__snapshots__/SidebarPanelInfoView.js.snap
@@ -3,7 +3,7 @@
 exports[`SidebarPanelInfoView renders 1`] = `
 <DocumentFragment>
   <div
-    class="sidebar sidebar-light sidebar-sm"
+    class="content-dashboard sidebar sidebar-light sidebar-sm"
   >
     <div
       class="sidebar-header"


### PR DESCRIPTION
**Description**

In Content Dashboard we have two sidebars: one for the product menu and another one for info and metrics of specific content. We were changing by CSS things not only for the Content Dashboard sidebar. For that reason, if the user deactivates the Applications Menu, the Product Menu after clicking on `Applications > Content > Content Dashboard` wasn't displayed.

**Technical description**

I added a new class to point out the info/metrics sidebar along with `sidebar` and changed the `main.scss` properly. This way we changed only styles from Content Info and Content Metrics sidebars, not Product Menu sidebar:

```js
<div className="content-dashboard sidebar sidebar-light sidebar-sm">
	<SidebarContext.Provider value={{onClose}}>
	{children}
	</SidebarContext.Provider>
</div>
```
From:

```css
.sidebar {}
```

To:

```css
.content-dashboard.sidebar {}
```

**Screenshot**

![Screenshot 2020-08-26 at 17 01 04](https://user-images.githubusercontent.com/15845466/91320679-1deb8c00-e7be-11ea-9e7c-823b6114defb.png)