### PR TITLE
Sync values from the theme in the token definition

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
@@ -292,7 +292,7 @@
 				{
 					"frontendTokens": [
 						{
-							"defaultValue": "#F1F2F5",
+							"defaultValue": "#FFF",
 							"editorType": "ColorPicker",
 							"label": "body-bg",
 							"mappings": [
@@ -973,7 +973,7 @@
 							"type": "String"
 						},
 						{
-							"defaultValue": "#6C757D",
+							"defaultValue": "#6B6C7E",
 							"editorType": "ColorPicker",
 							"label": "blockquote-small-color",
 							"mappings": [

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_variables.scss
@@ -53,8 +53,8 @@ $theme-colors-cp: map-deep-merge(
 
 	// Body
 
-	--body-bg: $body-bg;
-	--body-color: $body-color;
+	--body-bg: #{$body-bg};
+	--body-color: #{$body-color};
 
 	// Border radius
 


### PR DESCRIPTION
Some default values in the token definition of the classic theme were not the same as the one used in the CSS

Blockquote small color is defined [here](https://github.com/liferay/liferay-portal/blob/cad004434e6b19e9cea38776abe415c104f921f5/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_variables.scss#L51)

Body bg is defined [here](https://github.com/liferay/liferay-portal/blob/8fb1396b753a2583a0506423a65ea015e5c11afe/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss#L1)

In the case of body bg color maybe we want another color? I've used what the theme is defining right now, but maybe there is a mistake there also, can you review it?