### PR TITLE
[LPS-123675]- Fix assertion value none outside none to outside none none

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
@@ -127,7 +127,7 @@ definition {
 		AssertCssValue(
 			locator1 = "//ul[contains(@id,'controlMenu')]",
 			locator2 = "list-style",
-			value1 = "none outside none");
+			value1 = "outside none none");
 
 		takeScreenshot();
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
@@ -84,7 +84,7 @@ definition {
 		AssertCssValue(
 			locator1 = "//ul[contains(@id,'controlMenu')]",
 			locator2 = "list-style",
-			value1 = "none outside none");
+			value1 = "outside none none");
 
 		takeScreenshot();
 
@@ -100,7 +100,7 @@ definition {
 		AssertCssValue(
 			locator1 = "//ul[contains(@id,'controlMenu')]",
 			locator2 = "list-style",
-			value1 = "none outside none");
+			value1 = "outside none none");
 
 		takeScreenshot();
 	}


### PR DESCRIPTION
**JIRA Ticket:** 
https://issues.liferay.com/browse/LRQA-63100 
https://issues.liferay.com/browse/LRQA-63099
**Description:**
Fix poshi error java.lang.Exception: CSS Value outside none none does not match none outside none 
by adjusting assertions value from "none outside none" to "outside none none". 

To test enough to run Poshi test from the ticket's title and see if it paseed. 