### PR TITLE
LPS-121084 openSelectionModal sends the multiple parameter through the request

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -23,6 +23,7 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import './Modal.scss';
 import navigate from '../util/navigate.es';
+import createPortletURL from '../util/portlet_url/create_portlet_url.es';
 
 const openModal = (props) => {
 	if (
@@ -111,6 +112,7 @@ const openSelectionModal = ({
 	multiple = false,
 	onClose,
 	onSelect,
+	p_p_id,
 	selectEventName,
 	selectedData,
 	size,
@@ -195,7 +197,12 @@ const openSelectionModal = ({
 		},
 		size,
 		title,
-		url,
+		url: createPortletURL(url, {
+			multipleSelection: multiple,
+			p_p_id:
+				p_p_id ||
+				'com_liferay_item_selector_web_portlet_ItemSelectorPortlet',
+		}),
 		zIndex,
 	});
 };


### PR DESCRIPTION
**Motivation:** 

Currently, we have a generic Item Selector View that will now support single and multiple selection (completed in [LPS-120838](https://issues.liferay.com/browse/LPS-120838)) But for that, we will need a flag to indicate whether it is multiple or not, as the view slightly changes.

Taking in mind that we also need a flag from the frontend size, the idea is to use that and send it to the views through the url (See commit https://github.com/liferay-lima/liferay-portal/pull/800/commits/a73803ccfd9f644fdaa206ceced28be422eb0aaa). 

The `p_p_id` parameter is needed because item selector's urls are friendly and don't include the portlet id, but the function `createPortletURL` needs it. 

**Note**: it would be nice to have this merged before the /dev/24 talk, we need it for the demo. 
