### PR TITLE
LPS-120077 Remove uppercase transform to virtual instance

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
@@ -134,7 +134,6 @@
 
 .applications-menu-virtual-instance {
 	font-weight: 600;
-	text-transform: uppercase;
 }
 
 .applications-menu-shrink {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-120077

Virtual Instance was not meant to be transformed to uppercase, so we're removing that from the styles.

![image](https://user-images.githubusercontent.com/5803434/91704894-7df67f80-eb7c-11ea-9922-e313270dd0e4.png)
