### PR TITLE
LPS-114411 Don't ask for geolocatization if latitude or longitude is 0

### DIFF
--- a/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js
+++ b/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js
@@ -105,7 +105,7 @@ class MapBase extends State {
 				? this.position.location
 				: {};
 
-		if (!geolocation.lat || !geolocation.lng) {
+		if (!geolocation.hasOwnProperty('lat') || !geolocation.hasOwnProperty('lng')) {
 			Liferay.Util.getGeolocation(
 				(lat, lng) => {
 					this._initializeLocation({lat, lng});


### PR DESCRIPTION
This is a fix for the bug [Liferay asks for geolocation if latitude or longitude is 0](https://issues.liferay.com/browse/LPS-114411)

**Description**
Creating Web Content which contains geolocation field and passing for example latitude = 50 and longitude = 0 makes that Liferay uses Navigator.geolocation API to determine user location. Responsible for this is https://github.com/liferay/liferay-portal/blob/7.3.2-ga3/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js#L108. This line has wrong comparison and should check if latitude/longitude has been passed.

**Before:** 
Passing latitude or longitude equals to zero makes that Liferay want to use user location.

**After the fix:** 
Liferay will not ask for location if user pass latitude or longitude equals to zero.