### PR TITLE
LPS-120199 Update liferay-npm-scripts to v32.6.1

### DIFF
--- a/modules/apps/frontend-js/frontend-js-metal-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-metal-web/.npmbundlerrc
@@ -21,5 +21,6 @@
 		]
 	},
 	"output": "build/node/packageRunBuild/resources",
-	"preset": "liferay-npm-bundler-preset-standard"
+	"preset": "liferay-npm-bundler-preset-standard",
+	"sources": ["src/main/resources/META-INF/resources"]
 }

--- a/modules/apps/frontend-js/frontend-js-node-shims/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-node-shims/.npmbundlerrc
@@ -10,5 +10,6 @@
 		]
 	},
 	"output": "build/node/packageRunBuild/resources",
-	"preset": "liferay-npm-bundler-preset-standard"
+	"preset": "liferay-npm-bundler-preset-standard",
+	"sources": ["src/main/resources/META-INF/resources"]
 }

--- a/modules/apps/frontend-js/frontend-js-react-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-react-web/.npmbundlerrc
@@ -60,5 +60,6 @@
 		"whatwg-fetch": true
 	},
 	"output": "build/node/packageRunBuild/resources",
-	"preset": "liferay-npm-bundler-preset-standard"
+	"preset": "liferay-npm-bundler-preset-standard",
+	"sources": ["src/main/resources/META-INF/resources"]
 }

--- a/modules/apps/frontend-js/frontend-js-spa-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-spa-web/.npmbundlerrc
@@ -72,5 +72,6 @@
 		"url": true
 	},
 	"output": "build/node/packageRunBuild/resources",
-	"preset": "liferay-npm-bundler-preset-standard"
+	"preset": "liferay-npm-bundler-preset-standard",
+	"sources": ["src/main/resources/META-INF/resources"]
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-chart/.npmbundlerrc
+++ b/modules/apps/frontend-taglib/frontend-taglib-chart/.npmbundlerrc
@@ -194,5 +194,6 @@
 		"xss-filters": true
 	},
 	"output": "build/node/packageRunBuild/resources",
-	"preset": "liferay-npm-bundler-preset-standard"
+	"preset": "liferay-npm-bundler-preset-standard",
+	"sources": ["src/main/resources/META-INF/resources"]
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/.npmbundlerrc
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/.npmbundlerrc
@@ -112,5 +112,6 @@
 		"xss-filters": true
 	},
 	"output": "build/node/packageRunBuild/resources",
-	"preset": "liferay-npm-bundler-preset-standard"
+	"preset": "liferay-npm-bundler-preset-standard",
+	"sources": ["src/main/resources/META-INF/resources"]
 }

--- a/modules/package.json
+++ b/modules/package.json
@@ -5,7 +5,7 @@
 		"compass-mixins": "0.12.10",
 		"jsdoc": "3.6.3",
 		"liferay-frontend-common-css": "1.0.4",
-		"liferay-npm-scripts": "32.6.0",
+		"liferay-npm-scripts": "32.6.1",
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,

--- a/modules/package.json
+++ b/modules/package.json
@@ -5,7 +5,7 @@
 		"compass-mixins": "0.12.10",
 		"jsdoc": "3.6.3",
 		"liferay-frontend-common-css": "1.0.4",
-		"liferay-npm-scripts": "32.5.1",
+		"liferay-npm-scripts": "32.6.0",
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -4162,12 +4162,12 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-add-module-metadata@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.18.4.tgz#38c058de65f8b8823ba12aff7fd77d3b53285a03"
-  integrity sha512-xQOyaIvxdyYyOAq5+8H15eoErNL/3WBZv/0VlUsS7Q750CuLCKcX0syZiDIxgyYa4wWLGtHE1QQaohM09mmvig==
+babel-plugin-add-module-metadata@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.19.0.tgz#2cf63f12d90c6ec2fc4167ae4e07767feafa2289"
+  integrity sha512-jaYGJaPaRmDxs6rHmP8tYyyHoNkdqYTfOHLVjXEOQ47V0XY3AuFB6lyQG2gpNmAsX6qlgP2LtlGaPGrbwWtgNw==
   dependencies:
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
     read-json-sync "^2.0.1"
 
 babel-plugin-add-react-displayname@^0.0.5:
@@ -4175,12 +4175,12 @@ babel-plugin-add-react-displayname@^0.0.5:
   resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
   integrity sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=
 
-babel-plugin-alias-modules@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.18.4.tgz#afcfe695cc97264f5084936ad0858e5f3edd3adb"
-  integrity sha512-kdpcpVCuxAeyE3pe7gQqqd42gRUHws47SaAUIDUepGyv2YXdT84FaiqS3UyAN9btCazeAJlxEVfBo41cdifaGQ==
+babel-plugin-alias-modules@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.19.0.tgz#83595301c5dd72d4c55deef9c87b6f71f86ad878"
+  integrity sha512-NZgOlNnT1Tuqn9F1pCZA/oC+mLOw+OR5cx5KdZvBiViQ6hr/MRNvhSGsRwHfpEX258AN6XqLOMOGnHTJZizLJg==
   dependencies:
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
 
 babel-plugin-dynamic-import-node@2.2.0:
   version "2.2.0"
@@ -4348,38 +4348,38 @@ babel-plugin-minify-type-constructors@^0.4.3:
   dependencies:
     babel-helper-is-void-0 "^0.4.3"
 
-babel-plugin-name-amd-modules@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.18.4.tgz#fca0a86a010415c6562133fbba27c4a8a4a4f868"
-  integrity sha512-lbsZm08gFFsLuGf8ULP9MVLZ7seLhJ3F6keeUX1J8cygKChrZW3U6StcY3YMviUUwXQKhamgxBt9g7581/64GQ==
+babel-plugin-name-amd-modules@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.19.0.tgz#2c94887d98ad1f7a012c7fb71dc18258179a762a"
+  integrity sha512-rhE6Hz6eF/h0nFK07plmm4YJhw+IjOSImSGdgZtSdgHNYXCu90Z8YVlb4C/RNMSG9diEBG5MEdbfsljFjo1dRQ==
   dependencies:
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
 
 babel-plugin-named-asset-import@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.2.tgz#20978ed446b8e1bf4a2f42d0a94c0ece85f75f4f"
   integrity sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ==
 
