### PR TITLE
CLDSVCS-4198 Dashboard Users Portlet Soy template Does Not Work

### DIFF
--- a/modules/apps/portal-template/portal-template-soy-impl/src/main/java/com/liferay/portal/template/soy/internal/SoyTemplateRecord.java
+++ b/modules/apps/portal-template/portal-template-soy-impl/src/main/java/com/liferay/portal/template/soy/internal/SoyTemplateRecord.java
@@ -322,6 +322,7 @@ public class SoyTemplateRecord extends SoyAbstractValue implements SoyRecord {
 
 				if ((parameterTypes.length == 0) &&
 					!returnType.equals(Void.class) &&
+					!returnType.equals(void.class) &&
 					!declaringClass.equals(Object.class) &&
 					!declaringClass.equals(Annotation.class)) {
 


### PR DESCRIPTION
A simple fix to account for `void` return type in `SoyTemplateRecord` (and avoiding putting it into the `HashMap`; because if it returns `void` it's clearly not a getter).