### PR TITLE
LPS-121977 Update `@liferay/npm-scripts` to v33.1.3

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@liferay/npm-scripts": "33.1.2",
+		"@liferay/npm-scripts": "33.1.3",
 		"acorn": "7.1.0",
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1931,24 +1931,24 @@
     strip-ansi "6.0.0"
     xml "^1.0.1"
 
-"@liferay/npm-bundler-preset-liferay-dev@4.6.3":
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-bundler-preset-liferay-dev/-/npm-bundler-preset-liferay-dev-4.6.3.tgz#7ff6753516c2a363996f280caa798458eab6ed40"
-  integrity sha512-JItq3R2HoRyiScuVs++DAmOpM+M9sV2gbTjMA2ovAhvOU/q+C1TtWvhTlxYGBoPVWnMN9RIC7l4VdNBMODrq1A==
+"@liferay/npm-bundler-preset-liferay-dev@4.6.4":
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-bundler-preset-liferay-dev/-/npm-bundler-preset-liferay-dev-4.6.4.tgz#142f092f6bd8354bba6252df1c56b05ff9856026"
+  integrity sha512-PIIfnnFfLIjanKa5glB2s0w7rxEzQklm+u5sbxq9/UoBIMAaWgn7F0o4/Pm+jhnQPWn/IM2OetPEQ+EnIoeMgA==
   dependencies:
-    babel-preset-liferay-standard "2.19.3"
-    liferay-npm-bundler-loader-css-loader "2.19.3"
-    liferay-npm-bundler-plugin-exclude-imports "2.19.3"
-    liferay-npm-bundler-plugin-inject-imports-dependencies "2.19.3"
-    liferay-npm-bundler-plugin-inject-peer-dependencies "2.19.3"
-    liferay-npm-bundler-plugin-namespace-packages "2.19.3"
-    liferay-npm-bundler-plugin-replace-browser-modules "2.19.3"
-    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.3"
+    babel-preset-liferay-standard "2.19.4"
+    liferay-npm-bundler-loader-css-loader "2.19.4"
+    liferay-npm-bundler-plugin-exclude-imports "2.19.4"
+    liferay-npm-bundler-plugin-inject-imports-dependencies "2.19.4"
+    liferay-npm-bundler-plugin-inject-peer-dependencies "2.19.4"
+    liferay-npm-bundler-plugin-namespace-packages "2.19.4"
+    liferay-npm-bundler-plugin-replace-browser-modules "2.19.4"
+    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.4"
 
-"@liferay/npm-scripts@33.1.2":
-  version "33.1.2"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-33.1.2.tgz#7ac078842eafdeb5f9a16802f6627b4b9f42d3d6"
-  integrity sha512-OcKliuh0hP3l3aw6IxA+VdwYBRviJRC/hUXBmt5yBi/zttmUT2ZOlRNvuKRcppMszK6e9eiumwBuwk4cjfknyg==
+"@liferay/npm-scripts@33.1.3":
+  version "33.1.3"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-33.1.3.tgz#df33318d84b12d15a76eef0ce786f59f48389686"
+  integrity sha512-oQE1hEx/4HZ5H+74dBrH1IFPLOLEdxON5vLkJl2cYZa8IBhYsohunTmQUHM5n8pMOJHyYG9fnMO4UKrvj+YGNQ==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"
@@ -1962,7 +1962,7 @@
     "@babel/preset-typescript" "^7.10.4"
     "@liferay/eslint-config" "21.2.1"
     "@liferay/jest-junit-reporter" "1.2.0"
-    "@liferay/npm-bundler-preset-liferay-dev" "4.6.3"
+    "@liferay/npm-bundler-preset-liferay-dev" "4.6.4"
     "@storybook/addon-a11y" "^5.1.9"
     "@storybook/addon-actions" "^5.1.9"
     "@storybook/addon-knobs" "^5.1.9"
@@ -1994,8 +1994,8 @@
     jest-environment-jsdom-thirteen "1.0.1"
     jest-fetch-mock "^3.0.3"
     liferay-lang-key-dev-loader "^1.0.3"
