### PR TITLE
LPS-124133 Refactor Content Performance navigation to detail view

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -290,15 +290,19 @@ export default function Chart({
 	return (
 		<>
 			{timeSpanOptions.length && (
-				<TimeSpanSelector
-					disabledNextTimeSpan={disabledNextTimeSpan}
-					disabledPreviousPeriodButton={disabledPreviousPeriodButton}
-					onNextTimeSpanClick={handleNextTimeSpanClick}
-					onPreviousTimeSpanClick={handlePreviousTimeSpanClick}
-					onTimeSpanChange={handleTimeSpanChange}
-					timeSpanKey={chartState.timeSpanKey}
-					timeSpanOptions={timeSpanOptions}
-				/>
+				<div className="c-mb-3 c-mt-4">
+					<TimeSpanSelector
+						disabledNextTimeSpan={disabledNextTimeSpan}
+						disabledPreviousPeriodButton={
+							disabledPreviousPeriodButton
+						}
+						onNextTimeSpanClick={handleNextTimeSpanClick}
+						onPreviousTimeSpanClick={handlePreviousTimeSpanClick}
+						onTimeSpanChange={handleTimeSpanChange}
+						timeSpanKey={chartState.timeSpanKey}
+						timeSpanOptions={timeSpanOptions}
+					/>
+				</div>
 			)}
 
 			{dataSet ? (

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
@@ -17,6 +17,15 @@ import React from 'react';
 
 import Keywords from './Keywords';
 import TotalCount from './TotalCount';
+
+const TRAFFIC_CHANNELS = {
+	DIRECT: 'direct',
+	ORGANIC: 'organic',
+	PAID: 'paid',
+	REFERRAL: 'referral',
+	SOCIAL: 'social',
+};
+
 export default function Detail({
 	currentPage,
 	languageTag,
@@ -44,37 +53,50 @@ export default function Detail({
 				</div>
 			</div>
 
-			<div className="c-p-3 traffic-source-detail">
-				<TotalCount
-					className="mb-2"
-					dataProvider={trafficVolumeDataProvider}
-					label={Liferay.Util.sub(
-						Liferay.Language.get('traffic-volume')
-					)}
-					languageTag={languageTag}
-					popoverAlign={Align.Bottom}
-					popoverHeader={Liferay.Language.get('traffic-volume')}
-					popoverMessage={Liferay.Language.get(
-						'traffic-volume-is-the-number-of-page-views-coming-from-one-channel'
-					)}
-					popoverPosition="bottom"
-				/>
+			{(currentPage.view === TRAFFIC_CHANNELS.ORGANIC ||
+				currentPage.view === TRAFFIC_CHANNELS.PAID) &&
+				currentPage.data.countryKeywords.length > 0 && (
+					<>
+						<div className="c-p-3 traffic-source-detail">
+							<TotalCount
+								className="mb-2"
+								dataProvider={trafficVolumeDataProvider}
+								label={Liferay.Util.sub(
+									Liferay.Language.get('traffic-volume')
+								)}
+								languageTag={languageTag}
+								popoverAlign={Align.Bottom}
+								popoverHeader={Liferay.Language.get(
+									'traffic-volume'
+								)}
+								popoverMessage={Liferay.Language.get(
+									'traffic-volume-is-the-number-of-page-views-coming-from-one-channel'
+								)}
+								popoverPosition="bottom"
+							/>
 
-				<TotalCount
-					className="mb-4"
-					dataProvider={trafficShareDataProvider}
-					label={Liferay.Util.sub(
-						Liferay.Language.get('traffic-share')
-					)}
-					percentage={true}
-					popoverHeader={Liferay.Language.get('traffic-share')}
-					popoverMessage={Liferay.Language.get(
-						'traffic-share-is-the-percentage-of-traffic-sent-to-your-page-by-one-channel'
-					)}
-				/>
+							<TotalCount
+								className="mb-4"
+								dataProvider={trafficShareDataProvider}
+								label={Liferay.Util.sub(
+									Liferay.Language.get('traffic-share')
+								)}
+								percentage={true}
+								popoverHeader={Liferay.Language.get(
+									'traffic-share'
+								)}
+								popoverMessage={Liferay.Language.get(
+									'traffic-share-is-the-percentage-of-traffic-sent-to-your-page-by-one-channel'
+								)}
+							/>
 
-				<Keywords currentPage={currentPage} languageTag={languageTag} />
-			</div>
+							<Keywords
+								currentPage={currentPage}
+								languageTag={languageTag}
+							/>
+						</div>
+					</>
+				)}
 		</>
 	);
 }

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
@@ -11,12 +11,10 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import {Align} from 'metal-position';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Keywords from './Keywords';
-import TotalCount from './TotalCount';
+import KeywordsDetail from './detail/KeywordsDetail';
 
 const TRAFFIC_CHANNELS = {
 	DIRECT: 'direct',
@@ -56,46 +54,12 @@ export default function Detail({
 			{(currentPage.view === TRAFFIC_CHANNELS.ORGANIC ||
 				currentPage.view === TRAFFIC_CHANNELS.PAID) &&
 				currentPage.data.countryKeywords.length > 0 && (
-					<>
-						<div className="c-p-3 traffic-source-detail">
-							<TotalCount
-								className="mb-2"
-								dataProvider={trafficVolumeDataProvider}
-								label={Liferay.Util.sub(
-									Liferay.Language.get('traffic-volume')
-								)}
-								languageTag={languageTag}
-								popoverAlign={Align.Bottom}
-								popoverHeader={Liferay.Language.get(
-									'traffic-volume'
-								)}
-								popoverMessage={Liferay.Language.get(
-									'traffic-volume-is-the-number-of-page-views-coming-from-one-channel'
-								)}
-								popoverPosition="bottom"
-							/>
-
-							<TotalCount
-								className="mb-4"
-								dataProvider={trafficShareDataProvider}
-								label={Liferay.Util.sub(
-									Liferay.Language.get('traffic-share')
-								)}
-								percentage={true}
-								popoverHeader={Liferay.Language.get(
-									'traffic-share'
-								)}
-								popoverMessage={Liferay.Language.get(
-									'traffic-share-is-the-percentage-of-traffic-sent-to-your-page-by-one-channel'
-								)}
-							/>
-
-							<Keywords
-								currentPage={currentPage}
-								languageTag={languageTag}
-							/>
-						</div>
-					</>
+					<KeywordsDetail
+						currentPage={currentPage}
+						languageTag={languageTag}
+						trafficShareDataProvider={trafficShareDataProvider}
+						trafficVolumeDataProvider={trafficVolumeDataProvider}
+					/>
 				)}
 		</>
 	);

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -19,6 +19,14 @@ import APIService from '../utils/APIService';
 import Detail from './Detail';
 import Main from './Main';
 
+const TRAFFIC_CHANNELS = {
+	DIRECT: 'direct',
+	ORGANIC: 'organic',
+	PAID: 'paid',
+	REFERRAL: 'referral',
+	SOCIAL: 'social',
+};
+
 export default function Navigation({
 	author,
 	canonicalURL,
@@ -80,7 +88,7 @@ export default function Navigation({
 
 		setCurrentPage({
 			data: trafficSource,
-			view: 'traffic-source-detail',
+			view: trafficSource.name,
 		});
 	};
 
@@ -159,7 +167,8 @@ export default function Navigation({
 				</div>
 			)}
 
-			{currentPage.view === 'traffic-source-detail' &&
+			{(currentPage.view === TRAFFIC_CHANNELS.ORGANIC ||
+				currentPage.view === TRAFFIC_CHANNELS.PAID) &&
 				currentPage.data.countryKeywords.length > 0 && (
 					<Detail
 						currentPage={currentPage}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -19,14 +19,6 @@ import APIService from '../utils/APIService';
 import Detail from './Detail';
 import Main from './Main';
 
-const TRAFFIC_CHANNELS = {
-	DIRECT: 'direct',
-	ORGANIC: 'organic',
-	PAID: 'paid',
-	REFERRAL: 'referral',
-	SOCIAL: 'social',
-};
-
 export default function Navigation({
 	author,
 	canonicalURL,
@@ -167,18 +159,16 @@ export default function Navigation({
 				</div>
 			)}
 
-			{(currentPage.view === TRAFFIC_CHANNELS.ORGANIC ||
-				currentPage.view === TRAFFIC_CHANNELS.PAID) &&
-				currentPage.data.countryKeywords.length > 0 && (
-					<Detail
-						currentPage={currentPage}
-						languageTag={languageTag}
-						onCurrentPageChange={handleCurrentPage}
-						onTrafficSourceNameChange={handleTrafficSourceName}
-						trafficShareDataProvider={handleTrafficShare}
-						trafficVolumeDataProvider={handleTrafficVolume}
-					/>
-				)}
+			{currentPage.view !== 'main' && (
+				<Detail
+					currentPage={currentPage}
+					languageTag={languageTag}
+					onCurrentPageChange={handleCurrentPage}
+					onTrafficSourceNameChange={handleTrafficSourceName}
+					trafficShareDataProvider={handleTrafficShare}
+					trafficVolumeDataProvider={handleTrafficVolume}
+				/>
+			)}
 		</>
 	);
 }

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TimeSpanSelector.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TimeSpanSelector.js
@@ -29,7 +29,7 @@ export default function TimeSpanSelector({
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
 	return (
-		<div className="d-flex mb-3 mt-4">
+		<div className="d-flex">
 			<ClaySelect
 				aria-label={Liferay.Language.get('select-date-range')}
 				className="bg-white"

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/KeywordsDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/KeywordsDetail.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {Align} from 'metal-position';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Keywords from '../Keywords';
+import TotalCount from '../TotalCount';
+
+export default function KeywordsDetail({
+	currentPage,
+	languageTag,
+	trafficShareDataProvider,
+	trafficVolumeDataProvider,
+}) {
+	return (
+		<div className="c-p-3 traffic-source-detail">
+			<TotalCount
+				className="mb-2"
+				dataProvider={trafficVolumeDataProvider}
+				label={Liferay.Util.sub(Liferay.Language.get('traffic-volume'))}
+				languageTag={languageTag}
+				popoverAlign={Align.Bottom}
+				popoverHeader={Liferay.Language.get('traffic-volume')}
+				popoverMessage={Liferay.Language.get(
+					'traffic-volume-is-the-number-of-page-views-coming-from-one-channel'
+				)}
+				popoverPosition="bottom"
+			/>
+
+			<TotalCount
+				className="mb-4"
+				dataProvider={trafficShareDataProvider}
+				label={Liferay.Util.sub(Liferay.Language.get('traffic-share'))}
+				percentage={true}
+				popoverHeader={Liferay.Language.get('traffic-share')}
+				popoverMessage={Liferay.Language.get(
+					'traffic-share-is-the-percentage-of-traffic-sent-to-your-page-by-one-channel'
+				)}
+			/>
+
+			<Keywords currentPage={currentPage} languageTag={languageTag} />
+		</div>
+	);
+}
+
+KeywordsDetail.proptypes = {
+	currentPage: PropTypes.object.isRequired,
+	languageTag: PropTypes.string.isRequired,
+	trafficShareDataProvider: PropTypes.func.isRequired,
+	trafficVolumeDataProvider: PropTypes.func.isRequired,
+};

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Detail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Detail.js
@@ -101,7 +101,7 @@ const mockCurrentPage = {
 		title: 'Organic',
 		value: 278256,
 	},
-	view: 'traffic-source-detail',
+	view: 'organic',
 };
 
 const mockOnCurrentPageChange = jest.fn(() => Promise.resolve({view: 'main'}));

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Keywords.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Keywords.js
@@ -36,7 +36,7 @@ describe('Keywords', () => {
 				title: 'Organic',
 				value: 0,
 			},
-			view: 'traffic-source-detail',
+			view: 'organic',
 		};
 
 		const {getByText} = render(


### PR DESCRIPTION
**Description**
We are going to add a second level (detail view) for Referral and Social traffic channels. Now there is a detail only for Organic and Paid. To make this happen, first, we have to make a little refactor in the code and be prepared for it. The traffic channels are fixed values, we have Organic, Paid, Direct, Social, and Referral.

**In this pull**

- Navigate to detail view using the traffic channel name instead of generic `traffic-source-detail`
- `Detail` component will be the base for rendering all the traffic channel details, so I move the check (if we click on organic, paid, etc), inside the `Detail` component
- For better understanding, I create a new `KeywordsDetail` component to render the detail view if we clicked on Organic or Paid traffic channels. The idea of the `Detail` component is only to check what traffic channel is and render the proper detail component
- We are going to use the `TimeSpanSelector` component in the details, so it has to be reusable, so I move the CSS margins out of the component
- Fix frontend tests

**Notes**
This refactoring does not change any UI. It's only code refactor to prepare it for the new second-level screens (referral and social).