### PR TITLE
LPS-120078 Remove chatty logging

### DIFF
--- a/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
@@ -371,7 +371,5 @@ function receiveMessage(event) {
 }
 
 export default function init() {
-	log('init');
-
 	window.addEventListener('message', receiveMessage);
 }

--- a/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
@@ -56,22 +56,6 @@ function has(object, property) {
 
 const LOG_PREFIX = `[HOST: remote-app-support]`;
 
-function log(message, ...rest) {
-	if (process.env.NODE_ENV === 'development') {
-		const messages = [...rest];
-
-		if (typeof message === 'string') {
-			messages.unshift(`${LOG_PREFIX}: ${message}`);
-		}
-		else {
-			messages.unshift(LOG_PREFIX, message);
-		}
-
-		// eslint-disable-next-line no-console
-		console.log(...messages);
-	}
-}
-
 function warning(message, ...rest) {
 	if (process.env.NODE_ENV === 'development') {
 		const messages = [...rest];


### PR DESCRIPTION
This was added as a aid to testing during the early development of LPS-118339, but it's not really useful any more.

It is gated behind a `NODE_ENV === 'development'` check, but it's still too chatty, even for a developer environment. So let's remove it.