-    liferay-npm-bridge-generator "2.19.3"
-    liferay-npm-bundler "2.19.3"
+    liferay-npm-bridge-generator "2.19.4"
+    liferay-npm-bundler "2.19.4"
     liferay-theme-tasks "10.0.2"
     metal-tools-soy "4.3.2"
     mini-css-extract-plugin "0.11.2"
@@ -4379,12 +4379,12 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-add-module-metadata@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.19.3.tgz#df8e8ceb6d5c9731233f2976cc78b761a19a400a"
-  integrity sha512-Pr1POoMGQ8X6UVkfWrEmSDrJwV3RpCuRGy2BOF+vmIaZWrA1Tw2+DPj7QLaMGeGKtTDC7AFd39/1KgMeCl7BCw==
+babel-plugin-add-module-metadata@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.19.4.tgz#2359d427fa2230ffe91bc425ac313fdfbc35076b"
+  integrity sha512-OaDRjCDZymLIxv7DDh6NDJyTTWmpi6y0fVIWrTnohhDC1VlQZmpuxStYoIQhyLy/cy/9Cn6pYcsHV8Nta46/nw==
   dependencies:
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
     read-json-sync "^2.0.1"
 
 babel-plugin-add-react-displayname@^0.0.5:
@@ -4392,12 +4392,12 @@ babel-plugin-add-react-displayname@^0.0.5:
   resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
   integrity sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=
 
-babel-plugin-alias-modules@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.19.3.tgz#ba5be61c7d008eab04ba0dc375a0ffef92dffe8e"
-  integrity sha512-hmQUSvYmorxb6/sitBc3Dcx7sqwEzd5aCUnDwFM00oThV7+d3yAFunoakqO/Jl2x0csu+3y2/9nsyLJ0TiKeeA==
+babel-plugin-alias-modules@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.19.4.tgz#6992114f094e8ef25488111b39353256a08018a3"
+  integrity sha512-Y/HDq6gnmDP7lpjatPjjuHLbL3gQBviB/8EDMyDzGubZ9NANLAVx3IIq+MYnmA3ZtDUfpyF7TNt6co0ItbZ/Zw==
   dependencies:
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
 
 babel-plugin-dynamic-import-node@2.2.0:
   version "2.2.0"
@@ -4565,38 +4565,38 @@ babel-plugin-minify-type-constructors@^0.4.3:
   dependencies:
     babel-helper-is-void-0 "^0.4.3"
 
-babel-plugin-name-amd-modules@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.19.3.tgz#63de54598dd7a5abf9d62dc862e955fccc5335ff"
-  integrity sha512-4SZ6Ykn2IZ0MkNwi5nmTOzMYku9CwCeLqnX5jfeisT4UkQ8H1KnQYPigylgFamnic2hG7woeGpIRy9UKKV2jjg==
+babel-plugin-name-amd-modules@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.19.4.tgz#b1d74f4261ab057dd715932a26028cb6791a408e"
+  integrity sha512-UvzDMP+C7vP3JopHUcL3AR3aMD1VFc5kp4iZnrA56KlQyfekjUNybEPnsN/Id1vthvPJjpVXo9DqUbO8lmpttw==
   dependencies:
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
 
 babel-plugin-named-asset-import@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.2.tgz#20978ed446b8e1bf4a2f42d0a94c0ece85f75f4f"
   integrity sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ==
 
-babel-plugin-namespace-amd-define@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.19.3.tgz#06fb0b495ffd43066126a6fc43c4c6f41bfefa12"
-  integrity sha512-gS5CjER88usk00fescrOmSvigkFqO/3CiWvh/vMCMpyHq/RH80qe1GpG0E7Qp/2FVvva44VjqJpvciSNsCrS8A==
+babel-plugin-namespace-amd-define@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.19.4.tgz#557abe510d7a85783fb2fe1df2c4a16f2fe37b68"
+  integrity sha512-uK0uEIpVcO0uvqiH+hudIMrXK1cNxcrz/XAB5VQ24+X7YRpsycovrZz8gr9AnyN/qZEnTk7pigbLlFoy8mX96Q==
   dependencies:
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
 
