### PR TITLE
[7.4-only] LPS-122449 Replace usage of dom.delegate in multiple modules

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
@@ -189,10 +189,12 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 	module="js/PagesTreeEventHandler.es"
 />
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var layoutsTree = document.getElementById('<portlet:namespace />layoutsTree');
 
-	var viewCollectionItemsActionOptionQueryClickHandler = dom.delegate(
+	var delegate = delegateModule.default;
+
+	var viewCollectionItemsActionOptionQueryClickHandler = delegate(
 		layoutsTree,
 		'click',
 		'.view-collection-items-action-option.collection',
@@ -213,7 +215,7 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 			'<%= ProductNavigationProductMenuWebKeys.PAGES_TREE_EVENT_HANDLER %>'
 		);
 
-		viewCollectionItemsActionOptionQueryClickHandler.removeListener();
+		viewCollectionItemsActionOptionQueryClickHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
@@ -157,8 +157,10 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 	module="js/RedirectManagementToolbarDefaultEventHandler.es"
 />
 
-<aui:script require="metal-dom/src/all/dom as dom">
-	dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	delegate(
 		document.querySelector('#<portlet:namespace />fm'),
 		'click',
 		'.icon-shortcut',

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -171,12 +171,14 @@ request.setAttribute("view.jsp-eventName", eventName);
 	<aui:input name="siteRoleIds" type="hidden" />
 </aui:form>
 
-<aui:script require="metal-dom/src/all/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var form = document.getElementById(
 		'<portlet:namespace />updateSegmentsEntrySiteRolesFm'
 	);
 
-	dom.delegate(document, 'click', '.assign-site-roles-link', function (event) {
+	var delegate = delegateModule.default;
+
+	delegate(document, 'click', '.assign-site-roles-link', function (event) {
 		var link = event.target.closest('.assign-site-roles-link');
 
 		var itemSelectorURL = link.dataset.itemselectorurl;

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
@@ -59,8 +59,10 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-site-template"));
 		<portlet:param name="parentGroupId" value="<%= String.valueOf(selectSiteInitializerDisplayContext.getParentGroupId()) %>" />
 	</portlet:actionURL>
 
-	<aui:script require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal">
-		var addSiteActionOptionQueryClickHandler = dom.delegate(
+	<aui:script require="frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+		var delegate = delegateModule.default;
+
+		var addSiteActionOptionQueryClickHandler = delegate(
 			document.body,
 			'click',
 			'.add-site-action-button',
@@ -87,7 +89,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-site-template"));
 		);
 
 		function handleDestroyPortlet() {
-			addSiteActionOptionQueryClickHandler.removeListener();
+			addSiteActionOptionQueryClickHandler.dispose();
 
 			Liferay.detach('destroyPortlet', handleDestroyPortlet);
 		}

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
@@ -59,7 +59,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-site-template"));
 		<portlet:param name="parentGroupId" value="<%= String.valueOf(selectSiteInitializerDisplayContext.getParentGroupId()) %>" />
 	</portlet:actionURL>
 
-	<aui:script require="frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal">
 		var delegate = delegateModule.default;
 
 		var addSiteActionOptionQueryClickHandler = delegate(

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
@@ -98,7 +98,7 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 							</div>
 						</clay:sheet-footer>
 
-						<aui:script require="metal-dom/src/dom as dom">
+						<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 							var pwcWarning = document.getElementById('<portlet:namespace />pwcWarning');
 							var remoteStagingOptions = document.getElementById(
 								'<portlet:namespace />remoteStagingOptions'
@@ -116,8 +116,10 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 								remoteStagingOptions &&
 								trashWarning
 							) {
-								dom.delegate(stagingTypes, 'click', 'input', function (event) {
-									var value = event.delegateTarget.value;
+								var delegate = delegateModule.default;
+
+								delegate(stagingTypes, 'click', 'input', function (event) {
+									var value = event.target.closest('input').value;
 
 									if (value != '<%= StagingConstants.TYPE_LOCAL_STAGING %>') {
 										pwcWarning.classList.add('hide');

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
@@ -226,15 +226,15 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 	<portlet:param name="scope" value="<%= scope %>" />
 </portlet:renderURL>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var baseURL = '<%= reviewUADDataURL %>';
 
 	var clickListeners = [];
 
+	var delegate = delegateModule.default;
+
 	var registerClickHandler = function (element, clickHandlerFn) {
-		clickListeners.push(
-			dom.delegate(element, 'click', 'input', clickHandlerFn)
-		);
+		clickListeners.push(delegate(element, 'click', 'input', clickHandlerFn));
 	};
 
 	registerClickHandler(<portlet:namespace />applicationPanelBody, function (
@@ -276,7 +276,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 
 	function handleDestroyPortlet() {
 		for (var i = 0; i < clickListeners.length; i++) {
-			clickListeners[i].removeListener();
+			clickListeners[i].dispose();
 		}
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);


### PR DESCRIPTION
This PR removes usages of `dom.delegate` from files found inside the following modules:
- Product Navigation
- Redirect
- Segments
- Site
- Staging
- User Associated Data

 and replaces those usages with the modern `delegate` utility.

Continuation of #531 