### PR TITLE
LPS-122274 - Add aspect ratio custom property for card type asset

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
@@ -16,6 +16,10 @@
 	padding-bottom: var(--aspect-ratio-16-to-9);
 }
 
+.card-type-asset .aspect-ratio {
+	padding-bottom: var(--aspect-ratio-16-to-9);
+}
+
 // Background and text color variants
 
 @each $color, $value in $custom-properties-theme-colors {


### PR DESCRIPTION
This PR fixes the no correct aspect ratio for cards.

Since cards use a 16-9 aspect-ratio we can use the same custom property.

![image](https://user-images.githubusercontent.com/7963804/97463675-49b2fb80-1940-11eb-920a-77ae9c771efc.png)

---

How to test the PR:

1. Add widget of document and media
2. Uploads some docs, images, etc
3. Reload matrix