-babel-plugin-namespace-modules@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.19.3.tgz#166bfd20694748ba77b7af41ff6eea27a4c154a0"
-  integrity sha512-WL8C0wW0iFPWKM9HgCQBDqh6/7XXqLFkdrorRksKzhw/H7cq1WQ8HovDo1dhTyvGYXFdBP+2euB2/p055l1e7Q==
+babel-plugin-namespace-modules@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.19.4.tgz#7c4eeddbd82408100d2cd0790dbc7437d8294e73"
+  integrity sha512-hn/LH4w/jl5hy9itDoqVQ/aLHX+9IpAv6s1jsP8p4aMpsacnpCgB+nqT5/FpIh34/tBFtLDXHOpI7Wnlfb1ieg==
   dependencies:
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
 
-babel-plugin-normalize-requires@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.19.3.tgz#7f3d1b22fc09fd5963648b312f27178ada61e53a"
-  integrity sha512-DhycFI2duBaIBGDsycZR6rfnQqLQ1a2/20doK0wbHVuEirJr1kjl388kXvC6mo4nC14DaufqKupN4Gib5X8D6Q==
+babel-plugin-normalize-requires@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.19.4.tgz#852520e780267b4e20d54214e4512579405a3d62"
+  integrity sha512-4vhuAhYi+eIXkXaTBGYOop+n/bqYiQLbRdGLHBetppTqZhI2QVaE0NhqGDsN5bU2BgXJ2eOTIEMyaPaOZcqIfQ==
   dependencies:
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
 
 babel-plugin-react-docgen@^3.0.0:
   version "3.1.0"
@@ -4681,13 +4681,13 @@ babel-plugin-transform-undefined-to-void@^6.9.4:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"
   integrity sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=
 
-babel-plugin-wrap-modules-amd@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.19.3.tgz#708b33d74ce552eaaf69ddc1c6ead4430659a8ae"
-  integrity sha512-DlPKNJtmY3Iao5jZAkvIskay4nb9aujsa0PGf12E7Paf67VjTgnh3NUIvkeNPbVPie/twlC7n+fHxfN1E0x61Q==
+babel-plugin-wrap-modules-amd@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.19.4.tgz#8fd33d71f0c754a801ded2e8509a9c7a26f82aaf"
+  integrity sha512-E70+9ptcDVYs8oEb4YVXgLc1o2px7IBvrxaZCxJ4ydGBUqBtCfKx2mAjCGU/925HVp3im7KFJscNpzHCcHLzqA==
   dependencies:
     babel-template "^6.26.0"
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
     read-json-sync "^2.0.1"
 
 babel-preset-jest@^25.1.0:
@@ -4699,20 +4699,20 @@ babel-preset-jest@^25.1.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^25.1.0"
 
-babel-preset-liferay-standard@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.19.3.tgz#17f744705bfdb27135170c1d5d58957b1338cd98"
-  integrity sha512-TEU7t8c8wZJMnGlHtJSEUjwnBCc364TyRRcAoc2A5xdCsyS2NmfnnX85ZVeHDiSZMieA49Rjby+pu2ShD6G/JA==
+babel-preset-liferay-standard@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.19.4.tgz#506f8a65cc62d9c2329c5b6747aca0cdf486175c"
+  integrity sha512-Lkp0ASsldSAf6wSiK7+UHnyKIoutML4IWn1w76WvQtLv6/y0HO3riN5BwzwpPgQ0zDxposhiDMmwbFHzKEVdeg==
   dependencies:
-    babel-plugin-add-module-metadata "2.19.3"
-    babel-plugin-alias-modules "2.19.3"
+    babel-plugin-add-module-metadata "2.19.4"
+    babel-plugin-alias-modules "2.19.4"
     babel-plugin-minify-dead-code-elimination "0.5.1"
-    babel-plugin-name-amd-modules "2.19.3"
-    babel-plugin-namespace-amd-define "2.19.3"
-    babel-plugin-namespace-modules "2.19.3"
-    babel-plugin-normalize-requires "2.19.3"
+    babel-plugin-name-amd-modules "2.19.4"
+    babel-plugin-namespace-amd-define "2.19.4"
+    babel-plugin-namespace-modules "2.19.4"
+    babel-plugin-normalize-requires "2.19.4"
     babel-plugin-transform-node-env-inline "0.4.3"
