### PR TITLE
LPS-121302 - Remove no needed aria-expanded

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/templates/navigation.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/templates/navigation.ftl
@@ -3,7 +3,7 @@
 		<span class="navbar-toggler-icon"></span>
 	</button>
 
-	<div aria-expanded="false" class="collapse navbar-collapse" id="navigationCollapse">
+	<div aria-expanded="false" class="collapse navbar-collapse" id="navigationCollapse" role="button">
 		<@liferay.navigation_menu default_preferences="${preferences}" />
 	</div>
 </#if>

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/templates/navigation.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/templates/navigation.ftl
@@ -3,7 +3,7 @@
 		<span class="navbar-toggler-icon"></span>
 	</button>
 
-	<div aria-expanded="false" class="collapse navbar-collapse" id="navigationCollapse" role="button">
+	<div class="collapse navbar-collapse" id="navigationCollapse">
 		<@liferay.navigation_menu default_preferences="${preferences}" />
 	</div>
 </#if>


### PR DESCRIPTION
Remove no needed aria in order to fix validation error:

![image](https://user-images.githubusercontent.com/7963804/95321816-de738d80-089b-11eb-9376-cac225551d5d.png)


--- 

**How to test this:**

- Go to a widget page.
- Get the main navigation markup
- Use validator.w3.org to validate it 