### PR TITLE
LPS-114480 Only sending p_auth if present

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
@@ -145,13 +145,13 @@
 					authToken = authToken.substring(0, authToken.indexOf('#'));
 				}
 
-				form.append(
-					'<input name="p_auth" type="hidden" value="' +
-						authToken +
-						'" />'
-				);
-
 				if (authToken) {
+					form.append(
+						'<input name="p_auth" type="hidden" value="' +
+							authToken +
+							'" />'
+					);
+
 					searchParams.delete('p_auth');
 
 					action = baseURL + '?' + searchParams.toString();


### PR DESCRIPTION
From https://github.com/liferay-frontend/liferay-portal/pull/369/commits/30882850f748cb50e41976d0a2bed81430a64334:

When a form's URL does not contain the p_auth parameter (like the download portlet resource URL from the ticket)
the old code was including the p_auth input with an empty value.

Since a download URL does not trigger a page refresh, the empty value is
kept and causes subsequent action requests to fail with a 403.

The original resource request does not fail because resource requests
do not check p_auth.