### PR TITLE
LPS-101658 [Bug] Button "View Data in Analytics Cloud" is not always shown

### DIFF
--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/display/context/SegmentsExperimentDisplayContext.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/display/context/SegmentsExperimentDisplayContext.java
@@ -147,9 +147,6 @@ public class SegmentsExperimentDisplayContext {
 		).put(
 			"selectedSegmentsExperienceId", _getSelectedSegmentsExperienceId()
 		).put(
-			"viewSegmentsExperimentDetailsURL",
-			_getViewSegmentsExperimentDetailsURL()
-		).put(
 			"winnerSegmentsVariantId", _getWinnerSegmentsExperienceId()
 		).build();
 	}
@@ -492,26 +489,6 @@ public class SegmentsExperimentDisplayContext {
 		);
 
 		return _segmentsExperienceId;
-	}
-
-	private String _getViewSegmentsExperimentDetailsURL()
-		throws PortalException {
-
-		SegmentsExperiment segmentsExperiment = _getSegmentsExperiment();
-
-		if (segmentsExperiment == null) {
-			return StringPool.BLANK;
-		}
-
-		String liferayAnalyticsURL = getLiferayAnalyticsURL(
-			segmentsExperiment.getCompanyId());
-
-		if (Validator.isNull(liferayAnalyticsURL)) {
-			return StringPool.BLANK;
-		}
-
-		return liferayAnalyticsURL + "/tests/overview/" +
-			segmentsExperiment.getSegmentsExperimentKey();
 	}
 
 	private String _getWinnerSegmentsExperienceId() {

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/util/SegmentsExperimentUtil.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/util/SegmentsExperimentUtil.java
@@ -128,6 +128,9 @@ public class SegmentsExperimentUtil {
 			String.valueOf(segmentsExperiment.getSegmentsExperimentId())
 		).put(
 			"status", toStatusJSONObject(locale, segmentsExperiment.getStatus())
+		).put(
+			"viewSegmentsExperimentDetailsURL",
+			_getViewSegmentsExperimentDetailsURL(segmentsExperiment)
 		);
 	}
 
@@ -176,6 +179,28 @@ public class SegmentsExperimentUtil {
 		).put(
 			"value", statusObject.getValue()
 		);
