### PR TITLE
LPS-124253 Use new custom hooks in ReferralDetail to share TimeSpanSelector state between main and detail view

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -249,12 +249,6 @@ export default function Chart({
 
 		changeTimeSpanKey({key: value});
 	};
-	const handlePreviousTimeSpanClick = () => {
-		previousTimeSpan();
-	};
-	const handleNextTimeSpanClick = () => {
-		nextTimeSpan();
-	};
 
 	const legendFormatter =
 		dataSet &&
@@ -283,8 +277,8 @@ export default function Chart({
 						disabledPreviousPeriodButton={
 							isPreviousPeriodButtonDisabled
 						}
-						onNextTimeSpanClick={handleNextTimeSpanClick}
-						onPreviousTimeSpanClick={handlePreviousTimeSpanClick}
+						onNextTimeSpanClick={nextTimeSpan}
+						onPreviousTimeSpanClick={previousTimeSpan}
 						onTimeSpanChange={handleTimeSpanChange}
 						timeSpanKey={chartState.timeSpanKey}
 						timeSpanOptions={timeSpanOptions}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -265,8 +265,6 @@ export default function Chart({
 			validAnalyticsConnection
 		);
 
-	const disabledNextTimeSpan = chartState.timeSpanOffset === 0;
-
 	const xAxisFormatter =
 		chartState.timeSpanKey === LAST_24_HOURS
 			? dateFormatters.formatNumericHour
@@ -281,7 +279,7 @@ export default function Chart({
 			{timeSpanOptions.length && (
 				<div className="c-mb-3 c-mt-4">
 					<TimeSpanSelector
-						disabledNextTimeSpan={disabledNextTimeSpan}
+						disabledNextTimeSpan={chartState.timeSpanOffset === 0}
 						disabledPreviousPeriodButton={
 							isPreviousPeriodButtonDisabled
 						}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
@@ -14,18 +14,23 @@ import ClayList from '@clayui/list';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import {Align} from 'metal-position';
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 
+import {
+	useChangeTimeSpanKey,
+	useChartState,
+	useDateTitle,
+	useIsPreviousPeriodButtonDisabled,
+	useNextTimeSpan,
+	usePreviousTimeSpan,
+} from '../../context/ChartStateContext';
+import {generateDateFormatters as dateFormat} from '../../utils/dateFormat';
 import {numberFormat} from '../../utils/numberFormat';
 import Hint from '../Hint';
 import TimeSpanSelector from '../TimeSpanSelector';
 import TotalCount from '../TotalCount';
 
-const MOCK_TITLE = '19 - Nov 25, 2020';
-
 const ITEMS_TO_SHOW = 5;
-
-const noop = () => {};
 
 export default function ReferralDetail({
 	currentPage,
@@ -39,21 +44,55 @@ export default function ReferralDetail({
 	const {details} = currentPage.data;
 	const {referringDomains, referringPages} = details;
 
+	const dateFormatters = useMemo(() => dateFormat(languageTag), [
+		languageTag,
+	]);
+
+	const {firstDate, lastDate} = useDateTitle();
+
+	const title = useMemo(() => {
+		return dateFormatters.formatChartTitle([firstDate, lastDate]);
+	}, [dateFormatters, firstDate, lastDate]);
+
+	const chartState = useChartState();
+
+	const isPreviousPeriodButtonDisabled = useIsPreviousPeriodButtonDisabled();
+
+	const changeTimeSpanKey = useChangeTimeSpanKey();
+
+	const previousTimeSpan = usePreviousTimeSpan();
+
+	const nextTimeSpan = useNextTimeSpan();
+
+	const handleTimeSpanChange = (event) => {
+		const {value} = event.target;
+
+		changeTimeSpanKey({key: value});
+	};
+	const handlePreviousTimeSpanClick = () => {
+		previousTimeSpan();
+	};
+	const handleNextTimeSpanClick = () => {
+		nextTimeSpan();
+	};
+
 	return (
 		<div className="c-p-3 traffic-source-detail">
 			<div className="c-mb-3 c-mt-2">
 				<TimeSpanSelector
-					disabledNextTimeSpan={true}
-					disabledPreviousPeriodButton={true}
-					onNextTimeSpanClick={noop}
-					onPreviousTimeSpanClick={noop}
-					onTimeSpanChange={noop}
-					timeSpanKey={0}
+					disabledNextTimeSpan={chartState.timeSpanOffset === 0}
+					disabledPreviousPeriodButton={
+						isPreviousPeriodButtonDisabled
+					}
+					onNextTimeSpanClick={handleNextTimeSpanClick}
+					onPreviousTimeSpanClick={handlePreviousTimeSpanClick}
+					onTimeSpanChange={handleTimeSpanChange}
+					timeSpanKey={chartState.timeSpanKey}
 					timeSpanOptions={timeSpanOptions}
 				/>
 			</div>
 
-			{MOCK_TITLE && <h5 className="c-mb-4">{MOCK_TITLE}</h5>}
+			{title && <h5 className="c-mb-4">{title}</h5>}
 
 			<TotalCount
 				className="c-mb-2"

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
@@ -60,20 +60,14 @@ export default function ReferralDetail({
 
 	const changeTimeSpanKey = useChangeTimeSpanKey();
 
-	const previousTimeSpan = usePreviousTimeSpan();
-
 	const nextTimeSpan = useNextTimeSpan();
+
+	const previousTimeSpan = usePreviousTimeSpan();
 
 	const handleTimeSpanChange = (event) => {
 		const {value} = event.target;
 
 		changeTimeSpanKey({key: value});
-	};
-	const handlePreviousTimeSpanClick = () => {
-		previousTimeSpan();
-	};
-	const handleNextTimeSpanClick = () => {
-		nextTimeSpan();
 	};
 
 	return (
@@ -84,8 +78,8 @@ export default function ReferralDetail({
 					disabledPreviousPeriodButton={
 						isPreviousPeriodButtonDisabled
 					}
-					onNextTimeSpanClick={handleNextTimeSpanClick}
-					onPreviousTimeSpanClick={handlePreviousTimeSpanClick}
+					onNextTimeSpanClick={nextTimeSpan}
+					onPreviousTimeSpanClick={previousTimeSpan}
 					onTimeSpanChange={handleTimeSpanChange}
 					timeSpanKey={chartState.timeSpanKey}
 					timeSpanOptions={timeSpanOptions}

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Detail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Detail.js
@@ -15,6 +15,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import Detail from '../../../src/main/resources/META-INF/resources/js/components/Detail';
+import {ChartStateContextProvider} from '../../../src/main/resources/META-INF/resources/js/context/ChartStateContext';
 
 const mockOnCurrentPageChange = jest.fn(() => Promise.resolve({view: 'main'}));
 
@@ -433,16 +434,32 @@ describe('Detail', () => {
 
 	describe('Referral Detail', () => {
 		it('displays the referral detail according to API', async () => {
+			const testProps = {
+				pagePublishDate: 'Thu Aug 10 08:17:57 GMT 2020',
+				timeRange: {endDate: '2020-01-27', startDate: '2020-02-02'},
+				timeSpanKey: 'last-7-days',
+			};
+
 			const {getByText} = render(
-				<Detail
-					currentPage={mockCurrentPageReferral}
-					languageTag={'en-US'}
-					onCurrentPageChange={mockOnCurrentPageChange}
-					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
-					timeSpanOptions={mockTimeSpanOptions}
-					trafficShareDataProvider={mockTrafficShareDataProvider}
-					trafficVolumeDataProvider={mockTrafficVolumeDataProvider}
-				/>
+				<ChartStateContextProvider
+					publishDate={testProps.publishDate}
+					timeRange={testProps.timeRange}
+					timeSpanKey={testProps.timeSpanKey}
+				>
+					<Detail
+						currentPage={mockCurrentPageReferral}
+						languageTag={'en-US'}
+						onCurrentPageChange={mockOnCurrentPageChange}
+						onTrafficSourceNameChange={
+							mockOnTrafficSourceNameChange
+						}
+						timeSpanOptions={mockTimeSpanOptions}
+						trafficShareDataProvider={mockTrafficShareDataProvider}
+						trafficVolumeDataProvider={
+							mockTrafficVolumeDataProvider
+						}
+					/>
+				</ChartStateContextProvider>
 			);
 
 			await wait(() =>


### PR DESCRIPTION
**Description**
ReferralDetail should use/manage the same state as the main view. This detail will be hidden from now until we have the final data from AC (we don't display a link in this traffic channel in the PieChart section).

Two commits on top of https://github.com/liferay-frontend/liferay-portal/pull/578.

- https://github.com/liferay-frontend/liferay-portal/commit/864da00409d11805e75d3e2f7350c26c9b5aa104: LPS-124253 Use chart state custom hooks in referral detail view
- https://github.com/liferay-frontend/liferay-portal/commit/8adcb13947795c4c8b99de3fffe0bd50d9efdfd0: LPS-124253 Fix test


**Solution**
Use custom hooks created in https://github.com/liferay-frontend/liferay-portal/pull/578 to keep TimeSpanSelector state between main and detail views.