-babel-plugin-namespace-amd-define@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.18.4.tgz#c2321f3e49e0dc4f642fa268483c321b6580d361"
-  integrity sha512-fPc3ZQvN4lK6l9tuzQTGmnUMUG9EkH3YkxlzWkvuWXZOcweRMPfGAMhqkyAZHda31rpWkHGNd1zyiSolGT95Cg==
+babel-plugin-namespace-amd-define@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.19.0.tgz#8e64ecd6422da36fffc266a0255ba4a342f905d0"
+  integrity sha512-xx80+q77coh9N9Yp2iJHPnwnJdAnwCtOyozNjCOLqbh+exhA6BxfGvNxHnqEPW8IVWME0TCRxUzlJr35ROMEtw==
   dependencies:
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
 
-babel-plugin-namespace-modules@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.18.4.tgz#1aec810576e2c4df917e9223c0b4d27397c44760"
-  integrity sha512-0X+CihcrU/suhjjSGH8/gvKvBbu9opYQKrjfv7+hzuOU3kM9Ay1cbayAUyzHcSmWZv+c4jfe1t1J/MWsw5tUkQ==
+babel-plugin-namespace-modules@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.19.0.tgz#cb25491083035a5a4ffba92d06d765f48cbee618"
+  integrity sha512-CzuF6XnmvKKidic8HmNCBsnRHzLeoN5/yTvSv90g3t41J8+jlAVL9gqonjk6nQVLHaweuBx7LxcDyZEoUApN9Q==
   dependencies:
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
 
-babel-plugin-normalize-requires@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.18.4.tgz#52f0bc888aa46864d123b9ccf62112ffc773cd76"
-  integrity sha512-7MeV3/lXRCJ3GAGzpMUc1J5q4Nk2zJNL1+K9iLqe2Esz8CrSmUAhUFacYDFzzwFkW3LCGb9oVkKG3waber/wJg==
+babel-plugin-normalize-requires@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.19.0.tgz#9982f455152e54f2dfa358ad869645a9e5aeb0cf"
+  integrity sha512-3e5c5Th7zzouKrG0NtPgccjYWfCB5LDxxA/Ge2Q1kMFqgRt9nQxizzPGZrd5yomyOBq5ijQlQ9jGYluu+XQH3A==
   dependencies:
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
 
 babel-plugin-react-docgen@^3.0.0:
   version "3.1.0"
@@ -4464,13 +4464,13 @@ babel-plugin-transform-undefined-to-void@^6.9.4:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"
   integrity sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=
 
-babel-plugin-wrap-modules-amd@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.18.4.tgz#ea6c11fc8e73ce5607df68bcfe5b5b8da7f52d23"
-  integrity sha512-DZ11A7Krund256VetaIbFedpRreywnOR5ZJXoT1l6kjDG1yc6SGK6NlT/9qegndzO/QA/busR5dzUquREsPJ6A==
+babel-plugin-wrap-modules-amd@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.19.0.tgz#c9c57bf7431e0a1cbcb22dc1c2fb7dfef1773666"
+  integrity sha512-mC9AgPAWY3VJkcqcingjTti5VR6JvXtvLFVgtvjyxUTNMsamiWeLbzvLOpmvXw4qqrRKgsC0XzSI2Xjr6029iA==
   dependencies:
     babel-template "^6.26.0"
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
     read-json-sync "^2.0.1"
 
 babel-preset-jest@^25.1.0:
@@ -4482,20 +4482,20 @@ babel-preset-jest@^25.1.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^25.1.0"
 
-babel-preset-liferay-standard@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.18.4.tgz#5a68a3f4447cce059f27f98d3265390043170cbf"
-  integrity sha512-X+cBFrLZb46zxMFjAa+CAldYSa+WCbLOZFOSBlD1hq/rZUv4n9phgq7PhPMLDtCJwJDSPTK1AUFWV5ks7iWTBg==
+babel-preset-liferay-standard@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.19.0.tgz#2dbe851edeab6060ef7307d1e57fa647c948f650"
+  integrity sha512-7FU29WZU/9bLIRCJ86ebsw7Pd5ywQLgdNtswiI+PMjD/yB+YzMrzAtOkpP/lU5AadCgxVsH8HG3gtdS9NNV+nQ==
   dependencies:
-    babel-plugin-add-module-metadata "2.18.4"
-    babel-plugin-alias-modules "2.18.4"
+    babel-plugin-add-module-metadata "2.19.0"
+    babel-plugin-alias-modules "2.19.0"
     babel-plugin-minify-dead-code-elimination "0.5.1"
-    babel-plugin-name-amd-modules "2.18.4"
-    babel-plugin-namespace-amd-define "2.18.4"
-    babel-plugin-namespace-modules "2.18.4"
-    babel-plugin-normalize-requires "2.18.4"
+    babel-plugin-name-amd-modules "2.19.0"
+    babel-plugin-namespace-amd-define "2.19.0"
+    babel-plugin-namespace-modules "2.19.0"
+    babel-plugin-normalize-requires "2.19.0"
     babel-plugin-transform-node-env-inline "0.4.3"
-    babel-plugin-wrap-modules-amd "2.18.4"
+    babel-plugin-wrap-modules-amd "2.19.0"
 
 "babel-preset-minify@^0.5.0 || 0.6.0-alpha.5":
   version "0.5.0"
@@ -12105,25 +12105,25 @@ liferay-lang-key-dev-loader@^1.0.3:
     loader-utils "^1.1.0"
     properties "^1.2.1"
 
-liferay-npm-bridge-generator@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.18.4.tgz#dfc4d35026f1d998e8566b23a068ffc353e1fe02"
-  integrity sha512-yAQ+qzhg54F2S0HjlMVeQJtfbLb+nJzPguAlnAc2vFbFVyXmg/15RmwYyTuUJhuZ7zSRV++ZTCdg1bpyxOkNGg==
+liferay-npm-bridge-generator@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.19.0.tgz#e6c909d4c614ffc47beeb9c4faaefdc640ab6836"
+  integrity sha512-6G7X3GjUSbuFF5WFWy0W/mXqXumIIEv6LqDeurF6fSmmyr9Dc44QUzPdd7F4gBIwT6kBZGQGQZRUiuYlRmmslg==
   dependencies:
     fs-extra "^8.1.0"
     globby "^10.0.1"
     read-json-sync "^2.0.1"
     yargs "^14.0.0"
 
