### PR TITLE
LPS-123550 [7.4.x only] Turn off JS (and CSS) minifier by default

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7639,11 +7639,9 @@
     # Set this to true to enable run-time minification of CSS and JavaScript
     # resources by the com.liferay.portal.minifier.MinifierUtil class. Note that
     # even when run-time minification is off, build-time minification of
-    # frontend assets (JS and CSS) may still occur, as dictated by the
-    # "nodejs.node.env" build property. Specifically, when set to
-    # "development", build-time minfication does not take place; when set to
-    # any other value, including the default value of "production", build-time
-    # minification is performed.
+    # frontend assets (JS and CSS) may still occur.
+    #
+    # This property is deprecated and will be removed in a future release.
     #
     # Env: LIFERAY_MINIFIER_PERIOD_ENABLED
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7636,11 +7636,18 @@
 ##
 
     #
-    # Set this to true to enable minification of CSS and JavaScript resources.
+    # Set this to true to enable run-time minification of CSS and JavaScript
+    # resources by the com.liferay.portal.minifier.MinifierUtil class. Note that
+    # even when run-time minification is off, build-time minification of
+    # frontend assets (JS and CSS) may still occur, as dictated by the
+    # "nodejs.node.env" build property. Specifically, when set to
+    # "development", build-time minfication does not take place; when set to
+    # any other value, including the default value of "production", build-time
+    # minification is performed.
     #
     # Env: LIFERAY_MINIFIER_PERIOD_ENABLED
     #
-    minifier.enabled=true
+    minifier.enabled=false
 
     #
     # The strip filter will attempt to cache inline minified CSS and JavaScript

--- a/portal-impl/test/unit/com/liferay/portal/minifier/MinifierUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/minifier/MinifierUtilTest.java
@@ -15,11 +15,15 @@
 package com.liferay.portal.minifier;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ProxyFactory;
+import com.liferay.portal.util.PropsUtil;
 import com.liferay.registry.BasicRegistryImpl;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +35,11 @@ public class MinifierUtilTest {
 
 	@Before
 	public void setUp() {
+		_minifierEnabled = GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.MINIFIER_ENABLED));
+
+		PropsUtil.set(PropsKeys.MINIFIER_ENABLED, "true");
+
 		Registry registry = new BasicRegistryImpl();
 
 		RegistryUtil.setRegistry(registry);
@@ -38,6 +47,12 @@ public class MinifierUtilTest {
 		registry.registerService(
 			JavaScriptMinifier.class,
 			ProxyFactory.newDummyInstance(JavaScriptMinifier.class));
+	}
+
+	@After
+	public void tearDown() {
+		PropsUtil.set(
+			PropsKeys.MINIFIER_ENABLED, String.valueOf(_minifierEnabled));
 	}
 
 	@Test
@@ -92,5 +107,7 @@ public class MinifierUtilTest {
 				"calc(10px / 2);",
 			minifiedCss);
 	}
+
+	private static boolean _minifierEnabled;
 
 }

--- a/portal-impl/test/unit/com/liferay/portal/servlet/filters/strip/StripFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/filters/strip/StripFilterTest.java
@@ -18,8 +18,11 @@ import com.liferay.portal.cache.key.HashCodeHexStringCacheKeyGenerator;
 import com.liferay.portal.kernel.cache.key.CacheKeyGeneratorUtil;
 import com.liferay.portal.kernel.test.CaptureHandler;
 import com.liferay.portal.kernel.test.JDKLoggerTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.minifier.MinifierUtil;
 import com.liferay.portal.tools.ToolDependencies;
+import com.liferay.portal.util.PropsUtil;
 
 import java.io.StringWriter;
 
@@ -29,6 +32,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -48,6 +52,17 @@ public class StripFilterTest {
 
 		cacheKeyGeneratorUtil.setDefaultCacheKeyGenerator(
 			new HashCodeHexStringCacheKeyGenerator());
+
+		_minifierEnabled = GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.MINIFIER_ENABLED));
+
+		PropsUtil.set(PropsKeys.MINIFIER_ENABLED, "true");
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		PropsUtil.set(
+			PropsKeys.MINIFIER_ENABLED, String.valueOf(_minifierEnabled));
 	}
 
 	@Test
@@ -418,5 +433,7 @@ public class StripFilterTest {
 
 		Assert.assertEquals(4, charBuffer.position());
 	}
+
+	private static boolean _minifierEnabled;
 
 }

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -312,3 +312,32 @@ The first recommendation is to use the updated CSS classes from Clay `.container
 This change was made to remove deprecated legacy code from Portal and improve the code consistency and performance
 
 ---------------------------------------
+
+### Runtime minification of CSS and JS resources is now disabled by default
+- **Date:** 2020-Nov-27
+- **JIRA Ticket:** [LPS-123550](https://issues.liferay.com/browse/LPS-123550)
+
+#### What changed?
+
+The `minifier.enable` setting in `portal.properties` now defaults to
+`false`.  Instead of performing run-time minification of CSS and JS
+resources, we prepare pre-minified resources at build-time. There should
+be no user-visible changes in page styles or logic.
+
+#### Who is affected?
+
+Anybody who relies on specific implementation details of the run-time minifier
+(usually the Google Closure Compiler).
+
+#### How should I update my code?
+
+If you wish to maintain the run-time minification behavior, you can set
+`minifier.enable` back to `true` in `portal.properties`.
+
+#### Why was this change made?
+
+By moving minification of frontend resources from run-time to build-time
+we reduce server load and gain access to the latest minification
+technologies available within the frontend ecosystem.
+
+---------------------------------------

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -320,7 +320,7 @@ This change was made to remove deprecated legacy code from Portal and improve th
 #### What changed?
 
 The `minifier.enable` setting in `portal.properties` now defaults to
-`false`.  Instead of performing run-time minification of CSS and JS
+`false`. Instead of performing run-time minification of CSS and JS
 resources, we prepare pre-minified resources at build-time. There should
 be no user-visible changes in page styles or logic.
 


### PR DESCRIPTION
As per the LPS:

> We will attempt to shift minification from run-time to build-time.
>
> Once this is completed and js (and css) resources are minified by default, the next step is to disable run-time minification. Most settings can be found in the `#Minifier` section of our default `portal.properties` which includes:
>
> ```
> minifier.enabled
> minifier.inline.content.cache.enabled
> minifier.inline.content.cache.skip.css
> minifier.inline.content.cache.skip.javascript
> ```
>
> The **goal** of this story is to **disable run-time minification of resources by default**.
>
> ### Acceptance Criteria
>
> - Minification is no longer enabled by default in production-like setup in `portal.properties`
> - A breaking change warning explains this change in behaviour and how to enable it back for those that need it.
>
> ### Additional Considerations
>
> The `minifier.enabled` property enables both JS and CSS minification. For simplicity, since Simplify CSS minification scheme in DXP is in the short-term roadmap, we should be able to simply disable it now and make sure CSS minification doesn't depend on it before the release of 7.4 GA1