### PR TITLE
LPS-119792 Fix container-max in ccp-layer

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
@@ -128,9 +128,9 @@ body,
 
 // Container max
 
-@each $breakpoint, $container-max-width in $container-max-widths {
-	.container-max-#{$breakpoint} {
-		max-width: $container-max-width;
+@each $key, $value in $custom-properties-container-max-widths {
+	.container-fluid-max-#{$key} {
+		max-width: #{$value};
 	}
 }
 

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_variables.scss
@@ -1,3 +1,16 @@
+// Container max widths
+
+$custom-properties-container-max-widths: ();
+$custom-properties-container-max-widths: map-merge(
+	(
+		sm: var(--container-max-sm),
+		md: var(--container-max-md),
+		lg: var(--container-max-lg),
+		xl: var(--container-max-xl),
+	),
+	$custom-properties-container-max-widths
+);
+
 // Spacers map copy
 
 $spacers-cp: ();


### PR DESCRIPTION
This PR fixes the container-max CSS Custom Property

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/46778114/91748228-f0d51a00-ebbf-11ea-8d2e-81f346404a5c.gif)

**How to test it:**

- Create a page with and html fragment and insert the following code:
```html
<div class="container-fluid container-fluid-max-xl">
	<div class="bg-primary text-white">container-fluid-max-xl</div>
</div>
<div class="container-fluid container-fluid-max-lg">
	<div class="bg-success text-white">container-fluid-max-lg</div>
</div>
<div class="container-fluid container-fluid-max-md">
	<div class="bg-dangee text-white">container-fluid-max-md</div>
</div>
<div class="container-fluid container-fluid-max-sm">
	<div class="bg-warning text-white">container-fluid-max-sm</div>
</div>
```
- Go to ProductMenu > Design > StyleBook and create a new one
- Go to the Layout option on the right sidebar and edit the values