### PR TITLE
LPS-122449 Remove usages of dom.delegate

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/PersonAccountEntryEventHandler.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/PersonAccountEntryEventHandler.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {PortletBase, openSelectionModal} from 'frontend-js-web';
+import {PortletBase, delegate, openSelectionModal} from 'frontend-js-web';
 import * as dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 import {Config} from 'metal-state';
@@ -39,7 +39,7 @@ class PersonAccountEntryEventHandler extends PortletBase {
 		);
 
 		this.eventHandler_.add(
-			dom.delegate(
+			delegate(
 				this.container,
 				'click',
 				this.removeUserLinkSelector,
@@ -53,7 +53,7 @@ class PersonAccountEntryEventHandler extends PortletBase {
 	 */
 	detached() {
 		super.detached();
-		this.eventHandler_.removeAllListeners();
+		this.eventHandler_.dispose();
 	}
 
 	_handleOnSelect(selectedItemData) {

--- a/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -272,8 +272,10 @@
 		</aui:script>
 	</c:when>
 	<c:otherwise>
-		<aui:script require="metal-dom/src/all/dom as dom">
-			var delegateHandler = dom.delegate(
+		<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+			var delegate = delegateModule.default;
+
+			var delegateHandler = delegate(
 				document.querySelector('#<portlet:namespace />selectAssetFm'),
 				'click',
 				'.selector-button',
@@ -283,14 +285,14 @@
 					Liferay.Util.getOpener().Liferay.fire(
 						'<%= HtmlUtil.escapeJS(assetBrowserDisplayContext.getEventName()) %>',
 						{
-							data: event.delegateTarget.dataset,
+							data: event.target.closest('.selector-button').dataset,
 						}
 					);
 				}
 			);
 
 			var onDestroyPortlet = function () {
-				delegateHandler.removeListener();
+				delegateHandler.dispose();
 
 				Liferay.detach('destroyPortlet', onDestroyPortlet);
 			};

--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
@@ -53,8 +53,10 @@ AssetDisplayPagesItemSelectorViewDisplayContext assetDisplayPagesItemSelectorVie
 	</liferay-ui:search-container>
 </aui:form>
 
-<aui:script require="metal-dom/src/all/dom as dom">
-	var selectFragmentEntryHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	var selectFragmentEntryHandler = delegate(
 		document.querySelector('#<portlet:namespace />fm'),
 		'click',
 		'.layout-page-template-entry',
@@ -67,7 +69,7 @@ AssetDisplayPagesItemSelectorViewDisplayContext assetDisplayPagesItemSelectorVie
 				});
 			}
 
-			var newSelectedCard = event.delegateTarget.closest('.form-check-card');
+			var newSelectedCard = event.target.closest('.form-check-card');
 
 			if (newSelectedCard) {
 				newSelectedCard.classList.add('active');
@@ -76,14 +78,14 @@ AssetDisplayPagesItemSelectorViewDisplayContext assetDisplayPagesItemSelectorVie
 			Liferay.Util.getOpener().Liferay.fire(
 				'<%= assetDisplayPagesItemSelectorViewDisplayContext.getItemSelectedEventName() %>',
 				{
-					data: event.delegateTarget.dataset,
+					data: event.target.closest('.layout-page-template-entry').dataset,
 				}
 			);
 		}
 	);
 
 	function removeListener() {
-		selectFragmentEntryHandler.removeListener();
+		selectFragmentEntryHandler.dispose();
 
 		Liferay.detach('destroyPortlet', removeListener);
 	}

--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
@@ -78,7 +78,8 @@ AssetDisplayPagesItemSelectorViewDisplayContext assetDisplayPagesItemSelectorVie
 			Liferay.Util.getOpener().Liferay.fire(
 				'<%= assetDisplayPagesItemSelectorViewDisplayContext.getItemSelectedEventName() %>',
 				{
-					data: event.target.closest('.layout-page-template-entry').dataset,
+					data: event.target.closest('.layout-page-template-entry')
+						.dataset,
 				}
 			);
 		}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -245,7 +245,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 	</liferay-frontend:fieldset>
 </liferay-frontend:fieldset-group>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="metal-dom/src/dom as dom,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var Util = Liferay.Util;
 
 	var MAP_DDM_STRUCTURES = {};
@@ -542,14 +542,16 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 		});
 	}
 
