### PR TITLE
COMMERCE-5035 Fix broken redirect from modals [SAFE TO BACKPORT]

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/portlet_url.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/portlet_url.js
@@ -305,19 +305,23 @@ AUI.add(
 
 			RESOURCE_PHASE: '2',
 
-			createActionURL() {
+			// Note: these are constructor functions so
+			// must not use concise method syntax. See:
+			// https://issues.liferay.com/browse/COMMERCE-5035
+
+			createActionURL: function createActionURL() {
 				return new PortletURL(PortletURL.ACTION_PHASE);
 			},
 
-			createRenderURL() {
+			createRenderURL: function createRenderURL() {
 				return new PortletURL(PortletURL.RENDER_PHASE);
 			},
 
-			createResourceURL() {
+			createResourceURL: function createResourceURL() {
 				return new PortletURL(PortletURL.RESOURCE_PHASE);
 			},
 
-			createURL(basePortletURL, params) {
+			createURL: function createURL(basePortletURL, params) {
 				return new PortletURL(null, params, basePortletURL);
 			},
 		});


### PR DESCRIPTION
Since dropping support for IE from our build in [LPS-121753](https://issues.liferay.com/browse/LPS-121753), things like object concise method syntax are passing through to the browser without being transpiled; eg.

```js
Liferay.PortletURL = {
    createActionURL() {}
}
```

Used to be transpiled to something like:

```js
Liferay.PortletURL = {
    createActionURL: function createActionURL() {}
}
```

Which you could call like this:

```js
new Liferay.PortletURL.createActionURL()
```

After the build changes, trying to use the `new` operator in this way will result in error about `createActionURL()` not being a constructor, because concise methods cannot be used as constructors.

Seeing as we don't want to break the API, the fix is to write these without using concise method syntax.

FWIW, I think it is a smell that we have functions (like `createActionURL()`) that are used as constructors when really they're just functions, but like I said, we don't want to break APIs, so it will have to stay this way.