### PR TITLE
[TS] LPS-123883

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -52,9 +52,7 @@ const ClassicEditor = ({
 				data = '';
 			}
 
-			if (CKEDITOR.env.webkit) {
-				data = data.replace(/(\u200B){7}/, '');
-			}
+			data = data.replace(/(\u200B){7}/, '');
 		}
 
 		return data;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -51,6 +51,10 @@ const ClassicEditor = ({
 			if (CKEDITOR.env.gecko && CKEDITOR.tools.trim(data) === '<br />') {
 				data = '';
 			}
+
+			if (CKEDITOR.env.webkit) {
+				data = data.replace(/(\u200B){7}/, '');
+			}
 		}
 
 		return data;


### PR DESCRIPTION
From @jesseyeh-liferay:

> [LPS-123883](https://issues.liferay.com/browse/LPS-123883) addresses a use case in which 7 zero-width space characters are not removed from the thread body when publishing a Message Boards thread. These characters are added as part of a workaround for a WebKit selection bug (see https://dev.ckeditor.com/ticket/13816) and should not be included in the data.