-    babel-plugin-wrap-modules-amd "2.19.3"
+    babel-plugin-wrap-modules-amd "2.19.4"
 
 "babel-preset-minify@^0.5.0 || 0.6.0-alpha.5":
   version "0.5.0"
@@ -4859,7 +4859,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2, base64-js@^1.2.0:
+base64-js@^1.0.2, base64-js@^1.2.0, base64-js@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
@@ -12051,25 +12051,25 @@ liferay-lang-key-dev-loader@^1.0.3:
     loader-utils "^1.1.0"
     properties "^1.2.1"
 
-liferay-npm-bridge-generator@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.19.3.tgz#7852aebde976ce142922aa0d19acdc61494b7917"
-  integrity sha512-ropETVRU5p7hLVNqmqPWmuhPgdTK5D2TBYveGR4yjM35SDNDiMSjwph0DuFjxPiXft1YYfx8cDjE+qOYEobmqQ==
+liferay-npm-bridge-generator@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.19.4.tgz#b36c69b6d0d9a10cc828243545fbb33814c916d6"
+  integrity sha512-eJRNMHAqvxW8GoQJOFjf4Y3eCgHcdt3wgs8Jx+XBcIPMoWiME5YVBb7eIXDFSCjcoNd+eWiHTXsE8W8oFBDJuQ==
   dependencies:
     fs-extra "^8.1.0"
     globby "^10.0.1"
     read-json-sync "^2.0.1"
     yargs "^14.0.0"
 
-liferay-npm-build-tools-common@2.19.3, liferay-npm-build-tools-common@^2.17.1:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.19.3.tgz#29394b718b14ecea05c68275b2ee268a7e2e381d"
-  integrity sha512-9kac9aQHySNzYW7GuI+SyZ/39IwxzEfg16wYmIIwVd8khrIDBZYIEP6zgxVV0eu0Wu3SSYN7IP+eaVxPuPZrhw==
+liferay-npm-build-tools-common@2.19.4, liferay-npm-build-tools-common@^2.17.1:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.19.4.tgz#7c017ba3b540d9f3dfd63a4add7995c0160b6285"
+  integrity sha512-ovOfgJaG34CcAmTQTUx/d0F6RbHsPLwxqRP+sSJuDZ2rDTkkvmgnT9rUUYhpNji60Ca64LtoZDvAP79iziHg1w==
   dependencies:
     chalk "^2.4.2"
     dot-prop "^5.0.1"
     escape-string-regexp "^2.0.0"
-    liferay-npm-bundler-preset-standard "2.19.3"
+    liferay-npm-bundler-preset-standard "2.19.4"
     merge "^1.2.1"
     properties "^1.2.1"
     read-json-sync "^2.0.1"
@@ -12089,80 +12089,80 @@ liferay-npm-build-tools-common@3.0.0-snapshot.dda6cd1:
     resolve "^1.8.1"
     webpack "^4.41.6"
 
-liferay-npm-bundler-loader-css-loader@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.19.3.tgz#5c6908ace7b7b8609bbb3e5a209b2ab105e93b94"
-  integrity sha512-nWK/l8rKQYJBvMp6hjASWpL5QgLzOdFSgGJfl1J1VCR07L6TfXTYWCzL9EF7YQFgymfccyP5Ymvbkj/35H1pXg==
+liferay-npm-bundler-loader-css-loader@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.19.4.tgz#52a3ef2977bf2da5ffa33bf04789224a0f8d0dd5"
+  integrity sha512-eoN4oF4lPpw88RPLOsuTajQ7ifGMboVqYBCHSRXlkgTdm50IA0OKP/DavfLFv2avs/eFuOQ9brryfjUd8+YbPw==
   dependencies:
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
     read-json-sync "^2.0.1"
 
-liferay-npm-bundler-plugin-exclude-imports@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.19.3.tgz#a2f5c459407b73c6552a92d0f05d5563f162b093"
-  integrity sha512-UryCbCqv3PWQkHbnfh14AJ2x4yaB4UuNVbdGLhHNAG5jeDu5mNmrWIFgcbF5RWkd07m5Nsiael1unzmrxZlMPw==
+liferay-npm-bundler-plugin-exclude-imports@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.19.4.tgz#9a4bcc8262d793062b44d19fead6f13c796b1b88"
+  integrity sha512-B4d1ITwK+DcHM3ptUxXCMFcY5iIDL5BGGm3c8NBcrseqANwUCIm984gB7nwIm5c3/qLe0ygPRXJeBVhrEvfDwQ==
   dependencies:
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
 
