### PR TITLE
[7.4-only] LPS-121960 Migrate v2 usages of clay:vertical-card in depot/depot-web

### DIFF
--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view.jsp
@@ -97,7 +97,7 @@ DepotAdminManagementToolbarDisplayContext depotAdminManagementToolbarDisplayCont
 							%>
 
 							<liferay-ui:search-container-column-text>
-								<clay:vertical-card-v2
+								<clay:vertical-card
 									verticalCard="<%= depotAdminDisplayContext.getDepotEntryVerticalCard(depotEntry) %>"
 								/>
 							</liferay-ui:search-container-column-text>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view_depot_dashboard.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view_depot_dashboard.jsp
@@ -50,7 +50,7 @@ boolean panelsShown = false;
 					<li class="entry-card entry-display-style lfr-asset-item">
 						<c:choose>
 							<c:when test="<%= depotAdminViewDepotDashboardDisplayContext.isPrimaryPanelCategory(panelCategory) %>">
-								<clay:vertical-card-v2
+								<clay:vertical-card
 									verticalCard="<%= depotAdminViewDepotDashboardDisplayContext.getDepotDashboardApplicationVerticalCard(panelApp, locale) %>"
 								/>
 							</c:when>


### PR DESCRIPTION
**IMPORTANT**: This pr needs to be sent to @liferay-lima after internal review

In this change, we replace `<clay:vertical-card-v2 />`(clay 2.x: Metal+soy) with
`<clay:vertical-card />` (clay 3.x: React)

**Test plan**:

- Fetch this branch
- Deploy the `depot-web` and `frontend-taglib-clay` modules
- From the global menu, in the **Applications** tab, select **Content** > **Asset Libraries**
- Click on the **+** button in the top right corner of the page to
create a new asset library
- Enter a name for this asset library
- Scroll down to the end of the page and click on the **Save** button
- Assert that the asset library has been created and that a card is
visible and working as expected.