### PR TITLE
[7.4-only][LPS-122520] Removes metal-dom dependency from frontend-js-spa-web

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/package.json
@@ -1,7 +1,6 @@
 {
 	"dependencies": {
 		"frontend-js-web": "*",
-		"metal-dom": "2.16.8",
 		"metal-promise": "3.0.5",
 		"metal-uri": "2.4.0"
 	},

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
@@ -13,10 +13,9 @@
  */
 
 import {openToast} from 'frontend-js-web';
-import dom from 'metal-dom';
 
 import {App} from '../../senna/senna';
-import {getUid} from '../../senna/utils/utils';
+import {buildFragment, getUid} from '../../senna/utils/utils';
 import LiferaySurface from '../surface/Surface.es';
 import {getPortletBoundaryId, resetAllPortlets} from '../util/Utils.es';
 
@@ -78,7 +77,9 @@ class LiferayApp extends App {
 
 		this.addSurfaces(new LiferaySurface(body.id));
 
-		dom.append(body, '<div class="lfr-spa-loading-bar"></div>');
+		body.appendChild(
+			buildFragment('<div class="lfr-spa-loading-bar"></div>')
+		);
 	}
 
 	/**
@@ -213,7 +214,7 @@ class LiferayApp extends App {
 	 */
 
 	onDataLayoutConfigReady_() {
-		if (Liferay.Layout) {
+		if (Liferay.Layout && Liferay.Data.layoutConfig) {
 			Liferay.Layout.init(Liferay.Data.layoutConfig);
 		}
 		else {
@@ -235,7 +236,9 @@ class LiferayApp extends App {
 
 	onDocClickDelegate_(event) {
 		if (
-			this.isInPortletBlacklist(event.delegateTarget) ||
+			this.isInPortletBlacklist(
+				event.target.closest(this.getLinkSelector())
+			) ||
 			event.detail > 1
 		) {
 			return;
@@ -253,7 +256,11 @@ class LiferayApp extends App {
 	 */
 
 	onDocSubmitDelegate_(event) {
-		if (this.isInPortletBlacklist(event.delegateTarget)) {
+		if (
+			this.isInPortletBlacklist(
+				event.target.closest(this.getFormSelector())
+			)
+		) {
 			return;
 		}
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
@@ -12,9 +12,8 @@
  * details.
  */
 
-import dom from 'metal-dom';
-
 import Surface from '../../senna/surface/Surface';
+import {buildFragment} from '../../senna/utils/utils';
 
 /**
  * LiferaySurface
@@ -31,7 +30,7 @@ class LiferaySurface extends Surface {
 
 	addContent(screenId, content) {
 		if (typeof content === 'string') {
-			content = dom.buildFragment(content);
+			content = buildFragment(content);
 		}
 
 		Liferay.DOMTaskRunner.runTasks(content);

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/HtmlScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/HtmlScreen.js
@@ -13,13 +13,18 @@
  */
 
 import {runScriptsInElement} from 'frontend-js-web';
-import {buildFragment, globalEvalStyles, match} from 'metal-dom';
 import CancellablePromise from 'metal-promise';
 import Uri from 'metal-uri';
 
 import globals from '../globals/globals';
 import Surface from '../surface/Surface';
-import {clearNodeAttributes, copyNodeAttributes, getUid} from '../utils/utils';
+import {
+	buildFragment,
+	clearNodeAttributes,
+	copyNodeAttributes,
+	getUid,
+	runStylesInElement,
+} from '../utils/utils';
 import RequestScreen from './RequestScreen';
 
 class HtmlScreen extends RequestScreen {
@@ -81,8 +86,7 @@ class HtmlScreen extends RequestScreen {
 	 * @param {Element} newStyle
 	 */
 	appendStyleIntoDocument_(newStyle) {
-		var isTemporaryStyle = match(
-			newStyle,
+		var isTemporaryStyle = newStyle.matches(
 			HtmlScreen.selectors.stylesTemporary
 		);
 		if (isTemporaryStyle) {
@@ -172,7 +176,7 @@ class HtmlScreen extends RequestScreen {
 	evaluateStyles(surfaces) {
 		this.pendingStyles = [];
 		var evaluateTrackedStyles = this.evaluateTrackedResources_(
-			globalEvalStyles.runStylesInElement,
+			runStylesInElement,
 			HtmlScreen.selectors.styles,
 			HtmlScreen.selectors.stylesTemporary,
 			HtmlScreen.selectors.stylesPermanent,
@@ -247,7 +251,7 @@ class HtmlScreen extends RequestScreen {
 
 			// If resource has key and is permanent add to cache.
 
-			if (resourceKey && match(resource, selectorPermanent)) {
+			if (resourceKey && resource.matches(selectorPermanent)) {
 				HtmlScreen.permanentResourcesInDoc[resourceKey] = true;
 			}
 		});

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/surface/Surface.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/surface/Surface.js
@@ -12,11 +12,11 @@
  * details.
  */
 
-import {append, exitDocument, removeChildren} from 'metal-dom';
 import CancellablePromise from 'metal-promise';
 
 import Disposable from '../Disposable';
 import globals from '../globals/globals';
+import {buildFragment} from '../utils/utils';
 
 class Surface extends Disposable {
 
@@ -96,19 +96,25 @@ class Surface extends Disposable {
 		if (opt_content) {
 			child = this.getChild(screenId);
 			if (child) {
-				removeChildren(child);
+				while (child.firstChild) {
+					child.removeChild(child.firstChild);
+				}
 			}
 			else {
 				child = this.createChild(screenId);
 				this.transition(child, null);
 			}
-			append(child, opt_content);
+			child.appendChild(
+				typeof opt_content === 'string'
+					? buildFragment(opt_content)
+					: opt_content
+			);
 		}
 
 		var element = this.getElement();
 
 		if (element && child) {
-			append(element, child);
+			element.appendChild(child);
 		}
 
 		return child;
@@ -227,7 +233,7 @@ class Surface extends Disposable {
 
 		return this.transition(from, to).thenAlways(() => {
 			if (from && from !== to) {
-				exitDocument(from);
+				from.remove();
 			}
 		});
 	}
@@ -239,7 +245,7 @@ class Surface extends Disposable {
 	remove(screenId) {
 		var child = this.getChild(screenId);
 		if (child) {
-			exitDocument(child);
+			child.remove();
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/utils.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/utils.js
@@ -67,6 +67,24 @@ class utils {
 export default utils;
 
 /**
+ * Helper for converting a HTML string into a document fragment.
+ * @param {string} htmlString The HTML string to convert.
+ * @return {!Element} The resulting document fragment.
+ */
+export function buildFragment(htmlString) {
+	const tempDiv = document.createElement('div');
+	tempDiv.innerHTML = `<br>${htmlString}`;
+	tempDiv.removeChild(tempDiv.firstChild);
+
+	const fragment = document.createDocumentFragment();
+	while (tempDiv.firstChild) {
+		fragment.appendChild(tempDiv.firstChild);
+	}
+
+	return fragment;
+}
+
+/**
  * Removes all attributes form node.
  * @return {void}
  * @static

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/screen/HtmlScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/screen/HtmlScreen.js
@@ -12,12 +12,12 @@
  * details.
  */
 
-import dom from 'metal-dom';
 import Uri from 'metal-uri';
 
 import globals from '../../../src/main/resources/META-INF/resources/senna/globals/globals';
 import HtmlScreen from '../../../src/main/resources/META-INF/resources/senna/screen/HtmlScreen';
 import Surface from '../../../src/main/resources/META-INF/resources/senna/surface/Surface';
+import {buildFragment} from '../../../src/main/resources/META-INF/resources/senna/utils/utils';
 
 describe('HtmlScreen', () => {
 	beforeEach(() => {
@@ -294,7 +294,7 @@ describe('HtmlScreen', () => {
 		);
 		screen.evaluateStyles({}).then(() => {
 			document.head.appendChild(
-				dom.buildFragment(
+				buildFragment(
 					'<style id="mainStyle">body{background-color:rgb(255, 255, 255);}</style>'
 				)
 			);
@@ -351,7 +351,7 @@ describe('HtmlScreen', () => {
 	it('removes from document tracked pending styles on screen dispose', (done) => {
 		var screen = new HtmlScreen();
 		document.head.appendChild(
-			dom.buildFragment(
+			buildFragment(
 				'<style id="mainStyle">body{background-color:rgb(255, 255, 255);}</style>'
 			)
 		);
@@ -404,19 +404,21 @@ describe('HtmlScreen', () => {
 });
 
 function enterDocumentSurfaceElement(surfaceId, opt_content) {
-	dom.enterDocument(
-		'<div id="' +
-			surfaceId +
-			'">' +
-			(opt_content ? opt_content : '') +
-			'</div>'
+	document.body.appendChild(
+		buildFragment(
+			'<div id="' +
+				surfaceId +
+				'">' +
+				(opt_content ? opt_content : '') +
+				'</div>'
+		)
 	);
 
 	return document.getElementById(surfaceId);
 }
 
 function exitDocumentElement(surfaceId) {
-	return dom.exitDocument(document.getElementById(surfaceId));
+	return document.getElementById(surfaceId).remove();
 }
 
 function assertComputedStyle(property, value) {

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/screen/Screen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/screen/Screen.js
@@ -12,10 +12,9 @@
  * details.
  */
 
-import dom from 'metal-dom';
-
 import Screen from '../../../src/main/resources/META-INF/resources/senna/screen/Screen';
 import Surface from '../../../src/main/resources/META-INF/resources/senna/surface/Surface';
+import {buildFragment} from '../../../src/main/resources/META-INF/resources/senna/utils/utils';
 
 describe('Screen', () => {
 	it('exposes lifecycle activate', () => {
@@ -150,19 +149,21 @@ describe('Screen', () => {
 });
 
 function enterDocumentSurfaceElement(surfaceId, opt_content) {
-	dom.enterDocument(
-		'<div id="' +
-			surfaceId +
-			'">' +
-			(opt_content ? opt_content : '') +
-			'</div>'
+	document.body.appendChild(
+		buildFragment(
+			'<div id="' +
+				surfaceId +
+				'">' +
+				(opt_content ? opt_content : '') +
+				'</div>'
+		)
 	);
 
 	return document.getElementById(surfaceId);
 }
 
 function exitDocumentSurfaceElement(surfaceId) {
-	return dom.exitDocument(document.getElementById(surfaceId));
+	return document.getElementById(surfaceId).remove();
 }
 
 function assertComputedStyle(property, value) {

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/utils/utils.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/utils/utils.js
@@ -14,6 +14,7 @@
 
 import globals from '../../../src/main/resources/META-INF/resources/senna/globals/globals';
 import {
+	buildFragment,
 	clearNodeAttributes,
 	copyNodeAttributes,
 	getCurrentBrowserPath,
@@ -106,5 +107,16 @@ describe('utils', () => {
 
 	it('gets current browser path excluding hashbang', () => {
 		expect(getCurrentBrowserPathWithoutHash()).toBe('/path?a=1');
+	});
+
+	it('creates a document fragment from a string', () => {
+		const html = '<div>Hello World 1</div><div>Hello World 2</div>';
+		const fragment = buildFragment(html);
+
+		expect(fragment).toBeTruthy();
+		expect(fragment.nodeType).toBe(11);
+		expect(fragment.childNodes.length).toBe(2);
+		expect(fragment.childNodes[0].innerHTML).toBe('Hello World 1');
+		expect(fragment.childNodes[1].innerHTML).toBe('Hello World 2');
 	});
 });


### PR DESCRIPTION
As the title says, this removes `metal-dom` as a dependency from `frontend-js-spa-web`.

Taking a conservative approach here, the highlights are:
- Copy over `buildFragment` implementation to simplify initial transition. This is the same approach @bryceosterhaus was trying at [Remove createContextualFragment in senna for now](https://github.com/liferay-frontend/liferay-portal/pull/468/commits/3044cb3aa13a6b0022c1b6d8df6fa494b8529565)
- Copy over `runStylesInElement`. Similarly to `buildFragment`, to simplify evaluating styles before we do a full transition to `createContextualFragment`.
- Remove `delegate` dependency in favour of our internal implementation. This one's risky because we lack `delegateTarget` which as I said [here](https://github.com/liferay-frontend/liferay-portal/pull/525#discussion_r527677874), might be interesting to add to our implementation...

**Test Plan**
- Run unit tests (green)
- Do some exploratory tests both for navigations and form submissions (creation screens)
- Hope CI will catch additional issues

Still pending further refactors here, but we're treading dangerous waters, so I want to take it one step at a time, and I think getting rid of the deps is far more valuable than refactoring the thing... 