-liferay-npm-build-tools-common@2.18.4, liferay-npm-build-tools-common@^2.17.1:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.18.4.tgz#bfda608b515d69b90b1f1d647f34fde9034466b9"
-  integrity sha512-OLpUIvbxeaaKPDFqsbd3VG0RO1AV3I7Xn1DK67qlmSRsG2YLb6fNW4FprRkZMV68YacHSvyqs9na2E0lucYDDg==
+liferay-npm-build-tools-common@2.19.0, liferay-npm-build-tools-common@^2.17.1:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.19.0.tgz#4307ee203450f643c419cad0c0e60c52da56442c"
+  integrity sha512-Iu9SrvNtnU2BlTyQ/XbGShu7miRt40btqnFhDtVti68X9sY52/FGhf5jbdI0UmnQy56zEWTJskH5OzAoqlQvVw==
   dependencies:
     chalk "^2.4.2"
     dot-prop "^5.0.1"
     escape-string-regexp "^2.0.0"
-    liferay-npm-bundler-preset-standard "2.18.4"
+    liferay-npm-bundler-preset-standard "2.19.0"
     merge "^1.2.1"
     properties "^1.2.1"
     read-json-sync "^2.0.1"
@@ -12143,94 +12143,94 @@ liferay-npm-build-tools-common@3.0.0-snapshot.dda6cd1:
     resolve "^1.8.1"
     webpack "^4.41.6"
 
-liferay-npm-bundler-loader-css-loader@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.18.4.tgz#b884fc5a2203cbd2509429ceff1c540ecadc7f3b"
-  integrity sha512-KGXdjdZkW3//zA5/VX9vlWFDuy5ss3bH18YAyJ9lZ7xT9WTAAlOSI3QLJiLTisjsCKgNDs4jWlrbXwuK+YZw6A==
+liferay-npm-bundler-loader-css-loader@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.19.0.tgz#a3a641e91b171101631afb0695a27a7e5f7e5148"
+  integrity sha512-iCwaJ7Y+SxhxCw1e6M5zGA/XMjfLKqGXhDI7SuhHNXiE2rqHFuK/5OX9PPfQ65hyAKbgujSn4GrbPwjyrYVPMw==
   dependencies:
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
     read-json-sync "^2.0.1"
 
-liferay-npm-bundler-plugin-exclude-imports@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.18.4.tgz#091f5169b9be3618145958cb107f90910e27e4be"
-  integrity sha512-OSY128LVB19ppp3hKxMvX8LKDCV/0sXf2hBFXvpGt0+hQDuQ3Gqa5CTLu0hSR9vl8q5AuSVlUcD02sLsXog4Jg==
+liferay-npm-bundler-plugin-exclude-imports@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.19.0.tgz#0f51097cf006f6eda8b85fd27c739636dd37c9fc"
+  integrity sha512-QiBCKsmsT9QsN3LVvCKA2RH/4A+sH5HuCOS47Yi56U3rZgyMXOeH7DXZde8ow6qRjDLFkXvlMIscTeV7Bv9Uxg==
   dependencies:
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
 
-liferay-npm-bundler-plugin-inject-imports-dependencies@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.18.4.tgz#24050cadd4fd578c69a0177ab995cad8b4dfa035"
-  integrity sha512-yrtBTdWhyhSJTix1S8cGC4rDZSPFis6RBmX27ChMMqd8qcqZWL+dKZAaPnSDyIaykhtHXFqjo8ssrUDzd7IVFw==
+liferay-npm-bundler-plugin-inject-imports-dependencies@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.19.0.tgz#6b1247195e03c87c0fe6faec27c70803ed9ebae0"
+  integrity sha512-O1wgjrmZdHtaSAlzI3UpDoAEXSP6B3zpKohpXFn0B1Vfs8DHA69GMObZtK31oq/bWhVyRT85FuvvAlQQ+FBwOw==
   dependencies:
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
 
-liferay-npm-bundler-plugin-inject-peer-dependencies@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.18.4.tgz#2429e19ba2d13357b1334c9bdd7d064a58fe9fce"
-  integrity sha512-msQYO+e6APYZPU+LzlejOuHVBSQvo10R+IWWZ68XQ3cDvcat/Yoyv5Lb/RsFGu4KlUaRbce/YM+qBwCqedllLw==
+liferay-npm-bundler-plugin-inject-peer-dependencies@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.19.0.tgz#764759e88291bc08617fc24b9d239e6f31f5b28f"
+  integrity sha512-Gs8SCc6XtAqNJDXh5YMtk9gFii0fyISLAxlorn/QIzdtuybudd1TtbMGMFzXpliM7jPUkMB1VyyXQPW6pZYLRQ==
   dependencies:
     globby "^10.0.1"
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
     read-json-sync "^2.0.1"
     resolve "^1.8.1"
 
-liferay-npm-bundler-plugin-namespace-packages@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.18.4.tgz#a202d330654fdd69c78110b3fdb04158d5b5487e"
-  integrity sha512-nzGRLmbKWb2Mr8ddzZwXiG+/XefyvAO4qYn3wMjVfDEtpiAH3zimOJgKyCxZZ26Qah/hotTa7XaM0UofhNWmFg==
+liferay-npm-bundler-plugin-namespace-packages@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.19.0.tgz#4c5f85777b8d5cc6bbe5107a1e4bce76c5e4b89b"
+  integrity sha512-NciYzrGapGqwyotW/tXMyDwJaeAo/KwpZgN1JfBxNPfQKkzVepNkFfRWVCYkz0e4uLIDoFCOzOP/1SDqayNrsw==
   dependencies:
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
 
-liferay-npm-bundler-plugin-replace-browser-modules@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.18.4.tgz#9e9b2d5610239a96f3e6eee80ba3fdf53edc5643"
-  integrity sha512-DG1J1yFioVJKNxOX1bJuebezQXMYSMwnUTaqdRTr1HNxmJgdYQ6VyNgMttRISe2+AX0fA9FLZeo6aOZi4XEZcg==
+liferay-npm-bundler-plugin-replace-browser-modules@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.19.0.tgz#718e9e168b1733ac57bdabf270d65b2ca1c8ad07"
+  integrity sha512-DwaKczxDnYyRHRb4wqbUZTGfltG7aRPbtE5qJ9n5hPuVcV5kKnyCAip2l11KScl6S0fV9WZgPBHWQiPTlcp2Xg==
   dependencies:
     dot-prop "^5.0.1"
     fs-extra "^8.1.0"
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
 
