### PR TITLE
Remove {append, buildFragment, enterDocument} usages of metal-dom WIP

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
@@ -13,7 +13,6 @@
  */
 
 import core from 'metal';
-import dom from 'metal-dom';
 import Surface from 'senna/lib/surface/Surface';
 
 /**
@@ -31,7 +30,7 @@ class LiferaySurface extends Surface {
 
 	addContent(screenId, content) {
 		if (core.isString(content)) {
-			content = dom.buildFragment(content);
+			content = document.createRange().createContextualFragment(content);
 		}
 
 		Liferay.DOMTaskRunner.runTasks(content);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
@@ -231,8 +231,11 @@ class Modal extends Component {
 	 */
 
 	_valueOverlayElementFn() {
-		return dom.buildFragment('<div class="modal-backdrop fade show"></div>')
-			.firstChild;
+		return document
+			.createRange()
+			.createContextualFragment(
+				'<div class="modal-backdrop fade show"></div>'
+			).firstChild;
 	}
 }
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -14,7 +14,6 @@
 
 import ClayAlert from '@clayui/alert';
 import {render} from 'frontend-js-react-web';
-import {buildFragment} from 'metal-dom';
 import React from 'react';
 import {unmountComponentAtNode} from 'react-dom';
 
@@ -55,9 +54,9 @@ const getRootElement = ({container, containerId}) => {
 	let alertFixed = document.getElementById(DEFAULT_ALERT_CONTAINER_ID);
 
 	if (!alertFixed) {
-		alertFixed = buildFragment(TPL_ALERT_CONTAINER).querySelector(
-			'.alert-container.container'
-		);
+		alertFixed = document
+			.createRange()
+			.createContextualFragment(TPL_ALERT_CONTAINER).firstChild;
 
 		alertFixed = document.body.appendChild(alertFixed);
 	}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/get_form_element.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/get_form_element.es.js
@@ -14,13 +14,13 @@
 
 'use strict';
 
-import dom from 'metal-dom';
-
 import getFormElement from '../../../../src/main/resources/META-INF/resources/liferay/util/form/get_form_element.es';
 
 describe('Liferay.Util.getFormElement', () => {
 	it('returns null if the form parameter is not a form node', () => {
-		const fragment = dom.buildFragment('<div />');
+		const fragment = document
+			.createRange()
+			.createContextualFragment('<div />');
 
 		const form = fragment.firstElementChild;
 
@@ -29,7 +29,9 @@ describe('Liferay.Util.getFormElement', () => {
 	});
 
 	it('returns null if the elementName parameter is not a string', () => {
-		const fragment = dom.buildFragment('<form />');
+		const fragment = document
+			.createRange()
+			.createContextualFragment('<form />');
 
 		const form = fragment.firstElementChild;
 
@@ -38,7 +40,7 @@ describe('Liferay.Util.getFormElement', () => {
 	});
 
 	it('returns null if the element does not exist withing the form', () => {
-		const fragment = dom.buildFragment(`
+		const fragment = document.createRange().createContextualFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">
 					</form>
@@ -50,7 +52,7 @@ describe('Liferay.Util.getFormElement', () => {
 	});
 
 	it('returns element value if the element does exist withing the form', () => {
-		const fragment = dom.buildFragment(`
+		const fragment = document.createRange().createContextualFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">
 					</form>

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/post_form.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/post_form.es.js
@@ -14,8 +14,6 @@
 
 'use strict';
 
-import dom from 'metal-dom';
-
 import getFormElement from '../../../../src/main/resources/META-INF/resources/liferay/util/form/get_form_element.es';
 import postForm from '../../../../src/main/resources/META-INF/resources/liferay/util/form/post_form.es';
 
@@ -29,7 +27,9 @@ describe('Liferay.Util.postForm', () => {
 	});
 
 	it('does nothing if the form parameter is not a form node', () => {
-		const fragment = dom.buildFragment('<div />');
+		const fragment = document
+			.createRange()
+			.createContextualFragment('<div />');
 
 		postForm(undefined);
 		postForm(fragment.firstElementChild);
@@ -38,7 +38,9 @@ describe('Liferay.Util.postForm', () => {
 	});
 
 	it('submits form even if options parameter is not set', () => {
-		const fragment = dom.buildFragment('<form />');
+		const fragment = document
+			.createRange()
+			.createContextualFragment('<form />');
 
 		const form = fragment.firstElementChild;
 
@@ -48,7 +50,9 @@ describe('Liferay.Util.postForm', () => {
 	});
 
 	it('does nothing if the url optional parameter is not a string', () => {
-		const fragment = dom.buildFragment('<form />');
+		const fragment = document
+			.createRange()
+			.createContextualFragment('<form />');
 
 		const form = fragment.firstElementChild;
 
@@ -59,7 +63,9 @@ describe('Liferay.Util.postForm', () => {
 	});
 
 	it('does nothing if the data optional parameter is not an object', () => {
-		const fragment = dom.buildFragment('<form />');
+		const fragment = document
+			.createRange()
+			.createContextualFragment('<form />');
 
 		const form = fragment.firstElementChild;
 
@@ -70,7 +76,7 @@ describe('Liferay.Util.postForm', () => {
 	});
 
 	it('sets given element values in data parameter, and submit form to a given url', () => {
-		const fragment = dom.buildFragment(`
+		const fragment = document.createRange().createContextualFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">
 						<input name="_com_liferay_test_portlet_bar" type="text" value="123">

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/set_form_values.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/set_form_values.es.js
@@ -14,14 +14,12 @@
 
 'use strict';
 
-import dom from 'metal-dom';
-
 import getFormElement from '../../../../src/main/resources/META-INF/resources/liferay/util/form/get_form_element.es';
 import setFormValues from '../../../../src/main/resources/META-INF/resources/liferay/util/form/set_form_values.es';
 
 describe('Liferay.Util.setFormValues', () => {
 	it('sets the given values of form elements', () => {
-		const fragment = dom.buildFragment(`
+		const fragment = document.createRange().createContextualFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">
 						<input name="_com_liferay_test_portlet_bar" type="text" value="123">

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_crop_region.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_crop_region.es.js
@@ -14,8 +14,6 @@
 
 'use strict';
 
-import dom from 'metal-dom';
-
 import getCropRegion from '../../../src/main/resources/META-INF/resources/liferay/util/get_crop_region.es';
 
 describe('Liferay.Util.getCropRegion', () => {
@@ -39,7 +37,9 @@ describe('Liferay.Util.getCropRegion', () => {
 	});
 
 	it('throws an error if image parameter is not an image element', () => {
-		const image = dom.buildFragment('<div />');
+		const image = document
+			.createRange()
+			.createContextualFragment('<div />');
 
 		const region = {
 			height: 100,

--- a/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js
+++ b/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import {buildFragment} from 'metal-dom';
 import State, {Config} from 'metal-state';
 
 import GeoJSONBase from './GeoJSONBase.es';
@@ -213,9 +212,10 @@ class MapBase extends State {
 		const customControls = {};
 
 		if (controls.indexOf(this.constructor.CONTROLS.HOME) !== -1) {
-			const homeControl = buildFragment(TPL_HOME_BUTTON).querySelector(
-				'.btn.btn-secondary.home-button'
-			);
+			const homeControl = document
+				.createRange()
+				.createContextualFragment(TPL_HOME_BUTTON)
+				.querySelector('.btn.btn-secondary.home-button');
 			customControls[this.constructor.CONTROLS.HOME] = homeControl;
 			this.addControl(
 				homeControl,
@@ -227,9 +227,10 @@ class MapBase extends State {
 			controls.indexOf(this.constructor.CONTROLS.SEARCH) !== -1 &&
 			this.constructor.SearchImpl
 		) {
-			const searchControl = buildFragment(TPL_SEARCH_BOX).querySelector(
-				'div.col-md-6.search-controls'
-			);
+			const searchControl = document
+				.createRange()
+				.createContextualFragment(TPL_SEARCH_BOX)
+				.querySelector('div.col-md-6.search-controls');
 			customControls[
 				this.constructor.CONTROLS.SEARCH
 			] = new this.constructor.SearchImpl({


### PR DESCRIPTION
*THIS IS A WIP*

# append
Link to metal-dom impl: https://github.com/metal/metal.js/blob/466812085dd29e37c90b835c64cb49555d76a294/packages/metal-dom/src/domNamed.js#L179

(I noticed the JSDoc is wrong, (this is all old Diego's fault 😂)

Basically this function appends a text|child node or other nodes to a parent node. It can be easily replaced by native [ParentNode.append](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append) function.

# buildFragment
Link to metal-dom impl: https://github.com/metal/metal.js/blob/466812085dd29e37c90b835c64cb49555d76a294/packages/metal-dom/src/domNamed.js#L199

I researched about which is the best option for replacing buildFragment(a function that receives a string and returns a HTMLFragment and [I found a thread that explains that ](https://stackoverflow.com/a/25225983)

* `document.createRange().createContextualFragment(myStr)`  is a bit more widely supported (IE11 just got it, Safari, Chrome and FF have had it for a while).

* Custom elements within the HTML will be upgraded immediately with the range, but only when cloned into the real doc with template. The template approach is a bit more ‘inert’, which may be desirable.

So, I choose this option than just creating a fragment and then setting the content using `myFragment.innerHTML = myStr`.

However, this function doesn't work fine with some tags like `td`, see:

![image](https://user-images.githubusercontent.com/7663513/97658309-c3371080-1a4a-11eb-91bd-e7d817a07560.png)

it removes the `td` element and just pass the text to the DOM

![image](https://user-images.githubusercontent.com/7663513/97658338-d5b14a00-1a4a-11eb-9417-264a3afdff0f.png)

Can I proceed with this function or find other way more reliable?

## Test case
1. Type `Liferay.Util.openToast({message: 'Amanhã não existe, ainda'});` on Chrome console with the DXP opened
2. Try running the same command and observe the toasts stacking

When using `document.createRange()` function We have an issue already mentioned by our dear @wincent at https://github.com/wincent/liferay-portal/pull/208#issuecomment-616502610

I tried to fix [using this suggestion ](https://github.com/mui-org/material-ui/issues/15726#issuecomment-493124813) and 

```
    TypeError: document.createRange is not a function
```

Still being appearing for me. I tried to remove the “global” but still broken. I’ll take a look tomorrow(30 Oct)

# enterDocument

Link to metal-dom impl: https://github.com/metal/metal.js/blob/466812085dd29e37c90b835c64cb49555d76a294/packages/metal-dom/src/domNamed.js#L324

This function append the given nove(if defined) to document.body.

It can be easily replaced by native [ParentNode.append](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append) function, setting as a target `document.body`.
