### PR TITLE
Commerce 4757 add sorting capabilities to data-set-display

### DIFF
--- a/modules/apps/commerce/commerce-order-web/src/main/java/com/liferay/commerce/order/web/internal/display/context/CommerceOrderListDisplayContext.java
+++ b/modules/apps/commerce/commerce-order-web/src/main/java/com/liferay/commerce/order/web/internal/display/context/CommerceOrderListDisplayContext.java
@@ -20,6 +20,8 @@ import com.liferay.commerce.order.web.internal.search.CommerceOrderDisplayTerms;
 import com.liferay.commerce.order.web.internal.security.permission.resource.CommerceOrderPermission;
 import com.liferay.commerce.service.CommerceOrderNoteService;
 import com.liferay.frontend.taglib.clay.data.set.servlet.taglib.util.ClayDataSetActionDropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.SortItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.SortItemList;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -126,6 +128,19 @@ public class CommerceOrderListDisplayContext {
 		}
 
 		return portletURL;
+	}
+
+	public SortItemList getSortItemList() {
+		SortItemList sortItemList = new SortItemList();
+
+		SortItem sortItem = new SortItem();
+
+		sortItem.setDirection("desc");
+		sortItem.setKey("createDate");
+
+		sortItemList.add(sortItem);
+
+		return sortItemList;
 	}
 
 	private final CommerceOrderNoteService _commerceOrderNoteService;

--- a/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/view.jsp
@@ -29,5 +29,6 @@ CommerceOrderListDisplayContext commerceOrderListDisplayContext = (CommerceOrder
 	namespace="<%= liferayPortletResponse.getNamespace() %>"
 	pageNumber="<%= 1 %>"
 	portletURL="<%= commerceOrderListDisplayContext.getPortletURL() %>"
+	sortItemList="<%= commerceOrderListDisplayContext.getSortItemList() %>"
 	style="fluid"
 />

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 6.1.3
+Bundle-Version: 6.2.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.data,\
 	com.liferay.frontend.taglib.clay.data.set,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -91,5 +91,5 @@
 		"format": "liferay-npm-scripts fix",
 		"test": "liferay-npm-scripts test"
 	},
-	"version": "6.1.3"
+	"version": "6.2.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DataSetDisplayTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DataSetDisplayTag.java
@@ -21,6 +21,8 @@ import com.liferay.frontend.taglib.clay.internal.js.loader.modules.extender.npm.
 import com.liferay.frontend.taglib.clay.internal.servlet.ServletContextUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.SortItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.SortItemList;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -187,6 +189,10 @@ public class DataSetDisplayTag extends IncludeTag {
 		return _selectionType;
 	}
 
+	public List<SortItem> getSortItemList() {
+		return _sortItemList;
+	}
+
 	public String getStyle() {
 		return _style;
 	}
@@ -295,6 +301,10 @@ public class DataSetDisplayTag extends IncludeTag {
 		_showSearch = showSearch;
 	}
 
+	public void setSortItemList(SortItemList sortItemList) {
+		_sortItemList = sortItemList;
+	}
+
 	public void setStyle(String style) {
 		_style = style;
 	}
@@ -331,6 +341,7 @@ public class DataSetDisplayTag extends IncludeTag {
 		_showManagementBar = true;
 		_showPagination = true;
 		_showSearch = true;
+		_sortItemList = new SortItemList();
 		_style = "default";
 	}
 
@@ -390,6 +401,8 @@ public class DataSetDisplayTag extends IncludeTag {
 			"clay:data-set-display:showPagination", _showPagination);
 		request.setAttribute("clay:data-set-display:showSearch", _showSearch);
 		request.setAttribute("clay:data-set-display:style", _style);