-liferay-npm-bundler-plugin-resolve-linked-dependencies@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.18.4.tgz#28e30efc8ec05d1d3fc91ff766cb539fea539354"
-  integrity sha512-uf8zYxwNi6nARZ3FCrhQw9M53an8m5IzAx96oE9HP9RYjZMS3UG7UKclzR9Pytv7Q7PSPXTqRNF7hrvtklpANg==
+liferay-npm-bundler-plugin-resolve-linked-dependencies@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.19.0.tgz#0c92b4bb6dba76a3028140eadf061a0d11342a83"
+  integrity sha512-ozt5ViXXlrmaOMJNqf0qFHaNGgEdE1jbs2FAxkYD+rv4D5nQ7qxbYgcnqA6fyuo7ICoccC7uMJHcDN5zNqpeGg==
   dependencies:
-    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
     read-json-sync "^2.0.1"
     semver "^6.3.0"
 
-liferay-npm-bundler-preset-liferay-dev@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-liferay-dev/-/liferay-npm-bundler-preset-liferay-dev-4.5.0.tgz#bae206df9fffb9754e666334ea161b802c093f70"
-  integrity sha512-HYG+DUs/c1Fkxjt4aI9qvDNFvlTG76H39/wtTsMm3IDyVBQYkAWaDY4mnrq9D/Bmy3Q4LL1H/V/h8y9/wp+zfQ==
+liferay-npm-bundler-preset-liferay-dev@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-liferay-dev/-/liferay-npm-bundler-preset-liferay-dev-4.6.0.tgz#ab28721aa77120060ff0c514451e4e51de0a76c4"
+  integrity sha512-jRniRy4ZL3Qq6EiBDZ4b0uqa7CBPncErLFedqiGvIIgPwsggL0LsKHQQpMOQ8LtoMIbH3kCt1OeErl8f8XRYpg==
   dependencies:
-    babel-preset-liferay-standard "2.18.4"
-    liferay-npm-bundler-loader-css-loader "2.18.4"
-    liferay-npm-bundler-plugin-exclude-imports "2.18.4"
-    liferay-npm-bundler-plugin-inject-imports-dependencies "2.18.4"
-    liferay-npm-bundler-plugin-inject-peer-dependencies "2.18.4"
-    liferay-npm-bundler-plugin-namespace-packages "2.18.4"
-    liferay-npm-bundler-plugin-replace-browser-modules "2.18.4"
-    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.18.4"
+    babel-preset-liferay-standard "2.19.0"
+    liferay-npm-bundler-loader-css-loader "2.19.0"
+    liferay-npm-bundler-plugin-exclude-imports "2.19.0"
+    liferay-npm-bundler-plugin-inject-imports-dependencies "2.19.0"
+    liferay-npm-bundler-plugin-inject-peer-dependencies "2.19.0"
+    liferay-npm-bundler-plugin-namespace-packages "2.19.0"
+    liferay-npm-bundler-plugin-replace-browser-modules "2.19.0"
+    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.0"
 
-liferay-npm-bundler-preset-standard@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.18.4.tgz#79a12aa3175e7fb4e78e49107a07e616a1341dca"
-  integrity sha512-dAyCfosB9XhrYQdkSRGTxPsu1oz75uzMZs3AkwPc9jNoznFRN0Dg9e+8WTGu6dfx7uyGSBd/iYTHk3liMeW/nA==
+liferay-npm-bundler-preset-standard@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.19.0.tgz#5ff75c4adbc44f4ad420d2240e20535b59021ba2"
+  integrity sha512-sQFZrT5/zU12cE1atJOLk2hUsY2rG/YqDX/xfpflvQn4UmO0hHZ9ypa67UAN00CmaEtaCx+ZMUgVCyL0jeaM7w==
   dependencies:
-    babel-preset-liferay-standard "2.18.4"
-    liferay-npm-bundler-plugin-exclude-imports "2.18.4"
-    liferay-npm-bundler-plugin-inject-imports-dependencies "2.18.4"
-    liferay-npm-bundler-plugin-inject-peer-dependencies "2.18.4"
-    liferay-npm-bundler-plugin-namespace-packages "2.18.4"
-    liferay-npm-bundler-plugin-replace-browser-modules "2.18.4"
-    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.18.4"
+    babel-preset-liferay-standard "2.19.0"
+    liferay-npm-bundler-plugin-exclude-imports "2.19.0"
+    liferay-npm-bundler-plugin-inject-imports-dependencies "2.19.0"
+    liferay-npm-bundler-plugin-inject-peer-dependencies "2.19.0"
+    liferay-npm-bundler-plugin-namespace-packages "2.19.0"
+    liferay-npm-bundler-plugin-replace-browser-modules "2.19.0"
+    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.0"
 
-liferay-npm-bundler@2.18.4:
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler/-/liferay-npm-bundler-2.18.4.tgz#009a6939b586e2ced8d592d53c35f02429756664"
-  integrity sha512-u5lp53zI7LujaD8VH13cSJDBYS8c6O+vrvE8TWVSigutEw0fipVGJJe+gRiRo805YgPn71QQ6++a+D7hh5c2eg==
+liferay-npm-bundler@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler/-/liferay-npm-bundler-2.19.0.tgz#46f849741bdc6db9eab453dd809da254d786d837"
+  integrity sha512-Jit9QzQeVzSSoCOu2VAiUdd5d8IajGnvG5Ga2oG3zk90rgYNXTX3SzxezZ+J0YBPwT8iwNQtUW04Nv/5eN5UBw==
   dependencies:
     babel-core "^6.26.3"
     clone "^2.1.2"
@@ -12240,8 +12240,8 @@ liferay-npm-bundler@2.18.4:
     globby "^10.0.1"
     insight "0.10.3"
     jszip "^3.1.5"
-    liferay-npm-build-tools-common "2.18.4"
-    liferay-npm-bundler-preset-standard "2.18.4"
+    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-bundler-preset-standard "2.19.0"
     merge "^1.2.1"
     pretty-time "^1.1.0"
     read-json-sync "^2.0.1"
