### PR TITLE
LPS-124430 Saves tooltip trigger title on show events

### DIFF
--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
@@ -159,8 +159,11 @@ const TooltipProvider = () => {
 				document.body,
 				eventName,
 				SELECTOR_TRIGGER,
-				(event) =>
-					dispatch({target: event.delegateTarget, type: 'show'})
+				(event) => {
+					saveTitle(event.delegateTarget);
+
+					dispatch({target: event.delegateTarget, type: 'show'});
+				}
 			);
 		});
 
@@ -205,8 +208,6 @@ const TooltipProvider = () => {
 					Align.BottomCenter
 				)
 			);
-
-			saveTitle(state.target);
 		}
 	}, [state.target]);
 


### PR DESCRIPTION
From the commit itself:

> Before, the change of `title` to `data-restore-title` happened based on the component rendering and state, making it fail to execute under certain conditions.
>
> With this change, anytime the mouse moves over a tooltip trigger, its `title` attribute is moved to a `data-restore-title` attribute avoiding unnecessary rendering of the native tooltip.

The effect can be seen in this screencast and it happened to all tooltips in DXP:

![tooltip](https://user-images.githubusercontent.com/905006/102472891-b009ef80-404e-11eb-9ed3-ee9df2058a4f.gif)

**The Problem**
To take over the native tooltips, we move `title` attributes to `data-restore-title` when we enter a trigger element. This attribute is then restored back to `title` when we abandon it.

Previous logic depended on a `useEffect(... [target])` and some internal conditions to execute the `saveTitle` method while `restoreTitle` was running unconditionally when the trigger was abandoned (like to move into the tooltip).

**The Fix**
We simply move the `saveTitle` execution to the initial show trigger. This means there are more DOM changes but the DOM state remains consistent through interactions.

**Test Plan**
- Hover over an icon in DXP and wait until the tooltip shows
- Move the mouse over the tooltip
- Move it back over the icon
- Wait for the native tooltip to appear

**Additional Reference**
Just because I've kept this around all this time, in case someone goes into the implementation and wonders what's with all the craziness... this is the tooltip state diagram:

<img width="841" alt="tooltip" src="https://user-images.githubusercontent.com/905006/102473094-f65f4e80-404e-11eb-9905-06844c96f306.png">
