### PR TITLE
LPS-124616 override onInstanceReady event callback

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -54,6 +54,10 @@ const RichText = ({
 						onChange({}, data);
 					}
 				}}
+				onInstanceReady={({editor}) => {
+					editor.setData(currentValue);
+					setCurrentValue(currentValue);
+				}}
 				readOnly={readOnly}
 			/>
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -26,6 +26,7 @@ const ClassicEditor = ({
 	name,
 	onChange,
 	onChangeMethodName,
+	onInstanceReady,
 	title,
 	...otherProps
 }) => {
@@ -138,9 +139,11 @@ const ClassicEditor = ({
 							}
 						});
 
-						editor.on('instanceReady', () => {
-							editor.setData(contents);
-						});
+						if (!onInstanceReady) {
+							editor.on('instanceReady', () => {
+								editor.setData(contents);
+							});
+						}
 					});
 				}}
 				onChange={onChangeCallback}


### PR DESCRIPTION
Hi, 
I needed to make a little change in ClassicEditor component to fix an issue and I'd be very glad if you guys could evaluate that.

Basically, the issue was happening because the following code snippet was setting the wrong value into ckeditor component.
```
editor.on('instanceReady', () => {
    editor.setData(contents);
});
```

My solution consists in overriding this event callback with onIntanceReady function that is passed as a prop. Once onIntanceReady
is not passed, the original event callback will be called.

The related issue is that: https://issues.liferay.com/browse/LPS-124616

Thanks in advance.
