### PR TITLE
[7.4-only] LPS-121957 Migrate v2 usages of clay:vertical-card in asset-browser-web

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/servlet/taglib/clay/AssetEntryVerticalCard.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/servlet/taglib/clay/AssetEntryVerticalCard.java
@@ -58,6 +58,18 @@ public class AssetEntryVerticalCard implements VerticalCard {
 	}
 
 	@Override
+	public String getCssClass() {
+		if (_assetEntry.getEntryId() !=
+				_assetBrowserDisplayContext.getRefererAssetEntryId()) {
+
+			return "card-interactive card-interactive-secondary " +
+				"selector-button";
+		}
+
+		return StringPool.BLANK;
+	}
+
+	@Override
 	public Map<String, String> getData() {
 		if (_assetBrowserDisplayContext.isMultipleSelection()) {
 			return null;
@@ -100,18 +112,6 @@ public class AssetEntryVerticalCard implements VerticalCard {
 		}
 
 		return data;
-	}
-
-	@Override
-	public String getElementClasses() {
-		if (_assetEntry.getEntryId() !=
-				_assetBrowserDisplayContext.getRefererAssetEntryId()) {
-
-			return "card-interactive card-interactive-secondary " +
-				"selector-button";
-		}
-
-		return StringPool.BLANK;
 	}
 
 	@Override

--- a/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -140,7 +140,7 @@
 							%>
 
 							<liferay-ui:search-container-column-text>
-								<clay:vertical-card-v2
+								<clay:vertical-card
 									verticalCard="<%= new AssetEntryVerticalCard(assetEntry, renderRequest, assetBrowserDisplayContext) %>"
 								/>
 							</liferay-ui:search-container-column-text>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
@@ -16,7 +16,6 @@ package com.liferay.frontend.taglib.clay.servlet.taglib;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.soy.VerticalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.taglib.clay.servlet.taglib;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.soy.VerticalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;


### PR DESCRIPTION
In this change, we replace <clay:vertical-card-v2 />(clay 2.x: Metal+soy) with
<clay:vertical-card /> (clay 3.x: React)

**Test plan**

- Fetch this branch
- Deploy the asset-browser-web and frontend-taglib-clay modules
- Navigate to  **Site Builder** > **Collections**
- Create a new collection
- When selecting an item, in the modal window, change the display style
to "Cards"

**Additional notes**

Please take into account that currently there is [an open issue](https://issues.liferay.com/browse/LPS-123518)
with cards in this module (discussed with @liferay-echo)

For the moment, this submitting this PR as a draft for internal review with @carloslancha and @markocikos before sending it to @liferay-echo
