### PR TITLE
LPS-123865 [Bug] Publish winner button inside success alert has wrong colors

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_set.scss
@@ -57,7 +57,7 @@ body,
 
 @each $key, $map in $custom-properties-button-maps {
 	.btn-#{$key} {
-		&:not(.dropdown-item) {
+		&:not(.dropdown-item):not(.alert-btn) {
 			@include clay-button-variant($map);
 		}
 	}

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperiments.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperiments.es.js
@@ -192,21 +192,23 @@ function SegmentsExperiments({
 											),
 										}}
 									/>
-
-									<div className="mt-3">
-										<ClayButton
-											className="btn-success"
-											onClick={() =>
-												_handlePublishVariant(
-													winnerVariant.segmentsExperienceId
-												)
-											}
-										>
-											{Liferay.Language.get(
-												'publish-winner'
-											)}
-										</ClayButton>
-									</div>
+									<ClayAlert.Footer>
+										<ClayButton.Group>
+											<ClayButton
+												alert
+												displayType="success"
+												onClick={() =>
+													_handlePublishVariant(
+														winnerVariant.segmentsExperienceId
+													)
+												}
+											>
+												{Liferay.Language.get(
+													'publish-winner'
+												)}
+											</ClayButton>
+										</ClayButton.Group>
+									</ClayAlert.Footer>
 								</ClayAlert>
 							)}
 

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperiments.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperiments.es.js
@@ -196,7 +196,6 @@ function SegmentsExperiments({
 										<ClayButton.Group>
 											<ClayButton
 												alert
-												displayType="success"
 												onClick={() =>
 													_handlePublishVariant(
 														winnerVariant.segmentsExperienceId


### PR DESCRIPTION
**Description**
If there is a winner variant in an AB Test, we display an alert with a button "Publish Winner" to make more clear which is the winner one at the top of the AB Test, and in most of the cases, the user will publish the winner one. We found that the publish winner button inside the success alert has primary colors and should have success colors.

**Solution**

- Use new markup for ClayAlert with action buttons following this documentation: https://clayui.com/docs/components/alert.html#using-with-claybutton
- Fix custom properties (thanks to @eduardoallegrini) :)

**Screenshot**

![Screenshot 2020-11-24 at 10 43 50](https://user-images.githubusercontent.com/15845466/100076851-f4381480-2e41-11eb-9755-c648dc3dc58f.png)
