### PR TITLE
LPS-119875 Replaces custom ae_autolink with ootb autolink plugin

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/BaseAlloyEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/BaseAlloyEditorConfigContributor.java
@@ -62,9 +62,9 @@ public abstract class BaseAlloyEditorConfigContributor
 			"disableNativeSpellChecker", Boolean.FALSE
 		).put(
 			"extraPlugins",
-			"addimages,ae_autolink,ae_dragresize,ae_imagealignment," +
-				"ae_placeholder,ae_selectionregion,ae_tableresize," +
-					"ae_tabletools,ae_uicore"
+			"addimages,ae_dragresize,ae_imagealignment,ae_placeholder," +
+				"ae_selectionregion,ae_tableresize,ae_tabletools,ae_uicore," +
+					"autolink"
 		).put(
 			"imageScaleResize", "scale"
 		).put(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -80,7 +80,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 		);
 
 		String extraPlugins =
-			"addimages,autogrow,filebrowser,itemselector,lfrpopup," +
+			"addimages,autogrow,autolink,filebrowser,itemselector,lfrpopup," +
 				"media,stylescombo,videoembed";
 
 		boolean inlineEdit = GetterUtil.getBoolean(


### PR DESCRIPTION
Based on [Page freezes when long alphanumeric strings are pasted into a Blogs editor](https://issues.liferay.com/browse/LPS-119875). 

I haven't thoroughly tested this, but I suspected either our `addimages` or our `ae_autolink` plugins could be at fault, since they're both 2 plugins that inspect `keypress` and `paste` operations and do something with it, so it stands to reason that big chunks of text could impact their performance.

I reproduced on my own and [got confirmation](https://issues.liferay.com/browse/LPS-119875?focusedCommentId=2233816&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2233816) from @ambrinchaudhary that it did not reproduce without the `ae_autolink` plugin.

So, based on that, going here on a limb (which I wanted to do anyways) and:
- Replaced `ae_autolink` with [`autolink`](https://ckeditor.com/cke4/addon/autolink). All the functionality with none of the bugs or maintenance 🤞 
- Sneaked in `autolink` by default in the CKEditor configuration so we can get this everywhere

I tested and couldn't reproduce the frozen AlloyEditor, so hoping this does the trick!