### PR TITLE
COMMERCE-4836 New Boolean Data renderer for Data Set Display

### DIFF
--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/modal/page.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/modal/page.jsp
@@ -23,7 +23,7 @@ String containerId = randomNamespace + "modal-root";
 <div class="modal-root" id="<%= containerId %>"></div>
 
 <aui:script require="commerce-frontend-js/components/modal/entry as Modal">
-	new Modal.default('<%= id %>', '<%= containerId %>', {
+	Modal.default('<%= id %>', '<%= containerId %>', {
 		id: '<%= id %>',
 		onClose: <%= refreshPageOnClose %>
 			? function () {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/BooleanRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/BooleanRenderer.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import PropTypes from 'prop-types';
+
+function BooleanRenderer(props) {
+	if (typeof props.value !== 'boolean') {
+		return null;
+	}
+
+	return props.value
+		? props.options?.trueLabel || Liferay.Language.get('yes')
+		: props.options?.falseLabel || Liferay.Language.get('no');
+}
+
+BooleanRenderer.propTypes = {
+	options: PropTypes.shape({
+		falseLabel: PropTypes.string,
+		trueLabel: PropTypes.string,
+	}),
+	value: PropTypes.bool,
+};
+
+export default BooleanRenderer;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/index.js
@@ -15,6 +15,7 @@
 import getJsModule from '../utilities/modules';
 import ActionsLinkRenderer from './ActionLinkRenderer';
 import ActionsDropdownRenderer from './ActionsDropdownRenderer';
+import BooleanRenderer from './BooleanRenderer';
 import CheckboxRenderer from './CheckboxRenderer';
 import DateRenderer from './DateRenderer';
 import DefaultRenderer from './DefaultRenderer';
@@ -29,6 +30,7 @@ import TooltipPriceRenderer from './TooltipPriceRenderer';
 const dataRenderers = {
 	actionLink: ActionsLinkRenderer,
 	actionsDropdown: ActionsDropdownRenderer,
+	boolean: BooleanRenderer,
 	checkbox: CheckboxRenderer,
 	date: DateRenderer,
 	default: DefaultRenderer,


### PR DESCRIPTION
When headless APIs returns a boolean value, data set display should be able to display it using custom labels.

This renderer was created while the migration was in progress so it's available in the old implementations but not in the new one. I also included a small fix (the "new" keyword removal) for making Price Lists working and letting QA's testing the component in a real environment