@@ -12270,10 +12270,10 @@ liferay-npm-bundler@3.0.0-snapshot.dda6cd1:
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-liferay-npm-scripts@32.5.1:
-  version "32.5.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-32.5.1.tgz#ab42a2e3eb5ae47bed8e660b248b8412e48330ad"
-  integrity sha512-XzxZw0ISRwGUXPmryZhkervA63xj+SVn5lq3Bfm69zj3z9ay5u1jHNSjcE28iXvQ4VQDKb8KZqD/twF5TYflSg==
+liferay-npm-scripts@32.6.0:
+  version "32.6.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-32.6.0.tgz#6b329dea347c61c2f425e9cf7b508eb6aa8aeb7a"
+  integrity sha512-DOb+gM1MhNdX305In/FjlU3NxYusUKvorFj1uiRwPOkw7Ugv1avnz/59+Ox2DJCuq1et57/RmuCobO3TG/6RPQ==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"
@@ -12315,9 +12315,9 @@ liferay-npm-scripts@32.5.1:
     jest-fetch-mock "3.0.1"
     liferay-jest-junit-reporter "1.2.0"
     liferay-lang-key-dev-loader "^1.0.3"
-    liferay-npm-bridge-generator "2.18.4"
-    liferay-npm-bundler "2.18.4"
-    liferay-npm-bundler-preset-liferay-dev "4.5.0"
+    liferay-npm-bridge-generator "2.19.0"
+    liferay-npm-bundler "2.19.0"
+    liferay-npm-bundler-preset-liferay-dev "4.6.0"
     liferay-theme-tasks "10.0.2"
     metal-tools-soy "4.3.2"
     mini-css-extract-plugin "0.9.0"

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -4162,12 +4162,12 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-add-module-metadata@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.19.0.tgz#2cf63f12d90c6ec2fc4167ae4e07767feafa2289"
-  integrity sha512-jaYGJaPaRmDxs6rHmP8tYyyHoNkdqYTfOHLVjXEOQ47V0XY3AuFB6lyQG2gpNmAsX6qlgP2LtlGaPGrbwWtgNw==
+babel-plugin-add-module-metadata@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.19.1.tgz#4a6c5be2c6c6f8e356b851ca0f250cffb9e835bc"
+  integrity sha512-ye5OhlqLp2cRd2v6lTQsk4tJjO8CZquWGyXn9oGi4oqEq9CNoDyW+NS/dgur6ryKCDkLrUsdD5sRemZl3Zmcyw==
   dependencies:
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
     read-json-sync "^2.0.1"
 
 babel-plugin-add-react-displayname@^0.0.5:
@@ -4175,12 +4175,12 @@ babel-plugin-add-react-displayname@^0.0.5:
   resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
   integrity sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=
 
-babel-plugin-alias-modules@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.19.0.tgz#83595301c5dd72d4c55deef9c87b6f71f86ad878"
-  integrity sha512-NZgOlNnT1Tuqn9F1pCZA/oC+mLOw+OR5cx5KdZvBiViQ6hr/MRNvhSGsRwHfpEX258AN6XqLOMOGnHTJZizLJg==
+babel-plugin-alias-modules@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.19.1.tgz#e2bc4081764dfa6bd4f37dcbba5b2d80fcc35fb0"
+  integrity sha512-ROGmQs2kx/SE8QZgoyTcU0WVmzuwLGeojZkIxbjdU8AcfV48H5WBMaFgHVDzl/tcFwovJW5zem2j/H8pxPO2ng==
   dependencies:
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
 
 babel-plugin-dynamic-import-node@2.2.0:
   version "2.2.0"
@@ -4348,38 +4348,38 @@ babel-plugin-minify-type-constructors@^0.4.3:
   dependencies:
     babel-helper-is-void-0 "^0.4.3"
 
-babel-plugin-name-amd-modules@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.19.0.tgz#2c94887d98ad1f7a012c7fb71dc18258179a762a"
-  integrity sha512-rhE6Hz6eF/h0nFK07plmm4YJhw+IjOSImSGdgZtSdgHNYXCu90Z8YVlb4C/RNMSG9diEBG5MEdbfsljFjo1dRQ==
+babel-plugin-name-amd-modules@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.19.1.tgz#0635a69303c65f445b48354c59661ef99c114d7b"
+  integrity sha512-ztmq/TXdopzHCasVek5QHYbvi2Rga7dOothH1SF2NuOfWGBBWb32e5kbgQ4RUoWLVxb6IG4mfepbZOe5IbdCCw==
   dependencies:
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
 
 babel-plugin-named-asset-import@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.2.tgz#20978ed446b8e1bf4a2f42d0a94c0ece85f75f4f"
   integrity sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ==
 
-babel-plugin-namespace-amd-define@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.19.0.tgz#8e64ecd6422da36fffc266a0255ba4a342f905d0"
-  integrity sha512-xx80+q77coh9N9Yp2iJHPnwnJdAnwCtOyozNjCOLqbh+exhA6BxfGvNxHnqEPW8IVWME0TCRxUzlJr35ROMEtw==
+babel-plugin-namespace-amd-define@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.19.1.tgz#af7f1e5be4febc5db43f01d675b92c1215189314"
+  integrity sha512-/qA8NyVN6GRuWIYfRna7PN/sgeTZBHuyOaGQ6UVnJXYokUXHZw104ZPjGnXMSDaotoEjIbiIZklVAa6plFvZpw==
   dependencies:
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
 
-babel-plugin-namespace-modules@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.19.0.tgz#cb25491083035a5a4ffba92d06d765f48cbee618"
-  integrity sha512-CzuF6XnmvKKidic8HmNCBsnRHzLeoN5/yTvSv90g3t41J8+jlAVL9gqonjk6nQVLHaweuBx7LxcDyZEoUApN9Q==
+babel-plugin-namespace-modules@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.19.1.tgz#2985bf0d49fed36759a217538cba29d93b7e2f20"
+  integrity sha512-8Z42TruxvmQc3pfP6HDERAYfF87IHOvo/L+R8OHvN8DEnXbWiwZV1TigmL3iCr7n3g8hX71uom23k1WrtWkvng==
   dependencies:
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
 
-babel-plugin-normalize-requires@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.19.0.tgz#9982f455152e54f2dfa358ad869645a9e5aeb0cf"
-  integrity sha512-3e5c5Th7zzouKrG0NtPgccjYWfCB5LDxxA/Ge2Q1kMFqgRt9nQxizzPGZrd5yomyOBq5ijQlQ9jGYluu+XQH3A==
+babel-plugin-normalize-requires@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.19.1.tgz#7e7ab1289c41d37f1b7e1bfd3567f58257d861ce"
+  integrity sha512-EuB3sopjxSvLq/qXtS0EdToW8EH9ZZoD42rZ+9gIfKQzNtS3nk5PAIWtjeraa994Vg0a+5kxWlFlO29BVzbXSw==
   dependencies:
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
 
 babel-plugin-react-docgen@^3.0.0:
   version "3.1.0"
