### PR TITLE
PoC of A11y component

### DIFF
--- a/modules/apps/frontend-js/frontend-js-react-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-react-web/.npmbundlerrc
@@ -60,6 +60,24 @@
 		"whatwg-fetch": true
 	},
 	"output": "build/node/packageRunBuild/resources",
+	"rules": [
+		{
+			"test": "\\.css$",
+			"use": ["css-loader"]
+		},
+		{
+			"test": "\\.scss$",
+			"exclude": "node_modules",
+			"use": [
+				{
+					"loader": "css-loader",
+					"options": {
+						"extension": ".css"
+					}
+				}
+			]
+		}
+	],
 	"preset": "liferay-npm-bundler-preset-standard",
 	"sources": ["src/main/resources/META-INF/resources"]
 }

--- a/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -1,8 +1,9 @@
 {
 	"dependencies": {
+		"@clayui/button": "3.5.0",
 		"@clayui/icon": "3.1.0",
 		"@clayui/popover": "3.5.0",
-		"@clayui/button": "3.5.0",
+		"@reach/observe-rect": "^1.2.0",
 		"axe-core": "^4.0.2",
 		"classnames": "2.2.6",
 		"formik": "2.1.4",

--- a/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -1,6 +1,9 @@
 {
 	"dependencies": {
 		"@clayui/icon": "3.1.0",
+		"@clayui/popover": "3.5.0",
+		"@clayui/button": "3.5.0",
+		"axe-core": "^4.0.2",
 		"classnames": "2.2.6",
 		"formik": "2.1.4",
 		"prop-types": "15.7.2",

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.css
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.css
@@ -1,0 +1,33 @@
+.a11y-overlay {
+    cursor: pointer;
+    z-index: 999;
+    background: rgba(255, 91, 91, 0.2);
+    border-radius: 4px;
+    border: 1px solid rgb(255, 91, 91);
+    position: absolute;
+}
+
+.a11y-icon {
+    height: 28px;
+    width: 28px;
+}
+
+.a11y-help {
+    font-size: 18px;
+    font-weight: 500;
+    line-height: 18px;
+}
+
+.a11y-list {
+    list-style-type: none;
+    padding-left: 51px;
+    padding-top: 10px;
+}
+
+.a11y-list li {
+    margin-bottom: 5px;
+}
+
+.popover.popover-a11y {
+    max-width: 27.5rem;
+}

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.css
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.css
@@ -4,7 +4,7 @@
     background: rgba(255, 91, 91, 0.2);
     border-radius: 4px;
     border: 1px solid rgb(255, 91, 91);
-    position: absolute;
+    position: fixed;
 }
 
 .a11y-icon {

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.es.js
@@ -25,20 +25,36 @@ import useEventListener from './hooks/useEventListener.es';
 import './A11y.css';
 
 function segmentAlertsByNode(alerts) {
-	const nodes = alerts.flatMap((alert) =>
-		alert.nodes.flatMap((node) => node.target)
-	);
+	const nodes = alerts.reduce((prev, current, index) => {
+		current.nodes.forEach((node) => {
+			const {help, helpUrl, id, impact} = current;
 
-	return nodes.map((node) => {
-		const alertsByNode = alerts.filter((alert) =>
-			alert.nodes.some((n) => n.target.includes(node))
-		);
+			const alert = {
+				all: node.all,
+				any: node.any,
+				help,
+				helpUrl,
+				id,
+				impact,
+			};
 
-		return {
-			alerts: alertsByNode,
-			node,
-		};
-	});
+			const target = node.target[0];
+
+			if (!prev[target]) {
+				prev[target] = {
+					alerts: [alert],
+					node: target,
+				};
+			}
+			else {
+				prev[target].alerts[index] = alert;
+			}
+		});
+
+		return prev;
+	}, {});
+
+	return Object.values(nodes);
 }
 
 const Overlay = React.forwardRef(({style, ...othersProps}, ref) =>
@@ -116,65 +132,59 @@ function Alert({alerts, target}) {
 			show={visible}
 			trigger={<Overlay style={bounds} />}
 		>
-			{alerts.map((alert) => {
-				const [{all, any}] = alert.nodes.filter((node) =>
-					node.target.includes(target)
-				);
-
-				return (
-					<article key={alert.id}>
-						<div className="autofit-padded autofit-row">
-							<div className="autofit-col">
-								<ClayIcon
-									className="a11y-icon"
-									color={
-										alert.impact === 'minor'
-											? '#0B5FFF'
-											: alert.impact === 'moderate'
-											? '#FF8F39'
-											: '#DA1414'
-									}
-									symbol={
-										alert.impact === 'minor'
-											? 'info-circle'
-											: alert.impact === 'moderate'
-											? 'warning-full'
-											: 'exclamation-full'
-									}
-								/>
-							</div>
-							<div className="autofit-col">
-								<a
-									className="a11y-help"
-									href={alert.helpUrl}
-									rel="noopener noreferrer"
-									target="_blank"
-								>
-									{alert.help}
-								</a>
-								<span className="text-muted">
-									Fix {all.length > 0 ? 'all' : 'any'} of the
-									following
-								</span>
-							</div>
+			{alerts.map((alert) => (
+				<article key={alert.id}>
+					<div className="autofit-padded autofit-row">
+						<div className="autofit-col">
+							<ClayIcon
+								className="a11y-icon"
+								color={
+									alert.impact === 'minor'
+										? '#0B5FFF'
+										: alert.impact === 'moderate'
+										? '#FF8F39'
+										: '#DA1414'
+								}
+								symbol={
+									alert.impact === 'minor'
+										? 'info-circle'
+										: alert.impact === 'moderate'
+										? 'warning-full'
+										: 'exclamation-full'
+								}
+							/>
 						</div>
-						{all.length > 0 && (
-							<ul className="a11y-list">
-								{all.map((check) => (
-									<li key={check.id}>{check.message}</li>
-								))}
-							</ul>
-						)}
-						{any.length > 0 && (
-							<ul className="a11y-list">
-								{any.map((check) => (
-									<li key={check.id}>{check.message}</li>
-								))}
-							</ul>
-						)}
-					</article>
-				);
-			})}
+						<div className="autofit-col">
+							<a
+								className="a11y-help"
+								href={alert.helpUrl}
+								rel="noopener noreferrer"
+								target="_blank"
+							>
+								{alert.help}
+							</a>
+							<span className="text-muted">
+								Fix {alert.all.length > 0 ? 'all' : 'any'} of
+								the following
+							</span>
+						</div>
+					</div>
+					{alert.all.length > 0 && (
+						<ul className="a11y-list">
+							{alert.all.map((check) => (
+								<li key={check.id}>{check.message}</li>
+							))}
+						</ul>
+					)}
+					{alert.any.length > 0 && (
+						<ul className="a11y-list">
+							{alert.any.map((check) => (
+								<li key={check.id}>{check.message}</li>
+							))}
+						</ul>
+					)}
+				</article>
+			))}
 		</ClayPopover>
 	);
 }
@@ -262,8 +272,12 @@ export default function A11y({children, enable = true}) {
 		<>
 			<span ref={childrenRef}>{children}</span>
 			{!disabled &&
-				alertsByNode.map(({alerts, node}) => (
-					<Alert alerts={alerts} key={node} target={node} />
+				alertsByNode.map(({alerts, node}, index) => (
+					<Alert
+						alerts={alerts}
+						key={`${node}:${index}`}
+						target={node}
+					/>
 				))}
 		</>
 	);

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.es.js
@@ -15,6 +15,7 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayPopover from '@clayui/popover';
+import observeRect from '@reach/observe-rect';
 import axe from 'axe-core';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
@@ -61,21 +62,34 @@ function Alert({alerts, target}) {
 			return;
 		}
 
+		const setOverlayBounds = (bounds) => {
+			if (bounds.x > 0 || bounds.y > 0) {
+				const borderRadius = window
+					.getComputedStyle(node, null)
+					.getPropertyValue('border-radius');
+
+				setBounds({
+					'border-radius': borderRadius,
+					height: bounds.height,
+					left: bounds.left,
+					top: bounds.top,
+					width: bounds.width,
+				});
+			}
+		};
+
+		const {observe, unobserve} = observeRect(node, (targetRect) => {
+			setOverlayBounds(targetRect);
+		});
+
 		const bounds = node.getBoundingClientRect();
+		setOverlayBounds(bounds);
 
-		if (bounds.x > 0 || bounds.y > 0) {
-			const borderRadius = window
-				.getComputedStyle(node, null)
-				.getPropertyValue('border-radius');
+		observe();
 
-			setBounds({
-				'border-radius': borderRadius,
-				height: bounds.height,
-				left: bounds.left,
-				top: bounds.top,
-				width: bounds.width,
-			});
-		}
+		return () => {
+			unobserve();
+		};
 	}, [target, alerts]);
 
 	return (

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.es.js
@@ -17,8 +17,10 @@ import ClayIcon from '@clayui/icon';
 import ClayPopover from '@clayui/popover';
 import observeRect from '@reach/observe-rect';
 import axe from 'axe-core';
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
+
+import useEventListener from './hooks/useEventListener.es';
 
 import './A11y.css';
 
@@ -69,7 +71,7 @@ function Alert({alerts, target}) {
 					.getPropertyValue('border-radius');
 
 				setBounds({
-					'border-radius': borderRadius,
+					borderRadius,
 					height: bounds.height,
 					left: bounds.left,
 					top: bounds.top,
@@ -83,13 +85,12 @@ function Alert({alerts, target}) {
 		});
 
 		const bounds = node.getBoundingClientRect();
+
 		setOverlayBounds(bounds);
 
 		observe();
 
-		return () => {
-			unobserve();
-		};
+		return unobserve;
 	}, [target, alerts]);
 
 	return (
@@ -246,19 +247,16 @@ export default function A11y({children, enable = true}) {
 		};
 	}, [disabled]);
 
-	useEffect(() => {
-		const handler = (event) => {
+	const handlerKeydownEvent = useCallback(
+		(event) => {
 			if (event.ctrlKey && event.key === 'd' && enable) {
 				setDisabled(!disabled);
 			}
-		};
+		},
+		[disabled, enable]
+	);
 
-		document.addEventListener('keydown', handler);
-
-		return () => {
-			document.removeEventListener('keydown', handler);
-		};
-	}, [disabled, enable]);
+	useEventListener('keydown', handlerKeydownEvent, false, document);
 
 	return (
 		<>

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/A11y.es.js
@@ -1,0 +1,258 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ClayButtonWithIcon} from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import ClayPopover from '@clayui/popover';
+import axe from 'axe-core';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
+import ReactDOM from 'react-dom';
+
+import './A11y.css';
+
+function segmentAlertsByNode(alerts) {
+	const nodes = alerts.flatMap((alert) =>
+		alert.nodes.flatMap((node) => node.target)
+	);
+
+	return nodes.map((node) => {
+		const alertsByNode = alerts.filter((alert) =>
+			alert.nodes.some((n) => n.target.includes(node))
+		);
+
+		return {
+			alerts: alertsByNode,
+			node,
+		};
+	});
+}
+
+const Overlay = React.forwardRef(({style, ...othersProps}, ref) =>
+	ReactDOM.createPortal(
+		<div
+			{...othersProps}
+			className="a11y-overlay"
+			ref={ref}
+			style={style}
+		/>,
+		document.body
+	)
+);
+
+function Alert({alerts, target}) {
+	const [visible, setVisible] = useState(false);
+	const [bounds, setBounds] = useState();
+
+	useEffect(() => {
+		const node = document.querySelector(target);
+
+		if (!node) {
+			return;
+		}
+
+		const bounds = node.getBoundingClientRect();
+
+		if (bounds.x > 0 || bounds.y > 0) {
+			const borderRadius = window
+				.getComputedStyle(node, null)
+				.getPropertyValue('border-radius');
+
+			setBounds({
+				'border-radius': borderRadius,
+				height: bounds.height,
+				left: bounds.left,
+				top: bounds.top,
+				width: bounds.width,
+			});
+		}
+	}, [target, alerts]);
+
+	return (
+		<ClayPopover
+			className="popover-a11y"
+			header={
+				<div className="autofit-row autofit-row-center">
+					<div className="autofit-col autofit-col-expand">
+						<span>Accessibility violation</span>
+					</div>
+					<div className="autofit-col">
+						<ClayButtonWithIcon
+							borderless
+							displayType="secondary"
+							onClick={() => setVisible(!visible)}
+							small
+							symbol="times"
+						/>
+					</div>
+				</div>
+			}
+			onShowChange={setVisible}
+			show={visible}
+			trigger={<Overlay style={bounds} />}
+		>
+			{alerts.map((alert) => {
+				const [{all, any}] = alert.nodes.filter((node) =>
+					node.target.includes(target)
+				);
+
+				return (
+					<article key={alert.id}>
+						<div className="autofit-padded autofit-row">
+							<div className="autofit-col">
+								<ClayIcon
+									className="a11y-icon"
+									color={
+										alert.impact === 'minor'
+											? '#0B5FFF'
+											: alert.impact === 'moderate'
+											? '#FF8F39'
+											: '#DA1414'
+									}
+									symbol={
+										alert.impact === 'minor'
+											? 'info-circle'
+											: alert.impact === 'moderate'
+											? 'warning-full'
+											: 'exclamation-full'
+									}
+								/>
+							</div>
+							<div className="autofit-col">
+								<a
+									className="a11y-help"
+									href={alert.helpUrl}
+									rel="noopener noreferrer"
+									target="_blank"
+								>
+									{alert.help}
+								</a>
+								<span className="text-muted">
+									Fix {all.length > 0 ? 'all' : 'any'} of the
+									following
+								</span>
+							</div>
+						</div>
+						{all.length > 0 && (
+							<ul className="a11y-list">
+								{all.map((check) => (
+									<li key={check.id}>{check.message}</li>
+								))}
+							</ul>
+						)}
+						{any.length > 0 && (
+							<ul className="a11y-list">
+								{any.map((check) => (
+									<li key={check.id}>{check.message}</li>
+								))}
+							</ul>
+						)}
+					</article>
+				);
+			})}
+		</ClayPopover>
+	);
+}
+
+export default function A11y({children, enable = true}) {
+	const [alerts, setAlerts] = useState([]);
+	const [disabled, setDisabled] = useState(!enable);
+	const workInProgressRef = useRef(null);
+	const idleIdRef = useRef(null);
+	const childrenRef = useRef(null);
+
+	const alertsByNode = useMemo(() => segmentAlertsByNode(alerts), [alerts]);
+
+	useEffect(() => {
+		if (!childrenRef.current || disabled) {
+			return;
+		}
+
+		if (idleIdRef.current && window.cancelIdleCallback) {
+			window.cancelIdleCallback(idleIdRef.current);
+			idleIdRef.current = null;
+		}
+
+		const getAlerts = () =>
+			axe
+				.run(childrenRef.current, {reporter: 'v2'})
+				.then((results) => setAlerts(results.violations))
+				.catch(console.error);
+
+		const workCallback = () => {
+			if (!workInProgressRef.current) {
+				workInProgressRef.current = getAlerts()
+					.then(() => {
+						workInProgressRef.current = null;
+					})
+					.catch(() => {
+						workInProgressRef.current = null;
+					});
+			}
+		};
+
+		const mutationCallback = () => {
+			if (window.requestIdleCallback) {
+				if (idleIdRef.current) {
+					window.cancelIdleCallback(idleIdRef.current);
+				}
+
+				idleIdRef.current = window.requestIdleCallback(workCallback);
+			}
+			else {
+				workCallback();
+			}
+		};
+
+		const observer = new MutationObserver(mutationCallback);
+
+		observer.observe(childrenRef.current, {
+			attributes: true,
+			childList: true,
+			subtree: true,
+		});
+
+		return () => {
+			if (idleIdRef.current && window.cancelIdleCallback) {
+				window.cancelIdleCallback(idleIdRef.current);
+				idleIdRef.current = null;
+				workInProgressRef.current = null;
+			}
+			observer.disconnect();
+		};
+	}, [disabled]);
+
+	useEffect(() => {
+		const handler = (event) => {
+			if (event.ctrlKey && event.key === 'd' && enable) {
+				setDisabled(!disabled);
+			}
+		};
+
+		document.addEventListener('keydown', handler);
+
+		return () => {
+			document.removeEventListener('keydown', handler);
+		};
+	}, [disabled, enable]);
+
+	return (
+		<>
+			<span ref={childrenRef}>{children}</span>
+			{!disabled &&
+				alertsByNode.map(({alerts, node}) => (
+					<Alert alerts={alerts} key={node} target={node} />
+				))}
+		</>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
@@ -16,6 +16,8 @@ import {ClayIconSpriteContext} from '@clayui/icon';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import A11y from './A11y.es';
+
 let counter = 0;
 
 /**
@@ -71,7 +73,9 @@ export default function render(renderable, renderData, container) {
 		// eslint-disable-next-line @liferay/portal/no-react-dom-render
 		ReactDOM.render(
 			<ClayIconSpriteContext.Provider value={spritemap}>
-				{Component ? <Component {...renderData} /> : renderable}
+				<A11y enable={process.env.NODE_ENV === 'development'}>
+					{Component ? <Component {...renderData} /> : renderable}
+				</A11y>
 			</ClayIconSpriteContext.Provider>,
 			container
 		);

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -2068,6 +2068,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@reach/observe-rect@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.2.0.tgz#d7a6013b8aafcc64c778a0ccb83355a11204d3b2"
+  integrity sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==
+
 "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -4248,6 +4248,11 @@ axe-core@^3.2.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.3.1.tgz#3d1fa78cca8ead1b78c350581501e4e37b97b826"
   integrity sha512-gw1T0JptHPF4AdLLqE8yQq3Z7YvsYkpFmFWd84r6hnq/QoKRr8icYHFumhE7wYl5TVIHgVlchMyJsAYh0CfwCQ==
 
+axe-core@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.2.tgz#c7cf7378378a51fcd272d3c09668002a4990b1cb"
+  integrity sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==
+
 axios@0.18.1:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"


### PR DESCRIPTION
Right here is the PoC for the accessibility monitoring component, there is still a lot to do in this component and make performance adjustments and better positioning of the overlay in different UI scenarios, describing this more below. I ended up creating this on the DXP side but I see a value in adding this on the Clay side to be used in other products outside of DXP as well as in AC.

The component itself is very simple, just use [`axe-core`](https://github.com/dequelabs/axe-core) to validate the component's children element and render the Overlay to block developer interaction and a Popover to show details of violations. This is a component that can also be used to take the entire `document` instead of just the content of the application and use only one component of that globally.

![](https://user-images.githubusercontent.com/13750819/96045446-587db680-0e48-11eb-817a-23ed0d3ee6bd.gif)

### Performance

Using `exe-core` seems to be a bit heavy, it seems to occupy the thread for 300ms but it seems to depend on the [complexity of the page and can take much longer](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#very-large-pages). The disadvantage is that we are not able to perform this on a Worker, so we have to manage violation check requests, in some scenarios it works very well without blocking the screen but in some cases when an interaction causes many renderings or changes in the DOM they can cause slow perceptions, that's because I'm using `MutationObserver` to monitor `children`, but we can work harder to decrease it.

To prevent `axe-core` from being loaded into production and having to [load 568.8 Kb](https://bundlephobia.com/result?p=axe-core@4.0.2) (Minified), we can load via lazy and remove the component's `enable` API in favor of a conditional to work together with React's lazy.

### Overlay

The overlay in some cases may disappear and appear again depending on the interaction that makes a new element render when you are moving an element for example or when you click the element changes the interaction and loses sight of the target, this happens in some cases when some UI element is checking if there was any click outside to close. For example, the Sidebar. I think we managed to prevent this, I haven't tested it yet.

In the UI in some very specific cases, there seem to be elements that are not in view and that is why we did not render the overlay, I noticed some cases in the Page Editor with iframe.

Something that we can consider creating a floating button that can open a menu with the history of recent violations so that the developer can better track the problems.

### Tips

I noticed some cases that Facebook ends up dealing with, I think there may be some implementation on top of `axe-core` that provides tips on violations and how to solve centered on React components. For example, a Button with an `aria-label` problem, provides the tell which component it has the problem with and which component to use or property to correct the problem, this seems very valuable but we would need to understand more deeply how we could elaborate something from type.

### Rules

For this PoC I'm using the default settings of `axe-core` but we can define which rules we want to cover, I'm not sure which rule we want to follow to ensure that we are in compliance.