### PR TITLE
[7.4 only] LPS-123675 | Fix UIInfrastructureUsecase tests affected by chrome 86 update

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
@@ -85,7 +85,7 @@ definition {
 		AssertCssValue(
 			locator1 = "//ul[contains(@id,'controlMenu')]",
 			locator2 = "list-style",
-			value1 = "none outside none");
+			value1 = "outside none none");
 
 		takeScreenshot();
 
@@ -101,7 +101,7 @@ definition {
 		AssertCssValue(
 			locator1 = "//ul[contains(@id,'controlMenu')]",
 			locator2 = "list-style",
-			value1 = "none outside none");
+			value1 = "outside none none");
 
 		takeScreenshot();
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
@@ -129,7 +129,7 @@ definition {
 		AssertCssValue(
 			locator1 = "//ul[contains(@id,'controlMenu')]",
 			locator2 = "list-style",
-			value1 = "none outside none");
+			value1 = "outside none none");
 
 		takeScreenshot();
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
@@ -67,9 +67,8 @@ definition {
 	test RefreshHomePage {
 		property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
 		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
-		property environment.acceptance = "quarantine";
-		property portal.acceptance = "quarantine";
-		property portal.upstream = "quarantine";
+		property environment.acceptance = "true";
+		property portal.acceptance = "true";
 
 		Navigator.gotoPage(pageName = "Home");
 
@@ -111,9 +110,8 @@ definition {
 	test RefreshWebContent {
 		property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
 		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
-		property environment.acceptance = "quarantine";
-		property portal.acceptance = "quarantine";
-		property portal.upstream = "quarantine";
+		property environment.acceptance = "true";
+		property portal.acceptance = "true";
 
 		ProductMenu.gotoPortlet(
 			category = "Content &amp; Data",


### PR DESCRIPTION
Rebased from https://github.com/liferay-frontend/liferay-portal/pull/500 with fixes on git commit messages and unquarantining the tests.

**JIRA Tickets:**
https://issues.liferay.com/browse/LPS-123675
https://issues.liferay.com/browse/LRQA-63100
https://issues.liferay.com/browse/LRQA-63099

**Description:**
Chrome 86 update caused a css value to rearrange on control menu. So this is maintenance for poshi tests to match the css value on the control menu list-style class to "outside none none".

**Test Plan:**
Run the affected tests UIInfrastructureUsecase#RefreshHomePage and UIInfrastructureUsecase#RefreshWebContent on chrome 86 and make sure they pass. 