### PR TITLE
LPS 119814 - Documents and media move modal size

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
@@ -510,7 +510,8 @@ AUI.add(
 						);
 					}
 
-					Liferay.Util.openSelectionModal({
+					Liferay.Util.openModal({
+						height: 480,
 						id: namespace + 'selectFolder',
 						onSelect: (selectedItem) => {
 							if (parameterName && parameterValue) {
@@ -527,6 +528,7 @@ AUI.add(
 							}
 						},
 						selectEventName: namespace + 'selectFolder',
+						size: 'md',
 						title: Lang.sub(dialogTitle, [selectedItems]),
 						url: instance.get('selectFolderURL'),
 					});

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
@@ -528,7 +528,7 @@ AUI.add(
 							}
 						},
 						selectEventName: namespace + 'selectFolder',
-						size: 'md',
+						size: 'lg',
 						title: Lang.sub(dialogTitle, [selectedItems]),
 						url: instance.get('selectFolderURL'),
 					});

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
@@ -510,7 +510,7 @@ AUI.add(
 						);
 					}
 
-					Liferay.Util.openModal({
+					Liferay.Util.openSelectionModal({
 						height: 480,
 						id: namespace + 'selectFolder',
 						onSelect: (selectedItem) => {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
@@ -511,7 +511,7 @@ AUI.add(
 					}
 
 					Liferay.Util.openSelectionModal({
-						height: 480,
+						height: '480px',
 						id: namespace + 'selectFolder',
 						onSelect: (selectedItem) => {
 							if (parameterName && parameterValue) {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -106,11 +106,13 @@ const openSelectionModal = ({
 	buttonAddLabel = Liferay.Language.get('add'),
 	buttonCancelLabel = Liferay.Language.get('cancel'),
 	customSelectEvent = false,
+	height,
 	id,
 	multiple = false,
 	onSelect,
 	selectEventName,
 	selectedData,
+	size,
 	title,
 	url,
 	zIndex,
@@ -138,6 +140,7 @@ const openSelectionModal = ({
 					},
 			  ]
 			: null,
+		height,
 		id: id || selectEventName,
 		onClose: () => {
 			eventHandlers.forEach((eventHandler) => {
@@ -185,6 +188,7 @@ const openSelectionModal = ({
 				});
 			}
 		},
+		size,
 		title,
 		url,
 		zIndex,


### PR DESCRIPTION
Adjust the Documents and Media move modal width.

**Steps to reproduce:**
- Go to Documents & Media
- Add and item if there is none.
- Select and click the "move" icon in the Management Toolbar

**Before the fix:**
![image](https://user-images.githubusercontent.com/67901/91721464-18fd5280-eb99-11ea-8424-0f541a59a30f.png)


**After the fix:**
![image](https://user-images.githubusercontent.com/67901/91722166-2d8e1a80-eb9a-11ea-91b6-4b4b6b60a757.png)

I need to pass height and size props in openSelectionModal to Modal.