+		request.setAttribute(
+			"clay:headless-data-set-display:sortItemList", _sortItemList);
 	}
 
 	private List<ClayPaginationEntry> _getClayPaginationEntries() {
@@ -473,6 +486,7 @@ public class DataSetDisplayTag extends IncludeTag {
 	private boolean _showManagementBar = true;
 	private boolean _showPagination = true;
 	private boolean _showSearch = true;
+	private SortItemList _sortItemList = new SortItemList();
 	private String _style = "default";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HeadlessDataSetDisplayTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HeadlessDataSetDisplayTag.java
@@ -23,6 +23,8 @@ import com.liferay.frontend.taglib.clay.internal.js.loader.modules.extender.npm.
 import com.liferay.frontend.taglib.clay.internal.servlet.ServletContextUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.SortItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.SortItemList;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -149,6 +151,10 @@ public class HeadlessDataSetDisplayTag extends IncludeTag {
 		return _selectionType;
 	}
 
+	public List<SortItem> getSortItemList() {
+		return _sortItemList;
+	}
+
 	public String getStyle() {
 		return _style;
 	}
@@ -256,6 +262,10 @@ public class HeadlessDataSetDisplayTag extends IncludeTag {
 		_showSearch = showSearch;
 	}
 
+	public void setSortItemList(SortItemList sortItemList) {
+		_sortItemList = sortItemList;
+	}
+
 	public void setStyle(String style) {
 		_style = style;
 	}
@@ -292,6 +302,7 @@ public class HeadlessDataSetDisplayTag extends IncludeTag {
 		_showManagementBar = true;
 		_showPagination = true;
 		_showSearch = true;
+		_sortItemList = new SortItemList();
 		_style = "default";
 	}
 
@@ -360,6 +371,8 @@ public class HeadlessDataSetDisplayTag extends IncludeTag {
 			"clay:headless-data-set-display:showPagination", _showPagination);
 		request.setAttribute(
 			"clay:headless-data-set-display:showSearch", _showSearch);
+		request.setAttribute(
+			"clay:headless-data-set-display:sortItemList", _sortItemList);
 		request.setAttribute("clay:headless-data-set-display:style", _style);
 	}
 
@@ -450,6 +463,7 @@ public class HeadlessDataSetDisplayTag extends IncludeTag {
 	private boolean _showManagementBar = true;
 	private boolean _showPagination = true;
 	private boolean _showSearch = true;
+	private SortItemList _sortItemList = new SortItemList();
 	private String _style = "default";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/SortItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/SortItem.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib.util;
+
+import java.util.HashMap;
+
+/**
+ * @author Luca Pellizzon
+ */
+public class SortItem extends HashMap<String, Object> {
+
+	public void setDirection(String direction) {
+		put("direction", direction);
+	}
+
+	public void setKey(String key) {
+		put("key", key);
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/SortItemList.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/SortItemList.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib.util;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeSupplier;
+
+import java.util.ArrayList;
+
+/**
+ * @author Luca Pellizzon
+ */
+public class SortItemList extends ArrayList<SortItem> {
+
+	public static SortItemList of(SortItem... sortItems) {
+		SortItemList sortItemList = new SortItemList();
+
+		for (SortItem sortItem : sortItems) {
+			if (sortItem != null) {
+				sortItemList.add(sortItem);
+			}
+		}
+
+		return sortItemList;
+	}
+
+	public static SortItemList of(
+		UnsafeSupplier<SortItem, Exception>... unsafeSuppliers) {
+
+		SortItemList sortItemList = new SortItemList();
+
+		for (UnsafeSupplier<SortItem, Exception> unsafeSupplier :
+				unsafeSuppliers) {
+
+			try {
+				SortItem sortItem = unsafeSupplier.get();
+
+				if (sortItem != null) {
+					sortItemList.add(sortItem);
+				}
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
+
+		return sortItemList;
+	}
+
+	public void add(UnsafeConsumer<SortItem, Exception> unsafeConsumer) {
+		SortItem sortItem = new SortItem();
+
+		try {
+			unsafeConsumer.accept(sortItem);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+
+		add(sortItem);
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/SortItemListBuilder.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/SortItemListBuilder.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib.util;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeSupplier;
+
+/**
+ * @author Luca Pellizzon
+ */
+public class SortItemListBuilder {
+
+	public static SortItemListWrapper add(SortItem sortItem) {
+		SortItemListWrapper sortItemListWrapper = new SortItemListWrapper();
+
+		return sortItemListWrapper.add(sortItem);
+	}
+
+	public static SortItemListWrapper add(
+		UnsafeConsumer<SortItem, Exception> unsafeConsumer) {
+
+		SortItemListWrapper sortItemListWrapper = new SortItemListWrapper();
+
+		return sortItemListWrapper.add(unsafeConsumer);
+	}
+
+	public static SortItemListWrapper add(
+		UnsafeSupplier<Boolean, Exception> unsafeSupplier, SortItem sortItem) {
+
+		SortItemListWrapper sortItemListWrapper = new SortItemListWrapper();
+
+		return sortItemListWrapper.add(unsafeSupplier, sortItem);
+	}
+
+	public static SortItemListWrapper add(
+		UnsafeSupplier<Boolean, Exception> unsafeSupplier,
+		UnsafeConsumer<SortItem, Exception> unsafeConsumer) {
+
+		SortItemListWrapper sortItemListWrapper = new SortItemListWrapper();
+
+		return sortItemListWrapper.add(unsafeSupplier, unsafeConsumer);
+	}
+
+	public static final class SortItemListWrapper {
+
+		public SortItemListWrapper add(SortItem sortItem) {
+			_sortItemList.add(sortItem);
+
+			return this;
+		}
+
+		public SortItemListWrapper add(
+			UnsafeConsumer<SortItem, Exception> unsafeConsumer) {
+
+			_sortItemList.add(unsafeConsumer);
+
+			return this;
+		}
+
+		public SortItemListWrapper add(
+			UnsafeSupplier<Boolean, Exception> unsafeSupplier,
+			SortItem sortItem) {
+
+			try {
+				if (unsafeSupplier.get()) {
+					_sortItemList.add(sortItem);
+				}
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+
+			return this;
+		}
+
+		public SortItemListWrapper add(
+			UnsafeSupplier<Boolean, Exception> unsafeSupplier,
+			UnsafeConsumer<SortItem, Exception> unsafeConsumer) {
+
+			try {
+				if (unsafeSupplier.get()) {
+					_sortItemList.add(unsafeConsumer);
+				}
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+
+			return this;
+		}
+
+		public SortItemList build() {
+			return _sortItemList;
+		}
+
+		private final SortItemList _sortItemList = new SortItemList();
+
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -752,6 +752,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>sortItemList</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>style</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1359,6 +1364,11 @@
 		</attribute>
 		<attribute>
 			<name>showSearch</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>sortItemList</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/init.jsp
@@ -20,6 +20,7 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 <%@ page import="com.liferay.frontend.taglib.clay.data.set.model.ClayPaginationEntry" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem" %><%@
+page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.SortItemList" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONSerializer" %><%@
@@ -57,6 +58,7 @@ String selectionType = (String)request.getAttribute("clay:data-set-display:selec
 boolean showManagementBar = (boolean)request.getAttribute("clay:data-set-display:showManagementBar");
 boolean showPagination = (boolean)request.getAttribute("clay:data-set-display:showPagination");
 boolean showSearch = (boolean)request.getAttribute("clay:data-set-display:showSearch");
+SortItemList sortItemList = (SortItemList)request.getAttribute("clay:headless-data-set-display:sortItemList");
 String style = (String)request.getAttribute("clay:data-set-display:style");
 
 JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/page.jsp
@@ -55,6 +55,7 @@
 			selectedItems: <%= jsonSerializer.serializeDeep(selectedItems) %>,
 			selectedItemsKey: '<%= GetterUtil.getString(selectedItemsKey) %>',
 			selectionType: '<%= GetterUtil.getString(selectionType) %>',
+			sorting: <%= jsonSerializer.serializeDeep(sortItemList) %>,
 			style: '<%= style %>',
 			views: <%= jsonSerializer.serializeDeep(clayDataSetDisplayViewsContext) %>,
 		},

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/init.jsp
@@ -21,6 +21,7 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 page import="com.liferay.frontend.taglib.clay.data.set.servlet.taglib.util.ClayDataSetActionDropdownItem" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem" %><%@
+page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.SortItemList" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONSerializer" %><%@
@@ -59,5 +60,6 @@ String selectionType = (String)request.getAttribute("clay:headless-data-set-disp
 boolean showManagementBar = (boolean)request.getAttribute("clay:headless-data-set-display:showManagementBar");
 boolean showPagination = (boolean)request.getAttribute("clay:headless-data-set-display:showPagination");
 boolean showSearch = (boolean)request.getAttribute("clay:headless-data-set-display:showSearch");
+SortItemList sortItemList = (SortItemList)request.getAttribute("clay:headless-data-set-display:sortItemList");
 String style = (String)request.getAttribute("clay:headless-data-set-display:style");
 %>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/page.jsp
@@ -62,6 +62,7 @@ JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
 			style: '<%= style %>',
 			selectionType: '<%= GetterUtil.getString(selectionType) %>',
 			showPagination: <%= showPagination %>,
+			sorting: <%= jsonSerializer.serializeDeep(sortItemList) %>,
 			views: <%= jsonSerializer.serializeDeep(clayDataSetDisplayViewsContext) %>,
 		},
 		document.getElementById('<%= containerId %>')

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/util/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.4.0
+version 3.5.0


### PR DESCRIPTION
cc @marco-leo @FabioDiegoMastrorilli

Currently data-set-display component is missing a complete implementation regarding sorting.
The component itself already has part of this feature managed by the "sorting" parameter, but the underneath infrastructure is not ready.

This PR is solving this issue by implementing what's needed to give to the data-set-display component the parameter to manage sorting.
The taglib has been integrated, adding the "sortItemList". A list containing all the sorting properties we want to manage.
In order to do so, the tld has been updated and some utilities have been added, like SortItemList.
Everything has been done following the patterns already used inside Liferay.

This implementation is coming from a request regarding adding a default sorting (creation date) for the Commerce Orders list.

That said to test this functionality, checking the default behavior of Orders list is enough.
To test the full capabilities, adding the sort property to any data-set-display should do the job.