### PR TITLE
LPS-122492 - Replace uses of dom.triggerEvent with userEvent

### DIFF
--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/SiteNavigationMenuItemDOMHandler.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/SiteNavigationMenuItemDOMHandler.js
@@ -17,7 +17,6 @@ import {
 	closest,
 	contains,
 	hasClass,
-	next,
 	removeClasses,
 	toElement,
 } from 'metal-dom';
@@ -86,7 +85,19 @@ const getId = function (menuItem) {
  * @return {HTMLElement|null}
  */
 const getNextSibling = function (menuItem) {
-	next(menuItem, `.${MENU_ITEM_CLASSNAME}`);
+	const selector = `.${MENU_ITEM_CLASSNAME}`;
+
+	let element = menuItem;
+
+	while (element) {
+		element = element.nextSibling;
+
+		if (element && element.matches(selector)) {
+			return element;
+		}
+	}
+
+	return null;
 };
 
 /**


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122492

Replaced all uses of `triggerEvent` from metal-dom.

I noticed on some of the tests, they were being disabled via the package.json of the module. I decided to update the code but not enable to tests. I didn't want to spiral down a hole that wasn't necessary.