### PR TITLE
LPS-124075 - DM configuration portlet

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -131,7 +131,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 				<aui:input label="enable-ratings-for-comments" name="preferences--enableCommentRatings--" type="checkbox" value="<%= dlPortletInstanceSettings.isEnableCommentRatings() %>" />
 			</liferay-frontend:fieldset>
 
-			<aui:script require="metal-dom/src/dom as dom, frontend-js-web/liferay/util/build_fragment as buildFragment">
+			<aui:script sandbox="<%= true %>">
 				var selectFolderButton = document.getElementById(
 					'<portlet:namespace />selectFolderButton'
 				);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -131,7 +131,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 				<aui:input label="enable-ratings-for-comments" name="preferences--enableCommentRatings--" type="checkbox" value="<%= dlPortletInstanceSettings.isEnableCommentRatings() %>" />
 			</liferay-frontend:fieldset>
 
-			<aui:script require="metal-dom/src/dom as dom">
+			<aui:script require="metal-dom/src/dom as dom, frontend-js-web/liferay/util/build_fragment as buildFragment">
 				var selectFolderButton = document.getElementById(
 					'<portlet:namespace />selectFolderButton'
 				);
@@ -180,7 +180,9 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 						if (currentColumnsElement) {
 							if (showActionsInput.checked) {
 								currentColumnsElement.append(
-									'<option value="action"><%= UnicodeLanguageUtil.get(request, "action") %></option>'
+									buildFragment.default(
+										'<option value="action"><%= UnicodeLanguageUtil.get(request, "action") %></option>'
+									)
 								);
 							}
 							else {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -179,10 +179,12 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 						if (currentColumnsElement) {
 							if (showActionsInput.checked) {
-								currentColumnsElement.append(
-									buildFragment.default(
-										'<option value="action"><%= UnicodeLanguageUtil.get(request, "action") %></option>'
-									)
+								currentColumnsElement.appendChild(
+									document
+										.createRange()
+										.createContextualFragment(
+											'<option value="action"><%= UnicodeLanguageUtil.get(request, "action") %></option>'
+										)
 								);
 							}
 							else {


### PR DESCRIPTION
I have some problems in DM portlet configuration,
In section `Entries listing for table display style` the current select isn't rendering an option (only render a textNode instead of a dom element) I think is related to append updates (LPS-122456).

**Test Plan:** 
1. Add a DM portlet
1. Configure it
1. Enable show actions (maybe you need to disable before)
1. Scroll to `Entries listing for table display style`
1. Find `Action` option

**Before the fix**
![image](https://user-images.githubusercontent.com/67901/100738526-f7994600-33d5-11eb-919e-d4333237cff6.png)

**After the fix**
![image](https://user-images.githubusercontent.com/67901/100738661-34fdd380-33d6-11eb-9015-95af728b31ec.png)

/cc @ambrinchaudhary
