### PR TITLE
LPS-121012 aui:input with suffix visually breaks when working with an aui:validator

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_forms.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_forms.scss
@@ -146,6 +146,11 @@
 
 	// ---------- Input group ----------
 
+	.input-group .form-validator-stack {
+		order: 10;
+		width: 100%;
+	}
+
 	.input-group-addon {
 		align-items: center;
 		background-color: $input-group-addon-bg;


### PR DESCRIPTION
This is a bugfix, see https://issues.liferay.com/browse/LPS-121012

Steps to reproduce:
1. Go to Global Menu > Commerce > Discounts
1. Create a new Discount (any values)
1. Edit newly created discount. On this page is a sample of input with suffix + validator. These are 'Amount' and 'Maximum Discount Amount' fields.

What happens: 
- Validation is rendered before suffix.

Before fix:
![before](https://user-images.githubusercontent.com/5435511/93583459-2e012080-f9a4-11ea-9514-15d98851fe0d.png)

After fix:
![after](https://user-images.githubusercontent.com/5435511/93583468-322d3e00-f9a4-11ea-96dc-dfbee2a142a7.png)

Notes:
- In this PR we are setting order with CSS. An alternative would be to modify JS that appends validation message after input, to check if suffix exists. Unfortunately, this is a part of [core AUI form validator](https://alloyui.com/api/files/alloy-ui_src_aui-form-validator_js_aui-form-validator.js.html), and I believe we don't plan to ever update core AUI.
- The `order` line of CSS depends on container having flex display. This comes from [clay-css bootstrap styles](https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/bootstrap/_input-group.scss#L8-L12). As `form-validator-stack` is a portal-related class, it makes sense to me to put it in portal, rather than extend Clay styles.