### PR TITLE
LPS-121439 Escape modal title

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -355,7 +355,7 @@ AUI.add(
 					config.title = '&nbsp;';
 				}
 
-				modal.titleNode.html(config.title);
+				modal.titleNode.html(Lang.String.escapeHTML(config.title));
 
 				modal.fillHeight(modal.bodyNode);
 


### PR DESCRIPTION
A fix for [LPS-120752](https://issues.liferay.com/browse/LPS-120752) has been sent for `7.2.x` and `7.1.x` [here](https://github.com/liferay/liferay-portal-ee/pull/20916),
but the fix hasn't been applied in `master`; maybe because there's a [typo](https://github.com/liferay/liferay-portal-ee/pull/20916/files#diff-1eb942b3d4c14121e984c0de86bde0feR354)
in the commit (`cconfig` instead of `config`). 