### PR TITLE
Proposal - Reduce JS code on JSPs

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
@@ -52,6 +52,41 @@ portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
 
 renderResponse.setTitle((entry != null) ? BlogsEntryUtil.getDisplayTitle(resourceBundle, entry) : LanguageUtil.get(request, "new-blog-entry"));
+
+Map<String, Object> constants = HashMapBuilder.<String, Object>put(
+	"ACTION_PUBLISH", WorkflowConstants.ACTION_PUBLISH
+).put(
+	"ACTION_SAVE_DRAFT", WorkflowConstants.ACTION_SAVE_DRAFT
+).put(
+	"ADD", Constants.ADD
+).put(
+	"CMD", Constants.CMD
+).put(
+	"STATUS_DRAFT", WorkflowConstants.STATUS_DRAFT
+).put(
+	"UPDATE", Constants.UPDATE
+).build();
+
+Map<String, Object> context = HashMapBuilder.<String, Object>put(
+	"constants", constants
+).put(
+	"customAbstract", Constants.DELETE
+).put(
+	"descriptionLength", PropsValues.BLOGS_PAGE_ABSTRACT_LENGTH
+).put(
+	"rootPortletId", portletDisplay.getRootPortletId()
+).build();
+
+if (entry != null) {
+	context.put("content", UnicodeFormatter.toString(content));
+	context.put("customDescription", Constants.DELETE);
+	context.put("description", UnicodeFormatter.toString(description));
+	context.put("pending", entry.isPending());
+	context.put("status", entry.getStatus());
+	context.put("subtitle", UnicodeFormatter.toString(subtitle));
+	context.put("title", UnicodeFormatter.toString(title));
+	context.put("userId", entry.getUserId());
+}
 %>
 
 <portlet:actionURL name="/blogs/edit_entry" var="editEntryURL" />
