### PR TITLE
[Please BACKPORT to 7.3.x]LPS-123143 - Fix input localized text

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_sidebar.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_sidebar.scss
@@ -72,6 +72,10 @@
 			height: 2rem;
 			padding: 0.1875rem 0;
 			width: 2rem;
+
+			&.input-localized-trigger {
+				padding: 0;
+			}
 		}
 	}
 

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_app_components.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_app_components.scss
@@ -96,7 +96,6 @@
 
 		> span {
 			display: inherit;
-			height: inherit;
 			line-height: inherit;
 			width: inherit;
 		}


### PR DESCRIPTION
This PR fixes the input localized text:

![image](https://user-images.githubusercontent.com/7963804/98238739-24894300-1f67-11eb-9681-be9a6a3aa343.png)

There is a particularity in sidebar (only for localized buttons) so that's fixed in `sidebar.scss`:

The result:

![image](https://user-images.githubusercontent.com/7963804/98238906-64e8c100-1f67-11eb-8802-087465478609.png)

---

How to test it:

1º Deploy admin theme
2º Create a widget page or admin one
or
3º Create a webcontent