### PR TITLE
[7.4-only] LPS-121959 Migrate v2 usages of clay:vertical-card in blogs/blogs-web

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/entry_search_columns.jspf
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/entry_search_columns.jspf
@@ -72,7 +72,7 @@
 		%>
 
 		<liferay-ui:search-container-column-text>
-			<clay:vertical-card-v2
+			<clay:vertical-card
 				verticalCard="<%= new BlogsEntryVerticalCard(entry, renderRequest, renderResponse, searchContainer.getRowChecker(), trashHelper, rowURL.toString(), permissionChecker, resourceBundle) %>"
 			/>
 		</liferay-ui:search-container-column-text>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DefaultEventHandlersPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DefaultEventHandlersPropsTransformer.js
@@ -13,29 +13,33 @@
  */
 
 export default function propsTransformer({
+	actions,
 	defaultEventHandler,
 	items,
 	...otherProps
 }) {
+	const itemsMap = (item) => {
+		return {
+			...item,
+			onClick(event) {
+				const action = item.data?.action;
+
+				if (action) {
+					event.preventDefault();
+
+					Liferay.componentReady(defaultEventHandler).then(
+						(eventHandler) => {
+							eventHandler[action](item.data);
+						}
+					);
+				}
+			},
+		};
+	};
+
 	return {
 		...otherProps,
-		items: items.map((item) => {
-			return {
-				...item,
-				onClick(event) {
-					const action = item.data?.action;
-
-					if (action) {
-						event.preventDefault();
-
-						Liferay.componentReady(defaultEventHandler).then(
-							(eventHandler) => {
-								eventHandler[action](item.data);
-							}
-						);
-					}
-				},
-			};
-		}),
+		actions: actions?.map(itemsMap),
+		items: items?.map(itemsMap),
 	};
 }


### PR DESCRIPTION
**IMPORTANT** This PR needs to be sent to @liferay-lima after internal review

In this change, we replace `<clay:vertical-card-v2 />` (clay 2.x:Metal+soy) with `<clay:vertical-card />`  (clay 3.x: React)

**Test plan**:
- Navigate to **Content & Data** > **Blogs**
- Create a new Blog Entry
- Navigate to the previous page