### PR TITLE
[7.4-only] LPS-122492 - Replace uses of dom.triggerEvent with userEvent

### DIFF
--- a/modules/apps/analytics/analytics-client-js/test/plugins/blogs.js
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/blogs.js
@@ -12,8 +12,8 @@
  * details.
  */
 
+import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
-import dom from 'metal-dom';
 
 import AnalyticsClient from '../../src/analytics';
 
@@ -97,7 +97,7 @@ describe('Blogs Plugin', () => {
 
 			blogElement.appendChild(imageInsideBlog);
 
-			dom.triggerEvent(imageInsideBlog, 'click');
+			userEvent.click(imageInsideBlog);
 
 			expect(Analytics.getEvents()).toEqual([
 				expect.objectContaining({
@@ -127,7 +127,7 @@ describe('Blogs Plugin', () => {
 
 			blogElement.appendChild(linkInsideBlog);
 
-			dom.triggerEvent(linkInsideBlog, 'click');
+			userEvent.click(linkInsideBlog);
 
 			expect(Analytics.getEvents()).toEqual([
 				expect.objectContaining({
@@ -156,7 +156,7 @@ describe('Blogs Plugin', () => {
 
 			blogElement.appendChild(paragraphInsideBlog);
 
-			dom.triggerEvent(paragraphInsideBlog, 'click');
+			userEvent.click(paragraphInsideBlog);
 
 			expect(Analytics.getEvents()).toEqual([
 				expect.objectContaining({

--- a/modules/apps/analytics/analytics-client-js/test/plugins/custom.js
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/custom.js
@@ -12,8 +12,8 @@
  * details.
  */
 
+import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
-import dom from 'metal-dom';
 
 import AnalyticsClient from '../../src/analytics';
 
@@ -145,7 +145,7 @@ describe('Custom Asset Plugin', () => {
 
 			customAssetElement.appendChild(imageInsideCustomAsset);
 
-			dom.triggerEvent(imageInsideCustomAsset, 'click');
+			userEvent.click(imageInsideCustomAsset);
 
 			expect(Analytics.getEvents()).toEqual([
 				expect.objectContaining({
@@ -175,7 +175,7 @@ describe('Custom Asset Plugin', () => {
 
 			customAssetElement.appendChild(linkInsideCustomAsset);
 
-			dom.triggerEvent(linkInsideCustomAsset, 'click');
+			userEvent.click(linkInsideCustomAsset);
 
 			expect(Analytics.getEvents()).toEqual([
 				expect.objectContaining({
@@ -207,7 +207,7 @@ describe('Custom Asset Plugin', () => {
 
 			customAssetElement.appendChild(paragraphInsideCustomAsset);
 
-			dom.triggerEvent(paragraphInsideCustomAsset, 'click');
+			userEvent.click(paragraphInsideCustomAsset);
 
 			expect(Analytics.getEvents()).toEqual([
 				expect.objectContaining({
@@ -243,7 +243,7 @@ describe('Custom Asset Plugin', () => {
 
 			customAssetElement.appendChild(linkInsideCustomAsset);
 
-			dom.triggerEvent(linkInsideCustomAsset, 'click');
+			userEvent.click(linkInsideCustomAsset);
 
 			expect(Analytics.getEvents().length).toEqual(2);
 

--- a/modules/apps/analytics/analytics-client-js/test/plugins/web-content.js
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/web-content.js
@@ -12,8 +12,8 @@
  * details.
  */
 
+import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
-import dom from 'metal-dom';
 
 import AnalyticsClient from '../../src/analytics';
 
@@ -97,7 +97,7 @@ describe('WebContent Plugin', () => {
 
 			webContentElement.appendChild(imageInsideWebContent);
 
-			dom.triggerEvent(imageInsideWebContent, 'click');
+			userEvent.click(imageInsideWebContent);
 
 			expect(Analytics.getEvents()).toEqual([
 				expect.objectContaining({
@@ -127,7 +127,7 @@ describe('WebContent Plugin', () => {
 
 			webContentElement.appendChild(linkInsideWebContent);
 
-			dom.triggerEvent(linkInsideWebContent, 'click');
+			userEvent.click(linkInsideWebContent);
 
 			expect(Analytics.getEvents()).toEqual([
 				expect.objectContaining({
@@ -159,7 +159,7 @@ describe('WebContent Plugin', () => {
 
 			webContentElement.appendChild(paragraphInsideWebContent);
 
-			dom.triggerEvent(paragraphInsideWebContent, 'click');
+			userEvent.click(paragraphInsideWebContent);
 
 			expect(Analytics.getEvents()).toEqual([
 				expect.objectContaining({

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Page/PageRenderer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Page/PageRenderer.es.js
@@ -14,7 +14,7 @@
 
 import '../../__fixtures__/MockField.es';
 
-import {dom as MetalTestUtil} from 'metal-dom';
+import userEvent from '@testing-library/user-event';
 
 import PageRenderer from '../../../src/main/resources/META-INF/resources/js/components/Page/PageRenderer.es';
 import mockPages from '../../__mock__/mockPages.es';
@@ -61,10 +61,9 @@ describe('PageRenderer', () => {
 		);
 		const spy = jest.spyOn(component, 'emit');
 
-		pageTitle.value = 'Page Title';
-
 		jest.runAllTimers();
-		MetalTestUtil.triggerEvent(pageTitle, 'keyup', {});
+
+		userEvent.type(pageTitle, 'Page Title');
 
 		expect(spy).toHaveBeenCalled();
 		expect(spy).toHaveBeenCalledWith('updatePage', expect.any(Object));
@@ -82,10 +81,9 @@ describe('PageRenderer', () => {
 		);
 		const spy = jest.spyOn(component, 'emit');
 
-		pageDescription.value = 'Page Description';
-
 		jest.runAllTimers();
-		MetalTestUtil.triggerEvent(pageDescription, 'keyup', {});
+
+		userEvent.type(pageDescription, 'Page Description');
 
 		expect(spy).toHaveBeenCalled();
 		expect(spy).toHaveBeenCalledWith('updatePage', expect.any(Object));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleBuilder/RuleBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleBuilder/RuleBuilder.es.js
@@ -14,6 +14,7 @@
 
 import '../../__fixtures__/MockField.es';
 
+import userEvent from '@testing-library/user-event';
 import dom from 'metal-dom';
 
 import RuleBuilder from '../../../src/main/resources/META-INF/resources/js/components/RuleBuilder/RuleBuilder.es';
@@ -227,7 +228,7 @@ describe('RuleBuilder', () => {
 	it('renders rule screen creator when click add button', () => {
 		const addbutton = document.querySelector('#addFieldButton');
 
-		dom.triggerEvent(addbutton, 'click', {});
+		userEvent.click(addbutton);
 
 		jest.runAllTimers();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleEditor/RuleEditor.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleEditor/RuleEditor.es.js
@@ -14,7 +14,7 @@
 
 import '../../__fixtures__/MockField.es';
 
-import dom from 'metal-dom';
+import userEvent from '@testing-library/user-event';
 
 import RuleEditor from '../../../src/main/resources/META-INF/resources/js/components/RuleEditor/RuleEditor.es';
 import mockPages from '../../__mock__/mockPages.es';
@@ -1045,7 +1045,7 @@ describe('Rule Editor', () => {
 
 				jest.runAllTimers();
 
-				dom.triggerEvent(component.refs.save.element, 'click', {});
+				userEvent.click(component.refs.save.element);
 
 				jest.runAllTimers();
 
@@ -1113,7 +1113,7 @@ describe('Rule Editor', () => {
 
 				jest.runAllTimers();
 
-				dom.triggerEvent(component.refs.cancel.element, 'click', {});
+				userEvent.click(component.refs.cancel.element);
 
 				jest.runAllTimers();
 
@@ -1174,7 +1174,7 @@ describe('Rule Editor', () => {
 
 				jest.runAllTimers();
 
-				dom.triggerEvent(component.refs.save.element, 'click', {});
+				userEvent.click(component.refs.save.element);
 
 				jest.runAllTimers();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/components/Tooltip/Tooltip.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/components/Tooltip/Tooltip.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {dom as MetalTestUtil} from 'metal-dom';
+import userEvent from '@testing-library/user-event';
 
 import Tooltip from '../../../src/main/resources/META-INF/resources/components/Tooltip/Tooltip.es';
 
@@ -51,7 +51,7 @@ describe('Field Tooltip', () => {
 
 		const {tooltipTarget} = component.refs;
 
-		MetalTestUtil.triggerEvent(tooltipTarget, 'mouseover');
+		userEvent.hover(tooltipTarget);
 
 		expect(component.showContent).toBe(true);
 		expect(component).toMatchSnapshot();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/ShareFormModal/Email.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/ShareFormModal/Email.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import dom from 'metal-dom';
+import userEvent from '@testing-library/user-event';
 
 import Email from '../../../../src/main/resources/META-INF/resources/admin/js/components/ShareFormModal/Email.es';
 
@@ -74,9 +74,7 @@ describe('Email', () => {
 
 		const message = component.element.querySelector('#message');
 
-		message.value = 'New message';
-
-		dom.triggerEvent(message, 'input', {});
+		userEvent.type(message, 'New message');
 
 		jest.runAllTimers();
 
@@ -92,9 +90,7 @@ describe('Email', () => {
 
 		const subject = component.element.querySelector('#subject');
 
-		subject.value = 'New Subject';
-
-		dom.triggerEvent(subject, 'input', {});
+		userEvent.type(subject, 'New Subject');
 
 		jest.runAllTimers();
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/App.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {fireEvent} from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 import {dom, exitDocument} from 'metal-dom';
 import {EventEmitter} from 'metal-events';
 
@@ -1123,7 +1125,7 @@ describe('App', function () {
 			'syncScrollPositionSyncThenAsync_'
 		).mockImplementation(() => {});
 
-		dom.triggerEvent(enterDocumentLinkElement('/path'), 'click');
+		userEvent.click(enterDocumentLinkElement('/path'));
 		expect(this.app.pendingNavigate).toBeTruthy();
 		exitDocumentLinkElement();
 	});
@@ -1134,7 +1136,7 @@ describe('App', function () {
 		const link = enterDocumentLinkElement('/path');
 		link.setAttribute('target', '_blank');
 		link.addEventListener('click', (event) => event.preventDefault());
-		dom.triggerEvent(link, 'click');
+		userEvent.click(link);
 		exitDocumentLinkElement();
 		expect(this.app.pendingNavigate).toBeNull();
 	});
@@ -1157,7 +1159,7 @@ describe('App', function () {
 			expect(data.event).toBeTruthy();
 			expect(data.event.type).toBe('click');
 		});
-		dom.triggerEvent(enterDocumentLinkElement('/path'), 'click');
+		userEvent.click(enterDocumentLinkElement('/path'));
 		exitDocumentLinkElement();
 
 		expect(window.location.pathname).not.toBe('/path');
@@ -1170,7 +1172,7 @@ describe('App', function () {
 			data.event.preventDefault();
 			event.preventDefault();
 		});
-		dom.triggerEvent(enterDocumentLinkElement('/preventedPath'), 'click');
+		userEvent.click(enterDocumentLinkElement('/preventedPath'));
 		exitDocumentLinkElement();
 
 		expect(window.location.pathname).not.toBe('/preventedPath');
@@ -1181,7 +1183,7 @@ describe('App', function () {
 		this.app = new App();
 		this.app.setAllowPreventNavigate(false);
 		dom.on(link, 'click', preventDefault);
-		dom.triggerEvent(link, 'click');
+		userEvent.click(link);
 		expect(this.app.pendingNavigate).toBeFalsy();
 		exitDocumentLinkElement();
 	});
@@ -1192,7 +1194,7 @@ describe('App', function () {
 		this.app.setAllowPreventNavigate(false);
 		this.app.setBasePath('/base');
 		dom.on(link, 'click', preventDefault);
-		dom.triggerEvent(link, 'click');
+		userEvent.click(link);
 		expect(this.app.pendingNavigate).toBeFalsy();
 		exitDocumentLinkElement();
 	});
@@ -1202,7 +1204,7 @@ describe('App', function () {
 		this.app = new App();
 		this.app.setAllowPreventNavigate(false);
 		dom.on(link, 'click', preventDefault);
-		dom.triggerEvent(link, 'click');
+		userEvent.click(link);
 		expect(this.app.pendingNavigate).toBeFalsy();
 		exitDocumentLinkElement();
 	});
@@ -1212,22 +1214,16 @@ describe('App', function () {
 		this.app = new App();
 		this.app.setAllowPreventNavigate(false);
 		this.app.addRoutes(new Route('/path', Screen));
+
 		dom.on(link, 'click', preventDefault);
-		dom.triggerEvent(link, 'click', {
-			altKey: true,
-		});
-		dom.triggerEvent(link, 'click', {
-			ctrlKey: true,
-		});
-		dom.triggerEvent(link, 'click', {
-			metaKey: true,
-		});
-		dom.triggerEvent(link, 'click', {
-			shiftKey: true,
-		});
-		dom.triggerEvent(link, 'click', {
-			button: true,
-		});
+
+		userEvent.click(link, {altKey: false});
+		userEvent.click(link, {ctrlKey: false});
+		userEvent.click(link, {metaKey: false});
+		userEvent.click(link, {shiftKey: false});
+		userEvent.click(link, {button: 1});
+		userEvent.click(link, {button: 2});
+
 		expect(this.app.pendingNavigate).toBeFalsy();
 		exitDocumentLinkElement();
 	});
@@ -1241,7 +1237,7 @@ describe('App', function () {
 			throw new Error();
 		};
 		dom.on(link, 'click', preventDefault);
-		dom.triggerEvent(link, 'click');
+		userEvent.click(link);
 		expect(this.app.pendingNavigate).toBeFalsy();
 		exitDocumentLinkElement();
 	});
@@ -1338,7 +1334,7 @@ describe('App', function () {
 			expect(this.app.reloadPage).not.toHaveBeenCalled();
 			done();
 		});
-		dom.triggerEvent(globals.window, 'popstate');
+		fireEvent(globals.window, new PopStateEvent('popstate'));
 	});
 
 	it('does not navigate on clicking links when onbeforeunload returns truthy value', () => {
@@ -1358,7 +1354,7 @@ describe('App', function () {
 
 		this.app.addRoutes(new Route('/path', Screen));
 		const link = enterDocumentLinkElement('/path');
-		dom.triggerEvent(link, 'click');
+		userEvent.click(link);
 		exitDocumentLinkElement();
 		expect(beforeunload).toHaveBeenCalled();
 	});
@@ -1423,7 +1419,7 @@ describe('App', function () {
 
 		this.app.addRoutes(new Route('/path', Screen));
 		const form = enterDocumentFormElement('/path', 'post');
-		dom.triggerEvent(form, 'submit');
+		fireEvent.submit(form);
 		expect(this.app.pendingNavigate).toBeTruthy();
 
 		this.app.on('endNavigate', () => {
@@ -1443,7 +1439,7 @@ describe('App', function () {
 			exitDocument(form);
 			done();
 		});
-		dom.triggerEvent(form, 'submit');
+		fireEvent.submit(form);
 	});
 
 	it('does not capture form element when submit event was prevented', (done) => {
@@ -1458,7 +1454,7 @@ describe('App', function () {
 			done();
 		});
 
-		dom.triggerEvent(form, 'submit');
+		fireEvent.submit(form);
 	});
 
 	it('exposes form reference in event data when submitting routed forms', (done) => {
@@ -1470,7 +1466,7 @@ describe('App', function () {
 		this.app = new App();
 		this.app.addRoutes(new Route('/path', Screen));
 		const form = enterDocumentFormElement('/path', 'post');
-		dom.triggerEvent(form, 'submit');
+		fireEvent.submit(form);
 		this.app.on('startNavigate', (data) => {
 			expect(data.form).toBeTruthy();
 		});
@@ -1487,7 +1483,7 @@ describe('App', function () {
 		this.app.setAllowPreventNavigate(false);
 		this.app.addRoutes(new Route('/path', Screen));
 		dom.on(form, 'submit', preventDefault);
-		dom.triggerEvent(form, 'submit');
+		fireEvent.submit(form);
 		expect(this.app.pendingNavigate).toBeFalsy();
 		exitDocument(form);
 	});
@@ -1497,7 +1493,7 @@ describe('App', function () {
 		this.app = new App();
 		this.app.setAllowPreventNavigate(false);
 		dom.on(form, 'submit', preventDefault);
-		dom.triggerEvent(form, 'submit');
+		fireEvent.submit(form);
 		expect(this.app.pendingNavigate).toBeFalsy();
 		exitDocument(form);
 	});
@@ -1508,7 +1504,7 @@ describe('App', function () {
 		this.app.setAllowPreventNavigate(false);
 		this.app.setBasePath('/base');
 		dom.on(form, 'submit', preventDefault);
-		dom.triggerEvent(form, 'submit');
+		fireEvent.submit(form);
 		expect(this.app.pendingNavigate).toBeFalsy();
 		exitDocument(form);
 	});
@@ -1518,7 +1514,7 @@ describe('App', function () {
 		this.app = new App();
 		this.app.setAllowPreventNavigate(false);
 		dom.on(form, 'submit', preventDefault);
-		dom.triggerEvent(form, 'submit');
+		fireEvent.submit(form);
 		expect(this.app.pendingNavigate).toBeFalsy();
 		exitDocument(form);
 	});
@@ -1528,7 +1524,7 @@ describe('App', function () {
 		this.app = new App();
 		this.app.setAllowPreventNavigate(false);
 		dom.on(form, 'submit', preventDefault);
-		dom.triggerEvent(form, 'submit');
+		fireEvent.submit(form);
 		expect(globals.capturedFormElement).toBeFalsy();
 		exitDocument(form);
 	});
@@ -1557,7 +1553,7 @@ describe('App', function () {
 			done();
 		});
 		dom.on(form, 'submit', jest.fn());
-		dom.triggerEvent(form, 'submit');
+		fireEvent.submit(form);
 	});
 
 	it('captures form button when submitting', (done) => {
@@ -1587,7 +1583,7 @@ describe('App', function () {
 			done();
 		});
 
-		dom.triggerEvent(form, 'submit');
+		fireEvent.submit(form);
 	});
 
 	it('captures form button when clicking submit button', () => {
@@ -1913,7 +1909,7 @@ describe('App', function () {
 
 		class TestScreen extends Screen {
 			evaluateStyles(surfaces) {
-				dom.triggerEvent(enterDocumentLinkElement('/path2'), 'click');
+				userEvent.click(enterDocumentLinkElement('/path2'));
 				exitDocumentLinkElement();
 
 				return super.evaluateStyles(surfaces);
@@ -1928,7 +1924,7 @@ describe('App', function () {
 
 		class TestScreen2 extends Screen {
 			evaluateStyles(surfaces) {
-				dom.triggerEvent(enterDocumentLinkElement('/path3'), 'click');
+				userEvent.click(enterDocumentLinkElement('/path3'));
 				exitDocumentLinkElement();
 
 				return super.evaluateStyles(surfaces);
@@ -1961,7 +1957,7 @@ describe('App', function () {
 
 		class TestScreen extends Screen {
 			load(path) {
-				dom.triggerEvent(enterDocumentLinkElement('/path2'), 'click');
+				userEvent.click(enterDocumentLinkElement('/path2'));
 				exitDocumentLinkElement();
 
 				return super.load(path);
@@ -1970,7 +1966,7 @@ describe('App', function () {
 
 		class TestScreen2 extends Screen {
 			load(path) {
-				dom.triggerEvent(enterDocumentLinkElement('/path3'), 'click');
+				userEvent.click(enterDocumentLinkElement('/path3'));
 				exitDocumentLinkElement();
 
 				return super.load(path);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122492

Replaced all uses of `triggerEvent` from metal-dom.

I noticed on some of the tests, they were being disabled via the package.json of the module. I decided to update the code but not enable to tests. I didn't want to spiral down a hole that wasn't necessary.