### PR TITLE
LPS-120700 Fix inserting images in IE

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
+++ b/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
@@ -168,7 +168,6 @@
 			editor.insertElement(element);
 			editor.getSelection();
 
-
 			editor.fire('editorInteraction', {
 				nativeEvent: {},
 				selectionData: {

--- a/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
+++ b/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
@@ -148,10 +148,9 @@
 				);
 			}
 
-			var elementOuterHtml = element.getOuterHtml();
-
 			if (IE9AndLater) {
 				if (!editor.window.$.AlloyEditor) {
+					var elementOuterHtml = element.getOuterHtml();
 					var emptySelectionMarkup = '&nbsp;';
 
 					editor.insertHtml(elementOuterHtml + emptySelectionMarkup);
@@ -161,7 +160,7 @@
 				}
 			}
 			else {
-				editor.insertHtml(elementOuterHtml);
+				editor.insertElement(element);
 			}
 
 			element = new CKEDITOR.dom.element('br');

--- a/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
+++ b/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
@@ -158,14 +158,16 @@
 				}
 				else {
 					editor.insertElement(element);
-
-					element = new CKEDITOR.dom.element('br');
-					editor.insertElement(element);
 				}
 			}
 			else {
 				editor.insertHtml(elementOuterHtml);
 			}
+
+			element = new CKEDITOR.dom.element('br');
+			editor.insertElement(element);
+			editor.getSelection();
+
 
 			editor.fire('editorInteraction', {
 				nativeEvent: {},

--- a/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
+++ b/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
@@ -124,21 +124,10 @@
 			return pictureEl;
 		},
 
-		_isEmptySelection(editor) {
-			var selection = editor.getSelection();
-
-			var ranges = selection.getRanges();
-
-			return (
-				selection.getType() === CKEDITOR.SELECTION_NONE ||
-				(ranges.length === 1 && (ranges[0].collapsed || IE9AndLater))
-			);
-		},
-
 		_onSelectedImageChange(editor, imageSrc, selectedItem) {
 			var instance = this;
 
-			var el;
+			var element;
 
 			var fileEntryAttributeName =
 				editor.config.adaptiveMediaFileEntryAttributeName;
@@ -146,54 +135,45 @@
 			if (
 				selectedItem.returnType === STR_ADAPTIVE_MEDIA_URL_RETURN_TYPE
 			) {
-				el = instance._getPictureElement(
+				element = instance._getPictureElement(
 					selectedItem,
 					fileEntryAttributeName
 				);
 			}
 			else {
-				el = instance._getImgElement(
+				element = instance._getImgElement(
 					imageSrc,
 					selectedItem,
 					fileEntryAttributeName
 				);
 			}
 
-			var elementOuterHtml = el.getOuterHtml();
+			var elementOuterHtml = element.getOuterHtml();
 
-			editor.insertHtml(elementOuterHtml);
+			if (IE9AndLater) {
+				if (!editor.window.$.AlloyEditor) {
+					var emptySelectionMarkup = '&nbsp;';
 
-			if (instance._isEmptySelection(editor)) {
-				if (IE9AndLater) {
-					var usingAlloyEditor =
-						typeof editor.window.$.AlloyEditor === 'undefined';
-
-					if (!usingAlloyEditor) {
-						var emptySelectionMarkup = '&nbsp;';
-
-						emptySelectionMarkup =
-							elementOuterHtml + emptySelectionMarkup;
-
-						editor.insertHtml(emptySelectionMarkup);
-					}
-
-					var element = new CKEDITOR.dom.element('br');
-
-					editor.insertElement(element);
-					editor.getSelection();
-
-					editor.fire('editorInteraction', {
-						nativeEvent: {},
-						selectionData: {
-							element,
-							region: element.getClientRect(),
-						},
-					});
+					editor.insertHtml(elementOuterHtml + emptySelectionMarkup);
 				}
 				else {
-					editor.execCommand('enter');
+					editor.insertElement(element);
+
+					element = new CKEDITOR.dom.element('br');
+					editor.insertElement(element);
 				}
 			}
+			else {
+				editor.insertHtml(elementOuterHtml);
+			}
+
+			editor.fire('editorInteraction', {
+				nativeEvent: {},
+				selectionData: {
+					element,
+					region: element.getClientRect(),
+				},
+			});
 		},
 
 		init(editor) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -240,37 +240,31 @@
 
 						editor.insertHtml(elementOuterHtml);
 
-						if (instance._isEmptySelection(editor)) {
-							if (IE9AndLater) {
-								var usingAlloyEditor =
-									typeof editor.window.$.AlloyEditor ===
-									'undefined';
+						if (IE9AndLater) {
+							if (!editor.window.$.AlloyEditor) {
+								var emptySelectionMarkup = '&nbsp;';
 
-								if (!usingAlloyEditor) {
-									var emptySelectionMarkup = '&nbsp;';
+								emptySelectionMarkup =
+									elementOuterHtml + emptySelectionMarkup;
 
-									emptySelectionMarkup =
-										elementOuterHtml + emptySelectionMarkup;
-
-									editor.insertHtml(emptySelectionMarkup);
-								}
-
-								var element = new CKEDITOR.dom.element('br');
-
-								editor.insertElement(element);
-								editor.getSelection();
-
-								editor.fire('editorInteraction', {
-									nativeEvent: {},
-									selectionData: {
-										element,
-										region: element.getClientRect(),
-									},
-								});
+								editor.insertHtml(emptySelectionMarkup);
 							}
-							else {
-								editor.execCommand('enter');
-							}
+
+							var element = new CKEDITOR.dom.element('br');
+
+							editor.insertElement(element);
+							editor.getSelection();
+
+							editor.fire('editorInteraction', {
+								nativeEvent: {},
+								selectionData: {
+									element,
+									region: element.getClientRect(),
+								},
+							});
+						}
+						else {
+							editor.execCommand('enter');
 						}
 
 						editor.focus();


### PR DESCRIPTION
This fixes [LPS-120700](https://issues.liferay.com/browse/LPS-120700), what was happening is that in IE when inserting an image, only a `<br>` tag was inserted.

before:
![](https://user-images.githubusercontent.com/5572/93086361-5254b880-f697-11ea-9311-946f5ab7e138.gif)

after:
![](https://user-images.githubusercontent.com/5572/93086393-5bde2080-f697-11ea-8efa-1591401c9bda.gif)

