### PR TITLE
[7.4-only][LPS-122499, LPS-122448] Remove dom.delegate usages inside frontend-js/* & improve delegate util

### DIFF
--- a/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/resources/META-INF/resources/index.js
@@ -12,13 +12,13 @@
  * details.
  */
 
-import dom from 'metal-dom';
+import {delegate} from 'frontend-js-web';
 
 let handle;
 
 export default () => {
 	if (!handle) {
-		handle = dom.delegate(
+		handle = delegate(
 			document.body,
 			'click',
 			'[data-dismiss="liferay-alert"]',

--- a/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.js
+++ b/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import {delegate} from 'frontend-js-web';
 import dom from 'metal-dom';
 
 const CssClass = {
@@ -43,7 +44,7 @@ class CollapseProvider {
 
 		this._setTransitionEndEvent();
 
-		dom.delegate(
+		delegate(
 			document.body,
 			'click',
 			Selector.TRIGGER,

--- a/modules/apps/frontend-js/frontend-js-dropdown-support-web/src/main/resources/META-INF/resources/DropdownProvider.js
+++ b/modules/apps/frontend-js/frontend-js-dropdown-support-web/src/main/resources/META-INF/resources/DropdownProvider.js
@@ -13,7 +13,7 @@
  */
 
 import domAlign from 'dom-align';
-import dom from 'metal-dom';
+import {delegate} from 'frontend-js-web';
 
 const CssClass = {
 	SHOW: 'show',
@@ -39,19 +39,14 @@ class DropdownProvider {
 			return Liferay.DropdownProvider;
 		}
 
-		dom.delegate(
+		delegate(
 			document.body,
 			'click',
 			Selector.TRIGGER,
 			this._onTriggerClick
 		);
 
-		dom.delegate(
-			document.body,
-			'keydown',
-			Selector.TRIGGER,
-			this._onKeyDown
-		);
+		delegate(document.body, 'keydown', Selector.TRIGGER, this._onKeyDown);
 
 		Liferay.DropdownProvider = this;
 	}

--- a/modules/apps/frontend-js/frontend-js-tabs-support-web/src/main/resources/META-INF/resources/TabsProvider.js
+++ b/modules/apps/frontend-js/frontend-js-tabs-support-web/src/main/resources/META-INF/resources/TabsProvider.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import {delegate} from 'frontend-js-web';
 import dom from 'metal-dom';
 
 const CssClass = {
@@ -36,7 +37,7 @@ class TabsProvider {
 
 		this._setTransitionEndEvent();
 
-		dom.delegate(
+		delegate(
 			document.body,
 			'click',
 			Selector.TRIGGER,

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
@@ -14,7 +14,7 @@
 
 import ClayTooltip from '@clayui/tooltip';
 import {render, useTimeout} from 'frontend-js-react-web';
-import dom from 'metal-dom';
+import {delegate} from 'frontend-js-web';
 import {Align} from 'metal-position';
 import React, {
 	useEffect,
@@ -155,7 +155,7 @@ const TooltipProvider = () => {
 
 	useEffect(() => {
 		const TRIGGER_SHOW_HANDLES = TRIGGER_SHOW_EVENTS.map((eventName) => {
-			return dom.delegate(
+			return delegate(
 				document.body,
 				eventName,
 				SELECTOR_TRIGGER,
@@ -165,26 +165,21 @@ const TooltipProvider = () => {
 		});
 
 		const TRIGGER_HIDE_HANDLES = TRIGGER_HIDE_EVENTS.map((eventName) => {
-			return dom.delegate(
-				document.body,
-				eventName,
-				SELECTOR_TRIGGER,
-				() => {
-					dispatch({type: 'hide'});
+			return delegate(document.body, eventName, SELECTOR_TRIGGER, () => {
+				dispatch({type: 'hide'});
 
-					restoreTitle(state.target);
-				}
-			);
+				restoreTitle(state.target);
+			});
 		});
 
-		const TOOLTIP_ENTER = dom.delegate(
+		const TOOLTIP_ENTER = delegate(
 			document.body,
 			'mouseenter',
 			SELECTOR_TOOLTIP,
 			() => dispatch({target: state.target, type: 'show'})
 		);
 
-		const TOOLTIP_LEAVE = dom.delegate(
+		const TOOLTIP_LEAVE = delegate(
 			document.body,
 			'mouseleave',
 			SELECTOR_TOOLTIP,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -151,18 +151,16 @@ class DynamicInlineScroll extends PortletBase {
 	 */
 	onScroll_(event) {
 		const {cur, initialPages, pages} = this;
-		const {delegateTarget} = event;
+		const {target} = event;
 
-		let pageIndex = this.getNumber_(
-			delegateTarget.getAttribute('data-page-index')
-		);
+		let pageIndex = this.getNumber_(target.getAttribute('data-page-index'));
 		let pageIndexMax = this.getNumber_(
-			delegateTarget.getAttribute('data-max-index')
+			target.getAttribute('data-max-index')
 		);
 
 		if (pageIndex === 0) {
 			const pageIndexCurrent = this.getNumber_(
-				delegateTarget.getAttribute('data-current-index')
+				target.getAttribute('data-current-index')
 			);
 
 			if (pageIndexCurrent === 0) {
@@ -180,10 +178,10 @@ class DynamicInlineScroll extends PortletBase {
 		if (
 			cur <= pages &&
 			pageIndex < pageIndexMax &&
-			delegateTarget.getAttribute('scrollTop') >=
-				delegateTarget.getAttribute('scrollHeight') - 300
+			target.getAttribute('scrollTop') >=
+				target.getAttribute('scrollHeight') - 300
 		) {
-			this.addListItem_(delegateTarget, pageIndex);
+			this.addListItem_(target, pageIndex);
 		}
 	}
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -17,6 +17,7 @@ import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 
 import PortletBase from './PortletBase.es';
+import {delegate} from './delegate/delegate.es';
 
 /**
  * Appends list item elements to dropdown menus with inline-scrollers on scroll
@@ -42,7 +43,7 @@ class DynamicInlineScroll extends PortletBase {
 		rootNode = rootNode || document;
 
 		this.eventHandler_.add(
-			dom.delegate(
+			delegate(
 				rootNode,
 				'scroll',
 				'ul.pagination ul.inline-scroller',
@@ -57,7 +58,7 @@ class DynamicInlineScroll extends PortletBase {
 	detached() {
 		super.detached();
 
-		this.eventHandler_.removeAllListeners();
+		this.eventHandler_.dispose();
 	}
 
 	/**
@@ -150,16 +151,18 @@ class DynamicInlineScroll extends PortletBase {
 	 */
 	onScroll_(event) {
 		const {cur, initialPages, pages} = this;
-		const {target} = event;
+		const {delegateTarget} = event;
 
-		let pageIndex = this.getNumber_(target.getAttribute('data-page-index'));
+		let pageIndex = this.getNumber_(
+			delegateTarget.getAttribute('data-page-index')
+		);
 		let pageIndexMax = this.getNumber_(
-			target.getAttribute('data-max-index')
+			delegateTarget.getAttribute('data-max-index')
 		);
 
 		if (pageIndex === 0) {
 			const pageIndexCurrent = this.getNumber_(
-				target.getAttribute('data-current-index')
+				delegateTarget.getAttribute('data-current-index')
 			);
 
 			if (pageIndexCurrent === 0) {
@@ -177,10 +180,10 @@ class DynamicInlineScroll extends PortletBase {
 		if (
 			cur <= pages &&
 			pageIndex < pageIndexMax &&
-			target.getAttribute('scrollTop') >=
-				target.getAttribute('scrollHeight') - 300
+			delegateTarget.getAttribute('scrollTop') >=
+				delegateTarget.getAttribute('scrollHeight') - 300
 		) {
-			this.addListItem_(target, pageIndex);
+			this.addListItem_(delegateTarget, pageIndex);
 		}
 	}
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/delegate/delegate.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/delegate/delegate.es.js
@@ -41,10 +41,7 @@ function delegate(element, eventName, selector, callback) {
 			return;
 		}
 
-		if (
-			!defaultPrevented &&
-			(target.matches(selector) || target.closest(selector))
-		) {
+		if (!defaultPrevented && target.closest(selector)) {
 			event.delegateTarget = target.closest(selector);
 
 			callback(event);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/delegate/delegate.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/delegate/delegate.es.js
@@ -37,12 +37,14 @@ function delegate(element, eventName, selector, callback) {
 	const eventHandler = (event) => {
 		const {defaultPrevented, target} = event;
 
-		if (eventName === 'click' && isDisabled(target)) {
+		if (defaultPrevented || (eventName === 'click' && isDisabled(target))) {
 			return;
 		}
 
-		if (!defaultPrevented && target.closest(selector)) {
-			event.delegateTarget = target.closest(selector);
+		const delegateTarget = target.closest(selector);
+
+		if (delegateTarget) {
+			event.delegateTarget = delegateTarget;
 
 			callback(event);
 		}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/delegate/delegate.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/delegate/delegate.es.js
@@ -45,6 +45,8 @@ function delegate(element, eventName, selector, callback) {
 			!defaultPrevented &&
 			(target.matches(selector) || target.closest(selector))
 		) {
+			event.delegateTarget = target.closest(selector);
+
 			callback(event);
 		}
 	};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -17,11 +17,11 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import classNames from 'classnames';
 import {render} from 'frontend-js-react-web';
-import dom from 'metal-dom';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import './Modal.scss';
+import delegate from '../delegate/delegate.es';
 import navigate from '../util/navigate.es';
 
 const Modal = ({
@@ -452,14 +452,14 @@ class Iframe extends React.Component {
 		}
 
 		if (this.delegateHandler) {
-			this.delegateHandler.removeListener();
+			this.delegateHandler.dispose();
 		}
 	}
 
 	onLoadHandler = () => {
 		const iframeWindow = this.iframeRef.current.contentWindow;
 
-		this.delegateHandler = dom.delegate(
+		this.delegateHandler = delegate(
 			iframeWindow.document,
 			'click',
 			'.btn-cancel,.lfr-hide-dialog',

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/delegate/delegate.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/delegate/delegate.es.js
@@ -161,4 +161,24 @@ describe('delegate', () => {
 
 		expect(listener).not.toHaveBeenCalled();
 	});
+
+	it('gives access to delegateTarget inside the callback', () => {
+		document.body.innerHTML = `<div class="match" data-testid="match">
+				<div>
+					<div data-testid="most-inner-match"></div>
+				</div>
+			</div >`;
+
+		let delegateTarget;
+
+		const listener = (event) => {
+			delegateTarget = event.delegateTarget;
+		};
+
+		delegate(document, 'click', '.match', listener);
+
+		userEvent.click(getByTestId(document, 'most-inner-match'));
+
+		expect(delegateTarget).toBe(document.querySelector('.match'));
+	});
 });


### PR DESCRIPTION
## Overview
The goal of this PR is two-fold:
- [[LPS-122448](https://issues.liferay.com/browse/LPS-122448)] Improve the `delegate` utility by expanding it's functionality to include `delegateTarget` and optimize it slightly since we're already touching it
- [[LPS-122499](https://issues.liferay.com/browse/LPS-122449)]Replace usages of `dom.delegate` with the new `delegate` utility inside the `frontend-js` module

## `delegate` utility
When I started removing the usages of `dom.delegate` we noticed the discrepancy between it and the new `delegate` utility. The new one didn't provide access to the `delegateTarget` property. So we had to improve it before we could properly replace the old one, because otherwise we'd have to change a lot more than just the name of the utility that gets called. Since we did all this work on the utility we decided to improve it as well by optimizing the conditions and hoisting checks higher to prevent expensive calls being invoked if unnecessary.

## `delegate` usages
This is the first PR under this JIRA issue that passed the CI test, so we decided to combine these with the `delegate` utility improvements described above so we can instantly see how well they're working together.

## Testing
The `delegate` utility has it's automated tests defined so I used those to test the functionality and added a new test to it with @wincent's help. Outside of that, CI has been proving useful and doing other kinds of tests. I haven't done any manual testing on these files, I tried but couldn't find their usages in a reasonable amount of time.