### PR TITLE
COMMERCE-4677 data set display filters provided via apiURL decoded

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utilities/index.js
@@ -174,19 +174,10 @@ export function loadData(
 	page = 1,
 	sorting = []
 ) {
-	let providedFilters = '';
+	const url = new URL(apiURL, themeDisplay.getPortalURL());
+	const providedFilters = url.searchParams.get('filter');
 
-	const formattedUrl = apiURL.replace(
-		/[?|&]filter=(.*)[&.+]?/gm,
-		(matched) => {
-			providedFilters = matched.replace(/[?|&]filter=/, '');
-
-			return '';
-		}
-	);
-
-	const url = new URL(formattedUrl, themeDisplay.getPortalURL());
-
+	url.searchParams.delete('filter');
 	url.searchParams.append('currentURL', currentURL);
 
 	if (providedFilters || odataFiltersStrings.length) {


### PR DESCRIPTION
apiURL prop in data set display can contain filters already encoded which should be processed. 
At the moment there are issues due to encoded and decoded strings concatenation.