### PR TITLE
[7.4-only] LPS-122449 Replace usages of dom.delegate in layout modules

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
@@ -115,8 +115,10 @@ Layout curLayout = (Layout)row.getObject();
 	</c:if>
 </liferay-ui:icon-menu>
 
-<aui:script require="metal-dom/src/all/dom as dom">
-	var copyLayoutActionOptionQueryClickHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	var copyLayoutActionOptionQueryClickHandler = delegate(
 		document.body,
 		'click',
 		'.<portlet:namespace />copy-layout-action-option',
@@ -130,7 +132,7 @@ Layout curLayout = (Layout)row.getObject();
 		}
 	);
 
-	var viewCollectionItemsActionOptionQueryClickHandler = dom.delegate(
+	var viewCollectionItemsActionOptionQueryClickHandler = delegate(
 		document.body,
 		'click',
 		'.<portlet:namespace />view-collection-items-action-option',
@@ -145,8 +147,8 @@ Layout curLayout = (Layout)row.getObject();
 	);
 
 	function handleDestroyPortlet() {
-		copyLayoutActionOptionQueryClickHandler.removeListener();
-		viewCollectionItemsActionOptionQueryClickHandler.removeListener();
+		copyLayoutActionOptionQueryClickHandler.dispose();
+		viewCollectionItemsActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_collections.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_collections.jsp
@@ -50,10 +50,12 @@ SelectLayoutCollectionDisplayContext selectLayoutCollectionDisplayContext = (Sel
 	</liferay-ui:search-container>
 </div>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var collections = document.getElementById('<portlet:namespace />collections');
 
-	var addCollectionActionOptionQueryClickHandler = dom.delegate(
+	var delegate = delegateModule.default;
+
+	var addCollectionActionOptionQueryClickHandler = delegate(
 		collections,
 		'click',
 		'.select-collection-action-option',
@@ -61,7 +63,7 @@ SelectLayoutCollectionDisplayContext selectLayoutCollectionDisplayContext = (Sel
 	);
 
 	function handleDestroyPortlet() {
-		addCollectionActionOptionQueryClickHandler.removeListener();
+		addCollectionActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_collections.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_collections.jsp
@@ -59,10 +59,12 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-collection"));
 	/>
 </c:if>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var collections = document.getElementById('<portlet:namespace />collections');
 
-	var selectLayoutMasterLayoutActionOptionQueryClickHandler = dom.delegate(
+	var delegate = delegateModule.default;
+
+	var selectLayoutMasterLayoutActionOptionQueryClickHandler = delegate(
 		collections,
 		'click',
 		'.select-collection-action-option',
@@ -74,7 +76,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-collection"));
 	);
 
 	function handleDestroyPortlet() {
-		selectLayoutMasterLayoutActionOptionQueryClickHandler.removeListener();
+		selectLayoutMasterLayoutActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_master_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_master_layout.jsp
@@ -64,12 +64,14 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 	</clay:row>
 </clay:container-fluid>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var layoutPageTemplateEntries = document.getElementById(
 		'<portlet:namespace />layoutPageTemplateEntries'
 	);
 
-	var addLayoutActionOptionQueryClickHandler = dom.delegate(
+	var delegate = delegateModule.default;
+
+	var addLayoutActionOptionQueryClickHandler = delegate(
 		layoutPageTemplateEntries,
 		'click',
 		'.add-layout-action-option',
@@ -85,7 +87,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 	);
 
 	function handleDestroyPortlet() {
-		addLayoutActionOptionQueryClickHandler.removeListener();
+		addLayoutActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
@@ -167,12 +167,14 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 	</clay:row>
 </clay:container-fluid>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
 	var layoutPageTemplateEntries = document.getElementById(
 		'<portlet:namespace />layoutPageTemplateEntries'
 	);
 
-	var addLayoutActionOptionQueryClickHandler = dom.delegate(
+	var addLayoutActionOptionQueryClickHandler = delegate(
 		layoutPageTemplateEntries,
 		'click',
 		'.add-layout-action-option',
@@ -188,7 +190,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 	);
 
 	function handleDestroyPortlet() {
-		addLayoutActionOptionQueryClickHandler.removeListener();
+		addLayoutActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
@@ -44,8 +44,10 @@ List<LayoutPageTemplateEntry> masterLayoutPageTemplateEntries = selectLayoutPage
 	</ul>
 </aui:form>
 
-<aui:script require="metal-dom/src/dom as dom">
-	var delegateHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	var delegateHandler = delegate(
 		document.body,
 		'click',
 		'.select-master-layout-option',
@@ -74,7 +76,7 @@ List<LayoutPageTemplateEntry> masterLayoutPageTemplateEntries = selectLayoutPage
 	);
 
 	var onDestroyPortlet = function () {
-		delegateHandler.removeListener();
+		delegateHandler.dipose();
 
 		Liferay.detach('destroyPortlet', onDestroyPortlet);
 	};

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
@@ -58,8 +58,10 @@ List<StyleBookEntry> styleBookEntries = selectLayoutPageTemplateEntryDisplayCont
 	</ul>
 </aui:form>
 
-<aui:script require="metal-dom/src/dom as dom">
-	var delegateHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	var delegateHandler = delegate(
 		document.body,
 		'click',
 		'.select-master-layout-option',
@@ -88,7 +90,7 @@ List<StyleBookEntry> styleBookEntries = selectLayoutPageTemplateEntryDisplayCont
 	);
 
 	var onDestroyPortlet = function () {
-		delegateHandler.removeListener();
+		delegateHandler.dispose();
 
 		Liferay.detach('destroyPortlet', onDestroyPortlet);
 	};

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/page.jsp
@@ -73,11 +73,13 @@ LayoutClassedModelUsagesDisplayContext layoutClassedModelUsagesDisplayContext = 
 	</liferay-ui:search-container>
 </div>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	if (
 		document.querySelector('#<portlet:namespace />layoutClassedModelUsagesList')
 	) {
-		var previewLayoutClassedModelUsagesList = dom.delegate(
+		var delegate = delegateModule.default;
+
+		var previewLayoutClassedModelUsagesList = delegate(
 			document.querySelector(
 				'#<portlet:namespace />layoutClassedModelUsagesList'
 			),
@@ -93,7 +95,7 @@ LayoutClassedModelUsagesDisplayContext layoutClassedModelUsagesDisplayContext = 
 		);
 
 		function removeListener() {
-			previewLayoutClassedModelUsagesList.removeListener();
+			previewLayoutClassedModelUsagesList.dispose();
 
 			Liferay.detach('destroyPortlet', removeListener);
 		}


### PR DESCRIPTION
This PR removes usages of `dom.delegate` from files found inside the `layout` module and replaces those usages with the modern `delegate` utility.

Continuation of #531 