### PR TITLE
[7.4-only] LPS-123984 Migrate aspectRatioCssClasses usages to use new flush API

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/servlet/taglib/clay/BlogsEntryVerticalCard.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/servlet/taglib/clay/BlogsEntryVerticalCard.java
@@ -78,12 +78,6 @@ public class BlogsEntryVerticalCard extends BaseVerticalCard {
 	}
 
 	@Override
-	public String getAspectRatioCssClasses() {
-		return "aspect-ratio-item-center-middle " +
-			"aspect-ratio-item-vertical-fluid";
-	}
-
-	@Override
 	public String getDefaultEventHandler() {
 		return BlogsWebConstants.BLOGS_ELEMENTS_DEFAULT_EVENT_HANDLER;
 	}
@@ -144,6 +138,11 @@ public class BlogsEntryVerticalCard extends BaseVerticalCard {
 	@Override
 	public String getTitle() {
 		return BlogsEntryUtil.getDisplayTitle(_resourceBundle, _blogsEntry);
+	}
+
+	@Override
+	public Boolean isFlushHorizontal() {
+		return true;
 	}
 
 	private final BlogsEntry _blogsEntry;

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/servlet/taglib/clay/ItemDescriptorVerticalCard.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/servlet/taglib/clay/ItemDescriptorVerticalCard.java
@@ -35,12 +35,6 @@ public class ItemDescriptorVerticalCard extends BaseVerticalCard {
 	}
 
 	@Override
-	public String getAspectRatioCssClasses() {
-		return "aspect-ratio-item-center-middle " +
-			"aspect-ratio-item-vertical-fluid";
-	}
-
-	@Override
 	public String getCssClass() {
 		return "card-interactive card-interactive-secondary";
 	}
@@ -68,6 +62,11 @@ public class ItemDescriptorVerticalCard extends BaseVerticalCard {
 	@Override
 	public String getTitle() {
 		return _itemDescriptor.getTitle(themeDisplay.getLocale());
+	}
+
+	@Override
+	public Boolean isFlushHorizontal() {
+		return true;
 	}
 
 	private final ItemSelectorViewDescriptor.ItemDescriptor _itemDescriptor;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/CollectionProvidersVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/CollectionProvidersVerticalCard.java
@@ -56,12 +56,6 @@ public class CollectionProvidersVerticalCard extends BaseVerticalCard {
 	}
 
 	@Override
-	public String getAspectRatioCssClasses() {
-		return "aspect-ratio-item-center-middle " +
-			"aspect-ratio-item-vertical-fluid";
-	}
-
-	@Override
 	public String getCssClass() {
 		return "select-collection-action-option card-interactive " +
 			"card-interactive-secondary";
@@ -143,6 +137,11 @@ public class CollectionProvidersVerticalCard extends BaseVerticalCard {
 	@Override
 	public String getTitle() {
 		return _infoListProvider.getLabel(themeDisplay.getLocale());
+	}
+
+	@Override
+	public Boolean isFlushHorizontal() {
+		return true;
 	}
 
 	private String _getClassName(InfoListProvider<?> infoListProvider) {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/CollectionsVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/CollectionsVerticalCard.java
@@ -59,12 +59,6 @@ public class CollectionsVerticalCard extends BaseVerticalCard {
 	}
 
 	@Override
-	public String getAspectRatioCssClasses() {
-		return "aspect-ratio-item-center-middle " +
-			"aspect-ratio-item-vertical-fluid";
-	}
-
-	@Override
 	public String getCssClass() {
 		return "select-collection-action-option card-interactive " +
 			"card-interactive-secondary";
@@ -159,6 +153,11 @@ public class CollectionsVerticalCard extends BaseVerticalCard {
 		catch (PortalException portalException) {
 			return ReflectionUtil.throwException(portalException);
 		}
+	}
+
+	@Override
+	public Boolean isFlushHorizontal() {
+		return true;
 	}
 
 	private String _getAssetEntrySubtypeSubtypeLabel() {

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/servlet/taglib/clay/AssetRendererVerticalCard.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/servlet/taglib/clay/AssetRendererVerticalCard.java
@@ -39,12 +39,6 @@ public class AssetRendererVerticalCard implements VerticalCard {
 	}
 
 	@Override
-	public String getAspectRatioCssClasses() {
-		return "aspect-ratio-item-center-middle " +
-			"aspect-ratio-item-vertical-fluid";
-	}
-
-	@Override
 	public String getElementClasses() {
 		return "card-interactive card-interactive-secondary";
 	}
@@ -77,6 +71,11 @@ public class AssetRendererVerticalCard implements VerticalCard {
 		return HtmlUtil.escape(
 			StringUtil.shorten(
 				_assetRenderer.getTitle(_themeDisplay.getLocale()), 60));
+	}
+
+	@Override
+	public Boolean isFlushHorizontal() {
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
Some uses of the tags were implementing the
`getAspectRatioCssClasses` method (which should be deprecated)
to handle the card image aspect ratios in `<clay:vertical-card>`.

In this change, we're replacing it with the new `isFlushHorizontal`
method.

cc @carloslancha @markocikos 

PS: For the moment, submitting as a draft until the next clay release is in DXP.