### PR TITLE
LPS-119869 Instead of custom implement the input, use Clay components for deal with markup

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -491,7 +491,7 @@ function DataSetDisplay({
 				{style === 'fluid' && (
 					<div className="data-set-display data-set-display-fluid">
 						{managementBar}
-						<div className="container mt-3">
+						<div className="container-fluid container-xl mt-3">
 							{wrappedView}
 							{paginationComponent}
 						</div>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -383,7 +383,6 @@ function DataSetDisplay({
 				<ClayPaginationBarWithBasicItems
 					activeDelta={delta}
 					activePage={pageNumber}
-					className="mb-2"
 					deltas={pagination.deltas}
 					ellipsisBuffer={3}
 					onDeltaChange={(deltaVal) => {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_data_set_display.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_data_set_display.scss
@@ -120,6 +120,10 @@
 	}
 
 	&.data-set-display-inline {
+		.data-set-display-pagination-wrapper {
+			padding-top: 0.5rem;
+		}
+
 		.table {
 			border-bottom: 1px solid $border-color;
 		}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_data_set_display.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_data_set_display.scss
@@ -41,23 +41,9 @@
 		}
 	}
 
-	.main-input-wrapper {
-		position: relative;
-	}
-
 	.main-input-search {
 		padding-right: map-get($spacers, 5) !important;
 		width: 100%;
-	}
-
-	.main-input-reset-button {
-		color: currentColor;
-		height: 100%;
-		position: absolute;
-		right: 0;
-		text-align: center;
-		top: 0;
-		width: map-get($spacers, 5);
 	}
 
 	.table {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_data_set_display.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_data_set_display.scss
@@ -41,11 +41,6 @@
 		}
 	}
 
-	.main-input-search {
-		padding-right: map-get($spacers, 5) !important;
-		width: 100%;
-	}
-
 	.table {
 		border-collapse: separate;
 		border-spacing: 0;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/CreationMenu.js
@@ -25,7 +25,7 @@ function CreationMenu({primaryItems}) {
 	const dataSetContext = useContext(DataSetDisplayContext);
 
 	return (
-		primaryItems.length && (
+		!!primaryItems?.length && (
 			<ul className="navbar-nav">
 				<li className="nav-item">
 					{primaryItems.length > 1 ? (

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/MainSearch.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/MainSearch.js
@@ -51,9 +51,10 @@ function MainSearch() {
 						displayType="unstyled"
 						onClick={(event) => {
 							event.preventDefault();
+							
 							updateInputValue('');
 
-							return updateSearchParam('');
+							updateSearchParam('');
 						}}
 						style={{
 							opacity: !inputValue.length ? 0 : 1,
@@ -66,7 +67,7 @@ function MainSearch() {
 						onClick={(event) => {
 							event.preventDefault();
 
-							return updateSearchParam(inputValue);
+							updateSearchParam(inputValue);
 						}}
 						symbol="search"
 					/>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/MainSearch.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/MainSearch.js
@@ -12,8 +12,8 @@
  * details.
  */
 
-import Icon from '@clayui/icon';
-import classNames from 'classnames';
+import {ClayButtonWithIcon} from '@clayui/button';
+import {ClayInput} from '@clayui/form';
 import React, {useContext, useEffect, useState} from 'react';
 
 import DataSetDisplayContext from '../../DataSetDisplayContext';
@@ -36,55 +36,43 @@ function MainSearch() {
 	}
 
 	return (
-		<div className="d-inline">
-			<div className="input-group">
-				<div className="input-group-item">
-					<div className="main-input-wrapper">
-						<input
-							className="form-control input-group-inset input-group-inset-after main-input-search"
-							onChange={(event) =>
-								updateInputValue(event.target.value)
-							}
-							onKeyDown={handleKeyDown}
-							placeholder={Liferay.Language.get('search')}
-							type="text"
-							value={inputValue}
-						/>
+		<ClayInput.Group>
+			<ClayInput.GroupItem>
+				<ClayInput
+					className="input-group-inset input-group-inset-after"
+					onChange={(event) => updateInputValue(event.target.value)}
+					onKeyDown={handleKeyDown}
+					placeholder={Liferay.Language.get('search')}
+					value={inputValue}
+				/>
+				<ClayInput.GroupInsetItem after tag="div">
+					<ClayButtonWithIcon
+						disabled={!inputValue.length}
+						displayType="unstyled"
+						onClick={(event) => {
+							event.preventDefault();
+							updateInputValue('');
 
-						<button
-							className={classNames(
-								'main-input-reset-button btn btn-unstyled',
-								!inputValue.length && 'd-none'
-							)}
-							disabled={!inputValue.length}
-							onClick={(event) => {
-								event.preventDefault();
-								updateInputValue('');
+							return updateSearchParam('');
+						}}
+						style={{
+							opacity: !inputValue.length ? 0 : 1,
+							pointerEvents: !inputValue.length ? 'none' : 'auto',
+						}}
+						symbol="times-circle"
+					/>
+					<ClayButtonWithIcon
+						displayType="unstyled"
+						onClick={(event) => {
+							event.preventDefault();
 
-								return updateSearchParam('');
-							}}
-							type="button"
-						>
-							<Icon symbol="times-circle" />
-						</button>
-					</div>
-
-					<span className="input-group-inset-item input-group-inset-item-after">
-						<button
-							className="btn btn-unstyled"
-							onClick={(event) => {
-								event.preventDefault();
-
-								return updateSearchParam(inputValue);
-							}}
-							type="button"
-						>
-							<Icon symbol="search" />
-						</button>
-					</span>
-				</div>
-			</div>
-		</div>
+							return updateSearchParam(inputValue);
+						}}
+						symbol="search"
+					/>
+				</ClayInput.GroupInsetItem>
+			</ClayInput.GroupItem>
+		</ClayInput.Group>
 	);
 }
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/MainSearch.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/MainSearch.js
@@ -28,7 +28,7 @@ function MainSearch({setShowMobile}) {
 	}, [searchParam]);
 
 	function handleKeyDown(event) {
-		if (event.keyCode === 13) {
+		if (event.key === 'Enter') {
 			event.preventDefault();
 
 			return updateSearchParam(inputValue);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/MainSearch.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/MainSearch.js
@@ -18,7 +18,7 @@ import React, {useContext, useEffect, useState} from 'react';
 
 import DataSetDisplayContext from '../../DataSetDisplayContext';
 
-function MainSearch() {
+function MainSearch({setShowMobile}) {
 	const {searchParam, updateSearchParam} = useContext(DataSetDisplayContext);
 
 	const [inputValue, updateInputValue] = useState(searchParam);
@@ -39,6 +39,7 @@ function MainSearch() {
 		<ClayInput.Group>
 			<ClayInput.GroupItem>
 				<ClayInput
+					aria-label={Liferay.Language.get('search')}
 					className="input-group-inset input-group-inset-after"
 					onChange={(event) => updateInputValue(event.target.value)}
 					onKeyDown={handleKeyDown}
@@ -47,12 +48,16 @@ function MainSearch() {
 				/>
 				<ClayInput.GroupInsetItem after tag="div">
 					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get('clear')}
+						className="navbar-breakpoint-d-none"
 						disabled={!inputValue.length}
 						displayType="unstyled"
+						monospaced={false}
 						onClick={(event) => {
 							event.preventDefault();
-							
+
 							updateInputValue('');
+							setShowMobile(false);
 
 							updateSearchParam('');
 						}}
@@ -63,13 +68,16 @@ function MainSearch() {
 						symbol="times-circle"
 					/>
 					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get('search')}
 						displayType="unstyled"
+						monospaced={false}
 						onClick={(event) => {
 							event.preventDefault();
 
 							updateSearchParam(inputValue);
 						}}
 						symbol="search"
+						type="submit"
 					/>
 				</ClayInput.GroupInsetItem>
 			</ClayInput.GroupItem>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/NavBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/NavBar.js
@@ -12,8 +12,11 @@
  * details.
  */
 
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import ClayManagementToolbar from '@clayui/management-toolbar';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState} from 'react';
 
 import ActiveViewSelector from './ActiveViewSelector';
 import {useAppState} from './Context';
@@ -25,28 +28,55 @@ function NavBar({creationMenu, showSearch, views}) {
 	const {
 		state: {filters},
 	} = useAppState();
+	const [showMobile, setShowMobile] = useState(false);
 
 	return (
-		<nav className="management-bar management-bar-light navbar navbar-expand-md">
-			<div className="container-fluid container-fluid-max-xl">
+		<ClayManagementToolbar className="c-mb-0 justify-content-space-between">
+			<ClayManagementToolbar.ItemList>
 				{!!filters.length && (
-					<div className="mr-2 navbar-nav">
+					<ClayManagementToolbar.Item>
 						<FiltersDropdown />
-					</div>
+					</ClayManagementToolbar.Item>
 				)}
+			</ClayManagementToolbar.ItemList>
+
+			{showSearch && (
+				<>
+					<ClayManagementToolbar.Search
+						onSubmit={(event) => {
+							event.preventDefault();
+						}}
+						showMobile={showMobile}
+					>
+						<MainSearch setShowMobile={setShowMobile} />
+					</ClayManagementToolbar.Search>
+				</>
+			)}
+
+			<ClayManagementToolbar.ItemList>
 				{showSearch && (
-					<div className="navbar-form navbar-overlay-sm-down pl-0">
-						<MainSearch />
-					</div>
+					<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
+						<ClayButton
+							className="nav-link nav-link-monospaced"
+							displayType="unstyled"
+							onClick={() => setShowMobile(true)}
+						>
+							<ClayIcon symbol="search" />
+						</ClayButton>
+					</ClayManagementToolbar.Item>
 				)}
-				<div className="navbar-form navbar-form-autofit navbar-overlay navbar-overlay-sm-down pl-0">
-					{views?.length > 1 ? (
+				{views?.length > 1 && (
+					<ClayManagementToolbar.Item>
 						<ActiveViewSelector views={views} />
-					) : null}
-				</div>
-				{creationMenu && <CreationMenu {...creationMenu} />}
-			</div>
-		</nav>
+					</ClayManagementToolbar.Item>
+				)}
+				{creationMenu && (
+					<ClayManagementToolbar.Item>
+						<CreationMenu {...creationMenu} />
+					</ClayManagementToolbar.Item>
+				)}
+			</ClayManagementToolbar.ItemList>
+		</ClayManagementToolbar>
 	);
 }
 


### PR DESCRIPTION
## Test Case

1. Open Global Menu
2. Click on `Remote Apps`
3. Click into search field

**Expected Result**:
Focus border completely surrounds the search bar

**Actual Result**:
Focus border is missing on the right side of search bar

## Implementation Consequences

The custom CSS implementation was removed and was just replaced by Clay.

## Questions

#### The search wasn't working before the fix and I'm still not able to search.

Should I file an issue for it? @john-co  @brunobasto 

#### I added some additional styles for maintaining the same behaviour with the cancel/times button on the input.
The main idea is not stretch the input when showing/hiding the button and I'm not sure if we already have a class for it.

See this [diff](https://github.com/liferay-frontend/liferay-portal/pull/356/files#diff-66e13c025ac8b53baa36e4af965e285fR59).

Is there a reflow "passive" utility class for don't use style attr? @pat270 

#### Should I update on commerce component too? @jbalsas 

## Before:

![beforegifremoteapps](https://user-images.githubusercontent.com/7663513/92043786-2eb67780-ed53-11ea-8d95-bf46ea769a5d.gif)

## After:

![afterremoteapps](https://user-images.githubusercontent.com/7663513/92043868-5d345280-ed53-11ea-80cd-28ca6ae5b912.gif)

