### PR TITLE
LPS-122389 Remove {addClasses, hasClass, toggleClasses, removeClasses} usages of metal-dom

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountEntriesAdminPortlet.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountEntriesAdminPortlet.es.js
@@ -51,12 +51,10 @@ class AccountEntriesAdminPortlet extends PortletBase {
 	 * @private
 	 */
 	updateVisibility_(typeSelect) {
-		if (typeSelect.value === 'business') {
-			dom.removeClasses(this.businessAccountOnlySection, 'hide');
-		}
-		else {
-			dom.addClasses(this.businessAccountOnlySection, 'hide');
-		}
+		this.businessAccountOnlySection?.classList.toggle(
+			'hide',
+			typeSelect.value === 'person'
+		);
 	}
 
 	/**

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -305,7 +305,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 					);
 
 					if (announcementsDisplayed) {
-						dom.toggleClasses(announcementsDisplayed, 'hide');
+						announcementsDisplayed.classList.toggle('hide');
 					}
 				}
 			);

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/entry_select_scope.jspf
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/entry_select_scope.jspf
@@ -118,9 +118,9 @@ boolean hasDistributionScope = false;
 </aui:select>
 
 <c:if test="<%= !hasDistributionScope %>">
-	<aui:script require="metal-dom/src/dom">
-		var dom = metalDomSrcDom.default;
+	<aui:script>
+		var fieldSet = document.getElementById('#<portlet:namespace />fieldSet');
 
-		dom.addClasses('#<portlet:namespace />fieldSet', 'hide');
+		fieldSet.classList.add('hide');
 	</aui:script>
 </c:if>

--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
@@ -59,14 +59,19 @@ AssetDisplayPagesItemSelectorViewDisplayContext assetDisplayPagesItemSelectorVie
 		'click',
 		'.layout-page-template-entry',
 		function (event) {
-			dom.removeClasses(
-				document.querySelectorAll('.form-check-card.active'),
-				'active'
-			);
-			dom.addClasses(
-				dom.closest(event.delegateTarget, '.form-check-card'),
-				'active'
-			);
+			var activeCards = document.querySelectorAll('.form-check-card.active');
+
+			if (activeCards.length) {
+				activeCards.forEach(function (card) {
+					card.classList.remove('active');
+				});
+			}
+
+			var newSelectedCard = event.delegateTarget.closest('.form-check-card');
+
+			if (newSelectedCard) {
+				newSelectedCard.classList.add('active');
+			}
 
 			Liferay.Util.getOpener().Liferay.fire(
 				'<%= assetDisplayPagesItemSelectorViewDisplayContext.getItemSelectedEventName() %>',

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
@@ -123,31 +123,27 @@ if (organizationId > 0) {
 					);
 				</aui:script>
 
-				<aui:script require="metal-dom/src/dom">
-					var dom = metalDomSrcDom.default;
-
-					var <portlet:namespace />selectionMethod = document.getElementById(
+				<aui:script sandbox="<%= true %>">
+					var selectionMethodElement = document.getElementById(
 						'<portlet:namespace />selectionMethod'
 					);
 
-					if (<portlet:namespace />selectionMethod) {
-						<portlet:namespace />selectionMethod.addEventListener('change', function (
-							event
-						) {
+					if (selectionMethodElement) {
+						selectionMethodElement.addEventListener('change', function (event) {
 							var usersSelectionOptions = document.getElementById(
 								'<portlet:namespace />usersSelectionOptions'
 							);
 
 							if (usersSelectionOptions) {
 								var showUsersSelectionOptions = !(
-									<portlet:namespace />selectionMethod.val() === 'users'
+									selectionMethodElement.value === 'users'
 								);
 
 								if (showUsersSelectionOptions) {
-									dom.addClasses(usersSelectionOptions, 'hide');
+									usersSelectionOptions.classList.add('hide');
 								}
 								else {
-									dom.removeClasses(usersSelectionOptions, 'hide');
+									usersSelectionOptions.classList.remove('hide');
 								}
 							}
 						});

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -662,7 +662,7 @@ renderResponse.setTitle(headerTitle);
 </script>
 
 <c:if test="<%= (fileEntry != null) && !checkedOut && dlAdminDisplayContext.isVersioningStrategyOverridable() %>">
-	<aui:script require="metal-dom/src/dom as dom">
+	<aui:script>
 		var updateVersionDetailsElement = document.getElementById(
 			'<portlet:namespace />updateVersionDetails'
 		);
@@ -672,7 +672,7 @@ renderResponse.setTitle(headerTitle);
 
 		if (updateVersionDetailsElement && versionDetailsElement) {
 			updateVersionDetailsElement.addEventListener('click', function (event) {
-				dom.toggleClasses(versionDetailsElement, 'hide');
+				versionDetailsElement.classList.toggle('hide');
 			});
 		}
 	</aui:script>

--- a/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view.jsp
+++ b/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view.jsp
@@ -55,13 +55,11 @@ Group group = GroupLocalServiceUtil.getGroup(scopeGroupId);
 		</aui:script>
 	</c:when>
 	<c:otherwise>
-		<aui:script require="metal-dom/src/dom">
-			var dom = metalDomSrcDom.default;
-
+		<aui:script>
 			var portlet = document.getElementById('p_p_id<portlet:namespace />');
 
 			if (portlet) {
-				dom.addClasses(portlet, 'hide');
+				portlet.classList.add('hide');
 			}
 		</aui:script>
 	</c:otherwise>

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -221,14 +221,19 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 				'click',
 				'.entry',
 				function (event) {
-					dom.removeClasses(
-						document.querySelectorAll('.form-check-card.active'),
-						'active'
-					);
-					dom.addClasses(
-						dom.closest(event.delegateTarget, '.form-check-card'),
-						'active'
-					);
+					var activeCards = document.querySelectorAll('.form-check-card.active');
+
+					if (activeCards.length) {
+						activeCards.forEach(function (card) {
+							card.classList.remove('active');
+						});
+					}
+
+					var newSelectedCard = event.delegateTarget.closest('.form-check-card');
+
+					if (newSelectedCard) {
+						newSelectedCard.classList.add('active');
+					}
 
 					Liferay.Util.getOpener().Liferay.fire(
 						'<%= itemSelectorViewDescriptorRendererDisplayContext.getItemSelectedEventName() %>',

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -373,7 +373,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 	</liferay-ui:search-container>
 </clay:container-fluid>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="metal-dom/src/all/dom as dom" sandbox="<%= true %>">
 	var selectArticleHandler = dom.delegate(
 		document.querySelector('#<portlet:namespace />articlesContainer'),
 		'click',
@@ -381,24 +381,30 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 		function (event) {
 			<c:choose>
 				<c:when test='<%= Objects.equals(journalArticleItemSelectorViewDisplayContext.getDisplayStyle(), "icon") %>'>
-					dom.removeClasses(
-						document.querySelectorAll('.form-check-card.active'),
-						'active'
+					var activeFormCheckCards = document.querySelectorAll(
+						'.form-check-card.active'
 					);
-					dom.addClasses(
-						dom.closest(event.delegateTarget, '.form-check-card'),
-						'active'
-					);
+					var formCheckCard = event.delegateTarget.closest('.form-check-card');
+
+					if (activeFormCheckCards.length) {
+						activeFormCheckCards.forEach(function (card) {
+							card.classList.remove('active');
+						});
+					}
+
+					formCheckCard.classList.add('active');
 				</c:when>
 				<c:otherwise>
-					dom.removeClasses(
-						document.querySelectorAll('.articles.active'),
-						'active'
-					);
-					dom.addClasses(
-						dom.closest(event.delegateTarget, '.articles'),
-						'active'
-					);
+					var activeArticles = document.querySelectorAll('.articles.active');
+					var articles = event.delegateTarget.closest('.articles');
+
+					if (activeArticles.length) {
+						activeArticles.forEach(function (article) {
+							article.classList.remove('active');
+						});
+					}
+
+					articles.classList.add('active');
 				</c:otherwise>
 			</c:choose>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/customization_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/customization_settings.jsp
@@ -156,7 +156,7 @@ boolean hasUpdateLayoutPermission = GetterUtil.getBoolean(request.getAttribute(C
 					</div>
 				</li>
 
-				<aui:script require="metal-dom/src/dom as dom">
+				<aui:script>
 					var closeCustomizationOptions = document.getElementById(
 						'<%= portletNamespace %>closeCustomizationOptions'
 					);
@@ -166,7 +166,7 @@ boolean hasUpdateLayoutPermission = GetterUtil.getBoolean(request.getAttribute(C
 
 					if (closeCustomizationOptions && controlMenu) {
 						closeCustomizationOptions.addEventListener('click', function (event) {
-							dom.toggleClasses(controlMenu, 'open');
+							controlMenu.classList.toggle('open');
 						});
 					}
 
@@ -176,7 +176,7 @@ boolean hasUpdateLayoutPermission = GetterUtil.getBoolean(request.getAttribute(C
 
 					if (customizationButton && controlMenu) {
 						customizationButton.addEventListener('click', function (event) {
-							dom.toggleClasses(controlMenu, 'open');
+							controlMenu.classList.toggle('open');
 						});
 					}
 				</aui:script>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
@@ -50,14 +50,19 @@ List<LayoutPageTemplateEntry> masterLayoutPageTemplateEntries = selectLayoutPage
 		'click',
 		'.select-master-layout-option',
 		function (event) {
-			dom.removeClasses(
-				document.querySelectorAll('.form-check-card.active'),
-				'active'
-			);
-			dom.addClasses(
-				dom.closest(event.delegateTarget, '.form-check-card'),
-				'active'
-			);
+			var activeCards = document.querySelectorAll('.form-check-card.active');
+
+			if (activeCards.length) {
+				activeCards.forEach(function (card) {
+					card.classList.remove('active');
+				});
+			}
+
+			var newSelectedCard = event.delegateTarget.closest('.form-check-card');
+
+			if (newSelectedCard) {
+				newSelectedCard.classList.add('active');
+			}
 
 			Liferay.Util.getOpener().Liferay.fire(
 				'<%= HtmlUtil.escape(eventName) %>',

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
@@ -72,10 +72,7 @@ List<StyleBookEntry> styleBookEntries = selectLayoutPageTemplateEntryDisplayCont
 				});
 			}
 
-			var newSelectedCard = dom.closest(
-				event.delegateTarget,
-				'.form-check-card'
-			);
+			var newSelectedCard = event.delegateTarget.closest('.form-check-card');
 
 			if (newSelectedCard) {
 				newSelectedCard.classList.add('active');

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
@@ -64,14 +64,22 @@ List<StyleBookEntry> styleBookEntries = selectLayoutPageTemplateEntryDisplayCont
 		'click',
 		'.select-master-layout-option',
 		function (event) {
-			dom.removeClasses(
-				document.querySelectorAll('.form-check-card.active'),
-				'active'
+			var activeCards = document.querySelectorAll('.form-check-card.active');
+
+			if (activeCards.length) {
+				activeCards.forEach(function (card) {
+					card.classList.remove('active');
+				});
+			}
+
+			var newSelectedCard = dom.closest(
+				event.delegateTarget,
+				'.form-check-card'
 			);
-			dom.addClasses(
-				dom.closest(event.delegateTarget, '.form-check-card'),
-				'active'
-			);
+
+			if (newSelectedCard) {
+				newSelectedCard.classList.add('active');
+			}
 
 			Liferay.Util.getOpener().Liferay.fire(
 				'<%= HtmlUtil.escape(eventName) %>',

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/login_redirect.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/login_redirect.jsp
@@ -56,14 +56,13 @@ boolean anonymousAccount = ParamUtil.getBoolean(request, "anonymousUser");
 			);
 
 			if (messageContainer) {
-				dom.removeClasses(messageContainer, 'alert-danger');
-				dom.removeClasses(messageContainer, 'alert-success');
+				messageContainer.classList.remove('alert-danger', 'alert-success');
 
-				dom.addClasses(messageContainer, 'alert alert-' + type);
+				messageContainer.classList.add(`alert alert-${type}`);
 
 				messageContainer.innerHTML = message;
 
-				dom.removeClasses(messageContainer, 'hide');
+				messageContainer.classList.remove('hide');
 			}
 		});
 
@@ -81,9 +80,7 @@ boolean anonymousAccount = ParamUtil.getBoolean(request, "anonymousUser");
 					var anonymousAccount = form.querySelector('.anonymous-account');
 
 					if (anonymousAccount) {
-						dom.addClasses(anonymousAccount, 'hide');
-
-						dom.removeClasses(anonymousAccount, 'show');
+						anonymousAccount.classList.replace('show', 'hide');
 					}
 				}
 
@@ -119,9 +116,7 @@ boolean anonymousAccount = ParamUtil.getBoolean(request, "anonymousUser");
 						);
 
 						if (anonymousAccount) {
-							dom.addClasses(anonymousAccount, 'hide');
-
-							dom.removeClasses(anonymousAccount, 'show');
+							anonymousAccount.classList.replace('show', 'hide');
 						}
 					})
 					.catch(onError);

--- a/modules/apps/nested-portlets/nested-portlets-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/main/resources/META-INF/resources/view.jsp
@@ -31,9 +31,7 @@
 		<liferay-ui:message key="drag-applications-below-to-nest-them" />
 	</div>
 
-	<aui:script require="metal-dom/src/dom">
-		var dom = metalDomSrcDom.default;
-
+	<aui:script>
 		var portletWrapper = document.getElementById(
 			'p_p_id_<%= portletDisplay.getId() %>_'
 		);
@@ -49,9 +47,7 @@
 			);
 
 			if (nestedPortletsMsg) {
-				dom.addClasses(nestedPortletsMsg, 'show');
-
-				dom.removeClasses(nestedPortletsMsg, 'hide');
+				nestedPortletsMsg.classList.replace('hide', 'show');
 			}
 		}
 	</aui:script>

--- a/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/edit_entry.jsp
+++ b/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/edit_entry.jsp
@@ -150,7 +150,7 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 		'#<portlet:namespace />advancedMode, #<portlet:namespace />friendlyMode',
 		function (event) {
 			Array.prototype.forEach.call(alternatingElements, function (element) {
-				dom.toggleClasses(element, 'hide');
+				element.classList.toggle('hide');
 			});
 		}
 	);

--- a/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/test.jspf
+++ b/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/test.jspf
@@ -40,27 +40,21 @@
 	</aui:button-row>
 </aui:form>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script>
 	var onSendPushNotification = function (result) {
 		var success = document.getElementById('<portlet:namespace />success');
 
 		if (success) {
-			dom.addClasses(success, 'hide');
-
-			dom.removeClasses(success, 'show');
+			success.classList.replace('show', 'hide');
 
 			var error = document.getElementById('<portlet:namespace />error');
 
 			if (error) {
-				dom.addClasses(success, 'hide');
-
-				dom.removeClasses(success, 'show');
+				success.classList.replace('show', 'hide');
 			}
 
 			if (AUI().Object.isEmpty(result)) {
-				dom.addClasses(success, 'show');
-
-				dom.removeClasses(success, 'hide');
+				success.classList.replace('hide', 'show');
 			}
 			else {
 				var paragraph = error.querySelector('p');
@@ -69,9 +63,7 @@
 					paragraph.textContent = result;
 				}
 
-				dom.addClasses(error, 'show');
-
-				dom.removeClasses(error, 'hide');
+				success.classList.replace('hide', 'show');
 			}
 		}
 	};

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -404,7 +404,7 @@ else {
 						rootMenuItemNameSpan.innerText = selectedItem.name;
 						siteNavigationMenuIdInput.value = selectedItem.id;
 
-						dom.toggleClasses(removeSiteNavigationMenu, 'hide');
+						removeSiteNavigationMenu.classList.toggle('hide');
 
 						<portlet:namespace />resetPreview();
 					}
@@ -436,7 +436,7 @@ else {
 			rootMenuItemNameSpan.innerText = '';
 			siteNavigationMenuIdInput.value = '0';
 
-			dom.toggleClasses(removeSiteNavigationMenu, 'hide');
+			removeSiteNavigationMenu.classList.toggle('hide');
 
 			<portlet:namespace />resetPreview();
 		});

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/UserNameFields.es.js
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/UserNameFields.es.js
@@ -216,7 +216,7 @@ class UserNameFields extends PortletBase {
 	 * @protected
 	 */
 	_removeLoadingIndicator() {
-		dom.exitDocument(this.one('#loadingUserNameFields'));
+		this.one('#loadingUserNameFields').remove();
 
 		this.userNameFieldsNode.classList.remove('hide');
 	}

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/UserNameFields.es.js
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/UserNameFields.es.js
@@ -114,7 +114,7 @@ class UserNameFields extends PortletBase {
 			this._loadingAnimationMarkupText
 		);
 
-		dom.addClasses(this.userNameFieldsNode, 'hide');
+		this.userNameFieldsNode.classList.add('hide');
 	}
 
 	_cleanUp() {
@@ -218,7 +218,7 @@ class UserNameFields extends PortletBase {
 	_removeLoadingIndicator() {
 		dom.exitDocument(this.one('#loadingUserNameFields'));
 
-		dom.removeClasses(this.userNameFieldsNode, 'hide');
+		this.userNameFieldsNode.classList.remove('hide');
 	}
 
 	/**

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -78,7 +78,7 @@
 		'focusin',
 		'.portlet',
 		function(event) {
-			dom.addClasses(dom.closest(event.delegateTarget, '.portlet'), 'open');
+			dom.closest(event.delegateTarget, '.portlet').classList.add('open');
 		}
 	);
 
@@ -87,7 +87,7 @@
 		'focusout',
 		'.portlet',
 		function(event) {
-			dom.removeClasses(dom.closest(event.delegateTarget, '.portlet'), 'open');
+			dom.closest(event.delegateTarget, '.portlet').classList.remove('open');
 		}
 	);
 </aui:script>


### PR DESCRIPTION
The goal of this task is to remove all usages of addClasses, hasClass and removeClasses and toggleClasses from the metal-dom package.

Initial analysis shows that these usages can be replaced by standard [classList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) Apis.


# Questions

* Is there a possibility to enabling ES6 syntax on JSPs? 💔

* I found a lot of use cases where we 
```
if (showUsersSelectionOptions) {
    usersSelectionOptions.classList.add('hide');
    console.log('add: ', usersSelectionOptions.className);
}
else {
    usersSelectionOptions.classList.remove('hide');
    console.log('remove: ', usersSelectionOptions.className);
}
```

the most use cases are handling select elements and their options. Can I make a vanilla utility on `frontend-js-web` to avoid duplication of code everywhere?
