### PR TITLE
COMMERCE-4579 filters layout updated on data set display

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/ActiveFiltersBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/ActiveFiltersBar.js
@@ -13,6 +13,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {useAppState} from './Context';
@@ -75,5 +76,9 @@ function ActiveFiltersBar({disabled}) {
 		</div>
 	) : null;
 }
+
+ActiveFiltersBar.propTypes = {
+	disabled: PropTypes.bool,
+};
 
 export default ActiveFiltersBar;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FilterResume.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FilterResume.js
@@ -36,7 +36,7 @@ function FilterResume(props) {
 			closeButtonProps={{
 				className: 'filter-resume-close',
 				disabled: props.disabled,
-				onClick: () => actions.updateFilterState(props.id, null),
+				onClick: () => actions.updateFilterState(props.id),
 			}}
 			role="button"
 		>
@@ -59,11 +59,8 @@ function FilterResume(props) {
 			onActiveChange={setOpen}
 			trigger={label}
 		>
-			<ClayDropDown.ItemList>
-				<div className="p-3">
-					<Filter {...props} actions={actions} />
-				</div>
-			</ClayDropDown.ItemList>
+			<li className="dropdown-subheader">{props.label}</li>
+			<Filter {...{...props, actions}} />
 		</ClayDropDown>
 	);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FilterResume.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FilterResume.js
@@ -60,7 +60,7 @@ function FilterResume(props) {
 			trigger={label}
 		>
 			<li className="dropdown-subheader">{props.label}</li>
-			<Filter {...{...props, actions}} />
+			<Filter actions={actions} {...props} />
 		</ClayDropDown>
 	);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FiltersDropdown.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FiltersDropdown.js
@@ -37,18 +37,18 @@ function FiltersDropdown() {
 
 	useEffect(() => {
 		const results = state.filters.filter((filter) => {
-			switch (true) {
-				case !!filter.invisible:
-					return false;
-				case query &&
+			if (
+				filter.invisible ||
+				(query &&
 					!(
 						filter.id.toLowerCase().includes(query) ||
 						filter.label.toLowerCase().includes(query)
-					):
-					return false;
-				default:
-					return true;
+					))
+			) {
+				return false;
 			}
+
+			return true;
 		});
 
 		setVisibleFilter(results);
@@ -90,10 +90,7 @@ function FiltersDropdown() {
 					<Filter {...{...activeFilter, actions}} />
 				</>
 			) : (
-				<>
-					<li className="dropdown-subheader">
-						{Liferay.Language.get('filters')}
-					</li>
+				<ClayDropDown.Group header={Liferay.Language.get('filters')}>
 					<ClayDropDown.Search
 						onChange={(e) => setQuery(e.target.value)}
 						value={query}
@@ -115,11 +112,11 @@ function FiltersDropdown() {
 							))}
 						</ClayDropDown.ItemList>
 					) : (
-						<div className="dropdown-section text-muted">
+						<ClayDropDown.Caption>
 							{Liferay.Language.get('no-filters-were-found')}
-						</div>
+						</ClayDropDown.Caption>
 					)}
-				</>
+				</ClayDropDown.Group>
 			)}
 		</ClayDropDown>
 	) : null;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/NavBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/NavBar.js
@@ -40,7 +40,9 @@ function NavBar({creationMenu, showSearch, views}) {
 					</div>
 				)}
 				<div className="navbar-form navbar-form-autofit navbar-overlay navbar-overlay-sm-down pl-0">
-					{views?.length > 1 && <ActiveViewSelector views={views} />}
+					{views?.length > 1 ? (
+						<ActiveViewSelector views={views} />
+					) : null}
 				</div>
 				{creationMenu && <CreationMenu {...creationMenu} />}
 			</div>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/AutocompleteFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/AutocompleteFilter.js
