### PR TITLE
COMMERCE-4539 Standard width size for modals when not specified

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/modal/Modal.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/modal/Modal.js
@@ -81,13 +81,8 @@ function Modal({
 				setTitle(data.title);
 			}
 
-			/**
-			 * Based on ClayModal specs, the default size of a modal is 'null'.
-			 * Our initial modal size is 'lg'. If the input size is undefined,
-			 * the initial size won't be altered.
-			 */
-			if (data.size !== INITIAL_MODAL_SIZE && data.size !== undefined) {
-				setSize(data.size);
+			if (!data.size) {
+				setSize(INITIAL_MODAL_SIZE);
 			}
 		}
 


### PR DESCRIPTION
In the past it seemed as though if a modal `size` was `null` it would fallback to a default. This was not the case for `size` as `undefined`, which would mess up the whole component.

Now the fallback seems to be consistent whether `size` is `null` or `undefined`, hence the fix for modals handled by DataSet components. @brunobasto @jbalsas 