### PR TITLE
LPS-122448 Expand delegate utility to support cases where a target was the child element

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/delegate/delegate.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/delegate/delegate.es.js
@@ -35,11 +35,16 @@ function isDisabled(node) {
  */
 function delegate(element, eventName, selector, callback) {
 	const eventHandler = (event) => {
-		if (eventName === 'click' && isDisabled(event.target)) {
+		const {defaultPrevented, target} = event;
+
+		if (eventName === 'click' && isDisabled(target)) {
 			return;
 		}
 
-		if (!event.defaultPrevented && event.target.matches(selector)) {
+		if (
+			!defaultPrevented &&
+			(target.matches(selector) || target.closest(selector))
+		) {
 			callback(event);
 		}
 	};

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/delegate/delegate.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/delegate/delegate.es.js
@@ -40,18 +40,20 @@ describe('delegate', () => {
 		expect(listener).toHaveBeenCalled();
 	});
 
-	it("doesn't trigger delegated event for parents of given element", () => {
-		document.body.innerHTML = `<div class="match">
-				<div data-testid="nomatch"></div>
-			</div>`;
+	it('triggers event on the parent if target is the child of the selector element', () => {
+		document.body.innerHTML = `<div class="match" data-testid="match">
+				<div>
+					<div data-testid="most-inner-match"></div>
+				</div>
+			</div >`;
 
 		const listener = jest.fn();
 
 		delegate(document, 'click', '.match', listener);
 
-		userEvent.click(getByTestId(document, 'nomatch'));
+		userEvent.click(getByTestId(document, 'most-inner-match'));
 
-		expect(listener).not.toHaveBeenCalled();
+		expect(listener).toHaveBeenCalled();
 	});
 
 	it('stops triggering event if stopPropagation is called', () => {


### PR DESCRIPTION
This is a PR that extends the initial implementation done by @bryceosterhaus. I added the ability for the event to propagate from any child to the proper parent, removed the test that was testing against that, and added a new test that tests this newly added functionality.