### PR TITLE
LPS-123529 Add status and sorting filters to management toolbar

### DIFF
--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/search/spi/model/index/contributor/TranslationEntryModelDocumentContributor.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/search/spi/model/index/contributor/TranslationEntryModelDocumentContributor.java
@@ -38,6 +38,7 @@ public class TranslationEntryModelDocumentContributor
 		document.addText(Field.CONTENT, translationEntry.getContent());
 		document.addDate(
 			Field.MODIFIED_DATE, translationEntry.getModifiedDate());
+		document.addKeyword(Field.STATUS, translationEntry.getStatus());
 	}
 
 }

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/application/list/TranslationPanelApp.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/application/list/TranslationPanelApp.java
@@ -29,8 +29,8 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = {
-		"panel.app.order:Integer=210",
-		"panel.category.key=" + PanelCategoryKeys.SITE_ADMINISTRATION_CONFIGURATION
+		"panel.app.order:Integer=1300",
+		"panel.category.key=" + PanelCategoryKeys.SITE_ADMINISTRATION_CONTENT
 	},
 	service = PanelApp.class
 )

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslationEntryManagementToolbarDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslationEntryManagementToolbarDisplayContext.java
@@ -16,12 +16,24 @@ package com.liferay.translation.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.SearchContainerManagementToolbarDisplayContext;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortletURLUtil;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.translation.model.TranslationEntry;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.portlet.PortletURL;
@@ -45,6 +57,9 @@ public class TranslationEntryManagementToolbarDisplayContext
 			searchContainer);
 
 		_defaultEventHandler = defaultEventHandler;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
 	@Override
@@ -63,7 +78,13 @@ public class TranslationEntryManagementToolbarDisplayContext
 
 	@Override
 	public String getClearResultsURL() {
-		return getSearchActionURL();
+		PortletURL portletURL = getPortletURL();
+
+		portletURL.setParameter("keywords", StringPool.BLANK);
+		portletURL.setParameter("orderByCol", getOrderByCol());
+		portletURL.setParameter("orderByType", getOrderByType());
+
+		return portletURL.toString();
 	}
 
 	@Override
@@ -72,8 +93,38 @@ public class TranslationEntryManagementToolbarDisplayContext
 	}
 
 	@Override
+	public List<LabelItem> getFilterLabelItems() {
+		if (_getStatus() == WorkflowConstants.STATUS_ANY) {
+			return null;
+		}
+
+		return LabelItemListBuilder.add(
+			labelItem -> {
+				PortletURL removeLabelURL = PortletURLUtil.clone(
+					getPortletURL(), liferayPortletResponse);
+
+				removeLabelURL.setParameter("status", (String)null);
+
+				labelItem.putData("removeLabelURL", removeLabelURL.toString());
+
+				labelItem.setDismissible(true);
+				labelItem.setLabel(
+					WorkflowConstants.getStatusLabel(_getStatus()));
+			}
+		).build();
+	}
+
+	@Override
+	public List<DropdownItem> getFilterNavigationDropdownItems() {
+		return _getFilterStatusDropdownItems();
+	}
+
+	@Override
 	public String getSearchActionURL() {
 		PortletURL portletURL = liferayPortletResponse.createRenderURL();
+
+		portletURL.setParameter("orderByCol", getOrderByCol());
+		portletURL.setParameter("orderByType", getOrderByType());
 
 		return portletURL.toString();
 	}
@@ -83,6 +134,73 @@ public class TranslationEntryManagementToolbarDisplayContext
 		return "searchContainer";
 	}
 
+	@Override
+	protected String getFilterNavigationDropdownItemsLabel() {
+		return LanguageUtil.get(httpServletRequest, "filter-by-status");
+	}
+
+	@Override
+	protected String[] getOrderByKeys() {
+		return new String[] {"modified-date", "status", "title"};
+	}
+
+	private List<DropdownItem> _getFilterStatusDropdownItems() {
+		return new DropdownItemList() {
+			{
+				for (int status : _getStatuses()) {
+					add(
+						dropdownItem -> {
+							dropdownItem.setActive(_getStatus() == status);
+							dropdownItem.setHref(
+								getPortletURL(), "status",
+								String.valueOf(status));
+
+							dropdownItem.setLabel(
+								LanguageUtil.get(
+									httpServletRequest,
+									WorkflowConstants.getStatusLabel(status)));
+						});
+				}
+			}
+		};
+	}
+
+	private int _getStatus() {
+		if (_status != null) {
+			return _status;
+		}
+
+		_status = ParamUtil.getInteger(
+			httpServletRequest, "status", WorkflowConstants.STATUS_ANY);
+
+		return _status;
+	}
+
+	private List<Integer> _getStatuses() {
+		List<Integer> statuses = new ArrayList<>();
+
+		statuses.add(WorkflowConstants.STATUS_ANY);
+		statuses.add(WorkflowConstants.STATUS_DRAFT);
+
+		int workflowDefinitionLinksCount =
+			WorkflowDefinitionLinkLocalServiceUtil.
+				getWorkflowDefinitionLinksCount(
+					_themeDisplay.getCompanyId(),
+					_themeDisplay.getScopeGroupId(),
+					TranslationEntry.class.getName());
+
+		if (workflowDefinitionLinksCount > 0) {
+			statuses.add(WorkflowConstants.STATUS_PENDING);
+			statuses.add(WorkflowConstants.STATUS_DENIED);
+		}
+
+		statuses.add(WorkflowConstants.STATUS_APPROVED);
+
+		return statuses;
+	}
+
 	private final String _defaultEventHandler;
