### PR TITLE
LPS-123211 Fixes failed navigation on CORS redirect issues

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/screen/RequestScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/screen/RequestScreen.js
@@ -18,9 +18,13 @@ import {getUrlPath} from '../util/utils';
 import Screen from './Screen';
 
 const INVALID_STATUS = 'Invalid status code';
-const REQUEST_ERROR = 'Request error';
-const REQUEST_TIMEOUT = 'Request timeout';
-const REQUEST_PREMATURE_TERMINATION = 'Request terminated prematurely';
+
+const FAILED_TO_FETCH_MSG = 'Failed to fetch';
+const NETWORK_ERROR_MSG = 'NetworkError when attempting to fetch resource.';
+const PREFLIGHT_ERROR_MSG = 'Preflight response is not successful';
+const REQUEST_ERROR_MSG = 'Request error';
+const REQUEST_TIMEOUT_MSG = 'Request timeout';
+const REQUEST_PREMATURE_TERMINATION_MSG = 'Request terminated prematurely';
 
 class RequestScreen extends Screen {
 
@@ -282,20 +286,23 @@ class RequestScreen extends Screen {
 				}),
 			new Promise((_, reject) => {
 				setTimeout(
-					() => reject(new Error(REQUEST_TIMEOUT)),
+					() => reject(new Error(REQUEST_TIMEOUT_MSG)),
 					this.timeout
 				);
 			}),
 		]).catch((reason) => {
 			switch (reason.message) {
-				case REQUEST_TIMEOUT:
+				case REQUEST_TIMEOUT_MSG:
 					reason.timeout = true;
 					break;
-				case REQUEST_PREMATURE_TERMINATION:
+				case REQUEST_PREMATURE_TERMINATION_MSG:
+				case FAILED_TO_FETCH_MSG:
+				case NETWORK_ERROR_MSG:
+				case PREFLIGHT_ERROR_MSG:
 					reason.requestError = true;
 					reason.requestPrematureTermination = true;
 					break;
-				case REQUEST_ERROR:
+				case REQUEST_ERROR_MSG:
 				default:
 					reason.requestError = true;
 					break;


### PR DESCRIPTION
As outlined in both [Error message shows when editing the checkouted document in Sharepoint REST repository](https://issues.liferay.com/browse/LPS-123214) and [An error message will be displayed when adding google doc/slide/sheet](https://issues.liferay.com/browse/LPS-123211), it's currently not possible to access those services.

**Disclaimer**
I've only been able to properly setup and test the GDrive scenario and derive from there that any impediment this was causing should also be gone for the Sharepoint scenario (which is harder to configure).

**What's the problem**
Redirects to different domains done through `XMLHttpRequest` or `fetch` failed due to CORS restrictions.

**The fix**
More than a fix, a workaround, we already had in place a condition by which a "premature termination" would force a manual retry of the navigation via `window.location = event.path`. This handles the redirect directly from the server avoiding the CORS issue.

When migrating from `metal-ajax` to `fetch`,  the condition no longer holds true since the error is now "Failed to fetch". This could probably be improved further, but to simplify the fix, we simply add that to the set of conditions that can trigger a manual retry. 

If you try this scenario (now and even before in 7.3.x), you should be able to see the failed xhr attempt in the console if you preserve the logs and then the manual retry, so this should keep the existing behaviour.

**The future**
We should investigate further if a better approach that works through `fetch` is possible.