### PR TITLE
LPS-119863  Add better language key when the Remote App URL is deleted

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentRendererControllerImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentRendererControllerImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.servlet.PipingServletResponse;
@@ -135,7 +136,12 @@ public class FragmentRendererControllerImpl
 
 		sb.append("<div class=\"alert alert-danger m-2\">");
 
-		String errorMessage = "an-unexpected-error-occurred";
+		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+			"content.Language", getClass());
+
+		String errorMessage = LanguageUtil.get(
+			resourceBundle,
+			"the-remote-web-app-is-no-longer-available-or-was-deleted");
 
 		Throwable throwable = exception.getCause();
 

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted.
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ar.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=تكوين الأجزاء غير صالح.
 fragment.collection.label.content-display=عرض المحتوى
 select-content=عرض الصفحة
 the-display-page-content-will-be-shown-here=سيتم إظهار محتوى الصفحة المعروضة هنا.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=المحتوى المحدد لم يعد متوفرًا. يرجى تحديد محتوى آخر.
 the-selected-content-will-be-shown-here=سيتم إظهار المحتوى المحدد هنا.
 there-are-no-available-renderers-for-the-display-page-content=لا توجد عارضات متوفرة لمحتوى الصفحة المعروضة.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_bg.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ca.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=La configuració del fragment no és vàlida.
 fragment.collection.label.content-display=Visualització del contingut
 select-content=Pàgina de visualització
 the-display-page-content-will-be-shown-here=El contingut de la pàgina de visualització es mostrarà aquí.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=El contingut seleccionat ja no està disponible. Seleccioneu-ne un altre.
 the-selected-content-will-be-shown-here=El contingut seleccionat es mostrarà aquí.
 there-are-no-available-renderers-for-the-display-page-content=No hi ha renderitzadors disponibles per al contingut de la pàgina de visualització.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_cs.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_da.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_da.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_de.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_de.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Die Fragment-Konfiguration ist ungültig.
 fragment.collection.label.content-display=Content-Anzeige
 select-content=Seite anzeigen
 the-display-page-content-will-be-shown-here=Der Content der Anzeige-Seite wird hier angezeigt.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=Der ausgewählte Content ist nicht mehr verfügbar. Bitte wählen Sie etwas anderes aus.
 the-selected-content-will-be-shown-here=Der ausgewählte Content wird hier angezeigt.
 there-are-no-available-renderers-for-the-display-page-content=Es sind keine Renderer für den Content der angezeigten Seite verfügbar.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_el.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_el.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_en.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_en.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted.
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_en_AU.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid. (Automatic 
 fragment.collection.label.content-display=Content Display (Automatic Copy)
 select-content=Display Page (Automatic Copy)
 the-display-page-content-will-be-shown-here=The display page content will be shown here. (Automatic Copy)
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another. (Automatic Copy)
 the-selected-content-will-be-shown-here=The selected content will be shown here. (Automatic Copy)
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content. (Automatic Copy)

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_en_GB.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid. (Automatic 
 fragment.collection.label.content-display=Content Display (Automatic Copy)
 select-content=Display Page (Automatic Copy)
 the-display-page-content-will-be-shown-here=The display page content will be shown here. (Automatic Copy)
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another. (Automatic Copy)
 the-selected-content-will-be-shown-here=The selected content will be shown here. (Automatic Copy)
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content. (Automatic Copy)

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_es.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_es.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=La configuración del fragmento no es válida.
 fragment.collection.label.content-display=Visualización de contenido
 select-content=Página de visualización
 the-display-page-content-will-be-shown-here=El contenido de la página de visualización se mostrará aquí.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=El contenido seleccionado ya no está disponible. Seleccione otro contenido.
 the-selected-content-will-be-shown-here=El contenido seleccionado se mostrará aquí.
 there-are-no-available-renderers-for-the-display-page-content=No hay representadores disponibles para el contenido de la página de visualización.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_et.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_et.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_eu.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_fa.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=صفحه نمایش
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_fi.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragmentin määritys on virheellinen.
 fragment.collection.label.content-display=Sisällön Näyttö
 select-content=Näyttösivu
 the-display-page-content-will-be-shown-here=Näyttösivun sisältö näytetään täällä.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=Valittu sisältö ei ole enää saatavana. Valitse toinen.
 the-selected-content-will-be-shown-here=Valittu sisältö näytetään täällä.
 there-are-no-available-renderers-for-the-display-page-content=Näyttösivun sisällölle ei ole satavana hahmottelijoita.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_fr.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=La configuration du fragment n'est pas valide.
 fragment.collection.label.content-display=Affichage du contenu
 select-content=Afficher la page
 the-display-page-content-will-be-shown-here=Le contenu de la page sera affiché ici.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=Le contenu sélectionné n'est plus disponible. Veuillez en sélectionner un autre.
 the-selected-content-will-be-shown-here=Le contenu sélectionné sera affiché ici.
 there-are-no-available-renderers-for-the-display-page-content=Aucun rendu n'est disponible pour l'affichage du contenu de la page.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_fr_CA.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Page d'affichage
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_gl.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_hi_IN.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_hr.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_hu.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=A töredék konfigurációja érvénytelen.
 fragment.collection.label.content-display=Tartalom megjelenítése
 select-content=Oldal megjelenítése
 the-display-page-content-will-be-shown-here=A megjelenítő-oldal tartalma itt jelenik meg.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=A kiválasztott tartalom már nem elérhető. Válasszon másikat.
 the-selected-content-will-be-shown-here=A kiválasztott tartalom itt jelenik meg.
 there-are-no-available-renderers-for-the-display-page-content=A megjelenítő-oldal tartalmához nincs elérhető kirajzoló.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_in.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_in.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_it.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_it.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Pagina di visualizzazione
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_iw.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=הצג דף
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ja.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=フラグメント設定が正しくありま�
 fragment.collection.label.content-display=コンテンツの表示
 select-content=表示ページ
 the-display-page-content-will-be-shown-here=表示ページのコンテンツがここに表示されます。
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=選択したコンテンツはもう使用できません。別のコンテンツを選択してください。
 the-selected-content-will-be-shown-here=選択したコンテンツがここに表示されます。
 there-are-no-available-renderers-for-the-display-page-content=ディスプレイのコンテンツに使用できるレンダラーが見つかりません。

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_kk.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ko.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_lo.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_lt.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_nb.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragmentkonfigurasjon er ugyldig.
 fragment.collection.label.content-display=Innholdsvisning
 select-content=Display Page
 the-display-page-content-will-be-shown-here=Visningssideinnholdet blir vist her.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=Det valgte innholdet er ikke lenger tilgjengelig. Vennligst velg et annet innhold.
 the-selected-content-will-be-shown-here=Det valgte innholdet blir vist her.
 there-are-no-available-renderers-for-the-display-page-content=Det finnes ingen tilgjengelige gjengivere for innholdssideinnholdet.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_nl.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=De fragmentconfiguratie is ongeldig.
 fragment.collection.label.content-display=Inhoudweergave
 select-content=Weergavepagina
 the-display-page-content-will-be-shown-here=De inhoud van de weergavepagina wordt hier getoond.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=De geselecteerde inhoud is niet meer beschikbaar. Maak een andere selectie.
 the-selected-content-will-be-shown-here=De geselecteerde inhoud wordt hier getoond.
 there-are-no-available-renderers-for-the-display-page-content=Er zijn geen beschikbare renderers voor de inhoud van de weergavepagina.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_nl_BE.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_pl.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_pt_BR.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=A configuração de fragmento é inválida.
 fragment.collection.label.content-display=Exibição de Conteúdo
 select-content=Página de Exibição
 the-display-page-content-will-be-shown-here=O conteúdo da página de exibição será exibido aqui.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=O conteúdo selecionado não está mais disponível. Por favor, selecione outro.
 the-selected-content-will-be-shown-here=O conteúdo selecionado não pode ser exibido aqui.
 there-are-no-available-renderers-for-the-display-page-content=Não há renderizações disponíveis para o conteúdo de página de exibição.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_pt_PT.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ro.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ru.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_sk.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_sl.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_sr_RS.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_sr_RS_latin.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_sv.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragmentkonfiguration är ogiltig.
 fragment.collection.label.content-display=Innehållsvy
 select-content=Visa sida
 the-display-page-content-will-be-shown-here=Innehållet på visningssidan visas här.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=Det valda innehållet är inte längre tillgängligt. Välj ett annat.
 the-selected-content-will-be-shown-here=Det valda innehållet visas här.
 there-are-no-available-renderers-for-the-display-page-content=Det finns inga tillgängliga renderare för innehållet på visningssidan.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_ta_IN.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=பக்கத்தை காட்டு
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_th.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_th.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_tr.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_uk.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_vi.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_zh_CN.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=片段配置无效。
 fragment.collection.label.content-display=内容显示
 select-content=显示页
 the-display-page-content-will-be-shown-here=显示页内容将显示在这里。
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=选定内容不再可用。请选择其他内容。
 the-selected-content-will-be-shown-here=选定内容将显示在这里。
 there-are-no-available-renderers-for-the-display-page-content=没有适用于显示页内容的可用呈现器。

--- a/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/content/Language_zh_TW.properties
@@ -6,6 +6,7 @@ fragment-configuration-is-invalid=Fragment configuration is invalid.
 fragment.collection.label.content-display=Content Display
 select-content=Display Page
 the-display-page-content-will-be-shown-here=The display page content will be shown here.
+the-remote-web-app-is-no-longer-available-or-was-deleted=The remote web app is no longer available or was deleted. (Automatic Copy)
 the-selected-content-is-no-longer-available.-please-select-another=The selected content is no longer available. Please select another.
 the-selected-content-will-be-shown-here=The selected content will be shown here.
 there-are-no-available-renderers-for-the-display-page-content=There are no available renderers for the display page content.


### PR DESCRIPTION
This PR is a fix on error message when the remote web app URL is deleted => https://issues.liferay.com/browse/LPS-119863.
The previous error message was `"An unexpected error occurred.”.`
I have added new language key for this error saying `“The remote web app is no longer available or was deleted.”` , which is more descriptive to the issue.

Steps to Reproduce:

1. Go to Application Menu > Remote Apps
2. Create a remote web app
3. Add the created remote web app widget to page
4. Go back to Application Menu > Remote Apps
5. Delete the created remote app
6. Navigate to page and view the remote web app widget portlet

Old message:
![image](https://user-images.githubusercontent.com/25637907/91852425-1e25d480-ec61-11ea-9968-d6b61aefb37c.png)


New message:
<img width="1518" alt="remote_web_app_message" src="https://user-images.githubusercontent.com/25637907/91852370-08b0aa80-ec61-11ea-9f07-bcf69dd8c7ce.png">

