### PR TITLE
[7.4-only] LPS-123738 Move additionalProps inside its own property instead destructurint the content

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -52,10 +52,9 @@ const ACTIONS = {
 };
 
 export default function propsTransformer({
-	deleteVocabulariesURL,
+	additionalProps: {deleteVocabulariesURL, viewVocabulariesURL},
 	items,
 	portletNamespace,
-	viewVocabulariesURL,
 	...otherProps
 }) {
 	return {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -261,6 +261,10 @@ public class BaseContainerTag extends AttributesTagSupport {
 	}
 
 	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		if (_additionalProps != null) {
+			props.put("additionalProps", _additionalProps);
+		}
+
 		props.put("cssClass", getCssClass());
 
 		String defaultEventHandler = getDefaultEventHandler();
@@ -270,10 +274,6 @@ public class BaseContainerTag extends AttributesTagSupport {
 		}
 
 		props.put("id", getId());
-
-		if (_additionalProps != null) {
-			props.putAll(_additionalProps);
-		}
 
 		props.putAll(getDynamicAttributes());
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Button.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Button.js
@@ -18,6 +18,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 export default function Button({
+	additionalProps: _additionalProps,
 	componentId: _componentId,
 	cssClass,
 	icon,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Checkbox.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Checkbox.js
@@ -16,6 +16,7 @@ import {ClayCheckbox} from '@clayui/form';
 import React, {useState} from 'react';
 
 export default function Checkbox({
+	additionalProps: _additionalProps,
 	checked,
 	componentId: _componentId,
 	cssClass,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -21,6 +21,7 @@ import React from 'react';
 
 export default function DropdownMenu({
 	actionsDropdown = false,
+	additionalProps: _additionalProps,
 	componentId: _componentId,
 	cssClass,
 	icon,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/HorizontalCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/HorizontalCard.js
@@ -19,6 +19,7 @@ import getDataAttributes from './get_data_attributes';
 
 export default function HorizontalCard({
 	actions = [],
+	additionalProps: _additionalProps,
 	componentId: _componentId,
 	cssClass,
 	disabled,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/UserCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/UserCard.js
@@ -19,6 +19,7 @@ import getDataAttributes from './get_data_attributes';
 
 export default function UserCard({
 	actions = [],
+	additionalProps: _additionalProps,
 	componentId: _componentId,
 	cssClass,
 	inputName = '',

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
@@ -19,6 +19,7 @@ import getDataAttributes from './get_data_attributes';
 
 export default function VerticalCard({
 	actions = [],
+	additionalProps: _additionalProps,
 	componentId: _componentId,
 	cssClass,
 	description,

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -59,10 +59,12 @@ const ACTIONS = {
 };
 
 export default function propsTransformer({
-	deleteLayoutPageTemplateCollectionURL,
+	additionalProps: {
+		deleteLayoutPageTemplateCollectionURL,
+		viewLayoutPageTemplateCollectionURL,
+	},
 	items,
 	portletNamespace,
-	viewLayoutPageTemplateCollectionURL,
 	...otherProps
 }) {
 	return {

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-fido2-web/src/main/resources/META-INF/resources/js/AuthenticationTransformer.js
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-fido2-web/src/main/resources/META-INF/resources/js/AuthenticationTransformer.js
@@ -12,7 +12,7 @@
 import * as webauthn from './webauthn';
 
 export default function AuthenticationTransformer({
-	assertionRequest,
+	additionalProps: {assertionRequest},
 	portletNamespace,
 	...otherProps
 }) {

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-fido2-web/src/main/resources/META-INF/resources/js/RegistrationTransformer.js
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-fido2-web/src/main/resources/META-INF/resources/js/RegistrationTransformer.js
@@ -12,7 +12,7 @@
 import * as webauthn from './webauthn';
 
 export default function RegistrationTransformer({
-	pkccOptions,
+	additionalProps: {pkccOptions},
 	portletNamespace,
 	...otherProps
 }) {


### PR DESCRIPTION
This pr is solving the issue that anything added as an `additionalProp` would be passed destructured to the component, and that might end being rendered as attributes.

See full conversation in https://liferay.slack.com/archives/G3JBR21HA/p1605725869270000