### PR TITLE
COMMERCE-4605 data set display data refresh delayed after async action

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -393,13 +393,15 @@ function DataSetDisplay({
 	function executeAsyncItemAction(url, method) {
 		return executeAsyncAction(url, method)
 			.then((_) => {
-				if (isMounted()) {
-					refreshData();
+				delay(500).then(() => {
+					if (isMounted()) {
+						refreshData();
 
-					Liferay.fire(DATASET_ACTION_PERFORMED, {
-						id,
-					});
-				}
+						Liferay.fire(DATASET_ACTION_PERFORMED, {
+							id,
+						});
+					}
+				});
 			})
 			.catch((error) => {
 				logError(error);


### PR DESCRIPTION
Please note: THIS IS A FRONTEND PATCH WHICH HIDES A PROBLEM THAT SHOULD BE FIXED ON THE BE SIDE.

At the moment, an action executed via headless api needs some time to make the next headless "get" updated.
I just delayed the refreshData function call... nothing special.

It seems that at the moment we need this even if I'm not happy with it :/

More info here: https://issues.liferay.com/browse/PTR-1919

cc: @marco-leo 