### PR TITLE
[7.4-only] LPS-122449 Replace usages of dom.delegate and fix related bug

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -30,6 +30,7 @@ import {
 } from 'dynamic-data-mapping-form-builder/js/util/dom.es';
 import {sub} from 'dynamic-data-mapping-form-builder/js/util/strings.es';
 import {PagesVisitor, compose} from 'dynamic-data-mapping-form-renderer';
+import {delegate} from 'frontend-js-web';
 import core from 'metal';
 import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
@@ -201,13 +202,11 @@ class Form extends Component {
 			)
 		);
 
-		this._eventHandler.add(
-			dom.delegate(
-				document.body,
-				'click',
-				`#${namespace}controlMenu .sites-control-group span.lfr-portal-tooltip`,
-				this._handleBackButtonClicked.bind(this)
-			)
+		this._backButtonClickEventHandler = delegate(
+			document.body,
+			'click',
+			`#${namespace}controlMenu .sites-control-group span.lfr-portal-tooltip`,
+			this._handleBackButtonClicked.bind(this)
 		);
 
 		const shareURLButton = document.querySelector(
@@ -308,6 +307,8 @@ class Form extends Component {
 		}
 
 		Notifications.closeAlert();
+
+		this._backButtonClickEventHandler.dispose();
 
 		this._eventHandler.removeAllListeners();
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -42,13 +42,11 @@ class DynamicInlineScroll extends PortletBase {
 
 		rootNode = rootNode || document;
 
-		this.eventHandler_.add(
-			delegate(
-				rootNode,
-				'scroll',
-				'ul.pagination ul.inline-scroller',
-				this.onScroll_.bind(this)
-			)
+		this.inlineScrollEventHandler_ = delegate(
+			rootNode,
+			'scroll',
+			'ul.pagination ul.inline-scroller',
+			this.onScroll_.bind(this)
 		);
 	}
 
@@ -58,7 +56,8 @@ class DynamicInlineScroll extends PortletBase {
 	detached() {
 		super.detached();
 
-		this.eventHandler_.dispose();
+		this.inlineScrollEventHandler_.dispose();
+		this.eventHandler_.removeAllListeners();
 	}
 
 	/**


### PR DESCRIPTION
This PR replaces the only remaining usage of `dom.delegate` found in `dynamic-data-mapping-form-web` and fixes a bug introduced earlier where `.dispose()` was called on an invalid event handler.

This is the only remaining usage provided #566 goes smoothly.

/cc @julien, here I've sent a fix to the `.removeAllListeners()` change I introduced that we talked about. Note: I didn't manually test this as this specific change is very difficult to test.