### PR TITLE
LPS-119607 Uses proper portletId to account for instanceable portlets as well

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String portletId = portletDisplay.getRootPortletId();
+String portletId = portletDisplay.getId();
 
 boolean autoCreate = GetterUtil.getBoolean((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":autoCreate"));
 String contents = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":contents");


### PR DESCRIPTION
>The method getRootPortletId does not include the instance name in the case of instanceable portlets, which can cause misconfiguration between registering and disposing componetns causing memory leaks and orphaned components

**Steps to Reproduce**
- Add a Wiki Display Widget to a Widget Page
- Edit a page
- Change the page format (between HTML, Creole, Plain Text....)

**The issue**
Formats with CKEditor will only work the first time. This is technically a regression caused by [LPS-118801 Properly cleanup CKEditor and AlloyEditor resources on navigation](https://github.com/liferay-frontend/liferay-portal/pull/276).

It presents now because:
- On navigation we now remove CKEditor resources from the page
- CKEditor instantiation always start with a clean CKEditor context (no resources on the page, no `window.CKEDITOR`...)
- In the case of WikiDisplay, we don't dispose of the instances cleaning everything properly
- When we try to recreate, since we already have `window.CKEDITOR`, it will skip loading resources that are now needed since we manually removed them.

We fail to dispose the CKEditor instance in the case of `WikiDisplay` because:
- We register the component via `Liferay.component` using the wrong `portletId` value. We use `getRootPortletId()` rather than `getId()` which does not return the portlet instance.
- When we destroy registered components on navigation, the `portletId` values won't match for the `WikiDisplay` portlet, and since we don't mark the component as `destroyOnNavigate` it will remain on the page.

**The fix**
Use the proper `portletDisplay.getId()` to get the proper portlet Id.

/cc @brunobasto, I checked and see we're using this at least in [data_set_display](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/page.jsp#L69) and [headless_data_set_display](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/page.jsp#L72). This might be a hidden bug
/cc @marco-leo, @FabioDiegoMastrorilli, @gianmarcobrunialti, I see a lot of `portletId: '<%= portletDisplay.getRootPortletId() %>',` in `commerce` modules. Be aware this might be a source of bugs.
/cc @ambrinchaudhary, @boton, @julien, @adolfopa

PS: For reference, this had already been fixed a long time ago in `alloyeditor.jsp` with [LPS-72761 Using bad portlet id in frontend-editor-alloyeditor-web module](https://github.com/brianchandotcom/liferay-portal/pull/50577)