-liferay-npm-bundler-plugin-inject-imports-dependencies@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.19.3.tgz#9e77d3f79c81aa28c3dcc6852f4d7dba4fcef6c3"
-  integrity sha512-6a98Ah/3rNIPa+Fl3KmaniCt1M1a2twcvtUE3eOqvnnNdxWTa9e9teo5VlVN4/eMcZbSEQNBJFaD15KVxwe6hQ==
+liferay-npm-bundler-plugin-inject-imports-dependencies@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.19.4.tgz#a84b7a3b29aef875d18c9a12c63e528efe7b327a"
+  integrity sha512-7VmDI365evhhlEAp+N608ma29HyrrkuF+F9tOs107PDvqBquswQlgg+fRBpTY4SoNeXVhvGrT1OSQdxfYHiBSw==
   dependencies:
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
 
-liferay-npm-bundler-plugin-inject-peer-dependencies@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.19.3.tgz#75fb2416c6efccf745a8b34eb263ba8948d37e9e"
-  integrity sha512-nGCRv6FkLNkTWaEhgQ0/bLsnmh+l5zrE+v/I5VOVbHAFd6EgXArntpbGzKr/0kyouhVQKo/hhjGySB5W9DLIQQ==
+liferay-npm-bundler-plugin-inject-peer-dependencies@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.19.4.tgz#e249f7de7c75ebd412427da00cab1c6477d9f009"
+  integrity sha512-KBGWj8O+Y0IUaMybRYPJbsZ9Xm4eJVHsShAGZueWtqxkw3U4L44jK01RTnZs9lzn4Q33vueKd+Gtqmd3ybYd6A==
   dependencies:
     globby "^10.0.1"
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
     read-json-sync "^2.0.1"
     resolve "^1.8.1"
 
-liferay-npm-bundler-plugin-namespace-packages@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.19.3.tgz#c853346023e1baba72a5b463180f8cb7d2f6d38d"
-  integrity sha512-a8wDC9FoVfrY1O0A7lcIwRaKunv18BMOjycM4oi3rHy6P5TGSoj0lvmc+5iVnKau1KXK4rJIeGMX0G8m/QU7qw==
+liferay-npm-bundler-plugin-namespace-packages@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.19.4.tgz#43a6d97e62b05a63fc08498680463b88b961a218"
+  integrity sha512-pOwVnGiE/rY28xRoWQr7yqWxCxWqNZUcECTrBoC+TT92ZBn00tOEo42jl/TzYvBgteCsbuIzVVmQTmq2CbTY5w==
   dependencies:
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
 
-liferay-npm-bundler-plugin-replace-browser-modules@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.19.3.tgz#47614f48ad4fbf0349d58c08e4b895fc2545d8f1"
-  integrity sha512-uG1OWPdnZP3FABGdYQ+oTKASIHs0J3LFTiB2HTODGsuAXRKEy68oIdz3oUj2QH3AwiCqIS89nyg4KDJJUfqc+w==
+liferay-npm-bundler-plugin-replace-browser-modules@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.19.4.tgz#aba0c5da58605d3a1ed8c4822650f8f4c847a35b"
+  integrity sha512-AT5ksA9z3vRI95IRAiNyCW1zcm0izkkC7NWue1ZMy75LjxCdnpC+NI0SYZHSuEk54hJZ/GNrzGVMKmiZDrCnqQ==
   dependencies:
     dot-prop "^5.0.1"
     fs-extra "^8.1.0"
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
 
-liferay-npm-bundler-plugin-resolve-linked-dependencies@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.19.3.tgz#ca0850cd2ff9c436b7de2ab813c767e72e885650"
-  integrity sha512-g0+31QWlI/YKqLWSyCfOAkg050y6xUJ0alUExE+uERgIGx6F4e8GbI1WDKLSh2eSYimwLD2Yq1NFO3WvXhaVDw==
+liferay-npm-bundler-plugin-resolve-linked-dependencies@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.19.4.tgz#39627f972cda87c889fccdb9b2201de2b1dd2123"
+  integrity sha512-31B3O4FVwhh2wyVYxqrSauWbj4/VH5CNn4fxiRQ4FEbaYXaYollXPh0UPLxLx7YeG/vA1Cky1QDSGEzsX9oVbQ==
   dependencies:
