### PR TITLE
LPS-118820 [POC] Use ClayDualListBox instead of input-move-boxes in Content Dashboard configuration

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -29,6 +29,7 @@ ContentDashboardAdminConfigurationDisplayContext contentDashboardAdminConfigurat
 
 <liferay-frontend:edit-form
 	action="<%= configurationActionURL %>"
+	fluid="<%= true %>"
 	method="post"
 	name="fm"
 	onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveConfiguration();" %>'
@@ -43,19 +44,19 @@ ContentDashboardAdminConfigurationDisplayContext contentDashboardAdminConfigurat
 		<liferay-frontend:fieldset-group>
 			<liferay-frontend:fieldset>
 				<aui:field-wrapper>
-					<p class="sheet-text">
-						<liferay-ui:message key="select-vocabularies-description" />
-					</p>
+					<span aria-hidden="true" class="loading-animation loading-animation-sm"></span>
 
-					<liferay-ui:input-move-boxes
-						leftBoxName="availableAssetVocabularyNames"
-						leftList="<%= contentDashboardAdminConfigurationDisplayContext.getAvailableVocabularyNames() %>"
-						leftTitle="available"
-						rightBoxMaxItems="<%= 2 %>"
-						rightBoxName="currentAssetVocabularyNames"
-						rightList="<%= contentDashboardAdminConfigurationDisplayContext.getCurrentVocabularyNames() %>"
-						rightReorder="<%= Boolean.TRUE.toString() %>"
-						rightTitle="in-use"
+					<react:component
+						module="js/SelectVocabularies"
+						props='<%=
+							HashMapBuilder.<String, Object>put(
+								"availableVocabularyNames", contentDashboardAdminConfigurationDisplayContext.getAvailableVocabularyNames()
+							).put(
+								"currentVocabularyNames", contentDashboardAdminConfigurationDisplayContext.getCurrentVocabularyNames()
+							).put(
+								"namespace", liferayPortletResponse.getNamespace()
+							).build()
+						%>'
 					/>
 				</aui:field-wrapper>
 			</liferay-frontend:fieldset>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/SelectVocabularies.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/SelectVocabularies.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayAlert from '@clayui/alert';
+import {ClayDualListBox} from '@clayui/form';
+import React, {useState} from 'react';
+
+export default function ({
+	availableVocabularyNames,
+	currentVocabularyNames,
+	namespace,
+}) {
+	const vocabularies = [currentVocabularyNames, availableVocabularyNames];
+
+	const data = vocabularies.map((inner) =>
+		inner.map(({key, value}) => ({label: value, value: key}))
+	);
+
+	const [items, setItems] = useState(data);
+
+	const [firstSelectBoxItems] = items;
+
+	const [leftSelected, setLeftSelected] = useState([]);
+	const [rightSelected, setRightSelected] = useState([]);
+
+	const [showDismisible, setShowDismisible] = useState(true);
+
+	return (
+		<>
+			{showDismisible && !firstSelectBoxItems.length && (
+				<ClayAlert
+					displayType="warning"
+					onClose={() => setShowDismisible(false)}
+					title={Liferay.Language.get('warning')}
+				>
+					{Liferay.Language.get(
+						'select-at-least-one-vocabulary-to-show-on-the-chart'
+					)}
+				</ClayAlert>
+			)}
+
+			<p className="text-secondary">
+				{Liferay.Language.get('select-vocabularies-description')}
+			</p>
+
+			<ClayDualListBox
+				ariaLabels={{
+					transferLTR: Liferay.Util.sub(
+						Liferay.Language.get('move-selected-items-from-x-to-x'),
+						Liferay.Language.get('in-use'),
+						Liferay.Language.get('available')
+					),
+					transferRTL: Liferay.Util.sub(
+						Liferay.Language.get('move-selected-items-from-x-to-x'),
+						Liferay.Language.get('available'),
+						Liferay.Language.get('in-use')
+					),
+				}}
+				disableRTL={
+					firstSelectBoxItems.length >= 2 || rightSelected.length >= 2
+				}
+				items={items}
+				left={{
+					id: `${namespace}currentAssetVocabularyNames`,
+					label: Liferay.Language.get('in-use'),
+					onSelectChange: setLeftSelected,
+					selected: leftSelected,
+				}}
+				onItemsChange={setItems}
+				right={{
+					id: `${namespace}availableAssetVocabularyNames`,
+					label: Liferay.Language.get('available'),
+					onSelectChange: setRightSelected,
+					selected: rightSelected,
+				}}
+				size={8}
+			/>
+		</>
+	);
+}


### PR DESCRIPTION
**Description**

Using the new `ClayDualListBox` component instead of `<liferay-ui:input-move-boxes>` for the Content Dashborad configuration ([LPS-118820](https://issues.liferay.com/browse/LPS-118820)).

Also, I opened an issue in Clay to check and improve the reorder buttons: https://github.com/liferay/clay/issues/3682

**Screenshot**

![Screenshot 2020-09-03 at 18 34 07](https://user-images.githubusercontent.com/15845466/92142406-10fd1700-ee14-11ea-9406-41fdb93bdd8d.png)