+	}
+
+	private static String _getLiferayAnalyticsURL(long companyId) {
+		return PrefsPropsUtil.getString(companyId, "liferayAnalyticsURL");
+	}
+
+	private static String _getViewSegmentsExperimentDetailsURL(
+		SegmentsExperiment segmentsExperiment) {
+
+		if (segmentsExperiment == null) {
+			return StringPool.BLANK;
+		}
+
+		String liferayAnalyticsURL = _getLiferayAnalyticsURL(
+			segmentsExperiment.getCompanyId());
+
+		if (Validator.isNull(liferayAnalyticsURL)) {
+			return StringPool.BLANK;
+		}
+
+		return liferayAnalyticsURL + "/tests/overview/" +
+			segmentsExperiment.getSegmentsExperimentKey();
 	}
 
 	private static boolean _isEditable(SegmentsExperiment segmentsExperiment) {

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/util/SegmentsExperimentUtil.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/util/SegmentsExperimentUtil.java
@@ -111,6 +111,9 @@ public class SegmentsExperimentUtil {
 		).put(
 			"description", segmentsExperiment.getDescription()
 		).put(
+			"detailsURL",
+			_getViewSegmentsExperimentDetailsURL(segmentsExperiment)
+		).put(
 			"editable", _isEditable(segmentsExperiment)
 		).put(
 			"goal",
@@ -128,9 +131,6 @@ public class SegmentsExperimentUtil {
 			String.valueOf(segmentsExperiment.getSegmentsExperimentId())
 		).put(
 			"status", toStatusJSONObject(locale, segmentsExperiment.getStatus())
-		).put(
-			"viewSegmentsExperimentDetailsURL",
-			_getViewSegmentsExperimentDetailsURL(segmentsExperiment)
 		);
 	}
 

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/SegmentsExperimentApp.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/SegmentsExperimentApp.es.js
@@ -63,9 +63,6 @@ export default function ({context, props}) {
 				initialSelectedSegmentsExperienceId={
 					props.selectedSegmentsExperienceId
 				}
-				viewSegmentsExperimentDetailsURL={
-					props.viewSegmentsExperimentDetailsURL
-				}
 				winnerSegmentsVariantId={props.winnerSegmentsVariantId}
 			/>
 		</SegmentsExperimentsContext.Provider>

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsActions.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsActions.es.js
@@ -40,7 +40,7 @@ function SegmentsExperimentsActions({onEditSegmentsExperimentStatus}) {
 		experiment,
 		reviewExperimentModal,
 		variants,
-		viewExperimentURL,
+		viewExperimentDetailsURL,
 	} = useContext(StateContext);
 	const dispatch = useContext(DispatchContext);
 
@@ -48,9 +48,6 @@ function SegmentsExperimentsActions({onEditSegmentsExperimentStatus}) {
 		onClose: () => dispatch(closeReviewAndRunExperiment()),
 	});
 	const {APIService} = useContext(SegmentsExperimentsContext);
-
-	const viewExperimentDetailsURL =
-		viewExperimentURL || experiment.viewSegmentsExperimentDetailsURL;
 
 	return (
 		<>

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsActions.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsActions.es.js
@@ -49,6 +49,9 @@ function SegmentsExperimentsActions({onEditSegmentsExperimentStatus}) {
 	});
 	const {APIService} = useContext(SegmentsExperimentsContext);
 
+	const viewExperimentDetailsURL =
+		viewExperimentURL || experiment.viewSegmentsExperimentDetailsURL;
+
 	return (
 		<>
 			{experiment.status.value === STATUS_DRAFT && (
@@ -129,11 +132,11 @@ function SegmentsExperimentsActions({onEditSegmentsExperimentStatus}) {
 					variants={variants}
 				/>
 			)}
-			{viewExperimentURL && (
+			{viewExperimentDetailsURL && (
 				<ClayLink
 					className="btn btn-secondary btn-sm mt-3 w-100"
 					displayType="secondary"
-					href={viewExperimentURL}
+					href={viewExperimentDetailsURL}
 					target="_blank"
 				>
 					{Liferay.Language.get('view-data-in-analytics-cloud')}

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es.js
@@ -214,6 +214,7 @@ function SegmentsExperimentsSidebar({
 					segmentsExperienceId,
 					segmentsExperimentId,
 					status,
+					viewSegmentsExperimentDetailsURL,
 				} = segmentsExperiment;
 
 				openSuccessToast();
@@ -233,6 +234,7 @@ function SegmentsExperimentsSidebar({
 						segmentsExperienceId,
 						segmentsExperimentId,
 						status,
+						viewSegmentsExperimentDetailsURL,
 					})
 				);
 			})

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es.js
@@ -54,7 +54,6 @@ function SegmentsExperimentsSidebar({
 	initialSegmentsExperiment,
 	initialSegmentsVariants,
 	initialSelectedSegmentsExperienceId = '0',
-	viewSegmentsExperimentDetailsURL,
 	winnerSegmentsVariantId,
 }) {
 	const {APIService, page} = useContext(SegmentsExperimentsContext);
@@ -65,7 +64,6 @@ function SegmentsExperimentsSidebar({
 			initialSegmentsExperiment,
 			initialSegmentsVariants,
 			initialSelectedSegmentsExperienceId,
-			viewSegmentsExperimentDetailsURL,
 			winnerSegmentsVariantId,
 		},
 		getInitialState
@@ -207,6 +205,7 @@ function SegmentsExperimentsSidebar({
 				const {
 					confidenceLevel,
 					description,
+					detailsURL,
 					editable,
 					goal,
 					name,
@@ -214,7 +213,6 @@ function SegmentsExperimentsSidebar({
 					segmentsExperienceId,
 					segmentsExperimentId,
 					status,
-					viewSegmentsExperimentDetailsURL,
 				} = segmentsExperiment;
 
 				openSuccessToast();
@@ -227,6 +225,7 @@ function SegmentsExperimentsSidebar({
 					addSegmentsExperiment({
 						confidenceLevel,
 						description,
+						detailsURL,
 						editable,
 						goal,
 						name,
@@ -234,7 +233,6 @@ function SegmentsExperimentsSidebar({
 						segmentsExperienceId,
 						segmentsExperimentId,
 						status,
-						viewSegmentsExperimentDetailsURL,
 					})
 				);
 			})

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/state/context.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/state/context.es.js
@@ -29,7 +29,6 @@ export function getInitialState(firstState) {
 		initialSegmentsExperiment,
 		initialSegmentsVariants,
 		initialSelectedSegmentsExperienceId,
-		viewSegmentsExperimentDetailsURL,
 		winnerSegmentsVariantId,
 	} = firstState;
 
@@ -46,7 +45,7 @@ export function getInitialState(firstState) {
 
 			return initialVariant;
 		}),
-		viewExperimentURL: viewSegmentsExperimentDetailsURL,
+		viewExperimentDetailsURL: initialSegmentsExperiment?.detailsURL || '',
 	};
 
 	return {

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/state/reducer.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/state/reducer.es.js
@@ -15,6 +15,7 @@ export function reducer(state, action) {
 			return {
 				...state,
 				experiment: action.payload,
+				viewExperimentDetailsURL: action.payload.detailsURL,
 			};
 
 		case 'ADD_VARIANT':
@@ -33,7 +34,7 @@ export function reducer(state, action) {
 					...state.experimentHistory,
 				],
 				variants: [],
-				viewExperimentURL: undefined,
+				viewExperimentDetailsURL: undefined,
 			};
 
 		case 'CREATE_EXPERIMENT_FINISH':

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/types.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/types.es.js
@@ -18,8 +18,8 @@ const SegmentsExperimentGoal = PropTypes.shape({
 });
 
 const SegmentsExperimentStatus = PropTypes.shape({
-	label: PropTypes.string.isRequired,
-	value: PropTypes.string.isRequired,
+	label: PropTypes.string,
+	value: PropTypes.number,
 });
 
 const SegmentsExperimentType = PropTypes.shape({

--- a/modules/dxp/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
@@ -85,8 +85,12 @@ describe('SegmentsExperimentsSidebar', () => {
 		expect(defaultExperience).not.toBe(null);
 
 		getByText(segmentsExperiment.name);
-		getByText('review-and-run-test');
+
 		getByText('edit');
+		getByText('delete');
+
+		getByText('review-and-run-test');
+		getByText('view-data-in-analytics-cloud');
 	});
 
 	it('Renders modal to create experiment when the user clicks on create test button', async () => {

--- a/modules/dxp/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
@@ -357,7 +357,7 @@ describe('Review and Run test', () => {
 			...segmentsExperiment,
 			editable: false,
 			status: {
-				label: 'completed',
+				label: 'running',
 				status: STATUS_RUNNING,
 			},
 		};
@@ -392,7 +392,7 @@ describe('Experiment History Tab', () => {
 			...segmentsExperiment,
 			editable: false,
 			status: {
-				label: 'completed',
+				label: 'running',
 				value: STATUS_RUNNING,
 			},
 		};
@@ -411,6 +411,7 @@ describe('Experiment History Tab', () => {
 		expect(window.confirm).toBeCalled();
 		expect(editExperimentStatus).toHaveBeenCalledWith(
 			expect.objectContaining({
+				segmentsExperimentId: segmentsExperiment.segmentsExperimentId,
 				status: STATUS_TERMINATED,
 			})
 		);

--- a/modules/dxp/apps/segments/segments-experiment-web/test/js/fixtures.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/test/js/fixtures.es.js
@@ -23,6 +23,7 @@ export const controlVariant = [
 export const segmentsExperiment = {
 	confidenceLevel: 0,
 	description: 'Experiment 1 description',
+	detailsURL: 'www.example.com',
 	editable: true,
 	goal: {
 		label: 'Bounce Rate',


### PR DESCRIPTION
**Description**
When creating a new AB Test, the button "View Data in Analytics Cloud" doesn't display in the UI. If the user makes another action or refreshes the page the button appeared.

**Solution**
I add the detailsURL to the segmentsExperiment object and take that property into account from the response when creating the new AB Test on the frontend side. That way, the button appeared right after the creation without doing any action on the page. With this button, the user can go to the test details in Analytics Cloud.
Also, this property was added in the props when we load the component for the first time. I change it to not duplicate code.

**How to test it**
- Connect and sync your Liferay DXP with Analytics Cloud
- Click on the AB Test button
- Create a new AB Test

With these steps, you will be able to show the button when creating a new AB Test.