### PR TITLE
LPS-123157 Export frontend-js-web as a federated module

### DIFF
--- a/modules/apps/frontend-js/frontend-js-react-web/npmscripts.config.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/npmscripts.config.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const preset = require('@liferay/npm-scripts/src/presets/standard');
+
+module.exports = {
+	federation: true,
+	preset: '@liferay/npm-scripts/src/presets/standard',
+};

--- a/modules/apps/frontend-js/frontend-js-react-web/npmscripts.config.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/npmscripts.config.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-const preset = require('@liferay/npm-scripts/src/presets/standard');
-
 module.exports = {
 	federation: true,
 	preset: '@liferay/npm-scripts/src/presets/standard',

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useStateSafe.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useStateSafe.es.js
@@ -12,8 +12,9 @@
  * details.
  */
 
-import {useIsMounted} from 'frontend-js-react-web';
 import React from 'react';
+
+import useIsMounted from './useIsMounted.es';
 
 const {useCallback, useState} = React;
 

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useThunk.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useThunk.es.js
@@ -12,8 +12,9 @@
  * details.
  */
 
-import {useIsMounted} from 'frontend-js-react-web';
 import React from 'react';
+
+import useIsMounted from './useIsMounted.es';
 
 const {useRef} = React;
 

--- a/modules/apps/frontend-js/frontend-js-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-web/.npmbundlerrc
@@ -9,6 +9,7 @@
 		"**/liferay/lazy_load.js",
 		"**/liferay/liferay.js",
 		"**/liferay/portlet.js",
+		"**/liferay/webpack_federation.js",
 		"**/liferay/workflow.js",
 		"**/loader/config.js"
 	]

--- a/modules/apps/frontend-js/frontend-js-web/bnd.bnd
+++ b/modules/apps/frontend-js/frontend-js-web/bnd.bnd
@@ -9,6 +9,7 @@ Liferay-JS-Resources-Top-Head:\
 	/liferay/events.js,\
 	/liferay/lazy_load.js,\
 	/liferay/liferay.js,\
+	/liferay/webpack_federation.js,\
 	\
 	/liferay/global.bundle.js,\
 	/liferay/portlet.js,\

--- a/modules/apps/frontend-js/frontend-js-web/npmscripts.config.js
+++ b/modules/apps/frontend-js/frontend-js-web/npmscripts.config.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const preset = require('@liferay/npm-scripts/src/presets/standard');
+
+module.exports = {
+	federation: true,
+	preset: '@liferay/npm-scripts/src/presets/standard',
+};