@@ -4464,13 +4464,13 @@ babel-plugin-transform-undefined-to-void@^6.9.4:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"
   integrity sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=
 
-babel-plugin-wrap-modules-amd@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.19.0.tgz#c9c57bf7431e0a1cbcb22dc1c2fb7dfef1773666"
-  integrity sha512-mC9AgPAWY3VJkcqcingjTti5VR6JvXtvLFVgtvjyxUTNMsamiWeLbzvLOpmvXw4qqrRKgsC0XzSI2Xjr6029iA==
+babel-plugin-wrap-modules-amd@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.19.1.tgz#12d189dcae6b44bd94a5c429cf61244f145b9347"
+  integrity sha512-lVg0WxHdIdGzGRt/mqvVvaGQIl7UQJC9badQBPShPzHewCn3c3c/dAcxA0/D7/tWg7WWcYjydbjs33oykX2DUw==
   dependencies:
     babel-template "^6.26.0"
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
     read-json-sync "^2.0.1"
 
 babel-preset-jest@^25.1.0:
@@ -4482,20 +4482,20 @@ babel-preset-jest@^25.1.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^25.1.0"
 
-babel-preset-liferay-standard@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.19.0.tgz#2dbe851edeab6060ef7307d1e57fa647c948f650"
-  integrity sha512-7FU29WZU/9bLIRCJ86ebsw7Pd5ywQLgdNtswiI+PMjD/yB+YzMrzAtOkpP/lU5AadCgxVsH8HG3gtdS9NNV+nQ==
+babel-preset-liferay-standard@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.19.1.tgz#90a1cd31d0bd9d7337d6a352d6a5e1a206a94578"
+  integrity sha512-TXpNqKgClUUYANbqM9eKnHIYuTJGMCQEwqT0Ryilu+T9seTcngaj4EIW+7NsdEkMJLzTvTCmwZOzOTGaAmiWzQ==
   dependencies:
-    babel-plugin-add-module-metadata "2.19.0"
-    babel-plugin-alias-modules "2.19.0"
+    babel-plugin-add-module-metadata "2.19.1"
+    babel-plugin-alias-modules "2.19.1"
     babel-plugin-minify-dead-code-elimination "0.5.1"
-    babel-plugin-name-amd-modules "2.19.0"
-    babel-plugin-namespace-amd-define "2.19.0"
-    babel-plugin-namespace-modules "2.19.0"
-    babel-plugin-normalize-requires "2.19.0"
+    babel-plugin-name-amd-modules "2.19.1"
+    babel-plugin-namespace-amd-define "2.19.1"
+    babel-plugin-namespace-modules "2.19.1"
+    babel-plugin-normalize-requires "2.19.1"
     babel-plugin-transform-node-env-inline "0.4.3"
-    babel-plugin-wrap-modules-amd "2.19.0"
+    babel-plugin-wrap-modules-amd "2.19.1"
 
 "babel-preset-minify@^0.5.0 || 0.6.0-alpha.5":
   version "0.5.0"
@@ -12105,25 +12105,25 @@ liferay-lang-key-dev-loader@^1.0.3:
     loader-utils "^1.1.0"
     properties "^1.2.1"
 
-liferay-npm-bridge-generator@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.19.0.tgz#e6c909d4c614ffc47beeb9c4faaefdc640ab6836"
-  integrity sha512-6G7X3GjUSbuFF5WFWy0W/mXqXumIIEv6LqDeurF6fSmmyr9Dc44QUzPdd7F4gBIwT6kBZGQGQZRUiuYlRmmslg==
+liferay-npm-bridge-generator@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.19.1.tgz#a47015324d422a4957da8a202bd477d12983f06e"
+  integrity sha512-nOoGiru7Ft9ydkEklUuJKTuz7tE6i0C6AcTDzJ0BwBNinLCHY9ctBe1Rbp0twbBovJSlR98W9rFsyBr4SOhMzA==
   dependencies:
     fs-extra "^8.1.0"
     globby "^10.0.1"
     read-json-sync "^2.0.1"
     yargs "^14.0.0"
 
-liferay-npm-build-tools-common@2.19.0, liferay-npm-build-tools-common@^2.17.1:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.19.0.tgz#4307ee203450f643c419cad0c0e60c52da56442c"
-  integrity sha512-Iu9SrvNtnU2BlTyQ/XbGShu7miRt40btqnFhDtVti68X9sY52/FGhf5jbdI0UmnQy56zEWTJskH5OzAoqlQvVw==
+liferay-npm-build-tools-common@2.19.1, liferay-npm-build-tools-common@^2.17.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.19.1.tgz#359d48bfb8a9dc97680fd395b242d7975850d369"
+  integrity sha512-hvX8rnU6kFj3tUtk4Ygz4bIOtNMejPLBZ38aHR7Ztf7vy5WZ6IRZEyEDl9f49ExoXqUHpcLp6qPOHwpXVqFDbQ==
   dependencies:
     chalk "^2.4.2"
     dot-prop "^5.0.1"
     escape-string-regexp "^2.0.0"
-    liferay-npm-bundler-preset-standard "2.19.0"
+    liferay-npm-bundler-preset-standard "2.19.1"
     merge "^1.2.1"
     properties "^1.2.1"
     read-json-sync "^2.0.1"
@@ -12143,94 +12143,94 @@ liferay-npm-build-tools-common@3.0.0-snapshot.dda6cd1:
     resolve "^1.8.1"
     webpack "^4.41.6"
 
-liferay-npm-bundler-loader-css-loader@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.19.0.tgz#a3a641e91b171101631afb0695a27a7e5f7e5148"
-  integrity sha512-iCwaJ7Y+SxhxCw1e6M5zGA/XMjfLKqGXhDI7SuhHNXiE2rqHFuK/5OX9PPfQ65hyAKbgujSn4GrbPwjyrYVPMw==
+liferay-npm-bundler-loader-css-loader@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.19.1.tgz#29e69ced367652580965deab7fcf3fa8e15be5c6"
+  integrity sha512-so2gdvkk+PggwQnmyHkuUgfDsOZZbB3i6Ojc4U305oyZWzFIipWRFfSVBiqXP4T8M/J304TOXB3dNIh7I5KN7A==
   dependencies:
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
     read-json-sync "^2.0.1"
 
