### PR TITLE
LPS-121062 Double submit in Safari with SPA disabled

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
@@ -104,6 +104,12 @@
 			if (!hasErrors) {
 				var action = event.action || form.attr('action');
 
+				if (action === 'javascript:;') {
+					event.preventDefault();
+
+					return;
+				}
+
 				var singleSubmit = event.singleSubmit;
 
 				var inputs = form.all(


### PR DESCRIPTION
Issue: [LPS-121062](https://issues.liferay.com/browse/LPS-121062)

**Step to reproduce:**
(taken from [LPS-121062](https://issues.liferay.com/browse/LPS-121062))
1. Set up a Liferay instance, disabling SPA: `javascript.single.page.application.enabled=false`
1. Access the Liferay instance using a newer version of Safari (Note: Tested against Safari 13.1.2 (15609.3.5.1.3)) 
1. Create a new Content Page
1. Once the page has been created, view the page
1. Add a Basic Section (Add > Basic Sections > Banner Center) to the layout of the Content Page created in step 2
1. Publish
1. Attempt to click on the Edit icon on the top right hand menu (pencil icon)

Additional discussion on possible resolution steps available on internal ticket [PTR-1948](https://issues.liferay.com/browse/PTR-1948), but forwarding before the PTR is closed to allow for a more informed discussion using the actual code.