### PR TITLE
LPS-120556 Add the `propsTransformer` attribute in `<clay:button>`

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -255,6 +255,15 @@ public class ButtonTag extends BaseContainerTag {
 	}
 
 	@Override
+	protected String getHydratedModuleName() {
+		if ((getAdditionalProps() != null) && (getPropsTransformer() != null)) {
+			return "frontend-taglib-clay/Button";
+		}
+
+		return null;
+	}
+
+	@Override
 	protected Map<String, Object> prepareProps(Map<String, Object> props) {
 		props.put("block", _block);
 		props.put("borderless", _borderless);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -256,7 +256,7 @@ public class ButtonTag extends BaseContainerTag {
 
 	@Override
 	protected String getHydratedModuleName() {
-		if ((getAdditionalProps() != null) && (getPropsTransformer() != null)) {
+		if ((getAdditionalProps() != null) || (getPropsTransformer() != null)) {
 			return "frontend-taglib-clay/Button";
 		}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -197,6 +197,12 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.ButtonTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
+			<description></description>
+			<name>additionalProps</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>ariaLabel</name>
 			<required>false</required>
@@ -295,6 +301,12 @@
 		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>name</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>propsTransformer</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Button.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Button.js
@@ -26,15 +26,13 @@ export default function Button({
 	portletNamespace: _portletNamespace,
 	...otherProps
 }) {
-	return icon ? (
+	return (
 		<ClayButton className={cssClass} {...otherProps}>
-			<span className="inline-item inline-item-before">
-				<ClayIcon symbol={icon} />
-			</span>
-			{label}
-		</ClayButton>
-	) : (
-		<ClayButton className={cssClass} {...otherProps}>
+			{icon && (
+				<span className="inline-item inline-item-before">
+					<ClayIcon symbol={icon} />
+				</span>
+			)}
 			{label}
 		</ClayButton>
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Button.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Button.js
@@ -14,6 +14,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
 import React from 'react';
 
 export default function Button({
@@ -29,7 +30,11 @@ export default function Button({
 	return (
 		<ClayButton className={cssClass} {...otherProps}>
 			{icon && (
-				<span className="inline-item inline-item-before">
+				<span
+					className={classNames('inline-item', {
+						'inline-item-before': label,
+					})}
+				>
 					<ClayIcon symbol={icon} />
 				</span>
 			)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Button.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Button.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import React from 'react';
+
+export default function Button({
+	componentId: _componentId,
+	cssClass,
+	icon,
+	label,
+	locale: _locale,
+	portletId: _portletId,
+	portletNamespace: _portletNamespace,
+	...otherProps
+}) {
+	return icon ? (
+		<ClayButton className={cssClass} {...otherProps}>
+			<span className="inline-item inline-item-before">
+				<ClayIcon symbol={icon} />
+			</span>
+			{label}
+		</ClayButton>
+	) : (
+		<ClayButton className={cssClass} {...otherProps}>
+			{label}
+		</ClayButton>
+	);
+}


### PR DESCRIPTION
The `<clay:button>` tag now support the `propsTransformer` attribute
which can be used to modify properties passed to the `@clayui/button`
component.

This lets developers do something like this:

```jsp
<clay:button
	label="hello"
	propsTransformer="js/propsTransformer"
/>
```

And in the `propsTansformer.js` file modify the props received by the React component

```js
export default function propsTransformer({
	additionalProps,
	portletNamespace,
	...otherProps
}) {
	return {
		...otherProps,
                // Override the properties received, to add your custom logic
		onClick() {

		},
	};
}
```
