### PR TITLE
LPS-119623 [Testing] Update TrafficSources tests

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
@@ -37,7 +37,7 @@ describe('TrafficSources', () => {
 						],
 						helpMessage: 'Testing Help Message',
 						name: 'testing',
-						share: 30,
+						share: 30.0,
 						title: 'Testing',
 						value: 32178,
 					},
@@ -56,7 +56,7 @@ describe('TrafficSources', () => {
 						],
 						helpMessage: 'Second Testing Help Message',
 						name: 'second-testing',
-						share: 70,
+						share: 70.0,
 						title: 'Second Testing',
 						value: 278256,
 					},
@@ -114,7 +114,7 @@ describe('TrafficSources', () => {
 						],
 						helpMessage: 'Testing Help Message',
 						name: 'testing',
-						share: 0,
+						share: 0.0,
 						title: 'Testing',
 						value: 0,
 					},
@@ -133,7 +133,7 @@ describe('TrafficSources', () => {
 						],
 						helpMessage: 'Second Testing Help Message',
 						name: 'second-testing',
-						share: 0,
+						share: 0.0,
 						title: 'Second Testing',
 						value: 0,
 					},
@@ -172,7 +172,7 @@ describe('TrafficSources', () => {
 		expect(zeroValues.length).toBe(2);
 	});
 
-	it('displays the traffic sources without buttons to view keywords when the value is missing', async () => {
+	it('displays the traffic sources without buttons to view keywords when the value is 0 and there are country keywords', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
 			Promise.resolve({
 				trafficSources: [
@@ -191,26 +191,23 @@ describe('TrafficSources', () => {
 						],
 						helpMessage: 'Testing Help Message',
 						name: 'testing',
-						share: 0,
+						share: 80.0,
 						title: 'Testing',
+						value: 345,
 					},
 					{
-						countryKeywords: [
-							{
-								countryCode: 'us',
-								countryName: 'United States',
-								keywords: [],
-							},
-							{
-								countryCode: 'es',
-								countryName: 'Spain',
-								keywords: [],
-							},
-						],
 						helpMessage: 'Second Testing Help Message',
 						name: 'second-testing',
-						share: 0,
+						share: 0.0,
 						title: 'Second Testing',
+						value: 0,
+					},
+					{
+						helpMessage: 'Third Testing Help Message',
+						name: 'third-testing',
+						share: 20.0,
+						title: 'Third Testing',
+						value: 77,
 					},
 				],
 			})
@@ -235,42 +232,41 @@ describe('TrafficSources', () => {
 		const text1 = getByText('Testing');
 
 		expect(text1).toBeInTheDocument();
-		expect(text1).not.toHaveAttribute('type', 'button');
+		expect(text1).toHaveAttribute('type', 'button');
 
 		const text2 = getByText('Second Testing');
 
 		expect(text2).toBeInTheDocument();
 		expect(text2).not.toHaveAttribute('type', 'button');
 
-		const dashValues = getAllByText('-');
+		const zeroValues = getAllByText('0');
+		expect(zeroValues.length).toBe(2);
 
-		expect(dashValues.length).toBe(2);
+		const text3 = getByText('Third Testing');
+
+		expect(text3).toBeInTheDocument();
+		expect(text3).not.toHaveAttribute('type', 'button');
 	});
 
-	it('displays a dash instead of value when the value is missing', async () => {
+	it('displays a dash instead of value when there is an endpoint error', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
 			Promise.resolve({
 				trafficSources: [
 					{
-						countryKeywords: [],
 						helpMessage: 'Testing Help Message',
 						name: 'testing',
-						share: 100,
 						title: 'Testing',
-						value: 32178,
 					},
 					{
-						countryKeywords: [],
 						helpMessage: 'Second Testing Help Message',
 						name: 'second-testing',
-						share: 0,
 						title: 'Second Testing',
 					},
 				],
 			})
 		);
 
-		const {getByText} = render(
+		const {getAllByText, getByText} = render(
 			<TrafficSources
 				dataProvider={mockTrafficSourcesDataProvider}
 				languageTag="en-US"
@@ -286,11 +282,14 @@ describe('TrafficSources', () => {
 			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1)
 		);
 
-		expect(getByText('Testing')).toBeInTheDocument();
-		expect(getByText('32,178')).toBeInTheDocument();
+		const text1 = getByText('Testing');
+		const text2 = getByText('Second Testing');
 
-		expect(getByText('Second Testing')).toBeInTheDocument();
-		expect(getByText('-')).toBeInTheDocument();
+		const dashValues = getAllByText('-');
+		expect(dashValues.length).toBe(2);
+
+		expect(text1).not.toHaveAttribute('type', 'button');
+		expect(text2).not.toHaveAttribute('type', 'button');
 	});
 
 	it('displays a message informing the user that there is no incoming traffic from search engines yet', async () => {
@@ -301,7 +300,7 @@ describe('TrafficSources', () => {
 						countryKeywords: [],
 						helpMessage: 'Testing Help Message',
 						name: 'testing',
-						share: 0,
+						share: 0.0,
 						title: 'Testing',
 						value: 0,
 					},
@@ -309,7 +308,7 @@ describe('TrafficSources', () => {
 						countryKeywords: [],
 						helpMessage: 'Second Testing Help Message',
 						name: 'second-testing',
-						share: 0,
+						share: 0.0,
 						title: 'Second Testing',
 						value: 0,
 					},


### PR DESCRIPTION
**Description**
Traffic channels changed within this ticket: https://issues.liferay.com/browse/LPS-118107.
Now the traffic channels came from Analytics Cloud and we display:
- "0" instead of a "-" in most of the cases. We only display a "-" when the endpoints fail
- The share value comes to the frontend side with one decimal.
- The traffic channel has a link (to go to the detail view) iff (if and only if) the value > 0 and there are country keywords

**Solution**
I updated the frontend tests to be aligned with the new changes. There were only backend changes in the _Story_ so the frontend tests didn't fail.