### PR TITLE
LRQA-29748 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/functions/AssertElementNotPresent.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/AssertElementNotPresent.function
@@ -14,4 +14,14 @@ definition {
 		selenium.assertLiferayErrors();
 	}
 
+	function assertElementNotPresentNoSPARefresh {
+		selenium.waitForElementNotPresent();
+
+		selenium.assertElementNotPresent();
+
+		selenium.assertJavaScriptErrors();
+
+		selenium.assertLiferayErrors();
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/functions/AssertElementPresent.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/AssertElementPresent.function
@@ -14,6 +14,16 @@ definition {
 		selenium.assertLiferayErrors();
 	}
 
+	function assertElementPresentNoSPARefresh {
+		selenium.waitForElementPresent();
+
+		selenium.assertElementPresent();
+
+		selenium.assertJavaScriptErrors();
+
+		selenium.assertLiferayErrors();
+	}
+
 	function assertVisible {
 		WaitForSPARefresh();
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Alert.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Alert.macro
@@ -101,4 +101,10 @@ definition {
 			locator1 = "Message#WARNING_SPECIFIC");
 	}
 
+	macro viewWarningSpecificNoSPARefresh {
+		AssertElementPresent.assertElementPresentNoSPARefresh(
+			key_warningMessage = "${warningMessage}",
+			locator1 = "Message#WARNING_SPECIFIC");
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ServerAdministration.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ServerAdministration.macro
@@ -151,6 +151,22 @@ definition {
 		Alert.viewSuccessMessage();
 	}
 
+	macro executeScriptNoAlert {
+		Navigator.gotoNavItem(navItem = "Script");
+
+		Select(
+			locator1 = "ServerAdministrationScript#LANGUAGE_SELECT",
+			value1 = "${language}");
+
+		Type(
+			locator1 = "ServerAdministrationScript#SCRIPT_TEXT",
+			value1 = "${script}");
+
+		AssertClick(
+			locator1 = "ServerAdministrationScript#EXECUTE_BUTTON",
+			value1 = "Execute");
+	}
+
 	macro executeServerResourcesActions {
 		Navigator.gotoNavItem(navItem = "Resources");
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/marketplace/AppManager.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/marketplace/AppManager.path
@@ -11,7 +11,7 @@
 <!--APP-->
 <tr>
 	<td>APP_NAME</td>
-	<td>//div[contains(@class,'content')]//li[contains(@class,'list-group-item')]//a[contains(.,'${key_appName}')]</td>
+	<td>//div[contains(@class,'content')]//li[contains(@class,'list-group-item')]//*[contains(.,'${key_appName}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/SPA.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/SPA.testcase
@@ -33,4 +33,76 @@ definition {
 		AssertVisible.assertVisibleNoSPAWait(locator1 = "//html[contains(@class,'lfr-spa-loading')]");
 	}
 
+	@description = "Validate user can configure SPA timeout notification"
+	@priority = "4"
+	test ConfigureSPANotificationTimeout {
+		property test.name.skip.portal.instance = "SPA#AssertLoadingBar";
+
+		var appName = "Liferay Frontend JS SPA Web";
+		var warningMessage = "It looks like this is taking longer than expected.";
+
+		task ("Configure User Notification Timeout to 1 second") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Configuration",
+				panel = "Control Panel",
+				portlet = "System Settings");
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Infrastructure",
+				configurationName = "Frontend SPA Infrastructure",
+				configurationScope = "System Scope");
+
+			Type(
+				key_text = "User Notification Timeout",
+				locator1 = "TextInput#ANY",
+				value1 = "1000");
+
+			SystemSettings.saveConfiguration();
+
+			Refresh();
+		}
+
+		task ("Validate time out warning with 1 second script") {
+			ServerAdministration.openServerAdmin();
+
+			var script = '''
+				sleep(1000);
+				out.println("Timeout notification warning triggered");
+			''';
+
+			ServerAdministration.executeScriptNoAlert(
+				language = "Groovy",
+				script = "${script}");
+
+			Alert.viewWarningSpecificNoSPARefresh(warningMessage = "${warningMessage}");
+
+			AssertTextEquals(
+				locator1 = "ServerAdministrationScript#OUTPUT_FIELD",
+				value1 = "Timeout notification warning triggered");
+
+			WaitForElementNotPresent(
+				key_warningMessage = "${warningMessage}",
+				locator1 = "Message#WARNING_SPECIFIC");
+		}
+
+		task ("Validate no time out warning with 0.2 second script") {
+			var script = '''
+				sleep(200);
+				out.println("No timeout notification warning");
+			''';
+
+			ServerAdministration.executeScriptNoAlert(
+				language = "Groovy",
+				script = "${script}");
+
+			AssertElementNotPresent.assertElementNotPresentNoSPARefresh(
+				key_warningMessage = "${warningMessage}",
+				locator1 = "Message#WARNING_SPECIFIC");
+
+			AssertTextEquals(
+				locator1 = "ServerAdministrationScript#OUTPUT_FIELD",
+				value1 = "No timeout notification warning");
+		}
+	}
+
 }


### PR DESCRIPTION
OK to backport test in 7.x branches.

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-29748

**Description:**
Add a poshi functional test to check that configuring the SPA timeout notification throws warning notification message after the set time. This particular test uses the virtual instance settings to force the SPA timeout as it is a known area in portal to take a significant amount of time to complete SPA.

**Test Plan**
- Manual Steps:
1. Navigate to App Menu > System Settings > Infra > SPA
2. Set the value for "User notification timeout" to 1000 (ms)
3. Refresh the page
4. Go to System Admin > Script
5. Run script: sleep(1000); out.println("sample output text");
6. Assert the notification alert message is present
7. Assert sample output text is present
8. Wait for notification to not be present
9. Run script: sleep(200); out.println("sample output text");
10. Assert no notification for SPA timeout appears
11. Assert sample output text is present

- Run the auto test on ci and make sure it passes. | :heavy_check_mark: passes in https://github.com/john-co/liferay-portal/pull/363#issuecomment-747103055