### PR TITLE
LPS-120345 Use openToast from frontend-js-web in experiences

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -18,6 +18,7 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import {useModal} from '@clayui/modal';
 import {useIsMounted} from 'frontend-js-react-web';
+import {openToast} from 'frontend-js-web';
 import React, {useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 
@@ -166,9 +167,8 @@ const ExperienceSelector = ({
 						setEditingExperience({});
 						onModalClose();
 					}
-
-					Liferay.Util.openToast({
-						title: Liferay.Language.get(
+					openToast({
+						message: Liferay.Language.get(
 							'the-experience-was-updated-successfully'
 						),
 						type: 'success',
@@ -198,9 +198,8 @@ const ExperienceSelector = ({
 					if (isMounted()) {
 						onModalClose();
 					}
-
-					Liferay.Util.openToast({
-						title: Liferay.Language.get(
+					openToast({
+						message: Liferay.Language.get(
 							'the-experience-was-created-successfully'
 						),
 						type: 'success',
@@ -241,11 +240,23 @@ const ExperienceSelector = ({
 				segmentsExperienceId: id,
 				selectedExperienceId: selectedExperience.segmentsExperienceId,
 			})
-		).catch((_error) => {
-
-			// TODO handle error
-
-		});
+		)
+			.then(() => {
+				openToast({
+					message: Liferay.Language.get(
+						'the-experience-was-deleted-successfully'
+					),
+					type: 'success',
+				});
+			})
+			.catch(() => {
+				openToast({
+					message: Liferay.Language.get(
+						'an-unexpected-error-occurred'
+					),
+					type: 'danger',
+				});
+			});
 	};
 
 	const decreasePriority = (id) => {

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
@@ -27,6 +27,7 @@ import serviceFetch from '../../../../../../src/main/resources/META-INF/resource
 import {StoreAPIContextProvider} from '../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
 import {
 	CREATE_SEGMENTS_EXPERIENCE,
+	DELETE_SEGMENTS_EXPERIENCE,
 	UPDATE_SEGMENTS_EXPERIENCE,
 	UPDATE_SEGMENTS_EXPERIENCE_PRIORITY,
 } from '../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/experience/actions';
@@ -132,6 +133,10 @@ const mockConfig = {
 };
 
 describe('ExperienceToolbarSection', () => {
+	beforeAll(() => {
+		Liferay.component = jest.fn();
+	});
+
 	afterEach(() => {
 		cleanup();
 		serviceFetch.mockReset();
@@ -684,6 +689,12 @@ describe('ExperienceToolbarSection', () => {
 				}),
 			}),
 			expect.any(Function)
+		);
+
+		expect(mockDispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: DELETE_SEGMENTS_EXPERIENCE,
+			})
 		);
 	});
 });


### PR DESCRIPTION
**Description**

I found that there were some uses of `Liferay.Util.openToast` in the experiences part and I changed it to use `openToast` from `frontend-js-web` module instead. Also, I removed a pending TODO.

* Related issue: https://issues.liferay.com/browse/LPS-107024
