### PR TITLE
LPS-123392 Use the servlet context from the page context

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTag.java
@@ -79,7 +79,8 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 			namespace = NPMResolvedPackageNameUtil.get(servletContext);
 		}
 		else {
-			namespace = NPMResolvedPackageNameUtil.get(request);
+			namespace = NPMResolvedPackageNameUtil.get(
+				pageContext.getServletContext());
 		}
 
 		return namespace + "/" + _module;


### PR DESCRIPTION
Notes from @Noornajj:

> https://issues.liferay.com/browse/LPS-123392
> 
> We are unable to edit a message thread through an Asset Publisher because the module name was not rendering correctly.
> To fix this issue, I used the servlet context from the page context to get the correct namespace.

Test result: https://github.com/brianikim/liferay-portal/pull/120#issuecomment-725826503