### PR TITLE
LPS-119037 Fix clicking on user in mentions list throwing JavaScript error

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/autocomplete/autocomplete.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/autocomplete/autocomplete.js
@@ -19,6 +19,8 @@
 	var KeyMap = A.Event.KeyMap;
 	var Lang = A.Lang;
 
+	var BR_TAG = 'BR';
+
 	var CSS_LFR_AC_CONTENT = 'lfr-ac-content';
 
 	var STR_EDITOR = 'editor';
@@ -271,6 +273,16 @@
 			var prevTriggerPosition = instance._getPrevTriggerPosition();
 
 			var query = prevTriggerPosition.query;
+
+			if (
+				query &&
+				prevTriggerPosition.container.$.lastElementChild &&
+				prevTriggerPosition.container.$.lastElementChild.nodeName ===
+					BR_TAG
+			) {
+				query = null;
+			}
+
 			var trigger = prevTriggerPosition.value;
 
 			var res = instance._getRegExp().exec(query);
@@ -405,7 +417,7 @@
 				);
 			});
 
-			if (nextElement && nextElement.$.nodeName === 'BR') {
+			if (nextElement && nextElement.$.nodeName === BR_TAG) {
 				nextElement = null;
 			}
 


### PR DESCRIPTION
[Issue](https://issues.liferay.com/browse/LPS-119037)

Clicking on a user in the mentions list throws javascript error: `prevTriggerPosition.container.split is not a function`

**Step to reproduce:**
- Add a public user (user1)
- Add a Message board portlet to any page
- Add a new thread
- In the body, add a mention ( @user1 )
- Add a whitespace, then add a line break
- Add a whitespace, then press Backspace button to remove that whitespace
- Note the list of users is displayed
- Click on Mention list to add mention of user1 again