### PR TITLE
LPS-123551 Deprecate Java minification classes

### DIFF
--- a/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/liferay/frontend/js/minifier/internal/GoogleJavaScriptMinifier.java
+++ b/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/liferay/frontend/js/minifier/internal/GoogleJavaScriptMinifier.java
@@ -41,10 +41,12 @@ import org.osgi.service.component.annotations.Component;
 
 /**
  * @author Carlos Sierra Andrés
+ * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
 @Component(
 	property = "service.ranking:Integer=100", service = JavaScriptMinifier.class
 )
+@Deprecated
 public class GoogleJavaScriptMinifier implements JavaScriptMinifier {
 
 	@Override

--- a/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/liferay/frontend/js/minifier/internal/YahooJavaScriptMinifier.java
+++ b/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/liferay/frontend/js/minifier/internal/YahooJavaScriptMinifier.java
@@ -37,12 +37,14 @@ import org.osgi.service.component.annotations.Modified;
 
 /**
  * @author Carlos Sierra Andrés
+ * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
 @Component(
 	configurationPid = "com.frontend.js.minifier.configuration.YahooJavaScriptMinifierConfiguration",
 	configurationPolicy = ConfigurationPolicy.OPTIONAL,
 	service = JavaScriptMinifier.class
 )
+@Deprecated
 public class YahooJavaScriptMinifier implements JavaScriptMinifier {
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/minifier/CSSCompressor.java
+++ b/portal-impl/src/com/liferay/portal/minifier/CSSCompressor.java
@@ -30,7 +30,9 @@ import java.util.regex.Pattern;
 
 /**
  * @author Iván Zaera Avellón
+ * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
+@Deprecated
 public class CSSCompressor {
 
 	public CSSCompressor(Reader reader) throws IOException {

--- a/portal-impl/src/com/liferay/portal/minifier/JavaScriptMinifier.java
+++ b/portal-impl/src/com/liferay/portal/minifier/JavaScriptMinifier.java
@@ -16,7 +16,9 @@ package com.liferay.portal.minifier;
 
 /**
  * @author Carlos Sierra Andrés
+ * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
+@Deprecated
 public interface JavaScriptMinifier {
 
 	public String compress(String resourceName, String content);

--- a/portal-impl/src/com/liferay/portal/minifier/MinifierUtil.java
+++ b/portal-impl/src/com/liferay/portal/minifier/MinifierUtil.java
@@ -31,7 +31,9 @@ import org.apache.commons.lang.time.StopWatch;
  * @author Brian Wing Shun Chan
  * @author Raymond Augé
  * @author Roberto Díaz
+ * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
+@Deprecated
 public class MinifierUtil {
 
 	public static String minifyCss(String content) {


### PR DESCRIPTION
As a final step in our "Simplify JS minification scheme in DXP" epic (https://issues.liferay.com/browse/LPS-122883) we're marking the legacy runtime architecture as deprecated to give customers fair warning about its removal.

This includes the following classes:

- `CSSCompressor`
- `GoogleJavaScriptMinifier`
- `MinifierUtil`
- `YahooJavaScriptMinifier`

and interface:

- `JavaScriptMinifier`