### PR TITLE
[TS] LPS-124358

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -5,6 +5,22 @@
 	z-index: $control-menu-zindex;
 }
 
+.has-control-menu {
+	:not(.portlet):target::before {
+		content: '';
+		display: block;
+		height: $has-control-menu-margin-top-mobile;
+		margin-top: -$has-control-menu-margin-top-mobile;
+	}
+
+	@include media-breakpoint-up(sm) {
+		:not(.portlet):target::before {
+			height: $has-control-menu-margin-top-desktop;
+			margin-top: -$has-control-menu-margin-top-desktop;
+		}
+	}
+}
+
 .control-menu-icon {
 	display: inline-block;
 }


### PR DESCRIPTION
From @kevhlee:

> **Ticket:**
> <https://issues.liferay.com/browse/LPS-124358>
> 
> **Notes:**
> Currently, on `master` and `7.3.x`, the Control Menu covers the top of the page content after jumping to an anchor on the same page. This is because changes from [LPS-84652](https://issues.liferay.com/browse/LPS-84652) and [LPS-92406](https://issues.liferay.com/browse/LPS-92406), which fixed this issue previously, were removed by [LPS-107487](https://issues.liferay.com/browse/LPS-107487). Particularly, this commit is to blame: https://github.com/liferay/liferay-portal/commit/dabe98a (lines 13-31 in `_control_menu.scss`). Thus, the solution is to bring back these changes.
> 
> Let me know if you have any questions.

CC @wanderlast 