### PR TITLE
LPS-122793 Avoid throwing null pointer exception for themes that doesn't have token definition

### DIFF
--- a/modules/apps/frontend-token/frontend-token-definition-api/src/main/resources/com/liferay/frontend/token/definition/packageinfo
+++ b/modules/apps/frontend-token/frontend-token-definition-api/src/main/resources/com/liferay/frontend/token/definition/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 1.1.0

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/frontend/css/variables/DefaultThemeScopedCSSVariablesProvider.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/frontend/css/variables/DefaultThemeScopedCSSVariablesProvider.java
@@ -49,8 +49,6 @@ public class DefaultThemeScopedCSSVariablesProvider
 	public Collection<ScopedCSSVariables> getScopedCSSVariablesCollection(
 		HttpServletRequest httpServletRequest) {
 
-		Map<String, String> cssVariables = new HashMap<>();
-
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
@@ -61,6 +59,12 @@ public class DefaultThemeScopedCSSVariablesProvider
 		FrontendTokenDefinition frontendTokenDefinition =
 			_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
 				layoutSet.getThemeId());
+
+		if (frontendTokenDefinition == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, String> cssVariables = new HashMap<>();
 
 		Collection<FrontendToken> frontendTokens =
 			frontendTokenDefinition.getFrontendTokens();


### PR DESCRIPTION
A check for null was missing for when the theme doesn't have frontend token definition when generating the default token css variables