### PR TITLE
[7.4.x-only][LPS-121725,LPS-121754] Removes conditional branches targeting IE browsers

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -60,11 +60,9 @@ if (Validator.isNotNull(assetPublisherViewContentDisplayContext.getReturnToFullP
 
 <aui:script>
 	Liferay.once('allPortletsReady', function () {
-		if (!Liferay.Browser.isIe()) {
-			document
-				.getElementById('p_p_id_<%= portletDisplay.getId() %>_')
-				.scrollIntoView();
-		}
+		document
+			.getElementById('p_p_id_<%= portletDisplay.getId() %>_')
+			.scrollIntoView();
 	});
 </aui:script>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Calculator/Calculator.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Calculator/Calculator.es.js
@@ -99,9 +99,9 @@ class Calculator extends Component {
 			...state,
 			...this.getStateBasedOnExpression(expression),
 			expression: expression.replace(/[[\]]/g, ''),
-			placeholder: Liferay.Browser.isIe()
-				? ''
-				: Liferay.Language.get('the-expression-will-be-displayed-here'),
+			placeholder: Liferay.Language.get(
+				'the-expression-will-be-displayed-here'
+			),
 		};
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleBuilder/RulesSupport.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleBuilder/RulesSupport.es.js
@@ -102,6 +102,19 @@ const targetFieldExists = (target, pages) => {
 	return targetFieldExists;
 };
 
+const getFieldOptions = (fieldName, pages) => {
+	let options = [];
+	const visitor = new PagesVisitor(pages);
+
+	const field = visitor.findField((field) => {
+		return field.fieldName === fieldName;
+	});
+
+	options = field ? field.options : [];
+
+	return options;
+};
+
 const syncActions = (pages, actions) => {
 	actions.forEach((action) => {
 		if (action.action === 'auto-fill') {
@@ -307,19 +320,6 @@ const findRuleByFieldName = (fieldName, rules) => {
 
 const findInvalidRule = (rule) => {
 	return findRuleByFieldName('', [rule]);
-};
-
-const getFieldOptions = (fieldName, pages) => {
-	let options = [];
-	const visitor = new PagesVisitor(pages);
-
-	const field = visitor.findField((field) => {
-		return field.fieldName === fieldName;
-	});
-
-	options = field ? field.options : [];
-
-	return options;
 };
 
 export default {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
@@ -421,19 +421,6 @@ td.lfr-name-column {
 	}
 }
 
-.portlet-forms-ie {
-	.forms-navigation-bar,
-	.navigation-bar-secondary,
-	.management-bar {
-		position: inherit !important;
-		top: 0 !important;
-	}
-
-	.sidebar-container {
-		top: 56px !important;
-	}
-}
-
 .portal-popup {
 	.portlet-column {
 		padding: 0;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
@@ -217,8 +217,4 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 	Liferay.on('destroyPortlet', clearPortletHandlers);
 
 	Liferay.Forms.App.start();
-
-	if (Liferay.Browser.isIe()) {
-		document.querySelector('.portlet-forms').classList.add('portlet-forms-ie');
-	}
 </aui:script>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -288,10 +288,6 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 	Liferay.on('destroyPortlet', clearPortletHandlers);
 
 	Liferay.Forms.App.start();
-
-	if (Liferay.Browser.isIe()) {
-		document.querySelector('.portlet-forms').classList.add('portlet-forms-ie');
-	}
 </aui:script>
 
 <aui:script use="aui-base">

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/deprecated.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/deprecated.js
@@ -128,25 +128,6 @@
 	Util.addInputType = function (el) {
 		Util.addInputType = Lang.emptyFn;
 
-		if (Liferay.Browser.isIe() && Liferay.Browser.getMajorVersion() < 7) {
-			Util.addInputType = function (el) {
-				if (el) {
-					el = A.one(el);
-				}
-				else {
-					el = A.one(document.body);
-				}
-
-				var defaultType = 'text';
-
-				el.all('input').each((item) => {
-					var type = item.get('type') || defaultType;
-
-					item.addClass(type);
-				});
-			};
-		}
-
 		return Util.addInputType(el);
 	};
 

--- a/modules/apps/frontend-js/frontend-js-svg4everybody-web/src/main/java/com/liferay/frontend/js/svg4everybody/web/internal/servlet/taglib/SVG4EverybodyTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-svg4everybody-web/src/main/java/com/liferay/frontend/js/svg4everybody/web/internal/servlet/taglib/SVG4EverybodyTopHeadDynamicInclude.java
@@ -17,7 +17,6 @@ package com.liferay.frontend.js.svg4everybody.web.internal.servlet.taglib;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.servlet.BrowserSniffer;
 import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.util.Portal;
@@ -65,9 +64,7 @@ public class SVG4EverybodyTopHeadDynamicInclude extends BaseDynamicInclude {
 			}
 		}
 
-		if (!cdnDynamicResourcesEnabled ||
-			_browserSniffer.isIe(httpServletRequest)) {
-
+		if (!cdnDynamicResourcesEnabled) {
 			PrintWriter printWriter = httpServletResponse.getWriter();
 
 			AbsolutePortalURLBuilder absolutePortalURLBuilder =
@@ -110,9 +107,6 @@ public class SVG4EverybodyTopHeadDynamicInclude extends BaseDynamicInclude {
 
 	@Reference
 	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
-
-	@Reference
-	private BrowserSniffer _browserSniffer;
 
 	private BundleContext _bundleContext;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
@@ -147,10 +147,6 @@ Liferay = window.Liferay || {};
 			ioConfig.cache = false;
 		}
 
-		if (Liferay.PropsValues.NTLM_AUTH_ENABLED && Liferay.Browser.isIe()) {
-			ioConfig.type = 'GET';
-		}
-
 		return ioConfig;
 	};
 

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/_mixins.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/_mixins.scss
@@ -1,17 +1,14 @@
 // Flex mixin
 
 @mixin break-flex-item() {
-	-ms-flex-preferred-size: auto;
 	flex-basis: auto;
 	width: 100%;
 }
 
 @mixin stack-flex-container() {
-	-ms-flex-direction: column;
 	flex-direction: column;
 
 	.flex-item-full {
-		-ms-flex-preferred-size: auto;
 		flex-basis: auto;
 	}
 }
@@ -377,111 +374,72 @@
 // Transformations
 
 @mixin scale($ratio...) {
-	-ms-transform: scale($ratio); // IE9 only
-	-o-transform: scale($ratio);
-	-webkit-transform: scale($ratio);
 	transform: scale($ratio);
 }
 
 @mixin scaleX($ratio) {
-	-ms-transform: scaleX($ratio); // IE9 only
-	-o-transform: scaleX($ratio);
-	-webkit-transform: scaleX($ratio);
 	transform: scaleX($ratio);
 }
 
 @mixin scaleY($ratio) {
-	-ms-transform: scaleY($ratio); // IE9 only
-	-o-transform: scaleY($ratio);
-	-webkit-transform: scaleY($ratio);
 	transform: scaleY($ratio);
 }
 
 @mixin skew($x, $y) {
-	-ms-transform: skewX($x) skewY($y); // See https://github.com/twbs/bootstrap/issues/4885; IE9+
-	-o-transform: skewX($x) skewY($y);
-	-webkit-transform: skewX($x) skewY($y);
 	transform: skewX($x) skewY($y);
 }
 
 @mixin translate($x, $y) {
-	-ms-transform: translate($x, $y); // IE9 only
-	-o-transform: translate($x, $y);
-	-webkit-transform: translate($x, $y);
 	transform: translate($x, $y);
 }
 
 @mixin translate3d($x, $y, $z) {
-	-webkit-transform: translate3d($x, $y, $z);
 	transform: translate3d($x, $y, $z);
 }
 
 @mixin rotate($degrees) {
-	-ms-transform: rotate($degrees); // IE9 only
-	-o-transform: rotate($degrees);
-	-webkit-transform: rotate($degrees);
 	transform: rotate($degrees);
 }
 
 @mixin rotateX($degrees) {
-	-ms-transform: rotateX($degrees); // IE9 only
-	-o-transform: rotateX($degrees);
-	-webkit-transform: rotateX($degrees);
 	transform: rotateX($degrees);
 }
 
 @mixin rotateY($degrees) {
-	-ms-transform: rotateY($degrees); // IE9 only
-	-o-transform: rotateY($degrees);
-	-webkit-transform: rotateY($degrees);
 	transform: rotateY($degrees);
 }
 
 @mixin perspective($perspective) {
-	-moz-perspective: $perspective;
-	-webkit-perspective: $perspective;
 	perspective: $perspective;
 }
 
 @mixin perspective-origin($perspective) {
-	-moz-perspective-origin: $perspective;
-	-webkit-perspective-origin: $perspective;
 	perspective-origin: $perspective;
 }
 
 @mixin transform-origin($origin) {
-	-moz-transform-origin: $origin;
-	-ms-transform-origin: $origin; // IE9 only
-	-webkit-transform-origin: $origin;
 	transform-origin: $origin;
 }
 
 // Transitions
 
 @mixin transition-property($transition-property...) {
-	-webkit-transition-property: $transition-property;
 	transition-property: $transition-property;
 }
 
 @mixin transition-delay($transition-delay) {
-	-webkit-transition-delay: $transition-delay;
 	transition-delay: $transition-delay;
 }
 
 @mixin transition-duration($transition-duration...) {
-	-webkit-transition-duration: $transition-duration;
 	transition-duration: $transition-duration;
 }
 
 @mixin transition-timing-function($timing-function) {
-	-webkit-transition-timing-function: $timing-function;
 	transition-timing-function: $timing-function;
 }
 
 @mixin transition-transform($transition...) {
-	-moz-transition: -moz-transform $transition;
-	-o-transition: -o-transform $transition;
-	-webkit-transition: -webkit-transform $transition;
 	transition: transform $transition;
 }
 

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_simple_flexbox_grid.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_simple_flexbox_grid.scss
@@ -1,56 +1,42 @@
 @if $compat-simple_flexbox_grid {
 	.flex-container {
-		-ms-flex-direction: row;
-		-ms-flex-wrap: wrap;
-		display: -ms-flexbox;
 		display: flex;
 		flex-flow: row wrap;
 	}
 
 	.flex-container-stacked {
-		-ms-flex-direction: column;
 		flex-direction: column;
 	}
 
 	.flex-row-vertical {
-		-ms-flex-direction: column;
-		display: -ms-flexbox;
 		display: flex;
 		flex-direction: column;
 	}
 
 	.flex-item-expand {
-		-ms-flex: 1;
-		-ms-flex-wrap: wrap;
 		flex: 1;
 		flex-wrap: wrap;
 		min-width: 0;
 	}
 
 	.flex-item-full {
-		-ms-flex: 1 100%;
-		-ms-flex-wrap: wrap;
 		flex: 1 100%;
 		flex-wrap: wrap;
 
 		+ .flex-item-expand {
-			-ms-flex-preferred-size: auto;
 			flex-basis: auto;
 		}
 	}
 
 	.flex-item-bottom {
-		-ms-flex-item-align: end;
 		align-self: flex-end;
 	}
 
 	.flex-item-center {
-		-ms-flex-item-align: center;
 		align-self: center;
 	}
 
 	.flex-item-top {
-		-ms-flex-item-align: start;
 		align-self: flex-start;
 	}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/index.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/index.js
@@ -12,37 +12,12 @@
  * details.
  */
 
-import React, {useEffect} from 'react';
+import React from 'react';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import App from './components/App';
 import {initializeConfig} from './config/index';
-
-let removeChild;
-
-/**
- * LPS-120418 remove child function that doesn't throw a NotFoundError exception.
- * This is done by default in all browser except ie11
- *
- * When mounting the dropzones this error is thrown making the fragment fail,
- * swallowing seems harmless and makes the dropzones work in ie11
- */
-function safeRemoveChild() {
-	try {
-		return removeChild.apply(this, arguments);
-	}
-	catch (error) {
-		if (!!error && !!error.message && error.message === 'NotFoundError') {
-			if (process.env.NODE_ENV === 'development') {
-				console.warn('IE NotFoundError handled');
-			}
-		}
-		else {
-			throw error;
-		}
-	}
-}
 
 /**
  * Default application export.
@@ -52,21 +27,6 @@ function safeRemoveChild() {
  */
 export default function (data) {
 	initializeConfig(data.config);
-
-	if (Liferay?.Browser?.isIe()) {
-		removeChild = window.HTMLElement.prototype.removeChild;
-
-		window.HTMLElement.prototype.removeChild = safeRemoveChild;
-	}
-
-	useEffect(() => {
-		return () => {
-			if (removeChild) {
-				window.HTMLElement.prototype.removeChild = removeChild;
-				removeChild = undefined;
-			}
-		};
-	}, []);
 
 	return (
 		<DndProvider backend={HTML5Backend}>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getFrontendTokenValue.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getFrontendTokenValue.js
@@ -21,12 +21,7 @@ export function getFrontendTokenValue(styleValue) {
 	const frontendToken = config.frontendTokens[styleValue];
 
 	if (frontendToken) {
-		if (Liferay.Browser.isIe()) {
-			return frontendToken.value;
-		}
-		else {
-			return `var(--${frontendToken.cssVariable})`;
-		}
+		return `var(--${frontendToken.cssVariable})`;
 	}
 
 	return styleValue;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -66,7 +66,6 @@ import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
-import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -714,10 +713,6 @@ public class RenderLayoutStructureDisplayContext {
 			frontendTokensValuesJSONObject.getJSONObject(styleValue);
 
 		if (styleValueJSONObject == null) {
-			return styleValue;
-		}
-
-		if (BrowserSnifferUtil.isIe(_httpServletRequest)) {
 			return styleValue;
 		}
 

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/css/EditApp.scss
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/css/EditApp.scss
@@ -37,10 +37,6 @@ $navbarHeight: 120px;
 				}
 			}
 
-			.arrow-plus-button-ie {
-				margin-left: -15px;
-			}
-
 			.arrow-body {
 				display: flex;
 				justify-content: center;
@@ -52,10 +48,6 @@ $navbarHeight: 120px;
 					margin: auto;
 					margin-bottom: -4px;
 					margin-top: 4px;
-				}
-
-				.arrow-head-ie {
-					margin-left: -9px;
 				}
 
 				.arrow-tail {
@@ -71,10 +63,6 @@ $navbarHeight: 120px;
 				background-color: #fff;
 				border-radius: 50%;
 				font-size: 6px;
-			}
-
-			.arrow-point-ie {
-				margin-left: -2px;
 			}
 
 			.icon {

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/workflow-builder/WorkflowStep.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/workflow-builder/WorkflowStep.es.js
@@ -20,25 +20,17 @@ import React, {useState} from 'react';
 import ButtonInfo from '../../../../components/button-info/ButtonInfo.es';
 
 const Arrow = ({addStep, selected}) => {
-	const isIE = /Trident/.test(navigator.userAgent);
-
 	return (
 		<div className={classNames('arrow ', selected && 'selected')}>
 			<ClayIcon
-				className={classNames(
-					'arrow-point icon',
-					isIE && 'arrow-point-ie'
-				)}
+				className={classNames('arrow-point icon')}
 				symbol="live"
 			/>
 
 			{selected && (
 				<ClayTooltipProvider>
 					<div
-						className={classNames(
-							'arrow-plus-button',
-							isIE && 'arrow-plus-button-ie'
-						)}
+						className={classNames('arrow-plus-button')}
 						data-tooltip-align="left"
 						data-tooltip-delay="0"
 						onClick={addStep}
@@ -53,10 +45,7 @@ const Arrow = ({addStep, selected}) => {
 				<div className="arrow-tail" />
 
 				<ClayIcon
-					className={classNames(
-						'arrow-head icon',
-						isIE && 'arrow-head-ie'
-					)}
+					className={classNames('arrow-head icon')}
 					symbol="caret-bottom"
 				/>
 			</div>

--- a/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.configuration.Filter;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.BrowserSniffer;
-import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.BufferCacheServletResponse;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.PortalWebResourceConstants;
@@ -402,7 +401,7 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 		File cacheDataFile = new File(
 			_tempDir, cacheCommonFileName + "_E_DATA");
 
-		if (cacheDataFile.exists() && !_isLegacyIe(httpServletRequest)) {
+		if (cacheDataFile.exists()) {
 			long fileLastModifiedTime = -1;
 
 			try (Reader reader = new FileReader(cacheDataFile);
@@ -452,10 +451,8 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 
 				httpServletResponse.setContentType(ContentTypes.TEXT_CSS_UTF8);
 
-				if (!_isLegacyIe(httpServletRequest)) {
-					FileUtil.write(
-						cacheContentTypeFile, ContentTypes.TEXT_CSS_UTF8);
-				}
+				FileUtil.write(
+					cacheContentTypeFile, ContentTypes.TEXT_CSS_UTF8);
 			}
 			else if (resourcePath.endsWith(_JAVASCRIPT_EXTENSION)) {
 				if (_log.isInfoEnabled()) {
@@ -626,12 +623,6 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 		String content = _readResource(
 			httpServletRequest, httpServletResponse, resourcePath);
 
-		if (_isLegacyIe(httpServletRequest)) {
-			return getCssContent(
-				httpServletRequest, httpServletResponse, cssServletContext,
-				resourcePath, content);
-		}
-
 		content = aggregateCss(
 			new ServletPaths(cssServletContext, resourcePathRoot), content);
 
@@ -723,16 +714,6 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 					httpServletResponse, (String)minifiedContent);
 			}
 		}
-	}
-
-	private boolean _isLegacyIe(HttpServletRequest httpServletRequest) {
-		if (BrowserSnifferUtil.isIe(httpServletRequest) &&
-			(BrowserSnifferUtil.getMajorVersion(httpServletRequest) < 10)) {
-
-			return true;
-		}
-
-		return false;
 	}
 
 	private String _readResource(

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.kernel.portlet;
 
-import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -37,7 +36,7 @@ public class JSONPortletResponseUtil {
 			Object object)
 		throws IOException {
 
-		mimeResponse.setContentType(_getContentType(portletRequest));
+		mimeResponse.setContentType(ContentTypes.APPLICATION_JSON);
 
 		PortletResponseUtil.write(mimeResponse, object.toString());
 
@@ -52,23 +51,11 @@ public class JSONPortletResponseUtil {
 		HttpServletResponse httpServletResponse =
 			PortalUtil.getHttpServletResponse(portletResponse);
 
-		httpServletResponse.setContentType(_getContentType(portletRequest));
+		httpServletResponse.setContentType(ContentTypes.APPLICATION_JSON);
 
 		ServletResponseUtil.write(httpServletResponse, object.toString());
 
 		httpServletResponse.flushBuffer();
-	}
-
-	private static String _getContentType(PortletRequest portletRequest) {
-		String contentType = ContentTypes.APPLICATION_JSON;
-
-		if (BrowserSnifferUtil.isIe(
-				PortalUtil.getHttpServletRequest(portletRequest))) {
-
-			contentType = ContentTypes.TEXT_PLAIN;
-		}
-
-		return contentType;
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletApp;
-import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
@@ -370,16 +369,6 @@ public class LiferayPortlet extends GenericPortlet {
 		return method;
 	}
 
-	protected String getJSONContentType(PortletRequest portletRequest) {
-		if (BrowserSnifferUtil.isIe(
-				PortalUtil.getHttpServletRequest(portletRequest))) {
-
-			return ContentTypes.TEXT_HTML;
-		}
-
-		return ContentTypes.APPLICATION_JSON;
-	}
-
 	/**
 	 * @deprecated As of Mueller (7.2.x), with no direct replacement
 	 */
@@ -635,7 +624,7 @@ public class LiferayPortlet extends GenericPortlet {
 		HttpServletResponse httpServletResponse =
 			PortalUtil.getHttpServletResponse(actionResponse);
 
-		httpServletResponse.setContentType(getJSONContentType(portletRequest));
+		httpServletResponse.setContentType(ContentTypes.APPLICATION_JSON);
 
 		ServletResponseUtil.write(
 			httpServletResponse, _toXSSSafeJSON(object.toString()));
@@ -648,7 +637,7 @@ public class LiferayPortlet extends GenericPortlet {
 			Object object)
 		throws IOException {
 
-		mimeResponse.setContentType(getJSONContentType(portletRequest));
+		mimeResponse.setContentType(ContentTypes.APPLICATION_JSON);
 
 		PortletResponseUtil.write(
 			mimeResponse, _toXSSSafeJSON(object.toString()));

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletResponseUtil.java
@@ -18,12 +18,10 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -293,16 +291,8 @@ public class PortletResponseUtil {
 			if (!ascii) {
 				String encodedFileName = URLCodec.encodeURL(fileName, true);
 
-				if (BrowserSnifferUtil.isIe(
-						PortalUtil.getHttpServletRequest(portletRequest))) {
-
-					contentDispositionFileName =
-						"filename=\"" + encodedFileName + "\"";
-				}
-				else {
-					contentDispositionFileName =
-						"filename*=UTF-8''" + encodedFileName;
-				}
+				contentDispositionFileName =
+					"filename*=UTF-8''" + encodedFileName;
 			}
 		}
 		catch (Exception exception) {

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/bridges/mvc/BaseMVCActionCommand.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/bridges/mvc/BaseMVCActionCommand.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.kernel.portlet.bridges.mvc;
 
-import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
@@ -23,7 +21,6 @@ import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
-import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -32,7 +29,6 @@ import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -232,25 +228,6 @@ public abstract class BaseMVCActionCommand implements MVCActionCommand {
 
 		if (Validator.isNull(redirect)) {
 			return;
-		}
-
-		// LPS-1928
-
-		HttpServletRequest httpServletRequest =
-			PortalUtil.getHttpServletRequest(actionRequest);
-
-		if (BrowserSnifferUtil.isIe(httpServletRequest) &&
-			(BrowserSnifferUtil.getMajorVersion(httpServletRequest) == 6.0) &&
-			redirect.contains(StringPool.POUND)) {
-
-			String redirectToken = "&#";
-
-			if (!redirect.contains(StringPool.QUESTION)) {
-				redirectToken = StringPool.QUESTION + redirectToken;
-			}
-
-			redirect = StringUtil.replace(
-				redirect, CharPool.POUND, redirectToken);
 		}
 
 		redirect = PortalUtil.escapeRedirect(redirect);

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -473,14 +473,7 @@ public class ServletResponseUtil {
 		if (!ascii) {
 			String encodedFileName = URLCodec.encodeURL(fileName, true);
 
-			if (BrowserSnifferUtil.isIe(httpServletRequest)) {
-				contentDispositionFileName =
-					"filename=\"" + encodedFileName + "\"";
-			}
-			else {
-				contentDispositionFileName =
-					"filename*=UTF-8''" + encodedFileName;
-			}
+			contentDispositionFileName = "filename*=UTF-8''" + encodedFileName;
 		}
 
 		if (Validator.isNull(contentDispositionType)) {

--- a/portal-web/docroot/html/common/referer_js.jsp
+++ b/portal-web/docroot/html/common/referer_js.jsp
@@ -30,13 +30,7 @@ pageContext.setAttribute(WebKeys.THEME_DEFINE_OBJECTS, Boolean.FALSE);
 	if (logout == null) {
 		logout = Boolean.FALSE;
 	}
-	%>
 
-	<c:if test="<%= logout && BrowserSnifferUtil.isIe(request) && PrefsPropsUtil.getBoolean(themeDisplay.getCompanyId(), PropsKeys.NTLM_AUTH_ENABLED, PropsValues.NTLM_AUTH_ENABLED) %>">
-		document.execCommand('ClearAuthenticationCache');
-	</c:if>
-
-	<%
 	referer = HtmlUtil.escapeJSLink(referer);
 
 	referer = HtmlUtil.escapeJS(referer);

--- a/portal-web/docroot/html/common/themes/top_head.jsp
+++ b/portal-web/docroot/html/common/themes/top_head.jsp
@@ -20,7 +20,7 @@
 
 <liferay-util:dynamic-include key="/html/common/themes/top_head.jsp#pre" />
 
-<link href="<%= BrowserSnifferUtil.isIe(request) ? StringPool.BLANK : themeDisplay.getPathThemeImages() %>/<%= PropsValues.THEME_SHORTCUT_ICON %>" rel="icon" />
+<link href="<%= themeDisplay.getPathThemeImages() %>/<%= PropsValues.THEME_SHORTCUT_ICON %>" rel="icon" />
 
 <%-- Portal CSS --%>
 

--- a/portal-web/docroot/html/common/themes/top_meta.jspf
+++ b/portal-web/docroot/html/common/themes/top_meta.jspf
@@ -14,10 +14,6 @@
  */
 --%>
 
-<c:if test="<%= BrowserSnifferUtil.isIe(request) %>">
-	<meta content="<%= PropsValues.BROWSER_COMPATIBILITY_IE_VERSIONS %>" http-equiv="x-ua-compatible" />
-</c:if>
-
 <meta content="<%= ContentTypes.TEXT_HTML_UTF8 %>" http-equiv="content-type" />
 
 <%

--- a/portal-web/docroot/html/taglib/aui/select/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/select/end.jsp
@@ -89,31 +89,3 @@
 		</label>
 	</c:if>
 </div>
-
-<script>
-	(function() {
-		var select = document.getElementById('<%= namespace + id %>');
-
-		if (select) {
-			<c:if test="<%= BrowserSnifferUtil.isEdge(request) || BrowserSnifferUtil.isIe(request) %>">
-				select.addEventListener(
-					'keydown',
-					function(event) {
-						if (event.which === 27) {
-							event.stopPropagation();
-						}
-					}
-				);
-			</c:if>
-
-			<c:if test="<%= BrowserSnifferUtil.isIe(request) && (BrowserSnifferUtil.getMajorVersion(request) == 11.0) %>">
-				select.addEventListener(
-					'mousedown',
-					function(event) {
-						event.currentTarget.focus();
-					}
-				);
-			</c:if>
-		}
-	})();
-</script>

--- a/util-taglib/src/com/liferay/taglib/ui/IconTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconTag.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletApp;
 import com.liferay.portal.kernel.model.SpriteImage;
 import com.liferay.portal.kernel.model.Theme;
-import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -599,14 +598,6 @@ public class IconTag extends IncludeTag {
 			if (spriteImage != null) {
 				spriteFileName = spriteImage.getSpriteFileName();
 
-				if (BrowserSnifferUtil.isIe(httpServletRequest) &&
-					(BrowserSnifferUtil.getMajorVersion(httpServletRequest) <
-						7)) {
-
-					spriteFileName = StringUtil.replace(
-						spriteFileName, ".png", ".gif");
-				}
-
 				String cdnBaseURL = themeDisplay.getCDNBaseURL();
 
 				spriteFileURL = cdnBaseURL.concat(spriteFileName);
@@ -629,16 +620,6 @@ public class IconTag extends IncludeTag {
 
 				if (spriteImage != null) {
 					spriteFileName = spriteImage.getSpriteFileName();
-
-					float majorVersion = BrowserSnifferUtil.getMajorVersion(
-						httpServletRequest);
-
-					if (BrowserSnifferUtil.isIe(httpServletRequest) &&
-						(majorVersion < 7)) {
-
-						spriteFileName = StringUtil.replace(
-							spriteFileName, ".png", ".gif");
-					}
 
 					String cdnBaseURL = themeDisplay.getCDNBaseURL();
 


### PR DESCRIPTION
This is part of our work to [Remove IE11 Support](https://issues.liferay.com/browse/LPS-121721).

Technically, **this PR is not really necessary** but it cleans up the more obvious IE-specific code branches that could be found by grepping `.isIe(` in DXP codebase.

A deeper analysis of specific hacks and workarounds could be made digging through commit messages to see if something else pops up. I think the chances of finding many additional IE workarounds are small compared to the obvious effort it would take, so I would suggest we leave whatever's missing for future boy-scouts.

This PR **removes**:
- Branches based on `Liferay.Browser.isIe` in JS and JSP
- Branches based on `BrowserSnifferUtil.isIe` in Java
- Vendor prefixed css such as `-ms`, `-o` or `-webkit`
- `*-ie` obvious classes in SCSS

This PR does not touch:
- Modules inside `archived` folder (we keep them as they are as a compat canary)
- Usages in `NtlmFilter` and `NtlmPostFilter` since @liferay-appsec will remove that module entirely as part of their [SSO mechanism clean up cleaning up](https://issues.liferay.com/browse/LPS-121760) epic

**We want to hold this PR until @liferay-echo has had a chance to validate these particular changes:**
- [No longer needed `safeRemoveChild`](https://github.com/liferay-frontend/liferay-portal/pull/450/files#diff-5366757ae93c21d72843350dad9d4e8268ceeb6edf40752afe50b835ee3e7a3cL56)
- [Unnecessary css variable fallback in JS](https://github.com/liferay-frontend/liferay-portal/pull/450/files#diff-e851c56b139be4449cbea65c6b60ea2d8611da268b105ba8e52ea7bc276fc15bL24)
- [Unnecessary css variable fallback in Java](https://github.com/liferay-frontend/liferay-portal/pull/450/files#diff-d0189baee6c130c28310f3ac3afeff9941cc4b38f5af53300537b373336d54f9L720)