### PR TITLE
COMMERCE-4699 headless actions fixed on data set display

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/servlet/taglib/util/ClayDataSetActionDropdownItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/servlet/taglib/util/ClayDataSetActionDropdownItem.java
@@ -43,7 +43,7 @@ public class ClayDataSetActionDropdownItem extends DropdownItem {
 	}
 
 	public void setPermissionKey(String permissionKey) {
-		putData("permissionkey", permissionKey);
+		putData("permissionKey", permissionKey);
 	}
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionLinkRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionLinkRenderer.js
@@ -41,12 +41,12 @@ function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
 		return null;
 	}
 
-	if (currentAction.permissionKey) {
-		if (itemData.actions[currentAction.permissionKey]) {
+	if (currentAction.data?.permissionKey) {
+		if (itemData.actions[currentAction.data.permissionKey]) {
 			if (currentAction.target === 'headless') {
 				currentAction = {
 					...currentAction,
-					...itemData.actions[currentAction.id],
+					...itemData.actions[currentAction.data.id],
 				};
 			}
 		}
@@ -118,6 +118,11 @@ function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
 ActionLinkRenderer.propTypes = {
 	actions: PropTypes.arrayOf(
 		PropTypes.shape({
+			data: PropTypes.shape({
+				href: PropTypes.string,
+				method: PropTypes.oneOf(['get', 'delete']),
+				permissionKey: PropTypes.string,
+			}),
 			disabled: PropTypes.bool,
 			href: PropTypes.string,
 			icon: PropTypes.string,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionsDropdownRenderer.js
@@ -149,14 +149,16 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 
 	const formattedActions = actions
 		? actions.reduce((actions, action) => {
-				if (action.permissionKey) {
-					if (itemData.actions[action.permissionKey]) {
+				if (action.data?.permissionKey) {
+					if (itemData.actions[action.data.permissionKey]) {
 						if (action.target === 'headless') {
 							return [
 								...actions,
 								{
 									...action,
-									...itemData.actions[action.permissionKey],
+									...itemData.actions[
+										action.data.permissionKey
+									],
 								},
 							];
 						}
@@ -219,7 +221,7 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 							itemId,
 							method: actionData?.method,
 							setLoading,
-							url: action.href,
+							url: formatActionURL(action.href, itemData),
 							...action,
 						},
 						context
@@ -290,13 +292,14 @@ ActionsDropdownRenderer.propTypes = {
 	actions: PropTypes.arrayOf(
 		PropTypes.shape({
 			data: PropTypes.shape({
+				href: PropTypes.string,
 				method: PropTypes.oneOf(['get', 'delete']),
+				permissionKey: PropTypes.string,
 			}),
 			href: PropTypes.string,
 			icon: PropTypes.string,
 			label: PropTypes.string.isRequired,
 			onClick: PropTypes.string,
-			permissionKey: PropTypes.string,
 			target: PropTypes.oneOf([
 				'modal',
 				'sidePanel',


### PR DESCRIPTION
This PR fixes a typo, updates the action param keys in the dataset (props included) to align them to the server side and fixes a url formatting issue when there was only one action per item.