### PR TITLE
Apply styles also in the #wrapper to make those work with style books

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
@@ -41,7 +41,8 @@
 
 // Body
 
-body {
+body,
+#wrapper {
 	background-color: var(--body-bg);
 	color: var(--body-color);
 	font-family: var(--font-family-base);


### PR DESCRIPTION
In order to avoid admin controls to take the stylebook styles, we decided to apply those styles in the #wrapper element of a page, which resulted in some tokens not working.

The specific tokens that don't work are the ones defined by the theme in the body:

```
body {
    background-color: var(--body-bg);
    color: var(--body-color);
    font-family: var(--font-family-base);
    font-size: var(--font-size-base);
}
```

After a discussion in https://liferay.slack.com/archives/CNBG06JS3/p1598612754140300 we've concluded that a viable solution will be to apply those styles also in the wrapper element

```
#wrapper {
    background-color: var(--body-bg);
    color: var(--body-color);
    font-family: var(--font-family-base);
    font-size: var(--font-size-base);
}
```

### Steps to try the PR

Steps to reproduce

- Go to Style Books
- Create a new stylebook
- Go to typography category
- Update font family base value and set 'Courier New'