### PR TITLE
LPS-123739

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session.es.js
@@ -16,7 +16,7 @@ import fetch from './fetch.es';
 
 const TOKEN_SERIALIZE = 'serialize://';
 
-function getSessionClickFormData(cmd) {
+function getSessionClickFormData(cmd, options) {
 	const doAsUserIdEncoded = Liferay.ThemeDisplay.getDoAsUserIdEncoded();
 
 	const formData = new FormData();
@@ -26,6 +26,12 @@ function getSessionClickFormData(cmd) {
 
 	if (doAsUserIdEncoded) {
 		formData.append('doAsUserId', doAsUserIdEncoded);
+	}
+
+	if (options && typeof options === 'object') {
+		Object.entries(options).forEach(([key, value]) => {
+			formData.append(key, value);
+		});
 	}
 
 	return formData;
@@ -38,11 +44,12 @@ function getSessionClickURL() {
 /**
  * Gets the Store utility fetch value for given key
  * @param {String} key string for fetch request
+ * @param {Object} additional params for the request
  * @return {Promise}
  * @review
  */
-export function getSessionValue(key) {
-	const formData = getSessionClickFormData('get');
+export function getSessionValue(key, options) {
+	const formData = getSessionClickFormData('get', options);
 
 	formData.append('key', key);
 
@@ -66,11 +73,12 @@ export function getSessionValue(key) {
  * Sets the Store utility fetch value
  * @param {String} key of the formData
  * @param {Object|String} value of the key for the formData
+ * @param {Object} additional params for the request
  * @return {Promise}
  * @review
  */
-export function setSessionValue(key, value) {
-	const formData = getSessionClickFormData('set');
+export function setSessionValue(key, value, options) {
+	const formData = getSessionClickFormData('set', options);
 
 	if (value && typeof value === 'object') {
 		value = TOKEN_SERIALIZE + JSON.stringify(value);

--- a/modules/apps/portal/portal-user-locale-options-web/src/main/resources/META-INF/resources/dynamic_include/user_locale_options.jsp
+++ b/modules/apps/portal/portal-user-locale-options-web/src/main/resources/META-INF/resources/dynamic_include/user_locale_options.jsp
@@ -49,10 +49,11 @@ Locale userLocale = user.getLocale();
 			if (data.event) {
 				Liferay.Util.Session.set(
 					'com.liferay.portal.user.locale.options.web_ignoreUserLocaleOptions',
-					true
+					true,
+					{
+						useHttpSession: true,
+					}
 				);
-
-				Liferay.Util.Session.set('useHttpSession', true);
 			}
 		},
 		type: 'info',

--- a/portal-impl/src/com/liferay/portal/action/SessionClickAction.java
+++ b/portal-impl/src/com/liferay/portal/action/SessionClickAction.java
@@ -60,7 +60,10 @@ public class SessionClickAction implements Action {
 			while (enumeration.hasMoreElements()) {
 				String name = enumeration.nextElement();
 
-				if (!name.equals("doAsUserId") && !name.equals("p_auth")) {
+				if (!name.equals("cmd") &&
+					!name.equals("doAsUserId") &&
+					!name.equals("p_auth")) {
+
 					String value = ParamUtil.getString(
 						httpServletRequest, name);
 

--- a/portal-impl/src/com/liferay/portal/action/SessionClickAction.java
+++ b/portal-impl/src/com/liferay/portal/action/SessionClickAction.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SessionClicks;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.struts.Action;
 import com.liferay.portal.struts.model.ActionForward;
 import com.liferay.portal.struts.model.ActionMapping;
@@ -60,9 +61,9 @@ public class SessionClickAction implements Action {
 			while (enumeration.hasMoreElements()) {
 				String name = enumeration.nextElement();
 
-				if (!name.equals("cmd") &&
-					!name.equals("doAsUserId") &&
-					!name.equals("p_auth")) {
+				if (!StringUtil.equals(name, "cmd") &&
+					!StringUtil.equals(name, "doAsUserId") &&
+					!StringUtil.equals(name, "p_auth")) {
 
 					String value = ParamUtil.getString(
 						httpServletRequest, name);
@@ -82,7 +83,7 @@ public class SessionClickAction implements Action {
 				String cmd = ParamUtil.getString(
 					httpServletRequest, Constants.CMD);
 
-				if (cmd.equals("get")) {
+				if (StringUtil.equals(cmd, "get")) {
 					httpServletResponse.setContentType(ContentTypes.TEXT_PLAIN);
 				}
 				else {
@@ -114,7 +115,7 @@ public class SessionClickAction implements Action {
 		boolean useHttpSession = ParamUtil.getBoolean(
 			httpServletRequest, "useHttpSession");
 
-		if (cmd.equals("get")) {
+		if (StringUtil.equals(cmd, "get")) {
 			String key = ParamUtil.getString(httpServletRequest, "key");
 			String value = StringPool.BLANK;
 
@@ -127,7 +128,7 @@ public class SessionClickAction implements Action {
 
 			return value;
 		}
-		else if (cmd.equals("getAll")) {
+		else if (StringUtil.equals(cmd, "getAll")) {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
 			String[] keys = httpServletRequest.getParameterValues("key");

--- a/portal-web/docroot/html/common/themes/user_locale_options.jsp
+++ b/portal-web/docroot/html/common/themes/user_locale_options.jsp
@@ -52,8 +52,9 @@ String currentURL = PortalUtil.getCurrentURL(request);
 		ignoreUserLocaleOptionsNode.on(
 			'click',
 			function() {
-				Liferay.Util.Session.set('ignoreUserLocaleOptions', true);
-				Liferay.Util.Session.set('useHttpSession', true);
+				Liferay.Util.Session.set('ignoreUserLocaleOptions', true, {
+					useHttpSession: true
+				});
 			}
 		);
 	</aui:script>


### PR DESCRIPTION
**Description of the issue**
If the user discards the message that the portal shows when the user's preferred language differs from the language in the url, the action is not persisted during his http session. As a result, the user sees the message in each request.

**Steps to reproduce:**

1. Sign-in as Test
2. Verify that the user's preferred language is English, and also it is default language of the site.
3. Go to the _localhost:8080/web/guest/home_ page 
4. Go to _localhost:8080/es/web/guest/home_ => User will be notified through a toast on the bottom left that can swap to English version or change language preferences.
5. Close the message by clicking the X icon on the toast.
6. Reload localhost:8080/es/web/guest/home

**Expected result**
During the session, the user's action is remembered and he does not view the message again.

**Result obtained** 
The message is displayed again. In fact, every time you move to a different page, that toast will appear again and again.

**Solution**
Based on how it works in 7.1 and before (see [here](https://github.com/liferay/liferay-portal-ee/blob/7.1.x/portal-web/docroot/html/common/themes/user_locale_options.jsp#L52-L62) and [here](https://github.com/liferay/liferay-portal-ee/blob/7.1.x/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/store.js)) we are storing the user's action in the HttpSession again. 

PD: Feel free to get rid of it in case it does not match our frontend guidelines.