### PR TITLE
LPS-121656 Add siteGroupId property to Remote App SDK

### DIFF
--- a/modules/apps/remote-app/remote-app-client-js/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/remote-app/remote-app-client-js/src/main/resources/META-INF/resources/js/index.ts
@@ -45,8 +45,9 @@ type GettableProperties =
 	| 'css'
 	| 'defaultLanguageId'
 	| 'isControlPanel'
-	| 'languageId'
 	| 'isSignedIn'
+	| 'languageId'
+	| 'siteGroupId'
 	| 'userId'
 	| 'userName';
 

--- a/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
@@ -257,11 +257,14 @@ function receiveMessage(event) {
 
 						value = Liferay.ThemeDisplay.isControlPanel();
 					}
+					else if (property === 'isSignedIn') {
+						value = Liferay.ThemeDisplay.isSignedIn();
+					}
 					else if (property === 'languageId') {
 						value = Liferay.ThemeDisplay.getLanguageId();
 					}
-					else if (property === 'isSignedIn') {
-						value = Liferay.ThemeDisplay.isSignedIn();
+					else if (property === 'siteGroupId') {
+						value = Liferay.ThemeDisplay.getSiteGroupId();
 					}
 					else if (property === 'userId') {
 						value = Liferay.ThemeDisplay.getUserId();


### PR DESCRIPTION
`siteKey` (or `siteGroupId`) is needed to use a lot of the Liferay API so it's probably a good idea to add this property to the available list in the SDK