### PR TITLE
COMMERCE-4681 selected items input now works fine on data set display

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -347,16 +347,14 @@ function DataSetDisplay({
 	const view =
 		!loading && CurrentViewComponent ? (
 			<div className="data-set-display-content-wrapper">
-				{!formId && (
-					<input
-						hidden
-						name={`${namespace || id + '_'}${
-							actionParameterName ?? selectedItemsKey
-						}`}
-						readOnly
-						value={selectedItemsValue.join(',')}
-					/>
-				)}
+				<input
+					hidden
+					name={`${namespace || id + '_'}${
+						actionParameterName ?? selectedItemsKey
+					}`}
+					readOnly
+					value={selectedItemsValue.join(',')}
+				/>
 				{(items?.length ?? 0) || overrideEmptyResultView ? (
 					<CurrentViewComponent
 						dataSetDisplayContext={DataSetDisplayContext}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/init.jsp
@@ -24,8 +24,7 @@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONSerializer" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
-page import="com.liferay.portal.kernel.util.Validator" %>
+page import="com.liferay.portal.kernel.util.PortalUtil" %>
 
 <%@ page import="java.util.List" %>
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/page.jsp
@@ -27,13 +27,7 @@
 
 	dataSetDisplay.default(
 		{
-
-			<% if (Validator.isNotNull(actionParameterName)) { %>
-
-				actionParameterName: '<%= actionParameterName %>',
-
-			<% } %>
-
+			actionParameterName: '<%= GetterUtil.getString(actionParameterName) %>',
 			activeViewSettings: <%= activeViewSettingsJSON %>,
 			apiURL: '<%= apiURL %>',
 			appURL: '<%= appURL %>',
@@ -42,27 +36,11 @@
 			creationMenu: <%= jsonSerializer.serializeDeep(creationMenu) %>,
 			currentURL: '<%= PortalUtil.getCurrentURL(request) %>',
 			dataProviderKey: '<%= dataProviderKey %>',
-			formId: '<%= formId %>',
+			formId: '<%= GetterUtil.getString(formId) %>',
 			id: '<%= id %>',
-
-			<%
-			if (Validator.isNotNull(nestedItemsKey)) {
-			%>
-
-				nestedItemsKey: '<%= nestedItemsKey %>',
-
-				<%
-				}
-
-				if (Validator.isNotNull(nestedItemsReferenceKey)) {
-				%>
-
-				nestedItemsReferenceKey: '<%= nestedItemsReferenceKey %>',
-
-			<%
-			}
-			%>
-
+			nestedItemsKey: '<%= GetterUtil.getString(nestedItemsKey) %>',
+			nestedItemsReferenceKey:
+				'<%= GetterUtil.getString(nestedItemsReferenceKey) %>',
 			pagination: {
 				deltas: <%= jsonSerializer.serializeDeep(clayPaginationEntries) %>,
 				initialDelta: <%= itemsPerPage %>,
@@ -75,8 +53,8 @@
 			portletId: '<%= portletDisplay.getRootPortletId() %>',
 			portletURL: '<%= portletURL %>',
 			selectedItems: <%= jsonSerializer.serializeDeep(selectedItems) %>,
-			selectedItemsKey: '<%= selectedItemsKey %>',
-			selectionType: '<%= selectionType %>',
+			selectedItemsKey: '<%= GetterUtil.getString(selectedItemsKey) %>',
+			selectionType: '<%= GetterUtil.getString(selectionType) %>',
 			style: '<%= style %>',
 			views: <%= jsonSerializer.serializeDeep(clayDataSetDisplayViewsContext) %>,
 		},

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/page.jsp
@@ -27,7 +27,13 @@
 
 	dataSetDisplay.default(
 		{
-			actionParameterName: '<%= actionParameterName %>',
+
+			<% if (Validator.isNotNull(actionParameterName)) { %>
+
+				actionParameterName: '<%= actionParameterName %>',
+
+			<% } %>
+
 			activeViewSettings: <%= activeViewSettingsJSON %>,
 			apiURL: '<%= apiURL %>',
 			appURL: '<%= appURL %>',

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/init.jsp
@@ -25,8 +25,7 @@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONSerializer" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
-page import="com.liferay.portal.kernel.util.Validator" %>
+page import="com.liferay.portal.kernel.util.PortalUtil" %>
 
 <%@ page import="java.util.List" %>
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/page.jsp
@@ -33,7 +33,17 @@ JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
 <aui:script require='<%= module + " as dataSetDisplay" %>'>
 	dataSetDisplay.default(
 		{
-			actionParameterName: '<%= actionParameterName %>',
+
+			<%
+				if (Validator.isNotNull(actionParameterName)) {
+			%>
+
+				actionParameterName: '<%= actionParameterName %>',
+
+			<%
+				}
+			%>
+
 			activeViewSettings: <%= activeViewSettingsJSON %>,
 			apiURL: '<%= apiURL %>',
 			appURL: '<%= appURL %>',

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/page.jsp
@@ -33,17 +33,7 @@ JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
 <aui:script require='<%= module + " as dataSetDisplay" %>'>
 	dataSetDisplay.default(
 		{
-
-			<%
-				if (Validator.isNotNull(actionParameterName)) {
-			%>
-
-				actionParameterName: '<%= actionParameterName %>',
-
-			<%
-				}
-			%>
-
+			actionParameterName: '<%= GetterUtil.getString(actionParameterName) %>',
 			activeViewSettings: <%= activeViewSettingsJSON %>,
 			apiURL: '<%= apiURL %>',
 			appURL: '<%= appURL %>',
@@ -51,29 +41,13 @@ JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
 			creationMenu: <%= jsonSerializer.serializeDeep(creationMenu) %>,
 			currentURL: '<%= PortalUtil.getCurrentURL(request) %>',
 			filters: <%= jsonSerializer.serializeDeep(clayDataSetFiltersContext) %>,
-			formId: '<%= formId %>',
+			formId: '<%= GetterUtil.getString(formId) %>',
 			id: '<%= id %>',
 			itemsActions: <%= jsonSerializer.serializeDeep(clayDataSetActionDropdownItems) %>,
 			namespace: '<%= namespace %>',
-
-			<%
-			if (Validator.isNotNull(nestedItemsKey)) {
-			%>
-
-				nestedItemsKey: '<%= nestedItemsKey %>',
-
-				<%
-				}
-
-				if (Validator.isNotNull(nestedItemsReferenceKey)) {
-				%>
-
-				nestedItemsReferenceKey: '<%= nestedItemsReferenceKey %>',
-
-			<%
-			}
-			%>
-
+			nestedItemsKey: '<%= GetterUtil.getString(nestedItemsKey) %>',
+			nestedItemsReferenceKey:
+				'<%= GetterUtil.getString(nestedItemsReferenceKey) %>',
 			pagination: {
 				deltas: <%= jsonSerializer.serializeDeep(clayPaginationEntries) %>,
 				initialDelta: <%= itemsPerPage %>,
@@ -82,11 +56,11 @@ JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
 			portletId: '<%= portletDisplay.getRootPortletId() %>',
 			portletURL: '<%= portletURL %>',
 			selectedItems: <%= jsonSerializer.serializeDeep(selectedItems) %>,
-			selectedItemsKey: '<%= selectedItemsKey %>',
+			selectedItemsKey: '<%= GetterUtil.getString(selectedItemsKey) %>',
 			showManagementBar: <%= showManagementBar %>,
 			showSearch: <%= showSearch %>,
 			style: '<%= style %>',
-			selectionType: '<%= selectionType %>',
+			selectionType: '<%= GetterUtil.getString(selectionType) %>',
 			showPagination: <%= showPagination %>,
 			views: <%= jsonSerializer.serializeDeep(clayDataSetDisplayViewsContext) %>,
 		},


### PR DESCRIPTION
The selected items input had been moved out of an unnecessary condition who hid it in case an optional prop was not passed.
The only purpose of. the `formId` is avoiding the creation of nested forms in case the data set display is already wrapped. Also `actionParameterName` was passed as a string with value `null`.