### PR TITLE
LPS-119952 Adjusts Setup Wizard styling

### DIFF
--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -16,7 +16,7 @@
 
 <%@ include file="/html/portal/init.jsp" %>
 
-<div id="wrapper">
+<div class="pt-0" id="wrapper">
 	<header class="mb-4" id="banner">
 		<div class="mb-4 navbar navbar-classic navbar-top py-3">
 			<div class="container">
@@ -37,7 +37,7 @@
 	</header>
 
 	<div class="container" id="content">
-		<div class="sheet sheet-lg">
+		<div class="sheet sheet-lg" id="main-content">
 			<h2 class="sheet-title" title="<liferay-ui:message key="basic-configuration" />">
 				<liferay-ui:message key="basic-configuration" />
 			</h2>

--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -37,7 +37,7 @@
 	</header>
 
 	<div class="container" id="content">
-		<div class="sheet sheet-lg" id="main-content">
+		<div class="pl-4 position-relative pr-4 pt-4 sheet sheet-lg" id="main-content">
 			<h2 class="sheet-title" title="<liferay-ui:message key="basic-configuration" />">
 				<liferay-ui:message key="basic-configuration" />
 			</h2>
@@ -337,7 +337,7 @@
 						var loadingMask = new A.LoadingMask(
 							{
 								'strings.loading': '<%= UnicodeLanguageUtil.get(request, "liferay-is-being-installed") %>',
-								target: A.getBody()
+								target: A.one('#main-content')
 							}
 						);
 


### PR DESCRIPTION
This is a second adjustment to the Setup Wizard screen after [Improve Iframe loading perceived performance](https://issues.liferay.com/browse/LPS-118805).

From https://github.com/liferay-frontend/liferay-portal/pull/294#issue-471565990

> I don't remember what would be the reason why we need an additional class .dialog-iframe-popup and wouldn't want to style .portal-popup directly. I assume it has to do with other popups not programatically opened... but wouldn't we want them styled anyways?

Just in case anyone's keeping tabs... :)

From https://github.com/liferay-frontend/liferay-portal/pull/304

> **The problem**
>
>- We're styling .portal-popup:not(.article-preview) #main-content with position:absolute and other niceties.
>- Setup Wizard renders in "popup" mode but outside a dialog

Now, for a "better" solution, I have:
- Reverted https://github.com/liferay/liferay-portal/commit/e16ac7b2a8ff01a814c7aacc94e0dc4add43693e
- Added `position-relative pt-4 pl-4 pr-4` classes to `#main-content`
- Repositioned the loading mask to render within `#main-content` so it stays centered there

Since this is not our app, we're flying a bit blind here, but I hope this puts this to rest 🤞  