### PR TITLE
LPS-119827 Fixes initial state of the visible fields selector so that all fields are selected by default

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableHeadRow.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableHeadRow.js
@@ -35,6 +35,16 @@ const FieldsSelectorDropdown = ({fields}) => {
 	const [filteredFields, setFilteredFields] = useState(fields);
 	const [query, setQuery] = useState('');
 
+	const selectedFieldNames = Object.keys(visibleFieldNames).length
+		? visibleFieldNames
+		: fields.reduce(
+				(selectedFieldNames, field) => ({
+					...selectedFieldNames,
+					[field.fieldName]: true,
+				}),
+				{}
+		  );
+
 	useEffect(() => {
 		setFilteredFields(
 			fields.filter((field) =>
@@ -74,8 +84,8 @@ const FieldsSelectorDropdown = ({fields}) => {
 										id,
 										portletId,
 										visibleFieldNames: {
-											...visibleFieldNames,
-											[fieldName]: !visibleFieldNames[
+											...selectedFieldNames,
+											[fieldName]: !selectedFieldNames[
 												fieldName
 											],
 										},
@@ -83,7 +93,7 @@ const FieldsSelectorDropdown = ({fields}) => {
 								);
 							}}
 						>
-							{visibleFieldNames[fieldName] && (
+							{selectedFieldNames[fieldName] && (
 								<ClayIcon symbol="check" />
 							)}
 							{label}


### PR DESCRIPTION
In DataSet Display, the default state for the fields selector dropdown does not match what's actually displayed. The dropdown shows as if no fields were selected even though you can clearly see them on the table. 

**Steps to reproduce:**

1. Go to Product Menu -> Custom Apps -> Remote Apps
2. Add a Remote App
3. When you get redirected to the table, click on the arrow on the top right corner of the table to display the fields selector dropdown

**Expected Result:**
![Expected Result](https://user-images.githubusercontent.com/156388/91324599-a22b1880-e798-11ea-93f8-b1a0ab9664dc.png)

All fields are shown as selected (with a tick on the left) to match the fields that are actually displayed on the table.

**Actual Result:**
![Actual Result](https://user-images.githubusercontent.com/156388/91324663-af480780-e798-11ea-9d21-eb6f6e9484f6.png)

The dropdown shows as if no fields were selected: no tick on the left of each field name.

**Note:** This awkward behavior was first reported here: https://github.com/liferay-frontend/liferay-portal/pull/209#issuecomment-670030979