### PR TITLE
LPS-124157 Avoid initializing another tooltip

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleList/RuleList.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleList/RuleList.es.js
@@ -17,7 +17,6 @@ import 'clay-button';
 import 'clay-label';
 
 import 'clay-dropdown';
-import ClayTooltip from 'clay-tooltip';
 import {PagesVisitor} from 'dynamic-data-mapping-form-renderer';
 import Component from 'metal-component';
 import dom from 'metal-dom';
@@ -47,8 +46,6 @@ class RuleList extends Component {
 				true
 			)
 		);
-
-		ClayTooltip.init();
 	}
 
 	disposeInternal() {


### PR DESCRIPTION
This fixes the "duplicated" tooltips in
"Content & Data" > "Forms"

**Test plan**
- Deploy the `dynamic-data-mapping-form-builder` module
- Assert that tooltips are working as expected

**Before**

![](https://user-images.githubusercontent.com/5572/101151711-5b17b380-3622-11eb-8429-1490b32ec69c.png)

![](https://user-images.githubusercontent.com/5572/101151729-610d9480-3622-11eb-8dde-860d6baf3320.png)

**After**

![](https://user-images.githubusercontent.com/5572/101151750-68cd3900-3622-11eb-850c-f4242dd85dd7.png)

![](https://user-images.githubusercontent.com/5572/101151771-6f5bb080-3622-11eb-8248-b8c0e90e5da2.png)


**Additionally**:

- Some elements don't have a `title` attribute (like most "ellipsis" buttons) and will need to be updated to show the correct text in tooltips.

- I discovered this other [Tooltip component](https://github.com/liferay/liferay-portal/blob/dd77a9a725e3403b98c95e1126b2db1188f575f3/modules%2Fapps%2Fdynamic-data-mapping%2Fdynamic-data-mapping-form-field-type%2Fsrc%2Fmain%2Fresources%2FMETA-INF%2Fresources%2Fcomponents%2FTooltip%2FTooltip.es.js) and I'm not sure it's needed.

- While working on the issue, I noticed that [the following component](https://github.com/liferay/liferay-portal/blob/93b71aae5e9964c814151c5fba4d9b959288be19/modules%2Fapps%2Fdynamic-data-mapping%2Fdynamic-data-mapping-form-renderer%2Fsrc%2Fmain%2Fresources%2FMETA-INF%2Fresources%2Fjs%2Fcomponents%2FField%2FReactFieldAdapter.es.js#L33-L34) generates a React warning which looks like this:

![](https://user-images.githubusercontent.com/5572/101152022-c6618580-3622-11eb-9f12-9960b4849e7c.png)

According to @diegonvs this will be removed soon, but I thought it would be good mentioning 