### PR TITLE
LPS-120178 - Not use color picker for hr-border-color

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
@@ -1121,7 +1121,6 @@
 						},
 						{
 							"defaultValue": "rgba(0, 0, 0, .1)",
-							"editorType": "ColorPicker",
 							"label": "hr-border-color",
 							"mappings": [
 								{


### PR DESCRIPTION
This PR removes the `colorpicker` for `hr-border-color` in _stylebook_, in order to do not offer colorpiker to chose a new color

![image](https://user-images.githubusercontent.com/7963804/91959639-276a7c00-ed09-11ea-8900-7be8f59ce326.png)

---

To test it:

1. Add a page based on Blank
2. Add a Heading fragment to page
3. Open the body of Heading
4. Selection panel > Styles tab
5. Open the Text Color field