### PR TITLE
[7.4-only] LPS-122499 Remove dom.delegate usages inside DDM, Commerce, and portal-web

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
@@ -77,8 +77,10 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 	</div>
 </div>
 
-<aui:script require="metal-dom/src/dom as dom">
-	dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	var delegate = delegateModule.default;
+
+	delegate(
 		document.querySelector('.portlet-ddm-form-report-tabs'),
 		'click',
 		'li',

--- a/modules/dxp/apps/commerce/commerce-application-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/commerce/commerce-application-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -143,7 +143,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "applications"));
 		<portlet:param name="redirect" value="<%= currentURL %>" />
 	</portlet:actionURL>
 
-	<aui:script require="frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as modalCommands,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+	<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as modalCommands">
 		var delegate = delegateModule.default;
 
 		var handleAddApplicationBrandButtonClick = delegate(

--- a/modules/dxp/apps/commerce/commerce-application-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/commerce/commerce-application-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -143,8 +143,10 @@ renderResponse.setTitle(LanguageUtil.get(request, "applications"));
 		<portlet:param name="redirect" value="<%= currentURL %>" />
 	</portlet:actionURL>
 
-	<aui:script require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as modalCommands">
-		var handleAddApplicationBrandButtonClick = dom.delegate(
+	<aui:script require="frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as modalCommands,frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+		var delegate = delegateModule.default;
+
+		var handleAddApplicationBrandButtonClick = delegate(
 			document.body,
 			'click',
 			'#<portlet:namespace />addApplicationBrandButton',
@@ -163,7 +165,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "applications"));
 		);
 
 		function handleDestroyPortlet() {
-			handleAddApplicationBrandButtonClick.removeListener();
+			handleAddApplicationBrandButtonClick.dispose();
 
 			Liferay.detach('destroyPortlet', handleDestroyPortlet);
 		}

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -74,7 +74,7 @@
 
 <aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var delegate = delegateModule.default;
-	
+
 	delegate(
 		document,
 		'focusin',

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -72,10 +72,10 @@
 	}
 </aui:script>
 
-<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule" sandbox="<%= true %>">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var delegate = delegateModule.default;
 	
-	var focusInPortletHandler = delegate(
+	delegate(
 		document,
 		'focusin',
 		'.portlet',
@@ -84,7 +84,7 @@
 		}
 	);
 
-	var focusOutPortletHandler = delegate(
+	delegate(
 		document,
 		'focusout',
 		'.portlet',

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -72,8 +72,10 @@
 	}
 </aui:script>
 
-<aui:script require="metal-dom/src/all/dom as dom" sandbox="<%= true %>">
-	var focusInPortletHandler = dom.delegate(
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule" sandbox="<%= true %>">
+	var delegate = delegateModule.default;
+	
+	var focusInPortletHandler = delegate(
 		document,
 		'focusin',
 		'.portlet',
@@ -82,7 +84,7 @@
 		}
 	);
 
-	var focusOutPortletHandler = dom.delegate(
+	var focusOutPortletHandler = delegate(
 		document,
 		'focusout',
 		'.portlet',

--- a/portal-web/docroot/html/taglib/ui/input_repeat/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_repeat/page.jsp
@@ -192,13 +192,15 @@ int yearlyMonth1 = ParamUtil.getInteger(request, "yearlyMonth1", Calendar.JANUAR
 	</aui:col>
 </aui:fieldset>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var tables = document.querySelectorAll('#<portlet:namespace />recurrenceTypeDailyTable, #<portlet:namespace />recurrenceTypeMonthlyTable, #<portlet:namespace />recurrenceTypeNeverTable, #<portlet:namespace />recurrenceTypeWeeklyTable, #<portlet:namespace />recurrenceTypeYearlyTable');
 
 	var eventsContainer = document.getElementById('<portlet:namespace />eventsContainer');
 
 	if (eventsContainer) {
-		dom.delegate(
+		var delegate = delegateModule.default;
+
+		delegate(
 			eventsContainer,
 			'change',
 			'.field',


### PR DESCRIPTION
This PR removes usages of `dom.delegate` from files found inside DDM, Commerce and portal-web and replaces those usages with the modern `delegate` utility. Not sure how to treat the ones outside DXP, so here they are, bunched up with the ones in DDM

Continuation of #531 