### PR TITLE
LPS-124658 Auto-trigger PR test runs for liferay-frontend user fork

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -3,6 +3,7 @@ allowed.sender.names[brianchandotcom]=\
 
 ci.test.auto.recipients=\
     liferay-forms[relevant:sf],\
+    liferay-frontend[relevant:sf],\
     pyoo47[relevant:sf]
 
 ci.test.available.suites=\


### PR DESCRIPTION
Similar to what [this PR](https://github.com/brianchandotcom/liferay-portal/pull/96652/files) does for Forms.

As announced [here](https://liferay.slack.com/archives/C19PWQ74J/p1607104801225800?thread_ts=1607104801225800&cid=C19PWQ74J):

> The CI Infrastructure team has just implemented a new feature that allows Liferay GitHub users to specify a set of test suites that will automatically be run whenever that user receives a new pull request.
>
> In order to limit the number of pull requests that are automatically triggered, we are going to limit this feature to only be used for functional GitHub users created for Liferay teams such as:
>
> - liferay-echo
> - liferay-forms
> - liferay-frontend
> - liferay-headless
> - liferay-search
> - liferay-workflow
>
> **How-to**
>
> Edit `ci.properties` on the repository and branch where you want to automatically trigger pull request tests.
>
> The property `ci.test.auto.recipients` is a comma delimited list of entries that follow this pattern.
>
>     <GitHub-username>[<test-suite-name-1>:<test-suite-name-2>:...]
>
> Example:
>
>     liferay-forms[relevant:sf]
>
> Add your new value to the comma delimited list. Please note that if you want to invoke the default test-suite, (equivalent to invoking ci:test), you must explicitly include the test-suite name, “default” in your configuration value.
>
> Example:
>
>     liferay-forms[default]