### PR TITLE
LPS-122099 Accessibility: Navigation landmarks should describe the purpose of their links

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/navigation.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/navigation.ftl
@@ -1,5 +1,5 @@
-<nav aria-label="<@liferay.language key="navigation" />" class="${nav_css_class}" id="navigation" role="navigation">
-	<ul aria-label="<@liferay.language key="site-pages" />" role="menubar">
+<nav aria-label="<@liferay.language key="site-pages" />" class="${nav_css_class}" id="navigation" role="navigation">
+	<ul role="menubar">
 		<#list nav_items as nav_item>
 			<#assign
 				nav_item_attr_has_popup = ""

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/navigation.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/navigation.ftl
@@ -1,4 +1,4 @@
-<nav class="${nav_css_class}" id="navigation" role="navigation">
+<nav aria-label="<@liferay.language key="navigation" />" class="${nav_css_class}" id="navigation" role="navigation">
 	<ul aria-label="<@liferay.language key="site-pages" />" role="menubar">
 		<#list nav_items as nav_item>
 			<#assign

--- a/portal-web/docroot/html/taglib/ui/quick_access/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/quick_access/page.jsp
@@ -21,7 +21,7 @@ String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 %>
 
 <c:if test="<%= ((quickAccessEntries != null) && !quickAccessEntries.isEmpty()) || Validator.isNotNull(contentId) %>">
-	<nav class="quick-access-nav" id="<%= randomNamespace %>quickAccessNav">
+	<nav aria-label="<liferay-ui:message key="quick-links" />" class="quick-access-nav" id="<%= randomNamespace %>quickAccessNav">
 		<h1 class="hide-accessible"><liferay-ui:message key="navigation" /></h1>
 
 		<ul>


### PR DESCRIPTION
Hi guys,

Could you review this pull request, please?

We are trying to add some information to our navigation landmarks so they can describe the purpose of their links. 

This case is a more serious issue when we have more than one navigation landmark in the page (i.e., when we create a new simple theme from _unstyled_) because we'll have two navigation landmarks but we are not describing what they are for making accessibility validator to trigger an error.

In any case, even when we have only one, I think we should describe what it is for.

- `quick-access` taglib is used in our `portal_normal.ftl` templates for _unstyled_ and _Classic_ themes.
- `navigation.ftl` template is override by _Classic_ Theme avoiding using another `nav` label, but we need to consider the case of creating a new theme on top of _unstyled_ as I explained above. In this case, since we were already using an `aria-label` describing the link inside the landmark, I've just moved it up to the parent nav label.

Thanks.

Regards.

/cc @rolandpakai
