### PR TITLE
LPS-123843 Change webpack output path configuration to avoid the creation of untracked files

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-web/webpack.config.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/webpack.config.js
@@ -40,7 +40,7 @@ const config = {
 	},
 	output: {
 		filename: buildName,
-		path: path.resolve('src/main/resources/META-INF/resources/dist'),
+		path: path.resolve('./build/node/packageRunBuild/resources/'),
 		publicPath: '',
 	},
 };


### PR DESCRIPTION
Following @julien suggestion, I've changed webpack configuration to avoid the creation of untracked filed during the build process.

I think there are not too much space for making a mistake but I prefer not to underestimate myself.

Can you take a look to see everything is right?

Thank you so much!