### PR TITLE
LPS-121404 Add missing types to remote-app-client-js get() declaration

### DIFF
--- a/modules/apps/remote-app/remote-app-client-js/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/remote-app/remote-app-client-js/src/main/resources/META-INF/resources/js/index.ts
@@ -37,6 +37,20 @@ type ClientOptions = {
 };
 
 /**
+ * Properties accessible via the `get()` method. The remote-app-support-web
+ * module will reject requests for properties outside of this list.
+ */
+type GettableProperties =
+	| 'companyId'
+	| 'css'
+	| 'defaultLanguageId'
+	| 'isControlPanel'
+	| 'languageId'
+	| 'isSignedIn'
+	| 'userId'
+	| 'userName';
+
+/**
  * Payloads may only contain properties which we can send across iframes
  * using the `postMessage` API. Complex properties like functions cannot
  * be sent because the "Structured clone algorithm" does not support
@@ -807,7 +821,7 @@ const SDK = Object.freeze({
 				});
 			},
 
-			get(property: 'css'): Promise<string> {
+			get(property: GettableProperties): Promise<string> {
 				const requestID = getUUID();
 
 				postMessage({


### PR DESCRIPTION
No behavior changes here; just broadening the type definition.