-	dom.delegate(
+	var delegate = delegateModule.default;
+
+	delegate(
 		sourcePanel,
 		'click',
 		'.asset-subtypefields-wrapper-enable label',
 		function (event) {
-			var subtypeFieldsFilterEnabledInput = event.delegateTarget.querySelector(
-				'input'
-			);
+			var subtypeFieldsFilterEnabledInput = event.target
+				.closest('.asset-subtypefields-wrapper-enable label')
+				.querySelector('input');
 
 			var assetSubtypefieldsPopupButtons = document.querySelectorAll(
 				'.asset-subtypefields-popup .btn'
@@ -583,12 +585,10 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 		'<portlet:namespace />ddmStructureDisplayFieldValue'
 	);
 
-	dom.delegate(sourcePanel, 'click', '.asset-subtypefields-popup', function (
-		event
-	) {
-		var delegateTarget = event.delegateTarget;
+	delegate(sourcePanel, 'click', '.asset-subtypefields-popup', function (event) {
+		var target = event.target.closest('.asset-subtypefields-popup');
 
-		var btn = delegateTarget.querySelector('.btn');
+		var btn = target.querySelector('.btn');
 
 		var url = btn.dataset.href;
 
@@ -610,7 +610,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 
 		Util.openSelectionModal({
 			customSelectEvent: true,
-			id: '<portlet:namespace />selectDDMStructure' + delegateTarget.id,
+			id: '<portlet:namespace />selectDDMStructure' + target.id,
 			onSelect: function (selectedItem) {
 				setDDMFields(
 					selectedItem.className,

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
@@ -211,15 +211,17 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 	</c:otherwise>
 </c:choose>
 
-<aui:script require="metal-dom/src/dom as dom">
-	var delegateHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	var delegateHandler = delegate(
 		document.body,
 		'click',
 		'.asset-selector a',
 		function (event) {
 			event.preventDefault();
 
-			var delegateTarget = event.delegateTarget;
+			var target = event.target.closest('.asset-selector a');
 
 			Liferay.Util.openSelectionModal({
 				multiple: true,
@@ -241,14 +243,14 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 					}
 				},
 				selectEventName: '<portlet:namespace />selectAsset',
-				title: delegateTarget.dataset.title,
-				url: delegateTarget.dataset.href,
+				title: target.dataset.title,
+				url: target.dataset.href,
 			});
 		}
 	);
 
 	var onDestroyPortlet = function () {
-		delegateHandler.removeListener();
+		delegateHandler.dispose();
 
 		Liferay.detach('destroyPortlet', onDestroyPortlet);
 	};

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/TopLinkEventHandler.es.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/TopLinkEventHandler.es.js
@@ -12,30 +12,29 @@
  * details.
  */
 
-import {PortletBase} from 'frontend-js-web';
-import dom from 'metal-dom';
+import {PortletBase, delegate} from 'frontend-js-web';
 
 export default class TopLinkEventHandler extends PortletBase {
 	attached() {
-		this._delegateHandler = dom.delegate(
+		this._delegateHandler = delegate(
 			document.body,
 			'click',
 			'a',
 			(event) => {
 				const openerWindow = Liferay.Util.getTop();
 
-				if (openerWindow && event.delegateTarget.target === '_top') {
+				const delegateTarget = event.target.closest('a');
+
+				if (openerWindow && delegateTarget.target === '_top') {
 					event.preventDefault();
 
-					openerWindow.Liferay.Util.navigate(
-						event.delegateTarget.href
-					);
+					openerWindow.Liferay.Util.navigate(delegateTarget.href);
 				}
 			}
 		);
 	}
 
 	dispose() {
-		this._delegateHandler.removeListener();
+		this._delegateHandler.dispose();
 	}
 }

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
@@ -225,7 +225,7 @@ for (long groupId : groupIds) {
 	}
 </script>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	function selectAssets(assetEntryList) {
 		var assetClassName = '';
 		var assetEntryIds = [];
@@ -246,14 +246,16 @@ for (long groupId : groupIds) {
 		});
 	}
 
-	var delegateHandler = dom.delegate(
+	var delegate = delegateModule.default;
+
+	var delegateHandler = delegate(
 		document.body,
 		'click',
 		'.asset-selector a',
 		function (event) {
 			event.preventDefault();
 
-			var delegateTarget = event.delegateTarget;
+			var delegateTarget = event.target.closest('.asset-selector a');
 
 			Liferay.Util.openSelectionModal({
 				multiple: true,

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/create_asset_list.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/create_asset_list.jsp
@@ -26,7 +26,7 @@ String portletResource = ParamUtil.getString(request, "portletResource");
 	</aui:a>
 </div>
 
-<aui:script require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal">
+<aui:script require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	function handleCreateAssetListLinkClick(event) {
 		event.preventDefault();
 
@@ -43,7 +43,9 @@ String portletResource = ParamUtil.getString(request, "portletResource");
 		});
 	}
 
-	var createAssetListLinkClickHandler = dom.delegate(
+	var delegate = delegateModule.default;
+
+	var createAssetListLinkClickHandler = delegate(
 		document.body,
 		'click',
 		'a.create-collection-link',
@@ -51,7 +53,7 @@ String portletResource = ParamUtil.getString(request, "portletResource");
 	);
 
 	function handleDestroyPortlet() {
-		createAssetListLinkClickHandler.removeListener();
+		createAssetListLinkClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -221,7 +221,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 	</c:if>
 </aui:fieldset>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="metal-dom/src/dom as dom,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var Util = Liferay.Util;
 
 	var MAP_DDM_STRUCTURES = {};
@@ -490,12 +490,16 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		});
 	}
 
-	dom.delegate(
+	var delegate = delegateModule.default;
+
+	delegate(
 		sourcePanel,
 		'click',
 		'.asset-subtypefields-wrapper-enable label',
 		function (event) {
-			var subtypeFieldsFilterEnabledInput = event.delegateTarget.querySelector(
+			var delegateTarget = event.target.closest('.asset-subtypefields-wrapper-enable label');
+
+			var subtypeFieldsFilterEnabledInput = delegateTarget.querySelector(
 				'input'
 			);
 
@@ -531,10 +535,10 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		'<portlet:namespace />ddmStructureDisplayFieldValue'
 	);
 
-	dom.delegate(sourcePanel, 'click', '.asset-subtypefields-popup', function (
+	delegate(sourcePanel, 'click', '.asset-subtypefields-popup', function (
 		event
 	) {
-		var delegateTarget = event.delegateTarget;
+		var delegateTarget = event.target.closest('.asset-subtypefields-popup');
 
 		var btn = delegateTarget.querySelector('.btn');
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -497,7 +497,9 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		'click',
 		'.asset-subtypefields-wrapper-enable label',
 		function (event) {
-			var delegateTarget = event.target.closest('.asset-subtypefields-wrapper-enable label');
+			var delegateTarget = event.target.closest(
+				'.asset-subtypefields-wrapper-enable label'
+			);
 
 			var subtypeFieldsFilterEnabledInput = delegateTarget.querySelector(
 				'input'
@@ -535,9 +537,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		'<portlet:namespace />ddmStructureDisplayFieldValue'
 	);
 
-	delegate(sourcePanel, 'click', '.asset-subtypefields-popup', function (
-		event
-	) {
+	delegate(sourcePanel, 'click', '.asset-subtypefields-popup', function (event) {
 		var delegateTarget = event.target.closest('.asset-subtypefields-popup');
 
 		var btn = delegateTarget.querySelector('.btn');

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/page.jsp
@@ -73,14 +73,16 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 	</liferay-ui:search-container>
 </div>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	if (document.querySelector('#<portlet:namespace />assetEntryUsagesList')) {
-		var previewAssetEntryUsagesList = dom.delegate(
+		var delegate = delegateModule.default;
+
+		var previewAssetEntryUsagesList = delegate(
 			document.querySelector('#<portlet:namespace />assetEntryUsagesList'),
 			'click',
 			'.preview-asset-entry-usage',
 			function (event) {
-				var delegateTarget = event.delegateTarget;
+				var delegateTarget = event.target.closest('.preview-asset-entry-usage');
 
 				Liferay.Util.openModal({
 					iframeBodyCssClass: 'article-preview',
@@ -91,7 +93,7 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 		);
 
 		function removeListener() {
-			previewAssetEntryUsagesList.removeListener();
+			previewAssetEntryUsagesList.dispose();
 
 			Liferay.detach('destroyPortlet', removeListener);
 		}

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/page.jsp
@@ -82,7 +82,9 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 			'click',
 			'.preview-asset-entry-usage',
 			function (event) {
-				var delegateTarget = event.target.closest('.preview-asset-entry-usage');
+				var delegateTarget = event.target.closest(
+					'.preview-asset-entry-usage'
+				);
 
 				Liferay.Util.openModal({
 					iframeBodyCssClass: 'article-preview',

--- a/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
+++ b/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
@@ -97,7 +97,10 @@
 		'click',
 		'[data-key]',
 		function (event) {
-			connectedAppKeyInput.setAttribute('value', event.target.closest('[data-key]').dataset.key);
+			connectedAppKeyInput.setAttribute(
+				'value',
+				event.target.closest('[data-key]').dataset.key
+			);
 		}
 	);
 </aui:script>

--- a/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
+++ b/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
@@ -85,17 +85,19 @@
 	</div>
 </div>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var connectedAppKeyInput = document.querySelector(
 		'[name=<portlet:namespace />connectedAppKey]'
 	);
 
-	dom.delegate(
+	var delegate = delegateModule.default;
+
+	delegate(
 		document.getElementById('<portlet:namespace />connectedApp'),
 		'click',
 		'[data-key]',
 		function (event) {
-			connectedAppKeyInput.setAttribute('value', event.target.dataset.key);
+			connectedAppKeyInput.setAttribute('value', event.target.closest('[data-key]').dataset.key);
 		}
 	);
 </aui:script>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
@@ -68,13 +68,17 @@ DepotAdminSelectRoleDisplayContext depotAdminSelectRoleDisplayContext = (DepotAd
 				/>
 			</liferay-ui:search-container>
 
-			<aui:script require="metal-dom/src/dom as dom">
+			<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 				var form = document.<portlet:namespace />selectDepotRoleFm;
 
-				dom.delegate(form, 'click', '.group-selector-button', function (event) {
+				var delegate = delegateModule.default;
+
+				delegate(form, 'click', '.group-selector-button', function (event) {
+					var delegateTarget = event.target.closest('.group-selector-button');
+
 					Liferay.Util.postForm(form, {
 						data: {
-							groupId: event.delegateTarget.dataset.groupid,
+							groupId: delegateTarget.dataset.groupid,
 						},
 
 						url: '<%= step1.getSelectRolePortletURL() %>',

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries_resources.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries_resources.jsp
@@ -216,16 +216,18 @@ else {
 					}
 					%>
 
-					<aui:script position="inline" require="metal-dom/src/all/dom as dom">
+					<aui:script position="inline" require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 						var documentTypeMenuList = document.querySelector(
 							'#<portlet:namespace />documentTypeSelector .lfr-menu-list'
 						);
 
+						var delegate = delegateModule.default;
+
 						if (documentTypeMenuList) {
-							dom.delegate(documentTypeMenuList, 'click', 'li a', function (event) {
+							delegate(documentTypeMenuList, 'click', 'li a', function (event) {
 								event.preventDefault();
 
-								Liferay.Util.fetch(event.delegateTarget.getAttribute('href'))
+								Liferay.Util.fetch(event.target.closest('li a').getAttribute('href'))
 									.then(function (response) {
 										return response.text();
 									})

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
@@ -77,13 +77,15 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 	</div>
 </div>
 
-<aui:script require="metal-dom/src/dom as dom">
-	dom.delegate(
+<aui:script require="metal-dom/src/dom as dom,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	delegate(
 		document.querySelector('.portlet-ddm-form-report-tabs'),
 		'click',
 		'li',
 		function (event) {
-			var navItem = event.delegateTarget.closest('.nav-item');
+			var navItem = dom.closest(event.target, '.nav-item');
 			var navItemIndex = Number(navItem.dataset.navItemIndex);
 			var navLink = navItem.querySelector('.nav-link');
 

--- a/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/resources/META-INF/resources/index.js
@@ -12,20 +12,20 @@
  * details.
  */
 
-import dom from 'metal-dom';
+import {delegate} from 'frontend-js-web';
 
 let handle;
 
 export default () => {
 	if (!handle) {
-		handle = dom.delegate(
+		handle = delegate(
 			document.body,
 			'click',
 			'[data-dismiss="liferay-alert"]',
 			(event) => {
 				event.preventDefault();
 
-				const container = event.delegateTarget.closest('.alert');
+				const container = event.target.closest('.alert');
 
 				if (container) {
 					container.parentNode.removeChild(container);

--- a/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.js
+++ b/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import {delegate} from 'frontend-js-web';
 import dom from 'metal-dom';
 
 const CssClass = {
@@ -43,7 +44,7 @@ class CollapseProvider {
 
 		this._setTransitionEndEvent();
 
-		dom.delegate(
+		delegate(
 			document.body,
 			'click',
 			Selector.TRIGGER,
@@ -196,7 +197,7 @@ class CollapseProvider {
 	}
 
 	_onTriggerClick = (event) => {
-		const trigger = event.delegateTarget;
+		const trigger = event.target.closest(Selector.TRIGGER);
 
 		if (trigger.tagName === 'A') {
 			event.preventDefault();

--- a/modules/apps/frontend-js/frontend-js-dropdown-support-web/src/main/resources/META-INF/resources/DropdownProvider.js
+++ b/modules/apps/frontend-js/frontend-js-dropdown-support-web/src/main/resources/META-INF/resources/DropdownProvider.js
@@ -13,7 +13,7 @@
  */
 
 import domAlign from 'dom-align';
-import dom from 'metal-dom';
+import {delegate} from 'frontend-js-web';
 
 const CssClass = {
 	SHOW: 'show',
@@ -39,19 +39,14 @@ class DropdownProvider {
 			return Liferay.DropdownProvider;
 		}
 
-		dom.delegate(
+		delegate(
 			document.body,
 			'click',
 			Selector.TRIGGER,
 			this._onTriggerClick
 		);
 
-		dom.delegate(
-			document.body,
-			'keydown',
-			Selector.TRIGGER,
-			this._onKeyDown
-		);
+		delegate(document.body, 'keydown', Selector.TRIGGER, this._onKeyDown);
 
 		Liferay.DropdownProvider = this;
 	}
@@ -143,7 +138,7 @@ class DropdownProvider {
 	};
 
 	_onTriggerClick = (event) => {
-		const trigger = event.delegateTarget;
+		const trigger = event.target.closest(Selector.TRIGGER);
 
 		if (trigger.tagName === 'A') {
 			event.preventDefault();

--- a/modules/apps/frontend-js/frontend-js-tabs-support-web/src/main/resources/META-INF/resources/TabsProvider.js
+++ b/modules/apps/frontend-js/frontend-js-tabs-support-web/src/main/resources/META-INF/resources/TabsProvider.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import {delegate} from 'frontend-js-web';
 import dom from 'metal-dom';
 
 const CssClass = {
@@ -36,7 +37,7 @@ class TabsProvider {
 
 		this._setTransitionEndEvent();
 
-		dom.delegate(
+		delegate(
 			document.body,
 			'click',
 			Selector.TRIGGER,
@@ -129,7 +130,7 @@ class TabsProvider {
 	}
 
 	_onTriggerClick = (event) => {
-		const trigger = event.delegateTarget;
+		const trigger = event.target.closest(Selector.TRIGGER);
 
 		if (trigger.tagName === 'A') {
 			event.preventDefault();

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
@@ -14,7 +14,7 @@
 
 import ClayTooltip from '@clayui/tooltip';
 import {render, useTimeout} from 'frontend-js-react-web';
-import dom from 'metal-dom';
+import {delegate} from 'frontend-js-web';
 import {Align} from 'metal-position';
 import React, {
 	useEffect,
@@ -155,36 +155,34 @@ const TooltipProvider = () => {
 
 	useEffect(() => {
 		const TRIGGER_SHOW_HANDLES = TRIGGER_SHOW_EVENTS.map((eventName) => {
-			return dom.delegate(
+			return delegate(
 				document.body,
 				eventName,
 				SELECTOR_TRIGGER,
 				(event) =>
-					dispatch({target: event.delegateTarget, type: 'show'})
+					dispatch({
+						target: event.target.closest(SELECTOR_TRIGGER),
+						type: 'show',
+					})
 			);
 		});
 
 		const TRIGGER_HIDE_HANDLES = TRIGGER_HIDE_EVENTS.map((eventName) => {
-			return dom.delegate(
-				document.body,
-				eventName,
-				SELECTOR_TRIGGER,
-				() => {
-					dispatch({type: 'hide'});
+			return delegate(document.body, eventName, SELECTOR_TRIGGER, () => {
+				dispatch({type: 'hide'});
 
-					restoreTitle(state.target);
-				}
-			);
+				restoreTitle(state.target);
+			});
 		});
 
-		const TOOLTIP_ENTER = dom.delegate(
+		const TOOLTIP_ENTER = delegate(
 			document.body,
 			'mouseenter',
 			SELECTOR_TOOLTIP,
 			() => dispatch({target: state.target, type: 'show'})
 		);
 
-		const TOOLTIP_LEAVE = dom.delegate(
+		const TOOLTIP_LEAVE = delegate(
 			document.body,
 			'mouseleave',
 			SELECTOR_TOOLTIP,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -17,6 +17,7 @@ import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 
 import PortletBase from './PortletBase.es';
+import {delegate} from './delegate/delegate.es';
 
 /**
  * Appends list item elements to dropdown menus with inline-scrollers on scroll
@@ -42,7 +43,7 @@ class DynamicInlineScroll extends PortletBase {
 		rootNode = rootNode || document;
 
 		this.eventHandler_.add(
-			dom.delegate(
+			delegate(
 				rootNode,
 				'scroll',
 				'ul.pagination ul.inline-scroller',
@@ -57,7 +58,7 @@ class DynamicInlineScroll extends PortletBase {
 	detached() {
 		super.detached();
 
-		this.eventHandler_.removeAllListeners();
+		this.eventHandler_.dispose();
 	}
 
 	/**
@@ -150,16 +151,20 @@ class DynamicInlineScroll extends PortletBase {
 	 */
 	onScroll_(event) {
 		const {cur, initialPages, pages} = this;
-		const {target} = event;
+		const delegateTarget = event.target.closest(
+			'ul.pagination ul.inline-scroller'
+		);
 
-		let pageIndex = this.getNumber_(target.getAttribute('data-page-index'));
+		let pageIndex = this.getNumber_(
+			delegateTarget.getAttribute('data-page-index')
+		);
 		let pageIndexMax = this.getNumber_(
-			target.getAttribute('data-max-index')
+			delegateTarget.getAttribute('data-max-index')
 		);
 
 		if (pageIndex === 0) {
 			const pageIndexCurrent = this.getNumber_(
-				target.getAttribute('data-current-index')
+				delegateTarget.getAttribute('data-current-index')
 			);
 
 			if (pageIndexCurrent === 0) {
@@ -177,10 +182,10 @@ class DynamicInlineScroll extends PortletBase {
 		if (
 			cur <= pages &&
 			pageIndex < pageIndexMax &&
-			target.getAttribute('scrollTop') >=
-				target.getAttribute('scrollHeight') - 300
+			delegateTarget.getAttribute('scrollTop') >=
+				delegateTarget.getAttribute('scrollHeight') - 300
 		) {
-			this.addListItem_(target, pageIndex);
+			this.addListItem_(delegateTarget, pageIndex);
 		}
 	}
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -17,11 +17,11 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import classNames from 'classnames';
 import {render} from 'frontend-js-react-web';
-import dom from 'metal-dom';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import './Modal.scss';
+import delegate from '../delegate/delegate.es';
 import navigate from '../util/navigate.es';
 
 const Modal = ({
@@ -452,14 +452,14 @@ class Iframe extends React.Component {
 		}
 
 		if (this.delegateHandler) {
-			this.delegateHandler.removeListener();
+			this.delegateHandler.dispose();
 		}
 	}
 
 	onLoadHandler = () => {
 		const iframeWindow = this.iframeRef.current.contentWindow;
 
-		this.delegateHandler = dom.delegate(
+		this.delegateHandler = delegate(
 			iframeWindow.document,
 			'click',
 			'.btn-cancel,.lfr-hide-dialog',

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -116,7 +116,9 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 	_bindEvents() {
 		this._eventHandler.add(
 			delegate(this.rootNode, 'click', '.item-preview', (event) =>
-				this._onItemSelected(event.target.closest('.item-preview').dataset)
+				this._onItemSelected(
+					event.target.closest('.item-preview').dataset
+				)
 			)
 		);
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -14,8 +14,7 @@
 
 import {ClayAlert} from 'clay-alert';
 import {render} from 'frontend-js-react-web';
-import {PortletBase} from 'frontend-js-web';
-import dom from 'metal-dom';
+import {PortletBase, delegate} from 'frontend-js-web';
 import {EventHandler} from 'metal-events';
 import {Config} from 'metal-state';
 import ReactDOM from 'react-dom';
@@ -116,8 +115,8 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 	 */
 	_bindEvents() {
 		this._eventHandler.add(
-			dom.delegate(this.rootNode, 'click', '.item-preview', (event) =>
-				this._onItemSelected(event.delegateTarget.dataset)
+			delegate(this.rootNode, 'click', '.item-preview', (event) =>
+				this._onItemSelected(event.target.closest('.item-preview').dataset)
 			)
 		);
 

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -215,8 +215,10 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 		</aui:script>
 	</c:when>
 	<c:otherwise>
-		<aui:script require="metal-dom/src/all/dom as dom">
-			var selectItemHandler = dom.delegate(
+		<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+			var delegate = delegateModule.default;
+
+			var selectItemHandler = delegate(
 				document.querySelector('#<portlet:namespace />entriesContainer'),
 				'click',
 				'.entry',
@@ -229,11 +231,13 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 						});
 					}
 
-					var newSelectedCard = event.delegateTarget.closest('.form-check-card');
+					var newSelectedCard = event.target.closest('.form-check-card');
 
 					if (newSelectedCard) {
 						newSelectedCard.classList.add('active');
 					}
+
+					var delegateTarget = event.target.closest('.entry');
 
 					Liferay.Util.getOpener().Liferay.fire(
 						'<%= itemSelectorViewDescriptorRendererDisplayContext.getItemSelectedEventName() %>',
@@ -241,7 +245,7 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 							data: {
 								returnType:
 									'<%= itemSelectorViewDescriptorRendererDisplayContext.getReturnType() %>',
-								value: event.delegateTarget.dataset.value,
+								value: delegateTarget.dataset.value,
 							},
 						}
 					);
@@ -249,7 +253,7 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 			);
 
 			Liferay.on('destroyPortlet', function removeListener() {
-				selectItemHandler.removeListener();
+				selectItemHandler.dispose();
 
 				Liferay.detach('destroyPortlet', removeListener);
 			});

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -60,9 +60,7 @@
 
 	var delegate = delegateModule.default;
 
-	delegate(articlePreview, 'click', '.web-content-selector', function (
-		event
-	) {
+	delegate(articlePreview, 'click', '.web-content-selector', function (event) {
 		event.preventDefault();
 
 		Liferay.Util.openSelectionModal({

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -50,7 +50,7 @@
 	</liferay-frontend:edit-form-footer>
 </liferay-frontend:edit-form>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var articlePreview = document.getElementById(
 		'<portlet:namespace />articlePreview'
 	);
@@ -58,7 +58,9 @@
 		'<portlet:namespace />assetEntryId'
 	);
 
-	dom.delegate(articlePreview, 'click', '.web-content-selector', function (
+	var delegate = delegateModule.default;
+
+	delegate(articlePreview, 'click', '.web-content-selector', function (
 		event
 	) {
 		event.preventDefault();
@@ -75,7 +77,7 @@
 		});
 	});
 
-	dom.delegate(articlePreview, 'click', '.selector-button', function (event) {
+	delegate(articlePreview, 'click', '.selector-button', function (event) {
 		event.preventDefault();
 		retrieveWebContent(-1);
 	});

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -373,8 +373,8 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 	</liferay-ui:search-container>
 </clay:container-fluid>
 
-<aui:script require="metal-dom/src/all/dom as dom" sandbox="<%= true %>">
-	var selectArticleHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule" sandbox="<%= true %>">
+	var selectArticleHandler = delegate(
 		document.querySelector('#<portlet:namespace />articlesContainer'),
 		'click',
 		'.articles',
@@ -384,7 +384,8 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 					var activeFormCheckCards = document.querySelectorAll(
 						'.form-check-card.active'
 					);
-					var formCheckCard = event.delegateTarget.closest('.form-check-card');
+
+					var formCheckCard = event.target.closest('.form-check-card');
 
 					if (activeFormCheckCards.length) {
 						activeFormCheckCards.forEach(function (card) {
@@ -398,7 +399,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 				</c:when>
 				<c:otherwise>
 					var activeArticles = document.querySelectorAll('.articles.active');
-					var articles = event.delegateTarget.closest('.articles');
+					var articles = event.target.closest('.articles');
 
 					if (activeArticles.length) {
 						activeArticles.forEach(function (article) {
@@ -412,13 +413,15 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 				</c:otherwise>
 			</c:choose>
 
+			var delegateTarget = event.target.closest('.articles');
+
 			Liferay.Util.getOpener().Liferay.fire(
 				'<%= journalArticleItemSelectorViewDisplayContext.getItemSelectedEventName() %>',
 				{
 					data: {
 						returnType:
 							'<%= InfoItemItemSelectorReturnType.class.getName() %>',
-						value: event.delegateTarget.dataset.value,
+						value: delegateTarget.dataset.value,
 					},
 				}
 			);
@@ -426,7 +429,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 	);
 
 	Liferay.on('destroyPortlet', function removeListener() {
-		selectArticleHandler.removeListener();
+		selectArticleHandler.dispose();
 
 		Liferay.detach('destroyPortlet', removeListener);
 	});

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
@@ -111,9 +111,9 @@ JournalViewMoreMenuItemsDisplayContext journalViewMoreMenuItemsDisplayContext = 
 		Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(journalViewMoreMenuItemsDisplayContext.getEventName()) %>',
 			{
-				ddmStructureKey: event.target.closest('.selector-button').getAttribute(
-					'data-ddmStructureKey'
-				),
+				ddmStructureKey: event.target
+					.closest('.selector-button')
+					.getAttribute('data-ddmStructureKey'),
 			}
 		);
 	});

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
@@ -98,18 +98,20 @@ JournalViewMoreMenuItemsDisplayContext journalViewMoreMenuItemsDisplayContext = 
 	</liferay-ui:search-container>
 </aui:form>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
 	var Util = Liferay.Util;
 
 	var addMenuItemFm = document.getElementById(
 		'<portlet:namespace />addMenuItemFm'
 	);
 
-	dom.delegate(addMenuItemFm, 'click', '.selector-button', function (event) {
+	delegate(addMenuItemFm, 'click', '.selector-button', function (event) {
 		Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(journalViewMoreMenuItemsDisplayContext.getEventName()) %>',
 			{
-				ddmStructureKey: event.delegateTarget.getAttribute(
+				ddmStructureKey: event.target.closest('.selector-button').getAttribute(
 					'data-ddmStructureKey'
 				),
 			}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
@@ -183,7 +183,7 @@ if (portletTitleBasedNavigation) {
 	</liferay-ui:search-container>
 </aui:fieldset>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="metal-dom/src/dom as dom,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var compareVersionsButton = document.getElementById(
 		'<portlet:namespace />compare'
 	);
@@ -249,12 +249,14 @@ if (portletTitleBasedNavigation) {
 
 	<portlet:namespace />initRowsChecked();
 
-	dom.delegate(
+	var delegate = delegateModule.default;
+
+	delegate(
 		document.body,
 		'click',
 		'input[name=<portlet:namespace />rowIds]',
 		function (event) {
-			<portlet:namespace />updateRowsChecked(event.delegateTarget);
+			<portlet:namespace />updateRowsChecked(event.target.closest('input[name=<portlet:namespace />rowIds]'));
 		}
 	);
 </aui:script>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
@@ -256,7 +256,9 @@ if (portletTitleBasedNavigation) {
 		'click',
 		'input[name=<portlet:namespace />rowIds]',
 		function (event) {
-			<portlet:namespace />updateRowsChecked(event.target.closest('input[name=<portlet:namespace />rowIds]'));
+			<portlet:namespace />updateRowsChecked(
+				event.target.closest('input[name=<portlet:namespace />rowIds]')
+			);
 		}
 	);
 </aui:script>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
@@ -115,8 +115,10 @@ Layout curLayout = (Layout)row.getObject();
 	</c:if>
 </liferay-ui:icon-menu>
 
-<aui:script require="metal-dom/src/all/dom as dom">
-	var copyLayoutActionOptionQueryClickHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	var copyLayoutActionOptionQueryClickHandler = delegate(
 		document.body,
 		'click',
 		'.<portlet:namespace />copy-layout-action-option',
@@ -130,7 +132,7 @@ Layout curLayout = (Layout)row.getObject();
 		}
 	);
 
-	var viewCollectionItemsActionOptionQueryClickHandler = dom.delegate(
+	var viewCollectionItemsActionOptionQueryClickHandler = delegate(
 		document.body,
 		'click',
 		'.<portlet:namespace />view-collection-items-action-option',
@@ -145,8 +147,8 @@ Layout curLayout = (Layout)row.getObject();
 	);
 
 	function handleDestroyPortlet() {
-		copyLayoutActionOptionQueryClickHandler.removeListener();
-		viewCollectionItemsActionOptionQueryClickHandler.removeListener();
+		copyLayoutActionOptionQueryClickHandler.dispose();
+		viewCollectionItemsActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_collections.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_collections.jsp
@@ -50,10 +50,12 @@ SelectLayoutCollectionDisplayContext selectLayoutCollectionDisplayContext = (Sel
 	</liferay-ui:search-container>
 </div>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var collections = document.getElementById('<portlet:namespace />collections');
 
-	var addCollectionActionOptionQueryClickHandler = dom.delegate(
+	var delegate = delegateModule.default;
+
+	var addCollectionActionOptionQueryClickHandler = delegate(
 		collections,
 		'click',
 		'.select-collection-action-option',
@@ -61,7 +63,7 @@ SelectLayoutCollectionDisplayContext selectLayoutCollectionDisplayContext = (Sel
 	);
 
 	function handleDestroyPortlet() {
-		addCollectionActionOptionQueryClickHandler.removeListener();
+		addCollectionActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_collections.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_collections.jsp
@@ -59,22 +59,25 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-collection"));
 	/>
 </c:if>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var collections = document.getElementById('<portlet:namespace />collections');
 
-	var selectLayoutMasterLayoutActionOptionQueryClickHandler = dom.delegate(
+	var delegate = delegateModule.default;
+
+	var selectLayoutMasterLayoutActionOptionQueryClickHandler = delegate(
 		collections,
 		'click',
 		'.select-collection-action-option',
 		function (event) {
 			Liferay.Util.navigate(
-				event.delegateTarget.dataset.selectLayoutMasterLayoutUrl
+				event.target.closest('.select-collection-action-option').dataset
+					.selectLayoutMasterLayoutUrl
 			);
 		}
 	);
 
 	function handleDestroyPortlet() {
-		selectLayoutMasterLayoutActionOptionQueryClickHandler.removeListener();
+		selectLayoutMasterLayoutActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_master_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_master_layout.jsp
@@ -64,12 +64,14 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 	</clay:row>
 </clay:container-fluid>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var layoutPageTemplateEntries = document.getElementById(
 		'<portlet:namespace />layoutPageTemplateEntries'
 	);
 
-	var addLayoutActionOptionQueryClickHandler = dom.delegate(
+	var delegate = delegateModule.default;
+
+	var addLayoutActionOptionQueryClickHandler = delegate(
 		layoutPageTemplateEntries,
 		'click',
 		'.add-layout-action-option',
@@ -79,13 +81,14 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 				id: '<portlet:namespace />addLayoutDialog',
 				size: 'md',
 				title: '<liferay-ui:message key="add-collection-page" />',
-				url: event.delegateTarget.dataset.addLayoutUrl,
+				url: event.target.closest('.add-layout-action-option').dataset
+					.addLayoutUrl,
 			});
 		}
 	);
 
 	function handleDestroyPortlet() {
-		addLayoutActionOptionQueryClickHandler.removeListener();
+		addLayoutActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
@@ -167,12 +167,14 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 	</clay:row>
 </clay:container-fluid>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
 	var layoutPageTemplateEntries = document.getElementById(
 		'<portlet:namespace />layoutPageTemplateEntries'
 	);
 
-	var addLayoutActionOptionQueryClickHandler = dom.delegate(
+	var addLayoutActionOptionQueryClickHandler = delegate(
 		layoutPageTemplateEntries,
 		'click',
 		'.add-layout-action-option',
@@ -182,13 +184,14 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 				id: '<portlet:namespace />addLayoutDialog',
 				size: 'md',
 				title: '<liferay-ui:message key="add-page" />',
-				url: event.delegateTarget.dataset.addLayoutUrl,
+				url: event.target.closest('.add-layout-action-option').dataset
+					.addLayoutUrl,
 			});
 		}
 	);
 
 	function handleDestroyPortlet() {
-		addLayoutActionOptionQueryClickHandler.removeListener();
+		addLayoutActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
@@ -44,8 +44,10 @@ List<LayoutPageTemplateEntry> masterLayoutPageTemplateEntries = selectLayoutPage
 	</ul>
 </aui:form>
 
-<aui:script require="metal-dom/src/dom as dom">
-	var delegateHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	var delegateHandler = delegate(
 		document.body,
 		'click',
 		'.select-master-layout-option',
@@ -58,23 +60,25 @@ List<LayoutPageTemplateEntry> masterLayoutPageTemplateEntries = selectLayoutPage
 				});
 			}
 
-			var newSelectedCard = event.delegateTarget.closest('.form-check-card');
+			var newSelectedCard = event.target.closest('.form-check-card');
 
 			if (newSelectedCard) {
 				newSelectedCard.classList.add('active');
 			}
 
+			var delegateTarget = event.target.closest('.select-master-layout-option');
+
 			Liferay.Util.getOpener().Liferay.fire(
 				'<%= HtmlUtil.escape(eventName) %>',
 				{
-					data: event.delegateTarget.dataset,
+					data: delegateTarget.dataset,
 				}
 			);
 		}
 	);
 
 	var onDestroyPortlet = function () {
-		delegateHandler.removeListener();
+		delegateHandler.dipose();
 
 		Liferay.detach('destroyPortlet', onDestroyPortlet);
 	};

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
@@ -66,7 +66,9 @@ List<LayoutPageTemplateEntry> masterLayoutPageTemplateEntries = selectLayoutPage
 				newSelectedCard.classList.add('active');
 			}
 
-			var delegateTarget = event.target.closest('.select-master-layout-option');
+			var delegateTarget = event.target.closest(
+				'.select-master-layout-option'
+			);
 
 			Liferay.Util.getOpener().Liferay.fire(
 				'<%= HtmlUtil.escape(eventName) %>',

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
@@ -58,8 +58,10 @@ List<StyleBookEntry> styleBookEntries = selectLayoutPageTemplateEntryDisplayCont
 	</ul>
 </aui:form>
 
-<aui:script require="metal-dom/src/dom as dom">
-	var delegateHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	var delegateHandler = delegate(
 		document.body,
 		'click',
 		'.select-master-layout-option',
@@ -72,23 +74,25 @@ List<StyleBookEntry> styleBookEntries = selectLayoutPageTemplateEntryDisplayCont
 				});
 			}
 
-			var newSelectedCard = event.delegateTarget.closest('.form-check-card');
+			var newSelectedCard = event.target.closest('.form-check-card');
 
 			if (newSelectedCard) {
 				newSelectedCard.classList.add('active');
 			}
 
+			var delegateTarget = event.target.closest('.select-master-layout-option')
+
 			Liferay.Util.getOpener().Liferay.fire(
 				'<%= HtmlUtil.escape(eventName) %>',
 				{
-					data: event.delegateTarget.dataset,
+					data: delegateTarget.dataset,
 				}
 			);
 		}
 	);
 
 	var onDestroyPortlet = function () {
-		delegateHandler.removeListener();
+		delegateHandler.dispose();
 
 		Liferay.detach('destroyPortlet', onDestroyPortlet);
 	};

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
@@ -80,7 +80,9 @@ List<StyleBookEntry> styleBookEntries = selectLayoutPageTemplateEntryDisplayCont
 				newSelectedCard.classList.add('active');
 			}
 
-			var delegateTarget = event.target.closest('.select-master-layout-option')
+			var delegateTarget = event.target.closest(
+				'.select-master-layout-option'
+			);
 
 			Liferay.Util.getOpener().Liferay.fire(
 				'<%= HtmlUtil.escape(eventName) %>',

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_display_page_master_layout.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_display_page_master_layout.jsp
@@ -54,18 +54,21 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 <%
 StringBundler sb = new StringBundler(3);
 
-sb.append("metal-dom/src/all/dom as dom, ");
+sb.append("metal-dom/src/all/dom as dom,frontend-js-web/liferay/delegate/delegate.es as delegateModule, ");
 sb.append(npmResolvedPackageName);
 sb.append("/js/modal/openDisplayPageModal.es as openDisplayPageModal");
 %>
 
 <aui:script require="<%= sb.toString() %>" sandbox="<%= true %>">
-	var addDisplayPageClickHandler = dom.delegate(
+	var delegate = delegateModule.default;
+
+	var addDisplayPageClickHandler = delegate(
 		document.body,
 		'click',
 		'.add-master-page-action-option',
 		function (event) {
-			var data = event.delegateTarget.dataset;
+			var data = event.target.closest('.add-master-page-action-option')
+				.dataset;
 
 			event.preventDefault();
 
@@ -83,7 +86,7 @@ sb.append("/js/modal/openDisplayPageModal.es as openDisplayPageModal");
 	);
 
 	function handleDestroyPortlet() {
-		addDisplayPageClickHandler.removeListener();
+		addDisplayPageClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry_master_layout.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry_master_layout.jsp
@@ -60,13 +60,16 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 	</div>
 </clay:container-fluid>
 
-<aui:script require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal" sandbox="<%= true %>">
-	var addPageTemplateClickHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal,frontend-js-web/liferay/delegate/delegate.es as delegateModule" sandbox="<%= true %>">
+	var delegate = delegateModule.default;
+
+	var addPageTemplateClickHandler = delegate(
 		document.body,
 		'click',
 		'.add-master-page-action-option',
 		function (event) {
-			var data = event.delegateTarget.dataset;
+			var data = event.target.closest('.add-master-page-action-option')
+				.dataset;
 
 			event.preventDefault();
 
@@ -84,7 +87,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 	);
 
 	function handleDestroyPortlet() {
-		addPageTemplateClickHandler.removeListener();
+		addPageTemplateClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/page.jsp
@@ -73,27 +73,30 @@ LayoutClassedModelUsagesDisplayContext layoutClassedModelUsagesDisplayContext = 
 	</liferay-ui:search-container>
 </div>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	if (
 		document.querySelector('#<portlet:namespace />layoutClassedModelUsagesList')
 	) {
-		var previewLayoutClassedModelUsagesList = dom.delegate(
+		var delegate = delegateModule.default;
+
+		var previewLayoutClassedModelUsagesList = delegate(
 			document.querySelector(
 				'#<portlet:namespace />layoutClassedModelUsagesList'
 			),
 			'click',
 			'.preview-layout-classed-model-usage',
 			function (event) {
+				var delegateTarget = event.target.closest('.preview-layout-classed-model-usage')
 				Liferay.Util.openModal({
 					iframeBodyCssClass: 'article-preview',
 					title: '<liferay-ui:message key="preview" />',
-					url: event.delegateTarget.getAttribute('data-href'),
+					url: delegateTarget.getAttribute('data-href'),
 				});
 			}
 		);
 
 		function removeListener() {
-			previewLayoutClassedModelUsagesList.removeListener();
+			previewLayoutClassedModelUsagesList.dispose();
 
 			Liferay.detach('destroyPortlet', removeListener);
 		}

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/page.jsp
@@ -86,7 +86,9 @@ LayoutClassedModelUsagesDisplayContext layoutClassedModelUsagesDisplayContext = 
 			'click',
 			'.preview-layout-classed-model-usage',
 			function (event) {
-				var delegateTarget = event.target.closest('.preview-layout-classed-model-usage')
+				var delegateTarget = event.target.closest(
+					'.preview-layout-classed-model-usage'
+				);
 				Liferay.Util.openModal({
 					iframeBodyCssClass: 'article-preview',
 					title: '<liferay-ui:message key="preview" />',

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
@@ -105,26 +105,28 @@ Hits hits = searchDisplayContext.getHits();
 	</clay:col>
 </clay:row>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var facetNavigation = document.getElementById(
 		'<portlet:namespace />facetNavigation'
 	);
 
+	var delegate = delegateModule.default;
+
 	if (facetNavigation) {
-		dom.delegate(facetNavigation, 'click', '.facet-value a', function (event) {
+		delegate(facetNavigation, 'click', '.facet-value a', function (event) {
 			event.preventDefault();
 
-			var target = event.delegateTarget;
+			var delegateTarget = event.target.closest('.facet-value a');
 
-			if (!target.classList.contains('active')) {
-				target.classList.add('active');
+			if (!delegateTarget.classList.contains('active')) {
+				delegateTarget.classList.add('active');
 
-				var searchFacet = target.closest('.search-facet');
+				var searchFacet = delegateTarget.closest('.search-facet');
 
 				var facetValueSiblings = Array.prototype.filter.call(
-					target.parentNode.children,
+					delegateTarget.parentNode.children,
 					function (child) {
-						return child !== target;
+						return child !== delegateTarget;
 					}
 				);
 
@@ -140,7 +142,7 @@ Hits hits = searchDisplayContext.getHits();
 				);
 
 				if (field) {
-					field.value = target.dataset.value;
+					field.value = delegateTarget.dataset.value;
 
 					var fieldSelection = Liferay.Util.getFormElement(
 						form,
@@ -148,7 +150,7 @@ Hits hits = searchDisplayContext.getHits();
 					);
 
 					if (fieldSelection) {
-						fieldSelection.value = target.dataset.selection;
+						fieldSelection.value = delegateTarget.dataset.selection;
 					}
 
 					Liferay.Util.postForm(form, {
@@ -166,16 +168,16 @@ Hits hits = searchDisplayContext.getHits();
 	);
 
 	if (searchResultsContainer) {
-		dom.delegate(searchResultsContainer, 'click', '.expand-details', function (
+		delegate(searchResultsContainer, 'click', '.expand-details', function (
 			event
 		) {
-			var target = event.delegateTarget;
+			var delegateTarget = event.target.closest('.expand-details');
 
 			var targetSiblings = Array.prototype.filter.call(
-				target.parentNode.children,
+				delegateTarget.parentNode.children,
 				function (child) {
 					return (
-						child !== target &&
+						child !== delegateTarget &&
 						child.classList.contains('table-details')
 					);
 				}

--- a/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/edit_entry.jsp
+++ b/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/edit_entry.jsp
@@ -139,12 +139,14 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 	</aui:button-row>
 </aui:form>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var alternatingElements = document.querySelectorAll(
 		'#<portlet:namespace />advancedMode, #<portlet:namespace />friendlyMode, #<portlet:namespace />allowedServiceSignatures, #<portlet:namespace />allowedServiceSignaturesFriendlyContentBox'
 	);
 
-	dom.delegate(
+	var delegate = delegateModule.default;
+
+	delegate(
 		document.<portlet:namespace />fm,
 		'click',
 		'#<portlet:namespace />advancedMode, #<portlet:namespace />friendlyMode',

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
@@ -44,13 +44,15 @@
 			</liferay-frontend:edit-form-footer>
 		</liferay-frontend:edit-form>
 
-		<aui:script require="metal-dom/src/dom as dom">
-			dom.delegate(
+		<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+			var delegate = delegateModule.default;
+
+			delegate(
 				document.getElementById('<portlet:namespace />fm'),
 				'change',
 				'input[type=checkbox]',
 				function (event) {
-					var toggle = event.delegateTarget;
+					var toggle = event.target.closest('input[type=checkbox]');
 
 					var disableOnChecked = toggle.dataset.disableonchecked;
 					var inputs = document.querySelectorAll(toggle.dataset.inputselector);

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
@@ -199,7 +199,9 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 		'click',
 		'.view-collection-items-action-option.collection',
 		function (event) {
-			var delegateTarget = event.target.closest('.view-collection-items-action-option.collection');
+			var delegateTarget = event.target.closest(
+				'.view-collection-items-action-option.collection'
+			);
 
 			Liferay.Util.openModal({
 				id: '<portlet:namespace />viewCollectionItemsDialog',

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
@@ -189,18 +189,22 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 	module="js/PagesTreeEventHandler.es"
 />
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var layoutsTree = document.getElementById('<portlet:namespace />layoutsTree');
 
-	var viewCollectionItemsActionOptionQueryClickHandler = dom.delegate(
+	var delegate = delegateModule.default;
+
+	var viewCollectionItemsActionOptionQueryClickHandler = delegate(
 		layoutsTree,
 		'click',
 		'.view-collection-items-action-option.collection',
 		function (event) {
+			var delegateTarget = event.target.closest('.view-collection-items-action-option.collection');
+
 			Liferay.Util.openModal({
 				id: '<portlet:namespace />viewCollectionItemsDialog',
 				title: '<liferay-ui:message key="collection-items" />',
-				url: event.delegateTarget.dataset.viewCollectionItemsUrl,
+				url: delegateTarget.dataset.viewCollectionItemsUrl,
 			});
 		}
 	);
@@ -213,7 +217,7 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 			'<%= ProductNavigationProductMenuWebKeys.PAGES_TREE_EVENT_HANDLER %>'
 		);
 
-		viewCollectionItemsActionOptionQueryClickHandler.removeListener();
+		viewCollectionItemsActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
@@ -157,13 +157,15 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 	module="js/RedirectManagementToolbarDefaultEventHandler.es"
 />
 
-<aui:script require="metal-dom/src/all/dom as dom">
-	dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	delegate(
 		document.querySelector('#<portlet:namespace />fm'),
 		'click',
 		'.icon-shortcut',
 		function (event) {
-			var delegateTarget = event.delegateTarget;
+			var delegateTarget = event.target.closest('.icon-shortcut');
 
 			var destinationURL = delegateTarget.dataset.href;
 

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
@@ -156,13 +156,17 @@ else {
 				/>
 			</liferay-ui:search-container>
 
-			<aui:script require="metal-dom/src/dom as dom">
+			<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 				var form = document.<portlet:namespace />selectOrganizationRoleFm;
 
-				dom.delegate(form, 'click', '.organization-selector-button', function (event) {
+				var delegate = delegateModule.default;
+
+				delegate(form, 'click', '.organization-selector-button', function (event) {
+					var delegateTarget = event.target.closest('.organization-selector-button');
+
 					Liferay.Util.postForm(form, {
 						data: {
-							organizationId: event.delegateTarget.dataset.organizationid,
+							organizationId: delegateTarget.dataset.organizationid,
 						},
 
 						<%

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
@@ -130,13 +130,17 @@ SearchContainer<Role> roleSearchContainer = selectRoleManagementToolbarDisplayCo
 				/>
 			</liferay-ui:search-container>
 
-			<aui:script require="metal-dom/src/dom as dom">
+			<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 				var form = document.<portlet:namespace />selectSiteRoleFm;
 
-				dom.delegate(form, 'click', '.group-selector-button', function (event) {
+				var delegate = delegateModule.default;
+
+				delegate(form, 'click', '.group-selector-button', function (event) {
+					var delegateTarget = event.target.closest('.group-selector-button');
+
 					Liferay.Util.postForm(form, {
 						data: {
-							groupId: event.delegateTarget.dataset.groupid,
+							groupId: delegateTarget.dataset.groupid,
 						},
 
 						<%

--- a/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
+++ b/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
@@ -66,8 +66,10 @@ RoleItemSelectorViewDisplayContext roleItemSelectorViewDisplayContext = (RoleIte
 	</liferay-ui:search-container>
 </clay:container-fluid>
 
-<aui:script require="metal-dom/src/all/dom as dom">
-	var selectItemHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	var selectItemHandler = delegate(
 		document.getElementById('<portlet:namespace />roleSelectorWrapper'),
 		'change',
 		'.entry input',
@@ -91,7 +93,7 @@ RoleItemSelectorViewDisplayContext roleItemSelectorViewDisplayContext = (RoleIte
 	);
 
 	Liferay.on('destroyPortlet', function removeListener() {
-		selectItemHandler.removeListener();
+		selectItemHandler.dispose();
 
 		Liferay.detach('destroyPortlet', removeListener);
 	});

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -171,12 +171,14 @@ request.setAttribute("view.jsp-eventName", eventName);
 	<aui:input name="siteRoleIds" type="hidden" />
 </aui:form>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var form = document.getElementById(
 		'<portlet:namespace />updateSegmentsEntrySiteRolesFm'
 	);
 
-	dom.delegate(document, 'click', '.assign-site-roles-link', function (event) {
+	var delegate = delegateModule.default;
+
+	delegate(document, 'click', '.assign-site-roles-link', function (event) {
 		var link = event.target.closest('.assign-site-roles-link');
 
 		var itemSelectorURL = link.dataset.itemselectorurl;

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -147,13 +147,17 @@ SiteNavigationAdminManagementToolbarDisplayContext siteNavigationAdminManagement
 	</liferay-ui:search-container>
 </aui:form>
 
-<aui:script require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal" sandbox="<%= true %>">
-	var renameSiteNavigationMenuClickHandler = dom.delegate(
+<aui:script require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal,frontend-js-web/liferay/delegate/delegate.es as delegateModule" sandbox="<%= true %>">
+	var delegate = delegateModule.default;
+
+	var renameSiteNavigationMenuClickHandler = delegate(
 		document.body,
 		'click',
 		'.<portlet:namespace />update-site-navigation-menu-action-option > a',
 		function (event) {
-			var data = event.delegateTarget.dataset;
+			var data = event.target.closest(
+				'.<portlet:namespace />update-site-navigation-menu-action-option > a'
+			).dataset;
 
 			event.preventDefault();
 
@@ -175,7 +179,7 @@ SiteNavigationAdminManagementToolbarDisplayContext siteNavigationAdminManagement
 	);
 
 	function handleDestroyPortlet() {
-		renameSiteNavigationMenuClickHandler.removeListener();
+		renameSiteNavigationMenuClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -250,7 +250,7 @@ else {
 	</liferay-frontend:edit-form-footer>
 </liferay-frontend:edit-form>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var form = document.<portlet:namespace />fm;
 
 	form.addEventListener('change', <portlet:namespace />resetPreview);
@@ -490,7 +490,9 @@ else {
 		siteNavigationMenuIdInput &&
 		siteNavigationMenuType
 	) {
-		dom.delegate(
+		var delegate = delegateModule.default;
+
+		delegate(
 			document.<portlet:namespace />fm,
 			'change',
 			'.select-navigation',

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
@@ -92,7 +92,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-site-template"));
 		);
 
 		function handleDestroyPortlet() {
-			addSiteActionOptionQueryClickHandler.removeListener();
+			addSiteActionOptionQueryClickHandler.dispose();
 
 			Liferay.detach('destroyPortlet', handleDestroyPortlet);
 		}

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
@@ -60,13 +60,17 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-site-template"));
 		<portlet:param name="parentGroupId" value="<%= String.valueOf(selectSiteInitializerDisplayContext.getParentGroupId()) %>" />
 	</portlet:actionURL>
 
-	<aui:script require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal">
-		var addSiteActionOptionQueryClickHandler = dom.delegate(
+	<aui:script require="frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+		var delegate = delegateModule.default;
+
+		var addSiteActionOptionQueryClickHandler = delegate(
 			document.body,
 			'click',
 			'.add-site-action-button',
 			function (event) {
-				var data = event.delegateTarget.querySelector('.add-site-action-card')
+				var delegateTarget = event.target.closest('.add-site-action-button');
+
+				var data = delegateTarget.querySelector('.add-site-action-card')
 					.dataset;
 
 				openSimpleInputModal.default({

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
@@ -98,7 +98,7 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 							</div>
 						</clay:sheet-footer>
 
-						<aui:script require="metal-dom/src/dom as dom">
+						<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 							var pwcWarning = document.getElementById('<portlet:namespace />pwcWarning');
 							var remoteStagingOptions = document.getElementById(
 								'<portlet:namespace />remoteStagingOptions'
@@ -116,8 +116,10 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 								remoteStagingOptions &&
 								trashWarning
 							) {
-								dom.delegate(stagingTypes, 'click', 'input', function (event) {
-									var value = event.delegateTarget.value;
+								var delegate = delegateModule.default;
+
+								delegate(stagingTypes, 'click', 'input', function (event) {
+									var value = event.target.closest('input').value;
 
 									if (value != '<%= StagingConstants.TYPE_LOCAL_STAGING %>') {
 										pwcWarning.classList.add('hide');

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
@@ -226,15 +226,15 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 	<portlet:param name="scope" value="<%= scope %>" />
 </portlet:renderURL>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var baseURL = '<%= reviewUADDataURL %>';
 
 	var clickListeners = [];
 
+	var delegate = delegateModule.default;
+
 	var registerClickHandler = function (element, clickHandlerFn) {
-		clickListeners.push(
-			dom.delegate(element, 'click', 'input', clickHandlerFn)
-		);
+		clickListeners.push(delegate(element, 'click', 'input', clickHandlerFn));
 	};
 
 	registerClickHandler(<portlet:namespace />applicationPanelBody, function (
@@ -244,7 +244,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 
 		url.searchParams.set(
 			'<portlet:namespace />applicationKey',
-			event.target.value
+			event.target.closest('input').value
 		);
 
 		Liferay.Util.navigate(url.toString());
@@ -258,7 +258,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 
 			url.searchParams.set(
 				'<portlet:namespace />uadRegistryKey',
-				event.target.value
+				event.target.closest('input').value
 			);
 
 			Liferay.Util.navigate(url.toString());
@@ -269,14 +269,17 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 		var url = new URL(baseURL, window.location.origin);
 
 		url.searchParams.set('<portlet:namespace />applicationKey', '');
-		url.searchParams.set('<portlet:namespace />scope', event.target.value);
+		url.searchParams.set(
+			'<portlet:namespace />scope',
+			event.target.closest('input').value
+		);
 
 		Liferay.Util.navigate(url.toString());
 	});
 
 	function handleDestroyPortlet() {
 		for (var i = 0; i < clickListeners.length; i++) {
-			clickListeners[i].removeListener();
+			clickListeners[i].dispose();
 		}
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_iterator.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_iterator.jsp
@@ -268,7 +268,7 @@ for (int i = 0; i < pages.size(); i++) {
 />
 
 <c:if test='<%= navigation.equals("history") %>'>
-	<aui:script require="metal-dom/src/dom as dom">
+	<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 		function <portlet:namespace />initRowsChecked() {
 			var rowIdsNodes = document.querySelectorAll(
 				'input[name=<portlet:namespace />rowIds]'
@@ -359,12 +359,16 @@ for (int i = 0; i < pages.size(); i++) {
 		);
 
 		if (searchContainer) {
-			dom.delegate(
+			var delegate = delegateModule.default;
+
+			delegate(
 				searchContainer,
 				'click',
 				'input[name=<portlet:namespace />rowIds]',
 				function (event) {
-					<portlet:namespace />updateRowsChecked(event.delegateTarget);
+					var delegateTarget = event.target.closest('input[name=<portlet:namespace />rowIds]');
+
+					<portlet:namespace />updateRowsChecked(delegateTarget);
 				}
 			);
 		}

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_iterator.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_iterator.jsp
@@ -366,7 +366,9 @@ for (int i = 0; i < pages.size(); i++) {
 				'click',
 				'input[name=<portlet:namespace />rowIds]',
 				function (event) {
-					var delegateTarget = event.target.closest('input[name=<portlet:namespace />rowIds]');
+					var delegateTarget = event.target.closest(
+						'input[name=<portlet:namespace />rowIds]'
+					);
 
 					<portlet:namespace />updateRowsChecked(delegateTarget);
 				}

--- a/modules/dxp/apps/commerce/commerce-application-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/commerce/commerce-application-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -143,8 +143,10 @@ renderResponse.setTitle(LanguageUtil.get(request, "applications"));
 		<portlet:param name="redirect" value="<%= currentURL %>" />
 	</portlet:actionURL>
 
-	<aui:script require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as modalCommands">
-		var handleAddApplicationBrandButtonClick = dom.delegate(
+	<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as modalCommands">
+		var delegate = delegateModule.default;
+
+		var handleAddApplicationBrandButtonClick = delegate(
 			document.body,
 			'click',
 			'#<portlet:namespace />addApplicationBrandButton',
@@ -163,7 +165,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "applications"));
 		);
 
 		function handleDestroyPortlet() {
-			handleAddApplicationBrandButtonClick.removeListener();
+			handleAddApplicationBrandButtonClick.dispose();
 
 			Liferay.detach('destroyPortlet', handleDestroyPortlet);
 		}

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -72,22 +72,24 @@
 	}
 </aui:script>
 
-<aui:script require="metal-dom/src/all/dom as dom" sandbox="<%= true %>">
-	var focusInPortletHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule" sandbox="<%= true %>">
+	var delegate = delegateModule.default;
+
+	var focusInPortletHandler = delegate(
 		document,
 		'focusin',
 		'.portlet',
 		function(event) {
-			event.delegateTarget.closest('.portlet').classList.add('open');
+			event.target.closest('.portlet').classList.add('open');
 		}
 	);
 
-	var focusOutPortletHandler = dom.delegate(
+	var focusOutPortletHandler = delegate(
 		document,
 		'focusout',
 		'.portlet',
 		function(event) {
-			event.delegateTarget.closest('.portlet').classList.remove('open');
+			event.target.closest('.portlet').classList.remove('open');
 		}
 	);
 </aui:script>

--- a/portal-web/docroot/html/taglib/ui/input_repeat/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_repeat/page.jsp
@@ -192,18 +192,22 @@ int yearlyMonth1 = ParamUtil.getInteger(request, "yearlyMonth1", Calendar.JANUAR
 	</aui:col>
 </aui:fieldset>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var tables = document.querySelectorAll('#<portlet:namespace />recurrenceTypeDailyTable, #<portlet:namespace />recurrenceTypeMonthlyTable, #<portlet:namespace />recurrenceTypeNeverTable, #<portlet:namespace />recurrenceTypeWeeklyTable, #<portlet:namespace />recurrenceTypeYearlyTable');
 
 	var eventsContainer = document.getElementById('<portlet:namespace />eventsContainer');
 
+	var delegate = delegateModule.default;
+
 	if (eventsContainer) {
-		dom.delegate(
+		delegate(
 			eventsContainer,
 			'change',
 			'.field',
 			function(event) {
-				var tableId = event.delegateTarget.id + 'Table';
+				var delegateTarget = event.target.closest('.field');
+
+				var tableId = delegateTarget.id + 'Table';
 
 				Array.prototype.forEach.call(
 					tables,


### PR DESCRIPTION
I've started removing usages of `dom.delegate`. 

In the meanwhile I realised that the implementation of `delegate` isn't fully functional, at least from my investigations, so I've pushed a commit that extends the utility to find an ancestor that matches the provided `selector`. 

I've also provided some examples of usage with the pattern tested working, except a couple of them - ones that have selectors for html tags or children, e.g. `'.someClassName a'`