### PR TITLE
LPS-115278 Editing permanent redirect information about caching always appears

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -40,6 +40,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>


### PR DESCRIPTION
This PR adds `cssClass` attribute to recover the CSS class in the HTML render of `<clay:alert`. 
It is like #46 but in <clay:alert.

**Steps to reproduce:**

1. Go to Configuration -> Redirection 
2. Click on add button [+]
3. Type the source URL and destination URL
4. Select Type: Permanent (301)
5. Click Create
6. Edit this redirection


**Before the fix:**
Info about caching is on the page by default.
The `<clay:alert` HTML has a wired attribute `cssClass="hide"`.

![image](https://user-images.githubusercontent.com/67901/91987998-0caafe00-ed2f-11ea-8f91-17c67a2f3e42.png)


**After the fix:**
No info alert about caching render by default.
The `<clay:alert` HTML has a new css class `hide` in the `class` attribute.

![image](https://user-images.githubusercontent.com/67901/91988617-c0ac8900-ed2f-11ea-8584-c5d8d36dd6f8.png)