### PR TITLE
LPS-119791 Page elements in the footer of the permissions iframe are offset

### DIFF
--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
@@ -45,7 +45,7 @@ if (fixedHeader) {
 }
 %>
 
-<div class="table-responsive">
+<div class="c-mb-3 table-responsive">
 	<table class="<%= searchResultCssClass %>">
 		<c:if test="<%= Validator.isNotNull(summary) %>">
 			<caption class="sr-only"><%= summary %></caption>


### PR DESCRIPTION
`.table-responsive` were lost margin bottom in @clayui/css@3.13.0 (current now) in portal version 7.2.1-ga2 @clayui/css@3.0.1 works great.

**Steps to reproduce:**

Show any permissions modal, for example:

1. Navigate to Control Panel > Roles > Asset Library Roles
2. Click on any default role's action icon > Permissions
3. View iframe

---

**Before the fix:**
![image](https://user-images.githubusercontent.com/67901/91432051-7889f400-e861-11ea-9e01-8b9e969b6443.png)

**After the fix:**
![image](https://user-images.githubusercontent.com/67901/91432461-0bc32980-e862-11ea-946e-a966f8a5cfe7.png)