-    liferay-npm-build-tools-common "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
     read-json-sync "^2.0.1"
     semver "^6.3.0"
 
-liferay-npm-bundler-preset-standard@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.19.3.tgz#0747a983097627f0790eb8461df2a47162474d81"
-  integrity sha512-5R8FwLNZtQmnUO4jXrdcHh6ZFpLWGPTnFRo8fmGFpyNPEEIBRizMrz/ACMPQg7ZOK6C85b+5D1XSr6N5tQFi+Q==
+liferay-npm-bundler-preset-standard@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.19.4.tgz#8760e0eed7a18c1bec0bd82ff930d810f77704fe"
+  integrity sha512-Z2JnQR3NU67uK73qCtmOJYGb6QMvxtVU6jbSH2/bAsKLnw1Hovj9+KRzUR0S/Tuu8baGTQr+xGdIwcABCmDg9Q==
   dependencies:
-    babel-preset-liferay-standard "2.19.3"
-    liferay-npm-bundler-plugin-exclude-imports "2.19.3"
-    liferay-npm-bundler-plugin-inject-imports-dependencies "2.19.3"
-    liferay-npm-bundler-plugin-inject-peer-dependencies "2.19.3"
-    liferay-npm-bundler-plugin-namespace-packages "2.19.3"
-    liferay-npm-bundler-plugin-replace-browser-modules "2.19.3"
-    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.3"
+    babel-preset-liferay-standard "2.19.4"
+    liferay-npm-bundler-plugin-exclude-imports "2.19.4"
+    liferay-npm-bundler-plugin-inject-imports-dependencies "2.19.4"
+    liferay-npm-bundler-plugin-inject-peer-dependencies "2.19.4"
+    liferay-npm-bundler-plugin-namespace-packages "2.19.4"
+    liferay-npm-bundler-plugin-replace-browser-modules "2.19.4"
+    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.4"
 
-liferay-npm-bundler@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler/-/liferay-npm-bundler-2.19.3.tgz#ff446ba16893b353e6b5b9ff8742da394e1f82e1"
-  integrity sha512-S0PFQqhgu3+KP5ssvuHp1XAmeimeITWHTBRcBoKkhsCKly3RfVTjHl3VriPyIUvl0m1BcPOcbyEIOoK/HZvI7Q==
+liferay-npm-bundler@2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler/-/liferay-npm-bundler-2.19.4.tgz#b10eba18db6eee16c0b811e85f9312a9ff9bab0e"
+  integrity sha512-u7+c6jfFJrqQawwNNMUKDVwsiX1y6uio70HrY8KZBGNSscQNOHIcruk02MYmSKL1Sfz+MsChhURyFWdLeQXflQ==
   dependencies:
     babel-core "^6.26.3"
     clone "^2.1.2"
@@ -12172,8 +12172,8 @@ liferay-npm-bundler@2.19.3:
     globby "^10.0.1"
     insight "0.10.3"
     jszip "^3.1.5"
-    liferay-npm-build-tools-common "2.19.3"
-    liferay-npm-bundler-preset-standard "2.19.3"
+    liferay-npm-build-tools-common "2.19.4"
+    liferay-npm-bundler-preset-standard "2.19.4"
     merge "^1.2.1"
     pretty-time "^1.1.0"
     read-json-sync "^2.0.1"


### PR DESCRIPTION
This is just a maintenance release that should include no visible changes.

We recently consolidated a number of packages from an isolated repo into a monorepo, so we want to do an end-to-end release of everything and see it integrated into liferay-portal to see it all working.

[Release notes](https://github.com/liferay/liferay-frontend-projects/releases/tag/npm-scripts%2Fv33.1.3)

Done with:

    cd modules
    yarn add -W --dev @liferay/npm-scripts@33.1.3
    npx yarn-deduplicate yarn.lock
    yarn