### PR TITLE
LPS-124783 Clean up ClassicEditor and upgrade ckeditor4-react

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"ckeditor4-react": "1.0.1",
+		"ckeditor4-react": "1.3.0",
 		"frontend-js-web": "*",
 		"liferay-ckeditor": "4.14.1-liferay.13",
 		"prop-types": "15.7.2"

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -106,6 +106,7 @@ const ClassicEditor = ({
 			<Editor
 				className="lfr-editable"
 				config={getConfig()}
+				name={name}
 				onBeforeLoad={(CKEDITOR) => {
 					CKEDITOR.disableAutoInline = true;
 					CKEDITOR.dtd.$removeEmpty.i = 0;
@@ -116,34 +117,27 @@ const ClassicEditor = ({
 							? CKEDITOR.dialog._.currentZIndex + 10
 							: Liferay.zIndex.WINDOW + 10;
 					};
-
-					CKEDITOR.on('instanceCreated', ({editor}) => {
-						editor.name = name;
-
-						editor.on('drop', (event) => {
-							var data = event.data.dataTransfer.getData(
-								'text/html'
-							);
-
-							if (data) {
-								var fragment = CKEDITOR.htmlParser.fragment.fromHtml(
-									data
-								);
-
-								var name = fragment.children[0].name;
-
-								if (name) {
-									return editor.pasteFilter.check(name);
-								}
-							}
-						});
-
-						editor.on('instanceReady', () => {
-							editor.setData(contents);
-						});
-					});
 				}}
 				onChange={onChangeCallback}
+				onDrop={(event) => {
+					const data = event.data.dataTransfer.getData('text/html');
+					const editor = event.editor;
+
+					if (data) {
+						const fragment = CKEDITOR.htmlParser.fragment.fromHtml(
+							data
+						);
+
+						const name = fragment.children[0].name;
+
+						if (name) {
+							return editor.pasteFilter.check(name);
+						}
+					}
+				}}
+				onInstanceReady={({editor}) => {
+					editor.setData(contents);
+				}}
 				ref={editorRef}
 				{...otherProps}
 			/>

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -3984,10 +3984,10 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ckeditor4-react@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ckeditor4-react/-/ckeditor4-react-1.0.1.tgz#4c626ab31a4bda8b4e50e064ca1072f5ccaca5a0"
-  integrity sha512-Y27p/FZsUhkYBJ0aWzD1MMCu/U26iFiMryCMyQyMx9OTzo0045PYzrmoxgAtminEzW80y5Aln8asYL+QTe/5sg==
+ckeditor4-react@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ckeditor4-react/-/ckeditor4-react-1.3.0.tgz#de0d93380f1b634b896ed41eb9f476cfdfef308a"
+  integrity sha512-73PSba0K0Bx1m9rqCagX2ajPBFq4PDgkUAtqa8o2QrKVzhtPcnpo7uyuY6VYwAN0xLmmolsQu7x5XY4jmEJidg==
   dependencies:
     load-script "^1.0.0"
     prop-types "^15.6.2"


### PR DESCRIPTION
In this change, we pass event handlers and `name` as props to the
ClassicEditor component.

Additionally the `ckeditor4-react` package has been updated to version
`1.3.0` which fixes the problem with editor instances not being present
in the global `CKEDITOR.instances` variable.

**Before**

![](https://user-images.githubusercontent.com/5572/101897221-81050100-3baa-11eb-9d43-078301cd542f.png)

*Note that there should be 2 keys in the `CKEDITOR.instances` object*

**After**

![](https://user-images.githubusercontent.com/5572/101897265-94b06780-3baa-11eb-9f27-7289a4587396.png)
