### PR TITLE
[7.4-only] LPS-121958 Migrate v2 usages of clay:vertical-card in asset-display-page-item-selector-web

### DIFF
--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/java/com/liferay/asset/display/page/item/selector/web/internal/servlet/taglib/clay/LayoutPageTemplateEntryVerticalCard.java
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/java/com/liferay/asset/display/page/item/selector/web/internal/servlet/taglib/clay/LayoutPageTemplateEntryVerticalCard.java
@@ -42,22 +42,22 @@ public class LayoutPageTemplateEntryVerticalCard implements VerticalCard {
 	}
 
 	@Override
-	public Map<String, String> getData() {
-		return HashMapBuilder.put(
-			"id",
-			String.valueOf(
-				_layoutPageTemplateEntry.getLayoutPageTemplateEntryId())
-		).put(
-			"name", _layoutPageTemplateEntry.getName()
-		).put(
-			"type", "asset-display-page"
-		).build();
+	public String getCssClass() {
+		return "card-interactive card-interactive-secondary " +
+			"layout-page-template-entry";
 	}
 
 	@Override
-	public String getElementClasses() {
-		return "card-interactive card-interactive-secondary " +
-			"layout-page-template-entry";
+	public Map<String, String> getDynamicAttributes() {
+		return HashMapBuilder.put(
+			"data-id",
+			String.valueOf(
+				_layoutPageTemplateEntry.getLayoutPageTemplateEntryId())
+		).put(
+			"data-name", _layoutPageTemplateEntry.getName()
+		).put(
+			"data-type", "asset-display-page"
+		).build();
 	}
 
 	@Override

--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
@@ -40,7 +40,7 @@ AssetDisplayPagesItemSelectorViewDisplayContext assetDisplayPagesItemSelectorVie
 			%>
 
 			<liferay-ui:search-container-column-text>
-				<clay:vertical-card-v2
+				<clay:vertical-card
 					verticalCard="<%= new LayoutPageTemplateEntryVerticalCard(layoutPageTemplateEntry, renderRequest) %>"
 				/>
 			</liferay-ui:search-container-column-text>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BaseCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BaseCardTag.java
@@ -17,14 +17,34 @@ package com.liferay.frontend.taglib.clay.servlet.taglib;
 import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
 import com.liferay.frontend.taglib.clay.servlet.taglib.soy.BaseClayCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.petra.string.StringPool;
 
 import java.util.List;
 import java.util.Map;
+
+import javax.servlet.jsp.JspException;
 
 /**
  * @author Carlos Lancha
  */
 public class BaseCardTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		if (_cardModel != null) {
+			Map<String, String> dynamicAttributes =
+				_cardModel.getDynamicAttributes();
+
+			for (Map.Entry<String, String> entry :
+					dynamicAttributes.entrySet()) {
+
+				setDynamicAttribute(
+					StringPool.BLANK, entry.getKey(), entry.getValue());
+			}
+		}
+
+		return super.doStartTag();
+	}
 
 	public List<DropdownItem> getActionDropdownItems() {
 		if ((_actionDropdownItems == null) && (_cardModel != null)) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/BaseClayCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/BaseClayCard.java
@@ -48,6 +48,10 @@ public interface BaseClayCard {
 		return null;
 	}
 
+	public default Map<String, String> getDynamicAttributes() {
+		return null;
+	}
+
 	public default String getElementClasses() {
 		return null;
 	}


### PR DESCRIPTION
In this change, we replace <clay:vertical-card-v2 />(clay 2.x:
Metal+soy) with
<clay:vertical-card /> (clay 3.x: React)

Test plan

- Fetch this branch
- Deploy the `asset-display-page-item-selector-web` module
- Navigate to **Design** > **Pages Templates**
- Select the **Display Page Templates** tab
- Click on the **+** button to create a new Display Page Template
- Click on the **Blank** Card
- In the modal window that appears, type in a name for your new Display Page
Template
- In the **Content Type** field, select **Web Content Article**
- In the **Subtype** field, select **Basic Web Content** and click on
the **Save Button**
- Click on the **Publish Button** to publish this new Display Page
Template
- Navigate to **Content & Data** > **Web Content**
- Click on the **+** button to create a new **Web Content**
- Enter a title and some content for this **Web Content**
- In the sidebar on the right, toggle the **Display Page Template**
field
- Select **Specific Display Page Template**
- Click on the **Select** button
- In the modal window, click on the **Display Page Template** you
created previously
- Click on the **Publish** button

For the moment, submitting this as a draft for internal review with
@carloslancha and @markocikos before submitting to @liferay-echo