### PR TITLE
LPS-122722 Add maximum width to translation row

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/index.js
@@ -94,7 +94,7 @@ const TranslationManager = ({
 			)}
 
 			<div className="autofit-row">
-				<div className="autofit-col">
+				<div className="autofit-col autofit-col-expand">
 					<LocalesContainer
 						className={cssClass}
 						id={id}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/index.js
@@ -118,20 +118,22 @@ const TranslationManager = ({
 								setVisibleModal(true);
 							}}
 						/>
+						<div className="autofit-col">
+							<LocaleSelector
+								locales={locales}
+								onItemClick={(locale) => {
+									setAvailableLocales(
+										new Map(availableLocales).set(
+											locale.id,
+											locale
+										)
+									);
+
+									setEditingLocale(locale.id);
+								}}
+							/>
+						</div>
 					</LocalesContainer>
-				</div>
-
-				<div className="autofit-col">
-					<LocaleSelector
-						locales={locales}
-						onItemClick={(locale) => {
-							setAvailableLocales(
-								new Map(availableLocales).set(locale.id, locale)
-							);
-
-							setEditingLocale(locale.id);
-						}}
-					/>
 				</div>
 			</div>
 		</>


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-122772

Hi @liferay-frontend ,

On this pull request I have turned the div that contains the plus button from child to sibling of languages selected on this tag lib. This was required to make sure that both would be on the same line and I could not find any workaround that would include changing only css.
I have also changed the width on Forms css side, to ensure that it would have a wrap effect once the languages added could not fit in the page width.
As per my investigation, this taglib is only used by Forms.

Kindly request your review and let me know if any further changes are required.

Test steps:


1. Go to Content and Data > Forms;
2. Click on the plus icon in order to create a new Form;
3. Locate the language submenu on top of the form page and try to add as many languages as possible.

Current state:

![translation_manager_current](https://user-images.githubusercontent.com/42921279/100390919-b2a99400-3010-11eb-9f79-2c0303180bfb.gif)

Expected:

![image](https://user-images.githubusercontent.com/42921279/100390935-bb9a6580-3010-11eb-97a6-cad1ea9a2c68.png)
