### PR TITLE
LPS-122492 - Replace next method from metal-dom

### DIFF
--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/SiteNavigationMenuItemDOMHandler.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/SiteNavigationMenuItemDOMHandler.js
@@ -17,7 +17,6 @@ import {
 	closest,
 	contains,
 	hasClass,
-	next,
 	removeClasses,
 	toElement,
 } from 'metal-dom';
@@ -86,7 +85,17 @@ const getId = function (menuItem) {
  * @return {HTMLElement|null}
  */
 const getNextSibling = function (menuItem) {
-	next(menuItem, `.${MENU_ITEM_CLASSNAME}`);
+	let element = menuItem;
+
+	while (element) {
+		element = element.nextSibling;
+
+		if (element && element.classList.has(MENU_ITEM_CLASSNAME)) {
+			return element;
+		}
+	}
+
+	return null;
 };
 
 /**


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122466

Few notes:
1. `next` only seems to be used once in DXP
2. The function that uses `next` doesn't even seem to be used, but I figured its best to not remove that teams code in case they intend to use it.
3. Rather than use a relatively unknown api of `TreeWalker` I decided to use a similar implementation as metal-dom since its only used this once and was only a few lines of code.

Anyone have issues with this approach?