### PR TITLE
LPS-119999 Extract traffic sources to an endpoint

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-test/src/testIntegration/java/com/liferay/analytics/reports/web/internal/portlet/action/test/GetDataMVCResourceCommandTest.java
+++ b/modules/dxp/apps/analytics/analytics-reports-test/src/testIntegration/java/com/liferay/analytics/reports/web/internal/portlet/action/test/GetDataMVCResourceCommandTest.java
@@ -19,7 +19,6 @@ import com.liferay.analytics.reports.test.analytics.reports.info.item.MockAnalyt
 import com.liferay.analytics.reports.test.info.item.provider.MockInfoItemFieldValuesProvider;
 import com.liferay.analytics.reports.test.layout.display.page.MockLayoutDisplayPageProvider;
 import com.liferay.analytics.reports.test.util.MockContextUtil;
-import com.liferay.analytics.reports.web.internal.portlet.action.test.util.MockHttpUtil;
 import com.liferay.analytics.reports.web.internal.portlet.action.test.util.MockThemeDisplayUtil;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.info.item.InfoItemReference;
@@ -27,13 +26,10 @@ import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
 import com.liferay.layout.display.page.constants.LayoutDisplayPageWebKeys;
 import com.liferay.layout.test.util.LayoutTestUtil;
-import com.liferay.petra.function.UnsafeSupplier;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -43,21 +39,16 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PrefsProps;
-import com.liferay.portal.kernel.util.PrefsPropsUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -73,9 +64,7 @@ import java.time.format.DateTimeFormatter;
 
 import java.util.Arrays;
 import java.util.Date;
-import java.util.Dictionary;
 import java.util.Objects;
-import java.util.ResourceBundle;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -256,225 +245,6 @@ public class GetDataMVCResourceCommandTest {
 						"param_languageId=" +
 							LocaleUtil.toLanguageId(LocaleUtil.getDefault())));
 			});
-	}
-
-	@Test
-	public void testGetTrafficSources() throws Exception {
-		PrefsProps prefsProps = PrefsPropsUtil.getPrefsProps();
-
-		ValidPrefsPropsWrapper validPrefsPropsWrapper =
-			new ValidPrefsPropsWrapper(prefsProps);
-
-		ReflectionTestUtil.setFieldValue(
-			PrefsPropsUtil.class, "_prefsProps", validPrefsPropsWrapper);
-
-		String dataSourceId = validPrefsPropsWrapper.getString(
-			RandomTestUtil.nextLong(), "liferayAnalyticsDataSourceId");
-
-		ReflectionTestUtil.setFieldValue(
-			_mvcResourceCommand, "_http",
-			MockHttpUtil.geHttp(
-				HashMapBuilder.<String, UnsafeSupplier<String, Exception>>put(
-					"/api/1.0/data-sources/" + dataSourceId,
-					() -> StringPool.BLANK
-				).put(
-					"/api/seo/1.0/traffic-sources",
-					() -> JSONUtil.put(
-						JSONUtil.put(
-							"countryKeywords",
-							JSONUtil.put(
-								JSONUtil.put(
-									"countryCode", "us"
-								).put(
-									"countryName", "United States"
-								).put(
-									"keywords",
-									JSONUtil.put(
-										JSONUtil.put(
-											"keyword", "liferay"
-										).put(
-											"position", 1
-										).put(
-											"searchVolume", 3600
-										).put(
-											"traffic", 2880L
-										))
-								))
-						).put(
-							"name", "organic"
-						).put(
-							"trafficAmount", 3192L
-						).put(
-							"trafficShare", 93.93D
-						)
-					).toString()
-				).build()));
-
-		Dictionary<String, Object> properties = new HashMapDictionary<>();
-
-		properties.put("trafficSourcesEnabled", true);
-
-		try {
-			MockContextUtil.testWithMockContext(
-				MockContextUtil.MockContext.builder(
-					_classNameLocalService
-				).build(),
-				() -> {
-					MockLiferayResourceResponse mockLiferayResourceResponse =
-						new MockLiferayResourceResponse();
-
-					_mvcResourceCommand.serveResource(
-						_getMockLiferayResourceRequest(),
-						mockLiferayResourceResponse);
-
-					ByteArrayOutputStream byteArrayOutputStream =
-						(ByteArrayOutputStream)
-							mockLiferayResourceResponse.
-								getPortletOutputStream();
-
-					JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
-						new String(byteArrayOutputStream.toByteArray()));
-
-					JSONObject contextJSONObject = jsonObject.getJSONObject(
-						"context");
-
-					JSONArray jsonArray = contextJSONObject.getJSONArray(
-						"trafficSources");
-
-					Assert.assertEquals(2, jsonArray.length());
-
-					JSONObject jsonObject1 = jsonArray.getJSONObject(0);
-
-					Assert.assertEquals("organic", jsonObject1.get("name"));
-
-					Assert.assertEquals(93.93D, jsonObject1.get("share"));
-
-					Assert.assertEquals(3192, jsonObject1.get("value"));
-
-					JSONArray countryKeywordsJSONArray =
-						(JSONArray)jsonObject1.get("countryKeywords");
-
-					Assert.assertEquals(
-						JSONUtil.put(
-							JSONUtil.put(
-								"countryCode", "us"
-							).put(
-								"countryName", "United States"
-							).put(
-								"keywords",
-								JSONUtil.put(
-									JSONUtil.put(
-										"keyword", "liferay"
-									).put(
-										"position", 1
-									).put(
-										"searchVolume", 3600
-									).put(
-										"traffic", 2880
-									))
-							)
-						).toString(),
-						countryKeywordsJSONArray.toString());
-
-					JSONObject jsonObject2 = jsonArray.getJSONObject(1);
-
-					Assert.assertEquals("paid", jsonObject2.get("name"));
-
-					Assert.assertNull(jsonObject2.get("value"));
-				});
-		}
-		finally {
-			ReflectionTestUtil.setFieldValue(
-				PrefsPropsUtil.class, "_prefsProps", prefsProps);
-
-			ReflectionTestUtil.setFieldValue(
-				_mvcResourceCommand, "_http", _http);
-		}
-	}
-
-	@Test
-	public void testGetTrafficSourcesWithInvalidConnection() throws Exception {
-		PrefsProps prefsProps = PrefsPropsUtil.getPrefsProps();
-
-		InvalidPropsWrapper invalidPropsWrapper = new InvalidPropsWrapper(
-			prefsProps);
-
-		ReflectionTestUtil.setFieldValue(
-			PrefsPropsUtil.class, "_prefsProps", invalidPropsWrapper);
-
-		try {
-			MockContextUtil.testWithMockContext(
-				MockContextUtil.MockContext.builder(
-					_classNameLocalService
-				).build(),
-				() -> {
-					MockLiferayResourceResponse mockLiferayResourceResponse =
-						new MockLiferayResourceResponse();
-
-					_mvcResourceCommand.serveResource(
-						_getMockLiferayResourceRequest(),
-						mockLiferayResourceResponse);
-
-					ByteArrayOutputStream byteArrayOutputStream =
-						(ByteArrayOutputStream)
-							mockLiferayResourceResponse.
-								getPortletOutputStream();
-
-					JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
-						new String(byteArrayOutputStream.toByteArray()));
-
-					JSONObject contextJSONObject = jsonObject.getJSONObject(
-						"context");
-
-					JSONArray jsonArray = contextJSONObject.getJSONArray(
-						"trafficSources");
-
-					ResourceBundle resourceBundle =
-						ResourceBundleUtil.getBundle(
-							LocaleUtil.getDefault(),
-							_mvcResourceCommand.getClass());
-
-					Assert.assertEquals(
-						JSONUtil.putAll(
-							JSONUtil.put(
-								"helpMessage",
-								ResourceBundleUtil.getString(
-									resourceBundle,
-									"this-number-refers-to-the-volume-of-" +
-										"people-that-find-your-page-through-" +
-											"a-search-engine")
-							).put(
-								"name", "organic"
-							).put(
-								"title",
-								ResourceBundleUtil.getString(
-									resourceBundle, "organic")
-							),
-							JSONUtil.put(
-								"helpMessage",
-								ResourceBundleUtil.getString(
-									resourceBundle,
-									"this-number-refers-to-the-volume-of-" +
-										"people-that-find-your-page-through-" +
-											"paid-keywords")
-							).put(
-								"name", "paid"
-							).put(
-								"title",
-								ResourceBundleUtil.getString(
-									resourceBundle, "paid")
-							)
-						).toJSONString(),
-						jsonArray.toJSONString());
-				});
-		}
-		finally {
-			ReflectionTestUtil.setFieldValue(
-				PrefsPropsUtil.class, "_prefsProps", prefsProps);
-
-			ReflectionTestUtil.setFieldValue(
-				_mvcResourceCommand, "_http", _http);
-		}
 	}
 
 	@Test

