### PR TITLE
LPS-122662 Make vocabularies not searchable

### DIFF
--- a/modules/apps/asset/asset-categories-selector-web/src/main/java/com/liferay/asset/categories/selector/web/internal/display/context/AssetCategoriesSelectorDisplayContext.java
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/java/com/liferay/asset/categories/selector/web/internal/display/context/AssetCategoriesSelectorDisplayContext.java
@@ -141,6 +141,8 @@ public class AssetCategoriesSelectorDisplayContext {
 			"disabled", true
 		).put(
 			"expanded", true
+		).put(
+			"vocabulary", true
 		);
 
 		return JSONUtil.put(jsonObject);

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -30,6 +30,18 @@ function visit(nodes, callback) {
 	});
 }
 
+function getFilter(filterQuery) {
+	if (!filterQuery) {
+		return null;
+	}
+
+	const filterQueryLowerCase = filterQuery.toLowerCase();
+
+	return (node) =>
+		!node.vocabulary &&
+		node.name.toLowerCase().indexOf(filterQueryLowerCase) !== -1;
+}
+
 function SelectCategory({
 	addCategoryURL,
 	itemSelectorSaveEvent,
@@ -39,7 +51,7 @@ function SelectCategory({
 	nodes,
 }) {
 	const flattenedNodes = useMemo(() => {
-		if (nodes.length === 1 && nodes[0].vocabulary) {
+		if (nodes.length === 1 && nodes[0].vocabulary && nodes[0].id !== '0') {
 			return nodes[0].children;
 		}
 
@@ -49,12 +61,6 @@ function SelectCategory({
 	const [filterQuery, setFilterQuery] = useState('');
 
 	const selectedNodesRef = useRef(null);
-
-	const handleQueryChange = useCallback((event) => {
-		const value = event.target.value;
-
-		setFilterQuery(value);
-	}, []);
 
 	const handleAddCategoryClick = useCallback(() => {
 		const dialog = Liferay.Util.getWindow(itemSelectorSaveEvent);
@@ -160,7 +166,9 @@ function SelectCategory({
 						<div className="input-group-item">
 							<input
 								className="form-control h-100 input-group-inset input-group-inset-after"
-								onChange={handleQueryChange}
+								onChange={(event) =>
+									setFilterQuery(event.target.value)
+								}
 								placeholder={Liferay.Language.get('search')}
 								type="text"
 							/>
@@ -192,7 +200,7 @@ function SelectCategory({
 						{flattenedNodes.length > 0 ? (
 							<Treeview
 								NodeComponent={Treeview.Card}
-								filterQuery={filterQuery}
+								filter={getFilter(filterQuery)}
 								initialSelectedNodeIds={initialSelectedNodeIds}
 								multiSelection={multiSelection}
 								nodes={flattenedNodes}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewCard.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewCard.js
@@ -23,10 +23,10 @@ import TreeviewContext from './TreeviewContext';
 
 export default function TreeviewCard({node}) {
 	const {state} = useContext(TreeviewContext);
-	const {filterQuery, focusedNodeId} = state;
+	const {filter, focusedNodeId} = state;
 
 	const path =
-		node.nodePath && filterQuery ? (
+		node.nodePath && filter ? (
 			<div className="lfr-card-subtitle-text text-default text-truncate treeview-node-name">
 				{node.nodePath}
 			</div>

--- a/modules/apps/frontend-js/frontend-js-components-web/test/treeview/Treeview.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/treeview/Treeview.js
@@ -276,4 +276,57 @@ describe('Treeview', () => {
 			);
 		});
 	});
+
+	describe('Treeview with filter prop', () => {
+		it('filters the node comparing the node name ignoring case when a string is supplied', () => {
+			const nodes = [
+				{
+					icon: 'cog',
+					id: '1',
+					name: 'Sandro',
+				},
+				{
+					icon: 'cog',
+					id: '2',
+					name: 'sandro polo',
+				},
+				{
+					icon: 'cog',
+					id: '3',
+					name: 'Pablo',
+				},
+			];
+
+			const {getByText} = render(
+				<Treeview filter={'Sandro'} nodes={nodes} />
+			);
+
+			expect(getByText('Sandro')).toBeInTheDocument();
+			expect(getByText('sandro polo')).toBeInTheDocument();
+		});
+
+		it('uses custom filter function if passed', () => {
+			const nodes = [
+				{
+					icon: 'cog',
+					id: '1',
+					name: 'Sandro',
+				},
+				{
+					icon: 'cog',
+					id: '2',
+					name: 'sandro polo',
+				},
+			];
+
+			const exactMatchFilter = (node) => node.name === 'Sandro';
+
+			const {getByText, queryByText} = render(
+				<Treeview filter={exactMatchFilter} nodes={nodes} />
+			);
+
+			expect(getByText('Sandro')).toBeInTheDocument();
+			expect(queryByText('sandro polo')).not.toBeInTheDocument();
+		});
+	});
 });

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectFolder.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectFolder.es.js
@@ -19,7 +19,7 @@ import {Treeview} from 'frontend-js-components-web';
 import React, {useCallback, useMemo, useState} from 'react';
 
 const SelectFolder = ({itemSelectorSaveEvent, nodes}) => {
-	const [filterQuery, setFilterQuery] = useState('');
+	const [filter, setFilter] = useState('');
 
 	const nodesById = useMemo(() => {
 		const result = {};
@@ -40,7 +40,7 @@ const SelectFolder = ({itemSelectorSaveEvent, nodes}) => {
 	const handleQueryChange = useCallback((event) => {
 		const value = event.target.value;
 
-		setFilterQuery(value);
+		setFilter(value);
 	}, []);
 
 	const handleSelectionChange = (selectedNodeIds) => {
@@ -80,7 +80,7 @@ const SelectFolder = ({itemSelectorSaveEvent, nodes}) => {
 
 			<Treeview
 				NodeComponent={Treeview.Card}
-				filterQuery={filterQuery}
+				filter={filter}
 				nodes={nodes}
 				onSelectedNodesChange={handleSelectionChange}
 			/>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/AllowedFragmentSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/AllowedFragmentSelector.js
@@ -146,7 +146,7 @@ const AllowedFragmentSelector = ({dropZoneConfig, onSelectedFragment}) => {
 				<div className="mb-2 page-editor__allowed-fragment__tree">
 					<Treeview
 						NodeComponent={AllowedFragmentTreeNode}
-						filterQuery={filter}
+						filter={filter}
 						inheritSelection
 						initialSelectedNodeIds={[...fragmentEntryKeys]}
 						nodes={nodes}

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
@@ -46,7 +46,7 @@ const SelectLayout = ({
 	namespace,
 	nodes,
 }) => {
-	const [filterQuery, setFilterQuery] = useState();
+	const [filter, setFilter] = useState();
 
 	const handleSelectionChange = (selectedNodeIds) => {
 		if (!selectedNodeIds.size) {
@@ -100,9 +100,7 @@ const SelectLayout = ({
 								className="form-control input-group-inset input-group-inset-after"
 								name={`${namespace}filterKeywords`}
 								onInput={(event) => {
-									setFilterQuery(
-										event.target.value.toLowerCase()
-									);
+									setFilter(event.target.value.toLowerCase());
 								}}
 								placeholder={Liferay.Language.get('search-for')}
 								type="text"
@@ -135,7 +133,7 @@ const SelectLayout = ({
 					>
 						<Treeview
 							NodeComponent={Treeview.Card}
-							filterQuery={filterQuery}
+							filter={filter}
 							multiSelection={multiSelection}
 							nodes={nodes}
 							onSelectedNodesChange={handleSelectionChange}

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/js/SelectSiteNavigationMenuItem.js
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/js/SelectSiteNavigationMenuItem.js
@@ -42,12 +42,12 @@ function findSiteNavigationMenuItem(
 }
 
 const SelectSiteNavigationMenuItem = ({itemSelectorSaveEvent, nodes}) => {
-	const [filterQuery, setFilterQuery] = useState('');
+	const [filter, setFilter] = useState('');
 
 	const handleQueryChange = useCallback((event) => {
 		const value = event.target.value;
 
-		setFilterQuery(value);
+		setFilter(value);
 	}, []);
 
 	const handleSelectionChange = (selectedNodeIds) => {
@@ -94,7 +94,7 @@ const SelectSiteNavigationMenuItem = ({itemSelectorSaveEvent, nodes}) => {
 
 			<Treeview
 				NodeComponent={Treeview.Card}
-				filterQuery={filterQuery}
+				filter={filter}
 				nodes={nodes}
 				onSelectedNodesChange={handleSelectionChange}
 			/>


### PR DESCRIPTION
This pr includes:

- prop name filterQuery renamed to filter in TreeView component
- prop can now admit two types: string and function
    - string: same behaviour, when not falsy it will filter the nodes comparing the string with the name of the node
    - function: a function that receives the node and should return true or false deciding if the tree should include the node in the search
- Filter out vocabularies in SelectCategory component using the new API
- Adapt filterQuery usages to fit the new name

----

For testing:

- Go to Categorization
- Create a new vocabulary 'vocab1'
- Create a new category under vocabulary 'vocab1' called 'vocab1category'
- Go to Apps menu -> content dashboard
- Click Filter and Order -> Filter by.. Categories
- Type "vocab1" in the search field

Before:
- Both vocab1 and vocab1category are displayed

After: 
- only vocab1category is displayed

Thanks!
