### PR TITLE
LPS-120411 - Add color to btn-outline-secondary token

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
@@ -522,6 +522,19 @@
 							"type": "String"
 						},
 						{
+							"defaultValue": "#272833",
+							"editorType": "ColorPicker",
+							"label": "color",
+							"mappings": [
+								{
+									"type": "cssVariable",
+									"value": "btn-outline-secondary-color"
+								}
+							],
+							"name": "btnOutlineSecondaryColor",
+							"type": "String"
+						},
+						{
 							"defaultValue": "rgba(39, 40, 51, 0.03)",
 							"editorType": "ColorPicker",
 							"label": "hover-background-color",

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
@@ -9,8 +9,9 @@ $light-color: #e7e7ed;
 $lead-font-weight: 400;
 $small-font-size: 0.875rem;
 
-$portlet-decorate-bg: #fff;
-$portlet-decorate-border: 1px solid $light-color;
+$btn-outline-secondary: (
+	color: $dark-color,
+);
 
 $navigation-bar-size: (
 	active-border-offset-bottom: -0.4375rem,
@@ -21,6 +22,9 @@ $navigation-bar-size: (
 $navigation-bar-light: (
 	border-color: $border-color,
 );
+
+$portlet-decorate-bg: #fff;
+$portlet-decorate-border: 1px solid $light-color;
 
 // Compat
 


### PR DESCRIPTION
This PR adds a new token `text color` for `btn-outline-secondary`

--- 

How to test it:

- Product menu
- Open style
- Create a new stylebook
- Go to the button tab and see the new "color"

![image](https://user-images.githubusercontent.com/7963804/92225563-a98ea800-eea3-11ea-8b25-04b5c4fe0638.png)
