### PR TITLE
COMMERCE-4589 ActionDropdownRenderer changed actions prop structure

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionsDropdownRenderer.js
@@ -176,14 +176,13 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 		return null;
 	}
 
-	if (actions.length === 1) {
-		const action = formattedActions[0];
+	if (formattedActions.length === 1) {
+		const [action] = formattedActions;
+		const {data: actionData} = action;
 
-		if (action.id && !action.href) {
+		if (actionData?.id && !actionData?.href) {
 			return null;
 		}
-
-		const formattedHref = formatActionURL(action.href, itemData);
 
 		if (loading) {
 			return (
@@ -202,7 +201,7 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 		return isLink(action.target, action.onClick) ? (
 			<ClayLink
 				className="btn btn-secondary btn-sm"
-				href={formattedHref}
+				href={formatActionURL(actionData.href, itemData)}
 				monospaced={Boolean(action.icon)}
 			>
 				{content}
@@ -218,7 +217,7 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 						{
 							event,
 							itemId,
-							method: action.data?.method,
+							method: actionData?.method,
 							setLoading,
 							url: action.href,
 							...action,


### PR DESCRIPTION
Ever since the transfer of the DataSetDisplay component from the `commerce-frontend-js` module on to `frontend-taglib-clay`, the structure of the prop `actions` in the `ActionDropdownRenderer` DataSetDisplay renderer changed from 
```
	actions: PropTypes.arrayOf(
		PropTypes.shape({
			href: PropTypes.string,
			icon: PropTypes.string,
			label: PropTypes.string.isRequired,
			method: PropTypes.oneOf(['get', 'delete']),
			onClick: PropTypes.string,
			permissionKey: PropTypes.string,
			target: PropTypes.oneOf([
				'modal',
				'sidePanel',
				'link',
				'async',
				'headless'
			])
		})
	)
```
to 
```
	actions: PropTypes.arrayOf(
		PropTypes.shape({
			data: PropTypes.shape({
				method: PropTypes.oneOf(['get', 'delete']),
			}),
			href: PropTypes.string,
			icon: PropTypes.string,
			label: PropTypes.string.isRequired,
			onClick: PropTypes.string,
			permissionKey: PropTypes.string,
			target: PropTypes.oneOf([
				'modal',
				'sidePanel',
				'link',
				'async',
				'headless',
			]),
		})
	)
```

and I found out the change still needed to be reflected within the actual code, as this is causing a bug in our Admin sections.