### PR TITLE
LPS-122697 Avoid infinite loop in Content Performance

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -52,7 +52,7 @@ export default function Navigation({
 		page,
 	});
 
-	const {getHistoricalReads, getHistoricalViews} = api;
+	const {getHistoricalReads, getHistoricalViews, getTrafficSources} = api;
 
 	const handleCurrentPage = useCallback((currentPage) => {
 		setCurrentPage({view: currentPage.view});
@@ -68,12 +68,6 @@ export default function Navigation({
 		return api
 			.getTotalViews()
 			.then((response) => response.analyticsReportsTotalViews);
-	}, [api]);
-
-	const handleTrafficSources = useCallback(() => {
-		return api
-			.getTrafficSources()
-			.then((response) => response.trafficSources);
 	}, [api]);
 
 	const handleTrafficSourceClick = (trafficSources, trafficSourceName) => {
@@ -159,7 +153,7 @@ export default function Navigation({
 						timeSpanOptions={timeSpanOptions}
 						totalReadsDataProvider={handleTotalReads}
 						totalViewsDataProvider={handleTotalViews}
-						trafficSourcesDataProvider={handleTrafficSources}
+						trafficSourcesDataProvider={getTrafficSources}
 						viewURLs={viewURLs}
 					/>
 				</div>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -63,7 +63,7 @@ export default function TrafficSources({
 	useEffect(() => {
 		if (validAnalyticsConnection) {
 			dataProvider()
-				.then(setTrafficSources)
+				.then((response) => setTrafficSources(response.trafficSources))
 				.catch(() => {
 					setTrafficSources([]);
 					addWarning();

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/store.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/store.js
@@ -23,16 +23,12 @@ export const StoreContext = createContext([INITIAL_STATE, () => {}]);
 
 function reducer(state = INITIAL_STATE, action) {
 	if (action.type === ADD_HISTORICAL_WARNING) {
-		return {
-			...state,
-			historicalWarning: true,
-		};
+		return state.historicalWarning
+			? state
+			: {...state, historicalWarning: true};
 	}
 	else if (action.type === ADD_WARNING) {
-		return {
-			...state,
-			warning: true,
-		};
+		return state.warning ? state : {...state, warning: true};
 	}
 
 	return state;

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
@@ -20,46 +20,48 @@ describe('TrafficSources', () => {
 
 	it('displays the traffic sources with buttons to view keywords', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve([
-				{
-					countryKeywords: [
-						{
-							countryCode: 'us',
-							countryName: 'United States',
-							keywords: [],
-						},
-						{
-							countryCode: 'es',
-							countryName: 'Spain',
-							keywords: [],
-						},
-					],
-					helpMessage: 'Testing Help Message',
-					name: 'testing',
-					share: 30,
-					title: 'Testing',
-					value: 32178,
-				},
-				{
-					countryKeywords: [
-						{
-							countryCode: 'us',
-							countryName: 'United States',
-							keywords: [],
-						},
-						{
-							countryCode: 'es',
-							countryName: 'Spain',
-							keywords: [],
-						},
-					],
-					helpMessage: 'Second Testing Help Message',
-					name: 'second-testing',
-					share: 70,
-					title: 'Second Testing',
-					value: 278256,
-				},
-			])
+			Promise.resolve({
+				trafficSources: [
+					{
+						countryKeywords: [
+							{
+								countryCode: 'us',
+								countryName: 'United States',
+								keywords: [],
+							},
+							{
+								countryCode: 'es',
+								countryName: 'Spain',
+								keywords: [],
+							},
+						],
+						helpMessage: 'Testing Help Message',
+						name: 'testing',
+						share: 30,
+						title: 'Testing',
+						value: 32178,
+					},
+					{
+						countryKeywords: [
+							{
+								countryCode: 'us',
+								countryName: 'United States',
+								keywords: [],
+							},
+							{
+								countryCode: 'es',
+								countryName: 'Spain',
+								keywords: [],
+							},
+						],
+						helpMessage: 'Second Testing Help Message',
+						name: 'second-testing',
+						share: 70,
+						title: 'Second Testing',
+						value: 278256,
+					},
+				],
+			})
 		);
 
 		const {getByText} = render(
@@ -95,46 +97,48 @@ describe('TrafficSources', () => {
 
 	it('displays the traffic sources without buttons to view keywords when the value is 0', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve([
-				{
-					countryKeywords: [
-						{
-							countryCode: 'us',
-							countryName: 'United States',
-							keywords: [],
-						},
-						{
-							countryCode: 'es',
-							countryName: 'Spain',
-							keywords: [],
-						},
-					],
-					helpMessage: 'Testing Help Message',
-					name: 'testing',
-					share: 0,
-					title: 'Testing',
-					value: 0,
-				},
-				{
-					countryKeywords: [
-						{
-							countryCode: 'us',
-							countryName: 'United States',
-							keywords: [],
-						},
-						{
-							countryCode: 'es',
-							countryName: 'Spain',
-							keywords: [],
-						},
-					],
-					helpMessage: 'Second Testing Help Message',
-					name: 'second-testing',
-					share: 0,
-					title: 'Second Testing',
-					value: 0,
-				},
-			])
+			Promise.resolve({
+				trafficSources: [
+					{
+						countryKeywords: [
+							{
+								countryCode: 'us',
+								countryName: 'United States',
+								keywords: [],
+							},
+							{
+								countryCode: 'es',
+								countryName: 'Spain',
+								keywords: [],
+							},
+						],
+						helpMessage: 'Testing Help Message',
+						name: 'testing',
+						share: 0,
+						title: 'Testing',
+						value: 0,
+					},
+					{
+						countryKeywords: [
+							{
+								countryCode: 'us',
+								countryName: 'United States',
+								keywords: [],
+							},
+							{
+								countryCode: 'es',
+								countryName: 'Spain',
+								keywords: [],
+							},
+						],
+						helpMessage: 'Second Testing Help Message',
+						name: 'second-testing',
+						share: 0,
+						title: 'Second Testing',
+						value: 0,
+					},
+				],
+			})
 		);
 
 		const {getAllByText, getByText} = render(
@@ -170,44 +174,46 @@ describe('TrafficSources', () => {
 
 	it('displays the traffic sources without buttons to view keywords when the value is missing', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve([
-				{
-					countryKeywords: [
-						{
-							countryCode: 'us',
-							countryName: 'United States',
-							keywords: [],
-						},
-						{
-							countryCode: 'es',
-							countryName: 'Spain',
-							keywords: [],
-						},
-					],
-					helpMessage: 'Testing Help Message',
-					name: 'testing',
-					share: 0,
-					title: 'Testing',
-				},
-				{
-					countryKeywords: [
-						{
-							countryCode: 'us',
-							countryName: 'United States',
-							keywords: [],
-						},
-						{
-							countryCode: 'es',
-							countryName: 'Spain',
-							keywords: [],
-						},
-					],
-					helpMessage: 'Second Testing Help Message',
-					name: 'second-testing',
-					share: 0,
-					title: 'Second Testing',
-				},
-			])
+			Promise.resolve({
+				trafficSources: [
+					{
+						countryKeywords: [
+							{
+								countryCode: 'us',
+								countryName: 'United States',
+								keywords: [],
+							},
+							{
+								countryCode: 'es',
+								countryName: 'Spain',
+								keywords: [],
+							},
+						],
+						helpMessage: 'Testing Help Message',
+						name: 'testing',
+						share: 0,
+						title: 'Testing',
+					},
+					{
+						countryKeywords: [
+							{
+								countryCode: 'us',
+								countryName: 'United States',
+								keywords: [],
+							},
+							{
+								countryCode: 'es',
+								countryName: 'Spain',
+								keywords: [],
+							},
+						],
+						helpMessage: 'Second Testing Help Message',
+						name: 'second-testing',
+						share: 0,
+						title: 'Second Testing',
+					},
+				],
+			})
 		);
 
 		const {getAllByText, getByText} = render(
@@ -243,23 +249,25 @@ describe('TrafficSources', () => {
 
 	it('displays a dash instead of value when the value is missing', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve([
-				{
-					countryKeywords: [],
-					helpMessage: 'Testing Help Message',
-					name: 'testing',
-					share: 100,
-					title: 'Testing',
-					value: 32178,
-				},
-				{
-					countryKeywords: [],
-					helpMessage: 'Second Testing Help Message',
-					name: 'second-testing',
-					share: 0,
-					title: 'Second Testing',
-				},
-			])
+			Promise.resolve({
+				trafficSources: [
+					{
+						countryKeywords: [],
+						helpMessage: 'Testing Help Message',
+						name: 'testing',
+						share: 100,
+						title: 'Testing',
+						value: 32178,
+					},
+					{
+						countryKeywords: [],
+						helpMessage: 'Second Testing Help Message',
+						name: 'second-testing',
+						share: 0,
+						title: 'Second Testing',
+					},
+				],
+			})
 		);
 
 		const {getByText} = render(
@@ -287,24 +295,26 @@ describe('TrafficSources', () => {
 
 	it('displays a message informing the user that there is no incoming traffic from search engines yet', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve([
-				{
-					countryKeywords: [],
-					helpMessage: 'Testing Help Message',
-					name: 'testing',
-					share: 0,
-					title: 'Testing',
-					value: 0,
-				},
-				{
-					countryKeywords: [],
-					helpMessage: 'Second Testing Help Message',
-					name: 'second-testing',
-					share: 0,
-					title: 'Second Testing',
-					value: 0,
-				},
-			])
+			Promise.resolve({
+				trafficSources: [
+					{
+						countryKeywords: [],
+						helpMessage: 'Testing Help Message',
+						name: 'testing',
+						share: 0,
+						title: 'Testing',
+						value: 0,
+					},
+					{
+						countryKeywords: [],
+						helpMessage: 'Second Testing Help Message',
+						name: 'second-testing',
+						share: 0,
+						title: 'Second Testing',
+						value: 0,
+					},
+				],
+			})
 		);
 
 		const {getAllByText, getByText} = render(


### PR DESCRIPTION
**Description**
When the user has the Content Performance panel open and suddenly the network connection is lost but the user performs an action on the panel, there is an infinite loop calling three different endpoints: `getTotalViews`, `getTotalReads` and `getTrafficSources`. 

After a little research, we saw that the problem was the `addWarning` custom hook that we use in the `catch` part of the calls. See:
- `addWarning` in TotalCount component (for total views and total reads): https://github.com/liferay/liferay-portal/blob/afb229df01a027b6f438bf1628290d9470d1e4d8/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js#L46
- `addWarning` in TrafficSources component (for traffic sources): https://github.com/liferay/liferay-portal/blob/afb229df01a027b6f438bf1628290d9470d1e4d8/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js#L69

**Solution**
To avoid the infinite loop, I add a check in the custom hook action to not change the state if there is already a warning in the panel. A warning is displayed if the call to an endpoint failed.