### PR TITLE
[7.4-only] LPS-112478 Create ClayFileCard, ClayImageCard and ClayVerticalCard for clay v3

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/CardsDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/CardsDisplayContext.java
@@ -34,16 +34,41 @@ public class CardsDisplayContext {
 			return _actionDropdownItems;
 		}
 
-		_actionDropdownItems = DropdownItemListBuilder.add(
-			dropdownItem -> {
-				dropdownItem.setHref("#1");
-				dropdownItem.setLabel("Edit");
-				dropdownItem.setSeparator(true);
+		_actionDropdownItems = DropdownItemListBuilder.addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						dropdownItem -> {
+							dropdownItem.setHref("#1");
+							dropdownItem.setLabel("Group 1 - Option 1");
+						}
+					).add(
+						dropdownItem -> {
+							dropdownItem.setHref("#2");
+							dropdownItem.setLabel("Group 1 - Option 2");
+						}
+					).add(
+						dropdownItem -> dropdownItem.setType("divider")
+					).build());
+
+				dropdownGroupItem.setLabel("Group 1");
 			}
-		).add(
-			dropdownItem -> {
-				dropdownItem.setHref("#2");
-				dropdownItem.setLabel("Save");
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						dropdownItem -> {
+							dropdownItem.setHref("#3");
+							dropdownItem.setLabel("Group 2 - Option 1");
+						}
+					).add(
+						dropdownItem -> {
+							dropdownItem.setHref("#4");
+							dropdownItem.setLabel("Group 2 - Option 2");
+						}
+					).build());
+
+				dropdownGroupItem.setLabel("Group 2");
 			}
 		).build();
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleFileCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleFileCard.java
@@ -1,0 +1,338 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.sample.web.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.soy.FileCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
+import com.liferay.portal.kernel.security.RandomUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Julien Castelain
+ */
+public class ClaySampleFileCard implements FileCard {
+
+	public List<DropdownItem> getActionDropdownItems() {
+		if (_actionDropdownItems != null) {
+			return _actionDropdownItems;
+		}
+
+		_actionDropdownItems = DropdownItemListBuilder.addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						dropdownItem -> {
+							dropdownItem.setHref("#A");
+							dropdownItem.setLabel("Option A");
+						}
+					).add(
+						dropdownItem -> {
+							dropdownItem.setHref("#B");
+							dropdownItem.setLabel("Option B");
+						}
+					).add(
+						dropdownItem -> dropdownItem.setType("divider")
+					).build());
+
+				dropdownGroupItem.setLabel("Group 1");
+			}
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						dropdownItem -> {
+							dropdownItem.setHref("#C");
+							dropdownItem.setLabel("Option A");
+						}
+					).add(
+						dropdownItem -> {
+							dropdownItem.setHref("#D");
+							dropdownItem.setLabel("Option B");
+						}
+					).build());
+
+				dropdownGroupItem.setLabel("Group 2");
+			}
+		).build();
+
+		return _actionDropdownItems;
+	}
+
+	public String getCssClass() {
+		if (_cssClass != null) {
+			return _cssClass;
+		}
+
+		return "custom-file-card-css-class";
+	}
+
+	public String getHref() {
+		if (_href != null) {
+			return _href;
+		}
+
+		return "#file-card-href";
+	}
+
+	public String getIcon() {
+		if (_icon != null) {
+			return _icon;
+		}
+
+		return "documents-and-media";
+	}
+
+	public String getId() {
+		if (_id != null) {
+			return _id;
+		}
+
+		_currentIdNumber = _currentIdNumber + 1;
+
+		return "fileCardId" + _currentIdNumber;
+	}
+
+	public String getInputName() {
+		if (_inputName != null) {
+			return _inputName;
+		}
+
+		return "file-card-input-name";
+	}
+
+	public String getInputValue() {
+		if (_inputValue != null) {
+			return _inputValue;
+		}
+
+		return "file-card-input-value";
+	}
+
+	public List<LabelItem> getLabels() {
+		if (_labels != null) {
+			return _labels;
+		}
+
+		int numItems = 1 + RandomUtil.nextInt(3);
+
+		return LabelItemListBuilder.add(
+			labelItem -> {
+				labelItem.setLabel("Recommended");
+				labelItem.setStyle("success");
+			}
+		).add(
+			() -> numItems > 1, labelItem -> labelItem.setLabel("Approved")
+		).add(
+			() -> numItems > 2,
+			labelItem -> {
+				labelItem.setLabel("Rejected");
+				labelItem.setStyle("warning");
+			}
+		).build();
+	}
+
+	public Map<String, String> getLabelStylesMap() {
+		if (_labelStylesMap != null) {
+			return _labelStylesMap;
+		}
+
+		_labelStylesMap = HashMapBuilder.put(
+			"Approved", "info"
+		).build();
+
+		return _labelStylesMap;
+	}
+
+	public String getStickerCssClass() {
+		return _stickerCssClass;
+	}
+
+	public String getStickerIcon() {
+		return _stickerIcon;
+	}
+
+	public String getStickerImageAlt() {
+		return _stickerImageAlt;
+	}
+
+	public String getStickerImageSrc() {
+		return _stickerImageSrc;
+	}
+
+	public String getStickerLabel() {
+		if (_stickerLabel != null) {
+			return _stickerLabel;
+		}
+
+		return "DOC";
+	}
+
+	public String getStickerShape() {
+		if (_stickerShape != null) {
+			return _stickerShape;
+		}
+
+		return "";
+	}
+
+	public String getStickerStyle() {
+		if (_stickerStyle != null) {
+		}
+
+		return "info";
+	}
+
+	public String getSubtitle() {
+		if (_subtitle != null) {
+			return _subtitle;
+		}
+
+		return "File Action";
+	}
+
+	public String getTitle() {
+		if (_title != null) {
+			return _title;
+		}
+
+		return "File Card";
+	}
+
+	public boolean isDisabled() {
+		return _disabled;
+	}
+
+	public boolean isSelectable() {
+		return _selectable;
+	}
+
+	public boolean isSelected() {
+		return _selected;
+	}
+
+	public void setActionDropdownItems(List<DropdownItem> actionDropdownItems) {
+		_actionDropdownItems = actionDropdownItems;
+	}
+
+	public void setCssClass(String cssClass) {
+		_cssClass = cssClass;
+	}
+
+	public void setDisabled(boolean disabled) {
+		_disabled = disabled;
+	}
+
+	public void setHref(String href) {
+		_href = href;
+	}
+
+	public void setIcon(String icon) {
+		_icon = icon;
+	}
+
+	public void setId(String id) {
+		_id = id;
+	}
+
+	public void setInputName(String inputName) {
+		_inputName = inputName;
+	}
+
+	public void setInputValue(String inputValue) {
+		_inputValue = inputValue;
+	}
+
+	public void setLabels(List<LabelItem> labels) {
+		_labels = labels;
+	}
+
+	public void setLabelStylesMap(Map<String, String> labelStylesMap) {
+		_labelStylesMap = labelStylesMap;
+	}
+
+	public void setSelectable(boolean selectable) {
+		_selectable = selectable;
+	}
+
+	public void setSelected(boolean selected) {
+		_selected = selected;
+	}
+
+	public void setStickerCssClass(String stickerCssClass) {
+		_stickerCssClass = stickerCssClass;
+	}
+
+	public void setStickerIcon(String stickerIcon) {
+		_stickerIcon = stickerIcon;
+	}
+
+	public void setStickerImageAlt(String stickerImageAlt) {
+		_stickerImageAlt = stickerImageAlt;
+	}
+
+	public void setStickerImageSrc(String stickerImageSrc) {
+		_stickerImageSrc = stickerImageSrc;
+	}
+
+	public void setStickerLabel(String stickerLabel) {
+		_stickerLabel = stickerLabel;
+	}
+
+	public void setStickerShape(String stickerShape) {
+		_stickerShape = stickerShape;
+	}
+
+	public void setStickerStyle(String stickerStyle) {
+		_stickerStyle = stickerStyle;
+	}
+
+	public void setSubtitle(String subtitle) {
+		_subtitle = subtitle;
+	}
+
+	public void setTitle(String title) {
+		_title = title;
+	}
+
+	private List<DropdownItem> _actionDropdownItems;
+	private String _cssClass;
+	private int _currentIdNumber;
+	private boolean _disabled;
+	private String _href;
+	private String _icon;
+	private String _id;
+	private String _inputName;
+	private String _inputValue;
+	private List<LabelItem> _labels;
+	private Map<String, String> _labelStylesMap;
+	private boolean _selectable = true;
+	private boolean _selected;
+	private String _stickerCssClass;
+	private String _stickerIcon;
+	private String _stickerImageAlt;
+	private String _stickerImageSrc;
+	private String _stickerLabel;
+	private String _stickerShape;
+	private String _stickerStyle;
+	private String _subtitle;
+	private String _title;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleImageCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleImageCard.java
@@ -14,36 +14,66 @@
 
 package com.liferay.frontend.taglib.clay.sample.web.internal.display.context;
 
-import com.liferay.frontend.taglib.clay.servlet.taglib.soy.UserCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.soy.ImageCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
 import com.liferay.portal.kernel.security.RandomUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.List;
+import java.util.Map;
 
 /**
- * @author Carlos Lancha
+ * @author Julien Castelain
  */
-public class ClaySampleUserCard implements UserCard {
+public class ClaySampleImageCard implements ImageCard {
 
 	public List<DropdownItem> getActionDropdownItems() {
 		if (_actionDropdownItems != null) {
 			return _actionDropdownItems;
 		}
 
-		return DropdownItemListBuilder.add(
-			dropdownItem -> {
-				dropdownItem.setHref("#1");
-				dropdownItem.setLabel("Edit");
+		_actionDropdownItems = DropdownItemListBuilder.addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						dropdownItem -> {
+							dropdownItem.setHref("#1");
+							dropdownItem.setLabel("Group 1 - Option 1");
+						}
+					).add(
+						dropdownItem -> {
+							dropdownItem.setHref("#2");
+							dropdownItem.setLabel("Group 1 - Option 2");
+						}
+					).add(
+						dropdownItem -> dropdownItem.setType("divider")
+					).build());
+
+				dropdownGroupItem.setLabel("Group 1");
 			}
-		).add(
-			dropdownItem -> {
-				dropdownItem.setHref("#2");
-				dropdownItem.setLabel("Save");
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						dropdownItem -> {
+							dropdownItem.setHref("#3");
+							dropdownItem.setLabel("Group 2 - Option 1");
+						}
+					).add(
+						dropdownItem -> {
+							dropdownItem.setHref("#4");
+							dropdownItem.setLabel("Group 2 - Option 2");
+						}
+					).build());
+
+				dropdownGroupItem.setLabel("Group 2");
 			}
 		).build();
