### PR TITLE
LPS-80871 Update liferay-ckeditor to v4.14.1-liferay-10

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"ckeditor4-react": "1.0.1",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.14.1-liferay.9",
+		"liferay-ckeditor": "4.14.1-liferay.10",
 		"prop-types": "15.7.2"
 	},
 	"main": "index.js",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -12091,10 +12091,10 @@ liferay-amd-loader@4.3.0:
   resolved "https://registry.yarnpkg.com/liferay-amd-loader/-/liferay-amd-loader-4.3.0.tgz#5a6e6b94374f3d5298f637aca57220ec0b3c66ce"
   integrity sha512-8y7jgugf3RzcmA7t4eKJaNFMKI/e2K9+UaAAuT2maDd2X047E961nELmomRfEaXA5aWIS7SvKlP/dnvfGEvxPw==
 
-liferay-ckeditor@4.14.1-liferay.9:
-  version "4.14.1-liferay.9"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.14.1-liferay.9.tgz#e0aa59d064da89f70989909c17ce62e223492bb4"
-  integrity sha512-fmnM4pI9G4iVxYqG1Z1yaYcnpbv+OPgZ4b+a74WvuUq5QrPCQzqUe1kL9lrt30144rvvbNyL7FeNAgwUlmqBgA==
+liferay-ckeditor@4.14.1-liferay.10:
+  version "4.14.1-liferay.10"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.14.1-liferay.10.tgz#5c5e11519c18c33141de95cccdf9dd3c69534b64"
+  integrity sha512-HR6+KJI9jehYii+RXUbKOCoN69CuP4j5oD24s0wu8lLjr9RyzEE17pUJSvrq4+dzrv2E4Xsn9IYEQC2CmVfUfw==
 
 liferay-font-awesome@3.4.0:
   version "3.4.0"


### PR DESCRIPTION
Update `liferay-ckeditor`  to v4.14.1-liferay.10

[Release notes](https://github.com/liferay/liferay-ckeditor/releases/tag/v4.14.1-liferay.10)

This version includes a new `imagespacingbox` plugin that allows adding spacing around inserted images.

Before this change, this is what the "Image Properties" dialog looked like:

![](https://user-images.githubusercontent.com/5572/92596951-eba25a00-f2a6-11ea-8b03-1eab84bc3781.png)

After this change, it looks like this:

![](https://user-images.githubusercontent.com/5572/92596782-9fefb080-f2a6-11ea-8a8d-fb5d3994f76d.png)

 