### PR TITLE
LPS-119860 Fixes unpleasant flashing when requesting data in DataSet Display

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
@@ -16,6 +16,12 @@ import {fetch} from 'frontend-js-web';
 
 import createOdataFilter from './odata';
 
+export function delay(duration) {
+	return new Promise((resolve) => {
+		setTimeout(() => resolve(), duration);
+	});
+}
+
 function getAcceptLanguageHeaderParam() {
 	const browserLang = navigator.language ?? navigator.userLanguage;
 	const themeLang = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');


### PR DESCRIPTION
There's some unpleasant flashing happening when data is requested by the DataSet Display component.

**Steps to Reproduce:**
1. Go to Product Menu -> Custom Apps -> Remote Apps
2. Add a Remote App
3. Reload the page and observe carefully

**Expected Result:**
Loading state persists until data is completely retrieved.

![DataSet Flashing - After](https://user-images.githubusercontent.com/156388/91461092-fac4e900-e85e-11ea-8aa5-44ccfc8e98d9.gif)

**Actual Result:**
Loading state disappears and for a brief moment the empty state shows up right before the data shows up. 

![DataSet Flashing - Before](https://user-images.githubusercontent.com/156388/91461119-00baca00-e85f-11ea-860e-ab24f51fb94d.gif)

(I tried to record some gifs, but apparently the app I had doesn't generate anything useful. Will update this description once I find an app that works)

When the DataSet is mounted it does 2 parallel requests and both were controlling the loading state. That resulted in the loading state disappearing as soon as the first request was completed, but before the second one. I solved that by ~~wrapping both on a `Promise.all()`~~ using `Promise.race()` and a delay and controlling the loading state from there. From the diff it's hard to see because I had to move some code around, but [this comment](https://github.com/liferay-frontend/liferay-portal/pull/318#issuecomment-681997311) summarises it.