### PR TITLE
[7.4 only][LPS-122456] Remove {append, buildFragment, enterDocument} usages of metal-dom

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -279,8 +279,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 					'.panel-heading .sheet-subtitle'
 				);
 
-				dom.append(
-					displayTitle,
+				displayTitle.append(
 					'<span class="modified-notice"> (<liferay-ui:message key="modified" />) </span>'
 				);
 			}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -435,7 +435,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 								];
 
 							if (optTextOrderByColumn1) {
-								dom.append(orderByColumn1, optTextOrderByColumn1);
+								orderByColumn1.append(optTextOrderByColumn1);
 							}
 
 							var optTextOrderByColumn2 =
@@ -446,7 +446,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 								];
 
 							if (optTextOrderByColumn2) {
-								dom.append(orderByColumn2, optTextOrderByColumn2);
+								orderByColumn2.append(optTextOrderByColumn2);
 							}
 						}
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -395,7 +395,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 							];
 
 						if (optTextOrderByColumn1) {
-							dom.append(orderByColumn1, optTextOrderByColumn1);
+							orderByColumn1.append(optTextOrderByColumn1);
 						}
 
 						var optTextOrderByColumn2 =
@@ -406,7 +406,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 							];
 
 						if (optTextOrderByColumn2) {
-							dom.append(orderByColumn2, optTextOrderByColumn2);
+							orderByColumn2.append(optTextOrderByColumn2);
 						}
 
 						if (structureOptions) {

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/merge_tag.jsp
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/merge_tag.jsp
@@ -92,8 +92,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "merge-tags"));
 			var value = item.value;
 
 			if (value !== undefined) {
-				dom.append(
-					targetTagNameSelect,
+				targetTagNameSelect.append(
 					Liferay.Util.sub(
 						'<option value="{0}">{1}</option>',
 						value,

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -179,8 +179,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 						if (currentColumnsElement) {
 							if (showActionsInput.checked) {
-								dom.append(
-									currentColumnsElement,
+								currentColumnsElement.append(
 									'<option value="action"><%= UnicodeLanguageUtil.get(request, "action") %></option>'
 								);
 							}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
@@ -186,7 +186,7 @@ renderResponse.setTitle(headerTitle);
 			);
 
 			if (settingsParametersElement) {
-				dom.append(settingsSupported, settingsParametersElement);
+				settingsSupported.append(settingsParametersElement);
 			}
 
 			var className = select.value;
@@ -200,7 +200,7 @@ renderResponse.setTitle(headerTitle);
 			);
 
 			if (repositoryParameters) {
-				dom.append(settingsParametersContainer, repositoryParameters);
+				settingsParametersContainer.append(repositoryParameters);
 			}
 		}
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/FormBuilder/FormBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/FormBuilder/FormBuilder.es.js
@@ -123,9 +123,9 @@ describe('Builder', () => {
 
 		jest.useFakeTimers();
 
-		dom.enterDocument('<button id="addFieldButton"></button>');
-		dom.enterDocument('<div class="ddm-translation-manager"></div>');
-		dom.enterDocument('<div class="ddm-form-basic-info"></div>');
+		document.body.append('<button id="addFieldButton"></button>');
+		document.body.append('<div class="ddm-translation-manager"></div>');
+		document.body.append('<div class="ddm-form-basic-info"></div>');
 
 		addButton = document.querySelector('#addFieldButton');
 		basicInfo = document.querySelector('.ddm-form-basic-info');

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/FormBuilder/FormBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/FormBuilder/FormBuilder.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import dom from 'metal-dom';
-
 import Builder from '../../../../src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilder.es';
 import Pages from '../../__mock__/mockPages.es';
 import SuccessPageSettings from '../../__mock__/mockSuccessPage.es';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleBuilder/RuleBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleBuilder/RuleBuilder.es.js
@@ -15,7 +15,6 @@
 import '../../__fixtures__/MockField.es';
 
 import userEvent from '@testing-library/user-event';
-import dom from 'metal-dom';
 
 import RuleBuilder from '../../../src/main/resources/META-INF/resources/js/components/RuleBuilder/RuleBuilder.es';
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleBuilder/RuleBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleBuilder/RuleBuilder.es.js
@@ -200,7 +200,9 @@ describe('RuleBuilder', () => {
 
 		fetch.mockResponse(JSON.stringify([]));
 
-		dom.enterDocument('<button id="addFieldButton" class="hide"></button>');
+		document.body.append(
+			'<button id="addFieldButton" class="hide"></button>'
+		);
 
 		fetch.mockResponse(JSON.stringify([]));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/util/AutoSave.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/util/AutoSave.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import {dom} from 'metal-dom';
-
 import AutoSave from '../../../src/main/resources/META-INF/resources/admin/js/util/AutoSave.es';
 
 const AUTOSAVE_INTERVAL = 2;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/util/AutoSave.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/util/AutoSave.es.js
@@ -21,13 +21,13 @@ const AUTOSAVE_INTERVAL = 2;
 const URL = '/sample/autosave';
 
 const createForm = () => {
-	dom.enterDocument('<form id="mockForm"></form>');
+	document.body.append('<form id="mockForm"></form>');
 
 	return document.querySelector('#mockForm');
 };
 
 const createInput = (id) => {
-	dom.enterDocument(`<input id="${id}" value="0" />`);
+	document.body.append(`<input id="${id}" value="0" />`);
 
 	return document.querySelector(`#${id}`);
 };

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-import {openToast} from 'frontend-js-web';
+import {buildFragment, openToast} from 'frontend-js-web';
 
 import {App} from '../../senna/senna';
-import {buildFragment, getUid} from '../../senna/utils/utils';
+import {getUid} from '../../senna/utils/utils';
 import LiferaySurface from '../surface/Surface.es';
 import {getPortletBoundaryId, resetAllPortlets} from '../util/Utils.es';
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
@@ -12,8 +12,9 @@
  * details.
  */
 
+import {buildFragment} from 'frontend-js-web';
+
 import Surface from '../../senna/surface/Surface';
-import {buildFragment} from '../../senna/utils/utils';
 
 /**
  * LiferaySurface

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/HtmlScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/screen/HtmlScreen.js
@@ -12,14 +12,13 @@
  * details.
  */
 
-import {runScriptsInElement} from 'frontend-js-web';
+import {buildFragment, runScriptsInElement} from 'frontend-js-web';
 import CancellablePromise from 'metal-promise';
 import Uri from 'metal-uri';
 
 import globals from '../globals/globals';
 import Surface from '../surface/Surface';
 import {
-	buildFragment,
 	clearNodeAttributes,
 	copyNodeAttributes,
 	getUid,

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/surface/Surface.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/surface/Surface.js
@@ -12,11 +12,11 @@
  * details.
  */
 
+import {buildFragment} from 'frontend-js-web';
 import CancellablePromise from 'metal-promise';
 
 import Disposable from '../Disposable';
 import globals from '../globals/globals';
-import {buildFragment} from '../utils/utils';
 
 class Surface extends Disposable {
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/utils.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/senna/utils/utils.js
@@ -67,24 +67,6 @@ class utils {
 export default utils;
 
 /**
- * Helper for converting a HTML string into a document fragment.
- * @param {string} htmlString The HTML string to convert.
- * @return {!Element} The resulting document fragment.
- */
-export function buildFragment(htmlString) {
-	const tempDiv = document.createElement('div');
-	tempDiv.innerHTML = `<br>${htmlString}`;
-	tempDiv.removeChild(tempDiv.firstChild);
-
-	const fragment = document.createDocumentFragment();
-	while (tempDiv.firstChild) {
-		fragment.appendChild(tempDiv.firstChild);
-	}
-
-	return fragment;
-}
-
-/**
  * Removes all attributes form node.
  * @return {void}
  * @static

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/App.js
@@ -14,6 +14,7 @@
 
 import {fireEvent} from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import {buildFragment} from 'frontend-js-web';
 
 import App from '../../../src/main/resources/META-INF/resources/senna/app/App';
 import EventEmitter from '../../../src/main/resources/META-INF/resources/senna/events/EventEmitter';
@@ -23,7 +24,6 @@ import HtmlScreen from '../../../src/main/resources/META-INF/resources/senna/scr
 import Screen from '../../../src/main/resources/META-INF/resources/senna/screen/Screen';
 import Surface from '../../../src/main/resources/META-INF/resources/senna/surface/Surface';
 import utils, {
-	buildFragment,
 	getCurrentBrowserPath,
 	getNodeOffset,
 	getUrlPathWithoutHash,

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/AppDataAttributeHandler.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/app/AppDataAttributeHandler.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {buildFragment} from 'frontend-js-web';
+
 import AppDataAttributeHandler from '../../../src/main/resources/META-INF/resources/senna/app/AppDataAttributeHandler';
 import globals from '../../../src/main/resources/META-INF/resources/senna/globals/globals';
 import Screen from '../../../src/main/resources/META-INF/resources/senna/screen/Screen';
@@ -261,19 +263,6 @@ describe('AppDataAttributeHandler', () => {
 		});
 	});
 });
-
-function buildFragment(htmlString) {
-	const tempDiv = document.createElement('div');
-	tempDiv.innerHTML = `<br>${htmlString}`;
-	tempDiv.removeChild(tempDiv.firstChild);
-
-	const fragment = document.createDocumentFragment();
-	while (tempDiv.firstChild) {
-		fragment.appendChild(tempDiv.firstChild);
-	}
-
-	return fragment;
-}
 
 function enterDocumentRouteElement(path) {
 	document.body.appendChild(

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/screen/HtmlScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/screen/HtmlScreen.js
@@ -12,12 +12,12 @@
  * details.
  */
 
+import {buildFragment} from 'frontend-js-web';
 import Uri from 'metal-uri';
 
 import globals from '../../../src/main/resources/META-INF/resources/senna/globals/globals';
 import HtmlScreen from '../../../src/main/resources/META-INF/resources/senna/screen/HtmlScreen';
 import Surface from '../../../src/main/resources/META-INF/resources/senna/surface/Surface';
-import {buildFragment} from '../../../src/main/resources/META-INF/resources/senna/utils/utils';
 
 describe('HtmlScreen', () => {
 	beforeEach(() => {

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/screen/Screen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/screen/Screen.js
@@ -12,9 +12,10 @@
  * details.
  */
 
+import {buildFragment} from 'frontend-js-web';
+
 import Screen from '../../../src/main/resources/META-INF/resources/senna/screen/Screen';
 import Surface from '../../../src/main/resources/META-INF/resources/senna/surface/Surface';
-import {buildFragment} from '../../../src/main/resources/META-INF/resources/senna/utils/utils';
 
 describe('Screen', () => {
 	it('exposes lifecycle activate', () => {

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/surface/Surface.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/surface/Surface.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {buildFragment} from 'frontend-js-web';
+
 import Surface from '../../../src/main/resources/META-INF/resources/senna/surface/Surface';
 
 describe('Surface', () => {
@@ -225,19 +227,6 @@ describe('Surface', () => {
 		});
 	});
 });
-
-function buildFragment(htmlString) {
-	const tempDiv = document.createElement('div');
-	tempDiv.innerHTML = `<br>${htmlString}`;
-	tempDiv.removeChild(tempDiv.firstChild);
-
-	const fragment = document.createDocumentFragment();
-	while (tempDiv.firstChild) {
-		fragment.appendChild(tempDiv.firstChild);
-	}
-
-	return fragment;
-}
 
 function enterDocumentSurfaceElement(surfaceId, opt_content) {
 	document.body.appendChild(

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/senna/utils/utils.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/senna/utils/utils.js
@@ -14,7 +14,6 @@
 
 import globals from '../../../src/main/resources/META-INF/resources/senna/globals/globals';
 import {
-	buildFragment,
 	clearNodeAttributes,
 	copyNodeAttributes,
 	getCurrentBrowserPath,
@@ -107,16 +106,5 @@ describe('utils', () => {
 
 	it('gets current browser path excluding hashbang', () => {
 		expect(getCurrentBrowserPathWithoutHash()).toBe('/path?a=1');
-	});
-
-	it('creates a document fragment from a string', () => {
-		const html = '<div>Hello World 1</div><div>Hello World 2</div>';
-		const fragment = buildFragment(html);
-
-		expect(fragment).toBeTruthy();
-		expect(fragment.nodeType).toBe(11);
-		expect(fragment.childNodes.length).toBe(2);
-		expect(fragment.childNodes[0].innerHTML).toBe('Hello World 1');
-		expect(fragment.childNodes[1].innerHTML).toBe('Hello World 2');
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -75,6 +75,7 @@ export {default as throttle} from './liferay/throttle.es';
 // Util API
 
 export {default as addParams} from './liferay/util/add_params';
+export {default as buildFragment} from './liferay/util/build_fragment';
 export {default as fetch} from './liferay/util/fetch.es';
 export {default as focusFormField} from './liferay/util/focus_form_field';
 export {default as getPortletId} from './liferay/util/get_portlet_id';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -25,6 +25,7 @@ import PortletBase from './PortletBase.es';
  * @extends {Component}
  */
 class DynamicInlineScroll extends PortletBase {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -162,7 +163,8 @@ class DynamicInlineScroll extends PortletBase {
 
 			if (pageIndexCurrent === 0) {
 				pageIndex = initialPages;
-			} else {
+			}
+			else {
 				pageIndex = pageIndexCurrent + initialPages;
 			}
 		}
@@ -190,6 +192,7 @@ class DynamicInlineScroll extends PortletBase {
  * @type {!Object}
  */
 DynamicInlineScroll.STATE = {
+
 	/**
 	 * Current page index.
 	 *

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -25,7 +25,6 @@ import PortletBase from './PortletBase.es';
  * @extends {Component}
  */
 class DynamicInlineScroll extends PortletBase {
-
 	/**
 	 * @inheritDoc
 	 */
@@ -70,8 +69,7 @@ class DynamicInlineScroll extends PortletBase {
 	addListItem_(listElement, pageIndex) {
 		const listItem = document.createElement('li');
 
-		dom.append(
-			listItem,
+		listItem.append(
 			`<a href="${this.getHREF_(pageIndex)}">${pageIndex}</a>`
 		);
 
@@ -164,8 +162,7 @@ class DynamicInlineScroll extends PortletBase {
 
 			if (pageIndexCurrent === 0) {
 				pageIndex = initialPages;
-			}
-			else {
+			} else {
 				pageIndex = pageIndexCurrent + initialPages;
 			}
 		}
@@ -193,7 +190,6 @@ class DynamicInlineScroll extends PortletBase {
  * @type {!Object}
  */
 DynamicInlineScroll.STATE = {
-
 	/**
 	 * Current page index.
 	 *

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
@@ -27,7 +27,6 @@ const KEY_CODE_ESC = 27;
  */
 
 class Modal extends Component {
-
 	/**
 	 * @inheritDoc
 	 */
@@ -96,8 +95,7 @@ class Modal extends Component {
 			this._eventHandler.add(
 				dom.on(document, 'keyup', this._handleKeyup.bind(this))
 			);
-		}
-		else {
+		} else {
 			this._eventHandler.removeAllListeners();
 		}
 	}
@@ -111,12 +109,10 @@ class Modal extends Component {
 		const willShowOverlay = overlay && this.visible;
 
 		if (willShowOverlay) {
-			dom.enterDocument(this.overlayElement);
-
-			return;
+			document.body.append(this.overlayElement);
+		} else {
+			this.overlayElement.remove();
 		}
-
-		this.overlayElement.remove();
 	}
 
 	/**
@@ -132,8 +128,7 @@ class Modal extends Component {
 
 			this._autoFocus(this.autoFocus);
 			this._restrictFocus();
-		}
-		else {
+		} else {
 			this._unrestrictFocus();
 			this._shiftFocusBack();
 		}
@@ -243,7 +238,6 @@ class Modal extends Component {
 }
 
 Modal.STATE = {
-
 	/**
 	 * A selector for the element that should be automatically focused when the modal
 	 * becomes visible, or `false` if no auto focus should happen. Defaults to the

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
@@ -27,6 +27,7 @@ const KEY_CODE_ESC = 27;
  */
 
 class Modal extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -95,7 +96,8 @@ class Modal extends Component {
 			this._eventHandler.add(
 				dom.on(document, 'keyup', this._handleKeyup.bind(this))
 			);
-		} else {
+		}
+		else {
 			this._eventHandler.removeAllListeners();
 		}
 	}
@@ -110,7 +112,8 @@ class Modal extends Component {
 
 		if (willShowOverlay) {
 			document.body.append(this.overlayElement);
-		} else {
+		}
+		else {
 			this.overlayElement.remove();
 		}
 	}
@@ -128,7 +131,8 @@ class Modal extends Component {
 
 			this._autoFocus(this.autoFocus);
 			this._restrictFocus();
-		} else {
+		}
+		else {
 			this._unrestrictFocus();
 			this._shiftFocusBack();
 		}
@@ -238,6 +242,7 @@ class Modal extends Component {
 }
 
 Modal.STATE = {
+
 	/**
 	 * A selector for the element that should be automatically focused when the modal
 	 * becomes visible, or `false` if no auto focus should happen. Defaults to the

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
@@ -18,6 +18,7 @@ import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 import Soy from 'metal-soy';
 
+import buildFragment from '../../util/build_fragment';
 import templates from './Modal.soy';
 
 const KEY_CODE_ESC = 27;
@@ -236,7 +237,7 @@ class Modal extends Component {
 	 */
 
 	_valueOverlayElementFn() {
-		return dom.buildFragment('<div class="modal-backdrop fade show"></div>')
+		return buildFragment('<div class="modal-backdrop fade show"></div>')
 			.firstChild;
 	}
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -14,9 +14,10 @@
 
 import ClayAlert from '@clayui/alert';
 import {render} from 'frontend-js-react-web';
-import {buildFragment} from 'metal-dom';
 import React from 'react';
 import {unmountComponentAtNode} from 'react-dom';
+
+import buildFragment from '../../util/build_fragment';
 
 const DEFAULT_ALERT_CONTAINER_ID = 'ToastAlertContainer';
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/build_fragment.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/build_fragment.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function buildFragment(htmlString) {
+	const div = document.createElement('div');
+
+	div.innerHTML = `<br>${htmlString}`;
+
+	div.removeChild(div.firstChild);
+
+	const fragment = document.createDocumentFragment();
+
+	while (div.firstChild) {
+		fragment.appendChild(div.firstChild);
+	}
+
+	return fragment;
+}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/build_fragment.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/build_fragment.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import buildFragment from '../../../src/main/resources/META-INF/resources/liferay/util/build_fragment';
+
+describe('Liferay.Util.buildFragment', () => {
+	it('creates a document fragment from a string', () => {
+		const html = '<div>Hello World 1</div><div>Hello World 2</div>';
+		const fragment = buildFragment(html);
+
+		expect(fragment).toBeTruthy();
+		expect(fragment.nodeType).toBe(11);
+		expect(fragment.childNodes.length).toBe(2);
+		expect(fragment.childNodes[0].innerHTML).toBe('Hello World 1');
+		expect(fragment.childNodes[1].innerHTML).toBe('Hello World 2');
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/get_form_element.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/get_form_element.es.js
@@ -12,15 +12,12 @@
  * details.
  */
 
-'use strict';
-
-import dom from 'metal-dom';
-
+import buildFragment from '../../../../src/main/resources/META-INF/resources/liferay/util/build_fragment';
 import getFormElement from '../../../../src/main/resources/META-INF/resources/liferay/util/form/get_form_element.es';
 
 describe('Liferay.Util.getFormElement', () => {
 	it('returns null if the form parameter is not a form node', () => {
-		const fragment = dom.buildFragment('<div />');
+		const fragment = buildFragment('<div />');
 
 		const form = fragment.firstElementChild;
 
@@ -29,7 +26,7 @@ describe('Liferay.Util.getFormElement', () => {
 	});
 
 	it('returns null if the elementName parameter is not a string', () => {
-		const fragment = dom.buildFragment('<form />');
+		const fragment = buildFragment('<form />');
 
 		const form = fragment.firstElementChild;
 
@@ -38,7 +35,7 @@ describe('Liferay.Util.getFormElement', () => {
 	});
 
 	it('returns null if the element does not exist withing the form', () => {
-		const fragment = dom.buildFragment(`
+		const fragment = buildFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">
 					</form>
@@ -50,7 +47,7 @@ describe('Liferay.Util.getFormElement', () => {
 	});
 
 	it('returns element value if the element does exist withing the form', () => {
-		const fragment = dom.buildFragment(`
+		const fragment = buildFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">
 					</form>

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/post_form.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/post_form.es.js
@@ -12,10 +12,7 @@
  * details.
  */
 
-'use strict';
-
-import dom from 'metal-dom';
-
+import buildFragment from '../../../../src/main/resources/META-INF/resources/liferay/util/build_fragment';
 import getFormElement from '../../../../src/main/resources/META-INF/resources/liferay/util/form/get_form_element.es';
 import postForm from '../../../../src/main/resources/META-INF/resources/liferay/util/form/post_form.es';
 
@@ -29,7 +26,7 @@ describe('Liferay.Util.postForm', () => {
 	});
 
 	it('does nothing if the form parameter is not a form node', () => {
-		const fragment = dom.buildFragment('<div />');
+		const fragment = buildFragment('<div />');
 
 		postForm(undefined);
 		postForm(fragment.firstElementChild);
@@ -38,7 +35,7 @@ describe('Liferay.Util.postForm', () => {
 	});
 
 	it('submits form even if options parameter is not set', () => {
-		const fragment = dom.buildFragment('<form />');
+		const fragment = buildFragment('<form />');
 
 		const form = fragment.firstElementChild;
 
@@ -48,7 +45,7 @@ describe('Liferay.Util.postForm', () => {
 	});
 
 	it('does nothing if the url optional parameter is not a string', () => {
-		const fragment = dom.buildFragment('<form />');
+		const fragment = buildFragment('<form />');
 
 		const form = fragment.firstElementChild;
 
@@ -59,7 +56,7 @@ describe('Liferay.Util.postForm', () => {
 	});
 
 	it('does nothing if the data optional parameter is not an object', () => {
-		const fragment = dom.buildFragment('<form />');
+		const fragment = buildFragment('<form />');
 
 		const form = fragment.firstElementChild;
 
@@ -70,7 +67,7 @@ describe('Liferay.Util.postForm', () => {
 	});
 
 	it('sets given element values in data parameter, and submit form to a given url', () => {
-		const fragment = dom.buildFragment(`
+		const fragment = buildFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">
 						<input name="_com_liferay_test_portlet_bar" type="text" value="123">

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/set_form_values.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/set_form_values.es.js
@@ -12,16 +12,13 @@
  * details.
  */
 
-'use strict';
-
-import dom from 'metal-dom';
-
+import buildFragment from '../../../../src/main/resources/META-INF/resources/liferay/util/build_fragment';
 import getFormElement from '../../../../src/main/resources/META-INF/resources/liferay/util/form/get_form_element.es';
 import setFormValues from '../../../../src/main/resources/META-INF/resources/liferay/util/form/set_form_values.es';
 
 describe('Liferay.Util.setFormValues', () => {
 	it('sets the given values of form elements', () => {
-		const fragment = dom.buildFragment(`
+		const fragment = buildFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">
 						<input name="_com_liferay_test_portlet_bar" type="text" value="123">

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_crop_region.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_crop_region.es.js
@@ -12,10 +12,7 @@
  * details.
  */
 
-'use strict';
-
-import dom from 'metal-dom';
-
+import buildFragment from '../../../src/main/resources/META-INF/resources/liferay/util/build_fragment';
 import getCropRegion from '../../../src/main/resources/META-INF/resources/liferay/util/get_crop_region.es';
 
 describe('Liferay.Util.getCropRegion', () => {
@@ -39,7 +36,7 @@ describe('Liferay.Util.getCropRegion', () => {
 	});
 
 	it('throws an error if image parameter is not an image element', () => {
-		const image = dom.buildFragment('<div />');
+		const image = buildFragment('<div />');
 
 		const region = {
 			height: 100,

--- a/modules/apps/map/map-common/package.json
+++ b/modules/apps/map/map-common/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
+		"frontend-js-web": "*",
 		"metal": "2.16.8",
-		"metal-dom": "2.16.8",
 		"metal-state": "2.16.8"
 	},
 	"name": "map-common",

--- a/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js
+++ b/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {buildFragment} from 'metal-dom';
+import {buildFragment} from 'frontend-js-web';
 import State, {Config} from 'metal-state';
 
 import GeoJSONBase from './GeoJSONBase.es';

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
@@ -338,7 +338,7 @@ if (portletTitleBasedNavigation) {
 					);
 
 					if (messageContainer) {
-						dom.append(messageContainer, response);
+						messageContainer.append(response);
 
 						runScriptsInElement.default(messageContainer.parentElement);
 
@@ -347,7 +347,7 @@ if (portletTitleBasedNavigation) {
 						);
 
 						if (replyContainer) {
-							dom.append(messageContainer, replyContainer);
+							messageContainer.append(replyContainer);
 						}
 					}
 				});

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
@@ -159,7 +159,7 @@ AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayCont
 					);
 
 					if (navGlobalScopes && globalAccordion) {
-						dom.append(navGlobalScopes, globalAccordion);
+						navGlobalScopes.append(globalAccordion);
 					}
 				});
 
@@ -211,7 +211,7 @@ AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayCont
 				);
 
 				if (globalAccordion && modalBody) {
-					dom.append(modalBody, globalAccordion);
+					modalBody.append(globalAccordion);
 				}
 
 				event.preventDefault();

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationsManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationsManagementToolbarDefaultEventHandler.es.js
@@ -13,7 +13,6 @@
  */
 
 import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
-import dom from 'metal-dom';
 
 class OrganizationsManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	deleteSelectedOrganizations() {

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationsManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationsManagementToolbarDefaultEventHandler.es.js
@@ -37,7 +37,7 @@ class OrganizationsManagementToolbarDefaultEventHandler extends DefaultEventHand
 					);
 
 					selectedItem.forEach((item) => {
-						dom.append(addGroupOrganizationsFm, item);
+						addGroupOrganizationsFm.append(item);
 					});
 
 					submitForm(addGroupOrganizationsFm);

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserDropdownDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserDropdownDefaultEventHandler.es.js
@@ -37,7 +37,7 @@ class UserDropdownDefaultEventHandler extends DefaultEventHandler {
 					);
 
 					selectedItem.forEach((item) => {
-						dom.append(editUserGroupRoleFm, item);
+						editUserGroupRoleFm.append(item);
 					});
 
 					submitForm(

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserDropdownDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserDropdownDefaultEventHandler.es.js
@@ -13,7 +13,6 @@
  */
 
 import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
-import dom from 'metal-dom';
 
 class UserDropdownDefaultEventHandler extends DefaultEventHandler {
 	deleteGroupUsers(itemData) {

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarDefaultEventHandler.es.js
@@ -59,7 +59,7 @@ class UserGroupsManagementToolbarDefaultEventHandler extends DefaultEventHandler
 					const fm = this.one('#fm');
 
 					selectedItem.forEach((item) => {
-						dom.append(fm, item);
+						fm.append(item);
 					});
 
 					submitForm(fm, itemData.editUserGroupsRolesURL);
@@ -82,7 +82,7 @@ class UserGroupsManagementToolbarDefaultEventHandler extends DefaultEventHandler
 					);
 
 					selectedItem.forEach((item) => {
-						dom.append(addGroupUserGroupsFm, item);
+						addGroupUserGroupsFm.append(item);
 					});
 
 					submitForm(addGroupUserGroupsFm);

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarDefaultEventHandler.es.js
@@ -17,7 +17,6 @@ import {
 	addParams,
 	openSelectionModal,
 } from 'frontend-js-web';
-import dom from 'metal-dom';
 
 class UserGroupsManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	deleteSelectedUserGroups() {

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UsersManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UsersManagementToolbarDefaultEventHandler.es.js
@@ -18,7 +18,6 @@ import {
 	getPortletId,
 	openSelectionModal,
 } from 'frontend-js-web';
-import dom from 'metal-dom';
 
 class UsersManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	deleteSelectedUsers() {

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UsersManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UsersManagementToolbarDefaultEventHandler.es.js
@@ -60,7 +60,7 @@ class UsersManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 					const fm = this.one('#fm');
 
 					selectedItem.forEach((item) => {
-						dom.append(fm, item);
+						fm.append(item);
 					});
 
 					submitForm(fm, itemData.editUsersRolesURL);
@@ -81,7 +81,7 @@ class UsersManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 					const addGroupUsersFm = this.one('#addGroupUsersFm');
 
 					selectedItem.forEach((item) => {
-						dom.append(addGroupUsersFm, item);
+						addGroupUsersFm.append(item);
 					});
 
 					submitForm(addGroupUsersFm);

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_group_action.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_group_action.jsp
@@ -117,7 +117,7 @@ UserGroup userGroup = (UserGroup)row.getObject();
 							selectedItem,
 							index
 						) {
-							dom.append(addUserGroupGroupRoleFm, selectedItem);
+							addUserGroupGroupRoleFm.append(selectedItem);
 						});
 
 						submitForm(addUserGroupGroupRoleFm);
@@ -160,7 +160,7 @@ UserGroup userGroup = (UserGroup)row.getObject();
 							selectedItem,
 							index
 						) {
-							dom.append(unassignUserGroupGroupRoleFm, selectedItem);
+							unassignUserGroupGroupRoleFm.append(selectedItem);
 						});
 
 						submitForm(unassignUserGroupGroupRoleFm);

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUserGroupsManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUserGroupsManagementToolbarDefaultEventHandler.es.js
@@ -13,7 +13,6 @@
  */
 
 import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
-import dom from 'metal-dom';
 
 class EditTeamAssignmentsUserGroupsManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	selectUserGroup(itemData) {

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUserGroupsManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUserGroupsManagementToolbarDefaultEventHandler.es.js
@@ -26,7 +26,7 @@ class EditTeamAssignmentsUserGroupsManagementToolbarDefaultEventHandler extends 
 					);
 
 					selectedItem.forEach((item) => {
-						dom.append(addTeamUserGroupsFm, item);
+						addTeamUserGroupsFm.append(item);
 					});
 
 					submitForm(addTeamUserGroupsFm);

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUsersManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUsersManagementToolbarDefaultEventHandler.es.js
@@ -24,7 +24,7 @@ class EditTeamAssignmentsUsersManagementToolbarDefaultEventHandler extends Defau
 					const addTeamUsersFm = this.one('#addTeamUsersFm');
 
 					selectedItem.forEach((item) => {
-						dom.append(addTeamUsersFm, item);
+						addTeamUsersFm.append(item);
 					});
 
 					submitForm(addTeamUsersFm);

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUsersManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUsersManagementToolbarDefaultEventHandler.es.js
@@ -13,7 +13,6 @@
  */
 
 import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
-import dom from 'metal-dom';
 
 class EditTeamAssignmentsUsersManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	selectUser(itemData) {


### PR DESCRIPTION
This is a continuation of https://github.com/liferay-frontend/liferay-portal/pull/468 rebased on top of https://github.com/liferay-frontend/liferay-portal/pull/529 and staying with a custom `buildFragment` implementation rather than making the change to `createContextualFragment` at once.

This PR:
- Replaces `dom.append` calls
- Replaces `dom.enterDocument` calls
- Extracts `buildFragment` from `frontend-js-spa-web` and exposes it from `frontend-js-web` so we can make a simpler replacement.

Once CI is up to date we can slowly start getting rid of these usages as well, but usage inside senna might be trickier, so better get this in now and slowly try to improve it from within.

~~**Keeping this as a draft until https://github.com/liferay-frontend/liferay-portal/pull/529 is effectively merged**~~