### PR TITLE
LPS-122299 [Bug] Empty axis name in Content Dashboard

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
@@ -183,7 +183,10 @@ export default function AuditBarChart({rtl, vocabularies}) {
 
 	const axisNames = {
 		x: vocabularies[0]?.vocabularyName,
-		y: showLegend && vocabularies[0]?.categories?.[0]?.vocabularyName,
+		y:
+			showLegend &&
+			vocabularies.find(({categories}) => categories)?.categories[0]
+				.vocabularyName,
 	};
 
 	const noCheckboxesChecked = Object.keys(checkboxes).every(

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/AuditBarChart.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/AuditBarChart.js
@@ -20,7 +20,7 @@ import AuditBarChart from '../../../src/main/resources/META-INF/resources/js/com
 
 import '@testing-library/jest-dom/extend-expect';
 
-const mockVocabulariesOneCategory = [
+const mockOneVocabulary = [
 	{
 		key: 'business-decision-maker',
 		name: 'Business Decision Maker',
@@ -47,7 +47,7 @@ const mockVocabulariesOneCategory = [
 	},
 ];
 
-const mockVocabulariesTwoCategories = [
+const mockTwoVocabularies = [
 	{
 		categories: [
 			{
@@ -150,18 +150,42 @@ const mockVocabulariesTwoCategories = [
 	},
 ];
 
+const mockTwoVocabulariesWithCategoriesInTheFirstVocabulary = [
+	{
+		key: 'business-decision-maker',
+		name: 'Business Decision Maker',
+		vocabularyName: 'Audience',
+	},
+	{
+		categories: [
+			{
+				key: 'education',
+				name: 'Education',
+				value: 125,
+				vocabularyName: 'Stage',
+			},
+			{
+				key: 'selection',
+				name: 'Selection',
+				value: 317,
+				vocabularyName: 'Stage',
+			},
+		],
+		key: 'business-end-user',
+		name: 'Business End User',
+		vocabularyName: 'Audience',
+	},
+];
+
 describe('AuditBarChart', () => {
 	afterEach(() => {
 		jest.clearAllMocks();
 		cleanup();
 	});
 
-	it('renders audit bar chart from one category', () => {
+	it('renders audit bar chart from one vocabulary', () => {
 		const {container, getByText} = render(
-			<AuditBarChart
-				rtl={false}
-				vocabularies={mockVocabulariesOneCategory}
-			/>
+			<AuditBarChart rtl={false} vocabularies={mockOneVocabulary} />
 		);
 
 		expect(getByText('Audience')).toBeInTheDocument();
@@ -177,12 +201,9 @@ describe('AuditBarChart', () => {
 		expect(bars.length).toBe(4);
 	});
 
-	it('renders audit bar chart from two categories', () => {
+	it('renders audit bar chart from two vocabularies', () => {
 		const {container, getByText} = render(
-			<AuditBarChart
-				rtl={false}
-				vocabularies={mockVocabulariesTwoCategories}
-			/>
+			<AuditBarChart rtl={false} vocabularies={mockTwoVocabularies} />
 		);
 
 		expect(getByText('Stage:')).toBeInTheDocument();
@@ -202,12 +223,33 @@ describe('AuditBarChart', () => {
 		expect(bars.length).toBe(12);
 	});
 
-	it('renders audit bar chart only from checked categories from legend', () => {
-		const {container, getByLabelText} = render(
+	it('renders audit bar chart from two vocabularies without categories in the first one', () => {
+		const {container, getByText} = render(
 			<AuditBarChart
 				rtl={false}
-				vocabularies={mockVocabulariesTwoCategories}
+				vocabularies={
+					mockTwoVocabulariesWithCategoriesInTheFirstVocabulary
+				}
 			/>
+		);
+
+		expect(getByText('Stage:')).toBeInTheDocument();
+		expect(getByText('Education')).toBeInTheDocument();
+		expect(getByText('Selection')).toBeInTheDocument();
+
+		expect(getByText('Audience')).toBeInTheDocument();
+		expect(getByText('Business Decision Maker')).toBeInTheDocument();
+		expect(getByText('Business End User')).toBeInTheDocument();
+
+		const bars = container.getElementsByClassName(
+			'recharts-layer recharts-bar-rectangle'
+		);
+		expect(bars.length).toBe(4);
+	});
+
+	it('renders audit bar chart only from checked categories from legend', () => {
+		const {container, getByLabelText} = render(
+			<AuditBarChart rtl={false} vocabularies={mockTwoVocabularies} />
 		);
 
 		const bars = container.getElementsByClassName(
@@ -231,12 +273,9 @@ describe('AuditBarChart', () => {
 		expect(bars.length).toBe(0);
 	});
 
-	it('renders audit bar chart message when there are no categories selected', () => {
+	it('renders audit bar chart message when there are no vocabularies selected', () => {
 		const {getByLabelText, getByText} = render(
-			<AuditBarChart
-				rtl={false}
-				vocabularies={mockVocabulariesTwoCategories}
-			/>
+			<AuditBarChart rtl={false} vocabularies={mockTwoVocabularies} />
 		);
 
 		const educationCheckbox = getByLabelText('Education');


### PR DESCRIPTION
**Description**
Sometimes, depending on the categorization of the contents, the Content Dashboard does not display the name of the vocabulary on the Y-axis.

**Solution**
Find a vocabulary with categories to take the y-axis name. Taking into account that might be undefined if there are no categories for any vocabulary.

**How to test it**
- Create a Web Content wc1
- Categorized wc1 with two categories of two vocabularies (e.g.: topic = classics and audience = kids)
- Create a Web Content wc2
- Categorized wc2 with only one category (e.g.: topic = classics)
- Configure the chart with Topic and Audience vocabularies, in that order

**Screenshots**

- Before:

![Screenshot 2020-11-10 at 10 27 23](https://user-images.githubusercontent.com/15845466/98660206-532b6300-2345-11eb-8164-a99a3c4d2146.png)

- After:

![Screenshot 2020-11-10 at 11 06 18](https://user-images.githubusercontent.com/15845466/98660210-545c9000-2345-11eb-9a1c-6f50176a1dc1.png)