### PR TITLE
COMMERCE-4645 data set display now supports apiURLs with filter param already in it

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -112,10 +112,18 @@ function DataSetDisplay({
 	const {apiURL} = useContext(AppContext);
 
 	const requestData = useCallback(() => {
+		const activeFiltersOdataStrings = filters.reduce(
+			(activeFilters, filter) =>
+				filter.odataFilterString
+					? [...activeFilters, filter.odataFilterString]
+					: activeFilters,
+			[]
+		);
+
 		return loadData(
 			apiURL,
 			currentURL,
-			filters,
+			activeFiltersOdataStrings,
 			searchParam,
 			delta,
 			pageNumber,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
@@ -128,21 +128,53 @@ export function createSortingString(values) {
 		.join(',');
 }
 
+export function getFiltersString(odataFiltersStrings, providedFilters) {
+	let filtersString = '';
+
+	if (providedFilters) {
+		filtersString += providedFilters;
+	}
+
+	if (providedFilters && odataFiltersStrings.length) {
+		filtersString += ' and ';
+	}
+
+	if (odataFiltersStrings.length) {
+		filtersString += createOdataFilter(odataFiltersStrings);
+	}
+
+	return filtersString;
+}
+
 export function loadData(
 	apiURL,
 	currentURL,
-	filters,
+	odataFiltersStrings,
 	searchParam,
 	delta,
 	page = 1,
 	sorting = []
 ) {
-	const url = new URL(apiURL, themeDisplay.getPortalURL());
+	let providedFilters = '';
+
+	const formattedUrl = apiURL.replace(
+		/[?|&]filter=(.*)[&.+]?/gm,
+		(matched) => {
+			providedFilters = matched.replace(/[?|&]filter=/, '');
+
+			return '';
+		}
+	);
+
+	const url = new URL(formattedUrl, themeDisplay.getPortalURL());
 
 	url.searchParams.append('currentURL', currentURL);
 
-	if (filters.length) {
-		url.searchParams.append('filter', createOdataFilter(filters));
+	if (providedFilters || odataFiltersStrings.length) {
+		url.searchParams.append(
+			'filter',
+			getFiltersString(odataFiltersStrings, providedFilters)
+		);
 	}
 
 	url.searchParams.append('page', page);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/odata.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/odata.js
@@ -13,12 +13,5 @@
  */
 
 export default function createOdataFilter(filters) {
-	if (!filters.length) {
-		return null;
-	}
-
-	return filters
-		.map((filter) => filter.odataFilterString)
-		.map((filterString) => `(${filterString})`)
-		.join(' and ');
+	return filters.map((filter) => `(${filter})`).join(' and ');
 }


### PR DESCRIPTION
In some scenarios we might want to display a set of data already filtered and still being able to refine the query by adding more filters on top.

This PR make it possibile by making the data set able to digest an apiURL with filter param already in it