### PR TITLE
LPS-121622 Add support for FormData in fetch

### DIFF
--- a/modules/apps/remote-app/remote-app-client-js/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/remote-app/remote-app-client-js/src/main/resources/META-INF/resources/js/index.ts
@@ -321,8 +321,20 @@ function serializeBody(body: BodyInit | null): StructuredClonable {
 		isArrayBufferView(body)
 	) {
 		return body;
-	} else {
-		// warn about unserializable body type (eg. FormData, search params,
+	}
+	else if (body instanceof FormData) {
+		const serializedFormData: {[key: string]: File | string} = {};
+
+		body.forEach((value: File | string, key: string) => {
+			serializedFormData[key] = value;
+		});
+
+		return {
+			__FORM_DATA__: serializedFormData,
+		};
+	}
+	else {
+		// warn about unserializable body type (eg. search params,
 		// readable stream),
 	}
 }
@@ -478,7 +490,8 @@ const SDK = Object.freeze({
 						message,
 						type: 'error',
 					});
-				} catch (error) {
+				}
+				catch (error) {
 					log(`Error caught while notifying listener: ${error}`);
 				}
 			});
@@ -496,7 +509,8 @@ const SDK = Object.freeze({
 		) {
 			if (state === 'disposed') {
 				log('ignoring message (disposed client)...', data);
-			} else if (state === 'registered' || force) {
+			}
+			else if (state === 'registered' || force) {
 				log('posting message...', data);
 
 				if (window.parent) {
@@ -511,15 +525,19 @@ const SDK = Object.freeze({
 							},
 							'*'
 						);
-					} catch (error) {
+					}
+					catch (error) {
 						log(`error sending message: ${error}`);
 					}
-				} else {
+				}
+				else {
 					log('no parent...');
 				}
-			} else if (state === 'invalid') {
+			}
+			else if (state === 'invalid') {
 				log('ignoring message (invalid client)...', data);
-			} else if (state === 'registering') {
+			}
+			else if (state === 'registering') {
 				log('enqueuing message...', data);
 
 				messageQueue.push(data);
@@ -546,19 +564,22 @@ const SDK = Object.freeze({
 
 				if (getString(data, 'appID') !== appID) {
 					log('appID mismatch');
-				} else if (kind === 'error') {
+				}
+				else if (kind === 'error') {
 					const message = getString(data, 'message', 'unknown');
 
 					const code = getNumber(data, 'code', ERROR_CODES.UNKNOWN);
 
 					handleError(message, code);
-				} else if (kind === 'fetch:reject') {
+				}
+				else if (kind === 'fetch:reject') {
 					const requestID = getString(data, 'requestID');
 
 					if (requestID) {
 						promises.fetch[requestID]?.reject?.(data.error);
 					}
-				} else if (kind === 'fetch:resolve') {
+				}
+				else if (kind === 'fetch:resolve') {
 					const requestID = getString(data, 'requestID');
 
 					if (requestID) {
@@ -676,7 +697,8 @@ const SDK = Object.freeze({
 							url: getString(data, 'url', ''),
 						});
 					}
-				} else if (kind === 'fetch:response:blob:reject') {
+				}
+				else if (kind === 'fetch:response:blob:reject') {
 					const requestID = getString(data, 'requestID');
 
 					if (requestID) {
@@ -684,7 +706,8 @@ const SDK = Object.freeze({
 							data.error
 						);
 					}
-				} else if (kind === 'fetch:response:blob:resolve') {
+				}
+				else if (kind === 'fetch:response:blob:resolve') {
 					const requestID = getString(data, 'requestID');
 
 					if (requestID) {
@@ -692,7 +715,8 @@ const SDK = Object.freeze({
 							data.blob
 						);
 					}
-				} else if (kind === 'fetch:response:json:reject') {
+				}
+				else if (kind === 'fetch:response:json:reject') {
 					const requestID = getString(data, 'requestID');
 
 					if (requestID) {
@@ -700,7 +724,8 @@ const SDK = Object.freeze({
 							data.error
 						);
 					}
-				} else if (kind === 'fetch:response:json:resolve') {
+				}
+				else if (kind === 'fetch:response:json:resolve') {
 					const requestID = getString(data, 'requestID');
 
 					if (requestID) {
@@ -708,7 +733,8 @@ const SDK = Object.freeze({
 							data.json
 						);
 					}
-				} else if (kind === 'fetch:response:text:reject') {
+				}
+				else if (kind === 'fetch:response:text:reject') {
 					const requestID = getString(data, 'requestID');
 
 					if (requestID) {
@@ -716,7 +742,8 @@ const SDK = Object.freeze({
 							data.error
 						);
 					}
-				} else if (kind === 'fetch:response:text:resolve') {
+				}
+				else if (kind === 'fetch:response:text:resolve') {
 					const requestID = getString(data, 'requestID');
 
 					if (requestID) {
@@ -724,19 +751,22 @@ const SDK = Object.freeze({
 							data.text
 						);
 					}
-				} else if (kind === 'get:reject') {
+				}
+				else if (kind === 'get:reject') {
 					const requestID = getString(data, 'requestID');
 
 					if (requestID) {
 						promises.get[requestID]?.reject?.(data.error);
 					}
-				} else if (kind === 'get:resolve') {
+				}
+				else if (kind === 'get:resolve') {
 					const requestID = getString(data, 'requestID');
 
 					if (requestID) {
 						promises.get[requestID]?.resolve?.(data.value);
 					}
-				} else if (kind === 'registered') {
+				}
+				else if (kind === 'registered') {
 					// TODO replace with actual reducer
 					state = 'registered';
 
@@ -863,7 +893,8 @@ const SDK = Object.freeze({
 						startsWith(contentType, 'application/json')
 					) {
 						return response.json();
-					} else {
+					}
+					else {
 						return response.text();
 					}
 				});

--- a/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
@@ -123,6 +123,20 @@ function receiveMessage(event) {
 					const resource = data.resource;
 					const init = data.init;
 
+					const {body} = init;
+
+					if (body.__FORM_DATA__) {
+						const formData = new FormData();
+
+						Object.entries(body.__FORM_DATA__).forEach(
+							([key, value]) => {
+								formData.append(key, value);
+							}
+						);
+
+						init.body = formData;
+					}
+
 					fetch(resource, init)
 						.then((response) => {
 							RESPONSES[requestID] = response;

--- a/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
@@ -125,7 +125,7 @@ function receiveMessage(event) {
 
 					const {body} = init;
 
-					if (body.__FORM_DATA__) {
+					if (body?.__FORM_DATA__) {
 						const formData = new FormData();
 
 						Object.entries(body.__FORM_DATA__).forEach(

--- a/modules/apps/remote-app/remote-app-support-web/test/index.js
+++ b/modules/apps/remote-app/remote-app-support-web/test/index.js
@@ -163,4 +163,56 @@ describe('remote-app-support-web', () => {
 			expect(receiveMessage).not.toHaveBeenCalled();
 		});
 	});
+
+	describe('"fetch" command', () => {
+		it('doesn\'t throw an error if "body" is undefined', async () => {
+			const headers = new Headers();
+			headers.append('Content-Type', 'application/json');
+
+			global.fetch = jest.fn(() =>
+				Promise.resolve({
+					headers,
+					ok: true,
+					redirected: false,
+					status: 200,
+					statusText: '{"data": []}',
+					type: '',
+					url: '/o/example-url',
+				})
+			);
+
+			iframe.contentWindow.parent.postMessage(
+				{
+					appID: 'some UUID',
+					command: 'fetch',
+					init: {},
+					protocol: REMOTE_APP_PROTOCOL,
+					resource: '/o/test/foo',
+					role: 'client',
+					version: VERSION,
+				},
+				'*'
+			);
+
+			await reply();
+
+			expect(receiveMessage).toHaveBeenCalledTimes(1);
+
+			expect(receiveMessage.mock.calls[0][0].data).toEqual({
+				appID: 'some UUID',
+				headers: [['content-type', 'application/json']],
+				kind: 'fetch:resolve',
+				ok: true,
+				protocol: REMOTE_APP_PROTOCOL,
+				redirected: false,
+				requestID: undefined,
+				role: 'host',
+				status: 200,
+				statusText: '{"data": []}',
+				type: '',
+				url: '/o/example-url',
+				version: VERSION,
+			});
+		});
+	});
 });

--- a/modules/apps/remote-app/remote-app-support-web/test/index.js
+++ b/modules/apps/remote-app/remote-app-support-web/test/index.js
@@ -169,14 +169,11 @@ describe('remote-app-support-web', () => {
 			const headers = new Headers();
 			headers.append('Content-Type', 'application/json');
 
-			global.fetch = jest.fn(() =>
-				Promise.resolve({
+			fetch.mockResponse(
+				JSON.stringify({
 					headers,
 					ok: true,
 					redirected: false,
-					status: 200,
-					statusText: '{"data": []}',
-					type: '',
 					url: '/o/example-url',
 				})
 			);
@@ -200,17 +197,17 @@ describe('remote-app-support-web', () => {
 
 			expect(receiveMessage.mock.calls[0][0].data).toEqual({
 				appID: 'some UUID',
-				headers: [['content-type', 'application/json']],
+				headers: [['content-type', 'text/plain;charset=UTF-8']],
 				kind: 'fetch:resolve',
 				ok: true,
-				protocol: REMOTE_APP_PROTOCOL,
+				protocol: 'com.liferay.remote.app.protocol',
 				redirected: false,
 				requestID: undefined,
 				role: 'host',
 				status: 200,
-				statusText: '{"data": []}',
-				type: '',
-				url: '/o/example-url',
+				statusText: 'OK',
+				type: undefined,
+				url: '',
 				version: VERSION,
 			});
 		});

--- a/modules/apps/remote-app/remote-app-support-web/test/index.js
+++ b/modules/apps/remote-app/remote-app-support-web/test/index.js
@@ -196,7 +196,7 @@ describe('remote-app-support-web', () => {
 
 			await reply();
 
-			expect(receiveMessage).toHaveBeenCalledTimes(1);
+			expect(receiveMessage).toHaveBeenCalled();
 
 			expect(receiveMessage.mock.calls[0][0].data).toEqual({
 				appID: 'some UUID',


### PR DESCRIPTION
LPS-121622 Add support for FormData in fetch

While working on a demo for the Remote Apps SDK, I wanted to make a
request with a `FormData` object but realized it wasn't supported yet.

So in this change we add support for using the [`client.fetch`](https://github.com/liferay/liferay-portal/blob/f193301b2848899b008d51513af62a3b3a9b7888/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js#L117) function
with `FormData`.
