### PR TITLE
LPS-122157 Migrate v3 js-toolkit packages to named scope versions

### DIFF
--- a/modules/apps/frontend-js/frontend-js-recharts/package.json
+++ b/modules/apps/frontend-js/frontend-js-recharts/package.json
@@ -3,7 +3,7 @@
 		"recharts": "1.8.5"
 	},
 	"devDependencies": {
-		"liferay-npm-bundler": "3.0.0-snapshot.dda6cd1"
+		"@liferay/npm-bundler": "3.0.1-pre.0"
 	},
 	"name": "frontend-js-recharts",
 	"scripts": {

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1942,6 +1942,25 @@
     strip-ansi "6.0.0"
     xml "^1.0.1"
 
+"@liferay/js-toolkit-core@3.0.1-pre.0":
+  version "3.0.1-pre.0"
+  resolved "https://registry.yarnpkg.com/@liferay/js-toolkit-core/-/js-toolkit-core-3.0.1-pre.0.tgz#b962ce5ea66134c298fdd04419828f90bf45ad6a"
+  integrity sha512-KLdwqB3q9nnxMIPapKz7BYe0mD04NJyL6RYh9R06TRfPS/Pllp5rUMH7rTcImHvxB5kd0DUxZaLgzH7bi3TaHw==
+  dependencies:
+    acorn "^6.2.1"
+    chalk "^2.4.2"
+    clone "^2.1.2"
+    cross-spawn "^7.0.0"
+    dot-prop "^5.0.1"
+    escodegen "^1.14.1"
+    estraverse "^4.3.0"
+    fs-extra "^8.1.0"
+    properties "^1.2.1"
+    read-json-sync "^2.0.1"
+    resolve "^1.8.1"
+    source-map "^0.7.3"
+    webpack "^4.41.6"
+
 "@liferay/npm-bundler-preset-liferay-dev@4.6.4":
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/@liferay/npm-bundler-preset-liferay-dev/-/npm-bundler-preset-liferay-dev-4.6.4.tgz#142f092f6bd8354bba6252df1c56b05ff9856026"
@@ -1955,6 +1974,27 @@
     liferay-npm-bundler-plugin-namespace-packages "2.19.4"
     liferay-npm-bundler-plugin-replace-browser-modules "2.19.4"
     liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.4"
+
+"@liferay/npm-bundler@3.0.1-pre.0":
+  version "3.0.1-pre.0"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-bundler/-/npm-bundler-3.0.1-pre.0.tgz#b27606804718250f983748f98ab7362e05f57169"
+  integrity sha512-u1P4wiq5jm02QEs1OBfBlLDT9JJ8bpw6IeaMlwjys9A1T1X8IsUu78tv6uqLLfuq5ByC8xQvMkhX8wqc/U6vsw==
+  dependencies:
+    "@liferay/js-toolkit-core" "3.0.1-pre.0"
+    acorn "^6.2.1"
+    cross-spawn "^7.0.0"
+    ejs "^2.6.1"
+    escodegen "^1.14.1"
+    estraverse "^4.3.0"
+    fs-extra "^8.1.0"
+    globby "^11.0.1"
+    jszip "^3.1.5"
+    pretty-time "^1.1.0"
+    read-json-sync "^2.0.1"
+    source-map "^0.7.3"
+    webpack "^4.41.6"
+    xml-js "^1.6.8"
+    yargs "^14.0.0"
 
 "@liferay/npm-scripts@33.1.3":
   version "33.1.3"
@@ -12086,20 +12126,6 @@ liferay-npm-build-tools-common@2.19.4, liferay-npm-build-tools-common@^2.17.1:
     read-json-sync "^2.0.1"
     resolve "^1.8.1"
 
-liferay-npm-build-tools-common@3.0.0-snapshot.dda6cd1:
-  version "3.0.0-snapshot.dda6cd1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-3.0.0-snapshot.dda6cd1.tgz#c4faa7844e474fecd24a636b61d4b365911dfa48"
-  integrity sha512-ac33T0z7+femgva5d4AX3Dl0uk788OWiqplWYvWqEsZmajfefmPrYDM4IEFGAtVqwjvB4s0zvTt7ezPVkmrnFQ==
-  dependencies:
-    chalk "^2.4.2"
-    clone "^2.1.2"
-    dot-prop "^5.0.1"
-    fs-extra "^8.1.0"
-    properties "^1.2.1"
-    read-json-sync "^2.0.1"
-    resolve "^1.8.1"
-    webpack "^4.41.6"
-
 liferay-npm-bundler-loader-css-loader@2.19.4:
   version "2.19.4"
   resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.19.4.tgz#52a3ef2977bf2da5ffa33bf04789224a0f8d0dd5"
@@ -12191,25 +12217,6 @@ liferay-npm-bundler@2.19.4:
     resolve "^1.8.1"
     rimraf "^3.0.0"
     semver "^6.3.0"
-    xml-js "^1.6.8"
-    yargs "^14.0.0"
-
-liferay-npm-bundler@3.0.0-snapshot.dda6cd1:
-  version "3.0.0-snapshot.dda6cd1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler/-/liferay-npm-bundler-3.0.0-snapshot.dda6cd1.tgz#1aa21c3ab14f02f2a5b28aa367e7bbdb4a9d5873"
-  integrity sha512-7JYcgzXhS3nIVR84+Knf+q6uv4YsnVb/4g2dgYCWRPWbWpOOTzrT91csGv0Rq/7jkpMoJ4lO8qsMmcIxKG8Cuw==
-  dependencies:
-    acorn "^6.2.1"
-    ejs "^2.6.1"
-    escodegen "^1.14.1"
-    estraverse "^4.3.0"
-    fs-extra "^8.1.0"
-    globby "^10.0.1"
-    jszip "^3.1.5"
-    liferay-npm-build-tools-common "3.0.0-snapshot.dda6cd1"
-    pretty-time "^1.1.0"
-    read-json-sync "^2.0.1"
-    webpack "^4.41.6"
     xml-js "^1.6.8"
     yargs "^14.0.0"
 


### PR DESCRIPTION
The contents of the packages should be basically identical (other than the names), with a few small fixes applied on top to facilitate integration into DXP as described in [the release notes](https://github.com/liferay/liferay-frontend-projects/releases/tag/npm-bundler%2Fv3.0.1-pre.0).

Tested this out by deploying the "frontend-js-recharts" module, which is the only one in DXP currently using v3 of the toolkit.
