### PR TITLE
LPS-118290 Update liferay-ckeditor to v4.14.1-liferay-9

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"ckeditor4-react": "1.0.1",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.14.1-liferay.8",
+		"liferay-ckeditor": "4.14.1-liferay.9",
 		"prop-types": "15.7.2"
 	},
 	"main": "index.js",

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBBCodeConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBBCodeConfigContributor.java
@@ -53,7 +53,8 @@ public class CKEditorBBCodeConfigContributor
 		).put(
 			"enterMode", 2
 		).put(
-			"extraPlugins", "a11yhelpbtn,bbcode,itemselector,wikilink"
+			"extraPlugins",
+			"a11yhelpbtn,bbcode,itemselector,sourcearea,wikilink"
 		).put(
 			"fontSize_defaultLabel", "14"
 		).put(
@@ -71,9 +72,9 @@ public class CKEditorBBCodeConfigContributor
 			"newThreadURL", MBThreadConstants.NEW_THREAD_URL
 		).put(
 			"removePlugins",
-			"bidi,div,elementspath,flash,forms,indentblock,keystrokes,link," +
-				"maximize,newpage,pagebreak,preview,print,save,showblocks," +
-					"templates,video"
+			"bidi,codemirror,div,elementspath,flash,forms,indentblock," +
+				"keystrokes,link,maximize,newpage,pagebreak,preview," +
+					"print,save,showblocks,templates,video"
 		).put(
 			"smiley_descriptions",
 			toJSONArray(BBCodeTranslatorUtil.getEmoticonDescriptions())

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -213,7 +213,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 		}
 
 		if (isShowSource(inputEditorTaglibAttributes)) {
-			jsonArray.put(toJSONArray("['Source']"));
+			jsonArray.put(toJSONArray("['Source', 'Expand']"));
 		}
 
 		return jsonArray;
@@ -233,7 +233,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			toJSONArray("['Link', Unlink]"));
 
 		if (isShowSource(inputEditorTaglibAttributes)) {
-			jsonArray.put(toJSONArray("['Source']"));
+			jsonArray.put(toJSONArray("['Source', 'Expand']"));
 		}
 
 		return jsonArray;
@@ -249,7 +249,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			toJSONArray("['Link', Unlink]"));
 
 		if (isShowSource(inputEditorTaglibAttributes)) {
-			jsonArray.put(toJSONArray("['Source']"));
+			jsonArray.put(toJSONArray("['Source', 'Expand']"));
 		}
 
 		return jsonArray;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorCreoleConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorCreoleConfigContributor.java
@@ -73,7 +73,8 @@ public class CKEditorCreoleConfigContributor
 			"disableObjectResizing", Boolean.TRUE
 		).put(
 			"extraPlugins",
-			"a11yhelpbtn,creole,itemselector,lfrpopup,showborders,wikilink"
+			"a11yhelpbtn,creole,itemselector,lfrpopup,showborders," +
+				"sourcearea,wikilink"
 		).put(
 			"filebrowserWindowFeatures",
 			"title=" + LanguageUtil.get(themeDisplay.getLocale(), "browse")
@@ -81,11 +82,12 @@ public class CKEditorCreoleConfigContributor
 			"format_tags", "p;h1;h2;h3;h4;h5;h6;pre"
 		);
 
-		StringBundler sb = new StringBundler(4);
+		StringBundler sb = new StringBundler(5);
 
-		sb.append("bidi,colorbutton,colordialog,div,elementspath,flash,font,");
-		sb.append("forms,indentblock,justify,keystrokes,link,maximize,");
-		sb.append("newpage,pagebreak,preview,print,save,showblocks,smiley,");
+		sb.append("bidi,codemirror,colorbutton,colordialog,div,");
+		sb.append("elementspath,flash,font,forms,indentblock,");
+		sb.append("justify,keystrokes,link,maximize,newpage,");
+		sb.append("pagebreak,preview,print,save,showblocks,smiley,");
 		sb.append("stylescombo,templates,video");
 
 		jsonObject.put(

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -11831,10 +11831,10 @@ liferay-amd-loader@4.3.0:
   resolved "https://registry.yarnpkg.com/liferay-amd-loader/-/liferay-amd-loader-4.3.0.tgz#5a6e6b94374f3d5298f637aca57220ec0b3c66ce"
   integrity sha512-8y7jgugf3RzcmA7t4eKJaNFMKI/e2K9+UaAAuT2maDd2X047E961nELmomRfEaXA5aWIS7SvKlP/dnvfGEvxPw==
 
-liferay-ckeditor@4.14.1-liferay.8:
-  version "4.14.1-liferay.8"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.14.1-liferay.8.tgz#282ecb9db8c027f51cc5a912405943fd4dc9d772"
-  integrity sha512-joohVorctiVvN7LAdZj/FDWP4HXXl9lel1rnYY13jxkp5Vtyu98XAAHf6LAG3iUxvtTtzmHkh65bPhD6zKEvOQ==
+liferay-ckeditor@4.14.1-liferay.9:
+  version "4.14.1-liferay.9"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.14.1-liferay.9.tgz#e0aa59d064da89f70989909c17ce62e223492bb4"
+  integrity sha512-fmnM4pI9G4iVxYqG1Z1yaYcnpbv+OPgZ4b+a74WvuUq5QrPCQzqUe1kL9lrt30144rvvbNyL7FeNAgwUlmqBgA==
 
 liferay-font-awesome@3.4.0:
   version "3.4.0"


### PR DESCRIPTION
This new version of `liferay-ckeditor` contains the `codemirror` plugin

Before this change, editing source code with CKEditor looked like this:

![](https://user-images.githubusercontent.com/5572/91549605-7ab68600-e927-11ea-8a2c-7ce713cf2ed9.gif)

After this change it looks like this:

![](https://user-images.githubusercontent.com/5572/91548775-35458900-e926-11ea-9eff-0e99d3be75ac.gif)

Additionally, I also configured the `CKEditorBBCodeConfigContributor` and
`CKEditorCreoleConfigContributor` classes, to keep using the original 
`sourcearea` plugin because the `codemirror` plugin doesn't support 
`bbcode` and `creole` formatting