### PR TITLE
LPS-120294 Allow changing existing images in CKEditor using the Image Dialog

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -445,6 +445,15 @@
 							.setAttribute('readOnly', true);
 					};
 				}
+				else if (dialogName === 'image2') {
+					instance._bindBrowseButton(
+						event.editor,
+						dialogDefinition,
+						'info',
+						'imageselector',
+						'txtUrl'
+					);
+				}
 				else if (dialogName === 'video') {
 					instance._bindBrowseButton(
 						event.editor,


### PR DESCRIPTION
Issue discovered doing a review with Tarik from Echo about the migration from AlloyEditor to CKEditor.

**Steps to Reproduce**
- Navigate to `Content & Data > Web Content`
- Use the Image button to add an image previously uploaded to the `Document Library`
- Double click on the image element to show the image edition dialog
- Click on the `Browse Server` button to pick a different image
- Select a different image

![image](https://user-images.githubusercontent.com/905006/91971944-458ca800-ed1a-11ea-8f93-81e959ed9cf6.gif)

**The problem**
We switched from `image` to `image2` as our default CKEditor plugin for images. Because of that, our logic to bind the `Browse Button` to execute our own command fails.

**The fix**
Add the necessary additional logic to cover the `image2` plugin use case
