### PR TITLE
COMMERCE-4589 href action is temporarily not nested

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionsDropdownRenderer.js
@@ -180,7 +180,7 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 		const [action] = formattedActions;
 		const {data: actionData} = action;
 
-		if (actionData?.id && !actionData?.href) {
+		if (actionData?.id && !action?.href) {
 			return null;
 		}
 
@@ -201,7 +201,7 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 		return isLink(action.target, action.onClick) ? (
 			<ClayLink
 				className="btn btn-secondary btn-sm"
-				href={formatActionURL(actionData.href, itemData)}
+				href={formatActionURL(action.href, itemData)}
 				monospaced={Boolean(action.icon)}
 			>
 				{content}


### PR DESCRIPTION
This is an urgent fix, as discussed here: https://github.com/liferay-frontend/liferay-portal/pull/339#discussion_r480546429
Temporarily the `href` is still nested within the `action` object. @brunobasto 