### PR TITLE
LPS-119566 Fixes the error of the language deletion icon in the translation manager

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_translation_manager.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_translation_manager.scss
@@ -53,5 +53,9 @@
 	.lfr-translation-manager-delete-translation {
 		display: inline-block;
 		padding: 0 2px;
+
+		svg {
+			pointer-events: none;
+		}
 	}
 }

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/translation_manager.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/translation_manager.js
@@ -93,9 +93,11 @@ AUI.add(
 			' {cssClass}" locale="{locale}">' +
 			TPL_LOCALE_IMAGE +
 			'{displayName} ' +
-			'<i class="' +
+			'<span class="' +
 			CSS_DELETE_TRANSLATION +
-			' icon icon-remove"></i>' +
+			'">' +
+			Liferay.Util.getLexiconIconTpl('times') +
+			'</span>' +
 			'</span>';
 
 		var TPL_CHANGE_DEFAULT_LOCALE =


### PR DESCRIPTION
Fixes the error that it was not possible to delete a translation using the translation manager. It probably must have been after we deactivated fontawesome by default, so just switching to the Lexicon icon.

#### Steps
1. Go to Menu -> Content & Data -> Web Content -> Structures
2. Create new Structures
3. Add new language

#### With the fix
<img width="1666" alt="Screen Shot 2020-08-27 at 20 21 05" src="https://user-images.githubusercontent.com/13750819/91504208-d854bf00-e8a2-11ea-9321-4c1438afeebb.png">

#### Actual result
<img width="1664" alt="Screen Shot 2020-08-27 at 20 21 46" src="https://user-images.githubusercontent.com/13750819/91504243-ef93ac80-e8a2-11ea-852c-0d3eae69f803.png">