### PR TITLE
LRQA-58542 Fix name property testray.component.name to testray.component.names

### DIFF
--- a/modules/apps/asset/test.properties
+++ b/modules/apps/asset/test.properties
@@ -28,8 +28,8 @@
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (portal.acceptance == true) AND \
         (\
-            (testray.component.name ~ "Asset Lists") OR \
-            (testray.component.name ~ "Categories") OR \
+            (testray.component.names ~ "Asset Lists") OR \
+            (testray.component.names ~ "Categories") OR \
             (testray.main.component.name ~ "Asset Lists") OR \
             (testray.main.component.name ~ "Asset Publisher") OR \
             (testray.main.component.name ~ "Auto Tagging") OR \

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-test/src/testFunctional/OneDrive.testcase
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-test/src/testFunctional/OneDrive.testcase
@@ -5,7 +5,7 @@ definition {
 	property portal.upstream = "true";
 	property test.run.environment = "EE";
 	property testray.main.component.name = "Online Editing";
-	property testray.component.name = "OneDrive";
+	property testray.component.names = "OneDrive";
 	var pageName = "Documents and Media Page";
 	var portletName = "Documents and Media";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsUI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsUI.testcase
@@ -4,7 +4,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Fragments";
-	property testray.component.name = "Theme";
+	property testray.component.names = "Theme";
 
 	setUp {
 		task ("Set up instance and sign in") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/contentpage/ContentPagesWithFragmentConfiguration.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/contentpage/ContentPagesWithFragmentConfiguration.testcase
@@ -4,7 +4,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Fragments";
-	property testray.component.name = "Theme";
+	property testray.component.names = "Theme";
 
 	setUp {
 		TestCase.setUpPortalInstance();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPageTemplatesWithFragmentConfiguration.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPageTemplatesWithFragmentConfiguration.testcase
@@ -4,7 +4,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Fragments";
-	property testray.component.name = "Theme";
+	property testray.component.names = "Theme";
 
 	setUp {
 		TestCase.setUpPortalInstance();

--- a/test.properties
+++ b/test.properties
@@ -3615,7 +3615,7 @@
         unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][onedrive]=\
-        (testray.component.name ~ "OneDrive")
+        (testray.component.names ~ "OneDrive")
 
     #
     # Online Editing


### PR DESCRIPTION
Please backport to 7.3.x

**JIRA Ticket**: 
https://issues.liferay.com/browse/LRQA-58542  
**Description**: 
Fix poshi properties name typos from testray.component.name to testray.component.names in 6 files