### PR TITLE
COMMERCE-5332 data set actions dropdown can now highlight items

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionsDropdownRenderer.js
@@ -38,15 +38,15 @@ export function isLink(target, onClick) {
 export function handleAction(
 	{
 		event,
-		itemId = '',
+		itemId,
 		method,
-		onClick = '',
-		setLoading = () => {},
-		size = '',
-		target = '',
-		title = '',
+		onClick,
+		setLoading,
+		size,
 		successMessage,
-		url = '',
+		target,
+		title,
+		url,
 	},
 	{executeAsyncItemAction, highlightItems, openModal, openSidePanel}
 ) {
@@ -112,9 +112,11 @@ function ActionItem({
 	handleAction,
 	href,
 	icon,
+	itemId,
 	label,
 	method,
 	onClick,
+	setLoading,
 	size,
 	target,
 	title,
@@ -127,8 +129,10 @@ function ActionItem({
 		handleAction(
 			{
 				event,
+				itemId,
 				method,
 				onClick,
+				setLoading,
 				size: size || 'lg',
 				successMessage: data?.successMessage,
 				target,
@@ -280,8 +284,10 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 					closeMenu={() => setActive(false)}
 					handleAction={handleAction}
 					href={item.href && formatActionURL(item.href, itemData)}
+					itemId={itemId}
 					key={i}
 					method={item.method ?? item.data?.method}
+					setLoading={setLoading}
 				/>
 			);
 		});


### PR DESCRIPTION
When a side panel is supposed to be used for updating a data set item, the item should be highlighted. It happens when you click on an action link: 

![image-2020-12-15-10-36-38-527](https://user-images.githubusercontent.com/44569796/102211136-78c30380-3ed3-11eb-8813-f456d8858c12.png)

But it does not happen when you click on an action dropdown item:
![image-2020-12-15-10-40-43-047](https://user-images.githubusercontent.com/44569796/102211164-837d9880-3ed3-11eb-89e9-aed8c7fafab0.png)

I've also removed some unnecessary default values assignments.