### PR TITLE
LPS-120175 Make js_resolve_modules responses cacheable

### DIFF
--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/bnd.bnd
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Frontend JS Loader Modules Extender API
 Bundle-SymbolicName: com.liferay.frontend.js.loader.modules.extender.api
-Bundle-Version: 4.2.2
+Bundle-Version: 4.3.0
 Export-Package: com.liferay.frontend.js.loader.modules.extender.npm

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/NPMRegistryUpdatesListener.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/NPMRegistryUpdatesListener.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.loader.modules.extender.npm;
+
+import org.osgi.annotation.versioning.ConsumerType;
+
+/**
+ * Can be implemented by any service needing to be notified when the
+ * {@link NPMRegistry} is updated.
+ *
+ * @author Iván Zaera Avellón
+ */
+@ConsumerType
+public interface NPMRegistryUpdatesListener {
+
+	public void onAfterUpdate();
+
+}

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/resources/com/liferay/frontend/js/loader/modules/extender/npm/packageinfo
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/resources/com/liferay/frontend/js/loader/modules/extender/npm/packageinfo
@@ -1,1 +1,1 @@
-version 3.4.0
+version 3.5.0

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
@@ -58,7 +58,7 @@ import org.osgi.service.component.annotations.Reference;
 public class JSResolveModulesServlet extends HttpServlet {
 
 	public JSResolveModulesServlet() {
-		updateEtag();
+		updateETag();
 	}
 
 	@Override
@@ -94,7 +94,7 @@ public class JSResolveModulesServlet extends HttpServlet {
 		printWriter.close();
 	}
 
-	protected void updateEtag() {
+	protected void updateETag() {
 		_etag = StringBundler.concat(
 			"W/", StringPool.QUOTE, UUID.randomUUID(), StringPool.QUOTE);
 	}

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/NPMRegistryUpdatesListenerImpl.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/NPMRegistryUpdatesListenerImpl.java
@@ -37,7 +37,7 @@ public class NPMRegistryUpdatesListenerImpl
 			_bundleContext.getService(serviceReference);
 
 		try {
-			jsResolveModulesServlet.updateEtag();
+			jsResolveModulesServlet.updateETag();
 		}
 		finally {
 			_bundleContext.ungetService(serviceReference);

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/NPMRegistryUpdatesListenerImpl.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/NPMRegistryUpdatesListenerImpl.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.loader.modules.extender.internal.servlet;
+
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistryUpdatesListener;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Iván Zaera
+ */
+@Component(immediate = true, service = NPMRegistryUpdatesListener.class)
+public class NPMRegistryUpdatesListenerImpl
+	implements NPMRegistryUpdatesListener {
+
+	@Override
+	public void onAfterUpdate() {
+		ServiceReference<JSResolveModulesServlet> serviceReference =
+			_bundleContext.getServiceReference(JSResolveModulesServlet.class);
+
+		JSResolveModulesServlet jsResolveModulesServlet =
+			_bundleContext.getService(serviceReference);
+
+		try {
+			jsResolveModulesServlet.updateEtag();
+		}
+		finally {
+			_bundleContext.ungetService(serviceReference);
+		}
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
+	private BundleContext _bundleContext;
+
+}


### PR DESCRIPTION
See commits for a description of what the PR does.

Tested manually by retrieving the URL 

http://localhost:8080/o/js_resolve_modules?modules=frontend-js-spa-web%404.0.15%2Fliferay%2Finit.es

from a browser, opening the network devtools tab, and asserting that the first time the resource is retrieved the server returns a 200 status code, but the rest of the times it returns a 304.

Then, I redeployed frontend-js-spa-web and made sure that a new request triggers a 200 (to update the cached object) and then 304s again.