### PR TITLE
[7.4 only] LPS-122392 Remove {closest, contains, match} usages of metal-dom

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/ColumnOverlay.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/ColumnOverlay.es.js
@@ -14,7 +14,6 @@
 
 import classNames from 'classnames';
 import {useEventListener} from 'frontend-js-react-web';
-import dom from 'metal-dom';
 import React, {useContext, useLayoutEffect, useState} from 'react';
 
 import Button from '../../components/button/Button.es';
@@ -144,10 +143,7 @@ export default ({container, fields, onRemoveFieldName}) => {
 		'mouseleave',
 		({relatedTarget}) => {
 			const columnIndex = getColumnIndex(relatedTarget);
-			const outsideOverlay = !dom.closest(
-				relatedTarget,
-				'.column-overlay'
-			);
+			const outsideOverlay = !relatedTarget.closest('.column-overlay');
 
 			if (columnIndex === -1 && outsideOverlay) {
 				setHoveredFieldName(null);

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/utils.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/utils.es.js
@@ -13,18 +13,17 @@
  */
 
 import {DataDefinitionUtils} from 'data-engine-taglib';
-import dom from 'metal-dom';
 
 import {addItem, updateItem} from '../../utils/client.es';
 
 export const getColumnIndex = (node) => {
-	const rowNode = dom.closest(node, 'tr');
+	const rowNode = node.closest('tr');
 
 	if (!rowNode) {
 		return -1;
 	}
 
-	const columnNode = dom.closest(node, 'td,th');
+	const columnNode = node.closest('td,th');
 
 	if (!columnNode) {
 		return -1;

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/utils/clickOutside.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/utils/clickOutside.es.js
@@ -17,7 +17,7 @@ import dom from 'metal-dom';
 export default (target, ...elements) => {
 	return !elements.some((element) => {
 		if (typeof element === 'string') {
-			return !!dom.closest(target, element);
+			return !!target.closest(element);
 		}
 
 		return element && dom.contains(element, target);

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/utils/clickOutside.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/utils/clickOutside.es.js
@@ -12,14 +12,12 @@
  * details.
  */
 
-import dom from 'metal-dom';
-
 export default (target, ...elements) => {
 	return !elements.some((element) => {
 		if (typeof element === 'string') {
 			return !!target.closest(element);
 		}
 
-		return element && dom.contains(element, target);
+		return element && element.contains(target);
 	});
 };

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/display_settings.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/display_settings.jsp
@@ -73,7 +73,7 @@ PortletURL configurationRenderURL = (PortletURL)request.getAttribute("configurat
 	<aui:input label="exclude-assets-with-0-views" name="preferences--excludeZeroViewCount--" type="toggle-switch" value="<%= assetPublisherDisplayContext.isExcludeZeroViewCount() %>" />
 </c:if>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script>
 	var displayStyleSelect = document.getElementById(
 		'<portlet:namespace />displayStyle'
 	);
@@ -84,7 +84,7 @@ PortletURL configurationRenderURL = (PortletURL)request.getAttribute("configurat
 		var hiddenFields = document.querySelectorAll('.hidden-field');
 
 		Array.prototype.forEach.call(hiddenFields, function (field) {
-			var fieldContainer = dom.closest(field, '.form-group');
+			var fieldContainer = field.closest('.form-group');
 
 			if (fieldContainer) {
 				var fieldClassList = field.classList;

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/display_settings.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/display_settings.jsp
@@ -73,7 +73,7 @@ PortletURL configurationRenderURL = (PortletURL)request.getAttribute("configurat
 	<aui:input label="exclude-assets-with-0-views" name="preferences--excludeZeroViewCount--" type="toggle-switch" value="<%= assetPublisherDisplayContext.isExcludeZeroViewCount() %>" />
 </c:if>
 
-<aui:script>
+<aui:script sandbox="<%= true %>">
 	var displayStyleSelect = document.getElementById(
 		'<portlet:namespace />displayStyle'
 	);

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/clickOutside.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/clickOutside.es.js
@@ -17,7 +17,7 @@ import dom from 'metal-dom';
 export default (target, ...elements) => {
 	return !elements.some((element) => {
 		if (typeof element === 'string') {
-			return !!dom.closest(target, element);
+			return !!target.closest(element);
 		}
 
 		return element && dom.contains(element, target);

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/clickOutside.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/clickOutside.es.js
@@ -12,14 +12,12 @@
  * details.
  */
 
-import dom from 'metal-dom';
-
 export default (target, ...elements) => {
 	return !elements.some((element) => {
 		if (typeof element === 'string') {
 			return !!target.closest(element);
 		}
 
-		return element && dom.contains(element, target);
+		return element && element.contains(target);
 	});
 };

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withActionableFields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withActionableFields.es.js
@@ -13,7 +13,6 @@
  */
 
 import {FormSupport} from 'dynamic-data-mapping-form-renderer';
-import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 import Component from 'metal-jsx';
 import {Config} from 'metal-state';
@@ -297,7 +296,7 @@ const withActionableFields = (ChildComponent) => {
 		}
 
 		_hasLeftField(relatedTarget) {
-			return !relatedTarget.closest(
+			return !relatedTarget?.closest(
 				'.dropdown-menu,.ddm-field-actions-container'
 			);
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withActionableFields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withActionableFields.es.js
@@ -167,7 +167,7 @@ const withActionableFields = (ChildComponent) => {
 		}
 
 		_getClosestParent(node) {
-			return dom.closest(node.parentElement, `.ddm-field-container`);
+			return node.parentElement.closest('.ddm-field-container');
 		}
 
 		_getHoveredNode() {
@@ -183,8 +183,7 @@ const withActionableFields = (ChildComponent) => {
 			const {fieldName} = delegateTarget.dataset;
 			const {hoveredFieldActions, selectedFieldActions} = this.refs;
 			const activePage = parseInt(
-				dom.closest(event.delegateTarget, '[data-ddm-page]').dataset
-					.ddmPage,
+				event.delegateTarget.closest('[data-ddm-page]').dataset.ddmPage,
 				10
 			);
 			this.setState({activePage});
@@ -298,8 +297,7 @@ const withActionableFields = (ChildComponent) => {
 		}
 
 		_hasLeftField(relatedTarget) {
-			return !dom.closest(
-				relatedTarget,
+			return !relatedTarget.closest(
 				'.dropdown-menu,.ddm-field-actions-container'
 			);
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withActionableFields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withActionableFields.es.js
@@ -296,8 +296,11 @@ const withActionableFields = (ChildComponent) => {
 		}
 
 		_hasLeftField(relatedTarget) {
-			return !relatedTarget?.closest(
-				'.dropdown-menu,.ddm-field-actions-container'
+			return (
+				relatedTarget &&
+				!relatedTarget.closest(
+					'.dropdown-menu,.ddm-field-actions-container'
+				)
 			);
 		}
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withClickableFields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withClickableFields.es.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 import Component from 'metal-jsx';
 
@@ -51,7 +50,7 @@ const withClickableFields = (ChildComponent) => {
 				!event.delegateTarget.children[1].hasAttribute('aria-grabbed')
 			) {
 				activePage = parseInt(
-					dom.closest(event.delegateTarget, '[data-ddm-page]').dataset
+					event.delegateTarget.closest('[data-ddm-page]').dataset
 						.ddmPage,
 					10
 				);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMoveableFields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMoveableFields.es.js
@@ -13,7 +13,6 @@
  */
 
 import {FormSupport} from 'dynamic-data-mapping-form-renderer';
-import dom from 'metal-dom';
 import {DragDrop} from 'metal-drag-drop';
 import Component from 'metal-jsx';
 
@@ -80,7 +79,7 @@ const withMoveableFields = (ChildComponent) => {
 		}
 
 		_getClosestParent(node) {
-			return dom.closest(node.parentElement, `.ddm-field-container`);
+			return node.parentElement.closest('.ddm-field-container');
 		}
 
 		_handleDragAndDropEnd({source, target}) {
@@ -98,13 +97,10 @@ const withMoveableFields = (ChildComponent) => {
 			}
 
 			if (target) {
-				const sourceFieldNode = dom.closest(
-					source,
-					'.ddm-field-container'
-				);
+				const sourceFieldNode = source.closest('.ddm-field-container');
 
 				const sourceFieldPage = parseInt(
-					dom.closest(source, '[data-ddm-page]').dataset.ddmPage,
+					source.closest('[data-ddm-page]').dataset.ddmPage,
 					10
 				);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withResizeableColumns.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withResizeableColumns.es.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import dom from 'metal-dom';
 import {Drag} from 'metal-drag-drop';
 import Component from 'metal-jsx';
 
@@ -85,7 +84,7 @@ const withResizeableColumns = (ChildComponent) => {
 			const {store} = this.context;
 
 			if (!this._currentRow) {
-				this._currentRow = dom.closest(source, '.row');
+				this._currentRow = source.closest('.row');
 			}
 
 			const container = this._currentRow.querySelector(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleEditor/RuleEditor.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleEditor/RuleEditor.es.js
@@ -24,7 +24,6 @@ import 'dynamic-data-mapping-form-renderer/js/components/Field/ReactFieldAdapter
 import {PagesVisitor} from 'dynamic-data-mapping-form-renderer';
 import {makeFetch} from 'dynamic-data-mapping-form-renderer/js/util/fetch.es';
 import Component from 'metal-component';
-import dom from 'metal-dom';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';
 
@@ -660,7 +659,7 @@ class RuleEditor extends Component {
 	}
 
 	_getIndex(fieldInstance, fieldClass) {
-		const firstOperand = dom.closest(fieldInstance.element, fieldClass);
+		const firstOperand = fieldInstance.element.closest(fieldClass);
 
 		return firstOperand.getAttribute(`${fieldClass.substring(1)}-index`);
 	}
@@ -1044,7 +1043,7 @@ class RuleEditor extends Component {
 
 		let index;
 
-		if (dom.closest(fieldInstance.element, '.condition-type-value')) {
+		if (fieldInstance.element.closest('.condition-type-value')) {
 			index = this._getIndex(fieldInstance, '.condition-type-value');
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleList/RuleList.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleList/RuleList.es.js
@@ -286,7 +286,7 @@ class RuleList extends Component {
 	}
 
 	_handleDocumentMouseUp({target}) {
-		const dropdownSettings = dom.closest(target, '.ddm-rule-list-settings');
+		const dropdownSettings = target.closest('.ddm-rule-list-settings');
 
 		if (dropdownSettings) {
 			return;
@@ -301,7 +301,7 @@ class RuleList extends Component {
 		event.preventDefault();
 
 		const {dropdownExpandedIndex} = this;
-		const ruleNode = dom.closest(event.delegateTarget, '.component-action');
+		const ruleNode = event.delegateTarget.closest('.component-action');
 
 		let ruleIndex = parseInt(ruleNode.dataset.ruleIndex, 10);
 
@@ -315,7 +315,7 @@ class RuleList extends Component {
 	}
 
 	_handleRuleCardClicked({data, target}) {
-		const cardElement = dom.closest(target.element, '[data-card-id]');
+		const cardElement = target.element.closest('[data-card-id]');
 		const cardId = parseInt(cardElement.getAttribute('data-card-id'), 10);
 
 		if (data.item.settingsItem == 'edit') {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
@@ -614,7 +614,7 @@ class Sidebar extends Component {
 				indexes,
 			};
 
-			if (data.target.closest(data.target, '.col-empty')) {
+			if (data.target && data.target.closest('.col-empty')) {
 				const addedToPlaceholder = data.target.closest('.placeholder');
 
 				dispatch('fieldAdded', {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
@@ -614,7 +614,7 @@ class Sidebar extends Component {
 				indexes,
 			};
 
-			if (data.target.closest(data.target, '.col-empty')) {
+			if (data.target?.closest(data.target, '.col-empty')) {
 				const addedToPlaceholder = data.target.closest('.placeholder');
 
 				dispatch('fieldAdded', {
@@ -773,7 +773,7 @@ class Sidebar extends Component {
 	}
 
 	_isControlProductMenuItem(node) {
-		return !!node.closest('.sidenav-toggler');
+		return !!node?.closest('.sidenav-toggler');
 	}
 
 	_isEditMode() {
@@ -783,15 +783,15 @@ class Sidebar extends Component {
 	}
 
 	_isModalElement(node) {
-		return node.closest('.modal');
+		return node?.closest('.modal');
 	}
 
 	_isProductMenuSidebarItem(node) {
-		return !!node.closest('.sidenav-menu');
+		return !!node?.closest('.sidenav-menu');
 	}
 
 	_isOutsideModal(node) {
-		return !node.closest('.close-modal');
+		return !node?.closest('.close-modal');
 	}
 
 	_isSettingsElement(target) {
@@ -810,9 +810,9 @@ class Sidebar extends Component {
 
 	_isSidebarElement(node) {
 		const {element} = this;
-		const alloyEditorToolbarNode = node.closest('.ae-ui');
-		const fieldColumnNode = node.closest('.col-ddm');
-		const fieldTypesDropdownNode = node.closest('.dropdown-menu');
+		const alloyEditorToolbarNode = node?.closest('.ae-ui');
+		const fieldColumnNode = node?.closest('.col-ddm');
+		const fieldTypesDropdownNode = node?.closest('.dropdown-menu');
 
 		return (
 			alloyEditorToolbarNode ||
@@ -824,7 +824,7 @@ class Sidebar extends Component {
 	}
 
 	_isTranslationItem(node) {
-		return !!node.closest('.lfr-translationmanager');
+		return !!node?.closest('.lfr-translationmanager');
 	}
 
 	_mergeFieldTypeSettings(oldSettingsContext, newSettingsContext) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
@@ -614,7 +614,7 @@ class Sidebar extends Component {
 				indexes,
 			};
 
-			if (data.target?.closest(data.target, '.col-empty')) {
+			if (data.target.closest(data.target, '.col-empty')) {
 				const addedToPlaceholder = data.target.closest('.placeholder');
 
 				dispatch('fieldAdded', {
@@ -773,7 +773,7 @@ class Sidebar extends Component {
 	}
 
 	_isControlProductMenuItem(node) {
-		return !!node?.closest('.sidenav-toggler');
+		return node && !!node.closest('.sidenav-toggler');
 	}
 
 	_isEditMode() {
@@ -783,15 +783,15 @@ class Sidebar extends Component {
 	}
 
 	_isModalElement(node) {
-		return node?.closest('.modal');
+		return node && node.closest('.modal');
 	}
 
 	_isProductMenuSidebarItem(node) {
-		return !!node?.closest('.sidenav-menu');
+		return node && !!node.closest('.sidenav-menu');
 	}
 
 	_isOutsideModal(node) {
-		return !node?.closest('.close-modal');
+		return node && !node.closest('.close-modal');
 	}
 
 	_isSettingsElement(target) {
@@ -810,9 +810,11 @@ class Sidebar extends Component {
 
 	_isSidebarElement(node) {
 		const {element} = this;
-		const alloyEditorToolbarNode = node?.closest('.ae-ui');
-		const fieldColumnNode = node?.closest('.col-ddm');
-		const fieldTypesDropdownNode = node?.closest('.dropdown-menu');
+		const alloyEditorToolbarNode = node ? node.closest('.ae-ui') : null;
+		const fieldColumnNode = node ? node.closest('.col-ddm') : null;
+		const fieldTypesDropdownNode = node
+			? node.closest('.dropdown-menu')
+			: null;
 
 		return (
 			alloyEditorToolbarNode ||
@@ -824,7 +826,7 @@ class Sidebar extends Component {
 	}
 
 	_isTranslationItem(node) {
-		return !!node?.closest('.lfr-translationmanager');
+		return node && !!node.closest('.lfr-translationmanager');
 	}
 
 	_mergeFieldTypeSettings(oldSettingsContext, newSettingsContext) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
@@ -575,7 +575,7 @@ class Sidebar extends Component {
 
 		const {fieldTypes} = this.props;
 		const {fieldSetId} = data.source.dataset;
-		const columnNode = dom.closest(data.target, '.col-ddm');
+		const columnNode = data.target.closest('.col-ddm');
 		const indexes = FormSupport.getIndexes(columnNode);
 
 		if (fieldSetId) {
@@ -593,8 +593,7 @@ class Sidebar extends Component {
 				return name === data.source.dataset.fieldTypeName;
 			});
 			let parentFieldName;
-			const parentFieldNode = dom.closest(
-				data.target.parentElement,
+			const parentFieldNode = data.target.parentElement.closest(
 				'.ddm-field'
 			);
 
@@ -615,11 +614,8 @@ class Sidebar extends Component {
 				indexes,
 			};
 
-			if (dom.closest(data.target, '.col-empty')) {
-				const addedToPlaceholder = dom.closest(
-					data.target,
-					'.placeholder'
-				);
+			if (data.target.closest(data.target, '.col-empty')) {
+				const addedToPlaceholder = data.target.closest('.placeholder');
 
 				dispatch('fieldAdded', {
 					...payload,
@@ -639,9 +635,8 @@ class Sidebar extends Component {
 	}
 
 	_handleDragTargetEnter({target}) {
-		const parentFieldNode = dom.closest(
-			target.parentElement,
-			`.ddm-field-container`
+		const parentFieldNode = target.parentElement.closest(
+			'.ddm-field-container'
 		);
 
 		if (parentFieldNode) {
@@ -650,9 +645,8 @@ class Sidebar extends Component {
 	}
 
 	_handleDragTargetLeave({target}) {
-		const parentFieldNode = dom.closest(
-			target.parentElement,
-			`.ddm-field-container`
+		const parentFieldNode = target.parentElement.closest(
+			'.ddm-field-container'
 		);
 
 		if (parentFieldNode) {
@@ -763,7 +757,7 @@ class Sidebar extends Component {
 		const {target} = event;
 		const {
 			dataset: {index},
-		} = dom.closest(target, '.nav-item');
+		} = target.closest('.nav-item');
 
 		event.preventDefault();
 
@@ -779,7 +773,7 @@ class Sidebar extends Component {
 	}
 
 	_isControlProductMenuItem(node) {
-		return !!dom.closest(node, '.sidenav-toggler');
+		return !!node.closest('.sidenav-toggler');
 	}
 
 	_isEditMode() {
@@ -789,15 +783,15 @@ class Sidebar extends Component {
 	}
 
 	_isModalElement(node) {
-		return dom.closest(node, '.modal');
+		return node.closest('.modal');
 	}
 
 	_isProductMenuSidebarItem(node) {
-		return !!dom.closest(node, '.sidenav-menu');
+		return !!node.closest('.sidenav-menu');
 	}
 
 	_isOutsideModal(node) {
-		return !dom.closest(node, '.close-modal');
+		return !node.closest('.close-modal');
 	}
 
 	_isSettingsElement(target) {
@@ -816,9 +810,9 @@ class Sidebar extends Component {
 
 	_isSidebarElement(node) {
 		const {element} = this;
-		const alloyEditorToolbarNode = dom.closest(node, '.ae-ui');
-		const fieldColumnNode = dom.closest(node, '.col-ddm');
-		const fieldTypesDropdownNode = dom.closest(node, '.dropdown-menu');
+		const alloyEditorToolbarNode = node.closest('.ae-ui');
+		const fieldColumnNode = node.closest('.col-ddm');
+		const fieldTypesDropdownNode = node.closest('.dropdown-menu');
 
 		return (
 			alloyEditorToolbarNode ||
@@ -830,7 +824,7 @@ class Sidebar extends Component {
 	}
 
 	_isTranslationItem(node) {
-		return !!dom.closest(node, '.lfr-translationmanager');
+		return !!node.closest('.lfr-translationmanager');
 	}
 
 	_mergeFieldTypeSettings(oldSettingsContext, newSettingsContext) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/util/dragAndDrop.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/util/dragAndDrop.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import dom from 'metal-dom';
-
 import {getField, isFieldSet, isFieldSetChild} from './fieldSupport.es';
 
 export const disableFieldDropTargets = (element) => {
@@ -22,7 +20,7 @@ export const disableFieldDropTargets = (element) => {
 	for (let i = 0; i < dropTargets.length; i++) {
 		const target = dropTargets[i];
 
-		const parentFieldNode = dom.closest(target, '.ddm-field-container');
+		const parentFieldNode = target.closest('.ddm-field-container');
 
 		if (parentFieldNode) {
 			target.setAttribute('data-drop-disabled', true);
@@ -50,7 +48,7 @@ export const disableFieldSetDropTargets = (element, pages) => {
 	for (let i = 0; i < dropTargets.length; i++) {
 		const target = dropTargets[i];
 
-		const parentFieldNode = dom.closest(target, '.ddm-field-container');
+		const parentFieldNode = target.closest('.ddm-field-container');
 
 		if (parentFieldNode) {
 			const {fieldName} = parentFieldNode.dataset;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/formId.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/formId.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import dom from 'metal-dom';
-
-export const getFormNode = (element) => dom.closest(element, 'form');
+export const getFormNode = (element) => element.closest('form');
 
 export const getFormId = (form) => form?.dataset.ddmforminstanceid;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
@@ -83,7 +83,7 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 		'click',
 		'li',
 		function (event) {
-			var navItem = dom.closest(event.delegateTarget, '.nav-item');
+			var navItem = event.delegateTarget.closest('.nav-item');
 			var navItemIndex = Number(navItem.dataset.navItemIndex);
 			var navLink = navItem.querySelector('.nav-link');
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -726,7 +726,7 @@ class Form extends Component {
 
 	_handleFormNavClicked(event) {
 		const {delegateTarget} = event;
-		const navItem = dom.closest(delegateTarget, '.nav-item');
+		const navItem = delegateTarget.closest('.nav-item');
 		const navItemIndex = Number(navItem.dataset.navItemIndex);
 		const navLink = navItem.querySelector('.nav-link');
 

--- a/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/resources/META-INF/resources/index.js
@@ -25,7 +25,7 @@ export default () => {
 			(event) => {
 				event.preventDefault();
 
-				const container = dom.closest(event.delegateTarget, '.alert');
+				const container = event.delegateTarget.closest('.alert');
 
 				if (container) {
 					container.parentNode.removeChild(container);

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
@@ -154,7 +154,7 @@ class LiferayApp extends App {
 
 			return Array.prototype.slice
 				.call(portlets)
-				.some((portlet) => dom.contains(portlet, element));
+				.some((portlet) => portlet.contains(element));
 		});
 	}
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
@@ -15,7 +15,6 @@
 'use strict';
 
 import {async} from 'metal';
-import {match} from 'metal-dom';
 
 import globals from '../senna/globals/globals';
 import {utils, version} from '../senna/senna';
@@ -94,7 +93,7 @@ const initSPA = function () {
 			const url = formElement.action;
 
 			if (
-				match(formElement, formSelector) &&
+				formElement.matches(formSelector) &&
 				app.canNavigate(url) &&
 				formElement.method !== 'get' &&
 				!app.isInPortletBlacklist(formElement)
@@ -106,19 +105,17 @@ const initSPA = function () {
 				const buttonSelector =
 					'button:not([type]),button[type=submit],input[type=submit]';
 
-				if (match(globals.document.activeElement, buttonSelector)) {
+				if (globals.document.activeElement.matches(buttonSelector)) {
 					globals.capturedFormButtonElement =
 						globals.document.activeElement;
-				}
-				else {
+				} else {
 					globals.capturedFormButtonElement = formElement.querySelector(
 						buttonSelector
 					);
 				}
 
 				app.navigate(utils.getUrlPath(url));
-			}
-			else {
+			} else {
 				formElement.submit();
 			}
 		});
@@ -140,8 +137,7 @@ export default {
 			globals.document.addEventListener('DOMContentLoaded', () => {
 				callback.call(this, initSPA());
 			});
-		}
-		else {
+		} else {
 			callback.call(this, initSPA());
 		}
 	},

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
@@ -108,14 +108,16 @@ const initSPA = function () {
 				if (globals.document.activeElement.matches(buttonSelector)) {
 					globals.capturedFormButtonElement =
 						globals.document.activeElement;
-				} else {
+				}
+				else {
 					globals.capturedFormButtonElement = formElement.querySelector(
 						buttonSelector
 					);
 				}
 
 				app.navigate(utils.getUrlPath(url));
-			} else {
+			}
+			else {
 				formElement.submit();
 			}
 		});
@@ -137,7 +139,8 @@ export default {
 			globals.document.addEventListener('DOMContentLoaded', () => {
 				callback.call(this, initSPA());
 			});
-		} else {
+		}
+		else {
 			callback.call(this, initSPA());
 		}
 	},

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
@@ -14,7 +14,6 @@
 
 import ClayPopover from '@clayui/popover';
 import {useEventListener} from 'frontend-js-react-web';
-import {match} from 'metal-dom';
 import {Align} from 'metal-position';
 import React, {
 	useCallback,
@@ -76,7 +75,7 @@ const DisabledArea = () => {
 				!hasAbsolutePosition &&
 				!DEFAULT_WHITELIST.some(
 					(selector) =>
-						match(element, selector) ||
+						element.matches(selector) ||
 						element.querySelector(selector)
 				)
 			);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Layout.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Layout.js
@@ -15,7 +15,6 @@
 import ClayAlert from '@clayui/alert';
 import classNames from 'classnames';
 import {useIsMounted} from 'frontend-js-react-web';
-import {closest} from 'metal-dom';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef} from 'react';
 
@@ -75,7 +74,7 @@ export default function Layout({mainItemId}) {
 		const layout = layoutRef.current;
 
 		const preventLinkClick = (event) => {
-			const closestElement = closest(event.target, '[href]');
+			const closestElement = event.target.closest('[href]');
 
 			if (
 				closestElement &&

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MasterLayout.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MasterLayout.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import {closest} from 'metal-dom';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useRef} from 'react';
 
@@ -119,11 +118,11 @@ function Fragment({item}) {
 		const handler = (event) => {
 			const element = event.target;
 
-			if (closest(element, '[href]')) {
+			if (element.closest('[href]')) {
 				event.preventDefault();
 			}
 
-			if (!closest(event.target, '.page-editor')) {
+			if (!event.target.closest('.page-editor')) {
 				selectItem(null);
 			}
 		};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import {closest} from 'metal-dom';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {
@@ -41,13 +40,13 @@ const ctrlOrMeta = (event) =>
 	(event.ctrlKey && !event.metaKey) || (!event.ctrlKey && event.metaKey);
 
 const isEditableField = (element) =>
-	!!closest(element, '.page-editor__editable');
+	!!element.closest('.page-editor__editable');
 
 const isInteractiveElement = (element) => {
 	return (
 		['INPUT', 'OPTION', 'SELECT', 'TEXTAREA'].includes(element.tagName) ||
-		!!closest(element, '.cke_editable') ||
-		!!closest(element, '.alloy-editor-container')
+		!!element.closest('.cke_editable') ||
+		!!element.closest('.alloy-editor-container')
 	);
 };
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/getEditableElement.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/getEditableElement.js
@@ -12,17 +12,15 @@
  * details.
  */
 
-import {closest} from 'metal-dom';
-
 export function getEditableElement(target) {
-	let editableElement = closest(target, 'lfr-editable');
+	let editableElement = target.closest('lfr-editable');
 
 	if (!editableElement) {
-		editableElement = closest(target, '[data-lfr-editable-id]');
+		editableElement = target.closest('[data-lfr-editable-id]');
 	}
 
 	if (!editableElement) {
-		editableElement = closest(target, '[data-lfr-background-image-id]');
+		editableElement = target.closest('[data-lfr-background-image-id]');
 	}
 
 	return editableElement;

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
@@ -119,7 +119,7 @@ Hits hits = searchDisplayContext.getHits();
 			if (!target.classList.contains('active')) {
 				target.classList.add('active');
 
-				var searchFacet = dom.closest(target, '.search-facet');
+				var searchFacet = target.closest('.search-facet');
 
 				var facetValueSiblings = Array.prototype.filter.call(
 					target.parentNode.children,

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTreeEventHandler.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTreeEventHandler.es.js
@@ -13,7 +13,6 @@
  */
 
 import Component from 'metal-component';
-import dom from 'metal-dom';
 
 class PagesTreeEventHandler extends Component {
 	attached() {
@@ -25,9 +24,9 @@ class PagesTreeEventHandler extends Component {
 	}
 
 	_handleDropdownOpened({menu, trigger}) {
-		if (dom.closest(menu, '.pages-tree-dropdown')) {
+		if (menu.closest('.pages-tree-dropdown')) {
 			const handler = (event) => {
-				if (!dom.closest(event.target, '.pages-tree-dropdown')) {
+				if (!event.target.closest('.pages-tree-dropdown')) {
 					Liferay.DropdownProvider.hide({menu, trigger});
 
 					window.removeEventListener('click', handler);

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -177,7 +177,7 @@ request.setAttribute("view.jsp-eventName", eventName);
 	);
 
 	dom.delegate(document, 'click', '.assign-site-roles-link', function (event) {
-		var link = dom.closest(event.target, '.assign-site-roles-link');
+		var link = event.target.closest('.assign-site-roles-link');
 
 		var itemSelectorURL = link.dataset.itemselectorurl;
 		var segmentsEntryId = link.dataset.segmentsentryid;

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/js/ManageCollaborators.es.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/js/ManageCollaborators.es.js
@@ -22,7 +22,6 @@ import ClaySticker from '@clayui/sticker';
 import classNames from 'classnames';
 import {useTimeout} from 'frontend-js-react-web';
 import {fetch, objectToFormData} from 'frontend-js-web';
-import dom from 'metal-dom';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -119,8 +118,7 @@ const ManageCollaborators = ({
 		if (
 			invalidElements.indexOf(eventTarget.nodeName.toLowerCase()) === -1
 		) {
-			const collaboratorContainer = dom.closest(
-				eventTarget,
+			const collaboratorContainer = eventTarget.closest(
 				'.list-group-item'
 			);
 

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -78,7 +78,7 @@
 		'focusin',
 		'.portlet',
 		function(event) {
-			dom.closest(event.delegateTarget, '.portlet').classList.add('open');
+			event.delegateTarget.closest('.portlet').classList.add('open');
 		}
 	);
 
@@ -87,7 +87,7 @@
 		'focusout',
 		'.portlet',
 		function(event) {
-			dom.closest(event.delegateTarget, '.portlet').classList.remove('open');
+			event.delegateTarget.closest('.portlet').classList.remove('open');
 		}
 	);
 </aui:script>


### PR DESCRIPTION
Follow up from https://github.com/liferay-frontend/liferay-portal/pull/462

These are the issues that make me long for typescript and enforcing required/optional arguments... I'm tempted to just use optional chaining everywhere we call a method on a node, but I know thats not ideal.