### PR TITLE
[7.4 only] LPS-121947 Migrate v2 usages of clay:horizontal-card in depot-web

### DIFF
--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/css/main.scss
@@ -5,7 +5,7 @@
 		position: initial;
 	}
 
-	a.card-title {
+	.card-title a {
 		&::after {
 			bottom: 0;
 			content: '';

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view_depot_dashboard.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view_depot_dashboard.jsp
@@ -55,7 +55,7 @@ boolean panelsShown = false;
 								/>
 							</c:when>
 							<c:otherwise>
-								<clay:horizontal-card-v2
+								<clay:horizontal-card
 									horizontalCard="<%= depotAdminViewDepotDashboardDisplayContext.getDepotDashboardApplicationHorizontalCard(panelApp, locale) %>"
 								/>
 							</c:otherwise>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/.npmbundlerrc
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/.npmbundlerrc
@@ -112,6 +112,5 @@
 		"xss-filters": true
 	},
 	"output": "build/node/packageRunBuild/resources",
-	"preset": "liferay-npm-bundler-preset-standard",
 	"sources": ["src/main/resources/META-INF/resources"]
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
@@ -296,6 +296,9 @@ public class HorizontalCardTag extends BaseContainerTag {
 
 		JspWriter jspWriter = pageContext.getOut();
 
+		jspWriter.write("<style>.card > .card.card-horizontal {border-width:");
+		jspWriter.write(" 0; margin-bottom: 0;}</style>");
+
 		if (isSelectable()) {
 			jspWriter.write("<div class=\"custom-control custom-checkbox\">");
 			jspWriter.write("<label><input");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/HorizontalCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/HorizontalCard.js
@@ -15,6 +15,7 @@
 import {ClayCardWithHorizontal} from '@clayui/card';
 import React, {useState} from 'react';
 
+import './HorizontalCard.scss';
 import getDataAttributes from './get_data_attributes';
 
 export default function HorizontalCard({

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/HorizontalCard.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/HorizontalCard.scss
@@ -1,0 +1,4 @@
+.card > .card.card-horizontal {
+	border-width: 0;
+	margin-bottom: 0;
+}


### PR DESCRIPTION
See description of this task in https://issues.liferay.com/browse/LPS-121947

Steps to reproduce:
1. Go to Global Menu > Applications > Asset Libraries
1. Create a new asset library
1. Open the new asset library. The page has many horizontal cards, see gif on the bottom.

Notes:
- This card usage is an example of an `interactive` card. The only two horizontal cards that are not interactive are blocked by [this issue](https://github.com/liferay/clay/issues/3781). I wanted to explore migrating this as it was originally implemented, with interactive appearance achieved by only adding `card-interactive` CSS class. The alternative, leveraging `CardWithNavigation`, would require a new tag, which is a much larger task. It turns out that this in not a problem at all, none of the issues I encountered early are related to interactivity. Speaking of issues...  
- There is [an open issue](https://github.com/liferay/clay/issues/3789) in Clay that the `card` class is generated twice. In this PR we are making a workaround for that issue, by modifying styles on the tag side. It is not clear if or when the issue should be fixed on Clay side, so this can be a temporary workaround we can rollback later. @matuzalemsteles what do you think, does this make sense or should be wait for Clay fix?
- To modify `card`-related styles, we need to modify them on both client and server side. On the client side, this requires enabling `.scss` files to be built. @wincent @jbalsas I am very unsure that I did this in the correct way, by just removing the default preset. I don't understand why default preset does not build scss files. If I am looking at [the right line](https://github.com/liferay/liferay-frontend-projects/blob/master/projects/npm-tools/packages/npm-scripts/src/presets/standard/index.js#L12), and understand it correctly, it should. Or is this just for formatting, and not for building? :thinking: 
- The [style change](https://github.com/liferay-frontend/liferay-portal/compare/master...markocikos:LPS-121947?expand=1#diff-138164fd14a3d484d6d6c7644cc716c8675e41444d1ccc0112cac13c93016fe3R8) on `depot-web` is not related to above. It is caused by custom portlet styles expecting different markup. It is an example of a breaking change caused by different v2 / v3 markup.
- The custom styles from precious point enable clicking on padding of the card to navigate, instead of only on title. [Adding `:after`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/css/main.scss#L8-L24) that spreads the clickable area of anchor element is a very nice trick. I think this an improvement to default behavior, we should consider adding as default to the component. @boton :1st_place_medal: 

/cc @julien @carloslancha 

![after](https://user-images.githubusercontent.com/5435511/98571848-42331100-22b5-11eb-9af5-4143ac1ca8a0.gif)
