### PR TITLE
LPS-117317 Unable to drag and drop an image in ckeditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -645,10 +645,14 @@ name = HtmlUtil.escapeJS(name);
 			if (data) {
 				var fragment = CKEDITOR.htmlParser.fragment.fromHtml(data);
 
-				var name = fragment.children[0].name;
+				var element = fragment.children[0];
 
-				if (name) {
-					return this.pasteFilter.check(name);
+				if (element.hasClass('cke_widget_image')) {
+					element = element.children[0];
+				}
+
+				if (this.pasteFilter && element.name) {
+					return this.pasteFilter.check(element.name);
 				}
 			}
 		});


### PR DESCRIPTION
This is a bugfix, see https://issues.liferay.com/browse/LPS-117317. 

Steps to reproduce:
1. Add an image to web content.
1. Select the image, by clicking on it.
1. Drag & drop image to a different place in the editor.

Before fix:
![before](https://user-images.githubusercontent.com/5435511/94268974-48a43e00-ff3e-11ea-9150-9d55f6e808f5.gif)

After fix:
![after](https://user-images.githubusercontent.com/5435511/94268998-4f32b580-ff3e-11ea-89aa-f3e576d14ee2.gif)

Notes:
- I believe this was originally a bug only on IE11, but since it has changed to be a different bug, on all browsers. What changed is now we have different dragging behavior, consistent over all browsers. In Chrome, you no longer can drag an drop by clicking anywhere on image, you need to use the handler. This caused dragged content to be HTML consisting not only of `<img>` but also of `<span>`s containing handler icon and wrapper.
- The original bug on IE was that `pasteFilter` does not need to be defined, so one `if` would take care of it. But, the solution in this PR fixes both the original and new versions of the bug, as we are removing the check entirely.
- We added the listener on drop that checks paste filters to fix [drag & drop over different editors](https://issues.liferay.com/browse/LPS-113690). It seems that something unrelated fixed that issue, and we no longer need the check. In the 'After fix' gif, you can see drag & drop to Summary works as expected (nothing happens). @julien Is there perhaps some case that I am missing here, some reason why we would still need the filter check? Looking at [`pasteFilter` docs](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-pasteFilter), it seems to be designed as an internal mechanism, settable through config. We shouldn't be worrying about when to trigger it manually.
- One step in steps to reproduce is to click on the image and select it. On master, if you click outside the image and d&d, we don't even enter `drop` listener. I honestly cannot explain it. Still, it becomes irrelevant if we remove the listener, one less inconsistency to worry about.