### PR TITLE
[7.4-only] LPS-112459 Update Clay Checkbox Tag to JSP+React

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
@@ -32,24 +32,32 @@
 
 	<tbody>
 		<tr>
-			<td><clay:checkbox checked="<%= true %>" label="My Input" name="name" showLabel="<%= false %>" /></td>
+			<td><clay:checkbox checked="<%= true %>" name="name" /></td>
 			<td>On</td>
 		</tr>
 		<tr>
-			<td><clay:checkbox label="My Input" name="name" showLabel="<%= false %>" /></td>
+			<td><clay:checkbox name="name" /></td>
 			<td>Off</td>
 		</tr>
 		<tr>
-			<td><clay:checkbox checked="<%= true %>" disabled="<%= true %>" label="My Input" name="name" showLabel="<%= false %>" /></td>
+			<td><clay:checkbox cssClass="custom-css-class" checked="<%= true %>" id="customId" name="name" /></td>
+			<td>With custom class and id</td>
+		</tr>
+		<tr>
+			<td><clay:checkbox label="Checkbox with Label" name="checkboxWithLabel" /></td>
+			<td>With Label</td>
+		</tr>
+		<tr>
+			<td><clay:checkbox checked="<%= true %>" disabled="<%= true %>" name="name" /></td>
 			<td>On disabled</td>
 		</tr>
 		<tr>
-			<td><clay:checkbox disabled="<%= true %>" label="My Input" name="name" showLabel="<%= false %>" /></td>
+			<td><clay:checkbox disabled="<%= true %>" name="name" /></td>
 			<td>Off disabled</td>
 		</tr>
 		<tr>
-			<td><clay:checkbox indeterminate="<%= true %>" label="My Input" name="name" showLabel="<%= false %>" /></td>
-			<td>Checkbox Variable for multiple selection</td>
+			<td><clay:checkbox indeterminate="<%= true %>" name="name" /></td>
+			<td>Indeterminate</td>
 		</tr>
 	</tbody>
 </table>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
@@ -40,7 +40,7 @@
 			<td>Off</td>
 		</tr>
 		<tr>
-			<td><clay:checkbox cssClass="custom-css-class" checked="<%= true %>" id="customId" name="name" /></td>
+			<td><clay:checkbox checked="<%= true %>" cssClass="custom-css-class" id="customId" name="name" /></td>
 			<td>With custom class and id</td>
 		</tr>
 		<tr>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -363,20 +363,20 @@ public class BaseContainerTag extends AttributesTagSupport {
 		jspWriter.write("<");
 		jspWriter.write(_containerElement);
 
-		renderCssClassAttribute();
+		writeCssClassAttribute();
 
 		if (Validator.isNotNull(getId())) {
-			renderIdAttribute();
+			writeIdAttribute();
 		}
 
-		_writeDynamicAttributes(jspWriter);
+		writeDynamicAttributes();
 
 		jspWriter.write(">");
 
 		return EVAL_BODY_INCLUDE;
 	}
 
