### PR TITLE
LPS-121424 Fix inserting images in IE 11

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -236,18 +236,15 @@
 						callback(imageSrc, selectedItem);
 					}
 					else {
-						var elementOuterHtml = '<img src="' + imageSrc + '">';
+						var imageElement = new CKEDITOR.dom.element.createFromHtml(
+							'<img src="' + imageSrc + '">'
+						);
 
-						editor.insertHtml(elementOuterHtml);
+						editor.insertElement(imageElement);
 
 						if (IE9AndLater) {
 							if (!editor.window.$.AlloyEditor) {
-								var emptySelectionMarkup = '&nbsp;';
-
-								emptySelectionMarkup =
-									elementOuterHtml + emptySelectionMarkup;
-
-								editor.insertHtml(emptySelectionMarkup);
+								editor.insertHtml('&nbsp;');
 							}
 
 							var element = new CKEDITOR.dom.element('br');


### PR DESCRIPTION
In this change, we use CKEDITOR's `insertElement` method instead of
`insertHtml` - for some reason on IE, this was preventing the modal to be closed

Before fix:

![](https://user-images.githubusercontent.com/5572/94438161-03cb1200-019f-11eb-9a07-c23eb3d72c40.gif)

After fix:

![](https://user-images.githubusercontent.com/5572/94438182-0b8ab680-019f-11eb-9b46-9e353cab1c8d.gif)

**Test plan**

- Fetch this branch and deploy the `frontend-editor-ckeditor-web` module
- Open IE 11 
- Navigate to "Content & Data" > "Knowledge Base"
- Click on the blue "+" button in the top right and select "Basic" Article"
 - Add an image from the editor
- Assert that the selected image is inserted and that the modal is closed