### PR TITLE
LPS-122370 Fixed wrong selected language in input localized UI after save as draft

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -155,7 +155,7 @@
 
 							Locale curLocale = LocaleUtil.fromLanguageId(curLanguageId);
 
-							if (errorLocales.contains(curLocale) || ((index == 0) && errorLocales.isEmpty())) {
+							if (errorLocales.contains(curLocale) || (curLanguageId.equals(selectedLanguageId) && errorLocales.isEmpty())) {
 								linkCssClass += " active";
 							}
 


### PR DESCRIPTION
Reproduction Steps:

0. Use a vanilla 7.2 bundle with the latest fix pack.
1. Start the system and navigate to Control Panel → Content → Web Content.
2. Create a new basic web content. Fill out the title content and summary and publish the article.
3. Edit the article, add any transnational to each of the fields. 
4. Save as draft while the translation is the selected language.

Result: After the redirect, the selected language will stay the same but in the input localized language selector, the first element will be marked as active not the actually selected language.

---

Could you please review this pull request?
The modification is related to this pull #133.

https://issues.liferay.com/browse/LPS-122370

Best,
Attila