### PR TITLE
[7.4-only] LPS-122449 Replace usages of dom.delegate in Journal, Knowledge Base and Wiki

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -50,7 +50,7 @@
 	</liferay-frontend:edit-form-footer>
 </liferay-frontend:edit-form>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var articlePreview = document.getElementById(
 		'<portlet:namespace />articlePreview'
 	);
@@ -58,9 +58,9 @@
 		'<portlet:namespace />assetEntryId'
 	);
 
-	dom.delegate(articlePreview, 'click', '.web-content-selector', function (
-		event
-	) {
+	var delegate = delegateModule.default;
+
+	delegate(articlePreview, 'click', '.web-content-selector', function (event) {
 		event.preventDefault();
 
 		Liferay.Util.openSelectionModal({
@@ -75,7 +75,7 @@
 		});
 	});
 
-	dom.delegate(articlePreview, 'click', '.selector-button', function (event) {
+	delegate(articlePreview, 'click', '.selector-button', function (event) {
 		event.preventDefault();
 		retrieveWebContent(-1);
 	});

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -374,6 +374,8 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 </clay:container-fluid>
 
 <aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule" sandbox="<%= true %>">
+	var delegate = delegateModule.default;
+
 	var selectArticleHandler = delegate(
 		document.querySelector('#<portlet:namespace />articlesContainer'),
 		'click',

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -373,8 +373,8 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 	</liferay-ui:search-container>
 </clay:container-fluid>
 
-<aui:script require="metal-dom/src/all/dom as dom" sandbox="<%= true %>">
-	var selectArticleHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule" sandbox="<%= true %>">
+	var selectArticleHandler = delegate(
 		document.querySelector('#<portlet:namespace />articlesContainer'),
 		'click',
 		'.articles',
@@ -384,6 +384,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 					var activeFormCheckCards = document.querySelectorAll(
 						'.form-check-card.active'
 					);
+
 					var formCheckCard = event.delegateTarget.closest('.form-check-card');
 
 					if (activeFormCheckCards.length) {
@@ -426,7 +427,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 	);
 
 	Liferay.on('destroyPortlet', function removeListener() {
-		selectArticleHandler.removeListener();
+		selectArticleHandler.dispose();
 
 		Liferay.detach('destroyPortlet', removeListener);
 	});

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
@@ -98,14 +98,16 @@ JournalViewMoreMenuItemsDisplayContext journalViewMoreMenuItemsDisplayContext = 
 	</liferay-ui:search-container>
 </aui:form>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var Util = Liferay.Util;
 
 	var addMenuItemFm = document.getElementById(
 		'<portlet:namespace />addMenuItemFm'
 	);
 
-	dom.delegate(addMenuItemFm, 'click', '.selector-button', function (event) {
+	var delegate = delegateModule.default;
+
+	delegate(addMenuItemFm, 'click', '.selector-button', function (event) {
 		Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(journalViewMoreMenuItemsDisplayContext.getEventName()) %>',
 			{

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
@@ -183,7 +183,7 @@ if (portletTitleBasedNavigation) {
 	</liferay-ui:search-container>
 </aui:fieldset>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="metal-dom/src/dom as dom,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var compareVersionsButton = document.getElementById(
 		'<portlet:namespace />compare'
 	);
@@ -249,7 +249,9 @@ if (portletTitleBasedNavigation) {
 
 	<portlet:namespace />initRowsChecked();
 
-	dom.delegate(
+	var delegate = delegateModule.default;
+
+	delegate(
 		document.body,
 		'click',
 		'input[name=<portlet:namespace />rowIds]',

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
@@ -183,7 +183,7 @@ if (portletTitleBasedNavigation) {
 	</liferay-ui:search-container>
 </aui:fieldset>
 
-<aui:script require="metal-dom/src/dom as dom,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var compareVersionsButton = document.getElementById(
 		'<portlet:namespace />compare'
 	);

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_iterator.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_iterator.jsp
@@ -268,7 +268,7 @@ for (int i = 0; i < pages.size(); i++) {
 />
 
 <c:if test='<%= navigation.equals("history") %>'>
-	<aui:script require="metal-dom/src/dom as dom">
+	<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 		function <portlet:namespace />initRowsChecked() {
 			var rowIdsNodes = document.querySelectorAll(
 				'input[name=<portlet:namespace />rowIds]'
@@ -359,7 +359,9 @@ for (int i = 0; i < pages.size(); i++) {
 		);
 
 		if (searchContainer) {
-			dom.delegate(
+			var delegate = delegateModule.default;
+
+			delegate(
 				searchContainer,
 				'click',
 				'input[name=<portlet:namespace />rowIds]',


### PR DESCRIPTION
This PR removes usages of `dom.delegate` from files found inside the `Journal`, `Knowledge Base` and `Wiki` modules and replaces those usages with the modern `delegate` utility.

Continuation of #531 