--- a/modules/dxp/apps/analytics/analytics-reports-test/src/testIntegration/java/com/liferay/analytics/reports/web/internal/portlet/action/test/GetTrafficSourcesMVCResourceCommandTest.java
+++ b/modules/dxp/apps/analytics/analytics-reports-test/src/testIntegration/java/com/liferay/analytics/reports/web/internal/portlet/action/test/GetTrafficSourcesMVCResourceCommandTest.java
@@ -1,0 +1,435 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.analytics.reports.web.internal.portlet.action.test;
+
+import com.liferay.analytics.reports.test.MockObject;
+import com.liferay.analytics.reports.test.util.MockContextUtil;
+import com.liferay.analytics.reports.web.internal.portlet.action.test.util.MockHttpUtil;
+import com.liferay.analytics.reports.web.internal.portlet.action.test.util.MockThemeDisplayUtil;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.layout.display.page.LayoutDisplayPageProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
+import com.liferay.layout.display.page.constants.LayoutDisplayPageWebKeys;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PrefsProps;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PrefsPropsImpl;
+
+import java.io.ByteArrayOutputStream;
+
+import java.util.Dictionary;
+import java.util.Objects;
+import java.util.ResourceBundle;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Cristina González
+ */
+@RunWith(Arquillian.class)
+public class GetTrafficSourcesMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final TestRule testRule = new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addLayout(_group);
+	}
+
+	@Test
+	public void testGetTrafficSources() throws Exception {
+		PrefsProps prefsProps = PrefsPropsUtil.getPrefsProps();
+
+		ValidPrefsPropsWrapper validPrefsPropsWrapper =
+			new ValidPrefsPropsWrapper(prefsProps);
+
+		ReflectionTestUtil.setFieldValue(
+			PrefsPropsUtil.class, "_prefsProps", validPrefsPropsWrapper);
+
+		String dataSourceId = validPrefsPropsWrapper.getString(
+			RandomTestUtil.nextLong(), "liferayAnalyticsDataSourceId");
+
+		ReflectionTestUtil.setFieldValue(
+			_mvcResourceCommand, "_http",
+			MockHttpUtil.geHttp(
+				HashMapBuilder.<String, UnsafeSupplier<String, Exception>>put(
+					"/api/1.0/data-sources/" + dataSourceId,
+					() -> StringPool.BLANK
+				).put(
+					"/api/seo/1.0/traffic-sources",
+					() -> JSONUtil.put(
+						JSONUtil.put(
+							"countryKeywords",
+							JSONUtil.put(
+								JSONUtil.put(
+									"countryCode", "us"
+								).put(
+									"countryName", "United States"
+								).put(
+									"keywords",
+									JSONUtil.put(
+										JSONUtil.put(
+											"keyword", "liferay"
+										).put(
+											"position", 1
+										).put(
+											"searchVolume", 3600
+										).put(
+											"traffic", 2880L
+										))
+								))
+						).put(
+							"name", "organic"
+						).put(
+							"trafficAmount", 3192L
+						).put(
+							"trafficShare", 93.93D
+						)
+					).toString()
+				).build()));
+
+		Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+		properties.put("trafficSourcesEnabled", true);
+
+		try {
+			MockContextUtil.testWithMockContext(
+				MockContextUtil.MockContext.builder(
+					_classNameLocalService
+				).build(),
+				() -> {
+					MockLiferayResourceRequest mockLiferayResourceRequest =
+						_getMockLiferayResourceRequest();
+
+					ServiceContext serviceContext = new ServiceContext();
+
+					serviceContext.setRequest(
+						mockLiferayResourceRequest.getHttpServletRequest());
+
+					ServiceContextThreadLocal.pushServiceContext(
+						serviceContext);
+
+					MockLiferayResourceResponse mockLiferayResourceResponse =
+						new MockLiferayResourceResponse();
+
+					_mvcResourceCommand.serveResource(
+						mockLiferayResourceRequest,
+						mockLiferayResourceResponse);
+
+					ByteArrayOutputStream byteArrayOutputStream =
+						(ByteArrayOutputStream)
+							mockLiferayResourceResponse.
+								getPortletOutputStream();
+
+					JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+						new String(byteArrayOutputStream.toByteArray()));
+
+					JSONArray jsonArray = jsonObject.getJSONArray(
+						"trafficSources");
+
+					Assert.assertEquals(2, jsonArray.length());
+
+					JSONObject jsonObject1 = jsonArray.getJSONObject(0);
+
+					Assert.assertEquals("organic", jsonObject1.get("name"));
+
+					Assert.assertEquals(93.93D, jsonObject1.get("share"));
+
+					Assert.assertEquals(3192, jsonObject1.get("value"));
+
+					JSONArray countryKeywordsJSONArray =
+						(JSONArray)jsonObject1.get("countryKeywords");
+
+					Assert.assertEquals(
+						JSONUtil.put(
+							JSONUtil.put(
+								"countryCode", "us"
+							).put(
+								"countryName", "United States"
+							).put(
+								"keywords",
+								JSONUtil.put(
+									JSONUtil.put(
+										"keyword", "liferay"
+									).put(
+										"position", 1
+									).put(
+										"searchVolume", 3600
+									).put(
+										"traffic", 2880
+									))
+							)
+						).toString(),
+						countryKeywordsJSONArray.toString());
+
+					JSONObject jsonObject2 = jsonArray.getJSONObject(1);
+
+					Assert.assertEquals("paid", jsonObject2.get("name"));
+
+					Assert.assertNull(jsonObject2.get("value"));
+				});
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				PrefsPropsUtil.class, "_prefsProps", prefsProps);
+
+			ReflectionTestUtil.setFieldValue(
+				_mvcResourceCommand, "_http", _http);
+		}
+	}
+
+	@Test
+	public void testGetTrafficSourcesWithInvalidConnection() throws Exception {
+		PrefsProps prefsProps = PrefsPropsUtil.getPrefsProps();
+
+		InvalidPropsWrapper invalidPropsWrapper = new InvalidPropsWrapper(
+			prefsProps);
+
+		ReflectionTestUtil.setFieldValue(
+			PrefsPropsUtil.class, "_prefsProps", invalidPropsWrapper);
+
+		try {
+			MockContextUtil.testWithMockContext(
+				MockContextUtil.MockContext.builder(
+					_classNameLocalService
+				).build(),
+				() -> {
+					MockLiferayResourceRequest mockLiferayResourceRequest =
+						_getMockLiferayResourceRequest();
+
+					ServiceContext serviceContext = new ServiceContext();
+
+					serviceContext.setRequest(
+						mockLiferayResourceRequest.getHttpServletRequest());
+
+					ServiceContextThreadLocal.pushServiceContext(
+						serviceContext);
+
+					MockLiferayResourceResponse mockLiferayResourceResponse =
+						new MockLiferayResourceResponse();
+
+					_mvcResourceCommand.serveResource(
+						mockLiferayResourceRequest,
+						mockLiferayResourceResponse);
+
+					ByteArrayOutputStream byteArrayOutputStream =
+						(ByteArrayOutputStream)
+							mockLiferayResourceResponse.
+								getPortletOutputStream();
+
+					JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+						new String(byteArrayOutputStream.toByteArray()));
+
+					JSONArray jsonArray = jsonObject.getJSONArray(
+						"trafficSources");
+
+					ResourceBundle resourceBundle =
+						ResourceBundleUtil.getBundle(
+							LocaleUtil.getDefault(),
+							_mvcResourceCommand.getClass());
+
+					Assert.assertEquals(
+						JSONUtil.putAll(
+							JSONUtil.put(
+								"helpMessage",
+								ResourceBundleUtil.getString(
+									resourceBundle,
+									"this-number-refers-to-the-volume-of-" +
+										"people-that-find-your-page-through-" +
+											"a-search-engine")
+							).put(
+								"name", "organic"
+							).put(
+								"title",
+								ResourceBundleUtil.getString(
+									resourceBundle, "organic")
+							),
+							JSONUtil.put(
+								"helpMessage",
+								ResourceBundleUtil.getString(
+									resourceBundle,
+									"this-number-refers-to-the-volume-of-" +
+										"people-that-find-your-page-through-" +
+											"paid-keywords")
+							).put(
+								"name", "paid"
+							).put(
+								"title",
+								ResourceBundleUtil.getString(
+									resourceBundle, "paid")
+							)
+						).toJSONString(),
+						jsonArray.toJSONString());
+				});
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				PrefsPropsUtil.class, "_prefsProps", prefsProps);
+
+			ReflectionTestUtil.setFieldValue(
+				_mvcResourceCommand, "_http", _http);
+		}
+	}
+
+	private MockLiferayResourceRequest _getMockLiferayResourceRequest() {
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		try {
+			LayoutDisplayPageProvider<?> layoutDisplayPageProvider =
+				_layoutDisplayPageProviderTracker.
+					getLayoutDisplayPageProviderByClassName(
+						MockObject.class.getName());
+
+			mockLiferayResourceRequest.setAttribute(
+				LayoutDisplayPageWebKeys.LAYOUT_DISPLAY_PAGE_OBJECT_PROVIDER,
+				layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+					new InfoItemReference(MockObject.class.getName(), 0)));
+
+			mockLiferayResourceRequest.setAttribute(
+				WebKeys.THEME_DISPLAY,
+				MockThemeDisplayUtil.getThemeDisplay(
+					_companyLocalService.getCompany(
+						TestPropsValues.getCompanyId()),
+					_group, _layout,
+					_layoutSetLocalService.getLayoutSet(
+						_group.getGroupId(), false)));
+
+			return mockLiferayResourceRequest;
+		}
+		catch (PortalException portalException) {
+			throw new AssertionError(portalException);
+		}
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private Http _http;
+
+	@Inject
+	private Language _language;
+
+	private Layout _layout;
+
+	@Inject
+	private LayoutDisplayPageProviderTracker _layoutDisplayPageProviderTracker;
+
+	@Inject
+	private LayoutSetLocalService _layoutSetLocalService;
+
+	@Inject(filter = "mvc.command.name=/analytics_reports/get_traffic_sources")
+	private MVCResourceCommand _mvcResourceCommand;
+
+	@Inject
+	private Portal _portal;
+
+	private class InvalidPropsWrapper extends PrefsPropsImpl {
+
+		public InvalidPropsWrapper(PrefsProps prefsProps) {
+			_prefsProps = prefsProps;
+		}
+
+		@Override
+		public String getString(long companyId, String name) {
+			if (Objects.equals("liferayAnalyticsDataSourceId", name) ||
+				Objects.equals(
+					name, "liferayAnalyticsFaroBackendSecuritySignature") ||
+				Objects.equals("liferayAnalyticsFaroBackendURL", name)) {
+
+				return null;
+			}
+
+			return _prefsProps.getString(companyId, name);
+		}
+
+		private final PrefsProps _prefsProps;
+
+	}
+
+	private class ValidPrefsPropsWrapper extends PrefsPropsImpl {
+
+		public ValidPrefsPropsWrapper(PrefsProps prefsProps) {
+			_prefsProps = prefsProps;
+		}
+
+		@Override
+		public String getString(long companyId, String name) {
+			if (Objects.equals("liferayAnalyticsDataSourceId", name) ||
+				Objects.equals(
+					name, "liferayAnalyticsFaroBackendSecuritySignature") ||
+				Objects.equals("liferayAnalyticsFaroBackendURL", name)) {
+
+				return "test";
+			}
+
+			return _prefsProps.getString(companyId, name);
+		}
+
+		private final PrefsProps _prefsProps;
+
+	}
+
+}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetDataMVCResourceCommand.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetDataMVCResourceCommand.java
@@ -22,7 +22,6 @@ import com.liferay.analytics.reports.web.internal.info.display.contributor.util.
 import com.liferay.analytics.reports.web.internal.layout.seo.CanonicalURLProvider;
 import com.liferay.analytics.reports.web.internal.model.TimeRange;
 import com.liferay.analytics.reports.web.internal.model.TimeSpan;
