### PR TITLE
LRQA-62384 Skip tests running on portal instance

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -22,6 +22,8 @@ definition {
 
 	@priority = "4"
 	test ToastMessageAutoClose {
+		property test.name.skip.portal.instance = "ClayAlert#ToastMessageAutoClose";
+
 		var portalURL = PropsUtil.get("portal.url");
 
 		Navigator.openSpecificURL(url = "${portalURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fedit_configuration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_factoryPid=com.liferay.frontend.js.spa.web.internal.configuration.SPAConfiguration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_pid=com.liferay.frontend.js.spa.web.internal.configuration.SPAConfiguration");
@@ -46,6 +48,8 @@ definition {
 
 	@priority = "3"
 	test ToastMessageManualClose {
+		property test.name.skip.portal.instance = "ClayAlert#ToastMessageManualClose";
+
 		var portalURL = PropsUtil.get("portal.url");
 
 		Navigator.openSpecificURL(url = "${portalURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fedit_configuration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_factoryPid=com.liferay.frontend.js.spa.web.internal.configuration.SPAConfiguration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_pid=com.liferay.frontend.js.spa.web.internal.configuration.SPAConfiguration");


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-62384

This issue also affects 7.3.x, please backport to 7.3.x, thanks!

Description:
Skip ClayAlert tests running on Portal Instance, because the SPAConfiguration that used in tests is only available in System Settings.

This is a temporary fix so that tests can keep running, we'll eventually update the tests when we get a test widgets.

/cc @john-co