### PR TITLE
LPS-120062 Sync values from the theme in the token definition (Vol.2)

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
@@ -948,7 +948,7 @@
 							"type": "String"
 						},
 						{
-							"defaultValue": "#6C757D",
+							"defaultValue": "#A7A9BC",
 							"editorType": "ColorPicker",
 							"label": "text-muted",
 							"mappings": [


### PR DESCRIPTION
This is related to the pr I sent yesterday https://github.com/liferay-frontend/liferay-portal/pull/333

> Some default values in the token definition of the classic theme were not the same as the one used in the CSS
> 
> Blockquote small color is defined here
> 
> Body bg is defined here
> 
> In the case of body bg color maybe we want another color? I've used what the theme is defining right now, but maybe there is a mistake there also, can you review it?

I missed text-muted color that was not synchronized with the css value applied