### PR TITLE
[7.4 only] LPS-112473 Update Clay Select Tag to JSP+React

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
@@ -111,6 +111,7 @@ for (int i = 0; i < 8; i++) {
 %>
 
 <clay:select
+	containerCssClass="custom-container-css-class"
 	cssClass="custom-css-class"
 	id="customId"
 	label="Regular Select Element"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
@@ -111,6 +111,8 @@ for (int i = 0; i < 8; i++) {
 %>
 
 <clay:select
+	cssClass="custom-css-class"
+	id="customId"
 	label="Regular Select Element"
 	name="name"
 	options="<%= selectOptions %>"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SelectTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SelectTag.java
@@ -43,6 +43,10 @@ public class SelectTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
+	public String getContainerCssClass() {
+		return _containerCssClass;
+	}
+
 	public String getLabel() {
 		return LanguageUtil.get(
 			TagResourceBundleUtil.getResourceBundle(pageContext), _label);
@@ -62,6 +66,10 @@ public class SelectTag extends BaseContainerTag {
 
 	public boolean isMultiple() {
 		return _multiple;
+	}
+
+	public void setContainerCssClass(String containerCssClass) {
+		_containerCssClass = containerCssClass;
 	}
 
 	public void setDisabled(boolean disabled) {
@@ -88,6 +96,7 @@ public class SelectTag extends BaseContainerTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_containerCssClass = null;
 		_disabled = false;
 		_label = null;
 		_multiple = false;
@@ -163,7 +172,13 @@ public class SelectTag extends BaseContainerTag {
 	protected void writeCssClassAttribute() throws Exception {
 		JspWriter jspWriter = pageContext.getOut();
 
-		jspWriter.write(" class=\"form-group\"");
+		jspWriter.write(" class=\"form-group ");
+
+		if (Validator.isNotNull(_containerCssClass)) {
+			jspWriter.write(_containerCssClass);
+		}
+
+		jspWriter.write("\"");
 	}
 
 	@Override
@@ -176,6 +191,7 @@ public class SelectTag extends BaseContainerTag {
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:select:";
 
+	private String _containerCssClass;
 	private boolean _disabled;
 	private String _label;
 	private boolean _multiple;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SelectTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SelectTag.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.SelectOption;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Kresimir Coko
+ */
+public class SelectTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		if (Validator.isNotNull(getLabel())) {
+			setDynamicAttribute(StringPool.BLANK, "aria-label", getLabel());
+		}
+
+		return super.doStartTag();
+	}
+
+	public String getLabel() {
+		return LanguageUtil.get(
+			TagResourceBundleUtil.getResourceBundle(pageContext), _label);
+	}
+
+	public String getName() {
+		return _name;
+	}
+
+	public List<SelectOption> getOptions() {
+		return _options;
+	}
+
+	public boolean isDisabled() {
+		return _disabled;
+	}
+
+	public boolean isMultiple() {
+		return _multiple;
+	}
+
+	public void setDisabled(boolean disabled) {
+		_disabled = disabled;
+	}
+
+	public void setLabel(String label) {
+		_label = label;
+	}
+
+	public void setMultiple(boolean multiple) {
+		_multiple = multiple;
+	}
+
+	public void setName(String name) {
+		_name = name;
+	}
+
+	public void setOptions(List<SelectOption> options) {
+		_options = options;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_disabled = false;
+		_label = null;
+		_multiple = false;
+		_name = null;
+		_options = null;
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		cssClasses.add("form-control");
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		if (Validator.isNotNull(_label)) {
+			jspWriter.write("<label>");
+			jspWriter.write(_label);
+			jspWriter.write("</label>");
+		}
+
+		jspWriter.write("<select ");
+
+		super.writeDynamicAttributes();
+
+		super.writeCssClassAttribute();
+
+		if (_disabled) {
+			jspWriter.write(" disabled");
+		}
+
+		if (Validator.isNotNull(getId())) {
+			super.writeIdAttribute();
+		}
+
+		if (_multiple) {
+			jspWriter.write(" multiple");
+		}
+
+		if (Validator.isNotNull(_name)) {
+			jspWriter.write(" name=\"");
+			jspWriter.write(_name);
+			jspWriter.write("\"");
+		}
+
+		jspWriter.write(">");
+
+		for (SelectOption option : _options) {
+			jspWriter.write("<option value=\"");
+			jspWriter.write(option.getValue());
+			jspWriter.write("\"");
+
+			if (option.isSelected()) {
+				jspWriter.write(" selected");
+			}
+
+			jspWriter.write(">");
+			jspWriter.write(option.getLabel());
+			jspWriter.write("</option>");
+		}
+
+		jspWriter.write("</select>");
+
+		return SKIP_BODY;
+	}
+
+	@Override
+	protected void writeCssClassAttribute() throws Exception {
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write(" class=\"form-group\"");
+	}
+
+	@Override
+	protected void writeDynamicAttributes() {
+	}
+
+	@Override
+	protected void writeIdAttribute() {
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:select:";
+
+	private boolean _disabled;
+	private String _label;
+	private boolean _multiple;
+	private String _name;
+	private List<SelectOption> _options;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -3496,28 +3496,34 @@
 	<tag>
 		<description></description>
 		<name>select</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.SelectTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.SelectTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -3529,7 +3535,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -3565,11 +3571,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>wrapperType</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -3505,6 +3505,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description></description>
+			<name>containerCssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>


### PR DESCRIPTION
Creating a new `SelectTag` implementing the Clay v3 version of the Select component.

This tag isn't being hydrated in this iteration, we've decided to add hydration when necessary.

## Steps to test:
- Add Clay Sample Widget to any page.
- Go to Form Elements tab
- Under the Select section

## Before:
![image](https://user-images.githubusercontent.com/24564752/98824556-bc899f80-2433-11eb-8997-6fbbb0a38258.png)

## After:
![image](https://user-images.githubusercontent.com/24564752/98824052-1b024e00-2433-11eb-979b-d489769467be.png)