-	protected void renderCssClassAttribute() throws Exception {
+	protected void writeCssClassAttribute() throws Exception {
 		JspWriter jspWriter = pageContext.getOut();
 
 		jspWriter.write(" class=\"");
@@ -384,21 +384,24 @@ public class BaseContainerTag extends AttributesTagSupport {
 		jspWriter.write("\"");
 	}
 
-	protected void renderIdAttribute() throws Exception {
+	protected void writeDynamicAttributes() throws Exception {
+		String dynamicAttributesString = InlineUtil.buildDynamicAttributes(
+			getDynamicAttributes());
+
+		if (!dynamicAttributesString.isEmpty()) {
+			JspWriter jspWriter = pageContext.getOut();
+
+			jspWriter.write(" ");
+			jspWriter.write(dynamicAttributesString);
+		}
+	}
+
+	protected void writeIdAttribute() throws Exception {
 		JspWriter jspWriter = pageContext.getOut();
 
 		jspWriter.write(" id=\"");
 		jspWriter.write(getId());
 		jspWriter.write("\"");
-	}
-
-	private void _writeDynamicAttributes(JspWriter jspWriter) throws Exception {
-		String dynamicAttributesString = InlineUtil.buildDynamicAttributes(
-			getDynamicAttributes());
-
-		if (!dynamicAttributesString.isEmpty()) {
-			jspWriter.write(dynamicAttributesString);
-		}
 	}
 
 	private Map<String, Object> _additionalProps;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -391,7 +391,6 @@ public class BaseContainerTag extends AttributesTagSupport {
 		if (!dynamicAttributesString.isEmpty()) {
 			JspWriter jspWriter = pageContext.getOut();
 
-			jspWriter.write(" ");
 			jspWriter.write(dynamicAttributesString);
 		}
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -362,14 +362,11 @@ public class BaseContainerTag extends AttributesTagSupport {
 
 		jspWriter.write("<");
 		jspWriter.write(_containerElement);
-		jspWriter.write(" class=\"");
-		jspWriter.write(processCssClasses(new LinkedHashSet<>()));
-		jspWriter.write("\"");
+
+		renderCssClassAttribute();
 
 		if (Validator.isNotNull(getId())) {
-			jspWriter.write(" id=\"");
-			jspWriter.write(getId());
-			jspWriter.write("\"");
+			renderIdAttribute();
 		}
 
 		_writeDynamicAttributes(jspWriter);
@@ -377,6 +374,22 @@ public class BaseContainerTag extends AttributesTagSupport {
 		jspWriter.write(">");
 
 		return EVAL_BODY_INCLUDE;
+	}
+
+	protected void renderCssClassAttribute() throws Exception {
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write(" class=\"");
+		jspWriter.write(processCssClasses(new LinkedHashSet<>()));
+		jspWriter.write("\"");
+	}
+
+	protected void renderIdAttribute() throws Exception {
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write(" id=\"");
+		jspWriter.write(getId());
+		jspWriter.write("\"");
 	}
 
 	private void _writeDynamicAttributes(JspWriter jspWriter) throws Exception {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/CheckboxTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/CheckboxTag.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Kresimir Coko
+ */
+public class CheckboxTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		return super.doStartTag();
+	}
+
+	public boolean getChecked() {
+		return _checked;
+	}
+
+	public boolean getDisabled() {
+		return _disabled;
+	}
+
+	public boolean getIndeterminate() {
+		return _indeterminate;
+	}
+
+	public boolean getInline() {
+		return _inline;
+	}
+
+	public String getLabel() {
+		return _label;
+	}
+
+	public String getName() {
+		return _name;
+	}
+
+	public String getValue() {
+		return _value;
+	}
+
+	public void setChecked(boolean checked) {
+		_checked = checked;
+	}
+
+	public void setDisabled(boolean disabled) {
+		_disabled = disabled;
+	}
+
+	public void setIndeterminate(boolean indeterminate) {
+		_indeterminate = indeterminate;
+	}
+
+	public void setInline(boolean inline) {
+		_inline = inline;
+	}
+
+	public void setLabel(String label) {
+		_label = label;
+	}
+
+	public void setName(String name) {
+		_name = name;
+	}
+
+	public void setValue(String value) {
+		_value = value;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_checked = false;
+		_disabled = false;
+		_indeterminate = false;
+		_inline = false;
+		_label = null;
+		_name = null;
+		_value = null;
+	}
+
+	@Override
+	protected String getHydratedModuleName() {
+		return "frontend-taglib-clay/Checkbox";
+	}
+
+	@Override
+	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("checked", _checked);
+		props.put("disabled", _disabled);
+		props.put("indeterminate", _indeterminate);
+		props.put("inline", _inline);
+
+		if (Validator.isNotNull(_label)) {
+			props.put(
+				"label",
+				LanguageUtil.get(
+					TagResourceBundleUtil.getResourceBundle(pageContext),
+					_label));
+		}
+
+		props.put("name", _name);
+		props.put("value", _value);
+
+		return super.prepareProps(props);
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		cssClasses.add("custom-control-input");
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("<label><input");
+
+		if (Validator.isNotNull(_label)) {
+			setDynamicAttribute(StringPool.BLANK, "aria-label", _label);
+		}
+
+		if (_checked) {
+			jspWriter.write(" checked");
+		}
+
+		super.renderCssClassAttribute();
+
+		if (_disabled) {
+			jspWriter.write(" disabled");
+		}
+
+		if (Validator.isNotNull(getId())) {
+			super.renderIdAttribute();
+		}
+
+		if (Validator.isNotNull(_name)) {
+			jspWriter.write(" name=\"");
+			jspWriter.write(_name);
+			jspWriter.write("\"");
+		}
+
+		jspWriter.write(" type=\"checkbox\"");
+
+		if (Validator.isNotNull(_value)) {
+			jspWriter.write(" value=\"");
+			jspWriter.write(_value);
+			jspWriter.write("\"");
+		}
+
+		jspWriter.write(" /><span class=\"custom-control-label\">");
+
+		if (Validator.isNotNull(_label)) {
+			jspWriter.write("<span class=\"custom-control-label-text\">");
+			jspWriter.write(_label);
+			jspWriter.write("</span>");
+		}
+
+		jspWriter.write("</span></label>");
+
+		return SKIP_BODY;
+	}
+
+	@Override
+	protected void renderCssClassAttribute() throws Exception {
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write(" class=\"custom-checkbox custom-control");
+
+		if (_inline) {
+			jspWriter.write(" custom-control-inline");
+		}
+
+		jspWriter.write("\"");
+	}
+
+	@Override
+	protected void renderIdAttribute() {
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:checkbox:";
+
+	private boolean _checked;
+	private boolean _disabled;
+	private boolean _indeterminate;
+	private boolean _inline;
+	private String _label;
+	private String _name;
+	private String _value;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/CheckboxTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/CheckboxTag.java
@@ -35,23 +35,11 @@ public class CheckboxTag extends BaseContainerTag {
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
 
+		if (Validator.isNotNull(_label)) {
+			setDynamicAttribute(StringPool.BLANK, "aria-label", _label);
+		}
+
 		return super.doStartTag();
-	}
-
-	public boolean getChecked() {
-		return _checked;
-	}
-
-	public boolean getDisabled() {
-		return _disabled;
-	}
-
-	public boolean getIndeterminate() {
-		return _indeterminate;
-	}
-
-	public boolean getInline() {
-		return _inline;
 	}
 
 	public String getLabel() {
@@ -64,6 +52,22 @@ public class CheckboxTag extends BaseContainerTag {
 
 	public String getValue() {
 		return _value;
+	}
+
+	public boolean isChecked() {
+		return _checked;
+	}
+
+	public boolean isDisabled() {
+		return _disabled;
+	}
+
+	public boolean isIndeterminate() {
+		return _indeterminate;
+	}
+
+	public boolean isInline() {
+		return _inline;
 	}
 
 	public void setChecked(boolean checked) {
@@ -148,22 +152,20 @@ public class CheckboxTag extends BaseContainerTag {
 
 		jspWriter.write("<label><input");
 
-		if (Validator.isNotNull(_label)) {
-			setDynamicAttribute(StringPool.BLANK, "aria-label", _label);
-		}
+		super.writeDynamicAttributes();
 
 		if (_checked) {
 			jspWriter.write(" checked");
 		}
 
-		super.renderCssClassAttribute();
+		super.writeCssClassAttribute();
 
 		if (_disabled) {
 			jspWriter.write(" disabled");
 		}
 
 		if (Validator.isNotNull(getId())) {
-			super.renderIdAttribute();
+			super.writeIdAttribute();
 		}
 
 		if (Validator.isNotNull(_name)) {
@@ -194,7 +196,7 @@ public class CheckboxTag extends BaseContainerTag {
 	}
 
 	@Override
-	protected void renderCssClassAttribute() throws Exception {
+	protected void writeCssClassAttribute() throws Exception {
 		JspWriter jspWriter = pageContext.getOut();
 
 		jspWriter.write(" class=\"custom-checkbox custom-control");
@@ -207,7 +209,11 @@ public class CheckboxTag extends BaseContainerTag {
 	}
 
 	@Override
-	protected void renderIdAttribute() {
+	protected void writeDynamicAttributes() {
+	}
+
+	@Override
+	protected void writeIdAttribute() {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:checkbox:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/CheckboxTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/CheckboxTag.java
@@ -35,15 +35,16 @@ public class CheckboxTag extends BaseContainerTag {
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
 
-		if (Validator.isNotNull(_label)) {
-			setDynamicAttribute(StringPool.BLANK, "aria-label", _label);
+		if (Validator.isNotNull(getLabel())) {
+			setDynamicAttribute(StringPool.BLANK, "aria-label", getLabel());
 		}
 
 		return super.doStartTag();
 	}
 
 	public String getLabel() {
-		return _label;
+		return LanguageUtil.get(
+			TagResourceBundleUtil.getResourceBundle(pageContext), _label);
 	}
 
 	public String getName() {
@@ -123,12 +124,8 @@ public class CheckboxTag extends BaseContainerTag {
 		props.put("indeterminate", _indeterminate);
 		props.put("inline", _inline);
 
-		if (Validator.isNotNull(_label)) {
-			props.put(
-				"label",
-				LanguageUtil.get(
-					TagResourceBundleUtil.getResourceBundle(pageContext),
-					_label));
+		if (Validator.isNotNull(getLabel())) {
+			props.put("label", getLabel());
 		}
 
 		props.put("name", _name);
@@ -150,7 +147,7 @@ public class CheckboxTag extends BaseContainerTag {
 
 		JspWriter jspWriter = pageContext.getOut();
 
-		jspWriter.write("<label><input");
+		jspWriter.write("<label><input ");
 
 		super.writeDynamicAttributes();
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -357,7 +357,7 @@
 	<tag>
 		<description></description>
 		<name>checkbox</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.CheckboxTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.CheckboxTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
@@ -366,25 +366,31 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -396,7 +402,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -422,7 +428,7 @@
 		<attribute>
 			<description></description>
 			<name>label</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
@@ -432,7 +438,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>showLabel</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -443,6 +449,7 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>
@@ -2767,7 +2774,6 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Checkbox.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Checkbox.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ClayCheckbox} from '@clayui/form';
+import React, {useState} from 'react';
+
+export default function Checkbox({
+	checked,
+	componentId: _componentId,
+	cssClass,
+	locale: _locale,
+	portletId: _portletId,
+	portletNamespace: _portletNamespace,
+	...otherProps
+}) {
+	const [isChecked, setIsChecked] = useState(checked);
+
+	return (
+		<ClayCheckbox
+			checked={isChecked}
+			className={cssClass}
+			onChange={() => setIsChecked((isChecked) => !isChecked)}
+			{...otherProps}
+		/>
+	);
+}


### PR DESCRIPTION
Creating a new `CheckboxTag` implementing the Clay v3 version of the Checkbox component.

## Steps to test:
- Add Clay Sample Widget to any page.
- Go to Form Elements tab
- Under the Checkbox section

## Before:
![image](https://user-images.githubusercontent.com/24564752/97417819-67646e80-1908-11eb-952a-9428b086afe8.png)

## After:
![image](https://user-images.githubusercontent.com/24564752/97420097-27eb5180-190b-11eb-967f-f6fc52dd3c55.png)
