### PR TITLE
LPS-121748 Remove border on iframe

### DIFF
--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/display/css/main.css
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/display/css/main.css
@@ -1,5 +1,5 @@
 .portlet-remote-app iframe {
-	border: none;
+	border: 0;
 	min-height: 500px;
 	width: 100%;
 }

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/display/css/main.css
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/META-INF/resources/display/css/main.css
@@ -1,4 +1,5 @@
 .portlet-remote-app iframe {
-    min-height: 500px;
-    width: 100%;
+	border: none;
+	min-height: 500px;
+	width: 100%;
 }


### PR DESCRIPTION
When adding a Remote App to DXP, the `iframe` in which the Remote App is
loaded has an unneeded border. Ideally this should be configurable but
right now, because of [LPS-121720](https://issues.liferay.com/browse/LPS-121720),
the Page Editor is not really usable so the easiest way to achieve this
is via CSS.

**Before**

![](https://user-images.githubusercontent.com/5572/95063149-45f3d680-06fe-11eb-8b86-ac9a90475a31.png)

**After**

![](https://user-images.githubusercontent.com/5572/95063179-4f7d3e80-06fe-11eb-985c-65a5f11b8614.png)

