### PR TITLE
[7.4-only][LPS-122521,LPS-122514,LPS-122523,LPS-122519,LPS-122518] Removes metal* dependencies from frontend-js-spa-web

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/package.json
@@ -6,8 +6,7 @@
 		"metal-events": "2.16.8",
 		"metal-path-parser": "1.0.4",
 		"metal-promise": "3.0.5",
-		"metal-uri": "2.4.0",
-		"metal-useragent": "3.0.1"
+		"metal-uri": "2.4.0"
 	},
 	"name": "frontend-js-spa-web",
 	"scripts": {

--- a/modules/apps/frontend-js/frontend-js-spa-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/package.json
@@ -2,7 +2,6 @@
 	"dependencies": {
 		"frontend-js-web": "*",
 		"metal": "2.16.8",
-		"metal-debounce": "^2.0.2",
 		"metal-dom": "2.16.8",
 		"metal-events": "2.16.8",
 		"metal-path-parser": "1.0.4",

--- a/modules/apps/frontend-js/frontend-js-spa-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/package.json
@@ -2,7 +2,6 @@
 	"dependencies": {
 		"frontend-js-web": "*",
 		"metal-dom": "2.16.8",
-		"metal-path-parser": "1.0.4",
 		"metal-promise": "3.0.5",
 		"metal-uri": "2.4.0"
 	},

--- a/modules/apps/frontend-js/frontend-js-spa-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/package.json
@@ -2,7 +2,6 @@
 	"dependencies": {
 		"frontend-js-web": "*",
 		"metal-dom": "2.16.8",
-		"metal-events": "2.16.8",
 		"metal-path-parser": "1.0.4",
 		"metal-promise": "3.0.5",
 		"metal-uri": "2.4.0"

--- a/modules/apps/frontend-js/frontend-js-spa-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/package.json
@@ -1,7 +1,6 @@
 {
 	"dependencies": {
 		"frontend-js-web": "*",
-		"metal": "2.16.8",
 		"metal-dom": "2.16.8",
 		"metal-events": "2.16.8",
 		"metal-path-parser": "1.0.4",

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
@@ -16,10 +16,11 @@ import {openToast} from 'frontend-js-web';
 import dom from 'metal-dom';
 
 import {App} from '../../senna/senna';
-import utils from '../../senna/utils/utils';
+import {getUid} from '../../senna/utils/utils';
 import LiferaySurface from '../surface/Surface.es';
-import Utils from '../util/Utils.es';
+import {getPortletBoundaryId, resetAllPortlets} from '../util/Utils.es';
 
+const MAX_TIMEOUT = Math.pow(2, 31) - 1;
 const PROPAGATED_PARAMS = ['bodyCssClass'];
 
 /**
@@ -51,8 +52,7 @@ class LiferayApp extends App {
 
 		this.setShouldUseFacade(true);
 
-		this.timeout =
-			Math.max(Liferay.SPA.requestTimeout, 0) || Utils.getMaxTimeout();
+		this.timeout = Math.max(Liferay.SPA.requestTimeout, 0) || MAX_TIMEOUT;
 		this.timeoutAlert = null;
 
 		const exceptionsSelector = Liferay.SPA.navigationExceptionSelectors;
@@ -66,14 +66,14 @@ class LiferayApp extends App {
 		this.on('navigationError', this.onNavigationError);
 		this.on('startNavigate', this.onStartNavigate);
 
-		Liferay.on('beforeScreenFlip', Utils.resetAllPortlets);
+		Liferay.on('beforeScreenFlip', resetAllPortlets);
 		Liferay.on('beforeScreenFlip', Liferay.destroyUnfulfilledPromises);
 		Liferay.on('io:complete', this.onLiferayIOComplete, this);
 
 		const body = document.body;
 
 		if (!body.id) {
-			body.id = 'senna_surface' + utils.getUid();
+			body.id = 'senna_surface' + getUid();
 		}
 
 		this.addSurfaces(new LiferaySurface(body.id));
@@ -94,7 +94,7 @@ class LiferayApp extends App {
 			const uri = new URL(path, window.location.origin);
 
 			if (uri.searchParams.get('p_p_lifecycle') === '1') {
-				this.activePath = this.activePath + `__${utils.getUid()}`;
+				this.activePath = this.activePath + `__${getUid()}`;
 
 				this.screens[this.activePath] = this.screens[path];
 
@@ -146,7 +146,7 @@ class LiferayApp extends App {
 
 	isInPortletBlacklist(element) {
 		return Object.keys(this.portletsBlacklist).some((portletId) => {
-			const boundaryId = Utils.getPortletBoundaryId(portletId);
+			const boundaryId = getPortletBoundaryId(portletId);
 
 			const portlets = document.querySelectorAll(
 				'[id^="' + boundaryId + '"]'

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
@@ -13,10 +13,10 @@
  */
 
 import {openToast} from 'frontend-js-web';
-import core from 'metal';
 import dom from 'metal-dom';
 
 import {App} from '../../senna/senna';
+import utils from '../../senna/utils/utils';
 import LiferaySurface from '../surface/Surface.es';
 import Utils from '../util/Utils.es';
 
@@ -73,7 +73,7 @@ class LiferayApp extends App {
 		const body = document.body;
 
 		if (!body.id) {
-			body.id = 'senna_surface' + core.getUid();
+			body.id = 'senna_surface' + utils.getUid();
 		}
 
 		this.addSurfaces(new LiferaySurface(body.id));
@@ -94,7 +94,7 @@ class LiferayApp extends App {
 			const uri = new URL(path, window.location.origin);
 
 			if (uri.searchParams.get('p_p_lifecycle') === '1') {
-				this.activePath = this.activePath + `__${core.getUid()}`;
+				this.activePath = this.activePath + `__${utils.getUid()}`;
 
 				this.screens[this.activePath] = this.screens[path];
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
@@ -216,6 +216,12 @@ class LiferayApp extends App {
 		if (Liferay.Layout) {
 			Liferay.Layout.init(Liferay.Data.layoutConfig);
 		}
+		else {
+			this.dataLayoutConfigReadyHandle_ = Liferay.once(
+				'dataLayoutConfigReady',
+				this.onDataLayoutConfigReady_
+			);
+		}
 	}
 
 	/**
@@ -273,10 +279,7 @@ class LiferayApp extends App {
 		}
 
 		if (!event.error) {
-			this.dataLayoutConfigReadyHandle_ = Liferay.once(
-				'dataLayoutConfigReady',
-				this.onDataLayoutConfigReady_
-			);
+			this.onDataLayoutConfigReady_();
 		}
 
 		AUI().Get._insertCache = {};

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
@@ -116,7 +116,7 @@ const initSPA = function () {
 			else {
 				formElement.submit();
 			}
-		}, 0);
+		});
 	};
 
 	Liferay.initComponentCache();

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
@@ -13,7 +13,8 @@
  */
 
 import globals from '../senna/globals/globals';
-import {utils, version} from '../senna/senna';
+import {version} from '../senna/senna';
+import {getUrlPath} from '../senna/utils/utils';
 import App from './app/App.es';
 import ActionURLScreen from './screen/ActionURLScreen.es';
 import RenderURLScreen from './screen/RenderURLScreen.es';
@@ -111,7 +112,7 @@ const initSPA = function () {
 					);
 				}
 
-				app.navigate(utils.getUrlPath(url));
+				app.navigate(getUrlPath(url));
 			}
 			else {
 				formElement.submit();

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
@@ -12,10 +12,6 @@
  * details.
  */
 
-'use strict';
-
-import {async} from 'metal';
-
 import globals from '../senna/globals/globals';
 import {utils, version} from '../senna/senna';
 import App from './app/App.es';
@@ -81,7 +77,7 @@ const initSPA = function () {
 	]);
 
 	Liferay.Util.submitForm = function (form) {
-		async.nextTick(() => {
+		setTimeout(() => {
 			const formElement = Object.isPrototypeOf.call(
 				HTMLFormElement.prototype,
 				form
@@ -120,7 +116,7 @@ const initSPA = function () {
 			else {
 				formElement.submit();
 			}
-		});
+		}, 0);
 	};
 
 	Liferay.initComponentCache();

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/ActionURLScreen.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/ActionURLScreen.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {utils} from '../../senna/senna';
+import {getUrlPath} from '../../senna/utils/utils';
 import EventScreen from './EventScreen.es';
 
 /**
@@ -53,7 +53,7 @@ class ActionURLScreen extends EventScreen {
 				uri.searchParams.set('p_p_lifecycle', '0');
 			}
 
-			requestPath = utils.getUrlPath(uri.toString());
+			requestPath = getUrlPath(uri.toString());
 		}
 
 		return requestPath;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import core from 'metal';
 import dom from 'metal-dom';
 
 import Surface from '../../senna/surface/Surface';
@@ -31,7 +30,7 @@ class LiferaySurface extends Surface {
 	 */
 
 	addContent(screenId, content) {
-		if (core.isString(content)) {
+		if (typeof content === 'string') {
 			content = dom.buildFragment(content);
 		}
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/util/Utils.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/util/Utils.es.js
@@ -12,68 +12,46 @@
  * details.
  */
 
-const MAX_TIMEOUT = Math.pow(2, 31) - 1;
-
 /**
- * Utils
- *
- * A collection of utilities used by this module
+ * Given a portletId, returns the ID of the portlet's boundary DOM element
+ * @param  {!String} portletId The portlet ID
+ * @return {!String} The portlet boundary ID
  */
 
-class Utils {
-
-	/**
-	 * Returns the maximum number allowed by the `setTimeout` function
-	 * @return {!Number} The number
-	 */
-
-	static getMaxTimeout() {
-		return MAX_TIMEOUT;
-	}
-
-	/**
-	 * Given a portletId, returns the ID of the portlet's boundary DOM element
-	 * @param  {!String} portletId The portlet ID
-	 * @return {!String} The portlet boundary ID
-	 */
-
-	static getPortletBoundaryId(portletId) {
-		return 'p_p_id_' + portletId + '_';
-	}
-
-	/**
-	 * Given an array of portlet IDs, returns an array of portlet boundary IDs
-	 * @param  {!Array} The collection of portletIds
-	 * @return {!Array} The collection of portlet boundary IDs
-	 */
-
-	static getPortletBoundaryIds(portletIds) {
-		return portletIds.map((portletId) => {
-			return Utils.getPortletBoundaryId(portletId);
-		});
-	}
-
-	/**
-	 * Destroys all rendered portlets on the page
-	 */
-
-	static resetAllPortlets() {
-		Utils.getPortletBoundaryIds(Liferay.Portlet.list).forEach((value) => {
-			const portlet = document.querySelector('#' + value);
-
-			if (portlet) {
-				Liferay.Portlet.destroy(portlet);
-
-				portlet.portletProcessed = false;
-			}
-		});
-
-		Liferay.Portlet.readyCounter = 0;
-
-		Liferay.destroyComponents((component, componentConfig) => {
-			return componentConfig.destroyOnNavigate;
-		});
-	}
+export function getPortletBoundaryId(portletId) {
+	return 'p_p_id_' + portletId + '_';
 }
 
-export default Utils;
+/**
+ * Given an array of portlet IDs, returns an array of portlet boundary IDs
+ * @param  {!Array} The collection of portletIds
+ * @return {!Array} The collection of portlet boundary IDs
+ */
+
+export function getPortletBoundaryIds(portletIds) {
+	return portletIds.map((portletId) => {
+		return getPortletBoundaryId(portletId);
+	});
+}
+
+/**
+ * Destroys all rendered portlets on the page
+ */
+
+export function resetAllPortlets() {
+	getPortletBoundaryIds(Liferay.Portlet.list).forEach((value) => {
+		const portlet = document.querySelector('#' + value);
+
+		if (portlet) {
+			Liferay.Portlet.destroy(portlet);
+
+			portlet.portletProcessed = false;
+		}
+	});
+
+	Liferay.Portlet.readyCounter = 0;
+
+	Liferay.destroyComponents((component, componentConfig) => {
+		return componentConfig.destroyOnNavigate;
+	});
+}

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/Disposable.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/Disposable.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+/**
+ * Disposable utility. When inherited provides the `dispose` function to its
+ * subclass, which is responsible for disposing of any object references
+ * when an instance won't be used anymore. Subclasses should override
+ * `disposeInternal` to implement any specific disposing logic.
+ * @constructor
+ */
+class Disposable {
+
+	/**
+	 * Disposable constructor
+	 */
+	constructor() {
+
+		/**
+		 * Flag indicating if this instance has already been disposed.
+		 * @type {boolean}
+		 * @protected
+		 */
+		this.disposed_ = false;
+	}
+
+	/**
+	 * Disposes of this instance's object references. Calls `disposeInternal`.
+	 */
+	dispose() {
+		if (!this.disposed_) {
+			this.disposeInternal();
+			this.disposed_ = true;
+		}
+	}
+
+	/**
+	 * Subclasses should override this method to implement any specific
+	 * disposing logic (like clearing references and calling `dispose` on other
+	 * disposables).
+	 */
+	disposeInternal() {}
+
+	/**
+	 * Checks if this instance has already been disposed.
+	 * @return {boolean}
+	 */
+	isDisposed() {
+		return this.disposed_;
+	}
+}
+
+export default Disposable;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/app/App.js
@@ -14,10 +14,11 @@
 
 import {debounce} from 'frontend-js-web';
 import {addClasses, delegate, match, on, removeClasses} from 'metal-dom';
-import {EventEmitter, EventHandler} from 'metal-events';
 import CancellablePromise from 'metal-promise';
 import Uri from 'metal-uri';
 
+import EventEmitter from '../events/EventEmitter';
+import EventHandler from '../events/EventHandler';
 import globals from '../globals/globals';
 import Route from '../route/Route';
 import Screen from '../screen/Screen';

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/app/App.js
@@ -12,10 +12,8 @@
  * details.
  */
 
-'use strict';
-
+import {debounce} from 'frontend-js-web';
 import {array, async, isDefAndNotNull, isString, object} from 'metal';
-import debounce from 'metal-debounce';
 import {addClasses, delegate, match, on, removeClasses} from 'metal-dom';
 import {EventEmitter, EventHandler} from 'metal-events';
 import CancellablePromise from 'metal-promise';

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/app/App.js
@@ -745,7 +745,7 @@ class App extends EventEmitter {
 				winner = true;
 			}
 		};
-		setTimeout(switchScrollPositionRace, 0);
+		setTimeout(switchScrollPositionRace);
 		globals.document.addEventListener(
 			'scroll',
 			switchScrollPositionRace,
@@ -1113,7 +1113,7 @@ class App extends EventEmitter {
 			// after the load event occured, but not in the same event-loop cycle.
 
 			this.skipLoadPopstate = false;
-		}, 0);
+		});
 
 		// Try to reposition scroll to the hashed anchor when page loads.
 
@@ -1359,7 +1359,7 @@ class App extends EventEmitter {
 		const routeIndex = this.routes.indexOf(route);
 
 		if (routeIndex >= 0) {
-			Array.prototype.splice.call(this.routes, routeIndex, 1);
+			this.routes.splice(routeIndex, 1);
 		}
 
 		return routeIndex >= 0;
@@ -1510,9 +1510,14 @@ class App extends EventEmitter {
 			}
 		};
 
-		return new CancellablePromise(
-			(resolve) => sync() & setTimeout(() => sync() & resolve(), 0)
-		);
+		return new CancellablePromise((resolve) => {
+			sync();
+
+			setTimeout(() => {
+				sync();
+				resolve();
+			});
+		});
 	}
 
 	/**

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/app/AppDataAttributeHandler.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/app/AppDataAttributeHandler.js
@@ -16,7 +16,7 @@ import Disposable from '../Disposable';
 import globals from '../globals/globals';
 import Route from '../route/Route';
 import HtmlScreen from '../screen/HtmlScreen';
-import utils from '../utils/utils';
+import {getUid, log} from '../utils/utils';
 import App from './App';
 import dataAttributes from './dataAttributes';
 
@@ -63,7 +63,7 @@ class AppDataAttributeHandler extends Disposable {
 		}
 
 		if (!this.baseElement.hasAttribute(dataAttributes.senna)) {
-			utils.log(
+			log(
 				'Senna was not initialized from data attributes. ' +
 					'In order to enable its usage from data attributes try setting ' +
 					'in the base element, e.g. `<body data-senna>`.'
@@ -76,7 +76,7 @@ class AppDataAttributeHandler extends Disposable {
 			throw new Error('Senna app was already initialized.');
 		}
 
-		utils.log('Senna initialized from data attribute.');
+		log('Senna initialized from data attribute.');
 
 		this.app = new App();
 		this.maybeAddRoutes_();
@@ -124,7 +124,7 @@ class AppDataAttributeHandler extends Disposable {
 		);
 		if (!this.app.hasRoutes()) {
 			this.app.addRoutes(new Route(/.*/, HtmlScreen));
-			utils.log("Senna can't find route elements, adding default.");
+			log("Senna can't find route elements, adding default.");
 		}
 	}
 
@@ -161,7 +161,7 @@ class AppDataAttributeHandler extends Disposable {
 			this.maybeParseLinkRouteHandler_(link)
 		);
 		this.app.addRoutes(route);
-		utils.log('Senna scanned route ' + route.getPath());
+		log('Senna scanned route ' + route.getPath());
 	}
 
 	/**
@@ -203,7 +203,7 @@ class AppDataAttributeHandler extends Disposable {
 		var basePath = this.baseElement.getAttribute(dataAttributes.basePath);
 		if (basePath) {
 			this.app.setBasePath(basePath);
-			utils.log('Senna scanned base path ' + basePath);
+			log('Senna scanned base path ' + basePath);
 		}
 	}
 
@@ -217,7 +217,7 @@ class AppDataAttributeHandler extends Disposable {
 		);
 		if (linkSelector) {
 			this.app.setLinkSelector(linkSelector);
-			utils.log('Senna scanned link selector ' + linkSelector);
+			log('Senna scanned link selector ' + linkSelector);
 		}
 	}
 
@@ -231,7 +231,7 @@ class AppDataAttributeHandler extends Disposable {
 		);
 		if (loadingCssClass) {
 			this.app.setLoadingCssClass(loadingCssClass);
-			utils.log('Senna scanned loading css class ' + loadingCssClass);
+			log('Senna scanned loading css class ' + loadingCssClass);
 		}
 	}
 
@@ -250,9 +250,7 @@ class AppDataAttributeHandler extends Disposable {
 			else {
 				this.app.setUpdateScrollPosition(true);
 			}
-			utils.log(
-				'Senna scanned update scroll position ' + updateScrollPosition
-			);
+			log('Senna scanned update scroll position ' + updateScrollPosition);
 		}
 	}
 
@@ -275,7 +273,7 @@ class AppDataAttributeHandler extends Disposable {
 	 */
 	updateElementIdIfSpecialSurface_(element) {
 		if (!element.id && element === globals.document.body) {
-			element.id = 'senna_surface_' + utils.getUid();
+			element.id = 'senna_surface_' + getUid();
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/app/AppDataAttributeHandler.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/app/AppDataAttributeHandler.js
@@ -12,10 +12,7 @@
  * details.
  */
 
-'use strict';
-
-import {Disposable, getUid, isDefAndNotNull, isElement, object} from 'metal';
-
+import Disposable from '../Disposable';
 import globals from '../globals/globals';
 import Route from '../route/Route';
 import HtmlScreen from '../screen/HtmlScreen';
@@ -52,7 +49,12 @@ class AppDataAttributeHandler extends Disposable {
 	 * Inits application based on information scanned from document.
 	 */
 	handle() {
-		if (!isElement(this.baseElement)) {
+		if (
+			!(
+				this.baseElement &&
+				this.baseElement.nodeType === Node.ELEMENT_NODE
+			)
+		) {
 			throw new Error(
 				'Senna data attribute handler base element ' +
 					'not set or invalid, try setting a valid element that ' +
@@ -169,8 +171,10 @@ class AppDataAttributeHandler extends Disposable {
 	 */
 	maybeParseLinkRouteHandler_(link) {
 		var handler = link.getAttribute('type');
-		if (isDefAndNotNull(handler)) {
-			handler = object.getObjectByName(handler);
+		if (handler) {
+			handler = handler
+				.split('.')
+				.reduce((part, key) => part[key], window);
 		}
 
 		return handler;
@@ -183,7 +187,7 @@ class AppDataAttributeHandler extends Disposable {
 	 */
 	maybeParseLinkRoutePath_(link) {
 		var path = link.getAttribute('href');
-		if (isDefAndNotNull(path)) {
+		if (path) {
 			if (path.indexOf('regex:') === 0) {
 				path = new RegExp(path.substring(6));
 			}
@@ -197,7 +201,7 @@ class AppDataAttributeHandler extends Disposable {
 	 */
 	maybeSetBasePath_() {
 		var basePath = this.baseElement.getAttribute(dataAttributes.basePath);
-		if (isDefAndNotNull(basePath)) {
+		if (basePath) {
 			this.app.setBasePath(basePath);
 			utils.log('Senna scanned base path ' + basePath);
 		}
@@ -211,7 +215,7 @@ class AppDataAttributeHandler extends Disposable {
 		var linkSelector = this.baseElement.getAttribute(
 			dataAttributes.linkSelector
 		);
-		if (isDefAndNotNull(linkSelector)) {
+		if (linkSelector) {
 			this.app.setLinkSelector(linkSelector);
 			utils.log('Senna scanned link selector ' + linkSelector);
 		}
@@ -225,7 +229,7 @@ class AppDataAttributeHandler extends Disposable {
 		var loadingCssClass = this.baseElement.getAttribute(
 			dataAttributes.loadingCssClass
 		);
-		if (isDefAndNotNull(loadingCssClass)) {
+		if (loadingCssClass) {
 			this.app.setLoadingCssClass(loadingCssClass);
 			utils.log('Senna scanned loading css class ' + loadingCssClass);
 		}
@@ -239,7 +243,7 @@ class AppDataAttributeHandler extends Disposable {
 		var updateScrollPosition = this.baseElement.getAttribute(
 			dataAttributes.updateScrollPosition
 		);
-		if (isDefAndNotNull(updateScrollPosition)) {
+		if (updateScrollPosition) {
 			if (updateScrollPosition === 'false') {
 				this.app.setUpdateScrollPosition(false);
 			}
@@ -271,7 +275,7 @@ class AppDataAttributeHandler extends Disposable {
 	 */
 	updateElementIdIfSpecialSurface_(element) {
 		if (!element.id && element === globals.document.body) {
-			element.id = 'senna_surface_' + getUid();
+			element.id = 'senna_surface_' + utils.getUid();
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/cacheable/Cacheable.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/cacheable/Cacheable.js
@@ -12,9 +12,7 @@
  * details.
  */
 
-'use strict';
-
-import {Disposable} from 'metal';
+import Disposable from '../Disposable';
 
 class Cacheable extends Disposable {
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventEmitter.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventEmitter.js
@@ -13,7 +13,6 @@
  */
 
 import Disposable from '../Disposable';
-import utils from '../utils/utils';
 import EventHandle from './EventHandle';
 
 const singleArray = [0];
@@ -161,7 +160,7 @@ class EventEmitter extends Disposable {
 			return false;
 		}
 
-		const args = utils.slice(arguments, 1);
+		const args = Array.prototype.slice.call(arguments, 1);
 		this.runListeners_(listeners, args, this.buildFacade_(event));
 
 		return true;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventEmitter.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventEmitter.js
@@ -1,0 +1,478 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import Disposable from '../Disposable';
+import utils from '../utils/utils';
+import EventHandle from './EventHandle';
+
+const singleArray_ = [0];
+
+/**
+ * EventEmitter utility.
+ * @extends {Disposable}
+ */
+class EventEmitter extends Disposable {
+
+	/**
+	 * EventEmitter constructor
+	 */
+	constructor() {
+		super();
+
+		/**
+		 * Holds event listeners scoped by event type.
+		 * @type {Object<string, !Array<!function()>>}
+		 * @protected
+		 */
+		this.events_ = null;
+
+		/**
+		 * Handlers that are triggered when an event is listened to.
+		 * @type {Array}
+		 */
+		this.listenerHandlers_ = null;
+
+		/**
+		 * Configuration option which determines if an event facade should be sent
+		 * as a param of listeners when emitting events. If set to true, the facade
+		 * will be passed as the first argument of the listener.
+		 * @type {boolean}
+		 * @protected
+		 */
+		this.shouldUseFacade_ = false;
+	}
+
+	/**
+	 * Adds a handler to given holder variable. If the holder doesn't have a
+	 * value yet, it will receive the handler directly. If the holder is an array,
+	 * the value will just be added to it. Otherwise, the holder will be set to a
+	 * new array containing its previous value plus the new handler.
+	 * @param {*} holder
+	 * @param {!function()|Object} handler
+	 * @return {*} The holder's new value.
+	 * @protected
+	 */
+	addHandler_(holder, handler) {
+		if (!holder) {
+			holder = handler;
+		}
+		else {
+			if (!Array.isArray(holder)) {
+				holder = [holder];
+			}
+			holder.push(handler);
+		}
+
+		return holder;
+	}
+
+	/**
+	 * Adds a listener to the end of the listeners array for the specified events.
+	 * @param {!(Array|string)} event
+	 * @param {!Function} listener
+	 * @param {boolean} defaultListener Flag indicating if this listener is a default
+	 *   action for this event. Default actions are run last, and only if no previous
+	 *   listener call `preventDefault()` on the received event facade.
+	 * @return {!EventHandle} Can be used to remove the listener.
+	 */
+	addListener(event, listener, defaultListener) {
+		this.validateListener_(listener);
+
+		const events = this.toEventsArray_(event);
+		for (let i = 0; i < events.length; i++) {
+			this.addSingleListener_(events[i], listener, defaultListener);
+		}
+
+		return new EventHandle(this, event, listener);
+	}
+
+	/**
+	 * Adds a listener to the end of the listeners array for a single event.
+	 * @param {string} event
+	 * @param {!Function} listener
+	 * @param {boolean} defaultListener Flag indicating if this listener is a default
+	 *   action for this event. Default actions are run last, and only if no previous
+	 *   listener call `preventDefault()` on the received event facade.
+	 * @param {Function=} origin The original function that was added as a
+	 *   listener, if there is any.
+	 * @protected
+	 */
+	addSingleListener_(event, listener, defaultListener, origin) {
+		this.runListenerHandlers_(event);
+		if (defaultListener || origin) {
+			listener = {
+				default: defaultListener,
+				fn: listener,
+				origin,
+			};
+		}
+		this.events_ = this.events_ || {};
+		this.events_[event] = this.addHandler_(this.events_[event], listener);
+	}
+
+	/**
+	 * Builds facade for the given event.
+	 * @param {string} event
+	 * @return {Object}
+	 * @protected
+	 */
+	buildFacade_(event) {
+		if (this.getShouldUseFacade()) {
+			const facade = {
+				preventDefault() {
+					facade.preventedDefault = true;
+				},
+				target: this,
+				type: event,
+			};
+
+			return facade;
+		}
+	}
+
+	/**
+	 * Disposes of this instance's object references.
+	 * @override
+	 */
+	disposeInternal() {
+		this.events_ = null;
+	}
+
+	/**
+	 * Execute each of the listeners in order with the supplied arguments.
+	 * @param {string} event
+	 * @param {*} opt_args [arg1], [arg2], [...]
+	 * @return {boolean} Returns true if event had listeners, false otherwise.
+	 */
+	emit(event) {
+		const listeners = this.getRawListeners_(event);
+		if (listeners.length === 0) {
+			return false;
+		}
+
+		const args = utils.slice(arguments, 1);
+		this.runListeners_(listeners, args, this.buildFacade_(event));
+
+		return true;
+	}
+
+	/**
+	 * Gets the listener objects for the given event, if there are any.
+	 * @param {string} event
+	 * @return {!Array}
+	 * @protected
+	 */
+	getRawListeners_(event) {
+		const directListeners = toArray(this.events_ && this.events_[event]);
+
+		return directListeners.concat(
+			toArray(this.events_ && this.events_['*'])
+		);
+	}
+
+	/**
+	 * Gets the configuration option which determines if an event facade should
+	 * be sent as a param of listeners when emitting events. If set to true, the
+	 * facade will be passed as the first argument of the listener.
+	 * @return {boolean}
+	 */
+	getShouldUseFacade() {
+		return this.shouldUseFacade_;
+	}
+
+	/**
+	 * Returns an array of listeners for the specified event.
+	 * @param {string} event
+	 * @return {Array} Array of listeners.
+	 */
+	listeners(event) {
+		return this.getRawListeners_(event).map((listener) =>
+			listener.fn ? listener.fn : listener
+		);
+	}
+
+	/**
+	 * Adds a listener that will be invoked a fixed number of times for the
+	 * events. After each event is triggered the specified amount of times, the
+	 * listener is removed for it.
+	 * @param {!(Array|string)} event
+	 * @param {number} amount The amount of times this event should be listened
+	 * to.
+	 * @param {!Function} listener
+	 * @return {!EventHandle} Can be used to remove the listener.
+	 */
+	many(event, amount, listener) {
+		const events = this.toEventsArray_(event);
+		for (let i = 0; i < events.length; i++) {
+			this.many_(events[i], amount, listener);
+		}
+
+		return new EventHandle(this, event, listener);
+	}
+
+	/**
+	 * Adds a listener that will be invoked a fixed number of times for a single
+	 * event. After the event is triggered the specified amount of times, the
+	 * listener is removed.
+	 * @param {string} event
+	 * @param {number} amount The amount of times this event should be listened
+	 * to.
+	 * @param {!Function} listener
+	 * @protected
+	 */
+	many_(event, amount, listener) {
+		const self = this;
+
+		if (amount <= 0) {
+			return;
+		}
+
+		/**
+		 *
+		 */
+		function handlerInternal() {
+			if (--amount === 0) {
+				self.removeListener(event, handlerInternal);
+			}
+			listener.apply(self, arguments); // eslint-disable-line
+		}
+
+		self.addSingleListener_(event, handlerInternal, false, listener);
+	}
+
+	/**
+	 * Checks if a listener object matches the given listener function. To match,
+	 * it needs to either point to that listener or have it as its origin.
+	 * @param {!Object} listenerObj
+	 * @param {!Function} listener
+	 * @return {boolean}
+	 * @protected
+	 */
+	matchesListener_(listenerObj, listener) {
+		const fn = listenerObj.fn || listenerObj;
+
+		return (
+			fn === listener ||
+			(listenerObj.origin && listenerObj.origin === listener) // eslint-disable-line
+		);
+	}
+
+	/**
+	 * Removes a listener for the specified events.
+	 * Caution: changes array indices in the listener array behind the listener.
+	 * @param {!(Array|string)} event
+	 * @param {!Function} listener
+	 * @return {!Object} Returns emitter, so calls can be chained.
+	 */
+	off(event, listener) {
+		this.validateListener_(listener);
+		if (!this.events_) {
+			return this;
+		}
+
+		const events = this.toEventsArray_(event);
+		for (let i = 0; i < events.length; i++) {
+			this.events_[events[i]] = this.removeMatchingListenerObjs_(
+				toArray(this.events_[events[i]]),
+				listener
+			);
+		}
+
+		return this;
+	}
+
+	/**
+	 * Adds a listener to the end of the listeners array for the specified events.
+	 * @param {!(Array|string)} events
+	 * @param {!Function} listener
+	 * @return {!EventHandle} Can be used to remove the listener.
+	 */
+	on() {
+		return this.addListener.apply(this, arguments); // eslint-disable-line
+	}
+
+	/**
+	 * Adds handler that gets triggered when an event is listened to on this
+	 * instance.
+	 * @param {!function()} handler
+	 */
+	onListener(handler) {
+		this.listenerHandlers_ = this.addHandler_(
+			this.listenerHandlers_,
+			handler
+		); // eslint-disable-line
+	}
+
+	/**
+	 * Adds a one time listener for the events. This listener is invoked only the
+	 * next time each event is fired, after which it is removed.
+	 * @param {!(Array|string)} events
+	 * @param {!Function} listener
+	 * @return {!EventHandle} Can be used to remove the listener.
+	 */
+	once(events, listener) {
+		return this.many(events, 1, listener);
+	}
+
+	/**
+	 * Removes all listeners, or those of the specified events. It's not a good
+	 * idea to remove listeners that were added elsewhere in the code,
+	 * especially when it's on an emitter that you didn't create.
+	 * @param {(Array|string)=} event
+	 * @return {!Object} Returns emitter, so calls can be chained.
+	 */
+	removeAllListeners(event) {
+		if (this.events_) {
+			if (event) {
+				const events = this.toEventsArray_(event);
+				for (let i = 0; i < events.length; i++) {
+					this.events_[events[i]] = null;
+				}
+			}
+			else {
+				this.events_ = null;
+			}
+		}
+
+		return this;
+	}
+
+	/**
+	 * Removes all listener objects from the given array that match the given
+	 * listener function.
+	 * @param {Array.<Object>} listenerObjs
+	 * @param {!Function} listener
+	 * @return {Array.<Object>|Object} The new listeners array for this event.
+	 * @protected
+	 */
+	removeMatchingListenerObjs_(listenerObjs, listener) {
+		const finalListeners = [];
+		for (let i = 0; i < listenerObjs.length; i++) {
+			if (!this.matchesListener_(listenerObjs[i], listener)) {
+				finalListeners.push(listenerObjs[i]);
+			}
+		}
+
+		return finalListeners.length > 0 ? finalListeners : null;
+	}
+
+	/**
+	 * Removes a listener for the specified events.
+	 * Caution: changes array indices in the listener array behind the listener.
+	 * @param {!(Array|string)} events
+	 * @param {!Function} listener
+	 * @return {!Object} Returns emitter, so calls can be chained.
+	 */
+	removeListener() {
+		return this.off.apply(this, arguments); // eslint-disable-line
+	}
+
+	/**
+	 * Runs the handlers when an event is listened to.
+	 * @param {string} event
+	 * @protected
+	 */
+	runListenerHandlers_(event) {
+		let handlers = this.listenerHandlers_;
+		if (handlers) {
+			handlers = toArray(handlers);
+			for (let i = 0; i < handlers.length; i++) {
+				handlers[i](event);
+			}
+		}
+	}
+
+	/**
+	 * Runs the given listeners.
+	 * @param {!Array} listeners
+	 * @param {!Array} args
+	 * @param {Object} facade
+	 * @protected
+	 */
+	runListeners_(listeners, args, facade) {
+		if (facade) {
+			args.push(facade);
+		}
+
+		const defaultListeners = [];
+		for (let i = 0; i < listeners.length; i++) {
+			const listener = listeners[i].fn || listeners[i];
+			if (listeners[i].default) {
+				defaultListeners.push(listener);
+			}
+			else {
+				listener.apply(this, args);
+			}
+		}
+		if (!facade || !facade.preventedDefault) {
+			for (let j = 0; j < defaultListeners.length; j++) {
+				defaultListeners[j].apply(this, args);
+			}
+		}
+	}
+
+	/**
+	 * Sets the configuration option which determines if an event facade should
+	 * be sent as a param of listeners when emitting events. If set to true, the
+	 * facade will be passed as the first argument of the listener.
+	 * @param {boolean} shouldUseFacade
+	 * @return {!Object} Returns emitter, so calls can be chained.
+	 */
+	setShouldUseFacade(shouldUseFacade) {
+		this.shouldUseFacade_ = shouldUseFacade;
+
+		return this;
+	}
+
+	/**
+	 * Converts the parameter to an array if only one event is given. Reuses the
+	 * same array each time this conversion is done, to avoid using more memory
+	 * than necessary.
+	 * @param  {!(Array|string)} events
+	 * @return {!Array}
+	 * @protected
+	 */
+	toEventsArray_(events) {
+		if (typeof events === 'string') {
+			singleArray_[0] = events;
+			events = singleArray_;
+		}
+
+		return events;
+	}
+
+	/**
+	 * Checks if the given listener is valid, throwing an exception when it's not.
+	 * @param  {*} listener
+	 * @protected
+	 */
+	validateListener_(listener) {
+		if (typeof listener !== 'function') {
+			throw new TypeError('Listener must be a function');
+		}
+	}
+}
+
+/**
+ * Converts to an array
+ * @param {Object} val
+ * @return {Array}
+ */
+function toArray(val) {
+	val = val || [];
+
+	return Array.isArray(val) ? val : [val];
+}
+
+export default EventEmitter;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventEmitter.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventEmitter.js
@@ -16,7 +16,7 @@ import Disposable from '../Disposable';
 import utils from '../utils/utils';
 import EventHandle from './EventHandle';
 
-const singleArray_ = [0];
+const singleArray = [0];
 
 /**
  * EventEmitter utility.
@@ -245,7 +245,7 @@ class EventEmitter extends Disposable {
 			if (--amount === 0) {
 				self.removeListener(event, handlerInternal);
 			}
-			listener.apply(self, arguments); // eslint-disable-line
+			listener.apply(self, arguments);
 		}
 
 		self.addSingleListener_(event, handlerInternal, false, listener);
@@ -264,7 +264,7 @@ class EventEmitter extends Disposable {
 
 		return (
 			fn === listener ||
-			(listenerObj.origin && listenerObj.origin === listener) // eslint-disable-line
+			(listenerObj.origin && listenerObj.origin === listener)
 		);
 	}
 
@@ -299,7 +299,7 @@ class EventEmitter extends Disposable {
 	 * @return {!EventHandle} Can be used to remove the listener.
 	 */
 	on() {
-		return this.addListener.apply(this, arguments); // eslint-disable-line
+		return this.addListener.apply(this, arguments);
 	}
 
 	/**
@@ -311,7 +311,7 @@ class EventEmitter extends Disposable {
 		this.listenerHandlers_ = this.addHandler_(
 			this.listenerHandlers_,
 			handler
-		); // eslint-disable-line
+		);
 	}
 
 	/**
@@ -375,7 +375,7 @@ class EventEmitter extends Disposable {
 	 * @return {!Object} Returns emitter, so calls can be chained.
 	 */
 	removeListener() {
-		return this.off.apply(this, arguments); // eslint-disable-line
+		return this.off.apply(this, arguments);
 	}
 
 	/**
@@ -445,8 +445,8 @@ class EventEmitter extends Disposable {
 	 */
 	toEventsArray_(events) {
 		if (typeof events === 'string') {
-			singleArray_[0] = events;
-			events = singleArray_;
+			singleArray[0] = events;
+			events = singleArray;
 		}
 
 		return events;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventHandle.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventHandle.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import Disposable from '../Disposable';
+
+/**
+ * EventHandle utility. Holds information about an event subscription, and
+ * allows removing them easily.
+ * EventHandle is a Disposable, but it's important to note that the
+ * EventEmitter that created it is not the one responsible for disposing it.
+ * That responsibility is for the code that holds a reference to it.
+ * @extends {Disposable}
+ */
+class EventHandle extends Disposable {
+
+	/**
+	 * EventHandle constructor
+	 * @param {!EventEmitter} emitter Emitter the event was subscribed to.
+	 * @param {string} event The name of the event that was subscribed to.
+	 * @param {!Function} listener The listener subscribed to the event.
+	 */
+	constructor(emitter, event, listener) {
+		super();
+
+		/**
+		 * The EventEmitter instance that the event was subscribed to.
+		 * @type {EventEmitter}
+		 * @protected
+		 */
+		this.emitter_ = emitter;
+
+		/**
+		 * The name of the event that was subscribed to.
+		 * @type {string}
+		 * @protected
+		 */
+		this.event_ = event;
+
+		/**
+		 * The listener subscribed to the event.
+		 * @type {Function}
+		 * @protected
+		 */
+		this.listener_ = listener;
+	}
+
+	/**
+	 * Disposes of this instance's object references.
+	 * @override
+	 */
+	disposeInternal() {
+		this.removeListener();
+		this.emitter_ = null;
+		this.listener_ = null;
+	}
+
+	/**
+	 * Removes the listener subscription from the emitter.
+	 */
+	removeListener() {
+		if (!this.emitter_.isDisposed()) {
+			this.emitter_.removeListener(this.event_, this.listener_);
+		}
+	}
+}
+
+export default EventHandle;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventHandler.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventHandler.js
@@ -39,10 +39,10 @@ class EventHandler extends Disposable {
 	/**
 	 * Adds event handles to be removed later through the `removeAllListeners`
 	 * method.
-	 * @param {...(!EventHandle)} var_args
+	 * @param {...(!EventHandle)} args
 	 */
 	add(...args) {
-		for (let i = 0; i < arguments.length; i++) {
+		for (let i = 0; i < args.length; i++) {
 			this.eventHandles_.push(args[i]);
 		}
 	}

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventHandler.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/events/EventHandler.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import Disposable from '../Disposable';
+
+/**
+ * EventHandler utility. It's useful for easily removing a group of
+ * listeners from different EventEmitter instances.
+ * @extends {Disposable}
+ */
+class EventHandler extends Disposable {
+
+	/**
+	 * EventHandler constructor
+	 */
+	constructor() {
+		super();
+
+		/**
+		 * An array that holds the added event handles, so the listeners can be
+		 * removed later.
+		 * @type {Array.<EventHandle>}
+		 * @protected
+		 */
+		this.eventHandles_ = [];
+	}
+
+	/**
+	 * Adds event handles to be removed later through the `removeAllListeners`
+	 * method.
+	 * @param {...(!EventHandle)} var_args
+	 */
+	add(...args) {
+		for (let i = 0; i < arguments.length; i++) {
+			this.eventHandles_.push(args[i]);
+		}
+	}
+
+	/**
+	 * Disposes of this instance's object references.
+	 * @override
+	 */
+	disposeInternal() {
+		this.eventHandles_ = null;
+	}
+
+	/**
+	 * Removes all listeners that have been added through the `add` method.
+	 */
+	removeAllListeners() {
+		for (let i = 0; i < this.eventHandles_.length; i++) {
+			this.eventHandles_[i].removeListener();
+		}
+
+		this.eventHandles_ = [];
+	}
+}
+
+export default EventHandler;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/route/Route.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/route/Route.js
@@ -12,9 +12,6 @@
  * details.
  */
 
-'use strict';
-
-import {isDefAndNotNull, isFunction, isString} from 'metal';
 import {extractData, parse, toRegex} from 'metal-path-parser';
 
 class Route {
@@ -25,10 +22,10 @@ class Route {
 	 * @param {!Function} handler
 	 */
 	constructor(path, handler) {
-		if (!isDefAndNotNull(path)) {
+		if (!path) {
 			throw new Error('Route path not specified.');
 		}
-		if (!isFunction(handler)) {
+		if (typeof handler !== 'function') {
 			throw new Error('Route handler is not a function.');
 		}
 
@@ -73,7 +70,7 @@ class Route {
 	 *     null otherwise.
 	 */
 	extractParams(path) {
-		if (isString(this.path)) {
+		if (typeof this.path === 'string') {
 			return extractData(this.buildParsedData_().tokens, path);
 		}
 
@@ -104,10 +101,10 @@ class Route {
 	matchesPath(value) {
 		var path = this.path;
 
-		if (isFunction(path)) {
+		if (typeof path === 'function') {
 			return path(value);
 		}
-		if (isString(path)) {
+		if (typeof path === 'string') {
 			path = this.buildParsedData_().regex;
 		}
 		if (path instanceof RegExp) {

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/route/Route.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/route/Route.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {extractData, parse, toRegex} from 'metal-path-parser';
+import {extractData, parse, toRegex} from '../utils/pathParser';
 
 class Route {
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/HtmlScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/HtmlScreen.js
@@ -12,13 +12,10 @@
  * details.
  */
 
-'use strict';
-
 import {getUid} from 'metal';
 import {buildFragment, globalEval, globalEvalStyles, match} from 'metal-dom';
 import CancellablePromise from 'metal-promise';
 import Uri from 'metal-uri';
-import UA from 'metal-useragent';
 
 import globals from '../globals/globals';
 import Surface from '../surface/Surface';
@@ -125,17 +122,10 @@ class HtmlScreen extends RequestScreen {
 	copyNodeAttributesFromContent_(content, node) {
 		content = content.replace(/[<]\s*html/gi, '<senna');
 		content = content.replace(/\/html\s*>/gi, '/senna>');
-		let placeholder;
-		if (UA.isIe) {
-			const tempNode = globals.document
-				.createRange()
-				.createContextualFragment(content);
-			placeholder = tempNode.querySelector('senna');
-		}
-		else {
-			node.innerHTML = content;
-			placeholder = node.querySelector('senna');
-		}
+
+		node.innerHTML = content;
+
+		const placeholder = node.querySelector('senna');
 
 		if (placeholder) {
 			utils.clearNodeAttributes(node);
@@ -346,26 +336,9 @@ class HtmlScreen extends RequestScreen {
 			this.resolveTitleFromVirtualDocument();
 			this.resolveMetaTagsFromVirtualDocument();
 			this.assertSameBodyIdInVirtualDocument();
-			if (UA.isIe) {
-				this.makeTemporaryStylesHrefsUnique_();
-			}
 
 			return content;
 		});
-	}
-
-	/**
-	 * Queries temporary styles from virtual document, and makes them unique.
-	 * This is necessary for caching and load event firing issues specific to
-	 * IE11. https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7940171/
-	 */
-	makeTemporaryStylesHrefsUnique_() {
-		var temporariesInDoc = this.virtualQuerySelectorAll_(
-			HtmlScreen.selectors.stylesTemporary
-		);
-		temporariesInDoc.forEach((style) =>
-			this.replaceStyleAndMakeUnique_(style)
-		);
 	}
 
 	/**
@@ -392,7 +365,7 @@ class HtmlScreen extends RequestScreen {
 		return new CancellablePromise((resolve) => {
 			elements.forEach((element) =>
 				document.head.appendChild(
-					UA.isIe ? element : utils.setElementWithRandomHref(element)
+					utils.setElementWithRandomHref(element)
 				)
 			);
 			resolve();

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/HtmlScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/HtmlScreen.js
@@ -18,7 +18,7 @@ import Uri from 'metal-uri';
 
 import globals from '../globals/globals';
 import Surface from '../surface/Surface';
-import utils from '../utils/utils';
+import {clearNodeAttributes, copyNodeAttributes, getUid} from '../utils/utils';
 import RequestScreen from './RequestScreen';
 
 class HtmlScreen extends RequestScreen {
@@ -108,7 +108,7 @@ class HtmlScreen extends RequestScreen {
 	assertSameBodyIdInVirtualDocument() {
 		var bodySurface = this.virtualDocument.querySelector('body');
 		if (!globals.document.body.id) {
-			globals.document.body.id = 'senna_surface_' + utils.getUid();
+			globals.document.body.id = 'senna_surface_' + getUid();
 		}
 		if (bodySurface) {
 			bodySurface.id = globals.document.body.id;
@@ -127,8 +127,8 @@ class HtmlScreen extends RequestScreen {
 		const placeholder = node.querySelector('senna');
 
 		if (placeholder) {
-			utils.clearNodeAttributes(node);
-			utils.copyNodeAttributes(placeholder, node);
+			clearNodeAttributes(node);
+			copyNodeAttributes(placeholder, node);
 		}
 	}
 
@@ -145,7 +145,7 @@ class HtmlScreen extends RequestScreen {
 	 */
 	disposePendingStyles() {
 		if (this.pendingStyles) {
-			utils.removeElementsFromDocument(this.pendingStyles);
+			this.pendingStyles.forEach((element) => element.remove());
 		}
 	}
 
@@ -194,7 +194,7 @@ class HtmlScreen extends RequestScreen {
 		);
 
 		return new CancellablePromise((resolve) => {
-			utils.removeElementsFromDocument(resourcesInDocument);
+			resourcesInDocument.forEach((element) => element.remove());
 			this.runFaviconInElement_(resourcesInVirtual).then(() => resolve());
 		});
 	}
@@ -255,7 +255,7 @@ class HtmlScreen extends RequestScreen {
 			evaluatorFn(
 				frag,
 				() => {
-					utils.removeElementsFromDocument(temporariesInDoc);
+					temporariesInDoc.forEach((element) => element.remove());
 					resolve();
 				},
 				opt_appendResourceFn
@@ -268,8 +268,8 @@ class HtmlScreen extends RequestScreen {
 	 */
 	flip(surfaces) {
 		return super.flip(surfaces).then(() => {
-			utils.clearNodeAttributes(globals.document.documentElement);
-			utils.copyNodeAttributes(
+			clearNodeAttributes(globals.document.documentElement);
+			copyNodeAttributes(
 				this.virtualDocument,
 				globals.document.documentElement
 			);
@@ -282,7 +282,7 @@ class HtmlScreen extends RequestScreen {
 		const currentMetaNodes = this.querySelectorAll_('meta');
 		const metasFromVirtualDocument = this.metas;
 		if (currentMetaNodes) {
-			utils.removeElementsFromDocument(currentMetaNodes);
+			currentMetaNodes.forEach((element) => element.remove());
 			if (metasFromVirtualDocument) {
 				metasFromVirtualDocument.forEach((meta) =>
 					globals.document.head.appendChild(meta)
@@ -348,7 +348,7 @@ class HtmlScreen extends RequestScreen {
 		if (style.href) {
 			var newStyle = globals.document.createElement(style.tagName);
 			style.href = new Uri(style.href).makeUnique().toString();
-			utils.copyNodeAttributes(style, newStyle);
+			copyNodeAttributes(style, newStyle);
 			style.parentNode.replaceChild(newStyle, style);
 			style.disabled = true;
 		}
@@ -362,11 +362,11 @@ class HtmlScreen extends RequestScreen {
 	 */
 	runFaviconInElement_(elements) {
 		return new CancellablePromise((resolve) => {
-			elements.forEach((element) =>
-				document.head.appendChild(
-					utils.setElementWithRandomHref(element)
-				)
-			);
+			elements.forEach((element) => {
+				element.href = element.href + '?q=' + Math.random();
+
+				document.head.appendChild(element);
+			});
 			resolve();
 		});
 	}

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/HtmlScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/HtmlScreen.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import {getUid} from 'metal';
 import {buildFragment, globalEval, globalEvalStyles, match} from 'metal-dom';
 import CancellablePromise from 'metal-promise';
 import Uri from 'metal-uri';
@@ -109,7 +108,7 @@ class HtmlScreen extends RequestScreen {
 	assertSameBodyIdInVirtualDocument() {
 		var bodySurface = this.virtualDocument.querySelector('body');
 		if (!globals.document.body.id) {
-			globals.document.body.id = 'senna_surface_' + getUid();
+			globals.document.body.id = 'senna_surface_' + utils.getUid();
 		}
 		if (bodySurface) {
 			bodySurface.id = globals.document.body.id;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/RequestScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/RequestScreen.js
@@ -15,7 +15,6 @@
 'use strict';
 
 import {fetch} from 'frontend-js-web';
-import {isDefAndNotNull} from 'metal';
 import CancellablePromise from 'metal-promise';
 import Uri from 'metal-uri';
 
@@ -233,7 +232,7 @@ class RequestScreen extends Screen {
 	 */
 	load(path) {
 		const cache = this.getCache();
-		if (isDefAndNotNull(cache)) {
+		if (cache) {
 			return CancellablePromise.resolve(cache);
 		}
 		let body = null;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/RequestScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/RequestScreen.js
@@ -12,15 +12,13 @@
  * details.
  */
 
-'use strict';
-
 import {fetch} from 'frontend-js-web';
 import CancellablePromise from 'metal-promise';
 import Uri from 'metal-uri';
 
 import errors from '../errors/errors';
 import globals from '../globals/globals';
-import utils from '../utils/utils';
+import {getUrlPath} from '../utils/utils';
 import Screen from './Screen';
 
 class RequestScreen extends Screen {
@@ -174,7 +172,7 @@ class RequestScreen extends Screen {
 				}
 			}
 
-			return utils.getUrlPath(requestPath);
+			return getUrlPath(requestPath);
 		}
 
 		return null;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/Screen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/Screen.js
@@ -16,7 +16,7 @@ import {globalEval} from 'metal-dom';
 import CancellablePromise from 'metal-promise';
 
 import Cacheable from '../cacheable/Cacheable';
-import utils from '../utils/utils';
+import {getUid, log} from '../utils/utils';
 
 class Screen extends Cacheable {
 
@@ -33,7 +33,7 @@ class Screen extends Cacheable {
 		 * @type {string}
 		 * @protected
 		 */
-		this.id = this.makeId_(utils.getUid());
+		this.id = this.makeId_(getUid());
 
 		/**
 		 * Holds the screen meta tags. Relevant when the meta tags
@@ -56,7 +56,7 @@ class Screen extends Cacheable {
 	 * that requires its DOM to be visible. Lifecycle.
 	 */
 	activate() {
-		utils.log('Screen [' + this + '] activate');
+		log('Screen [' + this + '] activate');
 	}
 
 	/**
@@ -67,7 +67,7 @@ class Screen extends Cacheable {
 	 *     the current screen is locked and the next nagivation interrupted.
 	 */
 	beforeActivate() {
-		utils.log('Screen [' + this + '] beforeActivate');
+		log('Screen [' + this + '] beforeActivate');
 	}
 
 	/**
@@ -79,7 +79,7 @@ class Screen extends Cacheable {
 	 *     the current screen is locked and the next nagivation interrupted.
 	 */
 	beforeDeactivate() {
-		utils.log('Screen [' + this + '] beforeDeactivate');
+		log('Screen [' + this + '] beforeDeactivate');
 	}
 
 	/**
@@ -106,7 +106,7 @@ class Screen extends Cacheable {
 	 * timers. Lifecycle.
 	 */
 	deactivate() {
-		utils.log('Screen [' + this + '] deactivate');
+		log('Screen [' + this + '] deactivate');
 	}
 
 	/**
@@ -116,7 +116,7 @@ class Screen extends Cacheable {
 	 */
 	disposeInternal() {
 		super.disposeInternal();
-		utils.log('Screen [' + this + '] dispose');
+		log('Screen [' + this + '] dispose');
 	}
 
 	/**
@@ -155,7 +155,7 @@ class Screen extends Cacheable {
 	 *     navigation until it is resolved.
 	 */
 	flip(surfaces) {
-		utils.log('Screen [' + this + '] flip');
+		log('Screen [' + this + '] flip');
 
 		var transitions = [];
 
@@ -195,7 +195,7 @@ class Screen extends Cacheable {
 	 *     content is restored.
 	 */
 	getSurfaceContent() {
-		utils.log('Screen [' + this + '] getSurfaceContent');
+		log('Screen [' + this + '] getSurfaceContent');
 	}
 
 	/**
@@ -216,7 +216,7 @@ class Screen extends Cacheable {
 	 *     until it is resolved. This is useful for loading async content.
 	 */
 	load() {
-		utils.log('Screen [' + this + '] load');
+		log('Screen [' + this + '] load');
 
 		return CancellablePromise.resolve();
 	}

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/Screen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/Screen.js
@@ -12,9 +12,6 @@
  * details.
  */
 
-'use strict';
-
-import {getUid} from 'metal';
 import {globalEval} from 'metal-dom';
 import CancellablePromise from 'metal-promise';
 
@@ -36,7 +33,7 @@ class Screen extends Cacheable {
 		 * @type {string}
 		 * @protected
 		 */
-		this.id = this.makeId_(getUid());
+		this.id = this.makeId_(utils.getUid());
 
 		/**
 		 * Holds the screen meta tags. Relevant when the meta tags

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/surface/Surface.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/surface/Surface.js
@@ -12,12 +12,10 @@
  * details.
  */
 
-'use strict';
-
-import {Disposable, isDefAndNotNull} from 'metal';
 import {append, exitDocument, removeChildren} from 'metal-dom';
 import CancellablePromise from 'metal-promise';
 
+import Disposable from '../Disposable';
 import globals from '../globals/globals';
 
 class Surface extends Disposable {
@@ -95,7 +93,7 @@ class Surface extends Disposable {
 	addContent(screenId, opt_content) {
 		var child = this.defaultChild;
 
-		if (isDefAndNotNull(opt_content)) {
+		if (opt_content) {
 			child = this.getChild(screenId);
 			if (child) {
 				removeChildren(child);

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/pathParser.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/pathParser.js
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const REGEX = /([/])?(?:(?::(\w+)(?:\(((?:\\.|[^\\()])*)\))?|\(((?:\\.|[^\\()])+)\))([+*?])?)/g;
+
+/**
+ * Converts the given array of regex matches to a more readable object format.
+ * @param {!Array<string>} matches
+ * @return {!Object}
+ */
+function convertMatchesToObj(matches) {
+	return {
+		match: matches[0],
+		modifier: matches[5],
+		name: matches[2],
+		paramPattern: matches[3],
+		prefix: matches[1],
+		unnamedPattern: matches[4],
+	};
+}
+
+/**
+ * Converts the given tokens parsed from a route format string to a regex.
+ * @param {!Array<string|!Object>} tokens
+ * @return {!RegExp}
+ */
+function convertTokensToRegex(tokens) {
+	let regex = '';
+	for (let i = 0; i < tokens.length; i++) {
+		if (typeof tokens[i] === 'string') {
+			regex += escape(tokens[i]);
+		}
+		else {
+			let capture = encloseNonCapturingGroup(tokens[i].pattern);
+			if (tokens[i].repeat) {
+				capture += encloseNonCapturingGroup('\\/' + capture) + '*';
+			}
+			capture = escape(tokens[i].prefix) + `(${capture})`;
+			if (tokens[i].optional) {
+				if (!tokens[i].partial) {
+					capture = encloseNonCapturingGroup(capture);
+				}
+				capture += '?';
+			}
+			regex += capture;
+		}
+	}
+
+	return new RegExp('^' + makeTrailingSlashOptional(regex) + '$');
+}
+
+/**
+ * Encloses the given regex pattern into a non capturing group.
+ * @param {string} pattern
+ * @return {string}
+ */
+function encloseNonCapturingGroup(pattern) {
+	return `(?:${pattern})`;
+}
+
+/**
+ * Escapes the given string to show up in the path regex.
+ * @param {string} str
+ * @return {string}
+ */
+function escape(str) {
+	return str.replace(/([.+*?=^!:${}()[]|\/\\])/g, '\\$1');
+}
+
+/**
+ * Makes trailing slash optional on paths.
+ * @param {string} regex
+ * @param {string}
+ */
+function makeTrailingSlashOptional(regex) {
+	if (/\/$/.test(regex)) {
+		regex += '?';
+	}
+	else {
+		regex += '\\/?';
+	}
+
+	return regex;
+}
+
+/**
+ * Parses the given route format string into tokens representing its contents.
+ * @param {!Array|string} routeOrTokens Either a route format string or tokens
+ *     previously parsed via the `parse` function.
+ * @return {!Array<string|!Object>} An array of tokens that can be either plain
+ *     strings (part of the route) or objects containing informations on params.
+ */
+export function parse(routeOrTokens) {
+	if (typeof routeOrTokens !== 'string') {
+		return routeOrTokens;
+	}
+
+	const route = routeOrTokens;
+	let unnamedCount = 0;
+	const tokens = [];
+	let currPath = '';
+	let index = 0;
+
+	let matches = REGEX.exec(route);
+	while (matches) {
+		const data = convertMatchesToObj(matches);
+
+		currPath = route.slice(index, matches.index);
+		index = matches.index + data.match.length;
+		tokens.push(currPath);
+
+		tokens.push({
+			name: data.name ? data.name : '' + unnamedCount++,
+			optional: data.modifier === '*' || data.modifier === '?',
+			partial: route[index] && route[index] !== data.prefix,
+			pattern: data.paramPattern || data.unnamedPattern || '[^\\/]+',
+			prefix: data.prefix || '',
+			repeat: data.modifier === '*' || data.modifier === '+',
+		});
+
+		matches = REGEX.exec(route);
+	}
+
+	if (index < route.length) {
+		tokens.push(route.substr(index));
+	}
+
+	return tokens;
+}
+
+/**
+ * Converts the given route format string to a regex that can extract param
+ * data from paths matching it.
+ * @param {!Array|string} routeOrTokens Either a route format string or tokens
+ *     previously parsed via the `parse` function.
+ * @return {!RegExp}
+ */
+export function toRegex(routeOrTokens) {
+	return convertTokensToRegex(parse(routeOrTokens));
+}
+
+/**
+ * Extracts data from the given path according to the specified route format.
+ * @param {!Array|string} routeOrTokens Either a route format string or tokens
+ *     previously parsed via the `parse` function.
+ * @param {string} The path to extract param data from.
+ * @return {Object<string, string>} The data object, or null if the path doesn't
+ *     match the given format.
+ */
+export function extractData(routeOrTokens, path) {
+	const data = {};
+	const tokens = parse(routeOrTokens);
+	const match = path.match(convertTokensToRegex(tokens));
+
+	if (!match) {
+		return null;
+	}
+
+	let paramIndex = 1;
+	for (let i = 0; i < tokens.length; i++) {
+		if (typeof tokens[i] !== 'string') {
+			let value = match[paramIndex++];
+			if (value !== undefined) {
+				if (tokens[i].repeat) {
+					value = value.split('/');
+				}
+				data[tokens[i].name] = value;
+			}
+		}
+	}
+
+	return data;
+}

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/pathParser.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/pathParser.js
@@ -84,7 +84,7 @@ function escape(str) {
  * @param {string}
  */
 function makeTrailingSlashOptional(regex) {
-	if (/\/$/.test(regex)) {
+	if (regex.endsWith('/')) {
 		regex += '?';
 	}
 	else {

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/utils.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/utils.js
@@ -22,7 +22,7 @@ import globals from '../globals/globals';
  * @type {Number}
  * @private
  */
-let uniqueIdCounter_ = 1;
+let uniqueIdCounter = 1;
 
 /**
  * A collection of static utility functions.
@@ -86,7 +86,7 @@ class utils {
 	}
 
 	static getUid() {
-		return uniqueIdCounter_++;
+		return uniqueIdCounter++;
 	}
 
 	/**

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/utils.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/utils.js
@@ -12,12 +12,17 @@
  * details.
  */
 
-'use strict';
-
 import {exitDocument} from 'metal-dom';
 import Uri from 'metal-uri';
 
 import globals from '../globals/globals';
+
+/**
+ * Counter for unique id.
+ * @type {Number}
+ * @private
+ */
+let uniqueIdCounter_ = 1;
 
 /**
  * A collection of static utility functions.
@@ -78,6 +83,10 @@ class utils {
 			offsetLeft,
 			offsetTop,
 		};
+	}
+
+	static getUid() {
+		return uniqueIdCounter_++;
 	}
 
 	/**
@@ -228,6 +237,25 @@ class utils {
 				return referrer;
 			},
 		});
+	}
+
+	/**
+	 * Slices the given array, just like Array.prototype.slice, but this
+	 * is faster and working on all array-like objects (like arguments).
+	 * @param {!Object} arr Array-like object to slice.
+	 * @param {number} start The index that should start the slice.
+	 * @param {number=} end The index where the slice should end, not
+	 *   included in the final array. If not given, all elements after the
+	 *   start index will be included.
+	 * @return {!Array}
+	 */
+	static slice(arr, start, end = arr.length) {
+		const sliced = [];
+		for (let i = start; i < end; i++) {
+			sliced.push(arr[i]);
+		}
+
+		return sliced;
 	}
 }
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/utils.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/utils.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import {exitDocument} from 'metal-dom';
 import Uri from 'metal-uri';
 
 import globals from '../globals/globals';
@@ -31,31 +30,6 @@ let uniqueIdCounter = 1;
 class utils {
 
 	/**
-	 * Copies attributes form source node to target node.
-	 * @return {void}
-	 * @static
-	 */
-	static copyNodeAttributes(source, target) {
-		Array.prototype.slice
-			.call(source.attributes)
-			.forEach((attribute) =>
-				target.setAttribute(attribute.name, attribute.value)
-			);
-	}
-
-	/**
-	 * Gets the current browser path including hashbang.
-	 * @return {!string}
-	 * @static
-	 */
-	static getCurrentBrowserPath() {
-		return (
-			this.getCurrentBrowserPathWithoutHash() +
-			globals.window.location.hash
-		);
-	}
-
-	/**
 	 * Gets the current browser path excluding hashbang.
 	 * @return {!string}
 	 * @static
@@ -64,62 +38,6 @@ class utils {
 		return (
 			globals.window.location.pathname + globals.window.location.search
 		);
-	}
-
-	/**
-	 * Gets the given node offset coordinates.
-	 * @return {!object}
-	 * @static
-	 */
-	static getNodeOffset(node) {
-		let [offsetLeft, offsetTop] = [0, 0];
-		do {
-			offsetLeft += node.offsetLeft;
-			offsetTop += node.offsetTop;
-			node = node.offsetParent;
-		} while (node);
-
-		return {
-			offsetLeft,
-			offsetTop,
-		};
-	}
-
-	static getUid() {
-		return uniqueIdCounter++;
-	}
-
-	/**
-	 * Extracts the path part of an url.
-	 * @return {!string}
-	 * @static
-	 */
-	static getUrlPath(url) {
-		var uri = new Uri(url);
-
-		return uri.getPathname() + uri.getSearch() + uri.getHash();
-	}
-
-	/**
-	 * Extracts the path part of an url without hashbang.
-	 * @return {!string}
-	 * @static
-	 */
-	static getUrlPathWithoutHash(url) {
-		var uri = new Uri(url);
-
-		return uri.getPathname() + uri.getSearch();
-	}
-
-	/**
-	 * Extracts the path part of an url without hashbang and query search.
-	 * @return {!string}
-	 * @static
-	 */
-	static getUrlPathWithoutHashAndSearch(url) {
-		var uri = new Uri(url);
-
-		return uri.getPathname();
 	}
 
 	/**
@@ -132,131 +50,174 @@ class utils {
 		if (url) {
 			const currentBrowserPath = this.getCurrentBrowserPathWithoutHash();
 
+			//const currentBrowserPath = globals.window.location.pathname + globals.window.location.search;
+
 			// the getUrlPath will create a Uri and will normalize the path and
 			// remove the trailling '/' for properly comparing paths.
 
 			return (
-				utils.getUrlPathWithoutHash(url) ===
-				this.getUrlPath(currentBrowserPath)
+				getUrlPathWithoutHash(url) === getUrlPath(currentBrowserPath)
 			);
 		}
 
 		return false;
 	}
-
-	/**
-	 * Returns true if HTML5 History api is supported.
-	 * @return {boolean}
-	 * @static
-	 */
-	static isHtml5HistorySupported() {
-		return !!(globals.window.history && globals.window.history.pushState);
-	}
-
-	/**
-	 * Checks if a given url is a valid http(s) uri and returns the formed Uri
-	 * or false if the parsing failed
-	 * @return {Uri|boolean}
-	 * @static
-	 */
-	static isWebUri(url) {
-		try {
-			return new Uri(url);
-		}
-		catch (err) {
-			console.error(`${err.message} ${url}`);
-
-			return false;
-		}
-	}
-
-	/**
-	 * Logs the provided message in DEV environments
-	 * @param {String} message
-	 */
-	static log(message) {
-		if (process.env.NODE_ENV === 'development') {
-			// eslint-disable-next-line
-			console.log(message);
-		}
-	}
-
-	/**
-	 * Removes all attributes form node.
-	 * @return {void}
-	 * @static
-	 */
-	static clearNodeAttributes(node) {
-		Array.prototype.slice
-			.call(node.attributes)
-			.forEach((attribute) => node.removeAttribute(attribute.name));
-	}
-
-	/**
-	 * Remove elements from the document.
-	 * @param {!Array<Element>} elements
-	 */
-	static removeElementsFromDocument(elements) {
-		elements.forEach((element) => exitDocument(element));
-	}
-
-	/**
-	 * Removes trailing slash in path.
-	 * @param {!string}
-	 * @return {string}
-	 */
-	static removePathTrailingSlash(path) {
-		var length = path ? path.length : 0;
-		if (length > 1 && path[length - 1] === '/') {
-			path = path.substr(0, length - 1);
-		}
-
-		return path;
-	}
-
-	/**
-	 * Adds a random suffix to the href attribute of the element.
-	 * @param {!element} element
-	 * @return {element}
-	 */
-	static setElementWithRandomHref(element) {
-		element.href = element.href + '?q=' + Math.random();
-
-		return element;
-	}
-
-	/**
-	 * Overrides document referrer
-	 * @param {string} referrer
-	 * @static
-	 */
-	static setReferrer(referrer) {
-		Object.defineProperty(globals.document, 'referrer', {
-			configurable: true,
-			get() {
-				return referrer;
-			},
-		});
-	}
-
-	/**
-	 * Slices the given array, just like Array.prototype.slice, but this
-	 * is faster and working on all array-like objects (like arguments).
-	 * @param {!Object} arr Array-like object to slice.
-	 * @param {number} start The index that should start the slice.
-	 * @param {number=} end The index where the slice should end, not
-	 *   included in the final array. If not given, all elements after the
-	 *   start index will be included.
-	 * @return {!Array}
-	 */
-	static slice(arr, start, end = arr.length) {
-		const sliced = [];
-		for (let i = start; i < end; i++) {
-			sliced.push(arr[i]);
-		}
-
-		return sliced;
-	}
 }
 
 export default utils;
+
+/**
+ * Removes all attributes form node.
+ * @return {void}
+ * @static
+ */
+export function clearNodeAttributes(node) {
+	Array.prototype.slice
+		.call(node.attributes)
+		.forEach((attribute) => node.removeAttribute(attribute.name));
+}
+
+/**
+ * Copies attributes form source node to target node.
+ * @return {void}
+ * @static
+ */
+export function copyNodeAttributes(source, target) {
+	Array.prototype.slice
+		.call(source.attributes)
+		.forEach((attribute) =>
+			target.setAttribute(attribute.name, attribute.value)
+		);
+}
+
+/**
+ * Gets the current browser path including hashbang.
+ * @return {!string}
+ * @static
+ */
+export function getCurrentBrowserPath() {
+	return `${globals.window.location.pathname}${globals.window.location.search}${globals.window.location.hash}`;
+}
+
+/**
+ * Gets the current browser path excluding hashbang.
+ * @return {!string}
+ * @static
+ */
+export function getCurrentBrowserPathWithoutHash() {
+	return `${globals.window.location.pathname}${globals.window.location.search}`;
+}
+
+/**
+ * Gets the given node offset coordinates.
+ * @return {!object}
+ * @static
+ */
+export function getNodeOffset(node) {
+	let [offsetLeft, offsetTop] = [0, 0];
+	do {
+		offsetLeft += node.offsetLeft;
+		offsetTop += node.offsetTop;
+		node = node.offsetParent;
+	} while (node);
+
+	return {
+		offsetLeft,
+		offsetTop,
+	};
+}
+
+export function getUid() {
+	return uniqueIdCounter++;
+}
+
+/**
+ * Extracts the path part of an url.
+ * @return {!string}
+ * @static
+ */
+export function getUrlPath(url) {
+	var uri = new Uri(url);
+
+	return uri.getPathname() + uri.getSearch() + uri.getHash();
+}
+
+/**
+ * Extracts the path part of an url without hashbang.
+ * @return {!string}
+ * @static
+ */
+export function getUrlPathWithoutHash(url) {
+	var uri = new Uri(url);
+
+	return uri.getPathname() + uri.getSearch();
+}
+
+/**
+ * Extracts the path part of an url without hashbang and query search.
+ * @return {!string}
+ * @static
+ */
+export function getUrlPathWithoutHashAndSearch(url) {
+	var uri = new Uri(url);
+
+	return uri.getPathname();
+}
+
+/**
+ * Checks if url is in the same browser current url excluding the hashbang.
+ * @param  {!string} url
+ * @return {boolean}
+ * @static
+ */
+export function isCurrentBrowserPath(url) {
+	if (url) {
+		const currentBrowserPath = getCurrentBrowserPathWithoutHash();
+
+		// the getUrlPath will create a Uri and will normalize the path and
+		// remove the trailling '/' for properly comparing paths.
+
+		return getUrlPathWithoutHash(url) === getUrlPath(currentBrowserPath);
+	}
+
+	return false;
+}
+
+/**
+ * Logs the provided message in DEV environments
+ * @param {String} message
+ */
+export function log(message) {
+	if (process.env.NODE_ENV === 'development') {
+		// eslint-disable-next-line
+		console.log(message);
+	}
+}
+
+/**
+ * Removes trailing slash in path.
+ * @param {!string}
+ * @return {string}
+ */
+export function removePathTrailingSlash(path) {
+	var length = path ? path.length : 0;
+	if (length > 1 && path[length - 1] === '/') {
+		path = path.substr(0, length - 1);
+	}
+
+	return path;
+}
+
+/**
+ * Overrides document referrer
+ * @param {string} referrer
+ * @static
+ */
+export function setReferrer(referrer) {
+	Object.defineProperty(globals.document, 'referrer', {
+		configurable: true,
+		get() {
+			return referrer;
+		},
+	});
+}

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/App.js
@@ -23,7 +23,11 @@ import Route from '../../../src/main/resources/META-INF/resources/senna/route/Ro
 import HtmlScreen from '../../../src/main/resources/META-INF/resources/senna/screen/HtmlScreen';
 import Screen from '../../../src/main/resources/META-INF/resources/senna/screen/Screen';
 import Surface from '../../../src/main/resources/META-INF/resources/senna/surface/Surface';
-import utils from '../../../src/main/resources/META-INF/resources/senna/utils/utils';
+import utils, {
+	getCurrentBrowserPath,
+	getNodeOffset,
+	getUrlPathWithoutHash,
+} from '../../../src/main/resources/META-INF/resources/senna/utils/utils';
 
 class StubScreen extends Screen {}
 StubScreen.prototype.activate = jest.fn();
@@ -701,11 +705,6 @@ describe('App', function () {
 	});
 
 	it('clears pendingNavigate after navigate', (done) => {
-		jest.spyOn(
-			utils,
-			'getCurrentBrowserPathWithoutHash'
-		).mockImplementation(() => '/path');
-
 		this.app = new App();
 		this.app.addRoutes(new Route('/path', Screen));
 		this.app.navigate('/path').then(() => {
@@ -754,11 +753,6 @@ describe('App', function () {
 	});
 
 	it('does not navigate back on a hash change', (done) => {
-		jest.spyOn(
-			utils,
-			'getCurrentBrowserPathWithoutHash'
-		).mockImplementation(() => '/path1');
-
 		this.app = new App();
 		this.app.addRoutes(new Route('/path1', Screen));
 		this.app.addRoutes(new Route('/path2', Screen));
@@ -979,7 +973,7 @@ describe('App', function () {
 			globals.window.history.replaceState(
 				{},
 				'',
-				utils.getCurrentBrowserPath()
+				getCurrentBrowserPath()
 			);
 			done();
 		});
@@ -1260,11 +1254,6 @@ describe('App', function () {
 	});
 
 	it('updates referrer when Screen history state returns null', (done) => {
-		jest.spyOn(
-			utils,
-			'getCurrentBrowserPathWithoutHash'
-		).mockImplementation(() => '/path1');
-
 		class NullStateScreen extends Screen {
 			beforeUpdateHistoryState() {
 				return null;
@@ -1275,7 +1264,7 @@ describe('App', function () {
 		this.app.navigate('/path1').then(() => {
 			this.app.navigate('/path1#hash').then(() => {
 				dom.once(globals.window, 'popstate', () => {
-					expect(utils.getCurrentBrowserPath(document.referrer)).toBe(
+					expect(getCurrentBrowserPath(document.referrer)).toBe(
 						'/path1'
 					);
 					done();
@@ -1286,11 +1275,6 @@ describe('App', function () {
 	});
 
 	it('does not reload page on navigate back to a routed page with same path containing hashbang without history state', (done) => {
-		jest.spyOn(
-			utils,
-			'getCurrentBrowserPathWithoutHash'
-		).mockImplementation(() => '/path');
-
 		this.app = new App();
 		this.app.addRoutes(new Route('/path', Screen));
 		this.app.reloadPage = jest.fn();
@@ -1461,7 +1445,7 @@ describe('App', function () {
 		jest.spyOn(
 			utils,
 			'getCurrentBrowserPathWithoutHash'
-		).mockImplementation(() => '/path');
+		).mockImplementation(() => '/asdasdasdasas');
 
 		this.app = new App();
 		this.app.addRoutes(new Route('/path', Screen));
@@ -1650,7 +1634,7 @@ describe('App', function () {
 		this.app = new App();
 		this.app.addRoutes(new Route('/path', RedirectScreen));
 		this.app.navigate('/path#hash').then(() => {
-			expect(utils.getCurrentBrowserPath()).toBe('/path#hash');
+			expect(getCurrentBrowserPath()).toBe('/path#hash');
 			done();
 		});
 	});
@@ -1664,7 +1648,7 @@ describe('App', function () {
 		this.app = new App();
 		this.app.addRoutes(new Route('/path', RedirectScreen));
 		this.app.navigate('/path#hash').then(() => {
-			expect(utils.getCurrentBrowserPath()).toBe('/redirect');
+			expect(getCurrentBrowserPath()).toBe('/redirect');
 			done();
 		});
 	});
@@ -2093,7 +2077,7 @@ describe('App', function () {
 		this.app.addSurfaces(['surfaceId1']);
 		this.app.navigate('/path1#surfaceId1').then(() => {
 			const surfaceNode = document.querySelector('#surfaceId1');
-			const {offsetLeft, offsetTop} = utils.getNodeOffset(surfaceNode);
+			const {offsetLeft, offsetTop} = getNodeOffset(surfaceNode);
 			expect(window.pageYOffset).toBe(offsetTop);
 			expect(window.pageXOffset).toBe(offsetLeft);
 			dom.exitDocument(parentNode);
@@ -2113,23 +2097,21 @@ describe('App', function () {
 				return this.app.navigate('/path2');
 			})
 			.then(() => {
-				expect(
-					utils.getUrlPathWithoutHash(globals.document.referrer)
-				).toBe('/path1');
+				expect(getUrlPathWithoutHash(globals.document.referrer)).toBe(
+					'/path1'
+				);
 
 				return this.app.navigate('/path3');
 			})
 			.then(() => {
-				expect(
-					utils.getUrlPathWithoutHash(globals.document.referrer)
-				).toBe('/path2');
+				expect(getUrlPathWithoutHash(globals.document.referrer)).toBe(
+					'/path2'
+				);
 				this.app.on(
 					'endNavigate',
 					() => {
 						expect(
-							utils.getUrlPathWithoutHash(
-								globals.document.referrer
-							)
+							getUrlPathWithoutHash(globals.document.referrer)
 						).toBe('/path1');
 						done();
 					},

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/App.js
@@ -1676,7 +1676,7 @@ describe('App', function () {
 		setTimeout(() => {
 			expect(this.app.skipLoadPopstate).toBe(false);
 			done();
-		}, 0);
+		});
 	});
 
 	it('respects screen lifecycle on navigate', (done) => {

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/App.js
@@ -15,9 +15,9 @@
 import {fireEvent} from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import {dom, exitDocument} from 'metal-dom';
-import {EventEmitter} from 'metal-events';
 
 import App from '../../../src/main/resources/META-INF/resources/senna/app/App';
+import EventEmitter from '../../../src/main/resources/META-INF/resources/senna/events/EventEmitter';
 import globals from '../../../src/main/resources/META-INF/resources/senna/globals/globals';
 import Route from '../../../src/main/resources/META-INF/resources/senna/route/Route';
 import HtmlScreen from '../../../src/main/resources/META-INF/resources/senna/screen/HtmlScreen';

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/utils/utils.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/utils/utils.js
@@ -12,10 +12,17 @@
  * details.
  */
 
-import Uri from 'metal-uri';
-
 import globals from '../../../src/main/resources/META-INF/resources/senna/globals/globals';
-import utils from '../../../src/main/resources/META-INF/resources/senna/utils/utils';
+import {
+	clearNodeAttributes,
+	copyNodeAttributes,
+	getCurrentBrowserPath,
+	getCurrentBrowserPathWithoutHash,
+	getUrlPath,
+	getUrlPathWithoutHash,
+	getUrlPathWithoutHashAndSearch,
+	isCurrentBrowserPath,
+} from '../../../src/main/resources/META-INF/resources/senna/utils/utils';
 
 describe('utils', () => {
 	beforeAll(() => {
@@ -42,7 +49,7 @@ describe('utils', () => {
 		nodeA.setAttribute('b', 'valueB');
 
 		var nodeB = document.createElement('div');
-		utils.copyNodeAttributes(nodeA, nodeB);
+		copyNodeAttributes(nodeA, nodeB);
 
 		expect(nodeA.attributes.length).toBe(nodeB.attributes.length);
 		expect(nodeA.getAttribute('a')).toBe(nodeB.getAttribute('a'));
@@ -56,7 +63,7 @@ describe('utils', () => {
 		node.setAttribute('a', 'valueA');
 		node.setAttribute('b', 'valueB');
 
-		utils.clearNodeAttributes(node);
+		clearNodeAttributes(node);
 
 		expect(node.getAttribute('a')).toBeNull();
 		expect(node.getAttribute('b')).toBeNull();
@@ -64,57 +71,40 @@ describe('utils', () => {
 	});
 
 	it('gets path from url', () => {
-		expect(utils.getUrlPath('http://hostname/path?a=1#hash')).toBe(
+		expect(getUrlPath('http://hostname/path?a=1#hash')).toBe(
 			'/path?a=1#hash'
 		);
 	});
 
 	it('gets path from url excluding hashbang', () => {
-		expect(
-			utils.getUrlPathWithoutHash('http://hostname/path?a=1#hash')
-		).toBe('/path?a=1');
+		expect(getUrlPathWithoutHash('http://hostname/path?a=1#hash')).toBe(
+			'/path?a=1'
+		);
 	});
 
 	it('gets path from url excluding hashbang and search', () => {
 		expect(
-			utils.getUrlPathWithoutHashAndSearch(
-				'http://hostname/path?a=1#hash'
-			)
+			getUrlPathWithoutHashAndSearch('http://hostname/path?a=1#hash')
 		).toBe('/path');
 	});
 
 	it('tests if path is current browser path', () => {
+		expect(isCurrentBrowserPath('http://hostname/path?a=1')).toBeTruthy();
 		expect(
-			utils.isCurrentBrowserPath('http://hostname/path?a=1')
+			isCurrentBrowserPath('http://hostname/path?a=1#hash')
 		).toBeTruthy();
+		expect(!isCurrentBrowserPath('http://hostname/path1?a=1')).toBeTruthy();
 		expect(
-			utils.isCurrentBrowserPath('http://hostname/path?a=1#hash')
+			!isCurrentBrowserPath('http://hostname/path1?a=1#hash')
 		).toBeTruthy();
-		expect(
-			!utils.isCurrentBrowserPath('http://hostname/path1?a=1')
-		).toBeTruthy();
-		expect(
-			!utils.isCurrentBrowserPath('http://hostname/path1?a=1#hash')
-		).toBeTruthy();
-		expect(!utils.isCurrentBrowserPath()).toBeTruthy();
+		expect(!isCurrentBrowserPath()).toBeTruthy();
 	});
 
 	it('gets current browser path', () => {
-		expect(utils.getCurrentBrowserPath()).toBe('/path?a=1#hash');
+		expect(getCurrentBrowserPath()).toBe('/path?a=1#hash');
 	});
 
 	it('gets current browser path excluding hashbang', () => {
-		expect(utils.getCurrentBrowserPathWithoutHash()).toBe('/path?a=1');
-	});
-
-	it('tests if Html5 history is supported', () => {
-		expect(utils.isHtml5HistorySupported()).toBeTruthy();
-		globals.window.history = null;
-		expect(!utils.isHtml5HistorySupported()).toBeTruthy();
-	});
-
-	it('tests if a given url is a valid web (http/https) uri', () => {
-		expect(utils.isWebUri('tel:+999999999')).toBeFalsy();
-		expect(utils.isWebUri('http://localhost:12345')).toBeInstanceOf(Uri);
+		expect(getCurrentBrowserPathWithoutHash()).toBe('/path?a=1');
 	});
 });


### PR DESCRIPTION
This is the first followup after [[7.4-only] LPS-122511 Integrate Sena.js code into frontend-js-spa-web](https://github.com/liferay-frontend/liferay-portal/pull/470) and it removes some `metal*` dependencies from the `frontend-js-spa-web` module.

**What's in here**
- We now [use `frontend-js-web` internal debounce](https://github.com/liferay-frontend/liferay-portal/commit/9117cce7dfda50d3455ec0800a175f1c5e9db87f) implementation
- [Drops `metal-useragent`](https://github.com/liferay-frontend/liferay-portal/commit/58109b4b7d1d0a548d61b66c3a3ac2f9c35e0116) since it was used only for IE11
- [Inlines most dependencies coming from the `metal`](https://github.com/liferay-frontend/liferay-portal/commit/2d1b5be4281a1d76ec972fac88756db5f32eb99b) package. To simplify the transition, some classes are simply copied over like `Disposable` and `setImmediate` is changed to `setTimeout`. This last one we should keep an eye on.
- Brings over [`metal-events`](https://github.com/liferay-frontend/liferay-portal/commit/e601d7b729c05be33ca142bc9ca635c5f5e7a4a1) exported classes to simplify the migration
- Brings over [`metal-path-parser`](https://github.com/liferay-frontend/liferay-portal/commit/0414eb5c355dc517e98c928242ba054582d95fd6) utility.

As can be seen, in general, I've decided to copy code over directly to the `frontend-js-spa-web` to simplify the transition. The tests are super flaky so can't fully rely on them and CI is super expensive, so limiting the real changes felt like our best path forward.

**Test Plan**
- Run unit tests (still green)
- Start DXP locally and navigate around
- Run CI tests

**Special considerations**
- I tried refactoring `utils` to simply export functions and as it turns out it breaks many tests. There seems to be some shared state in that class and in the tests setup itself making it really hard to untangle. Thus, I reverted those changes and we'll work on it in the future.
- It's possible that general classes like `Disposable` or `EventEmitter` can help us further in the metal migration. I've decided to place them in `frontend-js-spa-web` temporarily and we can move them and expose them from somewhere else if we see the need.
- Still haven't removed all `use strict` declarations... trying to do them as I touch other files, but eventually will do one big pass to clear them out.