--- a/modules/apps/frontend-js/frontend-js-web/npmscripts.config.js
+++ b/modules/apps/frontend-js/frontend-js-web/npmscripts.config.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-const preset = require('@liferay/npm-scripts/src/presets/standard');
-
 module.exports = {
 	federation: true,
 	preset: '@liferay/npm-scripts/src/presets/standard',

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
@@ -18,8 +18,10 @@ import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayModal, {useModal} from '@clayui/modal';
 import {useIsMounted} from 'frontend-js-react-web';
-import {fetch, navigate} from 'frontend-js-web';
 import React, {useState} from 'react';
+
+import fetch from '../../util/fetch.es';
+import navigate from '../../util/navigate.es';
 
 /**
  * Manipulates small amounts of data with a form shown inside a modal.

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/webpack_federation.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/webpack_federation.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+Liferay = window.Liferay || {};
+
+Liferay.Webpack = {
+	Container: {},
+	SharedScope: {},
+};
+
+Liferay.require = (moduleName) =>
+	new Promise((resolve, reject) => {
+		const i = moduleName.indexOf('/');
+
+		let containerId, path;
+
+		if (i === -1) {
+			containerId = moduleName;
+			path = '.';
+		}
+		else {
+			containerId = moduleName.substring(0, i);
+			path = moduleName.substring(i + 1);
+		}
+
+		let container = Liferay.Webpack.Container[containerId];
+
+		if (container) {
+			Promise.resolve(container.get(path)).then((module) =>
+				resolve(module())
+			);
+		}
+		else {
+			const script = document.createElement('script');
+
+			script.src = '/o/' + containerId + '/__generated__/container.js';
+
+			script.onload = () => {
+				container = Liferay.Webpack.Container[containerId];
+
+				if (container) {
+					Promise.resolve(container.init(Liferay.Webpack.SharedScope))
+						.then(() => container.get(path))
+						.then((module) => resolve(module()));
+				}
+				else {
+					const message =
+						'Container ' +
+						containerId +
+						' was fetched but ' +
+						'did not define itself in Liferay.Webpack.Container';
+
+					console.warn(message);
+
+					reject(new Error(message));
+				}
+			};
+
+			document.body.appendChild(script);
+		}
+	});

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@liferay/npm-scripts": "36.0.1",
+		"@liferay/npm-scripts": "36.2.0",
 		"acorn": "7.1.0",
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1719,10 +1719,10 @@
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-"@liferay/npm-scripts@36.0.1":
-  version "36.0.1"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-36.0.1.tgz#dbd6ccc418cae1f8fd0fc65699e368fa36787a9c"
-  integrity sha512-8L/6z8h7GG8cI0XCPQVYUZ4yGsIsgDLqC5wZdKbAi0mJBbwiyNS12d615vEGBgK6g9DyDFpgl/wG49wCuyfjSg==
+"@liferay/npm-scripts@36.2.0":
+  version "36.2.0"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-36.2.0.tgz#97e8448b4b7e88fabc0ab393c1557eff36fb14c2"
+  integrity sha512-UbIJVXf433njEo2SS0ZOsG+SUEfILtw0i/7kbH1y9lDPHYtxn97aIZZC31VWP4/p/w0KiaUl4HUsugdvLsGosA==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"
@@ -1780,6 +1780,7 @@
     style-ext-html-webpack-plugin "4.1.2"
     style-loader "^1.1.3"
     stylelint "^13.2.0"
+    terser "5.3.8"
     ts-loader "^8.0.4"
     typescript "^4.0.3"
     webpack "^5.4.0"
@@ -14770,6 +14771,15 @@ terser-webpack-plugin@^5.0.3:
     serialize-javascript "^5.0.1"
     source-map "^0.6.1"
     terser "^5.3.8"
+
+terser@5.3.8:
+  version "5.3.8"
+  resolved "http://localhost:4873/terser/-/terser-5.3.8.tgz#991ae8ba21a3d990579b54aa9af11586197a75dd"
+  integrity sha512-zVotuHoIfnYjtlurOouTazciEfL7V38QMAOhGqpXDEg6yT13cF4+fEP9b0rrCEQTn+tT46uxgFsTZzhygk+CzQ==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
 
 terser@^4.6.3:
   version "4.7.0"


### PR DESCRIPTION
This PR configures portal's build to export `frontend-js-web` and `frontend-js-react-web` as federated webpack modules. It is WIP and should not be merged directly because most of the configuration should probably go inside `npm-tools` or `npm-bundler` to avoid duplication and make it easier to use.

I strongly recommend to read the commit messages before looking at the changes because they have important explanations on how things are done.

Regarding local testing, this PR can be built and can be seen in action simply by adding the `JS Clay Sample Web` portlet to the page and looking at the JS console. The result is not very exciting, but if you understand what you are seeing you will sure be amazed:

![image](https://user-images.githubusercontent.com/3273630/99798061-9d27fc00-2b30-11eb-94e3-1c989b8ad915.png)

The final object print is the `module.exports` object of `frontend-js-web` consumed through the webpack federated module.

----

Things not yet clear:

1. Where to hide configuration things (`npm-bundler` or `npm-tools`, or both)?
2. Do we use other name for the `webpack/container.js` file?
3. Do we like the `Liferay.Webpack.require` API?
4. Does this work when the portal is deployed to a non-root context?
5. Will we have any problems with having two copies of each module while we maintain two parallel builds (one in AMD loader, another in webpack runtime)?

