### PR TITLE
LPS-124521 Card view-style uses .lfr-asset-item width. If an item has a long name, 50% width will make the view unreadable in mobile view. We can remedy this using 100% width instead.

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_search_iterator.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_search_iterator.scss
@@ -136,7 +136,7 @@
 	}
 
 	.lfr-asset-item {
-		width: 50%;
+		width: 100%;
 
 		@include media-breakpoint-up(sm) {
 			width: 33%;


### PR DESCRIPTION
Resending from: https://github.com/liferay-frontend/liferay-portal/pull/601

Card view-style uses .lfr-asset-item width. If an item has a long name, 50% width will make the view unreadable in mobile view. We can remedy this using 100% width instead.


**Test plan:**

1. Log into a Liferay DXP 7.3 bundle
2. Create an additional site or two, one should have a longer name
3. Access the bundle via a mobile device or using a browser's developer tools
4. On the main landing page click on the user's Avatar -> My Sites -> Select Sites -> My Sites or Recent


