### PR TITLE
LPS-120913 CSS Custom properties should not affect borderless buttons

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
@@ -53,7 +53,9 @@ body,
 
 @each $key, $map in $custom-properties-button-maps {
 	.btn-#{$key} {
-		@include clay-button-variant($map);
+		&:not(.btn-outline-borderless) {
+			@include clay-button-variant($map);
+		}
 	}
 }
 


### PR DESCRIPTION
See https://issues.liferay.com/browse/LPS-120913 
**Before:**
<img width="1061" alt="Screenshot 2020-09-15 at 10 16 29" src="https://user-images.githubusercontent.com/8373764/93184507-9f3e9a80-f73c-11ea-9343-b1ac0e0b376d.png">

**After:**
<img width="1059" alt="Screenshot 2020-09-15 at 10 18 06" src="https://user-images.githubusercontent.com/8373764/93184625-c4330d80-f73c-11ea-9a35-4c5bdcff7a80.png">