+
+		return _actionDropdownItems;
 	}
 
 	public String getCssClass() {
@@ -51,7 +81,7 @@ public class ClaySampleUserCard implements UserCard {
 			return _cssClass;
 		}
 
-		return "custom-css-class";
+		return "custom-image-card-css-class";
 	}
 
 	public String getHref() {
@@ -59,11 +89,15 @@ public class ClaySampleUserCard implements UserCard {
 			return _href;
 		}
 
-		return "#user-card-href";
+		return "#image-card-href";
 	}
 
 	public String getIcon() {
-		return _icon;
+		if (_icon != null) {
+			return _icon;
+		}
+
+		return "camera";
 	}
 
 	public String getId() {
@@ -73,7 +107,7 @@ public class ClaySampleUserCard implements UserCard {
 
 		_currentIdNumber = _currentIdNumber + 1;
 
-		return "userCardId" + _currentIdNumber;
+		return "imageCardId" + _currentIdNumber;
 	}
 
 	public String getImageAlt() {
@@ -81,7 +115,7 @@ public class ClaySampleUserCard implements UserCard {
 			return _imageAlt;
 		}
 
-		return "User Card Image Alt Text";
+		return "An image";
 	}
 
 	public String getImageSrc() {
@@ -93,7 +127,7 @@ public class ClaySampleUserCard implements UserCard {
 			return _inputName;
 		}
 
-		return "user-card-input-name";
+		return "image-card-input-name";
 	}
 
 	public String getInputValue() {
@@ -101,7 +135,7 @@ public class ClaySampleUserCard implements UserCard {
 			return _inputValue;
 		}
 
-		return "user-card-input-value";
+		return "image-card-input-value";
 	}
 
 	public List<LabelItem> getLabels() {
@@ -127,12 +161,55 @@ public class ClaySampleUserCard implements UserCard {
 		).build();
 	}
 
-	public String getName() {
-		if (_name != null) {
-			return _name;
+	public Map<String, String> getLabelStylesMap() {
+		if (_labelStylesMap != null) {
+			return _labelStylesMap;
 		}
 
-		return "User Name";
+		_labelStylesMap = HashMapBuilder.put(
+			"Pending", "warning"
+		).build();
+
+		return _labelStylesMap;
+	}
+
+	public String getStickerCssClass() {
+		return _stickerCssClass;
+	}
+
+	public String getStickerIcon() {
+		return _stickerIcon;
+	}
+
+	public String getStickerImageAlt() {
+		return _stickerImageAlt;
+	}
+
+	public String getStickerImageSrc() {
+		return _stickerImageSrc;
+	}
+
+	public String getStickerLabel() {
+		if (_stickerLabel != null) {
+			return _stickerLabel;
+		}
+
+		return "JPG";
+	}
+
+	public String getStickerShape() {
+		if (_stickerShape != null) {
+			return _stickerShape;
+		}
+
+		return "circle";
+	}
+
+	public String getStickerStyle() {
+		if (_stickerStyle != null) {
+		}
+
+		return "danger";
 	}
 
 	public String getSubtitle() {
@@ -140,15 +217,15 @@ public class ClaySampleUserCard implements UserCard {
 			return _subtitle;
 		}
 
-		return "Latest Action";
+		return "Author Action";
 	}
 
-	public String getUserColorClass() {
-		if (_userColorClass != null) {
-			return _userColorClass;
+	public String getTitle() {
+		if (_title != null) {
+			return _title;
 		}
 
-		return "info";
+		return "Image Card";
 	}
 
 	public boolean isDisabled() {
@@ -207,8 +284,8 @@ public class ClaySampleUserCard implements UserCard {
 		_labels = labels;
 	}
 
-	public void setName(String name) {
-		_name = name;
+	public void setLabelStylesMap(Map<String, String> labelStylesMap) {
+		_labelStylesMap = labelStylesMap;
 	}
 
 	public void setSelectable(boolean selectable) {
@@ -219,12 +296,40 @@ public class ClaySampleUserCard implements UserCard {
 		_selected = selected;
 	}
 
+	public void setStickerCssClass(String stickerCssClass) {
+		_stickerCssClass = stickerCssClass;
+	}
+
+	public void setStickerIcon(String stickerIcon) {
+		_stickerIcon = stickerIcon;
+	}
+
+	public void setStickerImageAlt(String stickerImageAlt) {
+		_stickerImageAlt = stickerImageAlt;
+	}
+
+	public void setStickerImageSrc(String stickerImageSrc) {
+		_stickerImageSrc = stickerImageSrc;
+	}
+
+	public void setStickerLabel(String stickerLabel) {
+		_stickerLabel = stickerLabel;
+	}
+
+	public void setStickerShape(String stickerShape) {
+		_stickerShape = stickerShape;
+	}
+
+	public void setStickerStyle(String stickerStyle) {
+		_stickerStyle = stickerStyle;
+	}
+
 	public void setSubtitle(String subtitle) {
 		_subtitle = subtitle;
 	}
 
-	public void setUserColorClass(String userColorClass) {
-		_userColorClass = userColorClass;
+	public void setTitle(String title) {
+		_title = title;
 	}
 
 	private List<DropdownItem> _actionDropdownItems;
@@ -239,10 +344,17 @@ public class ClaySampleUserCard implements UserCard {
 	private String _inputName;
 	private String _inputValue;
 	private List<LabelItem> _labels;
-	private String _name;
+	private Map<String, String> _labelStylesMap;
 	private boolean _selectable = true;
 	private boolean _selected;
+	private String _stickerCssClass;
+	private String _stickerIcon;
+	private String _stickerImageAlt;
+	private String _stickerImageSrc;
+	private String _stickerLabel;
+	private String _stickerShape;
+	private String _stickerStyle;
 	private String _subtitle;
-	private String _userColorClass;
+	private String _title;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleVerticalCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleVerticalCard.java
@@ -14,36 +14,66 @@
 
 package com.liferay.frontend.taglib.clay.sample.web.internal.display.context;
 
-import com.liferay.frontend.taglib.clay.servlet.taglib.soy.UserCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.soy.VerticalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
 import com.liferay.portal.kernel.security.RandomUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.List;
+import java.util.Map;
 
 /**
- * @author Carlos Lancha
+ * @author Julien Castelain
  */
-public class ClaySampleUserCard implements UserCard {
+public class ClaySampleVerticalCard implements VerticalCard {
 
 	public List<DropdownItem> getActionDropdownItems() {
 		if (_actionDropdownItems != null) {
 			return _actionDropdownItems;
 		}
 
-		return DropdownItemListBuilder.add(
-			dropdownItem -> {
-				dropdownItem.setHref("#1");
-				dropdownItem.setLabel("Edit");
+		_actionDropdownItems = DropdownItemListBuilder.addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						dropdownItem -> {
+							dropdownItem.setHref("#1");
+							dropdownItem.setLabel("Option 1");
+						}
+					).add(
+						dropdownItem -> {
+							dropdownItem.setHref("#2");
+							dropdownItem.setLabel("Option 2");
+						}
+					).add(
+						dropdownItem -> dropdownItem.setType("divider")
+					).build());
+
+				dropdownGroupItem.setLabel("Group 1");
 			}
-		).add(
-			dropdownItem -> {
-				dropdownItem.setHref("#2");
-				dropdownItem.setLabel("Save");
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						dropdownItem -> {
+							dropdownItem.setHref("#3");
+							dropdownItem.setLabel("Option 1");
+						}
+					).add(
+						dropdownItem -> {
+							dropdownItem.setHref("#4");
+							dropdownItem.setLabel("Option 2");
+						}
+					).build());
+
+				dropdownGroupItem.setLabel("Group 2");
 			}
 		).build();
+
+		return _actionDropdownItems;
 	}
 
 	public String getCssClass() {
@@ -51,7 +81,7 @@ public class ClaySampleUserCard implements UserCard {
 			return _cssClass;
 		}
 
-		return "custom-css-class";
+		return "custom-vertical-card-css-class";
 	}
 
 	public String getHref() {
@@ -59,11 +89,15 @@ public class ClaySampleUserCard implements UserCard {
 			return _href;
 		}
 
-		return "#user-card-href";
+		return "#vertical-card-href";
 	}
 
 	public String getIcon() {
-		return _icon;
+		if (_icon != null) {
+			return _icon;
+		}
+
+		return "list";
 	}
 
 	public String getId() {
@@ -73,15 +107,11 @@ public class ClaySampleUserCard implements UserCard {
 
 		_currentIdNumber = _currentIdNumber + 1;
 
-		return "userCardId" + _currentIdNumber;
+		return "verticalCardId" + _currentIdNumber;
 	}
 
 	public String getImageAlt() {
-		if (_imageAlt != null) {
-			return _imageAlt;
-		}
-
-		return "User Card Image Alt Text";
+		return _imageAlt;
 	}
 
 	public String getImageSrc() {
@@ -93,7 +123,7 @@ public class ClaySampleUserCard implements UserCard {
 			return _inputName;
 		}
 
-		return "user-card-input-name";
+		return "vertical-card-input-name";
 	}
 
 	public String getInputValue() {
@@ -101,7 +131,7 @@ public class ClaySampleUserCard implements UserCard {
 			return _inputValue;
 		}
 
-		return "user-card-input-value";
+		return "vertical-card-input-value";
 	}
 
 	public List<LabelItem> getLabels() {
@@ -121,18 +151,61 @@ public class ClaySampleUserCard implements UserCard {
 		).add(
 			() -> numItems > 2,
 			labelItem -> {
-				labelItem.setLabel("Canceled");
-				labelItem.setStyle("danger");
+				labelItem.setLabel("Rejected");
+				labelItem.setStyle("warning");
 			}
 		).build();
 	}
 
-	public String getName() {
-		if (_name != null) {
-			return _name;
+	public Map<String, String> getLabelStylesMap() {
+		if (_labelStylesMap != null) {
+			return _labelStylesMap;
 		}
 
-		return "User Name";
+		_labelStylesMap = HashMapBuilder.put(
+			"Pending", "info"
+		).build();
+
+		return _labelStylesMap;
+	}
+
+	public String getStickerCssClass() {
+		return _stickerCssClass;
+	}
+
+	public String getStickerIcon() {
+		return _stickerIcon;
+	}
+
+	public String getStickerImageAlt() {
+		return _stickerImageAlt;
+	}
+
+	public String getStickerImageSrc() {
+		return _stickerImageSrc;
+	}
+
+	public String getStickerLabel() {
+		if (_stickerLabel != null) {
+			return _stickerLabel;
+		}
+
+		return "JPG";
+	}
+
+	public String getStickerShape() {
+		if (_stickerShape != null) {
+			return _stickerShape;
+		}
+
+		return "circle";
+	}
+
+	public String getStickerStyle() {
+		if (_stickerStyle != null) {
+		}
+
+		return "warning";
 	}
 
 	public String getSubtitle() {
@@ -140,15 +213,15 @@ public class ClaySampleUserCard implements UserCard {
 			return _subtitle;
 		}
 
-		return "Latest Action";
+		return "Card Action";
 	}
 
-	public String getUserColorClass() {
-		if (_userColorClass != null) {
-			return _userColorClass;
+	public String getTitle() {
+		if (_title != null) {
+			return _title;
 		}
 
-		return "info";
+		return "Vertical Card";
 	}
 
 	public boolean isDisabled() {
@@ -207,8 +280,8 @@ public class ClaySampleUserCard implements UserCard {
 		_labels = labels;
 	}
 
-	public void setName(String name) {
-		_name = name;
+	public void setLabelStylesMap(Map<String, String> labelStylesMap) {
+		_labelStylesMap = labelStylesMap;
 	}
 
 	public void setSelectable(boolean selectable) {
@@ -219,12 +292,40 @@ public class ClaySampleUserCard implements UserCard {
 		_selected = selected;
 	}
 
+	public void setStickerCssClass(String stickerCssClass) {
+		_stickerCssClass = stickerCssClass;
+	}
+
+	public void setStickerIcon(String stickerIcon) {
+		_stickerIcon = stickerIcon;
+	}
+
+	public void setStickerImageAlt(String stickerImageAlt) {
+		_stickerImageAlt = stickerImageAlt;
+	}
+
+	public void setStickerImageSrc(String stickerImageSrc) {
+		_stickerImageSrc = stickerImageSrc;
+	}
+
+	public void setStickerLabel(String stickerLabel) {
+		_stickerLabel = stickerLabel;
+	}
+
+	public void setStickerShape(String stickerShape) {
+		_stickerShape = stickerShape;
+	}
+
+	public void setStickerStyle(String stickerStyle) {
+		_stickerStyle = stickerStyle;
+	}
+
 	public void setSubtitle(String subtitle) {
 		_subtitle = subtitle;
 	}
 
-	public void setUserColorClass(String userColorClass) {
-		_userColorClass = userColorClass;
+	public void setTitle(String title) {
+		_title = title;
 	}
 
 	private List<DropdownItem> _actionDropdownItems;
@@ -239,10 +340,17 @@ public class ClaySampleUserCard implements UserCard {
 	private String _inputName;
 	private String _inputValue;
 	private List<LabelItem> _labels;
-	private String _name;
+	private Map<String, String> _labelStylesMap;
 	private boolean _selectable = true;
 	private boolean _selected;
+	private String _stickerCssClass;
+	private String _stickerIcon;
+	private String _stickerImageAlt;
+	private String _stickerImageSrc;
+	private String _stickerLabel;
+	private String _stickerShape;
+	private String _stickerStyle;
 	private String _subtitle;
-	private String _userColorClass;
+	private String _title;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -21,8 +21,11 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.frontend.taglib.clay.sample.web.constants.ClaySamplePortletKeys" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.CardsDisplayContext" %><%@
+page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleFileCard" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleHorizontalCard" %><%@
+page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleImageCard" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleUserCard" %><%@
+page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleVerticalCard" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.DropdownsDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ManagementToolbarsDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.NavigationBarsDisplayContext" %><%@

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
@@ -18,39 +18,40 @@
 
 <h3>Image cards</h3>
 
+<%
+ClaySampleImageCard claySampleImageCard = new ClaySampleImageCard();
+%>
+
 <clay:row>
 	<clay:col
-		id="image-card-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			href="#1"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			href="<%= claySampleImageCard.getHref() %>"
 			imageAlt="thumbnail"
 			imageSrc="https://images.unsplash.com/photo-1506976773555-b3da30a63b57"
-			subtitle="Author Action"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="Madrid"
 		/>
 	</clay:col>
 
 	<clay:col
-		id="image-card-icon-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			icon="camera"
-			subtitle="Author Action"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			icon="<%= claySampleImageCard.getIcon() %>"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="<%= _SVG_FILE_TITLE %>"
 		/>
 	</clay:col>
 
 	<clay:col
-		id="image-card-empty-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
 			subtitle="Author Action"
 			title="<%= _SVG_FILE_TITLE %>"
 		/>
@@ -61,44 +62,41 @@
 
 <clay:row>
 	<clay:col
-		id="image-card-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			href="#1"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			href="<%= claySampleImageCard.getHref() %>"
 			imageAlt="thumbnail"
 			imageSrc="https://images.unsplash.com/photo-1499310226026-b9d598980b90"
-			stickerLabel="JPG"
-			stickerStyle="danger"
-			subtitle="Author Action"
+			stickerLabel="<%= claySampleImageCard.getStickerLabel() %>"
+			stickerStyle="<%= claySampleImageCard.getStickerStyle() %>"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="California"
 		/>
 	</clay:col>
 
 	<clay:col
-		id="image-card-icon-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			icon="camera"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			icon="<%= claySampleImageCard.getIcon() %>"
 			stickerLabel="SVG"
-			stickerStyle="warning"
-			subtitle="Author Action"
+			stickerStyle="<%= claySampleImageCard.getStickerStyle() %>"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="<%= _SVG_FILE_TITLE %>"
 		/>
 	</clay:col>
 
 	<clay:col
-		id="image-card-empty-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			stickerLabel="PNG"
-			stickerStyle="info"
-			subtitle="Author Action"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			stickerLabel="<%= claySampleImageCard.getStickerLabel() %>"
+			stickerStyle="<%= claySampleImageCard.getStickerStyle() %>"
+			subtitle="<%= claySampleImageCard.getStickerStyle() %>"
 			title="<%= _PNG_FILE_TITLE %>"
 		/>
 	</clay:col>
@@ -108,49 +106,46 @@
 
 <clay:row>
 	<clay:col
-		id="image-card-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			href="#1"
-			imageAlt="thumbnail"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			href="<%= claySampleImageCard.getHref() %>"
+			imageAlt="<%= claySampleImageCard.getImageAlt() %>"
 			imageSrc="https://images.unsplash.com/photo-1490900245048-1bf948e866c2"
-			stickerLabel="JPG"
+			stickerLabel="<%= claySampleImageCard.getStickerLabel() %>"
 			stickerShape="circle"
-			stickerStyle="danger"
-			subtitle="Author Action"
+			stickerStyle="<%= claySampleImageCard.getStickerStyle() %>"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="California"
 		/>
 	</clay:col>
 
 	<clay:col
-		id="image-card-icon-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			icon="camera"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			icon="<%= claySampleImageCard.getIcon() %>"
 			stickerLabel="SVG"
 			stickerShape="circle"
 			stickerStyle="warning"
-			subtitle="Author Action"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="<%= _SVG_FILE_TITLE %>"
 		/>
 	</clay:col>
 
 	<clay:col
-		id="image-card-empty-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
 			stickerImageAlt="Alt Text"
 			stickerImageSrc="https://images.unsplash.com/photo-1502290822284-9538ef1f1291"
 			stickerLabel="PNG"
-			stickerShape="circle"
+			stickerShape="<%= claySampleImageCard.getStickerShape() %>"
 			stickerStyle="info"
-			subtitle="Author Action"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="<%= _PNG_FILE_TITLE %>"
 		/>
 	</clay:col>
@@ -160,48 +155,45 @@
 
 <clay:row>
 	<clay:col
-		id="image-card-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			href="#1"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			href="<%= claySampleImageCard.getHref() %>"
 			imageAlt="thumbnail"
 			imageSrc="https://images.unsplash.com/photo-1503703294279-c83bdf7b4bf4"
-			labels="<%= cardsDisplayContext.getLabelItems() %>"
-			stickerLabel="JPG"
+			labels="<%= claySampleImageCard.getLabels() %>"
+			stickerLabel="<% claySampleImageCard.getStickerLabel() %>"
 			stickerStyle="danger"
-			subtitle="Author Action"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="Beetle"
 		/>
 	</clay:col>
 
 	<clay:col
-		id="image-card-icon-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
 			icon="camera"
-			labels="<%= cardsDisplayContext.getLabelItems() %>"
-			labelStylesMap="<%= cardsDisplayContext.getLabelStylesMap() %>"
+			labels="<%= claySampleImageCard.getLabels() %>"
+			labelStylesMap="<%= claySampleImageCard.getLabelStylesMap() %>"
 			stickerLabel="SVG"
 			stickerStyle="warning"
-			subtitle="Author Action"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="<%= _SVG_FILE_TITLE %>"
 		/>
 	</clay:col>
 
 	<clay:col
-		id="image-card-empty-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			labels="<%= cardsDisplayContext.getLabelItems() %>"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			labels="<%= claySampleImageCard.getLabels() %>"
 			stickerLabel="PNG"
-			stickerStyle="info"
-			subtitle="Author Action"
+			stickerStyle="<%= claySampleImageCard.getStickerStyle() %>"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="<%= _SVG_FILE_TITLE %>"
 		/>
 	</clay:col>
@@ -211,20 +203,19 @@
 
 <clay:row>
 	<clay:col
-		id="image-card-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			href="#1"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			href="<%= claySampleImageCard.getHref() %>"
 			imageAlt="thumbnail"
-			imageSrc="https://images.unsplash.com/photo-1506020647804-b04ee956dc04"
-			labels="<%= cardsDisplayContext.getLabelItems() %>"
+			imageSrc="https://images.unsplash.com/photo-1510360638044-c6f328b5d283"
+			labels="<%= claySampleImageCard.getLabels() %>"
 			selectable="<%= true %>"
 			selected="<%= true %>"
-			stickerLabel="JPG"
-			stickerStyle="danger"
-			subtitle="Author Action"
+			stickerLabel="<%= claySampleImageCard.getStickerLabel() %>"
+			stickerStyle="<%= claySampleImageCard.getStickerStyle() %>"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="Beetle"
 		/>
 	</clay:col>
@@ -234,9 +225,9 @@
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
 			icon="camera"
-			labels="<%= cardsDisplayContext.getLabelItems() %>"
+			labels="<%= claySampleImageCard.getLabels() %>"
 			selectable="<%= true %>"
 			selected="<%= false %>"
 			stickerLabel="SVG"
@@ -247,49 +238,87 @@
 	</clay:col>
 
 	<clay:col
-		id="image-card-empty-block"
 		md="4"
 	>
 		<clay:image-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			labels="<%= cardsDisplayContext.getLabelItems() %>"
+			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			imageSrc="https://images.unsplash.com/photo-1525151212033-377d12acc381"
+			labels="<%= claySampleImageCard.getLabels() %>"
 			selectable="<%= true %>"
 			selected="<%= true %>"
 			stickerLabel="PNG"
-			stickerStyle="info"
-			subtitle="Author Action"
+			stickerStyle="<%= claySampleImageCard.getStickerStyle() %>"
+			subtitle="<%= claySampleImageCard.getSubtitle() %>"
 			title="<%= _SVG_FILE_TITLE %>"
+		/>
+	</clay:col>
+</clay:row>
+
+<h4>Image Card using Model</h4>
+
+<clay:row>
+	<clay:col
+		md="6"
+	>
+
+		<%
+		claySampleImageCard.setHref("#1");
+		claySampleImageCard.setImageSrc("https://images.unsplash.com/photo-1503891450247-ee5f8ec46dc3");
+		claySampleImageCard.setSelectable(false);
+		claySampleImageCard.setTitle("California");
+		%>
+
+		<clay:image-card
+			imageCard="<%= claySampleImageCard %>"
+		/>
+	</clay:col>
+
+	<clay:col
+		md="6"
+	>
+
+		<%
+		claySampleImageCard.setHref("#2");
+		claySampleImageCard.setImageSrc("https://images.unsplash.com/photo-1485970671356-ff9156bd4a98");
+		claySampleImageCard.setSelected(true);
+		claySampleImageCard.setTitle("Mountains");
+		%>
+
+		<clay:image-card
+			imageCard="<%= claySampleImageCard %>"
 		/>
 	</clay:col>
 </clay:row>
 
 <h4>File Cards</h4>
 
+<%
+ClaySampleFileCard claySampleFileCard = new ClaySampleFileCard();
+%>
+
 <clay:row>
 	<clay:col
-		id="image-card-block"
 		md="4"
 	>
 		<clay:file-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			labels="<%= cardsDisplayContext.getLabelItems() %>"
+			actionDropdownItems="<%= claySampleFileCard.getActionDropdownItems() %>"
+			disabled="<%= true %>"
+			labels="<%= claySampleFileCard.getLabels() %>"
 			stickerLabel="PDF"
-			stickerStyle="danger"
-			subtitle="Stevie Ray Vaughn"
+			stickerStyle="<%= claySampleFileCard.getStickerStyle() %>"
+			subtitle="<%= claySampleFileCard.getSubtitle() %>"
 			title="<%= _PDF_FILE_TITLE %>"
 		/>
 	</clay:col>
 
 	<clay:col
-		id="image-card-icon-block"
 		md="4"
 	>
 		<clay:file-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
-			labels="<%= cardsDisplayContext.getLabelItems() %>"
-			labelStylesMap="<%= cardsDisplayContext.getLabelStylesMap() %>"
-			selectable="<%= true %>"
-			selected="<%= true %>"
+			actionDropdownItems="<%= claySampleFileCard.getActionDropdownItems() %>"
+			labels="<%= claySampleFileCard.getLabels() %>"
+			labelStylesMap="<%= claySampleFileCard.getLabelStylesMap() %>"
+			selectable="<%= false %>"
 			stickerLabel="MP3"
 			stickerStyle="warning"
 			subtitle="Jimi Hendrix"
@@ -298,19 +327,59 @@
 	</clay:col>
 
 	<clay:col
-		id="image-card-empty-block"
 		md="4"
 	>
 		<clay:file-card
-			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
+			actionDropdownItems="<%= claySampleFileCard.getActionDropdownItems() %>"
 			icon="list"
-			labels="<%= cardsDisplayContext.getLabelItems() %>"
+			labels="<%= claySampleFileCard.getLabels() %>"
 			selectable="<%= true %>"
 			selected="<%= true %>"
-			stickerLabel="DOC"
-			stickerStyle="info"
-			subtitle="Paco de Lucia"
+			stickerLabel="<%= claySampleFileCard.getStickerLabel() %>"
+			stickerStyle="<%= claySampleFileCard.getStickerStyle() %>"
+			subtitle="<%= claySampleFileCard.getSubtitle() %>"
 			title="<%= _DOC_FILE_TITLE %>"
+		/>
+	</clay:col>
+</clay:row>
+
+<h4>File Cards using Model</h4>
+
+<clay:row>
+	<clay:col
+		md="6"
+	>
+
+		<%
+		claySampleFileCard.setDisabled(true);
+		claySampleFileCard.setStickerLabel("PDF");
+		claySampleFileCard.setStickerStyle("info");
+		claySampleFileCard.setSubtitle("Another PDF document");
+		claySampleFileCard.setTitle(_PDF_FILE_TITLE);
+		%>
+
+		<clay:file-card
+			fileCard="<%= claySampleFileCard %>"
+		/>
+	</clay:col>
+
+	<clay:col
+		md="6"
+	>
+
+		<%
+		ClaySampleFileCard sampleFileCard = new ClaySampleFileCard();
+
+		sampleFileCard.setSelectable(true);
+		sampleFileCard.setSelected(true);
+		sampleFileCard.setStickerLabel("MP3");
+		sampleFileCard.setStickerStyle("warning");
+		sampleFileCard.setSubtitle("More music");
+		sampleFileCard.setTitle(_MP3_FILE_TITLE);
+		%>
+
+		<clay:file-card
+			fileCard="<%= sampleFileCard %>"
 		/>
 	</clay:col>
 </clay:row>
@@ -542,6 +611,86 @@ ClaySampleUserCard claySampleUserCard = new ClaySampleUserCard();
 	>
 		<clay:horizontal-card
 			horizontalCard="<%= new ClaySampleHorizontalCard() %>"
+		/>
+	</clay:col>
+</clay:row>
+
+<h4>Vertical Cards</h4>
+
+<%
+ClaySampleVerticalCard claySampleVerticalCard = new ClaySampleVerticalCard();
+%>
+
+<clay:row>
+	<clay:col
+		md="6"
+	>
+		<clay:vertical-card
+			actionDropdownItems="<%= claySampleVerticalCard.getActionDropdownItems() %>"
+			imageAlt="Elephant"
+			imageSrc="https://images.unsplash.com/photo-1502290822284-9538ef1f1291"
+			labels="<%= claySampleVerticalCard.getLabels() %>"
+			selectable="<%= false %>"
+			stickerLabel="DXP"
+			stickerStyle="info"
+			subtitle="<%= claySampleVerticalCard.getSubtitle() %>"
+			title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
+		/>
+	</clay:col>
+
+	<clay:col
+		md="6"
+	>
+		<clay:vertical-card
+			actionDropdownItems="<%= claySampleVerticalCard.getActionDropdownItems() %>"
+			icon="camera"
+			labels="<%= claySampleVerticalCard.getLabels() %>"
+			selectable="<%= true %>"
+			selected="<%= true %>"
+			stickerLabel="JPG"
+			stickerStyle="<%= claySampleVerticalCard.getStickerStyle() %>"
+			subtitle="<%= claySampleVerticalCard.getSubtitle() %>"
+			title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
+		/>
+	</clay:col>
+</clay:row>
+
+<h4>Vertical Cards using Model</h4>
+
+<clay:row>
+	<clay:col
+		md="6"
+	>
+
+		<%
+		claySampleVerticalCard.setImageSrc("https://images.unsplash.com/photo-1554939437-ecc492c67b78");
+		claySampleVerticalCard.setSelectable(true);
+		claySampleVerticalCard.setStickerLabel("MAD");
+		claySampleVerticalCard.setStickerStyle("success");
+		claySampleVerticalCard.setSubtitle("A beautiful city");
+		claySampleVerticalCard.setTitle("Madrid");
+		%>
+
+		<clay:vertical-card
+			verticalCard="<%= claySampleVerticalCard %>"
+		/>
+	</clay:col>
+
+	<clay:col
+		md="6"
+	>
+
+		<%
+		ClaySampleVerticalCard sampleVerticalCard = new ClaySampleVerticalCard();
+
+		sampleVerticalCard.setDisabled(true);
+		sampleVerticalCard.setSelected(true);
+		sampleVerticalCard.setStickerStyle("warning");
+		sampleVerticalCard.setSubtitle("This card is disabled");
+		%>
+
+		<clay:vertical-card
+			verticalCard="<%= sampleVerticalCard %>"
 		/>
 	</clay:col>
 </clay:row>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/FileCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/FileCardTag.java
@@ -1,0 +1,301 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.soy.FileCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.jsp.JspException;
+
+/**
+ * @author Julien Castelain
+ */
+public class FileCardTag extends VerticalCardTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		return super.doStartTag();
+	}
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() {
+		List<DropdownItem> actionDropdownItems = super.getActionDropdownItems();
+
+		if ((actionDropdownItems == null) && (_fileCard != null)) {
+			return _fileCard.getActionDropdownItems();
+		}
+
+		return actionDropdownItems;
+	}
+
+	public FileCard getFileCard() {
+		return _fileCard;
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
+	@Override
+	public String getGroupName() {
+		String groupName = super.getGroupName();
+
+		if ((groupName == null) && (_fileCard != null)) {
+			return _fileCard.getGroupName();
+		}
+
+		return groupName;
+	}
+
+	@Override
+	public String getHref() {
+		String href = super.getHref();
+
+		if ((href == null) && (_fileCard != null)) {
+			return _fileCard.getHref();
+		}
+
+		return href;
+	}
+
+	@Override
+	public String getIcon() {
+		String icon = super.getIcon();
+
+		if ((icon == null) && (_fileCard != null)) {
+			return _fileCard.getIcon();
+		}
+
+		return "list";
+	}
+
+	@Override
+	public String getInputName() {
+		String inputName = super.getInputName();
+
+		if ((inputName == null) && (_fileCard != null)) {
+			return _fileCard.getInputName();
+		}
+
+		return inputName;
+	}
+
+	@Override
+	public String getInputValue() {
+		String inputValue = super.getInputValue();
+
+		if ((inputValue == null) && (_fileCard != null)) {
+			return _fileCard.getInputValue();
+		}
+
+		return inputValue;
+	}
+
+	@Override
+	public List<LabelItem> getLabels() {
+		List<LabelItem> labels = super.getLabels();
+
+		if ((labels == null) && (_fileCard != null)) {
+			return _fileCard.getLabels();
+		}
+
+		return labels;
+	}
+
+	@Override
+	public Map<String, String> getLabelStylesMap() {
+		Map<String, String> labelStylesMap = super.getLabelStylesMap();
+
+		if ((labelStylesMap == null) && (_fileCard != null)) {
+			return _fileCard.getLabelStylesMap();
+		}
+
+		return labelStylesMap;
+	}
+
+	@Override
+	public String getStickerCssClass() {
+		String stickerCssClass = super.getStickerCssClass();
+
+		if ((stickerCssClass == null) && (_fileCard != null)) {
+			return _fileCard.getStickerCssClass();
+		}
+
+		return stickerCssClass;
+	}
+
+	@Override
+	public String getStickerIcon() {
+		String stickerIcon = super.getStickerIcon();
+
+		if ((stickerIcon == null) && (_fileCard != null)) {
+			return _fileCard.getStickerIcon();
+		}
+
+		return stickerIcon;
+	}
+
+	@Override
+	public String getStickerLabel() {
+		String stickerLabel = super.getStickerLabel();
+
+		if ((stickerLabel == null) && (_fileCard != null)) {
+			return _fileCard.getStickerLabel();
+		}
+
+		return stickerLabel;
+	}
+
+	@Override
+	public String getStickerShape() {
+		String stickerShape = super.getStickerShape();
+
+		if ((stickerShape == null) && (_fileCard != null)) {
+			return _fileCard.getStickerShape();
+		}
+
+		return stickerShape;
+	}
+
+	@Override
+	public String getStickerStyle() {
+		String stickerStyle = super.getStickerStyle();
+
+		if ((stickerStyle == null) && (_fileCard != null)) {
+			return _fileCard.getStickerStyle();
+		}
+
+		return stickerStyle;
+	}
+
+	@Override
+	public String getSubtitle() {
+		String subtitle = super.getSubtitle();
+
+		if ((subtitle == null) && (_fileCard != null)) {
+			return _fileCard.getSubtitle();
+		}
+
+		return subtitle;
+	}
+
+	@Override
+	public String getTitle() {
+		String title = super.getTitle();
+
+		if ((title == null) && (_fileCard != null)) {
+			return _fileCard.getTitle();
+		}
+
+		return title;
+	}
+
+	@Override
+	public Boolean isDisabled() {
+		Boolean disabled = super.isDisabled();
+
+		if (disabled == null) {
+			if (_fileCard != null) {
+				return _fileCard.isDisabled();
+			}
+
+			return false;
+		}
+
+		return disabled;
+	}
+
+	@Override
+	public Boolean isFlushHorizontal() {
+		Boolean flushHorizontal = super.isFlushHorizontal();
+
+		if (flushHorizontal == null) {
+			if (_fileCard != null) {
+				return _fileCard.isFlushHorizontal();
+			}
+
+			return false;
+		}
+
+		return flushHorizontal;
+	}
+
+	@Override
+	public Boolean isFlushVertical() {
+		Boolean flushVertical = super.isFlushVertical();
+
+		if (flushVertical == null) {
+			if (_fileCard != null) {
+				return _fileCard.isFlushVertical();
+			}
+
+			return false;
+		}
+
+		return flushVertical;
+	}
+
+	@Override
+	public Boolean isSelectable() {
+		Boolean selectable = super.isSelectable();
+
+		if (selectable == null) {
+			if (_fileCard != null) {
+				return _fileCard.isSelectable();
+			}
+
+			return true;
+		}
+
+		return selectable;
+	}
+
+	@Override
+	public Boolean isSelected() {
+		Boolean selected = super.isSelected();
+
+		if (selected == null) {
+			if (_fileCard != null) {
+				return _fileCard.isSelected();
+			}
+
+			return false;
+		}
+
+		return selected;
+	}
+
+	public void setFileCard(FileCard fileCard) {
+		_fileCard = fileCard;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_fileCard = null;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:filecard:";
+
+	private FileCard _fileCard;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
@@ -257,7 +257,7 @@ public class HorizontalCardTag extends BaseContainerTag {
 
 	@Override
 	protected String getHydratedModuleName() {
-		return "frontend-taglib-clay/HorizontalCard";
+		return "frontend-taglib-clay/cards/HorizontalCard";
 	}
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ImageCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ImageCardTag.java
@@ -1,0 +1,345 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.soy.ImageCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.jsp.JspException;
+
+/**
+ * @author Julien Castelain
+ */
+public class ImageCardTag extends VerticalCardTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		return super.doStartTag();
+	}
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() {
+		List<DropdownItem> actionDropdownItems = super.getActionDropdownItems();
+
+		if ((actionDropdownItems == null) && (_imageCard != null)) {
+			return _imageCard.getActionDropdownItems();
+		}
+
+		return actionDropdownItems;
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
+	@Override
+	public String getGroupName() {
+		String groupName = super.getGroupName();
+
+		if ((groupName == null) && (_imageCard != null)) {
+			return _imageCard.getGroupName();
+		}
+
+		return groupName;
+	}
+
+	@Override
+	public String getHref() {
+		String href = super.getHref();
+
+		if ((href == null) && (_imageCard != null)) {
+			return _imageCard.getHref();
+		}
+
+		return href;
+	}
+
+	@Override
+	public String getIcon() {
+		String icon = super.getIcon();
+
+		if ((icon == null) && (_imageCard != null)) {
+			return _imageCard.getIcon();
+		}
+
+		return icon;
+	}
+
+	@Override
+	public String getImageAlt() {
+		String imageAlt = super.getImageAlt();
+
+		if ((imageAlt == null) && (_imageCard != null)) {
+			return _imageCard.getImageAlt();
+		}
+
+		return imageAlt;
+	}
+
+	public ImageCard getImageCard() {
+		return _imageCard;
+	}
+
+	@Override
+	public String getImageSrc() {
+		String imageSrc = super.getImageSrc();
+
+		if ((imageSrc == null) && (_imageCard != null)) {
+			return _imageCard.getImageSrc();
+		}
+
+		return imageSrc;
+	}
+
+	@Override
+	public String getInputName() {
+		String inputName = super.getInputName();
+
+		if ((inputName == null) && (_imageCard != null)) {
+			return _imageCard.getInputName();
+		}
+
+		return inputName;
+	}
+
+	@Override
+	public String getInputValue() {
+		String inputValue = super.getInputValue();
+
+		if ((inputValue == null) && (_imageCard != null)) {
+			return _imageCard.getInputValue();
+		}
+
+		return inputValue;
+	}
+
+	@Override
+	public List<LabelItem> getLabels() {
+		List<LabelItem> labels = super.getLabels();
+
+		if ((labels == null) && (_imageCard != null)) {
+			return _imageCard.getLabels();
+		}
+
+		return labels;
+	}
+
+	@Override
+	public Map<String, String> getLabelStylesMap() {
+		Map<String, String> labelStylesMap = super.getLabelStylesMap();
+
+		if ((labelStylesMap == null) && (_imageCard != null)) {
+			return _imageCard.getLabelStylesMap();
+		}
+
+		return labelStylesMap;
+	}
+
+	@Override
+	public String getStickerCssClass() {
+		String stickerCssClass = super.getStickerCssClass();
+
+		if ((stickerCssClass == null) && (_imageCard != null)) {
+			return _imageCard.getStickerCssClass();
+		}
+
+		return stickerCssClass;
+	}
+
+	@Override
+	public String getStickerIcon() {
+		String stickerIcon = super.getStickerIcon();
+
+		if ((stickerIcon == null) && (_imageCard != null)) {
+			return _imageCard.getStickerIcon();
+		}
+
+		return stickerIcon;
+	}
+
+	@Override
+	public String getStickerImageAlt() {
+		String stickerImageAlt = super.getStickerImageAlt();
+
+		if ((stickerImageAlt == null) && (_imageCard != null)) {
+			return _imageCard.getStickerImageAlt();
+		}
+
+		return stickerImageAlt;
+	}
+
+	@Override
+	public String getStickerImageSrc() {
+		String stickerImageSrc = super.getStickerImageSrc();
+
+		if ((stickerImageSrc == null) && (_imageCard != null)) {
+			return _imageCard.getStickerImageSrc();
+		}
+
+		return stickerImageSrc;
+	}
+
+	@Override
+	public String getStickerLabel() {
+		String stickerLabel = super.getStickerLabel();
+
+		if ((stickerLabel == null) && (_imageCard != null)) {
+			return _imageCard.getStickerLabel();
+		}
+
+		return stickerLabel;
+	}
+
+	@Override
+	public String getStickerShape() {
+		String stickerShape = super.getStickerShape();
+
+		if ((stickerShape == null) && (_imageCard != null)) {
+			return _imageCard.getStickerShape();
+		}
+
+		return stickerShape;
+	}
+
+	@Override
+	public String getStickerStyle() {
+		String stickerStyle = super.getStickerStyle();
+
+		if ((stickerStyle == null) && (_imageCard != null)) {
+			return _imageCard.getStickerStyle();
+		}
+
+		return stickerStyle;
+	}
+
+	@Override
+	public String getSubtitle() {
+		String subtitle = super.getSubtitle();
+
+		if ((subtitle == null) && (_imageCard != null)) {
+			return _imageCard.getSubtitle();
+		}
+
+		return subtitle;
+	}
+
+	@Override
+	public String getTitle() {
+		String title = super.getTitle();
+
+		if ((title == null) && (_imageCard != null)) {
+			return _imageCard.getTitle();
+		}
+
+		return title;
+	}
+
+	@Override
+	public Boolean isDisabled() {
+		Boolean disabled = super.isDisabled();
+
+		if (disabled == null) {
+			if (_imageCard != null) {
+				return _imageCard.isDisabled();
+			}
+
+			return false;
+		}
+
+		return disabled;
+	}
+
+	@Override
+	public Boolean isFlushHorizontal() {
+		Boolean flushHorizontal = super.isFlushHorizontal();
+
+		if (flushHorizontal == null) {
+			if (_imageCard != null) {
+				return _imageCard.isFlushHorizontal();
+			}
+
+			return false;
+		}
+
+		return flushHorizontal;
+	}
+
+	@Override
+	public Boolean isFlushVertical() {
+		Boolean flushVertical = super.isFlushVertical();
+
+		if (flushVertical == null) {
+			if (_imageCard != null) {
+				return _imageCard.isFlushVertical();
+			}
+
+			return false;
+		}
+
+		return flushVertical;
+	}
+
+	@Override
+	public Boolean isSelectable() {
+		Boolean selectable = super.isSelectable();
+
+		if (selectable == null) {
+			if (_imageCard != null) {
+				return _imageCard.isSelectable();
+			}
+
+			return true;
+		}
+
+		return selectable;
+	}
+
+	@Override
+	public Boolean isSelected() {
+		Boolean selected = super.isSelected();
+
+		if (selected == null) {
+			if (_imageCard != null) {
+				return _imageCard.isSelected();
+			}
+
+			return false;
+		}
+
+		return selected;
+	}
+
+	public void setImageCard(ImageCard imageCard) {
+		_imageCard = imageCard;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_imageCard = null;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:imagecard:";
+
+	private ImageCard _imageCard;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
@@ -58,10 +58,6 @@ public class StickerTag extends BaseContainerTag {
 		return _inline;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
 	public String getLabel() {
 		return _label;
 	}
@@ -119,10 +115,6 @@ public class StickerTag extends BaseContainerTag {
 		_inline = inline;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
 	public void setLabel(String label) {
 		_label = label;
 	}
@@ -242,6 +234,11 @@ public class StickerTag extends BaseContainerTag {
 			jspWriter.write("\" class=\"sticker-img\" src=\"");
 			jspWriter.write(_imageSrc);
 			jspWriter.write("\" />");
+
+			return SKIP_BODY;
+		}
+		else if (Validator.isNotNull(_label)) {
+			jspWriter.write(_label);
 
 			return SKIP_BODY;
 		}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/UserCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/UserCardTag.java
@@ -297,7 +297,7 @@ public class UserCardTag extends BaseContainerTag {
 
 	@Override
 	protected String getHydratedModuleName() {
-		return "frontend-taglib-clay/UserCard";
+		return "frontend-taglib-clay/cards/UserCard";
 	}
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
@@ -1,0 +1,810 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.frontend.taglib.clay.servlet.taglib.soy.VerticalCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Julien Castelain
+ */
+public class VerticalCardTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		return super.doStartTag();
+	}
+
+	public List<DropdownItem> getActionDropdownItems() {
+		if ((_actionDropdownItems == null) && (_verticalCard != null)) {
+			return _verticalCard.getActionDropdownItems();
+		}
+
+		return _actionDropdownItems;
+	}
+
+	@Override
+	public String getCssClass() {
+		if ((super.getCssClass() == null) && (_verticalCard != null)) {
+			if (_verticalCard.getCssClass() != null) {
+				return _verticalCard.getCssClass();
+			}
+
+			if (_verticalCard.getElementClasses() != null) {
+				return _verticalCard.getElementClasses();
+			}
+		}
+
+		return super.getCssClass();
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
+	@Override
+	public Map<String, String> getData() {
+		if ((super.getData() == null) && (_verticalCard != null)) {
+			return _verticalCard.getData();
+		}
+
+		return super.getData();
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
+	@Override
+	public String getDefaultEventHandler() {
+		if ((super.getDefaultEventHandler() == null) &&
+			(_verticalCard != null)) {
+
+			return _verticalCard.getDefaultEventHandler();
+		}
+
+		return super.getDefaultEventHandler();
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #getCssClass()}
+	 */
+	@Deprecated
+	@Override
+	public String getElementClasses() {
+		if ((super.getCssClass() == null) && (_verticalCard != null)) {
+			return _verticalCard.getElementClasses();
+		}
+
+		return super.getCssClass();
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getGroupName() {
+		return _groupName;
+	}
+
+	public String getHref() {
+		if ((_href == null) && (_verticalCard != null)) {
+			return _verticalCard.getHref();
+		}
+
+		return _href;
+	}
+
+	public String getIcon() {
+		if ((_icon == null) && (_verticalCard != null)) {
+			return _verticalCard.getIcon();
+		}
+
+		return "documents-and-media";
+	}
+
+	@Override
+	public String getId() {
+		if ((super.getId() == null) && (_verticalCard != null)) {
+			return _verticalCard.getId();
+		}
+
+		return super.getId();
+	}
+
+	public String getImageAlt() {
+		if ((_imageAlt == null) && (_verticalCard != null)) {
+			return _verticalCard.getImageAlt();
+		}
+
+		return _imageAlt;
+	}
+
+	public String getImageSrc() {
+		if ((_imageSrc == null) && (_verticalCard != null)) {
+			return _verticalCard.getImageSrc();
+		}
+
+		return _imageSrc;
+	}
+
+	public String getInputName() {
+		if ((_inputName == null) && (_verticalCard != null)) {
+			return _verticalCard.getInputName();
+		}
+
+		return _inputName;
+	}
+
+	public String getInputValue() {
+		if ((_inputValue == null) && (_verticalCard != null)) {
+			return _verticalCard.getInputValue();
+		}
+
+		return _inputValue;
+	}
+
+	public List<LabelItem> getLabels() {
+		if ((_labels == null) && (_verticalCard != null)) {
+			return _verticalCard.getLabels();
+		}
+
+		return _labels;
+	}
+
+	public Map<String, String> getLabelStylesMap() {
+		if ((_labelStylesMap == null) && (_verticalCard != null)) {
+			return _verticalCard.getLabelStylesMap();
+		}
+
+		return _labelStylesMap;
+	}
+
+	public String getStickerCssClass() {
+		if ((_stickerCssClass == null) && (_verticalCard != null)) {
+			return _verticalCard.getStickerCssClass();
+		}
+
+		return _stickerCssClass;
+	}
+
+	public String getStickerIcon() {
+		if ((_stickerIcon == null) && (_verticalCard != null)) {
+			return _verticalCard.getStickerIcon();
+		}
+
+		return _stickerIcon;
+	}
+
+	public String getStickerImageAlt() {
+		if ((_stickerImageAlt == null) && (_verticalCard != null)) {
+			return _verticalCard.getStickerImageAlt();
+		}
+
+		return _stickerImageAlt;
+	}
+
+	public String getStickerImageSrc() {
+		if ((_stickerImageSrc == null) && (_verticalCard != null)) {
+			return _verticalCard.getStickerImageSrc();
+		}
+
+		return _stickerImageSrc;
+	}
+
+	public String getStickerLabel() {
+		if ((_stickerLabel == null) && (_verticalCard != null)) {
+			return _verticalCard.getStickerLabel();
+		}
+
+		return LanguageUtil.get(
+			TagResourceBundleUtil.getResourceBundle(pageContext),
+			_stickerLabel);
+	}
+
+	public String getStickerShape() {
+		if ((_stickerShape == null) && (_verticalCard != null)) {
+			return _verticalCard.getStickerShape();
+		}
+
+		return _stickerShape;
+	}
+
+	public String getStickerStyle() {
+		if ((_stickerStyle == null) && (_verticalCard != null)) {
+			return _verticalCard.getStickerStyle();
+		}
+
+		return _stickerStyle;
+	}
+
+	public String getSubtitle() {
+		if ((_subtitle == null) && (_verticalCard != null)) {
+			return _verticalCard.getSubtitle();
+		}
+
+		return LanguageUtil.get(
+			TagResourceBundleUtil.getResourceBundle(pageContext), _subtitle);
+	}
+
+	public String getTitle() {
+		if ((_title == null) && (_verticalCard != null)) {
+			return _verticalCard.getTitle();
+		}
+
+		return LanguageUtil.get(
+			TagResourceBundleUtil.getResourceBundle(pageContext), _title);
+	}
+
+	public VerticalCard getVerticalCard() {
+		return _verticalCard;
+	}
+
+	public Boolean isDisabled() {
+		if (_disabled == null) {
+			if (_verticalCard != null) {
+				return _verticalCard.isDisabled();
+			}
+
+			return false;
+		}
+
+		return _disabled;
+	}
+
+	public Boolean isFlushHorizontal() {
+		if (_flushHorizontal == null) {
+			if (_verticalCard != null) {
+				return _verticalCard.isFlushHorizontal();
+			}
+
+			return false;
+		}
+
+		return _flushHorizontal;
+	}
+
+	public Boolean isFlushVertical() {
+		if (_flushVertical == null) {
+			if (_verticalCard != null) {
+				return _verticalCard.isFlushVertical();
+			}
+
+			return false;
+		}
+
+		return _flushVertical;
+	}
+
+	public Boolean isSelectable() {
+		if (_selectable == null) {
+			if (_verticalCard != null) {
+				return _verticalCard.isSelectable();
+			}
+
+			return true;
+		}
+
+		return _selectable;
+	}
+
+	public Boolean isSelected() {
+		if (_selected == null) {
+			if (_verticalCard != null) {
+				return _verticalCard.isSelected();
+			}
+
+			return false;
+		}
+
+		return _selected;
+	}
+
+	public void setActionDropdownItems(List<DropdownItem> actionDropdownItems) {
+		_actionDropdownItems = actionDropdownItems;
+	}
+
+	public void setDisabled(Boolean disabled) {
+		_disabled = disabled;
+	}
+
+	public void setFlushHorizontal(boolean flushHorizontal) {
+		_flushHorizontal = flushHorizontal;
+	}
+
+	public void setFlushVertical(boolean flushVertical) {
+		_flushVertical = flushVertical;
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setGroupName(String groupName) {
+		_groupName = groupName;
+	}
+
+	public void setHref(String href) {
+		_href = href;
+	}
+
+	public void setIcon(String icon) {
+		_icon = icon;
+	}
+
+	public void setImageAlt(String imageAlt) {
+		_imageAlt = imageAlt;
+	}
+
+	public void setImageSrc(String imageSrc) {
+		_imageSrc = imageSrc;
+	}
+
+	public void setInputName(String inputName) {
+		_inputName = inputName;
+	}
+
+	public void setInputValue(String inputValue) {
+		_inputValue = inputValue;
+	}
+
+	public void setLabels(List<LabelItem> labels) {
+		_labels = labels;
+	}
+
+	public void setLabelStylesMap(Map<String, String> labelStylesMap) {
+		_labelStylesMap = labelStylesMap;
+	}
+
+	public void setSelectable(Boolean selectable) {
+		_selectable = selectable;
+	}
+
+	public void setSelected(Boolean selected) {
+		_selected = selected;
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setSpritemap(String spritemap) {
+		_spritemap = spritemap;
+	}
+
+	public void setStickerCssClass(String stickerCssClass) {
+		_stickerCssClass = stickerCssClass;
+	}
+
+	public void setStickerIcon(String stickerIcon) {
+		_stickerIcon = stickerIcon;
+	}
+
+	public void setStickerImageAlt(String stickerImageAlt) {
+		_stickerImageAlt = stickerImageAlt;
+	}
+
+	public void setStickerImageSrc(String stickerImageSrc) {
+		_stickerImageSrc = stickerImageSrc;
+	}
+
+	public void setStickerLabel(String stickerLabel) {
+		_stickerLabel = stickerLabel;
+	}
+
+	public void setStickerShape(String stickerShape) {
+		_stickerShape = stickerShape;
+	}
+
+	public void setStickerStyle(String stickerStyle) {
+		_stickerStyle = stickerStyle;
+	}
+
+	public void setSubtitle(String subtitle) {
+		_subtitle = subtitle;
+	}
+
+	public void setTitle(String title) {
+		_title = title;
+	}
+
+	public void setVerticalCard(VerticalCard verticalCard) {
+		_verticalCard = verticalCard;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_actionDropdownItems = null;
+		_disabled = null;
+		_flushHorizontal = null;
+		_flushVertical = null;
+		_groupName = null;
+		_href = null;
+		_icon = null;
+		_imageAlt = null;
+		_imageSrc = null;
+		_inputName = null;
+		_inputValue = null;
+		_labels = null;
+		_labelStylesMap = null;
+		_selectable = null;
+		_selected = null;
+		_spritemap = null;
+		_stickerCssClass = null;
+		_stickerIcon = null;
+		_stickerImageAlt = null;
+		_stickerImageSrc = null;
+		_stickerLabel = null;
+		_stickerShape = null;
+		_stickerStyle = null;
+		_subtitle = null;
+		_title = null;
+		_verticalCard = null;
+	}
+
+	@Override
+	protected String getHydratedModuleName() {
+		return "frontend-taglib-clay/cards/VerticalCard";
+	}
+
+	@Override
+	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("actions", getActionDropdownItems());
+		props.put("description", getSubtitle());
+		props.put("disabled", isDisabled());
+		props.put("displayType", _getDisplayType());
+		props.put("flushHorizontal", isFlushHorizontal());
+		props.put("flushVertical", isFlushVertical());
+		props.put("href", getHref());
+		props.put("id", getId());
+		props.put("imageAlt", getImageAlt());
+		props.put("imageSrc", getImageSrc());
+		props.put("inputName", getInputName());
+		props.put("inputValue", getInputValue());
+		props.put("labels", getLabels());
+		props.put("labelStylesMap", getLabelStylesMap());
+		props.put("selectable", isSelectable());
+		props.put("selected", isSelected());
+		props.put("stickerCssClass", getStickerCssClass());
+		props.put("stickerIcon", getStickerIcon());
+		props.put("stickerImageAlt", getStickerImageAlt());
+		props.put("stickerImageSrc", getStickerImageSrc());
+		props.put("stickerLabel", getStickerLabel());
+		props.put("stickerShape", getStickerShape());
+		props.put("stickerStyle", getStickerStyle());
+		props.put("symbol", getIcon());
+		props.put("title", getTitle());
+
+		return super.prepareProps(props);
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		cssClasses.add("card-type-asset");
+
+		if (Validator.isNotNull(_imageSrc)) {
+			cssClasses.add("image-card");
+		}
+		else {
+			cssClasses.add("file-card");
+		}
+
+		if (!isSelectable()) {
+			cssClasses.add("card");
+		}
+		else {
+			cssClasses.add("form-check");
+			cssClasses.add("form-check-card");
+			cssClasses.add("form-check-top-left");
+		}
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		if (isSelectable()) {
+			jspWriter.write("<div class=\"card\"><div class=\"custom-control ");
+			jspWriter.write("custom-checkbox\"><label><input ");
+
+			if (isSelected()) {
+				jspWriter.write("checked ");
+			}
+
+			jspWriter.write("class=\"custom-control-input\" ");
+
+			if (isDisabled()) {
+				jspWriter.write("disabled ");
+			}
+
+			String inputName = getInputName();
+
+			if (Validator.isNotNull(inputName)) {
+				jspWriter.write("name=\"");
+				jspWriter.write(inputName);
+				jspWriter.write("\" ");
+			}
+
+			jspWriter.write("type=\"checkbox\" ");
+
+			String inputValue = getInputValue();
+
+			if (Validator.isNotNull(inputValue)) {
+				jspWriter.write("value=\"");
+				jspWriter.write(inputValue);
+				jspWriter.write("\" ");
+			}
+
+			jspWriter.write("/><span class=\"custom-control-label\"></span>");
+		}
+
+		jspWriter.write("<div class=\"card-item-first aspect-ratio\">");
+
+		if (Validator.isNotNull(getImageSrc())) {
+			jspWriter.write("<img");
+
+			String imageAlt = getImageAlt();
+
+			if (Validator.isNotNull(imageAlt)) {
+				jspWriter.write(" alt=\"");
+				jspWriter.write(imageAlt);
+				jspWriter.write("\"");
+			}
+
+			jspWriter.write(" class=\"aspect-ratio-item");
+			jspWriter.write(" aspect-ratio-item-center-middle");
+			jspWriter.write(" aspect-ratio-item-fluid ");
+
+			Boolean flushHorizontal = isFlushHorizontal();
+
+			if (flushHorizontal != null) {
+				jspWriter.write("aspect-ratio-item-flush");
+			}
+
+			Boolean flushVertical = isFlushVertical();
+
+			if (flushVertical != null) {
+				jspWriter.write("aspect-ratio-item-vertical-flush");
+			}
+
+			jspWriter.write("\" src=\"");
+			jspWriter.write(getImageSrc());
+			jspWriter.write("\">");
+		}
+		else {
+			jspWriter.write("<div class=\"aspect-ratio-item");
+			jspWriter.write(" aspect-ratio-item-center-middle");
+			jspWriter.write(" aspect-ratio-item-fluid card-type-asset-icon\">");
+
+			IconTag icon = new IconTag();
+
+			icon.setSymbol(getIcon());
+			icon.doTag(pageContext);
+
+			jspWriter.write("</div>");
+		}
+
+		StickerTag stickerTag = new StickerTag();
+
+		String stickerIcon = getStickerIcon();
+		String stickerImageSrc = getStickerImageSrc();
+		String stickerLabel = getStickerLabel();
+
+		if (Validator.isNotNull(stickerIcon)) {
+			stickerTag.setIcon(stickerIcon);
+		}
+		else if (Validator.isNotNull(stickerImageSrc)) {
+			String stickerImageAlt = getStickerImageAlt();
+
+			if (Validator.isNotNull(stickerImageAlt)) {
+				stickerTag.setImageAlt(stickerImageAlt);
+			}
+
+			stickerTag.setImageSrc(stickerImageSrc);
+		}
+		else if (Validator.isNotNull(stickerLabel)) {
+			stickerTag.setLabel(stickerLabel);
+		}
+
+		String stickerStyle = getStickerStyle();
+
+		if (Validator.isNotNull(stickerStyle)) {
+			stickerTag.setDisplayType(stickerStyle);
+		}
+		else {
+			stickerTag.setDisplayType("primary");
+		}
+
+		stickerTag.setPosition("bottom-left");
+
+		String stickerShape = getStickerShape();
+
+		if (Validator.isNotNull(stickerShape)) {
+			stickerTag.setShape(stickerShape);
+		}
+
+		stickerTag.doTag(pageContext);
+
+		if (isSelectable()) {
+			jspWriter.write("</div></label></div>");
+		}
+		else {
+			jspWriter.write("</div>");
+		}
+
+		jspWriter.write("<div class=\"card-body\"><div class=\"card-row\">");
+		jspWriter.write("<div class=\"autofit-col autofit-col-expand\">");
+
+		String title = getTitle();
+
+		jspWriter.write("<p class=\"card-title\" title=\"");
+
+		if (Validator.isNotNull(title)) {
+			jspWriter.write(title);
+		}
+
+		jspWriter.write("\"><span class=\"text-truncate-inline\">");
+
+		String href = getHref();
+
+		if (Validator.isNotNull(href) && !isDisabled()) {
+			LinkTag linkTag = new LinkTag();
+
+			linkTag.setCssClass("text-truncate");
+			linkTag.setHref(href);
+			linkTag.setLabel(title);
+			linkTag.doTag(pageContext);
+		}
+		else {
+			jspWriter.write("<span class=\"text-truncate\">");
+
+			if (Validator.isNotNull(title)) {
+				jspWriter.write(title);
+			}
+
+			jspWriter.write("</span>");
+		}
+
+		jspWriter.write("</span></p>");
+
+		jspWriter.write("<p class=\"card-subtitle\"><span class=\"");
+		jspWriter.write("text-truncate-inline\"><span class=\"");
+		jspWriter.write("text-truncate\">");
+
+		String subtitle = getSubtitle();
+
+		if (Validator.isNotNull(subtitle)) {
+			jspWriter.write(subtitle);
+		}
+
+		jspWriter.write("</span></span></p>");
+
+		List<LabelItem> labels = getLabels();
+
+		if (!ListUtil.isEmpty(labels)) {
+			jspWriter.write("<div class=\"card-detail\">");
+
+			for (LabelItem labelItem : labels) {
+				LabelTag labelTag = new LabelTag();
+
+				boolean labelIsDismissible = (boolean)labelItem.get(
+					"dismissible");
+				boolean labelIsLarge = (boolean)labelItem.get("large");
+				String labelDisplayType = (String)labelItem.get("displayType");
+				String labelLabel = (String)labelItem.get("label");
+
+				if (labelIsDismissible) {
+					labelTag.setDismissible(labelIsDismissible);
+				}
+
+				if (labelIsLarge) {
+					labelTag.setLarge(labelIsLarge);
+				}
+
+				if (Validator.isNotNull(labelDisplayType)) {
+					labelTag.setDisplayType(labelDisplayType);
+				}
+
+				labelTag.setLabel(labelLabel);
+
+				labelTag.doTag(pageContext);
+			}
+
+			jspWriter.write("</div>");
+		}
+
+		jspWriter.write("</div>");
+
+		if (!ListUtil.isEmpty(getActionDropdownItems())) {
+			jspWriter.write(
+				"<div class=\"autofit-col\"><div class=\"dropdown\">");
+			jspWriter.write("<div class=\"dropdown-toggle component-action\">");
+
+			IconTag iconTag = new IconTag();
+
+			iconTag.setSymbol("ellipsis-v");
+			iconTag.doTag(pageContext);
+
+			jspWriter.write("</div></div></div>");
+		}
+
+		jspWriter.write("</div></div>");
+
+		if (isSelectable()) {
+			jspWriter.write("</div>");
+		}
+
+		return SKIP_BODY;
+	}
+
+	private String _getDisplayType() {
+		if (Validator.isNotNull(_imageSrc)) {
+			return "image";
+		}
+
+		return "file";
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:verticalcard:";
+
+	private List<DropdownItem> _actionDropdownItems;
+	private Boolean _disabled;
+	private Boolean _flushHorizontal;
+	private Boolean _flushVertical;
+	private String _groupName;
+	private String _href;
+	private String _icon;
+	private String _imageAlt;
+	private String _imageSrc;
+	private String _inputName;
+	private String _inputValue;
+	private List<LabelItem> _labels;
+	private Map<String, String> _labelStylesMap;
+	private Boolean _selectable;
+	private Boolean _selected;
+	private String _spritemap;
+	private String _stickerCssClass;
+	private String _stickerIcon;
+	private String _stickerImageAlt;
+	private String _stickerImageSrc;
+	private String _stickerLabel;
+	private String _stickerShape;
+	private String _stickerStyle;
+	private String _subtitle;
+	private String _title;
+	private VerticalCard _verticalCard;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ImageCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ImageCard.java
@@ -14,68 +14,8 @@
 
 package com.liferay.frontend.taglib.clay.servlet.taglib.soy;
 
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
-
-import java.util.List;
-import java.util.Map;
-
 /**
  * @author Eudaldo Alonso
  */
-public interface ImageCard extends BaseClayCard {
-
-	public default String getIcon() {
-		return null;
-	}
-
-	public default String getImageAlt() {
-		return null;
-	}
-
-	public default String getImageSrc() {
-		return null;
-	}
-
-	public default List<LabelItem> getLabels() {
-		return null;
-	}
-
-	public default Map<String, String> getLabelStylesMap() {
-		return null;
-	}
-
-	public default String getStickerCssClass() {
-		return null;
-	}
-
-	public default String getStickerIcon() {
-		return null;
-	}
-
-	public default String getStickerImageAlt() {
-		return null;
-	}
-
-	public default String getStickerImageSrc() {
-		return null;
-	}
-
-	public default String getStickerLabel() {
-		return null;
-	}
-
-	public default String getStickerShape() {
-		return null;
-	}
-
-	public default String getStickerStyle() {
-		return null;
-	}
-
-	public default String getSubtitle() {
-		return null;
-	}
-
-	public String getTitle();
-
+public interface ImageCard extends VerticalCard {
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/VerticalCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/VerticalCard.java
@@ -82,4 +82,12 @@ public interface VerticalCard extends BaseClayCard {
 
 	public String getTitle();
 
+	public default Boolean isFlushHorizontal() {
+		return null;
+	}
+
+	public default Boolean isFlushVertical() {
+		return null;
+	}
+
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItem.java
@@ -39,4 +39,8 @@ public class DropdownItem extends NavigationItem {
 		put("target", target);
 	}
 
+	public void setType(String type) {
+		put("type", type);
+	}
+
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1097,6 +1097,187 @@
 	<tag>
 		<description></description>
 		<name>file-card</name>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.FileCardTag</tag-class>
+		<body-content>empty</body-content>
+		<attribute>
+			<description></description>
+			<name>actionDropdownItems</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
+			<name>contributorKey</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
+			<name>data</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
+			<name>defaultEventHandler</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>disabled</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
+			<name>elementClasses</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>fileCard</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
+			<name>groupName</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>href</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>icon</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>id</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>inputName</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>inputValue</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>labels</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>labelStylesMap</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>selectable</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>selected</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>spritemap</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerCssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerIcon</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerImageAlt</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerImageSrc</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerLabel</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerShape</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerStyle</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>subtitle</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>title</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
+	</tag>
+	<tag>
+		<description></description>
+		<name>file-card-v2</name>
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.FileCardTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
@@ -1682,6 +1863,205 @@
 	<tag>
 		<description></description>
 		<name>image-card</name>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.ImageCardTag</tag-class>
+		<body-content>empty</body-content>
+		<attribute>
+			<description></description>
+			<name>actionDropdownItems</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>aspectRatioClasses</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
+			<name>contributorKey</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
+			<name>data</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
+			<name>defaultEventHandler</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>disabled</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
+			<name>elementClasses</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
+			<name>groupName</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>href</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>icon</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>id</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>imageAlt</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>imageCard</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>imageSrc</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>inputName</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>inputValue</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>labels</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>labelStylesMap</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>selectable</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>selected</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>spritemap</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerCssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerIcon</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerImageAlt</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerImageSrc</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerLabel</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerShape</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>stickerStyle</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>subtitle</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>title</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
+	</tag>
+	<tag>
+		<description></description>
+		<name>image-card-v2</name>
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.ImageCardTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
@@ -3099,7 +3479,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
+			<description></description>
 			<name>label</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -3621,7 +4001,7 @@
 	<tag>
 		<description></description>
 		<name>vertical-card</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.VerticalCardTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCardTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
@@ -3630,25 +4010,31 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -3660,14 +4046,20 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>groupName</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>horizontalFlush</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -3803,6 +4195,13 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<description></description>
+			<name>verticalFlush</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/HorizontalCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/HorizontalCard.js
@@ -12,37 +12,32 @@
  * details.
  */
 
-import {ClayCardWithUser} from '@clayui/card';
+import {ClayCardWithHorizontal} from '@clayui/card';
 import React, {useState} from 'react';
 
-const getDataAttributes = (data) => {
-	return data
-		? Object.entries(data).reduce((acc, [key, value]) => {
-				acc[`data-${key}`] = value;
+import getDataAttributes from './get_data_attributes';
 
-				return acc;
-		  }, {})
-		: {};
-};
-
-export default function UserCard({
+export default function HorizontalCard({
 	actions = [],
 	componentId: _componentId,
 	cssClass,
+	disabled,
+	href,
 	inputName,
 	inputValue,
-	labels = [],
 	locale: _locale,
 	portletId: _portletId,
 	portletNamespace: _portletNamespace,
-	selected: initialSelected,
 	selectable,
+	selected: initialSelected,
+	symbol,
+	title,
 	...otherProps
 }) {
 	const [selected, setSelected] = useState(initialSelected);
 
 	return (
-		<ClayCardWithUser
+		<ClayCardWithHorizontal
 			actions={actions?.map(({data, ...rest}) => {
 				const dataAttributes = getDataAttributes(data);
 
@@ -52,27 +47,24 @@ export default function UserCard({
 				};
 			})}
 			checkboxProps={{
-				name: inputName,
-				value: inputValue,
+				name: inputName ?? '',
+				value: inputValue ?? '',
 			}}
 			className={cssClass}
-			labels={labels?.map(({data, label, style: _style, ...rest}) => {
-				const dataAttributes = getDataAttributes(data);
-
-				return {
-					value: label,
-					...dataAttributes,
-					...rest,
-				};
-			})}
+			disabled={disabled}
+			href={href}
+			interactive={false}
 			onSelectChange={
 				selectable
-					? () => {
-							setSelected(!selected);
+					? (selected) => {
+							setSelected(selected);
 					  }
 					: null
 			}
+			selectable={selectable}
 			selected={selected}
+			symbol={symbol}
+			title={title}
 			{...otherProps}
 		/>
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/UserCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/UserCard.js
@@ -12,39 +12,29 @@
  * details.
  */
 
-import {ClayCardWithHorizontal} from '@clayui/card';
+import {ClayCardWithUser} from '@clayui/card';
 import React, {useState} from 'react';
 
-const getDataAttributes = (data) => {
-	return data
-		? Object.entries(data).reduce((acc, [key, value]) => {
-				acc[`data-${key}`] = value;
+import getDataAttributes from './get_data_attributes';
 
-				return acc;
-		  }, {})
-		: {};
-};
-
-export default function HorizontalCard({
+export default function UserCard({
 	actions = [],
+	componentId: _componentId,
 	cssClass,
-	disabled,
-	href,
-	inputName,
-	inputValue,
+	inputName = '',
+	inputValue = '',
+	labels = [],
 	locale: _locale,
 	portletId: _portletId,
 	portletNamespace: _portletNamespace,
-	selectable,
 	selected: initialSelected,
-	symbol,
-	title,
+	selectable,
 	...otherProps
 }) {
 	const [selected, setSelected] = useState(initialSelected);
 
 	return (
-		<ClayCardWithHorizontal
+		<ClayCardWithUser
 			actions={actions?.map(({data, ...rest}) => {
 				const dataAttributes = getDataAttributes(data);
 
@@ -54,24 +44,35 @@ export default function HorizontalCard({
 				};
 			})}
 			checkboxProps={{
-				name: inputName,
-				value: inputValue,
+				name: inputName ?? '',
+				value: inputValue ?? '',
 			}}
 			className={cssClass}
-			disabled={disabled}
-			href={href}
-			interactive={false}
+			labels={labels?.map(
+				({
+					closeable: _closeable,
+					data,
+					label,
+					style: _style,
+					...rest
+				}) => {
+					const dataAttributes = getDataAttributes(data);
+
+					return {
+						value: label,
+						...dataAttributes,
+						...rest,
+					};
+				}
+			)}
 			onSelectChange={
 				selectable
-					? (selected) => {
-							setSelected(selected);
+					? () => {
+							setSelected(!selected);
 					  }
 					: null
 			}
-			selectable={selectable}
 			selected={selected}
-			symbol={symbol}
-			title={title}
 			{...otherProps}
 		/>
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ClayCardWithInfo} from '@clayui/card';
+import React, {useMemo, useState} from 'react';
+
+import getDataAttributes from './get_data_attributes';
+
+export default function VerticalCard({
+	actions = [],
+	componentId: _componentId,
+	cssClass,
+	description,
+	disabled,
+	displayType,
+	flushHorizontal,
+	flushVertical,
+	href,
+	imageAlt,
+	imageSrc,
+	inputName = '',
+	inputValue = '',
+	labels = [],
+	labelStylesMap: _labelStylesMap,
+	locale: _locale,
+	portletId: _portletId,
+	portletNamespace: _portletNamespace,
+	selectable,
+	selected: initialSelected,
+	stickerCssClass,
+	stickerIcon,
+	stickerImageAlt,
+	stickerImageSrc,
+	stickerLabel,
+	stickerShape,
+	stickerStyle,
+	symbol,
+	title,
+	...otherProps
+}) {
+	const [selected, setSelected] = useState(initialSelected);
+
+	const stickerProps = useMemo(
+		() => ({
+			className: stickerCssClass,
+			content: stickerLabel,
+			displayType: stickerStyle,
+			imageAlt: stickerImageAlt,
+			imageSrc: stickerImageSrc,
+			shape: stickerShape,
+			symbol: stickerIcon,
+		}),
+		[
+			stickerCssClass,
+			stickerIcon,
+			stickerImageAlt,
+			stickerImageSrc,
+			stickerLabel,
+			stickerShape,
+			stickerStyle,
+		]
+	);
+
+	return (
+		<ClayCardWithInfo
+			actions={actions?.map(({data, ...rest}) => {
+				const dataAttributes = getDataAttributes(data);
+
+				return {
+					...dataAttributes,
+					...rest,
+				};
+			})}
+			checkboxProps={{
+				name: inputName ?? '',
+				value: inputValue ?? '',
+			}}
+			className={cssClass}
+			description={description}
+			disabled={disabled}
+			displayType={displayType}
+			flushHorizontal={flushHorizontal}
+			flushVertical={flushVertical}
+			href={href}
+			imgProps={imageSrc && {alt: imageAlt, src: imageSrc}}
+			labels={labels?.map(
+				({
+					closeable: _closeable,
+					data,
+					label,
+					style: _style,
+					...rest
+				}) => {
+					const dataAttributes = getDataAttributes(data);
+
+					return {
+						value: label,
+						...dataAttributes,
+						...rest,
+					};
+				}
+			)}
+			onSelectChange={
+				selectable
+					? (selected) => {
+							setSelected(selected);
+					  }
+					: null
+			}
+			selectable={selectable}
+			selected={selected}
+			stickerProps={stickerProps}
+			symbol={symbol}
+			title={title}
+			{...otherProps}
+		/>
+	);
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/get_data_attributes.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/get_data_attributes.js
@@ -12,10 +12,12 @@
  * details.
  */
 
-package com.liferay.frontend.taglib.clay.servlet.taglib.soy;
+export default function getDataAttributes(data) {
+	return data
+		? Object.entries(data).reduce((acc, [key, value]) => {
+				acc[`data-${key}`] = value;
 
-/**
- * @author Eudaldo Alonso
- */
-public interface FileCard extends VerticalCard {
+				return acc;
+		  }, {})
+		: {};
 }


### PR DESCRIPTION
Created `FileCardTag`, `ImageCardTag` and `VerticalCardTag`  implementing Clay v3 version of these components.

Patterns, based on [#434](https://github.com/liferay-frontend/liferay-portal/pull/434)

**Test plan**:

- Fetch this branch
- Deploy the `frontend-taglib-clay` and `frontend-taglib-clay-sample-web` modules
- Using **Site builder** (> Pages), create a new (content) page, add the **Clay Sample** widget to the page and publish.
- Navigate to the **cards** tab

 