### PR TITLE
COMMERCE-4693 Fix assignee button style

### DIFF
--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/styles/main.scss
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/styles/main.scss
@@ -58,6 +58,16 @@
 			min-width: 100px;
 		}
 	}
+
+	.header-assign-label {
+		font-size: 0.625rem;
+		left: 13px;
+		top: -7px;
+	}
+
+	.header-assign-button {
+		min-width: 100px;
+	}
 }
 
 .filter-panel-head {

--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/styles/main.scss
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/styles/main.scss
@@ -33,10 +33,6 @@
 	}
 }
 
-.commerce-header-title {
-	max-width: 300px;
-}
-
 .commerce-header {
 	position: sticky;
 	top: 0;
@@ -50,18 +46,16 @@
 		}
 	}
 
-	.separator-left {
-		margin-left: 36px;
-		padding-left: 16px;
+	.header-details {
+		max-width: 300px;
 
-		&:before {
-			background-color: $border-color;
-			content: '';
-			height: 24px;
-			left: 0;
-			position: absolute;
-			top: 12px;
-			width: 1px;
+		@media screen and (max-width: 576px) {
+			flex-grow: 1;
+			width: 0;
+		}
+
+		@media screen and (min-width: 576px) {
+			min-width: 100px;
 		}
 	}
 }

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
@@ -32,337 +32,312 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 
 <div class="bg-white border-bottom commerce-header<%= fullWidth ? " container-fluid" : StringPool.BLANK %><%= Validator.isNotNull(wrapperCssClasses) ? StringPool.SPACE + wrapperCssClasses : StringPool.BLANK %> side-panel-top-anchor">
 	<div class="container<%= Validator.isNotNull(cssClasses) ? StringPool.SPACE + cssClasses : StringPool.BLANK %>">
-		<div class="d-lg-flex py-2">
-			<div class="align-items-center d-flex flex-grow-1">
-				<div class="flex-grow-1 row">
-					<c:if test="<%= Validator.isNotNull(thumbnailUrl) %>">
-						<div class="col-auto">
-							<span class="sticker sticker-primary sticker-xl">
-								<span class="sticker-overlay">
-									<img alt="thumbnail" class="img-fluid" src="<%= thumbnailUrl %>" />
-								</span>
+		<div class="align-items-center c-py-3 c-py-lg-2 d-lg-flex">
+			<div class="align-items-center d-flex">
+				<c:if test="<%= Validator.isNotNull(thumbnailUrl) %>">
+					<span class="d-none d-sm-block sticker sticker-xl">
+						<span class="sticker-overlay">
+							<img alt="thumbnail" class="sticker-img" src="<%= thumbnailUrl %>" />
+						</span>
+					</span>
+				</c:if>
+
+				<div class="border-right c-ml-sm-2 c-mr-3 c-pr-3 header-details">
+					<h3 class="c-mb-0 commerce-header-title text-truncate">
+						<%= HtmlUtil.escape(title) %>
+					</h3>
+
+					<c:if test="<%= isWorkflowedModel %>">
+
+						<%
+						WorkflowedModel workflowedModel = (WorkflowedModel)bean;
+						%>
+
+						<c:if test="<%= workflowedModel != null %>">
+							<aui:workflow-status bean="<%= bean %>" model="<%= model %>" showHelpMessage="<%= false %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= workflowedModel.getStatus() %>" />
+						</c:if>
+					</c:if>
+				</div>
+
+				<div class="header-info">
+					<c:if test="<%= Validator.isNotNull(beanIdLabel) %>">
+						<div class="align-items-center d-flex">
+							<span class="header-info-title">
+								<liferay-ui:message key="<%= beanIdLabel %>" />:
 							</span>
+
+							<strong class="c-ml-1 header-info-value">
+								<%= beanId %>
+							</strong>
+
+							<clay:button
+								cssClass="lfr-portal-tooltip text-secondary"
+								displayType="unstyled"
+								icon="question-circle"
+								small="<%= true %>"
+								title='<%= LanguageUtil.get(request, "identification-number") %>'
+							/>
 						</div>
 					</c:if>
 
-					<div class="col">
-						<div class="row">
-							<div class="col-auto">
-								<h3 class="commerce-header-title mb-0 truncate-text">
-									<%= HtmlUtil.escape(title) %>
-								</h3>
+					<c:if test="<%= Validator.isNotNull(externalReferenceCode) || Validator.isNotNull(externalReferenceCodeEditUrl) %>">
+						<div class="align-items-center c-mt-n2 d-flex">
+							<span class="header-info-title">
+								<liferay-ui:message key="erc" />:
+							</span>
 
-								<c:if test="<%= isWorkflowedModel %>">
+							<strong class="c-ml-1 header-info-value">
+								<%= externalReferenceCode %>
+							</strong>
 
-									<%
-									WorkflowedModel workflowedModel = (WorkflowedModel)bean;
-									%>
+							<clay:button
+								cssClass="lfr-portal-tooltip text-secondary"
+								displayType="unstyled"
+								icon="question-circle"
+								small="<%= true %>"
+								title='<%= LanguageUtil.get(request, "external-reference-code") %>'
+							/>
 
-									<c:if test="<%= workflowedModel != null %>">
-										<div>
-											<aui:workflow-status bean="<%= bean %>" model="<%= model %>" showHelpMessage="<%= false %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= workflowedModel.getStatus() %>" />
-										</div>
-									</c:if>
-								</c:if>
-							</div>
+							<c:if test="<%= Validator.isNotNull(externalReferenceCodeEditUrl) %>">
+								<clay:button
+									cssClass="text-secondary"
+									displayType="unstyled"
+									icon="pencil"
+									id="erc-edit-modal-opener"
+									small="<%= true %>"
+								/>
 
-							<div class="col d-flex flex-column justify-content-center separator-left">
-								<c:if test="<%= Validator.isNotNull(beanIdLabel) %>">
-									<small class="d-block">
-										<span class="header-info-title">
-											<liferay-ui:message key="<%= beanIdLabel %>" />:
-										</span>
+								<aui:script require="commerce-frontend-js/utilities/eventsDefinitions as events">
+									document
+										.querySelector('#erc-edit-modal-opener')
+										.addEventListener('click', function (e) {
+											e.preventDefault();
+											Liferay.fire(events.OPEN_MODAL, {id: 'erc-edit-modal'});
+										});
+								</aui:script>
 
-										<strong class="header-info-value">
-											<%= beanId %>
-										</strong>
-
-										<clay:button
-											cssClass="lfr-portal-tooltip text-secondary"
-											displayType="unstyled"
-											icon="question-circle"
-											small="<%= true %>"
-											title='<%= LanguageUtil.get(request, "identification-number") %>'
-										/>
-									</small>
-								</c:if>
-
-								<c:if test="<%= Validator.isNotNull(externalReferenceCode) || Validator.isNotNull(externalReferenceCodeEditUrl) %>">
-									<small class="d-block">
-										<span class="header-info-title">
-											<liferay-ui:message key="erc" />:
-										</span>
-
-										<strong class="header-info-value">
-											<%= externalReferenceCode %>
-										</strong>
-
-										<clay:button
-											cssClass="lfr-portal-tooltip text-secondary"
-											displayType="unstyled"
-											icon="question-circle"
-											small="<%= true %>"
-											title='<%= LanguageUtil.get(request, "external-reference-code") %>'
-										/>
-
-										<c:if test="<%= Validator.isNotNull(externalReferenceCodeEditUrl) %>">
-											<clay:button
-												cssClass="text-secondary"
-												displayType="unstyled"
-												icon="pencil"
-												id="erc-edit-modal-opener"
-												small="<%= true %>"
-											/>
-
-											<aui:script require="commerce-frontend-js/utilities/eventsDefinitions as events">
-												document
-													.querySelector('#erc-edit-modal-opener')
-													.addEventListener('click', function (e) {
-														e.preventDefault();
-														Liferay.fire(events.OPEN_MODAL, {id: 'erc-edit-modal'});
-													});
-											</aui:script>
-
-											<commerce-ui:modal
-												id="erc-edit-modal"
-												refreshPageOnClose="<%= true %>"
-												title='<%= LanguageUtil.format(request, "edit-x", "external-reference-code") %>'
-												url="<%= externalReferenceCodeEditUrl %>"
-											/>
-										</c:if>
-									</small>
-								</c:if>
-							</div>
+								<commerce-ui:modal
+									id="erc-edit-modal"
+									refreshPageOnClose="<%= true %>"
+									title='<%= LanguageUtil.format(request, "edit-x", "external-reference-code") %>'
+									url="<%= externalReferenceCodeEditUrl %>"
+								/>
+							</c:if>
 						</div>
-					</div>
-
-					<div class="col-auto d-lg-none">
-						<clay:button
-							cssClass="navbar-toggler"
-							data-target="#navbarNavAltMarkup"
-							data-toggle="liferay-collapse"
-							icon="bars"
-							style="secondary"
-							type="button"
-						/>
-					</div>
+					</c:if>
 				</div>
 			</div>
 
-			<div class="collapse d-lg-flex" id="navbarNavAltMarkup">
-				<div class="align-self-center row">
-					<c:if test="<%= Validator.isNotNull(reviewWorkflowTask) %>">
+			<hr class="d-lg-none" />
 
-						<%
-						boolean assignedToCurrentUser = false;
+			<div class="align-items-center c-ml-auto d-flex justify-content-end">
+				<c:if test="<%= Validator.isNotNull(reviewWorkflowTask) %>">
 
-						if (reviewWorkflowTask.getAssigneeUserId() == user.getUserId()) {
-							assignedToCurrentUser = true;
-						}
+					<%
+					boolean assignedToCurrentUser = false;
 
-						String assignee = PortalUtil.getUserName(reviewWorkflowTask.getAssigneeUserId(), "nobody");
+					if (reviewWorkflowTask.getAssigneeUserId() == user.getUserId()) {
+						assignedToCurrentUser = true;
+					}
 
-						if (assignedToCurrentUser) {
-							assignee = "me";
-						}
-						%>
+					String assignee = PortalUtil.getUserName(reviewWorkflowTask.getAssigneeUserId(), "nobody");
 
-						<div class="border-right col col-12 col-lg-auto d-flex mt-3 mt-lg-0">
-							<small class="d-block">
-								<span class="header-info-title mr-1">
-									<liferay-ui:message key="assigned-to" />:
-								</span>
+					if (assignedToCurrentUser) {
+						assignee = "me";
+					}
+					%>
 
-								<button aria-expanded="false" aria-haspopup="true" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" onclick="<portlet:namespace />toggleDropdown();" type="button">
-									<liferay-ui:message key="<%= assignee %>" />
+					<div class="border-right c-mr-1 c-mr-sm-3 c-pr-sm-3">
+						<span class="text-secondary">
+							<liferay-ui:message key="assigned-to" />:
+						</span>
 
-									<clay:icon
-										symbol="caret-bottom"
-									/>
-								</button>
+						<button aria-expanded="false" aria-haspopup="true" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" onclick="<portlet:namespace />toggleDropdown();" type="button">
+							<liferay-ui:message key="<%= assignee %>" />
 
-								<div class="dropdown-menu dropdown-menu-right" id="<portlet:namespace />commerce-dropdown-assigned-to">
-									<c:if test="<%= !assignedToCurrentUser %>">
-										<clay:button
-											elementClasses="dropdown-item transition-link"
-											id='<%= liferayPortletResponse.getNamespace() + "assign-to-me-modal-opener" %>'
-											label='<%= LanguageUtil.get(request, "assign-to-me") %>'
-											size="lg"
-											style="secondary"
-										/>
+							<clay:icon
+								symbol="caret-bottom"
+							/>
+						</button>
 
-										<liferay-portlet:renderURL portletName="<%= PortletKeys.MY_WORKFLOW_TASK %>" var="assignToMeURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-											<portlet:param name="mvcPath" value="/workflow_task_assign.jsp" />
-											<portlet:param name="hideDefaultSuccessMessage" value="<%= Boolean.TRUE.toString() %>" />
-											<portlet:param name="workflowTaskId" value="<%= String.valueOf(reviewWorkflowTask.getWorkflowTaskId()) %>" />
-											<portlet:param name="assigneeUserId" value="<%= String.valueOf(user.getUserId()) %>" />
-										</liferay-portlet:renderURL>
-
-										<aui:script>
-											document
-												.querySelector('#<portlet:namespace />assign-to-me-modal-opener')
-												.addEventListener('click', function (e) {
-													Liferay.Util.openWindow({
-														dialog: {
-															destroyOnHide: true,
-															height: 430,
-															resizable: false,
-															width: 896,
-														},
-														dialogIframe: {
-															bodyCssClass: 'dialog-with-footer task-dialog',
-														},
-														id: '<%= myWorkflowTasksPortletNamespace %>assignToDialog',
-														title: '<liferay-ui:message key="assign-to-me" />',
-														uri: '<%= assignToMeURL %>',
-													});
-												});
-										</aui:script>
-									</c:if>
-
-									<clay:button
-										elementClasses="dropdown-item transition-link"
-										id='<%= liferayPortletResponse.getNamespace() + "assign-to-modal-opener" %>'
-										label='<%= LanguageUtil.get(request, "assign-to-...") %>'
-										size="lg"
-										style="secondary"
-									/>
-
-									<liferay-portlet:renderURL portletName="<%= PortletKeys.MY_WORKFLOW_TASK %>" var="assignToURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-										<portlet:param name="mvcPath" value="/workflow_task_assign.jsp" />
-										<portlet:param name="hideDefaultSuccessMessage" value="<%= Boolean.TRUE.toString() %>" />
-										<portlet:param name="workflowTaskId" value="<%= String.valueOf(reviewWorkflowTask.getWorkflowTaskId()) %>" />
-									</liferay-portlet:renderURL>
-
-									<aui:script>
-										document
-											.querySelector('#<portlet:namespace />assign-to-modal-opener')
-											.addEventListener('click', function (e) {
-												Liferay.Util.openWindow({
-													dialog: {
-														destroyOnHide: true,
-														height: 430,
-														resizable: false,
-														width: 896,
-													},
-													dialogIframe: {
-														bodyCssClass: 'dialog-with-footer task-dialog',
-													},
-													id: '<%= myWorkflowTasksPortletNamespace %>assignToDialog',
-													title: '<liferay-ui:message key="assign-to-..." />',
-													uri: '<%= assignToURL %>',
-												});
-											});
-
-										function <%= myWorkflowTasksPortletNamespace %>refreshPortlet() {
-											window.location.reload();
-										}
-
-										Liferay.provide(window, '<portlet:namespace />toggleDropdown', function () {
-											var dropdownElement = window.document.querySelector(
-												'#<portlet:namespace />commerce-dropdown-assigned-to'
-											);
-
-											if (dropdownElement) {
-												if (dropdownElement.classList.contains('show')) {
-													dropdownElement.classList.remove('show');
-												}
-												else {
-													dropdownElement.classList.add('show');
-												}
-											}
-										});
-									</aui:script>
-								</div>
-							</small>
-						</div>
-					</c:if>
-
-					<c:if test="<%= Validator.isNotNull(actions) && !actions.isEmpty() %>">
-						<div class="col-12 col-lg-auto header-actions mt-3 mt-lg-0">
-
-							<%
-							for (HeaderActionModel action : actions) {
-								String buttonClasses = "btn ";
-
-								if (Validator.isNotNull(action.getAdditionalClasses())) {
-									buttonClasses += action.getAdditionalClasses();
-								}
-								else {
-									buttonClasses += "btn-secondary";
-								}
-
-								boolean submitCheck = Validator.isNull(action.getId());
-
-								String actionId = Validator.isNotNull(action.getId()) ? action.getId() : "header-action" + StringPool.UNDERLINE + PortalUtil.generateRandomKey(request, "taglib_step_tracker");
-							%>
-
-								<clay:link
-									elementClasses="<%= buttonClasses %>"
-									href="<%= Validator.isNotNull(action.getHref()) ? action.getHref() : StringPool.POUND %>"
-									id="<%= actionId %>"
-									label="<%= LanguageUtil.get(request, action.getLabel()) %>"
+						<div class="dropdown-menu dropdown-menu-right" id="<portlet:namespace />commerce-dropdown-assigned-to">
+							<c:if test="<%= !assignedToCurrentUser %>">
+								<clay:button
+									elementClasses="dropdown-item transition-link"
+									id='<%= liferayPortletResponse.getNamespace() + "assign-to-me-modal-opener" %>'
+									label='<%= LanguageUtil.get(request, "assign-to-me") %>'
+									size="lg"
+									style="secondary"
 								/>
 
-								<%
-								if (submitCheck && Validator.isNotNull(action.getFormId())) {
-								%>
+								<liferay-portlet:renderURL portletName="<%= PortletKeys.MY_WORKFLOW_TASK %>" var="assignToMeURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+									<portlet:param name="mvcPath" value="/workflow_task_assign.jsp" />
+									<portlet:param name="hideDefaultSuccessMessage" value="<%= Boolean.TRUE.toString() %>" />
+									<portlet:param name="workflowTaskId" value="<%= String.valueOf(reviewWorkflowTask.getWorkflowTaskId()) %>" />
+									<portlet:param name="assigneeUserId" value="<%= String.valueOf(user.getUserId()) %>" />
+								</liferay-portlet:renderURL>
 
-									<aui:script>
-										document
-											.getElementById('<%= actionId %>')
-											.addEventListener('click', function (e) {
-												e.preventDefault();
-												var form = document.getElementById('<%= action.getFormId() %>');
-												if (!form) {
-													throw new Error(
-														'Form with id: ' + <%= action.getFormId() %> + ' not found!'
-													);
-												}
-												submitForm(form);
+								<aui:script>
+									document
+										.querySelector('#<portlet:namespace />assign-to-me-modal-opener')
+										.addEventListener('click', function (e) {
+											Liferay.Util.openWindow({
+												dialog: {
+													destroyOnHide: true,
+													height: 430,
+													resizable: false,
+													width: 896,
+												},
+												dialogIframe: {
+													bodyCssClass: 'dialog-with-footer task-dialog',
+												},
+												id: '<%= myWorkflowTasksPortletNamespace %>assignToDialog',
+												title: '<liferay-ui:message key="assign-to-me" />',
+												uri: '<%= assignToMeURL %>',
 											});
-									</aui:script>
+										});
+								</aui:script>
+							</c:if>
 
-								<%
+							<clay:button
+								elementClasses="dropdown-item transition-link"
+								id='<%= liferayPortletResponse.getNamespace() + "assign-to-modal-opener" %>'
+								label='<%= LanguageUtil.get(request, "assign-to-...") %>'
+								size="lg"
+								style="secondary"
+							/>
+
+							<liferay-portlet:renderURL portletName="<%= PortletKeys.MY_WORKFLOW_TASK %>" var="assignToURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+								<portlet:param name="mvcPath" value="/workflow_task_assign.jsp" />
+								<portlet:param name="hideDefaultSuccessMessage" value="<%= Boolean.TRUE.toString() %>" />
+								<portlet:param name="workflowTaskId" value="<%= String.valueOf(reviewWorkflowTask.getWorkflowTaskId()) %>" />
+							</liferay-portlet:renderURL>
+
+							<aui:script>
+								document
+									.querySelector('#<portlet:namespace />assign-to-modal-opener')
+									.addEventListener('click', function (e) {
+										Liferay.Util.openWindow({
+											dialog: {
+												destroyOnHide: true,
+												height: 430,
+												resizable: false,
+												width: 896,
+											},
+											dialogIframe: {
+												bodyCssClass: 'dialog-with-footer task-dialog',
+											},
+											id: '<%= myWorkflowTasksPortletNamespace %>assignToDialog',
+											title: '<liferay-ui:message key="assign-to-..." />',
+											uri: '<%= assignToURL %>',
+										});
+									});
+
+								function <%= myWorkflowTasksPortletNamespace %>refreshPortlet() {
+									window.location.reload();
 								}
-								%>
+
+								Liferay.provide(window, '<portlet:namespace />toggleDropdown', function () {
+									var dropdownElement = window.document.querySelector(
+										'#<portlet:namespace />commerce-dropdown-assigned-to'
+									);
+
+									if (dropdownElement) {
+										if (dropdownElement.classList.contains('show')) {
+											dropdownElement.classList.remove('show');
+										}
+										else {
+											dropdownElement.classList.add('show');
+										}
+									}
+								});
+							</aui:script>
+						</div>
+					</div>
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(actions) && !actions.isEmpty() %>">
+					<div class="header-actions">
+
+						<%
+						for (HeaderActionModel action : actions) {
+							String buttonClasses = "btn c-mb-1 c-mb-sm-0 ";
+
+							if (Validator.isNotNull(action.getAdditionalClasses())) {
+								buttonClasses += action.getAdditionalClasses();
+							}
+							else {
+								buttonClasses += "btn-secondary";
+							}
+
+							boolean submitCheck = Validator.isNull(action.getId());
+
+							String actionId = Validator.isNotNull(action.getId()) ? action.getId() : "header-action" + StringPool.UNDERLINE + PortalUtil.generateRandomKey(request, "taglib_step_tracker");
+						%>
+
+							<clay:link
+								elementClasses="<%= buttonClasses %>"
+								href="<%= Validator.isNotNull(action.getHref()) ? action.getHref() : StringPool.POUND %>"
+								id="<%= actionId %>"
+								label="<%= LanguageUtil.get(request, action.getLabel()) %>"
+							/>
+
+							<%
+							if (submitCheck && Validator.isNotNull(action.getFormId())) {
+							%>
+
+								<aui:script>
+									document
+										.getElementById('<%= actionId %>')
+										.addEventListener('click', function (e) {
+											e.preventDefault();
+											var form = document.getElementById('<%= action.getFormId() %>');
+											if (!form) {
+												throw new Error(
+													'Form with id: ' + <%= action.getFormId() %> + ' not found!'
+												);
+											}
+											submitForm(form);
+										});
+								</aui:script>
 
 							<%
 							}
 							%>
 
+						<%
+						}
+						%>
+
+					</div>
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(dropdownItems) || Validator.isNotNull(previewUrl) %>">
+					<c:if test="<%= Validator.isNotNull(dropdownItems) && (dropdownItems.size() > 0) %>">
+						<div class="c-ml-3" id="dropdown-header-container">
+							<liferay-ui:icon
+								icon="ellipsis-v"
+								markupView="lexicon"
+							/>
 						</div>
+
+						<aui:script require="commerce-frontend-js/components/dropdown/entry as dropdown">
+							dropdown.default('dropdown-header', 'dropdown-header-container', {
+								items: <%= jsonSerializer.serializeDeep(dropdownItems) %>,
+								spritemap:
+									'<%= themeDisplay.getPathThemeImages() + "/lexicon/icons.svg" %>',
+							});
+						</aui:script>
 					</c:if>
 
-					<c:if test="<%= Validator.isNotNull(dropdownItems) || Validator.isNotNull(previewUrl) %>">
-						<div class="align-items-center col-auto d-flex pl-3">
-							<c:if test="<%= Validator.isNotNull(dropdownItems) && (dropdownItems.size() > 0) %>">
-								<div id="dropdown-header-container">
-									<liferay-ui:icon
-										icon="ellipsis-v"
-										markupView="lexicon"
-									/>
-								</div>
-
-								<aui:script require="commerce-frontend-js/components/dropdown/entry as dropdown">
-									dropdown.default('dropdown-header', 'dropdown-header-container', {
-										items: <%= jsonSerializer.serializeDeep(dropdownItems) %>,
-										spritemap:
-											'<%= themeDisplay.getPathThemeImages() + "/lexicon/icons.svg" %>',
-									});
-								</aui:script>
-							</c:if>
-
-							<c:if test="<%= Validator.isNotNull(previewUrl) %>">
-								<clay:link
-									elementClasses="btn btn-outline-borderless btn-outline-secondary btn-sm text-primary"
-									href="<%= previewUrl %>"
-									icon="shortcut"
-								/>
-							</c:if>
-						</div>
+					<c:if test="<%= Validator.isNotNull(previewUrl) %>">
+						<clay:link
+							elementClasses="btn btn-outline-borderless btn-outline-secondary btn-sm text-primary"
+							href="<%= previewUrl %>"
+							icon="shortcut"
+						/>
 					</c:if>
-				</div>
+				</c:if>
 			</div>
 		</div>
 	</div>

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
@@ -289,7 +289,7 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 									buttonClasses += action.getAdditionalClasses();
 								}
 								else {
-									buttonClasses += "btn-default";
+									buttonClasses += "btn-secondary";
 								}
 
 								boolean submitCheck = Validator.isNull(action.getId());

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
@@ -147,12 +147,12 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 					}
 					%>
 
-					<div class="border-right c-mr-1 c-mr-sm-3 c-pr-sm-3">
-						<span class="text-secondary">
+					<div class="border-right c-mr-1 c-mr-sm-3 c-pr-sm-3 position-relative">
+						<div class="bg-white c-px-1 header-assign-label position-absolute text-secondary">
 							<liferay-ui:message key="assigned-to" />:
-						</span>
+						</div>
 
-						<button aria-expanded="false" aria-haspopup="true" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" onclick="<portlet:namespace />toggleDropdown();" type="button">
+						<button aria-expanded="false" aria-haspopup="true" class="align-items-center btn btn-secondary d-flex dropdown-toggle header-assign-button justify-content-between" data-toggle="dropdown" onclick="<portlet:namespace />toggleDropdown();" type="button">
 							<liferay-ui:message key="<%= assignee %>" />
 
 							<clay:icon


### PR DESCRIPTION
In this PR we are fixing (at least) the following issues:
- [Secondary button style](https://issues.liferay.com/browse/COMMERCE-4685)
- [Header responsiveness](https://issues.liferay.com/browse/COMMERCE-4779)
- [Assignee button style](https://issues.liferay.com/browse/COMMERCE-4693)

But I may have fixed some other issue in the attempt of cleaning the markup structure

**Please, keep in mind that this is a temporary fix until we can work on the final version of the project**

In this phase I prefered to avoid the usage of `clay-taglibs` and `clay-css-variables`

[Design of reference](https://www.figma.com/file/SvueKimLHLZ2NJEXEnx9kT/Commerce-Admin-UI---v7.2?node-id=13102%3A0)

Current behavior:

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/46778114/98383517-dfd7d780-204c-11eb-80a1-8b82360d9ae2.gif)
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/46778114/98383530-e36b5e80-204c-11eb-9002-6f051f55ad13.gif)

---

How to test the `header-structure-and-responsiveness` and `secondary-button-style` fixes?

- Create a product from the `application-menu > commerce > product-management > products`
- Insert a name and select a catalog
   - If no catalog is available, create one from `application-menu > commerce > product-management > catalogs`

How to test the `assignee-button-style` fix?

- Go to sites: `application-menu > control-panel > site > sites`
- Create a new site and select the `speedwell` starter theme
- Go to channels `application-menu > commerce > store-management > channels`
- Select the channel assigned to your new site
- Assign a workflow to the channel
![image](https://user-images.githubusercontent.com/46778114/98385251-0f87df00-204f-11eb-9f38-7cfc38b58bae.png)
- Place an order from your new site
   - Go to the new site
   - Open the top left hamburger-icon menu
   - Choose `catalog` from the menu links
   - Click on `add to the cart` on an product
   - Click on the checkout cart-icon menu on the top right
   - Click `checkout`
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/46778114/98386167-2844c480-2050-11eb-84ee-5e9a49853841.gif)
- Go to the new order `application-menu > commerce > order-management > orders`

---

I'm sending this PR here to double check the changes and to be sure I'm not including not-ready-to-be-implemented modifications 😁

---

@marcoscv-work do you think the `assignee-button-style` modification could be an accessibility issue?

/cc @jbalsas 