-liferay-npm-bundler-plugin-exclude-imports@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.19.0.tgz#0f51097cf006f6eda8b85fd27c739636dd37c9fc"
-  integrity sha512-QiBCKsmsT9QsN3LVvCKA2RH/4A+sH5HuCOS47Yi56U3rZgyMXOeH7DXZde8ow6qRjDLFkXvlMIscTeV7Bv9Uxg==
+liferay-npm-bundler-plugin-exclude-imports@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.19.1.tgz#443e9d45d6bc90c726502d68772dcdf58f04b2e1"
+  integrity sha512-Jr0JX4x5pPS+gFCG+tJnY6tCoG9LEsJQBaQCJjHH8gM74GuSk2hETFzCROdK0lhHjL7YjOO3nqgNHz6yFXPlaw==
   dependencies:
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
 
-liferay-npm-bundler-plugin-inject-imports-dependencies@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.19.0.tgz#6b1247195e03c87c0fe6faec27c70803ed9ebae0"
-  integrity sha512-O1wgjrmZdHtaSAlzI3UpDoAEXSP6B3zpKohpXFn0B1Vfs8DHA69GMObZtK31oq/bWhVyRT85FuvvAlQQ+FBwOw==
+liferay-npm-bundler-plugin-inject-imports-dependencies@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.19.1.tgz#dba6481e334ea736a767be853cb5bd035251c59f"
+  integrity sha512-RXjXyEerasJ293aajTl0bEUmR5mugI8GJKcMO6AmCDTh6h3DLj98O0eyyxGNbA7SNUMvUEzfwGv5+aBZIGH73w==
   dependencies:
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
 
-liferay-npm-bundler-plugin-inject-peer-dependencies@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.19.0.tgz#764759e88291bc08617fc24b9d239e6f31f5b28f"
-  integrity sha512-Gs8SCc6XtAqNJDXh5YMtk9gFii0fyISLAxlorn/QIzdtuybudd1TtbMGMFzXpliM7jPUkMB1VyyXQPW6pZYLRQ==
+liferay-npm-bundler-plugin-inject-peer-dependencies@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.19.1.tgz#080d7feead88ac6d2861415a68be4fe470389694"
+  integrity sha512-gcCa35/I8rgtP7DdaIED2SUPpAbfUsSnpt2tLbMuB1Xo6j0pe+pxy3QUDCcHOB4qnF0xYR8Q6Ot6+2wPpT7O/A==
   dependencies:
     globby "^10.0.1"
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
     read-json-sync "^2.0.1"
     resolve "^1.8.1"
 
-liferay-npm-bundler-plugin-namespace-packages@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.19.0.tgz#4c5f85777b8d5cc6bbe5107a1e4bce76c5e4b89b"
-  integrity sha512-NciYzrGapGqwyotW/tXMyDwJaeAo/KwpZgN1JfBxNPfQKkzVepNkFfRWVCYkz0e4uLIDoFCOzOP/1SDqayNrsw==
+liferay-npm-bundler-plugin-namespace-packages@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.19.1.tgz#22e565824db218d1b71a8f2b391dcd1202fc5c90"
+  integrity sha512-fer72q+LD6mXTRkBEtE57wvYbwLE4Mxp+tHoVSRP80TJo2mig2qvnBmCMVOtNars4vNQJ7o4h988Ux+zf2mfZA==
   dependencies:
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
 
-liferay-npm-bundler-plugin-replace-browser-modules@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.19.0.tgz#718e9e168b1733ac57bdabf270d65b2ca1c8ad07"
-  integrity sha512-DwaKczxDnYyRHRb4wqbUZTGfltG7aRPbtE5qJ9n5hPuVcV5kKnyCAip2l11KScl6S0fV9WZgPBHWQiPTlcp2Xg==
+liferay-npm-bundler-plugin-replace-browser-modules@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.19.1.tgz#9b5275f21f5c38c7b62762b755480010ccf90666"
+  integrity sha512-+NoBaWMfYdTARFhE9JaEG9oVVAICCTv9U0mQMtSH6g8U49wqt2QNPHzq1yfJNCZ7f9uYXqDbk/lKsZWJmx+Xcw==
   dependencies:
     dot-prop "^5.0.1"
     fs-extra "^8.1.0"
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
 
-liferay-npm-bundler-plugin-resolve-linked-dependencies@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.19.0.tgz#0c92b4bb6dba76a3028140eadf061a0d11342a83"
-  integrity sha512-ozt5ViXXlrmaOMJNqf0qFHaNGgEdE1jbs2FAxkYD+rv4D5nQ7qxbYgcnqA6fyuo7ICoccC7uMJHcDN5zNqpeGg==
+liferay-npm-bundler-plugin-resolve-linked-dependencies@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.19.1.tgz#8c378af9b4e2343de0d02433492b148ae5d8e380"
+  integrity sha512-OZ0ucQ1ebtnQLyWu71YimGk4Dmql96g3abndPKa0wYG1SfUYGNdaqsEwIFV1II8A+AVITIHhAt/Q/jjjT3g6Aw==
   dependencies:
-    liferay-npm-build-tools-common "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
     read-json-sync "^2.0.1"
     semver "^6.3.0"
 
-liferay-npm-bundler-preset-liferay-dev@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-liferay-dev/-/liferay-npm-bundler-preset-liferay-dev-4.6.0.tgz#ab28721aa77120060ff0c514451e4e51de0a76c4"
-  integrity sha512-jRniRy4ZL3Qq6EiBDZ4b0uqa7CBPncErLFedqiGvIIgPwsggL0LsKHQQpMOQ8LtoMIbH3kCt1OeErl8f8XRYpg==
+liferay-npm-bundler-preset-liferay-dev@4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-liferay-dev/-/liferay-npm-bundler-preset-liferay-dev-4.6.1.tgz#773ae18b73aed616796ecc50a507a3dba42d2adb"
+  integrity sha512-t7B2s551e00GvuuGj373CAn+PwJsytjz0/ALbU+3kgsyi5Rhu42oAPeyX4+2l8OZVv8Ur6jBX2G0F/6lsfRW5w==
   dependencies:
