### PR TITLE
LPS-122265 Update @liferay/npm-bundler to v3.0.0-pre.1

### DIFF
--- a/modules/apps/frontend-js/frontend-js-recharts/package.json
+++ b/modules/apps/frontend-js/frontend-js-recharts/package.json
@@ -3,7 +3,7 @@
 		"recharts": "1.8.5"
 	},
 	"devDependencies": {
-		"@liferay/npm-bundler": "3.0.1-pre.0"
+		"@liferay/npm-bundler": "3.0.1-pre.1"
 	},
 	"name": "frontend-js-recharts",
 	"scripts": {

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1975,10 +1975,10 @@
     liferay-npm-bundler-plugin-replace-browser-modules "2.19.4"
     liferay-npm-bundler-plugin-resolve-linked-dependencies "2.19.4"
 
-"@liferay/npm-bundler@3.0.1-pre.0":
-  version "3.0.1-pre.0"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-bundler/-/npm-bundler-3.0.1-pre.0.tgz#b27606804718250f983748f98ab7362e05f57169"
-  integrity sha512-u1P4wiq5jm02QEs1OBfBlLDT9JJ8bpw6IeaMlwjys9A1T1X8IsUu78tv6uqLLfuq5ByC8xQvMkhX8wqc/U6vsw==
+"@liferay/npm-bundler@3.0.1-pre.1":
+  version "3.0.1-pre.1"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-bundler/-/npm-bundler-3.0.1-pre.1.tgz#466bd2c0395cdb2af032e9c807fbba15033d088d"
+  integrity sha512-Qy1piHRxg/sDr7d2gvhf6rNNh+qRfunbN2VGllwyxu4ny0TujFHXkOcNqzgol0bjlJjSWB9SeUsRH3dc/ebA8Q==
   dependencies:
     "@liferay/js-toolkit-core" "3.0.1-pre.0"
     acorn "^6.2.1"


### PR DESCRIPTION
This is just a routine update for hygiene with no visible impact.

We updated to v3.0.0-pre.0 yesterday in [LPS-122157](https://issues.liferay.com/browse/LPS-122157), but after that we applied [a small tweak](https://github.com/liferay/liferay-frontend-projects/pull/160) for the benefit of [the Fragments Toolkit](https://github.com/liferay/generator-liferay-fragments) and cut a pre.1 release.

[Release notes here](https://github.com/liferay/liferay-frontend-projects/releases/tag/npm-bundler%2Fv3.0.1-pre.1).

As a matter standard practice, we want to keep the versions in sync everywhere, so let's do a small update in DXP as well even though it won't have any visible effect beyond the version number.

Test plan: Deploy `frontend-js-recharts` and see it build and work (ie. in content dashboard).