### PR TITLE
[7.4-only] LPS-112463 Create HorizontalCard for Clay v3

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleHorizontalCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleHorizontalCard.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.sample.web.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.soy.HorizontalCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+
+import java.util.List;
+
+/**
+ * @author Marko Cikos
+ */
+public class ClaySampleHorizontalCard implements HorizontalCard {
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() {
+		return DropdownItemListBuilder.add(
+			dropdownItem -> {
+				dropdownItem.setHref("#1");
+				dropdownItem.setLabel("Custom Edit");
+			}
+		).add(
+			dropdownItem -> {
+				dropdownItem.setHref("#2");
+				dropdownItem.setLabel("Custom Save");
+			}
+		).build();
+	}
+
+	@Override
+	public String getCssClass() {
+		return "custom-horizontal-card-css-class";
+	}
+
+	@Override
+	public String getHref() {
+		return "#custom-horizontal-card-href";
+	}
+
+	@Override
+	public String getIcon() {
+		return "page";
+	}
+
+	@Override
+	public String getId() {
+		return "customHorizontalCardId";
+	}
+
+	@Override
+	public String getInputName() {
+		return "custom-horizontal-card-input-name";
+	}
+
+	@Override
+	public String getInputValue() {
+		return "custom-horizontal-card-input-value";
+	}
+
+	@Override
+	public String getTitle() {
+		return "asset-title";
+	}
+
+	@Override
+	public boolean isDisabled() {
+		return false;
+	}
+
+	@Override
+	public boolean isSelectable() {
+		return true;
+	}
+
+	@Override
+	public boolean isSelected() {
+		return true;
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -21,6 +21,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.frontend.taglib.clay.sample.web.constants.ClaySamplePortletKeys" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.CardsDisplayContext" %><%@
+page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleHorizontalCard" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleUserCard" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.DropdownsDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ManagementToolbarsDisplayContext" %><%@

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
@@ -516,23 +516,32 @@ ClaySampleUserCard claySampleUserCard = new ClaySampleUserCard();
 
 <clay:row>
 	<clay:col
-		id="image-card-block"
-		md="6"
+		id="simpleHorizontalCard"
+		md="4"
 	>
-		<clay:horizontal-card-v2
+		<clay:horizontal-card
 			title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
 		/>
 	</clay:col>
 
 	<clay:col
-		id="image-card-icon-block"
-		md="6"
+		id="selectableHorizontalCard"
+		md="4"
 	>
-		<clay:horizontal-card-v2
+		<clay:horizontal-card
 			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
+			disabled="<%= true %>"
 			selectable="<%= true %>"
-			selected="<%= true %>"
 			title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
+		/>
+	</clay:col>
+
+	<clay:col
+		id="modelHorizontalCard"
+		md="4"
+	>
+		<clay:horizontal-card
+			horizontalCard="<%= new ClaySampleHorizontalCard() %>"
 		/>
 	</clay:col>
 </clay:row>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
@@ -1,0 +1,432 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.frontend.taglib.clay.servlet.taglib.soy.HorizontalCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Marko Cikos
+ */
+public class HorizontalCardTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		Map<String, String> data = getData();
+
+		if (data != null) {
+			for (Map.Entry<String, String> entry : data.entrySet()) {
+				setDynamicAttribute(
+					StringPool.BLANK, "data-" + entry.getKey(),
+					entry.getValue());
+			}
+		}
+
+		return super.doStartTag();
+	}
+
+	public List<DropdownItem> getActionDropdownItems() {
+		if ((_actionDropdownItems == null) && (_horizontalCard != null)) {
+			return _horizontalCard.getActionDropdownItems();
+		}
+
+		return _actionDropdownItems;
+	}
+
+	@Override
+	public String getCssClass() {
+		if ((super.getCssClass() == null) && (_horizontalCard != null)) {
+			if (_horizontalCard.getCssClass() != null) {
+				return _horizontalCard.getCssClass();
+			}
+
+			if (_horizontalCard.getElementClasses() != null) {
+				return _horizontalCard.getElementClasses();
+			}
+		}
+
+		return super.getCssClass();
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
+	public Map<String, String> getData() {
+		if ((_data == null) && (_horizontalCard != null)) {
+			return _horizontalCard.getData();
+		}
+
+		return _data;
+	}
+
+	public String getHref() {
+		if ((_href == null) && (_horizontalCard != null)) {
+			return _horizontalCard.getHref();
+		}
+
+		return _href;
+	}
+
+	public String getIcon() {
+		if (_icon == null) {
+			if ((_horizontalCard != null) &&
+				(_horizontalCard.getIcon() != null)) {
+
+				return _horizontalCard.getIcon();
+			}
+
+			return "folder";
+		}
+
+		return _icon;
+	}
+
+	@Override
+	public String getId() {
+		if ((super.getId() == null) && (_horizontalCard != null)) {
+			return _horizontalCard.getId();
+		}
+
+		return super.getId();
+	}
+
+	public String getInputName() {
+		if ((_inputName == null) && (_horizontalCard != null)) {
+			return _horizontalCard.getInputName();
+		}
+
+		return _inputName;
+	}
+
+	public String getInputValue() {
+		if ((_inputValue == null) && (_horizontalCard != null)) {
+			return _horizontalCard.getInputValue();
+		}
+
+		return _inputValue;
+	}
+
+	public String getTitle() {
+		String title = _title;
+
+		if ((_title == null) && (_horizontalCard != null)) {
+			title = _horizontalCard.getTitle();
+		}
+
+		return LanguageUtil.get(
+			TagResourceBundleUtil.getResourceBundle(pageContext), title);
+	}
+
+	public Boolean isDisabled() {
+		if (_disabled == null) {
+			if (_horizontalCard != null) {
+				return _horizontalCard.isDisabled();
+			}
+
+			return false;
+		}
+
+		return _disabled;
+	}
+
+	public Boolean isSelectable() {
+		if (_selectable == null) {
+			if (_horizontalCard != null) {
+				return _horizontalCard.isSelectable();
+			}
+
+			return false;
+		}
+
+		return _selectable;
+	}
+
+	public Boolean isSelected() {
+		if (_selected == null) {
+			if (_horizontalCard != null) {
+				return _horizontalCard.isSelected();
+			}
+
+			return false;
+		}
+
+		return _selected;
+	}
+
+	public void setActionDropdownItems(List<DropdownItem> actionDropdownItems) {
+		_actionDropdownItems = actionDropdownItems;
+	}
+
+	public void setDisabled(Boolean disabled) {
+		_disabled = disabled;
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setGroupName(String groupName) {
+		_groupName = groupName;
+	}
+
+	public void setHorizontalCard(HorizontalCard horizontalCard) {
+		_horizontalCard = horizontalCard;
+	}
+
+	public void setHref(String href) {
+		_href = href;
+	}
+
+	public void setIcon(String icon) {
+		_icon = icon;
+	}
+
+	public void setInputName(String inputName) {
+		_inputName = inputName;
+	}
+
+	public void setInputValue(String inputValue) {
+		_inputValue = inputValue;
+	}
+
+	public void setSelectable(Boolean selectable) {
+		_selectable = selectable;
+	}
+
+	public void setSelected(Boolean selected) {
+		_selected = selected;
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setSpritemap(String spritemap) {
+		_spritemap = spritemap;
+	}
+
+	public void setTitle(String title) {
+		_title = title;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_actionDropdownItems = null;
+		_data = null;
+		_disabled = null;
+		_groupName = null;
+		_horizontalCard = null;
+		_href = null;
+		_icon = null;
+		_inputName = null;
+		_inputValue = null;
+		_selectable = null;
+		_selected = null;
+		_spritemap = null;
+		_title = null;
+	}
+
+	@Override
+	protected String getHydratedModuleName() {
+		return "frontend-taglib-clay/HorizontalCard";
+	}
+
+	@Override
+	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("actions", getActionDropdownItems());
+		props.put("disabled", isDisabled());
+		props.put("href", getHref());
+		props.put("inputName", getInputName());
+		props.put("inputValue", getInputValue());
+		props.put("selectable", isSelectable());
+		props.put("selected", isSelected());
+		props.put("symbol", getIcon());
+		props.put("title", getTitle());
+
+		return super.prepareProps(props);
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		if (isSelectable()) {
+			cssClasses.add("card-type-directory");
+			cssClasses.add("form-check");
+			cssClasses.add("form-check-card");
+			cssClasses.add("form-check-middle-left");
+		}
+		else {
+			cssClasses.add("card");
+		}
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		if (isSelectable()) {
+			jspWriter.write("<div class=\"custom-control custom-checkbox\">");
+			jspWriter.write("<label><input");
+
+			if (isSelected()) {
+				jspWriter.write(" checked");
+			}
+
+			jspWriter.write(" class=\"custom-control-input\"");
+
+			if (isDisabled()) {
+				jspWriter.write(" disabled");
+			}
+
+			String inputName = getInputName();
+
+			if (inputName != null) {
+				jspWriter.write(" name=\"");
+				jspWriter.write(inputName);
+				jspWriter.write("\"");
+			}
+
+			jspWriter.write(" type=\"checkbox\"");
+
+			String inputValue = getInputValue();
+
+			if (inputValue != null) {
+				jspWriter.write(" value=\"");
+				jspWriter.write(inputValue);
+				jspWriter.write("\"");
+			}
+
+			jspWriter.write(" /><span class=\"custom-control-label\"></span>");
+
+			_writeBody(jspWriter);
+
+			jspWriter.write("</label></div>");
+		}
+		else {
+			_writeBody(jspWriter);
+		}
+
+		return SKIP_BODY;
+	}
+
+	private void _writeBody(JspWriter jspWriter) throws Exception {
+		jspWriter.write("<div class=\"card card-horizontal\"><div class=\"");
+		jspWriter.write("card-body\"><div class=\"card-row\"><div class=\"");
+		jspWriter.write("autofit-col\">");
+
+		StickerTag stickerTag = new StickerTag();
+
+		stickerTag.setIcon(getIcon());
+		stickerTag.setInline(true);
+
+		stickerTag.doTag(pageContext);
+
+		jspWriter.write("</div><div class=\"autofit-col autofit-col-expand");
+		jspWriter.write(" autofit-col-gutters\"><p class=\"card-title\"");
+
+		String title = getTitle();
+
+		if (title != null) {
+			jspWriter.write(" title=\"");
+			jspWriter.write(title);
+			jspWriter.write("\"");
+		}
+
+		jspWriter.write("><span class=\"text-truncate-inline\">");
+
+		String href = getHref();
+		Boolean disabled = isDisabled();
+
+		if ((href != null) && !disabled) {
+			LinkTag linkTag = new LinkTag();
+
+			linkTag.setCssClass("text-truncate");
+			linkTag.setHref(href);
+
+			if (title != null) {
+				linkTag.setLabel(title);
+			}
+
+			linkTag.doTag(pageContext);
+		}
+		else {
+			jspWriter.write("<span class=\"text-truncate\">");
+
+			if (title != null) {
+				jspWriter.write(title);
+			}
+
+			jspWriter.write("</span>");
+		}
+
+		jspWriter.write("</span></p></div>");
+
+		if (!ListUtil.isEmpty(getActionDropdownItems())) {
+			jspWriter.write("<div class=\"autofit-col\">");
+
+			DropdownActionsTag dropdownActionsTag = new DropdownActionsTag();
+
+			dropdownActionsTag.setDropdownItems(getActionDropdownItems());
+
+			if (disabled) {
+				dropdownActionsTag.setDynamicAttribute(
+					StringPool.BLANK, "disabled", disabled);
+			}
+
+			dropdownActionsTag.doTag(pageContext);
+
+			jspWriter.write("</div>");
+		}
+
+		jspWriter.write("</div></div></div>");
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:horizontal-card:";
+
+	private List<DropdownItem> _actionDropdownItems;
+	private Map<String, String> _data;
+	private Boolean _disabled;
+	private String _groupName;
+	private HorizontalCard _horizontalCard;
+	private String _href;
+	private String _icon;
+	private String _inputName;
+	private String _inputValue;
+	private Boolean _selectable;
+	private Boolean _selected;
+	private String _spritemap;
+	private String _title;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1381,7 +1381,7 @@
 	<tag>
 		<description></description>
 		<name>horizontal-card</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.HorizontalCardTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.HorizontalCardTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
@@ -1390,25 +1390,31 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1420,13 +1426,13 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]></description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>groupName</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1480,7 +1486,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1491,6 +1497,7 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/HorizontalCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/HorizontalCard.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ClayCardWithHorizontal} from '@clayui/card';
+import React, {useState} from 'react';
+
+const getDataAttributes = (data) => {
+	return data
+		? Object.entries(data).reduce((acc, [key, value]) => {
+				acc[`data-${key}`] = value;
+
+				return acc;
+		  }, {})
+		: {};
+};
+
+export default function HorizontalCard({
+	actions = [],
+	cssClass,
+	disabled,
+	href,
+	inputName,
+	inputValue,
+	locale: _locale,
+	portletId: _portletId,
+	portletNamespace: _portletNamespace,
+	selectable,
+	selected: initialSelected,
+	symbol,
+	title,
+	...otherProps
+}) {
+	const [selected, setSelected] = useState(initialSelected);
+
+	return (
+		<ClayCardWithHorizontal
+			actions={actions?.map(({data, ...rest}) => {
+				const dataAttributes = getDataAttributes(data);
+
+				return {
+					...dataAttributes,
+					...rest,
+				};
+			})}
+			checkboxProps={{
+				name: inputName,
+				value: inputValue,
+			}}
+			className={cssClass}
+			disabled={disabled}
+			href={href}
+			interactive={false}
+			onSelectChange={
+				selectable
+					? (selected) => {
+							setSelected(selected);
+					  }
+					: null
+			}
+			selectable={selectable}
+			selected={selected}
+			symbol={symbol}
+			title={title}
+			{...otherProps}
+		/>
+	);
+}


### PR DESCRIPTION
@carloslancha @julien @jbalsas @wincent 

In this PR we are implementing horizontal card based on Clay 3. For description see https://issues.liferay.com/browse/LPS-112463 and parent epic.

Notes:
- This is a sibling PR to https://github.com/liferay-frontend/liferay-portal/pull/434 and https://github.com/liferay-frontend/liferay-portal/pull/448. Some code, like base card class changes, are present in all PRs, so it will have to be removed from whichever is not merged first. All should not be forwarded at the same time, or there will be conflicts. At some point we should consider merging common points of code.
- There is a commit increasing version of Clay, this will not be needed after https://github.com/liferay-frontend/liferay-portal/pull/442 is merged.
- In Clay 3 we have the concept of an 'interactive' card. With an interactive card we have different styles, for example we set cursor to pointer and have blue outline on hover. The styles inform user that the card is interactive. I Clay 2 we had this as well, implemented through CSS. In Clay 3 this is baked as a prop, so we are extending base model class and tag to support it. Card is not interactive by default. In usage in this PR, in `layout-admin-web`, card is interactive, so we are setting this attribute.
- Dropdown has slightly different styles (see gif). I find them to be an improvement to Clay 2 styles, so I opted not to override them.
- There are some existing attributes that, as far as I can see, are not used in Clay 2. These are `componentId`, `contributorKey` and `groupName`. In this PR, we are not doing anything with them, apart from passing them as `otherProps` to Clay component.

Misc. differences from https://github.com/liferay-frontend/liferay-portal/pull/434:
- I avoided usages of `Validator`, see  https://github.com/liferay-frontend/liferay-portal/pull/434#discussion_r512000581
- I handled `data` in backend. I believe this is not only slightly better as it covers [this edge case](https://github.com/liferay-frontend/liferay-portal/pull/434#discussion_r510255276), but also [code is cleaner]compared to handling in JS.

Steps to test:
- [Usage 1] Deploy `frontend-taglib-clay-sample-web` and place it on any page.
- [Usage 2] Create a new page.

![after](https://user-images.githubusercontent.com/5435511/97203010-a1bcf700-17b4-11eb-9577-fa169ebeff6b.gif)

