### PR TITLE
[7.4-only] LPS-121953 Migrate v2 usages of clay:user-card in segments/segments-web

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/BaseUserCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/BaseUserCard.java
@@ -44,6 +44,11 @@ public abstract class BaseUserCard
 	}
 
 	@Override
+	public String getIcon() {
+		return "user";
+	}
+
+	@Override
 	public String getImageSrc() {
 		if (user.getPortraitId() <= 0) {
 			return null;
@@ -66,6 +71,11 @@ public abstract class BaseUserCard
 	@Override
 	public String getSubtitle() {
 		return user.getScreenName();
+	}
+
+	@Override
+	public String getUserColorClass() {
+		return "primary";
 	}
 
 	protected final RenderRequest renderRequest;

--- a/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/user_item_selector.jsp
+++ b/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/user_item_selector.jsp
@@ -74,7 +74,7 @@ String displayStyle = userItemSelectorViewDisplayContext.getDisplayStyle();
 					%>
 
 					<liferay-ui:search-container-column-text>
-						<clay:user-card-v2
+						<clay:user-card
 							userCard="<%= new SelectUserUserCard(user, renderRequest, searchContainer.getRowChecker()) %>"
 						/>
 					</liferay-ui:search-container-column-text>


### PR DESCRIPTION
The `segments-web` module doesn't have a `<clay:user-card />` tag but it
does open a modal window in which a `<clay:user-card />` is displayed.

**Test Plan**

- Fetch this branch, and deploy:
    `frontend-taglib-clay` and `users-admin-item-selector-web` modules

- Navigate to *People* > **Segments**

- Create a new segment, add a title (in the top) and drag and a **User**
"Property" from the right sidebar to the **Conditions** container.

- In **User with property**, click on the **Select** button.

Expected result:

- A modal window is opened displaying the list of available users

- In the top right hand corner of the modal window, click on the grid icon
(which looks like a square divided in 4 sections) and select **Cards**

- Select one or more users and click on the **Select** button

- Assert than the user names appear in the **User with property**
condition