### PR TITLE
[7.4-only] LPS-122449 Remove dom.delegate usages inside multiple modules, 2nd batch

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/PersonAccountEntryEventHandler.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/PersonAccountEntryEventHandler.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {PortletBase, openSelectionModal} from 'frontend-js-web';
+import {PortletBase, delegate, openSelectionModal} from 'frontend-js-web';
 import * as dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 import {Config} from 'metal-state';
@@ -39,7 +39,7 @@ class PersonAccountEntryEventHandler extends PortletBase {
 		);
 
 		this.eventHandler_.add(
-			dom.delegate(
+			delegate(
 				this.container,
 				'click',
 				this.removeUserLinkSelector,
@@ -53,7 +53,7 @@ class PersonAccountEntryEventHandler extends PortletBase {
 	 */
 	detached() {
 		super.detached();
-		this.eventHandler_.removeAllListeners();
+		this.eventHandler_.dispose();
 	}
 
 	_handleOnSelect(selectedItemData) {

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/PersonAccountEntryEventHandler.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/PersonAccountEntryEventHandler.es.js
@@ -30,21 +30,17 @@ class PersonAccountEntryEventHandler extends PortletBase {
 	 * @inheritDoc
 	 */
 	attached() {
-		this.eventHandler_.add(
-			dom.on(
-				this.selectUserButton,
-				'click',
-				this._handleSelectUserButtonClicked.bind(this)
-			)
+		this.selectUserButtonHandle_ = dom.on(
+			this.selectUserButton,
+			'click',
+			this._handleSelectUserButtonClicked.bind(this)
 		);
 
-		this.eventHandler_.add(
-			delegate(
-				this.container,
-				'click',
-				this.removeUserLinkSelector,
-				this._handleRemoveUserButtonClicked.bind(this)
-			)
+		this.removeUserButtonHandle_ = delegate(
+			this.container,
+			'click',
+			this.removeUserLinkSelector,
+			this._handleRemoveUserButtonClicked.bind(this)
 		);
 	}
 
@@ -53,7 +49,8 @@ class PersonAccountEntryEventHandler extends PortletBase {
 	 */
 	detached() {
 		super.detached();
-		this.eventHandler_.dispose();
+		this.selectUserButtonHandle_.removeListener();
+		this.removeUserButtonHandle_.dispose();
 	}
 
 	_handleOnSelect(selectedItemData) {

--- a/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
+++ b/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
@@ -85,12 +85,14 @@
 	</div>
 </div>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var connectedAppKeyInput = document.querySelector(
 		'[name=<portlet:namespace />connectedAppKey]'
 	);
 
-	dom.delegate(
+	var delegate = delegateModule.default;
+
+	delegate(
 		document.getElementById('<portlet:namespace />connectedApp'),
 		'click',
 		'[data-key]',

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
@@ -68,10 +68,12 @@ DepotAdminSelectRoleDisplayContext depotAdminSelectRoleDisplayContext = (DepotAd
 				/>
 			</liferay-ui:search-container>
 
-			<aui:script require="metal-dom/src/dom as dom">
+			<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 				var form = document.<portlet:namespace />selectDepotRoleFm;
 
-				dom.delegate(form, 'click', '.group-selector-button', function (event) {
+				var delegate = delegateModule.default;
+
+				delegate(form, 'click', '.group-selector-button', function (event) {
 					Liferay.Util.postForm(form, {
 						data: {
 							groupId: event.delegateTarget.dataset.groupid,

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries_resources.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries_resources.jsp
@@ -216,13 +216,15 @@ else {
 					}
 					%>
 
-					<aui:script position="inline" require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/util/run_scripts_in_element.es as runScriptsInElement">
+					<aui:script position="inline" require="frontend-js-web/liferay/delegate/delegate.es as delegateModule,frontend-js-web/liferay/util/run_scripts_in_element.es as runScriptsInElement">
 						var documentTypeMenuList = document.querySelector(
 							'#<portlet:namespace />documentTypeSelector .lfr-menu-list'
 						);
 
 						if (documentTypeMenuList) {
-							dom.delegate(documentTypeMenuList, 'click', 'li a', function (event) {
+							var delegate = delegateModule.default;
+
+							delegate(documentTypeMenuList, 'click', 'li a', function (event) {
 								event.preventDefault();
 
 								Liferay.Util.fetch(event.delegateTarget.getAttribute('href'))

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
@@ -105,13 +105,15 @@ Hits hits = searchDisplayContext.getHits();
 	</clay:col>
 </clay:row>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var facetNavigation = document.getElementById(
 		'<portlet:namespace />facetNavigation'
 	);
 
+	var delegate = delegateModule.default;
+
 	if (facetNavigation) {
-		dom.delegate(facetNavigation, 'click', '.facet-value a', function (event) {
+		delegate(facetNavigation, 'click', '.facet-value a', function (event) {
 			event.preventDefault();
 
 			var target = event.delegateTarget;
@@ -166,7 +168,7 @@ Hits hits = searchDisplayContext.getHits();
 	);
 
 	if (searchResultsContainer) {
-		dom.delegate(searchResultsContainer, 'click', '.expand-details', function (
+		delegate(searchResultsContainer, 'click', '.expand-details', function (
 			event
 		) {
 			var target = event.delegateTarget;

--- a/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/edit_entry.jsp
+++ b/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/edit_entry.jsp
@@ -139,12 +139,14 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 	</aui:button-row>
 </aui:form>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
 	var alternatingElements = document.querySelectorAll(
 		'#<portlet:namespace />advancedMode, #<portlet:namespace />friendlyMode, #<portlet:namespace />allowedServiceSignatures, #<portlet:namespace />allowedServiceSignaturesFriendlyContentBox'
 	);
 
-	dom.delegate(
+	var delegate = delegateModule.default;
+
+	delegate(
 		document.<portlet:namespace />fm,
 		'click',
 		'#<portlet:namespace />advancedMode, #<portlet:namespace />friendlyMode',

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
@@ -44,8 +44,10 @@
 			</liferay-frontend:edit-form-footer>
 		</liferay-frontend:edit-form>
 
-		<aui:script require="metal-dom/src/dom as dom">
-			dom.delegate(
+		<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
+			var delegate = delegateModule.default;
+
+			delegate(
 				document.getElementById('<portlet:namespace />fm'),
 				'change',
 				'input[type=checkbox]',


### PR DESCRIPTION
This PR removes usages of `dom.delegate` from files found inside the following modules:
- Account
- Connected App
- Depot
- Document Library
- Portal Search
- Portal Security
- Portlet Configuration

 and replaces those usages with the modern `delegate` utility.

Continuation of #531 