### PR TITLE
LPS-119846 Call proper method to retrieve JavaScript source map input stream

### DIFF
--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BaseBuiltInJSModuleServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BaseBuiltInJSModuleServlet.java
@@ -160,16 +160,24 @@ public abstract class BaseBuiltInJSModuleServlet extends HttpServlet {
 			String moduleName = resourceDescriptor.getPackagePath();
 
 			if (extension.equals("map")) {
-				moduleName = moduleName.substring(0, moduleName.length() - 7);
-			}
-			else if (extension.equals("js")) {
-				moduleName = moduleName.substring(0, moduleName.length() - 3);
-			}
+				JSModule jsModule = jsPackage.getJSModule(
+					moduleName.substring(0, moduleName.length() - 7));
 
-			JSModule jsModule = jsPackage.getJSModule(moduleName);
+				if (jsModule != null) {
+					inputStream = jsModule.getSourceMapInputStream();
+				}
+			}
+			else {
+				if (extension.equals("js")) {
+					moduleName = moduleName.substring(
+						0, moduleName.length() - 3);
+				}
 
-			if (jsModule != null) {
-				inputStream = jsModule.getInputStream();
+				JSModule jsModule = jsPackage.getJSModule(moduleName);
+
+				if (jsModule != null) {
+					inputStream = jsModule.getInputStream();
+				}
 			}
 		}
 


### PR DESCRIPTION
As some of you may have noticed, JavaScript source maps started to fail to load. @jbalsas pointed me towards https://github.com/brianchandotcom/liferay-portal/pull/93087 as the possible cause of the problem and indeed it was. To my understanding, in that PR @izaera introduced two distinct methods to retrieve input streams:
1. `jsModule.getInputStream()`
2. `jsModule.getSourceMapInputStream()`

But only the first was called. The fix consists of simply calling the right method when we detect a source map was requested.

**Steps to Reproduce:**

1. Start portal
2. Go to the URL: http://localhost:8080/o/js/resolved-module/frontend-js-spa-web@4.0.14/liferay/app/App.es.js.map

**Expected Result:**
The file served by the portal is a [source map](https://sourcemaps.info/spec.html).

**Actual Result:**
The file served by the portal is the JavaScript source code. 

Chrome will actually give you lots of warnings too:
![Source Map Errors](https://user-images.githubusercontent.com/156388/91347516-df070780-e7b8-11ea-9403-e90e757ea2d6.png)