### PR TITLE
[7.4-only] LPS-112478 Deprecate labelStylesMap attribute

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleFileCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleFileCard.java
@@ -20,10 +20,8 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuil
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
 import com.liferay.portal.kernel.security.RandomUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author Julien Castelain
@@ -149,18 +147,6 @@ public class ClaySampleFileCard implements FileCard {
 		).build();
 	}
 
-	public Map<String, String> getLabelStylesMap() {
-		if (_labelStylesMap != null) {
-			return _labelStylesMap;
-		}
-
-		_labelStylesMap = HashMapBuilder.put(
-			"Approved", "info"
-		).build();
-
-		return _labelStylesMap;
-	}
-
 	public String getStickerCssClass() {
 		return _stickerCssClass;
 	}
@@ -264,10 +250,6 @@ public class ClaySampleFileCard implements FileCard {
 		_labels = labels;
 	}
 
-	public void setLabelStylesMap(Map<String, String> labelStylesMap) {
-		_labelStylesMap = labelStylesMap;
-	}
-
 	public void setSelectable(boolean selectable) {
 		_selectable = selectable;
 	}
@@ -322,7 +304,6 @@ public class ClaySampleFileCard implements FileCard {
 	private String _inputName;
 	private String _inputValue;
 	private List<LabelItem> _labels;
-	private Map<String, String> _labelStylesMap;
 	private boolean _selectable = true;
 	private boolean _selected;
 	private String _stickerCssClass;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleImageCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleImageCard.java
@@ -20,10 +20,8 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuil
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
 import com.liferay.portal.kernel.security.RandomUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author Julien Castelain
@@ -161,18 +159,6 @@ public class ClaySampleImageCard implements ImageCard {
 		).build();
 	}
 
-	public Map<String, String> getLabelStylesMap() {
-		if (_labelStylesMap != null) {
-			return _labelStylesMap;
-		}
-
-		_labelStylesMap = HashMapBuilder.put(
-			"Pending", "warning"
-		).build();
-
-		return _labelStylesMap;
-	}
-
 	public String getStickerCssClass() {
 		return _stickerCssClass;
 	}
@@ -284,10 +270,6 @@ public class ClaySampleImageCard implements ImageCard {
 		_labels = labels;
 	}
 
-	public void setLabelStylesMap(Map<String, String> labelStylesMap) {
-		_labelStylesMap = labelStylesMap;
-	}
-
 	public void setSelectable(boolean selectable) {
 		_selectable = selectable;
 	}
@@ -344,7 +326,6 @@ public class ClaySampleImageCard implements ImageCard {
 	private String _inputName;
 	private String _inputValue;
 	private List<LabelItem> _labels;
-	private Map<String, String> _labelStylesMap;
 	private boolean _selectable = true;
 	private boolean _selected;
 	private String _stickerCssClass;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleVerticalCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleVerticalCard.java
@@ -20,10 +20,8 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuil
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
 import com.liferay.portal.kernel.security.RandomUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author Julien Castelain
@@ -157,18 +155,6 @@ public class ClaySampleVerticalCard implements VerticalCard {
 		).build();
 	}
 
-	public Map<String, String> getLabelStylesMap() {
-		if (_labelStylesMap != null) {
-			return _labelStylesMap;
-		}
-
-		_labelStylesMap = HashMapBuilder.put(
-			"Pending", "info"
-		).build();
-
-		return _labelStylesMap;
-	}
-
 	public String getStickerCssClass() {
 		return _stickerCssClass;
 	}
@@ -280,10 +266,6 @@ public class ClaySampleVerticalCard implements VerticalCard {
 		_labels = labels;
 	}
 
-	public void setLabelStylesMap(Map<String, String> labelStylesMap) {
-		_labelStylesMap = labelStylesMap;
-	}
-
 	public void setSelectable(boolean selectable) {
 		_selectable = selectable;
 	}
@@ -340,7 +322,6 @@ public class ClaySampleVerticalCard implements VerticalCard {
 	private String _inputName;
 	private String _inputValue;
 	private List<LabelItem> _labels;
-	private Map<String, String> _labelStylesMap;
 	private boolean _selectable = true;
 	private boolean _selected;
 	private String _stickerCssClass;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
@@ -177,7 +177,6 @@ ClaySampleImageCard claySampleImageCard = new ClaySampleImageCard();
 			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
 			icon="camera"
 			labels="<%= claySampleImageCard.getLabels() %>"
-			labelStylesMap="<%= claySampleImageCard.getLabelStylesMap() %>"
 			stickerLabel="SVG"
 			stickerStyle="warning"
 			subtitle="<%= claySampleImageCard.getSubtitle() %>"
@@ -318,7 +317,6 @@ ClaySampleFileCard claySampleFileCard = new ClaySampleFileCard();
 		<clay:file-card
 			actionDropdownItems="<%= claySampleFileCard.getActionDropdownItems() %>"
 			labels="<%= claySampleFileCard.getLabels() %>"
-			labelStylesMap="<%= claySampleFileCard.getLabelStylesMap() %>"
 			selectable="<%= false %>"
 			stickerLabel="MP3"
 			stickerStyle="warning"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
@@ -89,6 +89,10 @@ public class VerticalCardTag extends BaseCardTag {
 		return _labels;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public Map<String, String> getLabelStylesMap() {
 		VerticalCard verticalCard = getVerticalCard();
 
@@ -245,6 +249,10 @@ public class VerticalCardTag extends BaseCardTag {
 		_labels = labels;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public void setLabelStylesMap(Map<String, String> labelStylesMap) {
 		_labelStylesMap = labelStylesMap;
 	}
@@ -324,7 +332,6 @@ public class VerticalCardTag extends BaseCardTag {
 		props.put("imageAlt", getImageAlt());
 		props.put("imageSrc", getImageSrc());
 		props.put("labels", getLabels());
-		props.put("labelStylesMap", getLabelStylesMap());
 		props.put("stickerCssClass", getStickerCssClass());
 		props.put("stickerIcon", getStickerIcon());
 		props.put("stickerImageAlt", getStickerImageAlt());

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1203,7 +1203,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>labelStylesMap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1987,7 +1987,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>labelStylesMap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -4377,7 +4377,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>labelStylesMap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
@@ -32,7 +32,6 @@ export default function VerticalCard({
 	inputName = '',
 	inputValue = '',
 	labels = [],
-	labelStylesMap: _labelStylesMap,
 	locale: _locale,
 	portletId: _portletId,
 	portletNamespace: _portletNamespace,


### PR DESCRIPTION
We're deprecating the `labelStylesMap` attribute for `<clay:file-card />`, `<clay:image-card />` and `<clay:vertical-card />`, the reason is that this was added in clay 2.x to be able to map labels with styles and ended up being unused. 

There are no usages, and this isn't needed in for our clay 3.x tags.