-import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.item.InfoItemFieldValues;
 import com.liferay.info.item.InfoItemServiceTracker;
@@ -403,10 +402,6 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 
 	@Reference
 	private AnalyticsReportsInfoItemTracker _analyticsReportsInfoItemTracker;
-
-	@Reference
-	private AssetDisplayPageFriendlyURLProvider
-		_assetDisplayPageFriendlyURLProvider;
 
 	@Reference
 	private Http _http;

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetDataMVCResourceCommand.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetDataMVCResourceCommand.java
@@ -220,33 +220,33 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 		).put(
 			"endpoints",
 			JSONUtil.put(
-				"getAnalyticsReportsHistoricalReadsURL",
+				"analyticsReportsHistoricalReadsURL",
 				String.valueOf(
 					_getResourceURL(
 						layoutDisplayPageObjectProvider, urlLocale,
 						resourceResponse,
 						"/analytics_reports/get_historical_reads"))
 			).put(
-				"getAnalyticsReportsHistoricalViewsURL",
+				"analyticsReportsHistoricalViewsURL",
 				String.valueOf(
 					_getResourceURL(
 						layoutDisplayPageObjectProvider, urlLocale,
 						resourceResponse,
 						"/analytics_reports/get_historical_views"))
 			).put(
-				"getAnalyticsReportsTotalReadsURL",
+				"analyticsReportsTotalReadsURL",
 				String.valueOf(
 					_getResourceURL(
 						layoutDisplayPageObjectProvider, urlLocale,
 						resourceResponse, "/analytics_reports/get_total_reads"))
 			).put(
-				"getAnalyticsReportsTotalViewsURL",
+				"analyticsReportsTotalViewsURL",
 				String.valueOf(
 					_getResourceURL(
 						layoutDisplayPageObjectProvider, urlLocale,
 						resourceResponse, "/analytics_reports/get_total_views"))
 			).put(
-				"getAnalyticsReportsTrafficSourcesURL",
+				"analyticsReportsTrafficSourcesURL",
 				String.valueOf(
 					_getResourceURL(
 						layoutDisplayPageObjectProvider, urlLocale,

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetTrafficSourcesMVCResourceCommand.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetTrafficSourcesMVCResourceCommand.java
@@ -14,18 +14,15 @@
 
 package com.liferay.analytics.reports.web.internal.portlet.action;
 
-import com.liferay.analytics.reports.info.item.AnalyticsReportsInfoItemTracker;
 import com.liferay.analytics.reports.web.internal.constants.AnalyticsReportsPortletKeys;
 import com.liferay.analytics.reports.web.internal.data.provider.AnalyticsReportsDataProvider;
 import com.liferay.analytics.reports.web.internal.layout.seo.CanonicalURLProvider;
 import com.liferay.analytics.reports.web.internal.model.TrafficSource;
-import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
 import com.liferay.layout.seo.kernel.LayoutSEOLinkManager;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
@@ -188,16 +185,7 @@ public class GetTrafficSourcesMVCResourceCommand
 		GetTrafficSourcesMVCResourceCommand.class);
 
 	@Reference
-	private AnalyticsReportsInfoItemTracker _analyticsReportsInfoItemTracker;
-
-	@Reference
 	private Http _http;
-
-	@Reference
-	private Language _language;
-
-	@Reference
-	private LayoutDisplayPageProviderTracker _layoutDisplayPageProviderTracker;
 
 	@Reference
 	private LayoutSEOLinkManager _layoutSEOLinkManager;

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetTrafficSourcesMVCResourceCommand.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetTrafficSourcesMVCResourceCommand.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.analytics.reports.web.internal.portlet.action;
+
+import com.liferay.analytics.reports.info.item.AnalyticsReportsInfoItemTracker;
+import com.liferay.analytics.reports.web.internal.constants.AnalyticsReportsPortletKeys;
+import com.liferay.analytics.reports.web.internal.data.provider.AnalyticsReportsDataProvider;
+import com.liferay.analytics.reports.web.internal.layout.seo.CanonicalURLProvider;
+import com.liferay.analytics.reports.web.internal.model.TrafficSource;
+import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
+import com.liferay.layout.seo.kernel.LayoutSEOLinkManager;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.ResourceBundle;
+import java.util.stream.Stream;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Cristina González
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + AnalyticsReportsPortletKeys.ANALYTICS_REPORTS,
+		"mvc.command.name=/analytics_reports/get_traffic_sources"
+	},
+	service = MVCResourceCommand.class
+)
+public class GetTrafficSourcesMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+			themeDisplay.getLocale(), getClass());
+
+		try {
+			AnalyticsReportsDataProvider analyticsReportsDataProvider =
+				new AnalyticsReportsDataProvider(_http);
+			CanonicalURLProvider canonicalURLProvider =
+				new CanonicalURLProvider(
+					_portal.getHttpServletRequest(resourceRequest),
+					_layoutSEOLinkManager, _portal);
+
+			JSONObject jsonObject = JSONUtil.put(
+				"trafficSources",
+				_getTrafficSourcesJSONArray(
+					analyticsReportsDataProvider, themeDisplay.getCompanyId(),
+					canonicalURLProvider.getCanonicalURL(),
+					themeDisplay.getLocale(), resourceBundle));
+
+			JSONPortletResponseUtil.writeJSON(
+				resourceRequest, resourceResponse, jsonObject);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			JSONPortletResponseUtil.writeJSON(
+				resourceRequest, resourceResponse,
+				JSONUtil.put(
+					"error",
+					ResourceBundleUtil.getString(
+						resourceBundle, "an-unexpected-error-occurred")));
+		}
+	}
+
+	private List<TrafficSource> _getTrafficSources(
+		AnalyticsReportsDataProvider analyticsReportsDataProvider,
+		String canonicalURL, long companyId) {
+
+		if (!analyticsReportsDataProvider.isValidAnalyticsConnection(
+				companyId)) {
+
+			return Collections.emptyList();
+		}
+
+		try {
+			return analyticsReportsDataProvider.getTrafficSources(
+				companyId, canonicalURL);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException, portalException);
+
+			return Collections.emptyList();
+		}
+	}
+
+	private JSONArray _getTrafficSourcesJSONArray(
+		AnalyticsReportsDataProvider analyticsReportsDataProvider,
+		long companyId, String canonicalURL, Locale locale,
+		ResourceBundle resourceBundle) {
+
+		Map<String, String> helpMessageMap = HashMapBuilder.put(
+			"organic",
+			ResourceBundleUtil.getString(
+				resourceBundle,
+				"this-number-refers-to-the-volume-of-people-that-find-your-" +
+					"page-through-a-search-engine")
+		).put(
+			"paid",
+			ResourceBundleUtil.getString(
+				resourceBundle,
+				"this-number-refers-to-the-volume-of-people-that-find-your-" +
+					"page-through-paid-keywords")
+		).build();
+
+		Map<String, String> titleMap = HashMapBuilder.put(
+			"organic", ResourceBundleUtil.getString(resourceBundle, "organic")
+		).put(
+			"paid", ResourceBundleUtil.getString(resourceBundle, "paid")
+		).build();
+
+		List<TrafficSource> trafficSources = _getTrafficSources(
+			analyticsReportsDataProvider, canonicalURL, companyId);
+
+		return JSONUtil.putAll(
+			Stream.of(
+				"organic", "paid"
+			).map(
+				name -> {
+					Stream<TrafficSource> stream = trafficSources.stream();
+
+					return stream.filter(
+						trafficSource -> Objects.equals(
+							name, trafficSource.getName())
+					).findFirst(
+					).map(
+						trafficSource -> trafficSource.toJSONObject(
+							helpMessageMap.get(name), locale,
+							titleMap.get(name))
+					).orElse(
+						JSONUtil.put(
+							"helpMessage", helpMessageMap.get(name)
+						).put(
+							"name", name
+						).put(
+							"title", titleMap.get(name)
+						)
+					);
+				}
+			).toArray());
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GetTrafficSourcesMVCResourceCommand.class);
+
+	@Reference
+	private AnalyticsReportsInfoItemTracker _analyticsReportsInfoItemTracker;
+
+	@Reference
+	private Http _http;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private LayoutDisplayPageProviderTracker _layoutDisplayPageProviderTracker;
+
+	@Reference
+	private LayoutSEOLinkManager _layoutSEOLinkManager;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/AnalyticsReportsApp.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/AnalyticsReportsApp.js
@@ -148,7 +148,6 @@ export default function ({context}) {
 							timeRange={state.data.timeRange}
 							timeSpanKey={state.data.timeSpanKey}
 							timeSpanOptions={state.data.timeSpans}
-							trafficSources={state.data.trafficSources}
 							viewURLs={state.data.viewURLs}
 						/>
 					</div>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -138,7 +138,7 @@ export default function Chart({
 
 	const [{publishedToday}] = useContext(StoreContext);
 
-	const [hasHistoricalWarning, addHistoricalWarning] = useHistoricalWarning();
+	const [, addHistoricalWarning] = useHistoricalWarning();
 
 	const {actions, state: chartState} = useChartState({
 		publishDate,
@@ -184,7 +184,7 @@ export default function Chart({
 							...data[i].value,
 						};
 					}
-					else if (!hasHistoricalWarning) {
+					else {
 						addHistoricalWarning();
 					}
 				}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
@@ -32,7 +32,7 @@ export default function Main({
 	timeSpanOptions,
 	totalReadsDataProvider,
 	totalViewsDataProvider,
-	trafficSources,
+	trafficSourcesDataProvider,
 	viewURLs,
 }) {
 	return (
@@ -89,13 +89,11 @@ export default function Main({
 				timeSpanOptions={timeSpanOptions}
 			/>
 
-			{trafficSources.length > 0 && (
-				<TrafficSources
-					languageTag={languageTag}
-					onTrafficSourceClick={onTrafficSourceClick}
-					trafficSources={trafficSources}
-				/>
-			)}
+			<TrafficSources
+				dataProvider={trafficSourcesDataProvider}
+				languageTag={languageTag}
+				onTrafficSourceClick={onTrafficSourceClick}
+			/>
 		</div>
 	);
 }
@@ -119,7 +117,7 @@ Main.proptypes = {
 	).isRequired,
 	totalReadsDataProvider: PropTypes.func.isRequired,
 	totalViewsDataProvider: PropTypes.func.isRequired,
-	trafficSources: PropTypes.array.isRequired,
+	trafficSourcesDataProvider: PropTypes.func.isRequired,
 	viewURLs: PropTypes.arrayOf(
 		PropTypes.shape({
 			default: PropTypes.bool.isRequired,

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -32,7 +32,6 @@ export default function Navigation({
 	timeSpanKey,
 	timeRange,
 	timeSpanOptions,
-	trafficSources,
 	viewURLs,
 }) {
 	const [{historicalWarning, publishedToday, warning}] = useContext(
@@ -42,6 +41,8 @@ export default function Navigation({
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
 	const [currentPage, setCurrentPage] = useState({view: 'main'});
+
+	const [trafficSources, setTrafficSources] = useState([]);
 
 	const [trafficSourceName, setTrafficSourceName] = useState('');
 
@@ -69,15 +70,14 @@ export default function Navigation({
 			.then((response) => response.analyticsReportsTotalViews);
 	}, [api]);
 
-	const handleTrafficShare = useCallback(() => {
-		const trafficSource = trafficSources.find((trafficSource) => {
-			return trafficSource['name'] === trafficSourceName;
-		});
+	const handleTrafficSources = useCallback(() => {
+		return api
+			.getTrafficSources()
+			.then((response) => response.trafficSources);
+	}, [api]);
 
-		return Promise.resolve(trafficSource?.share ?? '-');
-	}, [trafficSourceName, trafficSources]);
-
-	const handleTrafficSourceClick = (trafficSourceName) => {
+	const handleTrafficSourceClick = (trafficSources, trafficSourceName) => {
+		setTrafficSources(trafficSources);
 		setTrafficSourceName(trafficSourceName);
 
 		const trafficSource = trafficSources.find((trafficSource) => {
@@ -90,9 +90,16 @@ export default function Navigation({
 		});
 	};
 
-	const handleTrafficSourceName = useCallback((trafficSourceName) => {
+	const handleTrafficSourceName = (trafficSourceName) =>
 		setTrafficSourceName(trafficSourceName);
-	}, []);
+
+	const handleTrafficShare = useCallback(() => {
+		const trafficSource = trafficSources.find((trafficSource) => {
+			return trafficSource['name'] === trafficSourceName;
+		});
+
+		return Promise.resolve(trafficSource?.share ?? '-');
+	}, [trafficSourceName, trafficSources]);
 
 	const handleTrafficVolume = useCallback(() => {
 		const trafficSource = trafficSources.find((trafficSource) => {
@@ -152,7 +159,7 @@ export default function Navigation({
 						timeSpanOptions={timeSpanOptions}
 						totalReadsDataProvider={handleTotalReads}
 						totalViewsDataProvider={handleTotalViews}
-						trafficSources={trafficSources}
+						trafficSourcesDataProvider={handleTrafficSources}
 						viewURLs={viewURLs}
 					/>
 				</div>
@@ -195,7 +202,6 @@ Navigation.proptypes = {
 			label: PropTypes.string.isRequired,
 		})
 	).isRequired,
-	trafficSources: PropTypes.array.isRequired,
 	viewURLs: PropTypes.arrayOf(
 		PropTypes.shape({
 			default: PropTypes.bool.isRequired,

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -81,7 +81,7 @@ export default function Navigation({
 		setTrafficSourceName(trafficSourceName);
 
 		const trafficSource = trafficSources.find((trafficSource) => {
-			return trafficSource['name'] === trafficSourceName;
+			return trafficSource.name === trafficSourceName;
 		});
 
 		setCurrentPage({
@@ -95,7 +95,7 @@ export default function Navigation({
 
 	const handleTrafficShare = useCallback(() => {
 		const trafficSource = trafficSources.find((trafficSource) => {
-			return trafficSource['name'] === trafficSourceName;
+			return trafficSource.name === trafficSourceName;
 		});
 
 		return Promise.resolve(trafficSource?.share ?? '-');
@@ -103,7 +103,7 @@ export default function Navigation({
 
 	const handleTrafficVolume = useCallback(() => {
 		const trafficSource = trafficSources.find((trafficSource) => {
-			return trafficSource['name'] === trafficSourceName;
+			return trafficSource.name === trafficSourceName;
 		});
 
 		return Promise.resolve(trafficSource?.value ?? '-');

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
@@ -35,7 +35,7 @@ function TotalCount({
 
 	const isMounted = useIsMounted();
 
-	const [, addWarning] = useWarning();
+	const [warning, addWarning] = useWarning();
 
 	const [{publishedToday}] = useContext(StoreContext);
 
@@ -50,7 +50,9 @@ function TotalCount({
 				.catch(() => {
 					if (isMounted()) {
 						setValue('-');
-						addWarning();
+						if (!warning) {
+							addWarning();
+						}
 					}
 				});
 		}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
@@ -35,7 +35,7 @@ function TotalCount({
 
 	const isMounted = useIsMounted();
 
-	const [warning, addWarning] = useWarning();
+	const [, addWarning] = useWarning();
 
 	const [{publishedToday}] = useContext(StoreContext);
 
@@ -50,9 +50,7 @@ function TotalCount({
 				.catch(() => {
 					if (isMounted()) {
 						setValue('-');
-						if (!warning) {
-							addWarning();
-						}
+						addWarning();
 					}
 				});
 		}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -49,7 +49,7 @@ export default function TrafficSources({
 }) {
 	const [highlighted, setHighlighted] = useState(null);
 
-	const [warning, addWarning] = useWarning();
+	const [, addWarning] = useWarning();
 
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
@@ -70,37 +70,27 @@ export default function TrafficSources({
 				.catch(() => {
 					setTrafficSources([]);
 					if (isMounted()) {
-						if (!warning) {
-							addWarning();
-						}
+						addWarning();
 					}
 				});
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [dataProvider, validAnalyticsConnection, warning]);
+	}, [addWarning, dataProvider, isMounted, validAnalyticsConnection]);
 
 	const fullPieChart = useMemo(
-		() => trafficSources.some((source) => !!source.value),
-
+		() => trafficSources.some(({value}) => value),
 		[trafficSources]
 	);
 
 	const missingTrafficSourceValue = useMemo(
-		() =>
-			trafficSources.some(
-				(trafficSource) => trafficSource.value === undefined
-			),
+		() => trafficSources.some(({value}) => value === undefined),
 		[trafficSources]
 	);
 
 	useEffect(() => {
 		if (missingTrafficSourceValue) {
-			if (!warning) {
-				addWarning();
-			}
+			addWarning();
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [warning, missingTrafficSourceValue]);
+	}, [addWarning, missingTrafficSourceValue]);
 
 	function handleLegendMouseEnter(name) {
 		setHighlighted(name);

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -59,9 +59,12 @@ export default function TrafficSources({
 
 	useEffect(() => {
 		if (missingTrafficSourceValue) {
-			addWarning();
+			if (!warning) {
+				addWarning();
+			}
 		}
-	}, [addWarning, missingTrafficSourceValue]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [warning, missingTrafficSourceValue]);
 
 	function handleLegendMouseEnter(name) {
 		setHighlighted(name);

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/APIService.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/APIService.js
@@ -13,10 +13,10 @@ import {fetch} from 'frontend-js-web';
 
 function APIService({
 	endpoints: {
-		getAnalyticsReportsHistoricalReadsURL,
-		getAnalyticsReportsHistoricalViewsURL,
-		getAnalyticsReportsTotalReadsURL,
-		getAnalyticsReportsTotalViewsURL,
+		analyticsReportsHistoricalReadsURL,
+		analyticsReportsHistoricalViewsURL,
+		analyticsReportsTotalReadsURL,
+		analyticsReportsTotalViewsURL,
 	},
 	namespace,
 	page: {plid},
@@ -24,7 +24,7 @@ function APIService({
 	function getHistoricalReads({timeSpanKey, timeSpanOffset}) {
 		const body = {plid, timeSpanKey, timeSpanOffset};
 
-		return _fetchWithError(getAnalyticsReportsHistoricalReadsURL, {
+		return _fetchWithError(analyticsReportsHistoricalReadsURL, {
 			body: _getFormDataRequest(body, namespace),
 			method: 'POST',
 		});
@@ -33,7 +33,7 @@ function APIService({
 	function getHistoricalViews({timeSpanKey, timeSpanOffset}) {
 		const body = {plid, timeSpanKey, timeSpanOffset};
 
-		return _fetchWithError(getAnalyticsReportsHistoricalViewsURL, {
+		return _fetchWithError(analyticsReportsHistoricalViewsURL, {
 			body: _getFormDataRequest(body, namespace),
 			method: 'POST',
 		});
@@ -42,7 +42,7 @@ function APIService({
 	function getTotalReads() {
 		const body = {plid};
 
-		return _fetchWithError(getAnalyticsReportsTotalReadsURL, {
+		return _fetchWithError(analyticsReportsTotalReadsURL, {
 			body: _getFormDataRequest(body, namespace),
 			method: 'POST',
 		});
@@ -51,7 +51,7 @@ function APIService({
 	function getTotalViews() {
 		const body = {plid};
 
-		return _fetchWithError(getAnalyticsReportsTotalViewsURL, {
+		return _fetchWithError(analyticsReportsTotalViewsURL, {
 			body: _getFormDataRequest(body, namespace),
 			method: 'POST',
 		});

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/APIService.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/APIService.js
@@ -17,6 +17,7 @@ function APIService({
 		analyticsReportsHistoricalViewsURL,
 		analyticsReportsTotalReadsURL,
 		analyticsReportsTotalViewsURL,
+		analyticsReportsTrafficSourcesURL,
 	},
 	namespace,
 	page: {plid},
@@ -57,11 +58,21 @@ function APIService({
 		});
 	}
 
+	function getTrafficSources() {
+		const body = {plid};
+
+		return _fetchWithError(analyticsReportsTrafficSourcesURL, {
+			body: _getFormDataRequest(body, namespace),
+			method: 'POST',
+		});
+	}
+
 	return {
 		getHistoricalReads,
 		getHistoricalViews,
 		getTotalReads,
 		getTotalViews,
+		getTrafficSources,
 	};
 }
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Navigation.js
@@ -19,116 +19,11 @@ import {StoreContextProvider} from '../../../src/main/resources/META-INF/resourc
 import '@testing-library/jest-dom/extend-expect';
 
 const mockEndpoints = {
-	getHistoricalReads: jest.fn(() =>
-		Promise.resolve({
-			analyticsReportsHistoricalReads: {
-				histogram: [
-					{
-						key: '2020-01-27T00:00',
-						previousKey: '2020-01-20T00:00',
-						previousValue: 22.0,
-						value: 33.0,
-					},
-					{
-						key: '2020-01-28T00:00',
-						previousKey: '2020-01-21T00:00',
-						previousValue: 23.0,
-						value: 33.0,
-					},
-					{
-						key: '2020-01-29T00:00',
-						previousKey: '2020-01-22T00:00',
-						previousValue: 24.0,
-						value: 34.0,
-					},
-					{
-						key: '2020-01-30T00:00',
-						previousKey: '2020-01-23T00:00',
-						previousValue: 25.0,
-						value: 33.0,
-					},
-					{
-						key: '2020-01-31T00:00',
-						previousKey: '2020-01-24T00:00',
-						previousValue: 26.0,
-						value: 32.0,
-					},
-					{
-						key: '2020-02-01T00:00',
-						previousKey: '2020-01-25T00:00',
-						previousValue: 27.0,
-						value: 31.0,
-					},
-					{
-						key: '2020-02-02T00:00',
-						previousKey: '2020-01-26T00:00',
-						previousValue: 28.0,
-						value: 30.0,
-					},
-				],
-				previousValue: 175.0,
-				value: 226.0,
-			},
-		})
-	),
-	getHistoricalViews: jest.fn(() =>
-		Promise.resolve({
-			analyticsReportsHistoricalViews: {
-				histogram: [
-					{
-						key: '2020-01-27T00:00',
-						previousKey: '2020-01-20T00:00',
-						previousValue: 22.0,
-						value: 32.0,
-					},
-					{
-						key: '2020-01-28T00:00',
-						previousKey: '2020-01-21T00:00',
-						previousValue: 23.0,
-						value: 33.0,
-					},
-					{
-						key: '2020-01-29T00:00',
-						previousKey: '2020-01-22T00:00',
-						previousValue: 24.0,
-						value: 34.0,
-					},
-					{
-						key: '2020-01-30T00:00',
-						previousKey: '2020-01-23T00:00',
-						previousValue: 25.0,
-						value: 33.0,
-					},
-					{
-						key: '2020-01-31T00:00',
-						previousKey: '2020-01-24T00:00',
-						previousValue: 26.0,
-						value: 32.0,
-					},
-					{
-						key: '2020-02-01T00:00',
-						previousKey: '2020-01-25T00:00',
-						previousValue: 27.0,
-						value: 31.0,
-					},
-					{
-						key: '2020-02-02T00:00',
-						previousKey: '2020-01-26T00:00',
-						previousValue: 28.0,
-						value: 30.0,
-					},
-				],
-				previousValue: 175.0,
-				value: 225.0,
-			},
-		})
-	),
-	getTotalReads: jest.fn(() => {
-		return Promise.resolve(999);
-	}),
-	getTotalViews: jest.fn(() => {
-		return Promise.resolve(12345);
-	}),
+	analyticsReportsHistoricalReadsURL: 'analyticsReportsHistoricalReadsURL',
+	analyticsReportsHistoricalViewsURL: 'analyticsReportsHistoricalViewsURL',
+	analyticsReportsTotalReadsURL: 'analyticsReportsTotalReadsURL',
+	analyticsReportsTotalViewsURL: 'analyticsReportsTotalViewsURL',
+	analyticsReportsTrafficSourcesURL: 'analyticsReportsTrafficSourcesURL',
 };
 
 const mockTimeSpanOptions = [
@@ -139,24 +34,6 @@ const mockTimeSpanOptions = [
 	{
 		key: 'last-7-days',
 		label: 'Last 7 Days',
-	},
-];
-
-const mockTrafficSources = [
-	{
-		countryKeywords: [],
-		helpMessage: 'Testing Help Message',
-		name: 'testing',
-		share: 100,
-		title: 'Testing',
-		value: 32178,
-	},
-	{
-		countryKeywords: [],
-		helpMessage: 'Second Testing Help Message',
-		name: 'second-testing',
-		share: 0,
-		title: 'Second Testing',
 	},
 ];
 
@@ -175,33 +52,11 @@ const mockViewURLs = [
 	},
 ];
 
-const mockData = {
-	author: {
-		authorId: '20125',
-		name: 'Test Test',
-	},
-	canonicalURL: 'http://localhost:8080/-/basic-web-content',
-	endpoints: mockEndpoints,
-	languageTag: 'en-US',
-	namespace:
-		'_com_liferay_analytics_reports_web_internal_portlet_AnalyticsReportsPortlet_',
-	page: {
-		plid: 19,
-	},
-	publishDate: '2020-08-23',
-	timeRange: {
-		endDate: '2020-08-23',
-		startDate: '2020-08-17',
-	},
-	timeSpanKey: 'last-7-days',
-	timeSpans: mockTimeSpanOptions,
-	title: 'Basic Web Content',
-	trafficSources: mockTrafficSources,
-	validAnalyticsConnection: true,
-	viewURLs: mockViewURLs,
-};
-
 describe('Navigation', () => {
+	beforeEach(() => {
+		fetch.mockResponse(JSON.stringify({}));
+	});
+
 	afterEach(() => {
 		jest.clearAllMocks();
 		cleanup();
@@ -233,7 +88,7 @@ describe('Navigation', () => {
 				<Navigation
 					author={testProps.author}
 					canonicalURL={testProps.canonicalURL}
-					endpoints={{}}
+					endpoints={mockEndpoints}
 					languageTag={testProps.languageTag}
 					onSelectedLanguageClick={() => {}}
 					page={testProps.page}
@@ -242,7 +97,6 @@ describe('Navigation', () => {
 					timeRange={testProps.timeRange}
 					timeSpanKey={testProps.timeSpanKey}
 					timeSpanOptions={mockTimeSpanOptions}
-					trafficSources={mockTrafficSources}
 					viewURLs={mockViewURLs}
 				/>
 			</ConnectionContext.Provider>
@@ -251,13 +105,7 @@ describe('Navigation', () => {
 		expect(getByText('an-unexpected-error-occurred')).toBeInTheDocument();
 	});
 
-	it('displays an alert warning message if some data is temporarily unavailable', async () => {
-		global.fetch = jest.fn(() =>
-			Promise.resolve({
-				json: () => Promise.resolve(mockData),
-			})
-		);
-
+	it('displays an alert warning message if some data is temporarily unavailable', () => {
 		const testProps = {
 			author: {
 				authorId: '',
@@ -275,7 +123,7 @@ describe('Navigation', () => {
 		};
 
 		const {getByText} = render(
-			<StoreContextProvider>
+			<StoreContextProvider value={{warning: true}}>
 				<Navigation
 					author={testProps.author}
 					canonicalURL={testProps.canonicalURL}
@@ -288,7 +136,6 @@ describe('Navigation', () => {
 					timeRange={testProps.timeRange}
 					timeSpanKey={testProps.timeSpanKey}
 					timeSpanOptions={mockTimeSpanOptions}
-					trafficSources={mockTrafficSources}
 					viewURLs={mockViewURLs}
 				/>
 			</StoreContextProvider>
@@ -296,6 +143,48 @@ describe('Navigation', () => {
 
 		expect(
 			getByText('some-data-is-temporarily-unavailable')
+		).toBeInTheDocument();
+	});
+
+	it('displays an alert info message if the content was published today', () => {
+		const testProps = {
+			author: {
+				authorId: '',
+				name: 'John Tester',
+				url: '',
+			},
+			canonicalURL:
+				'http://localhost:8080/en/web/guest/-/basic-web-content',
+			languageTag: 'en-US',
+			page: {plid: 20},
+			pagePublishDate: 'Thu Feb 02 08:17:57 GMT 2020',
+			pageTitle: 'A testing page',
+			timeRange: {endDate: '2020-01-27', startDate: '2020-02-02'},
+			timeSpanKey: 'last-7-days',
+		};
+
+		const {getByText} = render(
+			<StoreContextProvider value={{publishedToday: true}}>
+				<Navigation
+					author={testProps.author}
+					canonicalURL={testProps.canonicalURL}
+					endpoints={mockEndpoints}
+					languageTag={testProps.languageTag}
+					onSelectedLanguageClick={() => {}}
+					page={testProps.page}
+					pagePublishDate={testProps.pagePublishDate}
+					pageTitle={testProps.pageTitle}
+					timeRange={testProps.timeRange}
+					timeSpanKey={testProps.timeSpanKey}
+					timeSpanOptions={mockTimeSpanOptions}
+					viewURLs={mockViewURLs}
+				/>
+			</StoreContextProvider>
+		);
+
+		expect(getByText('no-data-is-available-yet')).toBeInTheDocument();
+		expect(
+			getByText('content-has-just-been-published')
 		).toBeInTheDocument();
 	});
 });

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
@@ -10,7 +10,7 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
-import {cleanup, render} from '@testing-library/react';
+import {cleanup, render, wait} from '@testing-library/react';
 import React from 'react';
 
 import TrafficSources from '../../../src/main/resources/META-INF/resources/js/components/TrafficSources';
@@ -18,54 +18,64 @@ import TrafficSources from '../../../src/main/resources/META-INF/resources/js/co
 describe('TrafficSources', () => {
 	afterEach(cleanup);
 
-	it('displays the traffic sources with buttons to view keywords', () => {
-		const mockTrafficSources = [
-			{
-				countryKeywords: [
-					{
-						countryCode: 'us',
-						countryName: 'United States',
-						keywords: [],
-					},
-					{
-						countryCode: 'es',
-						countryName: 'Spain',
-						keywords: [],
-					},
-				],
-				helpMessage: 'Testing Help Message',
-				name: 'testing',
-				share: 30,
-				title: 'Testing',
-				value: 32178,
-			},
-			{
-				countryKeywords: [
-					{
-						countryCode: 'us',
-						countryName: 'United States',
-						keywords: [],
-					},
-					{
-						countryCode: 'es',
-						countryName: 'Spain',
-						keywords: [],
-					},
-				],
-				helpMessage: 'Second Testing Help Message',
-				name: 'second-testing',
-				share: 70,
-				title: 'Second Testing',
-				value: 278256,
-			},
-		];
+	it('displays the traffic sources with buttons to view keywords', async () => {
+		const mockTrafficSourcesDataProvider = jest.fn(() =>
+			Promise.resolve([
+				{
+					countryKeywords: [
+						{
+							countryCode: 'us',
+							countryName: 'United States',
+							keywords: [],
+						},
+						{
+							countryCode: 'es',
+							countryName: 'Spain',
+							keywords: [],
+						},
+					],
+					helpMessage: 'Testing Help Message',
+					name: 'testing',
+					share: 30,
+					title: 'Testing',
+					value: 32178,
+				},
+				{
+					countryKeywords: [
+						{
+							countryCode: 'us',
+							countryName: 'United States',
+							keywords: [],
+						},
+						{
+							countryCode: 'es',
+							countryName: 'Spain',
+							keywords: [],
+						},
+					],
+					helpMessage: 'Second Testing Help Message',
+					name: 'second-testing',
+					share: 70,
+					title: 'Second Testing',
+					value: 278256,
+				},
+			])
+		);
 
 		const {getByText} = render(
 			<TrafficSources
+				dataProvider={mockTrafficSourcesDataProvider}
 				languageTag="en-US"
 				onTrafficSourceClick={() => {}}
-				trafficSources={mockTrafficSources}
 			/>
+		);
+
+		await wait(() =>
+			expect(mockTrafficSourcesDataProvider).toHaveBeenCalled()
+		);
+
+		await wait(() =>
+			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1)
 		);
 
 		const button1 = getByText('Testing');
@@ -83,54 +93,64 @@ describe('TrafficSources', () => {
 		expect(getByText('278,256')).toBeInTheDocument();
 	});
 
-	it('displays the traffic sources without buttons to view keywords when the value is 0', () => {
-		const mockTrafficSources = [
-			{
-				countryKeywords: [
-					{
-						countryCode: 'us',
-						countryName: 'United States',
-						keywords: [],
-					},
-					{
-						countryCode: 'es',
-						countryName: 'Spain',
-						keywords: [],
-					},
-				],
-				helpMessage: 'Testing Help Message',
-				name: 'testing',
-				share: 0,
-				title: 'Testing',
-				value: 0,
-			},
-			{
-				countryKeywords: [
-					{
-						countryCode: 'us',
-						countryName: 'United States',
-						keywords: [],
-					},
-					{
-						countryCode: 'es',
-						countryName: 'Spain',
-						keywords: [],
-					},
-				],
-				helpMessage: 'Second Testing Help Message',
-				name: 'second-testing',
-				share: 0,
-				title: 'Second Testing',
-				value: 0,
-			},
-		];
+	it('displays the traffic sources without buttons to view keywords when the value is 0', async () => {
+		const mockTrafficSourcesDataProvider = jest.fn(() =>
+			Promise.resolve([
+				{
+					countryKeywords: [
+						{
+							countryCode: 'us',
+							countryName: 'United States',
+							keywords: [],
+						},
+						{
+							countryCode: 'es',
+							countryName: 'Spain',
+							keywords: [],
+						},
+					],
+					helpMessage: 'Testing Help Message',
+					name: 'testing',
+					share: 0,
+					title: 'Testing',
+					value: 0,
+				},
+				{
+					countryKeywords: [
+						{
+							countryCode: 'us',
+							countryName: 'United States',
+							keywords: [],
+						},
+						{
+							countryCode: 'es',
+							countryName: 'Spain',
+							keywords: [],
+						},
+					],
+					helpMessage: 'Second Testing Help Message',
+					name: 'second-testing',
+					share: 0,
+					title: 'Second Testing',
+					value: 0,
+				},
+			])
+		);
 
 		const {getAllByText, getByText} = render(
 			<TrafficSources
+				dataProvider={mockTrafficSourcesDataProvider}
 				languageTag="en-US"
 				onTrafficSourceClick={() => {}}
-				trafficSources={mockTrafficSources}
 			/>
+		);
+
+		await wait(() =>
+			expect(mockTrafficSourcesDataProvider).toHaveBeenCalled()
+		);
+
+		await wait(() =>
+			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1)
 		);
 
 		const text1 = getByText('Testing');
@@ -148,52 +168,62 @@ describe('TrafficSources', () => {
 		expect(zeroValues.length).toBe(2);
 	});
 
-	it('displays the traffic sources without buttons to view keywords when the value is missing', () => {
-		const mockTrafficSources = [
-			{
-				countryKeywords: [
-					{
-						countryCode: 'us',
-						countryName: 'United States',
-						keywords: [],
-					},
-					{
-						countryCode: 'es',
-						countryName: 'Spain',
-						keywords: [],
-					},
-				],
-				helpMessage: 'Testing Help Message',
-				name: 'testing',
-				share: 0,
-				title: 'Testing',
-			},
-			{
-				countryKeywords: [
-					{
-						countryCode: 'us',
-						countryName: 'United States',
-						keywords: [],
-					},
-					{
-						countryCode: 'es',
-						countryName: 'Spain',
-						keywords: [],
-					},
-				],
-				helpMessage: 'Second Testing Help Message',
-				name: 'second-testing',
-				share: 0,
-				title: 'Second Testing',
-			},
-		];
+	it('displays the traffic sources without buttons to view keywords when the value is missing', async () => {
+		const mockTrafficSourcesDataProvider = jest.fn(() =>
+			Promise.resolve([
+				{
+					countryKeywords: [
+						{
+							countryCode: 'us',
+							countryName: 'United States',
+							keywords: [],
+						},
+						{
+							countryCode: 'es',
+							countryName: 'Spain',
+							keywords: [],
+						},
+					],
+					helpMessage: 'Testing Help Message',
+					name: 'testing',
+					share: 0,
+					title: 'Testing',
+				},
+				{
+					countryKeywords: [
+						{
+							countryCode: 'us',
+							countryName: 'United States',
+							keywords: [],
+						},
+						{
+							countryCode: 'es',
+							countryName: 'Spain',
+							keywords: [],
+						},
+					],
+					helpMessage: 'Second Testing Help Message',
+					name: 'second-testing',
+					share: 0,
+					title: 'Second Testing',
+				},
+			])
+		);
 
 		const {getAllByText, getByText} = render(
 			<TrafficSources
+				dataProvider={mockTrafficSourcesDataProvider}
 				languageTag="en-US"
 				onTrafficSourceClick={() => {}}
-				trafficSources={mockTrafficSources}
 			/>
+		);
+
+		await wait(() =>
+			expect(mockTrafficSourcesDataProvider).toHaveBeenCalled()
+		);
+
+		await wait(() =>
+			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1)
 		);
 
 		const text1 = getByText('Testing');
@@ -211,31 +241,41 @@ describe('TrafficSources', () => {
 		expect(dashValues.length).toBe(2);
 	});
 
-	it('displays a dash instead of value when the value is missing', () => {
-		const mockTrafficSources = [
-			{
-				countryKeywords: [],
-				helpMessage: 'Testing Help Message',
-				name: 'testing',
-				share: 100,
-				title: 'Testing',
-				value: 32178,
-			},
-			{
-				countryKeywords: [],
-				helpMessage: 'Second Testing Help Message',
-				name: 'second-testing',
-				share: 0,
-				title: 'Second Testing',
-			},
-		];
+	it('displays a dash instead of value when the value is missing', async () => {
+		const mockTrafficSourcesDataProvider = jest.fn(() =>
+			Promise.resolve([
+				{
+					countryKeywords: [],
+					helpMessage: 'Testing Help Message',
+					name: 'testing',
+					share: 100,
+					title: 'Testing',
+					value: 32178,
+				},
+				{
+					countryKeywords: [],
+					helpMessage: 'Second Testing Help Message',
+					name: 'second-testing',
+					share: 0,
+					title: 'Second Testing',
+				},
+			])
+		);
 
 		const {getByText} = render(
 			<TrafficSources
+				dataProvider={mockTrafficSourcesDataProvider}
 				languageTag="en-US"
 				onTrafficSourceClick={() => {}}
-				trafficSources={mockTrafficSources}
 			/>
+		);
+
+		await wait(() =>
+			expect(mockTrafficSourcesDataProvider).toHaveBeenCalled()
+		);
+
+		await wait(() =>
+			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1)
 		);
 
 		expect(getByText('Testing')).toBeInTheDocument();
@@ -245,32 +285,42 @@ describe('TrafficSources', () => {
 		expect(getByText('-')).toBeInTheDocument();
 	});
 
-	it('displays a message informing the user that there is no incoming traffic from search engines yet', () => {
-		const mockTrafficSources = [
-			{
-				countryKeywords: [],
-				helpMessage: 'Testing Help Message',
-				name: 'testing',
-				share: 0,
-				title: 'Testing',
-				value: 0,
-			},
-			{
-				countryKeywords: [],
-				helpMessage: 'Second Testing Help Message',
-				name: 'second-testing',
-				share: 0,
-				title: 'Second Testing',
-				value: 0,
-			},
-		];
+	it('displays a message informing the user that there is no incoming traffic from search engines yet', async () => {
+		const mockTrafficSourcesDataProvider = jest.fn(() =>
+			Promise.resolve([
+				{
+					countryKeywords: [],
+					helpMessage: 'Testing Help Message',
+					name: 'testing',
+					share: 0,
+					title: 'Testing',
+					value: 0,
+				},
+				{
+					countryKeywords: [],
+					helpMessage: 'Second Testing Help Message',
+					name: 'second-testing',
+					share: 0,
+					title: 'Second Testing',
+					value: 0,
+				},
+			])
+		);
 
 		const {getAllByText, getByText} = render(
 			<TrafficSources
+				dataProvider={mockTrafficSourcesDataProvider}
 				languageTag="en-US"
 				onTrafficSourceClick={() => {}}
-				trafficSources={mockTrafficSources}
 			/>
+		);
+
+		await wait(() =>
+			expect(mockTrafficSourcesDataProvider).toHaveBeenCalled()
+		);
+
+		await wait(() =>
+			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1)
 		);
 
 		expect(getByText('Testing')).toBeInTheDocument();


### PR DESCRIPTION
**Description**

Instead of injecting the traffic sources directly, we add a new endpoint to retrieve them. Now in the frontend, we have to create a new `APIService` called `getTrafficSources` and call it when rendering `TrafficSources` component.

**PRs history:**

* Back: https://github.com/liferay-tango/liferay-portal/pull/283
* Back & Front: https://github.com/dgarciasarai/liferay-portal/pull/274 (same as this PR)
* Greg's help for the tests: https://github.com/dgarciasarai/liferay-portal/pull/275. Thanks!

**Note:** The backend part only moves code from one place to another.