### PR TITLE
LPS-121775 null check on the new value before we render it

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/fullscreen_source_editor.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/fullscreen_source_editor.js
@@ -135,7 +135,7 @@ AUI.add(
 				_onEditorChange(event) {
 					var instance = this;
 
-					if (event.newVal) {
+					if (event.newVal || event.newVal === '') {
 						instance._previewPanel.html(
 							instance._getHtml(event.newVal)
 						);

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/fullscreen_source_editor.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/fullscreen_source_editor.js
@@ -135,9 +135,11 @@ AUI.add(
 				_onEditorChange(event) {
 					var instance = this;
 
-					instance._previewPanel.html(
-						instance._getHtml(event.newVal)
-					);
+					if (event.newVal) {
+						instance._previewPanel.html(
+							instance._getHtml(event.newVal)
+						);
+					}
 				},
 
 				_onLayoutChange(event) {


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

**Steps to reproduce**

1. Create a blank page.
2. From the 'Fragments' list add the basic component 'HTML'
3. Edit default text
4. Popup to edit is opened. Make some changes and you'll see them in the Preview on the right side of that window. So far, so good.
5. Now, just click on the right side of that window, where the preview is being shown.

**Expected behavior**
Nothing happens.

**Actual behavior**
Preview text is changed by 'undefined'

**Solution**
You can see original message from @NemethNorbert

> Hey,
> 
> LPS-121775
> When we click outside of the editor the value we render is undefined, I made a null check to solve it.
> Please review my changes.
> 
> Thanks

Thanks.

Regards.