### PR TITLE
[7.4-only] LPS-121975 Replace vertical-card-v2 with vertical-card

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DefaultEventHandlersPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DefaultEventHandlersPropsTransformer.js
@@ -13,29 +13,33 @@
  */
 
 export default function propsTransformer({
+	actions,
 	defaultEventHandler,
 	items,
 	...otherProps
 }) {
+	const itemsMap = (item) => {
+		return {
+			...item,
+			onClick(event) {
+				const action = item.data?.action;
+
+				if (action) {
+					event.preventDefault();
+
+					Liferay.componentReady(defaultEventHandler).then(
+						(eventHandler) => {
+							eventHandler[action](item.data);
+						}
+					);
+				}
+			},
+		};
+	};
+
 	return {
 		...otherProps,
-		items: items.map((item) => {
-			return {
-				...item,
-				onClick(event) {
-					const action = item.data?.action;
-
-					if (action) {
-						event.preventDefault();
-
-						Liferay.componentReady(defaultEventHandler).then(
-							(eventHandler) => {
-								eventHandler[action](item.data);
-							}
-						);
-					}
-				},
-			};
-		}),
+		actions: actions?.map(itemsMap),
+		items: items?.map(itemsMap),
 	};
 }

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -112,7 +112,7 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 											/>
 										</c:when>
 										<c:otherwise>
-											<clay:horizontal-card-v2
+											<clay:horizontal-card
 												horizontalCard="<%= new TrashContentHorizontalCard(curTrashedModel, curTrashRenderer, liferayPortletResponse, renderRequest, rowURL.toString()) %>"
 											/>
 										</c:otherwise>

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -107,7 +107,7 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 								<liferay-ui:search-container-column-text>
 									<c:choose>
 										<c:when test="<%= !curTrashHandler.isContainerModel() %>">
-											<clay:vertical-card-v2
+											<clay:vertical-card
 												verticalCard="<%= new TrashContentVerticalCard(curTrashedModel, curTrashRenderer, liferayPortletResponse, renderRequest, rowURL.toString()) %>"
 											/>
 										</c:when>


### PR DESCRIPTION
__IMPORTANT: THIS PR IS NOT TO BE FORWARDED BUT SENT TO ECHO TEAM__

Replacing old vertical-card and horizontal-card tag uses in trash-web.

Adding support for defaultEventHandler transformation so it can accept either items or actions.

Before
![image](https://user-images.githubusercontent.com/5803434/99699767-a1054100-2a92-11eb-8d9f-f5584f3d0476.png)

After
![image](https://user-images.githubusercontent.com/5803434/99699170-effea680-2a91-11eb-9976-3a168cd78d0f.png)