### PR TITLE
LPS-120545 Fix ckeditor_classic

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
@@ -33,8 +33,11 @@ JSONObject editorConfigJSONObject = null;
 if (editorData != null) {
 	editorConfigJSONObject = (JSONObject)editorData.get("editorConfig");
 }
+
+name = HtmlUtil.escapeAttribute(name);
 %>
 
+<textarea id="<%= name %>" name="<%= name %>" style="display: none;"></textarea>
 <div>
 	<react:component
 		module="editor/ClassicEditor"

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -114,34 +114,26 @@ const ClassicEditor = ({
 							? CKEDITOR.dialog._.currentZIndex + 10
 							: Liferay.zIndex.WINDOW + 10;
 					};
-
-					CKEDITOR.on('instanceCreated', ({editor}) => {
-						editor.name = name;
-
-						editor.on('drop', (event) => {
-							var data = event.data.dataTransfer.getData(
-								'text/html'
-							);
-
-							if (data) {
-								var fragment = CKEDITOR.htmlParser.fragment.fromHtml(
-									data
-								);
-
-								var name = fragment.children[0].name;
-
-								if (name) {
-									return editor.pasteFilter.check(name);
-								}
-							}
-						});
-
-						editor.on('instanceReady', () => {
-							editor.setData(contents);
-						});
-					});
 				}}
 				onChange={onChangeCallback}
+				onDrop={(event) => {
+					const data = event.data.dataTransfer.getData('text/html');
+
+					if (data) {
+						const fragment = CKEDITOR.htmlParser.fragment.fromHtml(
+							data
+						);
+
+						const name = fragment.children[0].name;
+
+						if (name) {
+							return event.editor.pasteFilter.check(name);
+						}
+					}
+				}}
+				onInstanceReady={({editor}) => {
+					editor.setData(contents);
+				}}
 				ref={editorRef}
 				{...otherProps}
 			/>


### PR DESCRIPTION
This has a couple of fixes for our `ClassicEditor.js` component:

Avoid [`CKEDITOR.on('instanceCreated', ...)`](https://github.com/liferay-frontend/liferay-portal/pull/390/files#diff-60128641efe40efd4a4df0325f6e6070L118) because this will be invoked for each (created) CKEDITOR instance - which means that before this fix all editors had the same `name` property and the `CKEDITOR.instance` object will only ever contain one key.

Prefer passing props that the component supports like `onDrop` and `onInstanceCreated`

Add a temporary `textarea` element to `ckeditor_classic.jsp` because at the moment, the `CKEditor` (from `ckeditor4-react`) does not set an `id` or `name` to the element it renders, and this is a problem with the [InputLocalized](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js) component that tries to use that element.

**Before this change, this would cause errors**:

![](https://user-images.githubusercontent.com/5572/93580509-30fa1200-f9a0-11ea-8ec6-3558489f2405.png)

![](https://user-images.githubusercontent.com/5572/93580623-52f39480-f9a0-11ea-8915-1bfaafd54a4d.png)

**After this change, it looks like this**:

![](https://user-images.githubusercontent.com/5572/93580653-5edf5680-f9a0-11ea-8fa6-fd9ed977cbb4.png)

![](https://user-images.githubusercontent.com/5572/93580672-643ca100-f9a0-11ea-919d-3afed9275c15.png)

**Test plan**:

- Add : 
  ```properties
  editor.wysiwyg.portal-impl.portlet.ddm.text_html.ftl=ckeditor_classic
  editor.wysiwyg.portal-web.docroot.html.taglib.ui.email_notification_settings.jsp=ckeditor_classic
  ``` 
  to your `portal-ext.properties` file
- Fetch this branch
- Deploy the `frontend-editor-ckeditor-web` module
- Navigate to Web Content, click on the **+** button in the top right and choose Basic Web Content
- Assert that no errors are present when typing text in any of the editors present in the page
- From the global menu, select the Control Panel tab, click on Instance Settings and choose Email
- Assert that no errors are present when typing text in any of the editors present in the page


