### PR TITLE
Turn div that contains plus button from child to sibling of languages selected

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
@@ -5,6 +5,9 @@
 			max-width: 300px;
 			position: relative;
 		}
+		.autofit-row > .autofit-col:first-child {
+			width: 100%;
+		}
 	}
 }
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/index.js
@@ -118,20 +118,19 @@ const TranslationManager = ({
 								setVisibleModal(true);
 							}}
 						/>
+						<div className="autofit-col">
+							<LocaleSelector
+								locales={locales}
+								onItemClick={(locale) => {
+									setAvailableLocales(
+										new Map(availableLocales).set(locale.id, locale)
+									);
+
+									setEditingLocale(locale.id);
+								}}
+							/>
+						</div>
 					</LocalesContainer>
-				</div>
-
-				<div className="autofit-col">
-					<LocaleSelector
-						locales={locales}
-						onItemClick={(locale) => {
-							setAvailableLocales(
-								new Map(availableLocales).set(locale.id, locale)
-							);
-
-							setEditingLocale(locale.id);
-						}}
-					/>
 				</div>
 			</div>
 		</>


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-122772

Hi @liferay-frontend ,

On this pull request I have turned the div that contains the plus button from child to sibling of languages selected on this tag lib. This was required to make sure that both would be on the same line and I could not find any workaround that would include changing only css. 
I have also changed the width on Forms css side, to ensure that it would have a wrap effect once the languages added could not fit in the page width. 
As per my investigation, this taglib is only used by Forms.

Kindly request your review and let me know if any further changes are required.