### PR TITLE
Commerce 3885 Implement order date filter on orders dataset display

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/filter/BaseDateRangeClayDataSetFilter.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/filter/BaseDateRangeClayDataSetFilter.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.data.set.filter;
+
+/**
+ * @author Luca Pellizzon
+ */
+public abstract class BaseDateRangeClayDataSetFilter
+	implements ClayDataSetFilter {
+
+	public abstract DateClayDataSetFilterItem getMax();
+
+	public abstract DateClayDataSetFilterItem getMin();
+
+	@Override
+	public String getType() {
+		return "dateRange";
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/filter/DateClayDataSetFilterItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/filter/DateClayDataSetFilterItem.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.data.set.filter;
+
+/**
+ * @author Luca Pellizzon
+ */
+public class DateClayDataSetFilterItem {
+
+	public DateClayDataSetFilterItem(int day, int month, int year) {
+		_day = day;
+		_month = month;
+		_year = year;
+	}
+
+	public int getDay() {
+		return _day;
+	}
+
+	public int getMonth() {
+		return _month;
+	}
+
+	public int getYear() {
+		return _year;
+	}
+
+	private final int _day;
+	private final int _month;
+	private final int _year;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/data/set/filter/DateRangeClayDataSetFilterContextContributor.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/data/set/filter/DateRangeClayDataSetFilterContextContributor.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.internal.data.set.filter;
+
+import com.liferay.frontend.taglib.clay.data.set.filter.BaseDateRangeClayDataSetFilter;
+import com.liferay.frontend.taglib.clay.data.set.filter.ClayDataSetFilter;
+import com.liferay.frontend.taglib.clay.data.set.filter.ClayDataSetFilterContextContributor;
+import com.liferay.frontend.taglib.clay.data.set.filter.DateClayDataSetFilterItem;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Luca Pellizzon
+ */
+@Component(
+	property = "clay.data.set.filter.type=dateRange",
+	service = ClayDataSetFilterContextContributor.class
+)
+public class DateRangeClayDataSetFilterContextContributor
+	implements ClayDataSetFilterContextContributor {
+
+	@Override
+	public Map<String, Object> getClayDataSetFilterContext(
+		ClayDataSetFilter clayDataSetFilter, Locale locale) {
+
+		if (clayDataSetFilter instanceof BaseDateRangeClayDataSetFilter) {
+			return _serialize(
+				(BaseDateRangeClayDataSetFilter)clayDataSetFilter);
+		}
+
+		return Collections.emptyMap();
+	}
+
+	private JSONObject _getJSONObject(
+		DateClayDataSetFilterItem dateClayDataSetFilterItem) {
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject();
+
+		jsonObject.put(
+			"day", dateClayDataSetFilterItem.getDay()
+		).put(
+			"month", dateClayDataSetFilterItem.getMonth()
+		).put(
+			"year", dateClayDataSetFilterItem.getYear()
+		);
+
+		return jsonObject;
+	}
+
+	private Map<String, Object> _serialize(
+		BaseDateRangeClayDataSetFilter baseDateRangeClayDataSetFilter) {
+
+		return HashMapBuilder.<String, Object>put(
+			"max", _getJSONObject(baseDateRangeClayDataSetFilter.getMax())
+		).put(
+			"min", _getJSONObject(baseDateRangeClayDataSetFilter.getMin())
+		).build();
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/data/set/filter/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/data/set/filter/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
Implementing a new filter for orders dataset display.
Currently the date range filter frontend component is ready, but the back structure is missing.

In order to do so, a new date-range filter has been added to frontend-taglib-clay and then the filter is applied to the orders dataset table.

Testing it is just a matter of filtering the dataset table used for orders list in the commerce admin section.

cc @riccardo-alberti @marco-leo @FabioDiegoMastrorilli