@@ -449,48 +484,17 @@ renderResponse.setTitle((entry != null) ? BlogsEntryUtil.getDisplayTitle(resourc
 	</c:if>
 </aui:script>
 
-<aui:script use="liferay-blogs">
-	var blogs = Liferay.component(
-		'<portlet:namespace />Blogs',
-		new Liferay.Blogs({
-			constants: {
-				ACTION_PUBLISH: '<%= WorkflowConstants.ACTION_PUBLISH %>',
-				ACTION_SAVE_DRAFT: '<%= WorkflowConstants.ACTION_SAVE_DRAFT %>',
-				ADD: '<%= Constants.ADD %>',
-				CMD: '<%= Constants.CMD %>',
-				STATUS_DRAFT: '<%= WorkflowConstants.STATUS_DRAFT %>',
-				UPDATE: '<%= Constants.UPDATE %>',
-			},
-			descriptionLength: '<%= PropsValues.BLOGS_PAGE_ABSTRACT_LENGTH %>',
-			editEntryURL: '<%= editEntryURL %>',
-
-			<c:if test="<%= entry != null %>">
-				entry: {
-					content: '<%= UnicodeFormatter.toString(content) %>',
-					customDescription: <%= customAbstract %>,
-					description: '<%= UnicodeFormatter.toString(description) %>',
-					pending: <%= entry.isPending() %>,
-					status: '<%= entry.getStatus() %>',
-					subtitle: '<%= UnicodeFormatter.toString(subtitle) %>',
-					title: '<%= UnicodeFormatter.toString(title) %>',
-					userId: '<%= entry.getUserId() %>',
-				},
-			</c:if>
-
-			namespace: '<portlet:namespace />',
-		})
-	);
-
-	var clearSaveDraftHandle = function (event) {
-		if (event.portletId === '<%= portletDisplay.getRootPortletId() %>') {
-			blogs.destroy();
-
-			Liferay.detach('destroyPortlet', clearSaveDraftHandle);
-		}
-	};
-
-	Liferay.on('destroyPortlet', clearSaveDraftHandle);
-</aui:script>
+<liferay-frontend:component
+	componentId="<portlet:namespace />Blogs"
+	context='<%=
+		HashMapBuilder.<String, Object>put(
+			"context", context
+		).put(
+			"editEntryURL", editEntryURL
+		).build()
+	%>'
+	module="blogs/js/blogs_main.es"
+/>
 
 <%
 if (entry != null) {

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs_main.es.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs_main.es.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function blogsMain({
+	context: {constants, descriptionLength, rootPortletId, ...entry},
+	editEntryURL,
+	namespace,
+}) {
+	AUI().use('liferay-blogs', () => {
+		const blogs = new Liferay.Blogs({
+			constants,
+			descriptionLength,
+			editEntryURL,
+			entry,
+			namespace,
+		});
+
+		function clearSaveDraftHandle(event) {
+			if (event.portletId === rootPortletId) {
+				blogs.destroy();
+
+				Liferay.detach('destroyPortlet', clearSaveDraftHandle);
+			}
+		}
+
+		Liferay.on('destroyPortlet', clearSaveDraftHandle);
+	});
+}

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogImagesManagementToolbarHandler.es.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogImagesManagementToolbarHandler.es.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+function deleteImages({constantsCMD, constantsDELETE, namespace}) {
+	if (
+		confirm(
+			Liferay.Language.get(
+				'are-you-sure-you-want-to-delete-the-selected-images'
+			)
+		)
+	) {
+		const form = document.getElementById(`${namespace}fm`);
+
+		if (form) {
+			const cmd = form.querySelector(`#${namespace}${constantsCMD}`);
+
+			if (cmd) {
+				cmd.setAttribute('value', constantsDELETE);
+			}
+
+			const deleteFileEntryIds = form.querySelector(
+				`#${namespace}deleteFileEntryIds`
+			);
+
+			if (deleteFileEntryIds) {
+				deleteFileEntryIds.setAttribute(
+					'value',
+					Liferay.Util.listCheckedExcept(
+						form,
+						`${namespace}allRowIds`
+					)
+				);
+			}
+
+			submitForm(form);
+		}
+	}
+}
+
+const ACTIONS = {
+	deleteImages,
+};
+
+export default function BlogImagesManagementToolbarHandler(props) {
+	Liferay.componentReady('blogImagesManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				const itemData = event?.data?.item?.data;
+
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action](props);
+				}
+			});
+		}
+	);
+}

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
@@ -110,56 +110,14 @@ String displayStyle = blogImagesManagementToolbarDisplayContext.getDisplayStyle(
 	</aui:form>
 </clay:container-fluid>
 
-<aui:script>
-	var deleteImages = function () {
-		if (
-			confirm(
-				'<liferay-ui:message key="are-you-sure-you-want-to-delete-the-selected-images" />'
-			)
-		) {
-			var form = document.getElementById('<portlet:namespace />fm');
-
-			if (form) {
-				var cmd = form.querySelector(
-					'#<portlet:namespace /><%= Constants.CMD %>'
-				);
-
-				if (cmd) {
-					cmd.setAttribute('value', '<%= Constants.DELETE %>');
-				}
-
-				var deleteFileEntryIds = form.querySelector(
-					'#<portlet:namespace />deleteFileEntryIds'
-				);
-
-				if (deleteFileEntryIds) {
-					deleteFileEntryIds.setAttribute(
-						'value',
-						Liferay.Util.listCheckedExcept(
-							form,
-							'<portlet:namespace />allRowIds'
-						)
-					);
-				}
-
-				submitForm(form);
-			}
-		}
-	};
-
-	var ACTIONS = {
-		deleteImages: deleteImages,
-	};
-
-	Liferay.componentReady('blogImagesManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
-
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
-</aui:script>
+<liferay-frontend:component
+	componentId="<portlet:namespace />BlogImagesManagementToolbarHandler"
+	context='<%=
+		HashMapBuilder.<String, Object>put(
+			"constantsCMD", Constants.CMD
+		).put(
+			"constantsDELETE", Constants.DELETE
+		).build()
+	%>'
+	module="blogs_admin/js/BlogImagesManagementToolbarHandler.es"
+/>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
@@ -26,6 +26,11 @@ if (organizationId > 0) {
 
 	organizationName = organization.getName();
 }
+
+PortletURL selectOrganizationURL = PortletProviderUtil.getPortletURL(request, Organization.class.getName(), PortletProvider.Action.BROWSE);
+
+selectOrganizationURL.setParameter("tabs1", "organizations");
+selectOrganizationURL.setWindowState(LiferayWindowState.POP_UP);
 %>
 
 <liferay-portlet:actionURL portletConfiguration="<%= true %>" var="configurationActionURL" />
@@ -61,10 +66,17 @@ if (organizationId > 0) {
 					<aui:button name="removeOrganizationButton" onClick="<%= taglibRemoveFolder %>" value="remove" />
 				</div>
 
-				<aui:script sandbox="<%= true %>">
-					var <portlet:namespace />selectOrganizationButton = document.getElementById(
-						'<portlet:namespace />selectOrganizationButton'
-					);
+				<liferay-frontend:component
+					componentId="<portlet:namespace />selectOrganization"
+					context='<%=
+						HashMapBuilder.<String, Object>put(
+							"title", LanguageUtil.format(locale, "select-x", "organization")
+						).put(
+							"url", selectOrganizationURL.toString()
+						).build()
+					%>'
+					module="blogs_aggregator/js/SelectOrganization.es"
+				/>
 
 				<liferay-frontend:component
 					componentId="<portlet:namespace />handleSelectionMethod"

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
@@ -66,93 +66,10 @@ if (organizationId > 0) {
 						'<portlet:namespace />selectOrganizationButton'
 					);
 
-					<portlet:namespace />selectOrganizationButton.addEventListener(
-						'click',
-						function (event) {
-							Liferay.Util.openSelectionModal({
-								onSelect: function (event) {
-									var form = document.getElementById('<portlet:namespace />fm');
-
-									if (form) {
-										var organizationId = form.querySelector(
-											'#<portlet:namespace />organizationId'
-										);
-
-										if (organizationId) {
-											organizationId.setAttribute('value', event.entityid);
-										}
-
-										var organizationName = form.querySelector(
-											'#<portlet:namespace />organizationName'
-										);
-
-										if (organizationName) {
-											organizationName.setAttribute(
-												'value',
-												event.entityname
-											);
-										}
-									}
-
-									Liferay.Util.toggleDisabled(
-										'#<portlet:namespace />removeOrganizationButton',
-										false
-									);
-								},
-
-								<%
-								String portletId = PortletProviderUtil.getPortletId(User.class.getName(), PortletProvider.Action.VIEW);
-								%>
-
-								selectEventName:
-									'<%= PortalUtil.getPortletNamespace(portletId) %>selectOrganization',
-
-								title:
-									'<liferay-ui:message arguments="organization" key="select-x" />',
-
-								<%
-								PortletURL selectOrganizationURL = PortletProviderUtil.getPortletURL(request, Organization.class.getName(), PortletProvider.Action.BROWSE);
-
-								selectOrganizationURL.setParameter("tabs1", "organizations");
-								selectOrganizationURL.setWindowState(LiferayWindowState.POP_UP);
-								%>
-
-								url: '<%= selectOrganizationURL.toString() %>',
-							});
-						}
-					);
-				</aui:script>
-
-				<aui:script require="metal-dom/src/dom">
-					var dom = metalDomSrcDom.default;
-
-					var <portlet:namespace />selectionMethod = document.getElementById(
-						'<portlet:namespace />selectionMethod'
-					);
-
-					if (<portlet:namespace />selectionMethod) {
-						<portlet:namespace />selectionMethod.addEventListener('change', function (
-							event
-						) {
-							var usersSelectionOptions = document.getElementById(
-								'<portlet:namespace />usersSelectionOptions'
-							);
-
-							if (usersSelectionOptions) {
-								var showUsersSelectionOptions = !(
-									<portlet:namespace />selectionMethod.val() === 'users'
-								);
-
-								if (showUsersSelectionOptions) {
-									dom.addClasses(usersSelectionOptions, 'hide');
-								}
-								else {
-									dom.removeClasses(usersSelectionOptions, 'hide');
-								}
-							}
-						});
-					}
-				</aui:script>
+				<liferay-frontend:component
+					componentId="<portlet:namespace />handleSelectionMethod"
+					module="blogs_aggregator/js/handleSelectionMethod.es"
+				/>
 
 				<aui:select name="preferences--displayStyle--" value="<%= displayStyle %>">
 					<aui:option label="body-and-image" />

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/js/SelectOrganization.es.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/js/SelectOrganization.es.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {openSelectionModal, toggleDisabled} from 'frontend-js-web';
+
+export default function selectOrganization({namespace, title, url}) {
+	const selectEventName = `${namespace}selectOrganization`;
+
+	const selectOrganizationButton = document.getElementById(
+		`${namespace}selectOrganizationButton`
+	);
+
+	selectOrganizationButton.addEventListener('click', () =>
+		openSelectionModal({
+			onSelect: (event) => {
+				const form = document.getElementById(`${namespace}fm`);
+
+				if (form) {
+					const organizationId = form.querySelector(
+						`#${namespace}organizationId`
+					);
+
+					if (organizationId) {
+						organizationId.setAttribute('value', event.entityid);
+					}
+
+					const organizationName = form.querySelector(
+						`#${namespace}organizationName`
+					);
+
+					if (organizationName) {
+						organizationName.setAttribute(
+							'value',
+							event.entityname
+						);
+					}
+				}
+
+				toggleDisabled(`#${namespace}removeOrganizationButton`, false);
+			},
+			selectEventName,
+			title,
+			url,
+		})
+	);
+}

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/js/handleSelectionMethod.es.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/js/handleSelectionMethod.es.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {addClasses, removeClasses} from 'metal-dom';
+
+export default function handleSelectionMethod({namespace}) {
+	const selectionMethodElement = document.getElementById(
+		`${namespace}selectionMethod`
+	);
+
+	if (selectionMethodElement) {
+		selectionMethodElement.addEventListener('change', () => {
+			const usersSelectionOptions = document.getElementById(
+				`${namespace}usersSelectionOptions`
+			);
+
+			if (usersSelectionOptions) {
+				const showUsersSelectionOptions = !(
+					selectionMethodElement.value === 'users'
+				);
+
+				if (showUsersSelectionOptions) {
+					addClasses(usersSelectionOptions, 'hide');
+				}
+				else {
+					removeClasses(usersSelectionOptions, 'hide');
+				}
+			}
+		});
+	}
+}


### PR DESCRIPTION
# Reduce JS code on JSPs

## JS code outside a web/taglib module within a `aui:script`
We don’t have any occurrence alongside JSP code in non-web modules.

See:

![546AC47E-A4A3-46DC-BE54-E61A29FEB5BC](https://user-images.githubusercontent.com/7663513/94499495-3d1d7500-01d3-11eb-8c2e-9aace3e87e05.png)

However, we have some `script`s (without an `aui:script` tag loaded by Java, via string bundler and by [iframe.jsp](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/deploy/dependencies/iframe.jsp#L56..L123) JSP.

![EDB18ADC-A571-43DE-8624-BE5A2486DD02](https://user-images.githubusercontent.com/7663513/94499519-4870a080-01d3-11eb-9eb5-e0d95cc76979.png)

We can use (#AUI-specific-cases) caveat in this case.

## JS code inside a web/taglib module

1. Search where JS code is being stored and create a file with a `.js` extension there
2. Abstract and use modern syntax for importing dependencies listed on the `use` property

We can use `liferay-frontend:component` taglib to pass the pass of the JS file containing the logic.

## AUI specific cases

### For AUI components:
When requiring AUI components(in this example, `liferay-example-module`, We could takes this action:

1. Check if the desired AUI module is inserted on the a `config.js` file
2. Create a folder called `js/` where We can place the JS files related for it
3. Inside each JS file, we could dynamic import an AUI module like this example:

```js
AUI().use('liferay-example-module', () => {
	    // Use our module here, as the content within the `aui:script` tag
		const EM = new Liferay.ExampleModule({...});
	});
);
```

4. Then we can use `liferay-frontend:component` tag lib to load this JS file when requiring the page

## Questions

* I don’t have too much certain about the usage of `liferay-frontend:component` taglib. Is this the most indicated approach for adding a JS resource on the page. We have other ways to load a JS file on the page. See https://github.com/liferay/liferay-frontend-guidelines/blob/master/dxp/resource_injection.md#dynamicinclude-in-portal-kernel

* Sometimes we have two aui:scripts in the same page(sometimes an AUI component and a pure JS component). Could we have a double `liferay-frontend:component` call in this situation?(It works well but I don't know if it fits properly)