### PR TITLE
LPS-102117 Remove compat-layer:toolbar

### DIFF
--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view.jsp
@@ -90,7 +90,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 			<aui:input name="type" type="hidden" value="" />
 
 			<clay:row>
-				<aui:col cssClass="toolbar" width="<%= 100 %>">
+				<aui:col cssClass="d-flex justify-content-between toolbar" width="<%= 100 %>">
 					<div class="filter-container">
 						<clay:row>
 							<aui:col cssClass="contact-group-filter form-inline">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
@@ -51,7 +51,7 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 
 	<nav class="management-bar management-bar-light navbar navbar-expand-md toolbar-group-field">
 		<clay:container-fluid
-			cssClass="toolbar"
+			cssClass="d-flex justify-content-between toolbar"
 		>
 			<ul class="navbar-nav toolbar-group-field"></ul>
 			<ul class="navbar-nav toolbar-group-field">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -56,7 +56,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 
 	<nav class="hide management-bar management-bar-light navbar navbar-expand-md toolbar-group-field" id="<portlet:namespace />managementToolbar">
 		<clay:container-fluid
-			cssClass="autosave-bar toolbar"
+			cssClass="autosave-bar d-flex justify-content-between toolbar"
 		>
 			<div class="autosave-feedback-container navbar-form navbar-form-autofit navbar-overlay toolbar-group-content">
 				<span class="autosave-feedback management-bar-text" id="<portlet:namespace />autosaveMessage"></span>

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/_components.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/_components.scss
@@ -12,7 +12,6 @@
 @import 'components/panels';
 @import 'components/popover';
 @import 'components/toggle_switch';
-@import 'components/toolbar';
 @import 'components/user_icons';
 
 @import 'components/liferay';

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/_variables.scss
@@ -11,7 +11,6 @@ $compat-navs: true !default;
 $compat-pagination: true !default;
 $compat-panels: true !default;
 $compat-toggle_switch: true !default;
-$compat-toolbar: true !default;
 $compat-user_icons: true !default;
 
 // Map Bootstrap 4 Variables to Bootstrap 3 equivalent

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_toolbar.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_toolbar.scss
@@ -1,7 +1,0 @@
-@if $compat-toolbar {
-	.toolbar {
-		display: flex;
-
-		@extend .justify-content-between;
-	}
-}


### PR DESCRIPTION
Remove compat-layer:toolbar

Since we were using the class `.toolbar` for JS functions and the I prefered to add the missing style classes and remove the compat-layer