-    babel-preset-liferay-standard "2.19.0"
-    liferay-npm-bundler-loader-css-loader "2.19.0"
-    liferay-npm-bundler-plugin-exclude-imports "2.19.0"
-    liferay-npm-bundler-plugin-inject-imports-dependencies "2.19.0"
-    liferay-npm-bundler-plugin-inject-peer-dependencies "2.19.0"
-    liferay-npm-bundler-plugin-namespace-packages "2.19.0"
-    liferay-npm-bundler-plugin-replace-browser-modules "2.19.0"
-    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.0"
+    babel-preset-liferay-standard "2.19.1"
+    liferay-npm-bundler-loader-css-loader "2.19.1"
+    liferay-npm-bundler-plugin-exclude-imports "2.19.1"
+    liferay-npm-bundler-plugin-inject-imports-dependencies "2.19.1"
+    liferay-npm-bundler-plugin-inject-peer-dependencies "2.19.1"
+    liferay-npm-bundler-plugin-namespace-packages "2.19.1"
+    liferay-npm-bundler-plugin-replace-browser-modules "2.19.1"
+    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.1"
 
-liferay-npm-bundler-preset-standard@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.19.0.tgz#5ff75c4adbc44f4ad420d2240e20535b59021ba2"
-  integrity sha512-sQFZrT5/zU12cE1atJOLk2hUsY2rG/YqDX/xfpflvQn4UmO0hHZ9ypa67UAN00CmaEtaCx+ZMUgVCyL0jeaM7w==
+liferay-npm-bundler-preset-standard@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.19.1.tgz#0b305cbb64d1adeda286f016d39e6103736f92d6"
+  integrity sha512-huNMhvtQyz3ZQaN2sCuxAqmg+60UKaaP/4yrNwNrkv57q9buvJzUHW7WB1hAXGPwzCkgCNRx8G0M09uZC7juVw==
   dependencies:
-    babel-preset-liferay-standard "2.19.0"
-    liferay-npm-bundler-plugin-exclude-imports "2.19.0"
-    liferay-npm-bundler-plugin-inject-imports-dependencies "2.19.0"
-    liferay-npm-bundler-plugin-inject-peer-dependencies "2.19.0"
-    liferay-npm-bundler-plugin-namespace-packages "2.19.0"
-    liferay-npm-bundler-plugin-replace-browser-modules "2.19.0"
-    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.0"
+    babel-preset-liferay-standard "2.19.1"
+    liferay-npm-bundler-plugin-exclude-imports "2.19.1"
+    liferay-npm-bundler-plugin-inject-imports-dependencies "2.19.1"
+    liferay-npm-bundler-plugin-inject-peer-dependencies "2.19.1"
+    liferay-npm-bundler-plugin-namespace-packages "2.19.1"
+    liferay-npm-bundler-plugin-replace-browser-modules "2.19.1"
+    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.1"
 
-liferay-npm-bundler@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler/-/liferay-npm-bundler-2.19.0.tgz#46f849741bdc6db9eab453dd809da254d786d837"
-  integrity sha512-Jit9QzQeVzSSoCOu2VAiUdd5d8IajGnvG5Ga2oG3zk90rgYNXTX3SzxezZ+J0YBPwT8iwNQtUW04Nv/5eN5UBw==
+liferay-npm-bundler@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler/-/liferay-npm-bundler-2.19.1.tgz#cc3af9a167fe43d4a77c75118280db532bee0f0e"
+  integrity sha512-EFaZ4MFDS48jZCfMRW+adA6Btm0K6aCEbaZmeFFwVKr/N2IzFJhRRgZ2pS/qFtDoGzaNvXpg0SJnVLdmOQa4Sg==
   dependencies:
     babel-core "^6.26.3"
     clone "^2.1.2"
@@ -12240,8 +12240,8 @@ liferay-npm-bundler@2.19.0:
     globby "^10.0.1"
     insight "0.10.3"
     jszip "^3.1.5"
-    liferay-npm-build-tools-common "2.19.0"
-    liferay-npm-bundler-preset-standard "2.19.0"
+    liferay-npm-build-tools-common "2.19.1"
+    liferay-npm-bundler-preset-standard "2.19.1"
     merge "^1.2.1"
     pretty-time "^1.1.0"
     read-json-sync "^2.0.1"
@@ -12270,10 +12270,10 @@ liferay-npm-bundler@3.0.0-snapshot.dda6cd1:
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-liferay-npm-scripts@32.6.0:
-  version "32.6.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-32.6.0.tgz#6b329dea347c61c2f425e9cf7b508eb6aa8aeb7a"
-  integrity sha512-DOb+gM1MhNdX305In/FjlU3NxYusUKvorFj1uiRwPOkw7Ugv1avnz/59+Ox2DJCuq1et57/RmuCobO3TG/6RPQ==
+liferay-npm-scripts@32.6.1:
+  version "32.6.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-32.6.1.tgz#de64072dee0c6381cc07805360d4537de173c41d"
+  integrity sha512-cCuJmIGf6F2Bgn1293LzE+MUuW7Bzj5UPRqiz4e8Enmp5kbVG8kb13aHwPUFJsOAm75ZAxX+ysoBb/W44wG5PQ==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"
@@ -12315,9 +12315,9 @@ liferay-npm-scripts@32.6.0:
     jest-fetch-mock "3.0.1"
     liferay-jest-junit-reporter "1.2.0"
     liferay-lang-key-dev-loader "^1.0.3"
-    liferay-npm-bridge-generator "2.19.0"
-    liferay-npm-bundler "2.19.0"
-    liferay-npm-bundler-preset-liferay-dev "4.6.0"
+    liferay-npm-bridge-generator "2.19.1"
+    liferay-npm-bundler "2.19.1"
+    liferay-npm-bundler-preset-liferay-dev "4.6.1"
     liferay-theme-tasks "10.0.2"
     metal-tools-soy "4.3.2"
     mini-css-extract-plugin "0.9.0"


### PR DESCRIPTION
- [Release notes for v32.6.0](https://github.com/liferay/liferay-npm-tools/releases/tag/liferay-npm-scripts%2Fv32.6.0).
- [Release notes for v32.6.1](https://github.com/liferay/liferay-npm-tools/releases/tag/liferay-npm-scripts%2Fv32.6.1).

Two main things of interest:

1.  Updates JS toolkit dependencies, in order to get [this PR](https://github.com/liferay/liferay-js-toolkit/pull/632) which adds "preload" to link tags to improve Lighthouse performance audit; that one will close [LPS-115876](https://issues.liferay.com/browse/LPS-115876).

2.  Only merge babel options into babel webpack loader, not other loaders; requested by Commerce folks ([related PR](https://github.com/liferay/liferay-npm-tools/pull/481)); cc @FabioDiegoMastrorilli

The second commit is just some defensive future-proofing of the configuration, which I believe shouldn't actually impact current behavior at all.
