### PR TITLE
PoC of Global store using pure js and via react hook

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-sample-web/src/main/resources/META-INF/resources/js/App.js
+++ b/modules/apps/frontend-js/frontend-js-clay-sample-web/src/main/resources/META-INF/resources/js/App.js
@@ -12,20 +12,33 @@
  * details.
  */
 
-import ClayAlert from '@clayui/alert';
 import React from 'react';
+import useLiferayState from 'frontend-js-react-web/js/hooks/useLiferayState.es';
 
 import '../css/main.scss';
 
 export default () => {
+	const [user, setUser] = useLiferayState(
+		'user',
+		{nickname: Liferay.themeDisplay.getUserName()},
+		true
+	);
+
 	return (
 		<div>
-			<ClayAlert title="Info">
-				This widget is used to test out Clay components. Simply add
-				whatever JS you want to App.js and redeploy.
-			</ClayAlert>
+			<h2>Nickname Updater:</h2>
 
-			<div className="clay-test-class">This is where your code goes.</div>
+			<div>
+				<input
+					value={user.nickname}
+					onChange={(e) => {
+						setUser({
+							...user,
+							nickname: e.target.value,
+						});
+					}}
+				/>
+			</div>
 		</div>
 	);
 };

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useLiferayState.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useLiferayState.es.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export default function useLiferayState(
+	name,
+	initState = {},
+	dependenciesOrPersist
+) {
+	let initialValue = Liferay.State.getState(name);
+
+	if (!initialValue) {
+		Liferay.State.register(name, initState, dependenciesOrPersist);
+
+		initialValue = Liferay.State.getState(name);
+	}
+
+	const [value, setValue] = React.useState(initialValue);
+
+	React.useEffect(() => {
+		const unsub = Liferay.State.subscribe(name, (newData) =>
+			setValue(newData)
+		);
+
+		return unsub;
+	}, [name]);
+
+	const setLiferayValue = React.useCallback(
+		(val) => Liferay.State.setState(name, val),
+		[name]
+	);
+
+	return [value, setLiferayValue];
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -75,6 +75,7 @@ import createResourceURL from './util/portlet_url/create_resource_url.es';
 import {getSessionValue, setSessionValue} from './util/session.es';
 import toCharCode from './util/to_char_code.es';
 import toggleDisabled from './util/toggle_disabled';
+import createGlobalState from './store/create_global_state.es';
 
 Liferay = window.Liferay || {};
 
@@ -275,5 +276,7 @@ Liferay.Util.Session = {
 
 Liferay.Util.unescape = unescape;
 Liferay.Util.unescapeHTML = unescapeHTML;
+
+Liferay.State = createGlobalState();
 
 export {portlet};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/store/create_global_state.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/store/create_global_state.es.js
@@ -1,0 +1,220 @@
+function emitError(val) {
+	throw new Error('Liferay.State: ' + val);
+}
+
+function getStateFromStorage(storeID, initialValue) {
+	try {
+		const item = window.localStorage.getItem(storeID);
+
+		return item ? JSON.parse(item) : initialValue;
+	} catch (error) {
+		return initialValue;
+	}
+}
+
+function setStateToStorage(storeID, value) {
+	try {
+		window.localStorage.setItem(storeID, JSON.stringify(value));
+	} catch (error) {}
+}
+
+const STORAGE_KEY = 'LIFERAY-GLOBAL-STATE';
+
+export default function createGlobalState() {
+	/**
+	 * Keeps track of dependencies for a selector
+	 */
+	let _selectorsDependencyMap = new Map();
+
+	/**
+	 * Keeps track of each selectorID and its callback function
+	 */
+	let _selectors = new Map();
+
+	/**
+	 * Global State Object
+	 */
+	let _stores = getStateFromStorage(STORAGE_KEY, {});
+
+	/**
+	 * Keeps track of subscribers for a given store or selector
+	 */
+	let _subscribers = {};
+
+	/**
+	 * Iterates subscriberIDs so that each subscriber is unique
+	 */
+	let _subscriberID = 0;
+
+	/**
+	 * Keeps track of stores that should be persisted via localStorage
+	 */
+	let _persistedStores = new Set(Object.keys(_stores));
+
+	function runSubscribers(storeID, data) {
+		if (_subscribers[storeID]) {
+			for (const subscriber of _subscribers[storeID].values()) {
+				subscriber(data);
+			}
+		}
+	}
+
+	function registerState(storeID, data, persistInStorage) {
+		_stores[storeID] = {..._stores[storeID], ...data};
+		_selectorsDependencyMap.set(storeID, []);
+
+		if (persistInStorage && !_persistedStores.has(storeID)) {
+			_persistedStores.add(storeID);
+		}
+
+		return function unregister() {
+			delete _stores[storeID];
+			delete _selectorsDependencyMap.delete(storeID);
+		};
+	}
+
+	function registerSelector(selectorID, selector, dependencies) {
+		dependencies.forEach((storeID) => {
+			const selectorIDs = _selectorsDependencyMap.get(storeID);
+
+			_selectorsDependencyMap.set(storeID, [...selectorIDs, selectorID]);
+		});
+
+		if (!_selectors.has(selectorID)) {
+			_selectors.set(selectorID, selector);
+		}
+
+		return function unregisterSelector() {
+			dependencies.forEach((storeID) => {
+				const filteredSelectors = _selectorsDependencyMap
+					.get(storeID)
+					.filter((item) => item !== selectorID);
+
+				_selectorsDependencyMap.set(storeID, filteredSelectors);
+			});
+
+			_selectors.delete(selectorID);
+		};
+	}
+
+	function collectDataForSelector(selectorID) {
+		let data = {};
+
+		for (const storeID of _selectorsDependencyMap.keys()) {
+			if (_selectorsDependencyMap.get(storeID).includes(selectorID)) {
+				data[storeID] = {..._stores[storeID]};
+			}
+		}
+
+		return data;
+	}
+
+	const store = {
+		/**
+		 * Registers data store or selector function
+		 * @param {String} id - Unique identifier of store or selector
+		 * @param {Object|Function} storeOrSelector - Store data or selector function
+		 * @param {String[]|Boolean} dependenciesOrPersist - Array of IDs that the selector is dependent on or a boolean for using localStorage
+		 * @return {Function} Callback to unregister the store or selector
+		 */
+		register(id, storeOrSelector, dependenciesOrPersist) {
+			if (!id || typeof id !== 'string') {
+				emitError('`id` must be a non-empty string');
+			} else if (_selectors.has(id) || _stores[id]) {
+				emitError(`'${id}' is already a registered id`);
+			}
+
+			if (!dependenciesOrPersist || dependenciesOrPersist === true) {
+				return registerState(
+					id,
+					storeOrSelector,
+					dependenciesOrPersist
+				);
+			} else {
+				return registerSelector(
+					id,
+					storeOrSelector,
+					dependenciesOrPersist
+				);
+			}
+		},
+
+		/**
+		 * Subscribes to changes from a store or a selector
+		 * @param {String} id - Unique identifier of data or selector
+		 * @param {Function} subscriber - Callback for when data changes
+		 * @return {Function} Callback to unsibscribe from the data or selector
+		 */
+		subscribe(id, subscriber) {
+			if (!_subscribers[id]) {
+				_subscribers[id] = new Map();
+			}
+
+			const nextSubscriberID = ++_subscriberID;
+
+			_subscribers[id].set(nextSubscriberID, subscriber);
+
+			return function unsubscribe() {
+				_subscribers[id].delete(nextSubscriberID);
+			};
+		},
+
+		/**
+		 * Returns the value of a store or computed selector
+		 * @param {String} id - Unique identifier of data or selector
+		 * @return {any} Value of store or selector
+		 */
+		getState(id) {
+			if (!id) {
+				return _stores;
+			} else if (_stores[id]) {
+				return _stores[id];
+			} else if (_selectors.get(id)) {
+				const selector = _selectors.get(id);
+
+				const data = collectDataForSelector(id);
+
+				return selector(data);
+			} else {
+				emitError(`No data available for '${id}'`);
+			}
+		},
+
+		/**
+		 * Sets the value of the data store on the given id
+		 * @param {String} storeID - Unique identifier of data store
+		 * @param {any} data - Value to store
+		 */
+		setState(storeID, data) {
+			if (typeof _stores[storeID] === 'undefined') {
+				emitError(`'${storeID}' is not registered`);
+			}
+
+			_stores[storeID] = data;
+
+			const selectorIDs = _selectorsDependencyMap.get(storeID);
+
+			if (selectorIDs && selectorIDs.length) {
+				selectorIDs.forEach((selectorID) => {
+					const selector = _selectors.get(selectorID);
+
+					const data = collectDataForSelector(selectorID);
+
+					runSubscribers(selectorID, selector(data));
+				});
+			}
+
+			runSubscribers(storeID, data);
+
+			if (_persistedStores.has(storeID)) {
+				const currentStorage = getStateFromStorage(STORAGE_KEY, {});
+
+				const newStorage = {...currentStorage, [storeID]: data};
+
+				setStateToStorage(STORAGE_KEY, newStorage);
+			}
+		},
+	};
+
+	return store;
+}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/store/create_global_state.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/store/create_global_state.es.js
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+'use strict';
+
+import createGlobalState from '../../../src/main/resources/META-INF/resources/liferay/store/create_global_state.es';
+
+describe('Liferay.State', () => {
+	let Liferay;
+
+	beforeEach(() => {
+		Liferay = {State: createGlobalState()};
+	});
+
+	it('registers a store', () => {
+		const id = 'my-apps-store';
+
+		Liferay.State.register(id, {});
+
+		expect(Liferay.State.getState()).toMatchObject({
+			'my-apps-store': {},
+		});
+	});
+
+	it('updates store via setState', () => {
+		const id = 'my-apps-store';
+
+		Liferay.State.register(id, {foo: 'bar'});
+
+		expect(Liferay.State.getState()).toMatchObject({
+			'my-apps-store': {
+				foo: 'bar',
+			},
+		});
+
+		Liferay.State.setState(id, {foo: 'baz'});
+
+		expect(Liferay.State.getState()).toMatchObject({
+			'my-apps-store': {
+				foo: 'baz',
+			},
+		});
+	});
+
+	it('registers a selector', () => {
+		const id = 'my-apps-selector';
+
+		Liferay.State.register(
+			id,
+			() => {
+				return 'foo bar';
+			},
+			[]
+		);
+
+		expect(Liferay.State.getState()).toMatchObject({});
+		expect(Liferay.State.getState(id)).toEqual('foo bar');
+	});
+
+	it('registers a store with initial data', () => {
+		const id = 'my-apps-store';
+		const val = {hello: 'world'};
+
+		Liferay.State.register(id, val);
+
+		expect(Liferay.State.getState(id)).toMatchObject(val);
+	});
+
+	it('updates selector when store dependency updates', () => {
+		const storeID = 'my-apps-store';
+		const selectorID = 'my-apps-selector';
+
+		const val = {name: 'joe Bloggs'};
+
+		Liferay.State.register(storeID, val);
+		Liferay.State.register(
+			selectorID,
+			(data) => data[storeID].name.toUpperCase(),
+			[storeID]
+		);
+
+		expect(Liferay.State.getState(selectorID)).toEqual('JOE BLOGGS');
+
+		Liferay.State.setState(storeID, {name: 'Test Test'});
+
+		expect(Liferay.State.getState(selectorID)).toEqual('TEST TEST');
+	});
+
+	it('subscribes to store changes', () => {
+		const storeID = 'my-apps-store';
+		const val = {name: 'joe Bloggs'};
+
+		const subscriber = jest.fn();
+
+		Liferay.State.register(storeID, val);
+		Liferay.State.subscribe(storeID, subscriber);
+
+		expect(subscriber).not.toHaveBeenCalled();
+
+		Liferay.State.setState(storeID, {name: 'Test Test'});
+
+		expect(subscriber).toHaveBeenCalled();
+	});
+
+	it('subscribes to selector changes', () => {
+		const storeID = 'my-apps-store';
+		const selectorID = 'my-apps-selector';
+
+		const val = {name: 'joe Bloggs'};
+
+		Liferay.State.register(storeID, val);
+		Liferay.State.register(
+			selectorID,
+			(data) => data[storeID].name.toUpperCase(),
+			[storeID]
+		);
+
+		const subscriber = jest.fn();
+
+		Liferay.State.subscribe(selectorID, subscriber);
+
+		expect(subscriber).not.toHaveBeenCalled();
+
+		Liferay.State.setState(storeID, {name: 'Test Test'});
+
+		expect(subscriber).toHaveBeenCalled();
+	});
+
+	it("does not fire subscription to selector if store dependency isn't updated", () => {
+		const storeID = 'my-apps-store';
+		const selectorID = 'my-apps-selector';
+
+		const val = {name: 'joe Bloggs'};
+
+		Liferay.State.register(storeID, val);
+		Liferay.State.register(selectorID, () => 'test', []);
+
+		const subscriber = jest.fn();
+
+		Liferay.State.subscribe(selectorID, subscriber);
+
+		expect(subscriber).not.toHaveBeenCalled();
+
+		Liferay.State.setState(storeID, {name: 'Test Test'});
+
+		expect(subscriber).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Using inspiration from [here](https://github.com/wincent/liferay-portal/blob/92632beed7fe25005e0f1a92a8c55d7af0d4cb48/modules/apps/remote-web-component/remote-web-component-support-web/src/main/resources/META-INF/resources/index.js). I put together a small demo of what a possibly style of global state for liferay components might be.

In the gif below, the left side of the page is react and the right side is jsp and pure js. Each subscribe to changes to the global store and also emit changes to that store.

![store-demo](https://user-images.githubusercontent.com/6843530/95522410-e1947980-0980-11eb-9759-ead9bfa5ede1.gif)

I went with following @wincent's approach with the redux style, however I'm not totally sold on using reducers and I can imagine it might get a little wacky as portlets interact and try to set or accidentally override reducers. It might be more straight forward to just subscribe to store changes and calling `get` and `set`.

I'll leave some comments in the code for some additional things I added