### PR TITLE
[BACKPORT TO 7.3.x] LPS-122909 Deprecates unused tags

### DIFF
--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -12,6 +12,7 @@
 	<short-name>liferay-ui</short-name>
 	<uri>http://liferay.com/tld/ui</uri>
 	<tag>
+		<description>Deprecated as of 7.3.0, replaced by the <![CDATA[<code>clay:alert</code>]]> tag.</description>
 		<name>alert</name>
 		<tag-class>com.liferay.taglib.ui.AlertTag</tag-class>
 		<body-content>JSP</body-content>
@@ -2178,6 +2179,7 @@
 		</attribute>
 	</tag>
 	<tag>
+		<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 		<name>organization-search-container-results</name>
 		<tag-class>com.liferay.taglib.ui.OrganizationSearchContainerResultsTag</tag-class>
 		<body-content>JSP</body-content>
@@ -2474,6 +2476,7 @@
 		</attribute>
 	</tag>
 	<tag>
+		<description>Deprecated as of 7.3.0, replaced by the <![CDATA[<code>liferay-ratings:ratings</code>]]> tag.</description>
 		<name>ratings</name>
 		<tag-class>com.liferay.taglib.ui.RatingsTag</tag-class>
 		<body-content>JSP</body-content>
@@ -3411,6 +3414,7 @@
 		</attribute>
 	</tag>
 	<tag>
+		<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 		<name>search-speed</name>
 		<tag-class>com.liferay.taglib.ui.SearchSpeedTag</tag-class>
 		<body-content>JSP</body-content>
@@ -3514,6 +3518,7 @@
 		</attribute>
 	</tag>
 	<tag>
+		<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 		<name>table-iterator</name>
 		<tag-class>com.liferay.taglib.ui.TableIteratorTag</tag-class>
 		<tei-class>com.liferay.taglib.ui.TableIteratorTei</tei-class>
@@ -3653,7 +3658,7 @@
 		</attribute>
 	</tag>
 	<tag>
-		<description>Creates a component that toggles the visibility of the content of the component matching the given <![CDATA[<code>id</code>]]>. Default icons are used as the component's default mechanism for showing and hiding the content.</description>
+		<description>Creates a component that toggles the visibility of the content of the component matching the given <![CDATA[<code>id</code>]]>. Default icons are used as the component's default mechanism for showing and hiding the content. Deprecated as of 7.3.0, with no direct replacement.</description>
 		<name>toggle</name>
 		<tag-class>com.liferay.taglib.ui.ToggleTag</tag-class>
 		<body-content>JSP</body-content>
@@ -3702,7 +3707,7 @@
 		</attribute>
 	</tag>
 	<tag>
-		<description>Creates a component that toggles the visibility of a <![CDATA[<code>div</code>]]> and its contents.</description>
+		<description>Creates a component that toggles the visibility of a <![CDATA[<code>div</code>]]> and its contents. Deprecated as of 7.3.0, with no direct replacement.</description>
 		<name>toggle-area</name>
 		<tag-class>com.liferay.taglib.ui.ToggleAreaTag</tag-class>
 		<body-content>JSP</body-content>

--- a/util-taglib/src/com/liferay/taglib/ui/AlertTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/AlertTag.java
@@ -30,7 +30,10 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Carlos Lancha
+ * @deprecated As of Athanasius (7.3.x), replaced by {@link
+ *             com.liferay.frontend.taglib.clay.servlet.taglib.AlertTag}
  */
+@Deprecated
 public class AlertTag extends IncludeTag {
 
 	@Override

--- a/util-taglib/src/com/liferay/taglib/ui/OrganizationSearchContainerResultsTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/OrganizationSearchContainerResultsTag.java
@@ -24,7 +24,9 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Pei-Jung Lan
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
  */
+@Deprecated
 public class OrganizationSearchContainerResultsTag<R> extends IncludeTag {
 
 	public LinkedHashMap<String, Object> getOrganizationParams() {

--- a/util-taglib/src/com/liferay/taglib/ui/SearchSpeedTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchSpeedTag.java
@@ -20,7 +20,9 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Brian Wing Shun Chan
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
  */
+@Deprecated
 public class SearchSpeedTag<R> extends SearchFormTag<R> {
 
 	public Hits getHits() {

--- a/util-taglib/src/com/liferay/taglib/ui/TableIteratorTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/TableIteratorTag.java
@@ -28,7 +28,9 @@ import javax.servlet.jsp.tagext.TagSupport;
 
 /**
  * @author Brian Wing Shun Chan
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
  */
+@Deprecated
 public class TableIteratorTag extends TagSupport {
 
 	@Override

--- a/util-taglib/src/com/liferay/taglib/ui/ToggleAreaTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/ToggleAreaTag.java
@@ -24,7 +24,9 @@ import javax.servlet.jsp.JspWriter;
 
 /**
  * @author Raymond Augé
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
  */
+@Deprecated
 public class ToggleAreaTag extends IncludeTag {
 
 	@Override

--- a/util-taglib/src/com/liferay/taglib/ui/ToggleTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/ToggleTag.java
@@ -32,7 +32,9 @@ import javax.servlet.jsp.JspException;
 
 /**
  * @author Brian Wing Shun Chan
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
  */
+@Deprecated
 public class ToggleTag extends IncludeTag {
 
 	public static void doTag(


### PR DESCRIPTION
This is just a bit of due diligence so we can clean up some unused tags in `7.4`.

**The plan is to backport this to `7.3.x` before GA1 so we can give fair warning and remove these tags in `7.4`**

Some tags had already been Java-deprecated but not "tld-deprecated", which can account for the mismatch in numbers if you check the diffs.

This PR should create no perceivable effect.