### PR TITLE
LPS-124473 Info Panels should have white background

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/components/_sidebar.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/components/_sidebar.scss
@@ -92,8 +92,4 @@
 			border-color: transparent;
 		}
 	}
-
-	@include media-breakpoint-up(sm) {
-		background-color: transparent;
-	}
 }

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/base/_util.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/base/_util.scss
@@ -3,8 +3,16 @@
 }
 
 .hide-accessible {
+	border: 0 !important;
 	clip: rect(0 0 0 0) !important;
+	height: 1px !important;
+	margin: -1px !important;
+	overflow: hidden !important;
+	padding: 0 !important;
 	position: absolute !important;
+	position: absolute !important;
+	white-space: nowrap !important;
+	width: 1px !important;
 }
 
 .force-offset {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-124473
fixes:
- Info Panel Subscribe Button text intended for screen readers is causing horizontal overflow
- Info Panel has transparent background in documents and media
- Info Panel has transparent background in Applications > App Builder > Apps > Workflow Powered and try to create a new app (or choose one that already exists)

The remove compat sidebar pr made info panels transparent. Not sure why we need transparent info panels at screen sizes sm and up, but I'm guessing it might be related to the gap between management-bar, info-panel, and bottom of page.
