### PR TITLE
LPS-117287 Reduce multiple clicks on navigable links to single navigation

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
@@ -220,14 +220,18 @@ class LiferayApp extends App {
 
 	/**
 	 * @inheritDoc
-	 * Overrides Senna's default `onDocClickDelegate_ handler` and
-	 * halts SPA behavior if the click target is inside a blacklisted
-	 * portlet
+	 * Overrides Senna's default `onDocClickDelegate_ handler`. Halts
+	 * SPA behavior if the click target is inside a blacklisted portlet.
+	 * Reduces navigations from multiple clicks to a single navigation.
+	 *
 	 * @param  {!Event} event The event object
 	 */
 
 	onDocClickDelegate_(event) {
-		if (this.isInPortletBlacklist(event.delegateTarget)) {
+		if (
+			this.isInPortletBlacklist(event.delegateTarget) ||
+			event.detail > 1
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Ticket history:
- https://github.com/liferay-frontend/liferay-portal/pull/233 
- https://github.com/liferay/senna.js/pull/337
- https://github.com/liferay/senna.js/pull/338
- https://github.com/markocikos/liferay-portal/pull/190

Change from https://github.com/markocikos/liferay-portal/pull/190:
- We are extending `onDocClickDelegate`, instead of adding new delegation. With this, we are using internal definitions of valid navigation element and valid navigable URL.