+	private Integer _status;
+	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ViewDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ViewDisplayContext.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchContextFactory;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -151,11 +150,6 @@ public class ViewDisplayContext {
 
 	public String getDefaultEventHandler() {
 		return "translationManagementToolbarDefaultEventHandler";
-	}
-
-	public String getModelName(TranslationEntry translationEntry) {
-		return ResourceActionsUtil.getModelResource(
-			_themeDisplay.getLocale(), translationEntry.getClassName());
 	}
 
 	public SearchContainer<TranslationEntry> getSearchContainer()

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ViewDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ViewDisplayContext.java
@@ -27,6 +27,10 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.search.BooleanClause;
+import com.liferay.portal.kernel.search.BooleanClauseFactoryUtil;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
@@ -34,6 +38,10 @@ import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchContextFactory;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -42,12 +50,14 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.translation.model.TranslationEntry;
 import com.liferay.translation.service.TranslationEntryLocalService;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionURL;
@@ -178,10 +188,12 @@ public class ViewDisplayContext {
 			_httpServletRequest);
 
 		searchContext.setAttribute("paginationType", "regular");
+		searchContext.setBooleanClauses(_getBooleanClauses());
 		searchContext.setCompanyId(_themeDisplay.getCompanyId());
 		searchContext.setEnd(_searchContainer.getEnd());
 		searchContext.setKeywords(
 			ParamUtil.getString(_httpServletRequest, "keywords"));
+		searchContext.setSorts(_getSorts());
 		searchContext.setStart(_searchContainer.getStart());
 		searchContext.setUserId(_themeDisplay.getUserId());
 
@@ -252,6 +264,53 @@ public class ViewDisplayContext {
 			getDefaultEventHandler(), _httpServletRequest,
 			_liferayPortletRequest, _liferayPortletResponse,
 			getSearchContainer());
+	}
+
+	private BooleanClause[] _getBooleanClauses() {
+		long status = ParamUtil.getLong(
+			_httpServletRequest, "status", WorkflowConstants.STATUS_ANY);
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return null;
+		}
+
+		BooleanQuery booleanQuery = new BooleanQueryImpl();
+
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		TermsFilter termsFilter = new TermsFilter(Field.STATUS);
+
+		termsFilter.addValue(String.valueOf(status));
+
+		booleanFilter.add(termsFilter, BooleanClauseOccur.MUST);
+
+		booleanQuery.setPreBooleanFilter(booleanFilter);
+
+		return new BooleanClause[] {
+			BooleanClauseFactoryUtil.create(
+				booleanQuery, BooleanClauseOccur.MUST.getName())
+		};
+	}
+
+	private Sort[] _getSorts() {
+		boolean reverse = false;
+
+		if (Objects.equals(_searchContainer.getOrderByType(), "desc")) {
+			reverse = true;
+		}
+
+		if (Objects.equals(_searchContainer.getOrderByCol(), "modified-date")) {
+			return new Sort[] {new Sort(Field.MODIFIED_DATE, reverse)};
+		}
+		else if (Objects.equals(_searchContainer.getOrderByCol(), "status")) {
+			return new Sort[] {new Sort(Field.STATUS, reverse)};
+		}
+		else if (Objects.equals(_searchContainer.getOrderByCol(), "title")) {
+			return new Sort[] {new Sort(Field.TITLE, reverse)};
+		}
+		else {
+			return null;
+		}
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ViewDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ViewDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -39,6 +40,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.translation.model.TranslationEntry;
 import com.liferay.translation.service.TranslationEntryLocalService;
@@ -150,6 +152,12 @@ public class ViewDisplayContext {
 
 	public String getDefaultEventHandler() {
 		return "translationManagementToolbarDefaultEventHandler";
+	}
+
+	public String getLanguageLabel(TranslationEntry translationEntry) {
+		return StringUtil.replace(
+			translationEntry.getLanguageId(), CharPool.UNDERLINE,
+			CharPool.DASH);
 	}
 
 	public SearchContainer<TranslationEntry> getSearchContainer()

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
@@ -52,7 +52,7 @@ ViewDisplayContext viewDisplayContext = (ViewDisplayContext)request.getAttribute
 
 				<liferay-ui:search-container-column-text
 					name="language"
-					property="languageId"
+					value="<%= viewDisplayContext.getLanguageLabel(translationEntry) %>"
 				/>
 
 				<liferay-ui:search-container-column-status

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
@@ -51,12 +51,6 @@ ViewDisplayContext viewDisplayContext = (ViewDisplayContext)request.getAttribute
 				/>
 
 				<liferay-ui:search-container-column-text
-					cssClass="table-cell-expand"
-					name="type"
-					value="<%= viewDisplayContext.getModelName(translationEntry) %>"
-				/>
-
-				<liferay-ui:search-container-column-text
 					name="language"
 					property="languageId"
 				/>


### PR DESCRIPTION
Dear Frontend Dwellers,

In this PR I'm updating a ManagementToolbarDisplayContext, adding some filter and order dropdown items. Everything seems to be working fine except for the button to change the sorting order, which fails to appear.

I've compared my implementation with other equivalent ones, and I don't see any major piece missing, so I need some help here. Can you provide some pointers as to what do I need to do so that the sorting button shows up?

To see the problem, deploy the `apps/translation/translation-web` module and go to Content & Data > Translation app in the product menu.

You'll need to add a translation first; for that:
- Go to Content & Data > Web Content
- Create a Basic Article (actual content doesn't really matter)
- Go to Content & Data > Web Content
- For the article you just created, select the "Translate" action from its action dropdown
- Type anything in the side by side and click Publish

Thanks!