### PR TITLE
[7.4 only] LPS-122468 - Remove {toElement} usages of metal-dom

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
@@ -14,9 +14,16 @@
 
 import core from 'metal';
 import Component from 'metal-component';
-import dom from 'metal-dom';
 
 import objectToFormData from './util/form/object_to_form_data.es';
+
+function toElementHelper(elementOrSelector) {
+	if (typeof elementOrSelector === 'string') {
+		elementOrSelector = document.querySelector(elementOrSelector);
+	}
+
+	return elementOrSelector;
+}
 
 /**
  * Provides helper functions that simplify querying the DOM for elements related
@@ -40,7 +47,7 @@ class PortletBase extends Component {
 	 *         tree order.
 	 */
 	all(selectors, root) {
-		root = dom.toElement(root) || this.rootNode || document;
+		root = toElementHelper(root) || this.rootNode || document;
 
 		return root.querySelectorAll(
 			this.namespaceSelectors_(
@@ -133,7 +140,7 @@ class PortletBase extends Component {
 	 *         or <code>null</code>.
 	 */
 	one(selectors, root) {
-		root = dom.toElement(root) || this.rootNode || document;
+		root = toElementHelper(root) || this.rootNode || document;
 
 		return root.querySelector(
 			this.namespaceSelectors_(
@@ -151,8 +158,8 @@ class PortletBase extends Component {
 	 * @return {Element} The portlet's default root node element.
 	 */
 	rootNodeValueFn_() {
-		return dom.toElement(
-			`#p_p_id${this.portletNamespace || this.namespace}`
+		return document.getElementById(
+			`p_p_id${this.portletNamespace || this.namespace}`
 		);
 	}
 }
@@ -197,7 +204,7 @@ PortletBase.STATE = {
 	 * @type {Element}
 	 */
 	rootNode: {
-		setter: dom.toElement,
+		setter: toElementHelper,
 		valueFn: 'rootNodeValueFn_',
 	},
 };

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/form/post_form.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/form/post_form.es.js
@@ -13,7 +13,6 @@
  */
 
 import {isDef, isObject, isString} from 'metal';
-import dom from 'metal-dom';
 
 import setFormValues from './set_form_values.es';
 
@@ -28,7 +27,9 @@ import setFormValues from './set_form_values.es';
  */
 
 export default function postForm(form, options) {
-	form = dom.toElement(form);
+	if (typeof form === 'string') {
+		form = document.querySelector(form);
+	}
 
 	if (form && form.nodeName === 'FORM') {
 		form.setAttribute('method', 'post');

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/form_navigator/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/form_navigator/page.jsp
@@ -72,7 +72,7 @@ String tabs1Param = randomNamespace + "tabs1";
 </c:if>
 
 <aui:script require="metal-dom/src/dom as dom">
-	var redirectField = dom.toElement(
+	var redirectField = document.querySelector(
 		'input[name="<portlet:namespace />redirect"]'
 	);
 	var tabs1Param = '<portlet:namespace /><%= tabs1Param %>';

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/form_navigator_steps/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/form_navigator_steps/page.jsp
@@ -90,7 +90,7 @@ for (int i = 0; i < categoryKeys.length; i++) {
 <aui:script require="metal-dom/src/dom">
 	var dom = metalDomSrcDom.default;
 
-	var redirectField = dom.toElement(
+	var redirectField = document.querySelector(
 		'input[name="<portlet:namespace />redirect"]'
 	);
 	var tabs1Param = '<portlet:namespace /><%= tabs1Param %>';

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsSearch.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsSearch.es.js
@@ -13,7 +13,6 @@
  */
 
 import {isInputNode} from 'map-common/js/validators.es';
-import {toElement} from 'metal-dom';
 import State, {Config} from 'metal-state';
 
 /**
@@ -29,7 +28,7 @@ class GoogleMapsSearch extends State {
 	 */
 	constructor(...args) {
 		super(...args);
-		const inputNode = toElement(this.inputNode);
+		const inputNode = this.inputNode;
 		this._handlePlaceChanged = this._handlePlaceChanged.bind(this);
 
 		this._autocomplete = new google.maps.places.Autocomplete(inputNode);

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js
@@ -13,7 +13,6 @@
  */
 
 import MapBase from 'map-common/js/MapBase.es';
-import {toElement} from 'metal-dom';
 
 import GoogleMapsDialog from './GoogleMapsDialog.es';
 import GoogleMapsGeoJSON from './GoogleMapsGeoJSON.es';
@@ -50,7 +49,7 @@ class MapGoogleMaps extends MapBase {
 		};
 
 		const map = new google.maps.Map(
-			toElement(this.boundingBox),
+			document.querySelector(this.boundingBox),
 			Object.assign(mapConfig, controlsConfig)
 		);
 
@@ -78,7 +77,11 @@ class MapGoogleMaps extends MapBase {
 	 */
 	addControl(control, position) {
 		if (this._map.controls[position]) {
-			this._map.controls[position].push(toElement(control));
+			if (typeof control === 'string') {
+				control = document.querySelector(control);
+			}
+
+			this._map.controls[position].push(control);
 		}
 	}
 

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js
@@ -13,7 +13,6 @@
  */
 
 import MapBase from 'map-common/js/MapBase.es';
-import {toElement} from 'metal-dom';
 import {Config} from 'metal-state';
 
 import OpenStreetMapDialog from './OpenStreetMapDialog.es';
@@ -50,7 +49,7 @@ class MapOpenStreetMap extends MapBase {
 		};
 
 		const map = L.map(
-			toElement(this.boundingBox),
+			document.querySelector(this.boundingBox),
 			Object.assign(mapConfig, controlsConfig)
 		);
 
@@ -79,7 +78,11 @@ class MapOpenStreetMap extends MapBase {
 	addControl(control, position) {
 		const LeafLetControl = L.Control.extend({
 			onAdd() {
-				return toElement(control);
+				if (typeof control === 'string') {
+					control = document.querySelector(control);
+				}
+
+				return control;
 			},
 
 			options: {

--- a/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/resources/META-INF/resources/router/SoyPortletRouter.js
+++ b/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/resources/META-INF/resources/router/SoyPortletRouter.js
@@ -13,7 +13,6 @@
  */
 
 import {openToast} from 'frontend-js-web';
-import dom from 'metal-dom';
 import {toRegex} from 'metal-path-parser';
 import Router from 'metal-router';
 import State from 'metal-state';
@@ -580,7 +579,7 @@ SoyPortletRouter.STATE = {
 	 * @type {string}
 	 */
 	element: {
-		setter: dom.toElement,
+		setter: (val) => document.querySelector(val),
 	},
 
 	/**
@@ -631,7 +630,7 @@ SoyPortletRouter.STATE = {
 	 * @type {string}
 	 */
 	portletWrapper: {
-		setter: dom.toElement,
+		setter: (val) => document.querySelector(val),
 	},
 };
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/UserNameFields.es.js
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/UserNameFields.es.js
@@ -254,7 +254,9 @@ UserNameFields.STATE = {
 	 * @memberof UserNameFields
 	 * @type {String}
 	 */
-	formNode: Config.required().setter(dom.toElement).writeOnce(),
+	formNode: Config.required()
+		.setter((selector) => document.querySelector(selector))
+		.writeOnce(),
 
 	/**
 	 * Language id select field.
@@ -262,7 +264,9 @@ UserNameFields.STATE = {
 	 * @memberof UserNameFields
 	 * @type {String}
 	 */
-	languageIdSelectNode: Config.required().setter(dom.toElement).writeOnce(),
+	languageIdSelectNode: Config.required()
+		.setter((selector) => document.querySelector(selector))
+		.writeOnce(),
 
 	/**
 	 * HTML element containing the user name fields.
@@ -270,7 +274,9 @@ UserNameFields.STATE = {
 	 * @memberof UserNameFields
 	 * @type {String}
 	 */
-	userNameFieldsNode: Config.required().setter(dom.toElement).writeOnce(),
+	userNameFieldsNode: Config.required()
+		.setter((selector) => document.querySelector(selector))
+		.writeOnce(),
 };
 
 export default UserNameFields;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122468

I had to check whether the argument was a string or element in a few places, but overall I think this change is pretty straight forward. Some of the metal-soy setters were a little odd since they, but I think they should be good to go.