### PR TITLE
[7.4-only] LPS-122449 Replace usages of dom.delegate in Item Selector, Roles, and Site Navigation

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -14,8 +14,7 @@
 
 import {ClayAlert} from 'clay-alert';
 import {render} from 'frontend-js-react-web';
-import {PortletBase} from 'frontend-js-web';
-import dom from 'metal-dom';
+import {PortletBase, delegate} from 'frontend-js-web';
 import {EventHandler} from 'metal-events';
 import {Config} from 'metal-state';
 import ReactDOM from 'react-dom';
@@ -116,7 +115,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 	 */
 	_bindEvents() {
 		this._eventHandler.add(
-			dom.delegate(this.rootNode, 'click', '.item-preview', (event) =>
+			delegate(this.rootNode, 'click', '.item-preview', (event) =>
 				this._onItemSelected(event.delegateTarget.dataset)
 			)
 		);

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -215,8 +215,10 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 		</aui:script>
 	</c:when>
 	<c:otherwise>
-		<aui:script require="metal-dom/src/all/dom as dom">
-			var selectItemHandler = dom.delegate(
+		<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+			var delegate = delegateModule.default;
+
+			var selectItemHandler = delegate(
 				document.querySelector('#<portlet:namespace />entriesContainer'),
 				'click',
 				'.entry',
@@ -249,7 +251,7 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 			);
 
 			Liferay.on('destroyPortlet', function removeListener() {
-				selectItemHandler.removeListener();
+				selectItemHandler.dispose();
 
 				Liferay.detach('destroyPortlet', removeListener);
 			});

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
@@ -156,10 +156,12 @@ else {
 				/>
 			</liferay-ui:search-container>
 
-			<aui:script require="metal-dom/src/dom as dom">
+			<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 				var form = document.<portlet:namespace />selectOrganizationRoleFm;
 
-				dom.delegate(form, 'click', '.organization-selector-button', function (event) {
+				var delegate = delegateModule.default;
+
+				delegate(form, 'click', '.organization-selector-button', function (event) {
 					Liferay.Util.postForm(form, {
 						data: {
 							organizationId: event.delegateTarget.dataset.organizationid,

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
@@ -130,10 +130,12 @@ SearchContainer<Role> roleSearchContainer = selectRoleManagementToolbarDisplayCo
 				/>
 			</liferay-ui:search-container>
 
-			<aui:script require="metal-dom/src/dom as dom">
+			<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 				var form = document.<portlet:namespace />selectSiteRoleFm;
 
-				dom.delegate(form, 'click', '.group-selector-button', function (event) {
+				var delegate = delegateModule.default;
+
+				delegate(form, 'click', '.group-selector-button', function (event) {
 					Liferay.Util.postForm(form, {
 						data: {
 							groupId: event.delegateTarget.dataset.groupid,

--- a/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
+++ b/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
@@ -66,8 +66,10 @@ RoleItemSelectorViewDisplayContext roleItemSelectorViewDisplayContext = (RoleIte
 	</liferay-ui:search-container>
 </clay:container-fluid>
 
-<aui:script require="metal-dom/src/all/dom as dom">
-	var selectItemHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	var selectItemHandler = delegate(
 		document.getElementById('<portlet:namespace />roleSelectorWrapper'),
 		'change',
 		'.entry input',
@@ -91,7 +93,7 @@ RoleItemSelectorViewDisplayContext roleItemSelectorViewDisplayContext = (RoleIte
 	);
 
 	Liferay.on('destroyPortlet', function removeListener() {
-		selectItemHandler.removeListener();
+		selectItemHandler.dispose();
 
 		Liferay.detach('destroyPortlet', removeListener);
 	});

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -147,7 +147,7 @@ SiteNavigationAdminManagementToolbarDisplayContext siteNavigationAdminManagement
 	</liferay-ui:search-container>
 </aui:form>
 
-<aui:script require="frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal,frontend-js-web/liferay/delegate/delegate.es as delegateModule" sandbox="<%= true %>">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal">
 	var delegate = delegateModule.default;
 
 	var renameSiteNavigationMenuClickHandler = delegate(

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -147,8 +147,10 @@ SiteNavigationAdminManagementToolbarDisplayContext siteNavigationAdminManagement
 	</liferay-ui:search-container>
 </aui:form>
 
-<aui:script require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal" sandbox="<%= true %>">
-	var renameSiteNavigationMenuClickHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal,frontend-js-web/liferay/delegate/delegate.es as delegateModule" sandbox="<%= true %>">
+	var delegate = delegateModule.default;
+
+	var renameSiteNavigationMenuClickHandler = delegate(
 		document.body,
 		'click',
 		'.<portlet:namespace />update-site-navigation-menu-action-option > a',
@@ -175,7 +177,7 @@ SiteNavigationAdminManagementToolbarDisplayContext siteNavigationAdminManagement
 	);
 
 	function handleDestroyPortlet() {
-		renameSiteNavigationMenuClickHandler.removeListener();
+		renameSiteNavigationMenuClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -250,7 +250,7 @@ else {
 	</liferay-frontend:edit-form-footer>
 </liferay-frontend:edit-form>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var form = document.<portlet:namespace />fm;
 
 	form.addEventListener('change', <portlet:namespace />resetPreview);
@@ -490,7 +490,9 @@ else {
 		siteNavigationMenuIdInput &&
 		siteNavigationMenuType
 	) {
-		dom.delegate(
+		var delegate = delegateModule.default;
+
+		delegate(
 			document.<portlet:namespace />fm,
 			'change',
 			'.select-navigation',


### PR DESCRIPTION
This PR removes usages of `dom.delegate` from files found inside the `Item Selector`, `Roles` and `Site Navigation` modules and replaces those usages with the modern `delegate` utility.

Continuation of #531 