@@ -38,18 +38,15 @@ function fetchData(apiURL, searchParam, currentPage = 1) {
 	url.searchParams.append('page', currentPage);
 	url.searchParams.append('pageSize', DEFAULT_PAGE_SIZE);
 
-	if(searchParam) {
+	if (searchParam) {
 		url.searchParams.append('search', encodeURIComponent(searchParam));
 	}
 
-	return fetch(
-		url,
-		{
-			headers: {
-				'Accept-Language': getAcceptLanguageHeaderParam(),
-			},
-		}
-	).then((response) => response.json());
+	return fetch(url, {
+		headers: {
+			'Accept-Language': getAcceptLanguageHeaderParam(),
+		},
+	}).then((response) => response.json());
 }
 
 function Item(props) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/AutocompleteFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/AutocompleteFilter.js
@@ -14,7 +14,8 @@
 
 import ClayAutocomplete from '@clayui/autocomplete';
 import ClayButton from '@clayui/button';
-import {ClayCheckbox, ClayRadio} from '@clayui/form';
+import ClayDropDown from '@clayui/drop-down';
+import {ClayCheckbox, ClayRadio, ClayToggle} from '@clayui/form';
 import ClayLabel from '@clayui/label';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {useIsMounted} from 'frontend-js-react-web';
@@ -22,19 +23,26 @@ import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
-import {fetchParams, getValueFromItem} from '../../../utilities/index';
+import {
+	getAcceptLanguageHeaderParam,
+	getValueFromItem,
+	isValuesArrayChanged,
+} from '../../../utilities/index';
 import {logError} from '../../../utilities/logError';
 
 const DEFAULT_PAGE_SIZE = 10;
 
 function fetchData(apiURL, searchParam, currentPage = 1) {
 	return fetch(
-		`${apiURL}?page=${currentPage}&pageSize=${DEFAULT_PAGE_SIZE}${
+		`${apiURL}${
+			apiURL.includes('?') ? '&' : '?'
+		}page=${currentPage}&pageSize=${DEFAULT_PAGE_SIZE}${
 			searchParam ? `&search=${encodeURIComponent(searchParam)}` : ''
 		}`,
 		{
-			...fetchParams,
-			method: 'GET',
+			headers: {
+				'Accept-Language': getAcceptLanguageHeaderParam(),
+			},
 		}
 	).then((response) => response.json());
 }
@@ -62,7 +70,11 @@ Item.propTypes = {
 	value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 };
 
-function getOdataString(value, key, selectionType) {
+const formatValue = (value, exclude) =>
+	(exclude ? `(${Liferay.Language.get('exclude')}) ` : '') +
+	value.map((el) => el.label).join(', ');
+
+function getOdataString(value, key, selectionType, exclude) {
 	if (!value || !value.length) {
 		return null;
 	}
@@ -71,24 +83,34 @@ function getOdataString(value, key, selectionType) {
 		? `${key}/any(x:${value
 				.map(
 					(v) =>
-						`(x eq ${
+						`(x ${exclude ? 'ne' : 'eq'} ${
 							typeof v.value === 'string'
 								? `'${v.value}'`
 								: v.value
 						})`
 				)
-				.join(' or ')})`
-		: `${key} eq ${
+				.join(exclude ? ' and ' : ' or ')})`
+		: `${key} ${exclude ? 'ne' : 'eq'} ${
 				typeof value[0].value === 'string'
 					? `'${value[0].value}'`
 					: value[0].value
 		  }`;
 }
-
-function AutocompleteFilter(props) {
+function AutocompleteFilter({
+	actions,
+	apiURL,
+	id,
+	inputPlaceholder,
+	itemKey,
+	itemLabel: itemLabelProp,
+	selectionType,
+	value: valueProp,
+}) {
 	const [query, setQuery] = useState('');
 	const [search, setSearch] = useState('');
-	const [selectedItems, setSelectedItems] = useState(props.value || []);
+	const [selectedItems, setSelectedItems] = useState(
+		(valueProp && valueProp.items) || []
+	);
 	const [items, updateItems] = useState(null);
 	const [loading, setLoading] = useState(false);
 	const [currentPage, setCurrentPage] = useState(1);
@@ -97,12 +119,15 @@ function AutocompleteFilter(props) {
 	const [scrollingAreaRendered, setScrollingAreaRendered] = useState(false);
 	const infiniteLoader = useRef(null);
 	const [infiniteLoaderRendered, setInfiniteLoaderRendered] = useState(false);
+	const [exclude, setExclude] = useState(
+		(valueProp && valueProp.exclude) || false
+	);
 
 	const loaderVisible = items && items.length < total;
 
 	useEffect(() => {
-		setSelectedItems(props.value || []);
-	}, [props.value]);
+		setSelectedItems((valueProp && valueProp.items) || []);
+	}, [valueProp]);
 
 	useEffect(() => {
 		if (query === search) {
@@ -116,22 +141,20 @@ function AutocompleteFilter(props) {
 
 	useEffect(() => {
 		setLoading(true);
-		fetchData(props.apiURL, search, currentPage)
+		fetchData(apiURL, search, currentPage)
 			.then((data) => {
 				if (!isMounted()) {
 					return;
 				}
 
 				setLoading(false);
-
 				if (currentPage === 1) {
 					updateItems(data.items);
 				}
 				else {
 					updateItems((items) => [...items, ...data.items]);
 				}
-
-				updateTotal(data.total);
+				updateTotal(data.totalCount);
 			})
 			.catch((error) => {
 				logError(error);
@@ -140,7 +163,7 @@ function AutocompleteFilter(props) {
 					setLoading(false);
 				}
 			});
-	}, [currentPage, isMounted, props.apiURL, search]);
+	}, [currentPage, isMounted, search, apiURL]);
 
 	const setScrollingArea = useCallback((node) => {
 		scrollingArea.current = node;
@@ -164,7 +187,11 @@ function AutocompleteFilter(props) {
 	]);
 
 	const setObserver = useCallback(() => {
-		if (!scrollingArea.current || !infiniteLoader.current) {
+		if (
+			!scrollingArea.current ||
+			!infiniteLoader.current ||
+			!IntersectionObserver
+		) {
 			return;
 		}
 
@@ -184,140 +211,204 @@ function AutocompleteFilter(props) {
 		observer.observe(infiniteLoader.current);
 	}, []);
 
-	function isValueChanged(prevValue = [], newValue = []) {
-		if (prevValue.length !== newValue.length) {
-			return true;
-		}
+	let actionType = 'edit';
 
-		const prevValues = prevValue.map((element) => element.value).sort();
-		const newValues = newValue.map((element) => element.value).sort();
+	if (valueProp && valueProp.items && !selectedItems.length) {
+		actionType = 'delete';
+	}
 
-		return prevValues.some((element, i) => element !== newValues[i]);
+	if (!valueProp) {
+		actionType = 'add';
+	}
+
+	let submitDisabled = true;
+
+	if (
+		actionType === 'delete' ||
+		(!valueProp && selectedItems.length) ||
+		(valueProp && isValuesArrayChanged(valueProp.items, selectedItems)) ||
+		(valueProp && selectedItems.length && valueProp.exclude !== exclude)
+	) {
+		submitDisabled = false;
 	}
 
 	return (
-		<div className="form-group">
-			<ClayAutocomplete className="mb-2">
-				<ClayAutocomplete.Input
-					onChange={(event) => setQuery(event.target.value)}
-				/>
-				{loading && <ClayAutocomplete.LoadingIndicator />}
-			</ClayAutocomplete>
-			<div className="selected-elements-wrapper">
-				{selectedItems.map((selectedItem) => {
-					return (
-						<ClayLabel
-							closeButtonProps={{
-								onClick: () =>
-									setSelectedItems((items) =>
-										items.filter(
-											(item) =>
-												item.value !==
-												selectedItem.value
-										)
-									),
-							}}
-							key={selectedItem.value}
-						>
-							{selectedItem.label}
-						</ClayLabel>
-					);
-				})}
-			</div>
-			{items && items.length ? (
-				<ul
-					className="inline-scroller mt-2 mx-n3 px-3"
-					ref={setScrollingArea}
-				>
-					{items.map((item) => {
-						const itemValue = item[props.itemKey];
-						const itemLabel = getValueFromItem(
-							item,
-							props.itemLabel
-						);
-						const newValue = {
-							label: itemLabel,
-							value: itemValue,
-						};
-
-						return (
-							<Item
-								key={itemValue}
-								label={itemLabel}
-								onChange={() => {
-									setSelectedItems(
-										selectedItems.find(
-											(el) => el.value === itemValue
-										)
-											? selectedItems.filter(
-													(el) =>
-														el.value !== itemValue
-											  )
-											: props.selectionType === 'multiple'
-											? [...selectedItems, newValue]
-											: [newValue]
-									);
+		<>
+			<ClayDropDown.Caption>
+				<ClayAutocomplete>
+					<ClayAutocomplete.Input
+						onChange={(event) => setQuery(event.target.value)}
+						placeholder={inputPlaceholder}
+					/>
+					{loading && <ClayAutocomplete.LoadingIndicator />}
+				</ClayAutocomplete>
+				{selectedItems.length ? (
+					<div className="mt-2 selected-elements-wrapper">
+						{selectedItems.map((selectedItem) => (
+							<ClayLabel
+								closeButtonProps={{
+									onClick: () =>
+										setSelectedItems((items) =>
+											items.filter(
+												(item) =>
+													item.value !==
+													selectedItem.value
+											)
+										),
 								}}
-								selected={Boolean(
-									selectedItems.find(
-										(el) => el.value === itemValue
-									)
-								)}
-								selectionType={props.selectionType}
-								value={itemValue}
-							/>
-						);
-					})}
-					{loaderVisible && (
-						<ClayLoadingIndicator ref={setInfiniteLoader} small />
-					)}
-				</ul>
-			) : (
-				<div className="mt-2 p-2 text-muted">
-					{Liferay.Language.get('no-items-were-found')}
+								key={selectedItem.value}
+							>
+								{selectedItem.label}
+							</ClayLabel>
+						))}
+					</div>
+				) : null}
+			</ClayDropDown.Caption>
+			<ClayDropDown.Divider />
+			<ClayDropDown.Caption className="py-0">
+				<div className="row">
+					<div className="col">
+						<label htmlFor={`autocomplete-exclude-${id}`}>
+							{Liferay.Language.get('exclude')}
+						</label>
+					</div>
+					<div className="col-auto">
+						<ClayToggle
+							id={`autocomplete-exclude-${id}`}
+							onToggle={() => setExclude(!exclude)}
+							toggled={exclude}
+						/>
+					</div>
 				</div>
-			)}
-			<div className="mt-3">
+			</ClayDropDown.Caption>
+			<ClayDropDown.Divider />
+			<ClayDropDown.Caption>
+				<div className="form-group">
+					{items && items.length ? (
+						<ul
+							className="inline-scroller mb-n2 mx-n2 px-2"
+							ref={setScrollingArea}
+						>
+							{items.map((item) => {
+								const itemValue = item[itemKey];
+								const itemLabel = getValueFromItem(
+									item,
+									itemLabelProp
+								);
+								const newValue = {
+									label: itemLabel,
+									value: itemValue,
+								};
+
+								return (
+									<Item
+										key={itemValue}
+										label={itemLabel}
+										onChange={() => {
+											setSelectedItems(
+												selectedItems.find(
+													(el) =>
+														el.value === itemValue
+												)
+													? selectedItems.filter(
+															(el) =>
+																el.value !==
+																itemValue
+													  )
+													: selectionType ===
+													  'multiple'
+													? [
+															...selectedItems,
+															newValue,
+													  ]
+													: [newValue]
+											);
+										}}
+										selected={Boolean(
+											selectedItems.find(
+												(el) => el.value === itemValue
+											)
+										)}
+										selectionType={selectionType}
+										value={itemValue}
+									/>
+								);
+							})}
+							{loaderVisible && (
+								<ClayLoadingIndicator
+									ref={setInfiniteLoader}
+									small
+								/>
+							)}
+						</ul>
+					) : (
+						<div className="mt-2 p-2 text-muted">
+							{Liferay.Language.get('no-items-were-found')}
+						</div>
+					)}
+				</div>
+			</ClayDropDown.Caption>
+			<ClayDropDown.Divider />
+			<ClayDropDown.Caption>
 				<ClayButton
-					className="btn-sm"
-					disabled={!isValueChanged(props.value || [], selectedItems)}
+					disabled={submitDisabled}
 					onClick={() =>
-						props.actions.updateFilterState(
-							props.id,
-							selectedItems.length ? selectedItems : null,
-							getOdataString(
-								selectedItems,
-								props.id,
-								props.selectionType
-							)
-						)
+						actionType !== 'delete'
+							? actions.updateFilterState(
+									id,
+									{
+										exclude,
+										items: selectedItems,
+									},
+									formatValue(selectedItems, exclude),
+									getOdataString(
+										selectedItems,
+										id,
+										selectionType,
+										exclude
+									)
+							  )
+							: actions.updateFilterState(id)
 					}
+					small
 				>
-					{props.value
-						? Liferay.Language.get('edit-filter')
-						: Liferay.Language.get('add-filter')}
+					{actionType === 'add' && Liferay.Language.get('add-filter')}
+					{actionType === 'edit' &&
+						Liferay.Language.get('edit-filter')}
+					{actionType === 'delete' &&
+						Liferay.Language.get('delete-filter')}
 				</ClayButton>
-			</div>
-		</div>
+			</ClayDropDown.Caption>
+		</>
 	);
 }
 
 AutocompleteFilter.propTypes = {
+	actions: PropTypes.shape({
+		updateFilterState: PropTypes.func.isRequired,
+	}),
+	apiURL: PropTypes.string.isRequired,
 	id: PropTypes.string.isRequired,
 	inputPlaceholder: PropTypes.string,
-	invisible: PropTypes.bool,
 	itemKey: PropTypes.string.isRequired,
 	itemLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
 		.isRequired,
-	label: PropTypes.string.isRequired,
 	selectionType: PropTypes.oneOf(['single', 'multiple']).isRequired,
-	type: PropTypes.oneOf(['autocomplete']).isRequired,
-	value: PropTypes.arrayOf(
-		PropTypes.shape({
-			id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-			label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-		})
-	),
+	value: PropTypes.shape({
+		exclude: PropTypes.bool,
+		items: PropTypes.arrayOf(
+			PropTypes.shape({
+				label: PropTypes.oneOfType([
+					PropTypes.string,
+					PropTypes.number,
+				]),
+				value: PropTypes.oneOfType([
+					PropTypes.string,
+					PropTypes.number,
+				]),
+			})
+		),
+	}),
 };
 
 AutocompleteFilter.defaultProps = {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/CheckboxesFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/CheckboxesFilter.js
@@ -20,13 +20,13 @@ import React, {useEffect, useState} from 'react';
 
 import {isValuesArrayChanged} from '../../../utilities/index';
 
-export const formatValue = (value, items, exclude) => {
-	const formattedValue = value
-		? value
-				.map((v) => {
+export const formatValue = (values, items, exclude) => {
+	const formattedValue = values
+		? values
+				.map((value) => {
 					return items.reduce(
 						(found, item) =>
-							found || (item.value === v ? item.label : null),
+							found || (item.value === value ? item.label : null),
 						null
 					);
 				})
@@ -40,18 +40,18 @@ export const formatValue = (value, items, exclude) => {
 };
 
 function getOdataString(values, key, exclude = false) {
-	if (!values || !values.length) {
-		return null;
+	if (values?.length) {
+		return `${key}/any(x:${values
+			.map(
+				(value) =>
+					`(x ${exclude ? 'ne' : 'eq'} ${
+						typeof value === 'string' ? `'${value}'` : value
+					})`
+			)
+			.join(exclude ? ' and ' : ' or ')})`;
 	}
 
-	return `${key}/any(x:${values
-		.map(
-			(v) =>
-				`(x ${exclude ? 'ne' : 'eq'} ${
-					typeof v === 'string' ? `'${v}'` : v
-				})`
-		)
-		.join(exclude ? ' and ' : ' or ')})`;
+	return null;
 }
 function CheckboxesFilter({actions, id, items, value: valueProp}) {
 	const [itemsValues, setItemsValues] = useState(
@@ -63,7 +63,9 @@ function CheckboxesFilter({actions, id, items, value: valueProp}) {
 
 	function selectCheckbox(selected) {
 		if (itemsValues.includes(selected)) {
-			return setItemsValues(itemsValues.filter((v) => v !== selected));
+			return setItemsValues(
+				itemsValues.filter((value) => value !== selected)
+			);
 		}
 
 		return setItemsValues(itemsValues.concat(selected));
@@ -76,7 +78,7 @@ function CheckboxesFilter({actions, id, items, value: valueProp}) {
 
 	let actionType = 'edit';
 
-	if (valueProp && valueProp.itemsValues && !itemsValues.length) {
+	if (valueProp?.itemsValues && !itemsValues.length) {
 		actionType = 'delete';
 	}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/DateRangeFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/DateRangeFilter.js
@@ -13,97 +13,118 @@
  */
 
 import ClayButton from '@clayui/button';
+import ClayDropDown from '@clayui/drop-down';
 import ClayForm from '@clayui/form';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
 import {
+	convertObjectDateToIsoString,
 	formatDateObject,
+	formatDateRangeObject,
 	getDateFromDateString,
 } from '../../../utilities/dates';
 
-export function convertObjectDateToIsoString(objDate, direction) {
-	const time = direction === 'from' ? [0, 0, 0, 0] : [23, 59, 59, 999];
-	const date = new Date(
-		objDate.year,
-		objDate.month - 1,
-		objDate.day,
-		...time
-	);
-
-	return date.toISOString();
-}
-
 function getOdataString(value, key) {
-	const from = convertObjectDateToIsoString(value.from, 'from');
-	const to = convertObjectDateToIsoString(value.to, 'to');
-
 	if (value.from && value.to) {
-		return `${key} ge ${from}) and (${key} le ${to}`;
+		return `${key} ge ${convertObjectDateToIsoString(
+			value.from,
+			'from'
+		)}) and (${key} le ${convertObjectDateToIsoString(value.to, 'to')}`;
 	}
-	else if (value.from) {
-		return `${key} ge ${from}`;
+	if (value.from) {
+		return `${key} ge ${convertObjectDateToIsoString(value.from, 'from')}`;
 	}
-	else if (value.to) {
-		return `${key} le ${to}`;
+	if (value.to) {
+		return `${key} le ${convertObjectDateToIsoString(value.to, 'to')}`;
 	}
-
-	return null;
 }
-
-function DateRangeFilter({actions, id, max, min, placeholder, value}) {
+function DateRangeFilter({
+	actions,
+	id,
+	max,
+	min,
+	placeholder,
+	value: valueProp,
+}) {
 	const [fromValue, setFromValue] = useState(
-		value?.from && formatDateObject(value.from)
+		valueProp && valueProp.from && formatDateObject(valueProp.from)
 	);
 	const [toValue, setToValue] = useState(
-		value?.to && formatDateObject(value.to)
+		valueProp && valueProp.to && formatDateObject(valueProp.to)
 	);
 
-	return (
-		<div className="form-group">
-			<ClayForm.Group className="form-group-sm">
-				<label htmlFor={`from-${id}`}>
-					{Liferay.Language.get('from')}
-				</label>
-				<input
-					className="form-control"
-					id={`from-${id}`}
-					max={toValue || (max && formatDateObject(max))}
-					min={min && formatDateObject(min)}
-					onChange={(event) => setFromValue(event.target.value)}
-					pattern="\d{4}-\d{2}-\d{2}"
-					placeholder={placeholder || 'yyyy-mm-dd'}
-					type="date"
-					value={fromValue || ''}
-				/>
-			</ClayForm.Group>
-			<ClayForm.Group className="form-group-sm mt-2">
-				<label htmlFor={`to-${id}`}>{Liferay.Language.get('to')}</label>
-				<input
-					className="form-control"
-					id={`to-${id}`}
-					max={max && formatDateObject(max)}
-					min={fromValue || (min && formatDateObject(min))}
-					onChange={(event) => setToValue(event.target.value)}
-					pattern="\d{4}-\d{2}-\d{2}"
-					placeholder={placeholder || 'yyyy-mm-dd'}
-					type="date"
-					value={toValue || ''}
-				/>
-			</ClayForm.Group>
+	let actionType = 'edit';
 
-			<div className="mt-3">
+	if (valueProp && !fromValue && !toValue) {
+		actionType = 'delete';
+	}
+
+	if (!valueProp) {
+		actionType = 'add';
+	}
+
+	let submitDisabled = true;
+
+	if (
+		actionType === 'delete' ||
+		((!valueProp || !valueProp.from) && fromValue) ||
+		((!valueProp || !valueProp.to) && toValue) ||
+		(valueProp &&
+			valueProp.from &&
+			fromValue !== formatDateObject(valueProp.from)) ||
+		(valueProp &&
+			valueProp.to &&
+			toValue !== formatDateObject(valueProp.to))
+	) {
+		submitDisabled = false;
+	}
+
+	return (
+		<>
+			<ClayDropDown.Caption>
+				<div className="form-group">
+					<ClayForm.Group className="form-group-sm">
+						<label htmlFor={`from-${id}`}>
+							{Liferay.Language.get('from')}
+						</label>
+						<input
+							className="form-control"
+							id={`from-${id}`}
+							max={toValue || (max && formatDateObject(max))}
+							min={min && formatDateObject(min)}
+							onChange={(e) => setFromValue(e.target.value)}
+							pattern="\d{4}-\d{2}-\d{2}"
+							placeholder={placeholder || 'yyyy-mm-dd'}
+							type="date"
+							value={fromValue || ''}
+						/>
+					</ClayForm.Group>
+					<ClayForm.Group className="form-group-sm mt-2">
+						<label htmlFor={`to-${id}`}>
+							{Liferay.Language.get('to')}
+						</label>
+						<input
+							className="form-control"
+							id={`to-${id}`}
+							max={max && formatDateObject(max)}
+							min={fromValue || (min && formatDateObject(min))}
+							onChange={(e) => setToValue(e.target.value)}
+							pattern="\d{4}-\d{2}-\d{2}"
+							placeholder={placeholder || 'yyyy-mm-dd'}
+							type="date"
+							value={toValue || ''}
+						/>
+					</ClayForm.Group>
+				</div>
+			</ClayDropDown.Caption>
+			<ClayDropDown.Divider />
+			<ClayDropDown.Caption>
 				<ClayButton
-					className="btn-sm"
-					disabled={
-						fromValue ===
-							(value?.from ? formatDateObject(value.from) : '') &&
-						toValue ===
-							(value?.to ? formatDateObject(value.to) : '')
-					}
+					disabled={submitDisabled}
 					onClick={() => {
-						if (!fromValue && !toValue) {
-							actions.updateFilterState(id, null, null);
+						if (actionType === 'delete') {
+							actions.updateFilterState(id);
 						}
 						else {
 							const newValue = {
@@ -114,21 +135,24 @@ function DateRangeFilter({actions, id, max, min, placeholder, value}) {
 									? getDateFromDateString(toValue)
 									: null,
 							};
-
 							actions.updateFilterState(
 								id,
 								newValue,
+								formatDateRangeObject(newValue),
 								getOdataString(newValue, id)
 							);
 						}
 					}}
+					small
 				>
-					{value
-						? Liferay.Language.get('edit-filter')
-						: Liferay.Language.get('add-filter')}
+					{actionType === 'add' && Liferay.Language.get('add-filter')}
+					{actionType === 'edit' &&
+						Liferay.Language.get('edit-filter')}
+					{actionType === 'delete' &&
+						Liferay.Language.get('delete-filter')}
 				</ClayButton>
-			</div>
-		</div>
+			</ClayDropDown.Caption>
+		</>
 	);
 }
 
@@ -139,13 +163,13 @@ const dateShape = PropTypes.shape({
 });
 
 DateRangeFilter.propTypes = {
+	actions: PropTypes.shape({
+		updateFilterState: PropTypes.func.isRequired,
+	}),
 	id: PropTypes.string.isRequired,
-	invisible: PropTypes.bool,
-	label: PropTypes.string.isRequired,
 	max: dateShape,
 	min: dateShape,
 	placeholder: PropTypes.string,
-	type: PropTypes.oneOf(['dateRange']).isRequired,
 	value: PropTypes.shape({
 		from: dateShape,
 		to: dateShape,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/NumberFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/NumberFilter.js
@@ -13,6 +13,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import ClayDropDown from '@clayui/drop-down';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
@@ -25,57 +26,65 @@ function NumberFilter({actions, id, inputText, max, min, value: valueProp}) {
 	const [value, setValue] = useState(valueProp);
 
 	return (
-		<div className="form-group">
-			<div className="input-group">
-				<div
-					className={classNames('input-group-item', {
-						'input-group-prepend': inputText,
-					})}
-				>
-					<input
-						className="form-control"
-						max={max}
-						min={min}
-						onChange={(event) => setValue(event.target.value)}
-						type="number"
-						value={value || ''}
-					/>
-				</div>
-				{inputText && (
-					<div className="input-group-append input-group-item input-group-item-shrink">
-						<span className="input-group-text">{inputText}</span>
+		<>
+			<ClayDropDown.Caption>
+				<div className="form-group">
+					<div className="input-group">
+						<div
+							className={classNames('input-group-item', {
+								'input-group-prepend': inputText,
+							})}
+						>
+							<input
+								className="form-control"
+								max={max}
+								min={min}
+								onChange={(e) => setValue(e.target.value)}
+								type="number"
+								value={value || ''}
+							/>
+						</div>
+						{inputText && (
+							<div className="input-group-append input-group-item input-group-item-shrink">
+								<span className="input-group-text">
+									{inputText}
+								</span>
+							</div>
+						)}
 					</div>
-				)}
-			</div>
-			<div className="mt-3">
+				</div>
+			</ClayDropDown.Caption>
+			<ClayDropDown.Divider />
+			<ClayDropDown.Caption>
 				<ClayButton
-					className="btn-sm"
 					disabled={Number(value) === valueProp}
 					onClick={() =>
 						actions.updateFilterState(
 							id,
 							Number(value),
+							value,
 							getOdataString(Number(value, id))
 						)
 					}
+					small
 				>
 					{valueProp
 						? Liferay.Language.get('edit-filter')
 						: Liferay.Language.get('add-filter')}
 				</ClayButton>
-			</div>
-		</div>
+			</ClayDropDown.Caption>
+		</>
 	);
 }
 
 NumberFilter.propTypes = {
+	actions: PropTypes.shape({
+		updateFilterState: PropTypes.func.isRequired,
+	}),
 	id: PropTypes.string.isRequired,
 	inputText: PropTypes.string,
-	invisible: PropTypes.bool,
-	label: PropTypes.string.isRequired,
 	max: PropTypes.number,
 	min: PropTypes.number,
-	type: PropTypes.oneOf(['number']).isRequired,
 	value: PropTypes.number,
 };
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/RadioFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/RadioFilter.js
@@ -34,7 +34,7 @@ function RadioFilter({actions, id, items, value: valueProp}) {
 	const [itemValue, setItemValue] = useState(
 		valueProp && valueProp.itemValue
 	);
-	const [exclude, setExclude] = useState(valueProp && valueProp.exclude);
+	const [exclude, setExclude] = useState(!!valueProp?.exclude);
 
 	const actionType = valueProp ? 'edit' : 'add';
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/TestFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/TestFilter.js
@@ -13,6 +13,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import ClayDropDown from '@clayui/drop-down';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
@@ -21,56 +22,61 @@ function getOdataString() {
 	return `test ne 4`;
 }
 
-function TestFilter({actions, id, inputText, label, value: valueProp}) {
+function TestFilter({actions, id, inputText, value: valueProp}) {
 	const [value, setValue] = useState(valueProp);
 
 	return (
-		<div className="form-group">
-			<div className="input-group">
-				<div
-					className={classNames('input-group-item', {
-						'input-group-prepend': inputText,
-					})}
-				>
-					<input
-						aria-label={label}
-						className="form-control"
-						onChange={(e) => setValue(e.target.value)}
-						type="text"
-						value={value || ''}
-					/>
+		<ClayDropDown.Caption>
+			<div className="form-group">
+				<div className="input-group">
+					<div
+						className={classNames('input-group-item', {
+							'input-group-prepend': inputText,
+						})}
+					>
+						<input
+							className="form-control"
+							onChange={(e) => setValue(e.target.value)}
+							type="text"
+							value={value || ''}
+						/>
+					</div>
+					<div className="input-group-append input-group-item input-group-item-shrink">
+						<span className="input-group-text">
+							{Liferay.Language.get('test')}
+						</span>
+					</div>
 				</div>
-				<div className="input-group-append input-group-item input-group-item-shrink">
-					<span className="input-group-text">
-						{Liferay.Language.get('test')}
-					</span>
+
+				<div className="mt-3">
+					<ClayButton
+						disabled={value === valueProp}
+						onClick={() =>
+							actions.updateFilterState(
+								id,
+								value,
+								value,
+								getOdataString(value, id)
+							)
+						}
+						small
+					>
+						{valueProp
+							? Liferay.Language.get('edit-filter')
+							: Liferay.Language.get('add-filter')}
+					</ClayButton>
 				</div>
 			</div>
-			<div className="mt-3">
-				<ClayButton
-					className="btn-sm"
-					disabled={value === valueProp}
-					onClick={() =>
-						actions.updateFilterState(
-							id,
-							value,
-							getOdataString(value, id)
-						)
-					}
-				>
-					{valueProp
-						? Liferay.Language.get('edit-filter')
-						: Liferay.Language.get('add-filter')}
-				</ClayButton>
-			</div>
-		</div>
+		</ClayDropDown.Caption>
 	);
 }
 
 TestFilter.propTypes = {
+	actions: PropTypes.shape({
+		updateFilterState: PropTypes.func.isRequired,
+	}),
 	id: PropTypes.string.isRequired,
-	invisible: PropTypes.bool,
-	label: PropTypes.string.isRequired,
+	inputText: PropTypes.string,
 	value: PropTypes.string,
 };
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/TextFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/TextFilter.js
@@ -22,7 +22,7 @@ function getOdataString(value, key) {
 	return `${key} eq '${value}'`;
 }
 
-function TextFilter({actions, id, inputText, label, value: valueProp}) {
+function TextFilter({actions, id, inputText, value: valueProp}) {
 	const [value, setValue] = useState(valueProp);
 
 	let actionType = 'edit';
@@ -30,7 +30,8 @@ function TextFilter({actions, id, inputText, label, value: valueProp}) {
 	if (valueProp && !value) {
 		actionType = 'delete';
 	}
-	else if (!valueProp && value) {
+
+	if (!valueProp && value) {
 		actionType = 'add';
 	}
 
@@ -45,7 +46,6 @@ function TextFilter({actions, id, inputText, label, value: valueProp}) {
 							})}
 						>
 							<input
-								aria-label={label}
 								className="form-control"
 								onChange={(e) => setValue(e.target.value)}
 								type="text"
@@ -65,7 +65,7 @@ function TextFilter({actions, id, inputText, label, value: valueProp}) {
 			<ClayDropDown.Divider />
 			<ClayDropDown.Caption>
 				<ClayButton
-					disabled={(!value && value) || value !== value}
+					disabled={(!valueProp && value) || valueProp !== value}
 					onClick={() =>
 						actions.updateFilterState(
 							id,
@@ -88,11 +88,11 @@ function TextFilter({actions, id, inputText, label, value: valueProp}) {
 }
 
 TextFilter.propTypes = {
+	actions: PropTypes.shape({
+		updateFilterState: PropTypes.func.isRequired,
+	}),
 	id: PropTypes.string.isRequired,
 	inputText: PropTypes.string,
-	invisible: PropTypes.bool,
-	label: PropTypes.string.isRequired,
-	type: PropTypes.oneOf(['text']).isRequired,
 	value: PropTypes.string,
 };
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/index.js
@@ -59,7 +59,7 @@ export function Filter(props) {
 	}, [moduleURL]);
 
 	return Component ? (
-		<div className="data-set-filter test">
+		<div className="data-set-filter">
 			<Component {...props} />
 		</div>
 	) : (

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
@@ -22,7 +22,7 @@ export function delay(duration) {
 	});
 }
 
-function getAcceptLanguageHeaderParam() {
+export function getAcceptLanguageHeaderParam() {
 	const browserLang = navigator.language ?? navigator.userLanguage;
 	const themeLang = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
 
@@ -59,6 +59,25 @@ export function liferayNavigate(url) {
 	else {
 		window.location.href = url;
 	}
+}
+
+export function isValuesArrayChanged(prevValue = [], newValue = []) {
+	if (prevValue.length !== newValue.length) {
+		return true;
+	}
+
+	const prevValues = prevValue.map((el) => el.value || el).sort();
+	const newValues = newValue.map((el) => el.value || el).sort();
+
+	let changed = false;
+
+	prevValues.forEach((element, i) => {
+		if (element !== newValues[i]) {
+			changed = true;
+		}
+	});
+
+	return changed;
 }
 
 export function getValueFromItem(item, fieldName) {


### PR DESCRIPTION
While the data set migration was going on, we made some changes on filters.

This PR updates the filters dropdown and resume to make them compliant with the most recent designs we have in commerce. It also fixes the way labels looks:

Before: 
![Screenshot from 2020-08-25 18-33-49](https://user-images.githubusercontent.com/44569796/91412396-0659e500-e84a-11ea-923e-b3d963b374ec.png)
Now:
![Screenshot from 2020-08-25 18-49-55](https://user-images.githubusercontent.com/44569796/91412696-710b2080-e84a-11ea-9b05-464599055625.png)

