### PR TITLE
LPS-120347 Some unexpected things are happening when selecting the image with the item selector

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -109,6 +109,7 @@ const openSelectionModal = ({
 	height,
 	id,
 	multiple = false,
+	onClose,
 	onSelect,
 	selectEventName,
 	selectedData,
@@ -148,6 +149,10 @@ const openSelectionModal = ({
 			});
 
 			eventHandlers.splice(0, eventHandlers.length);
+
+			if (onClose) {
+				onClose();
+			}
 		},
 		onOpen: ({container, processClose}) => {
 			const selectEventHandler = Liferay.on(selectEventName, (event) => {


### PR DESCRIPTION
**Steps to reproduce:**

- Add a blank page
- Add an Image fragment to the page
- Double click the fragment to add an image
- Upload an image (or select an available one)


**Before the fix:**
- Selecting one image and try to change come into a loop
- Clear button is opening the modal

**After the fix:**
- Item selector disappears and image is displayed on the fragment.
- Clear button clear the value

---

I realized that the onClose function was lost in some refactor, I just put it back.

I tested and fixed in `da23ec114d56d3d2e42c23606b0e8fc847b9332a` in master.

/cc @liferay-echo