### PR TITLE
LPS-124871 Propagate NODE_ENV to YUI loader

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/.babelrc.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/.babelrc.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+module.exports = {
+	plugins: ['transform-node-env-inline'],
+};

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
@@ -49,7 +49,7 @@
 		base: Liferay.ThemeDisplay.getCDNBaseURL() + PATH_JAVASCRIPT + '/aui/',
 		combine: COMBINE,
 		comboBase: LiferayAUI.getComboPath(),
-		filter: Liferay.AUI.getFilter(),
+		filter: process.env.NODE_ENV === 'development' ? 'raw' : 'min',
 		groups: {
 			editor: {
 				base: PATH_EDITOR_CKEDITOR,


### PR DESCRIPTION
Our other resources are toggled between minified and non-minified form based on the value of `NODE_ENV`, so we do the same here in the name of consistency for resources that are loaded via the YUI loader.

This means we effectively ignore [the old logic](https://github.com/liferay/liferay-portal/blob/012adf4b2836179a5478bf04b5337955917fccb8/portal-web/docroot/html/common/themes/top_js.jspf#L329-L342) that consults `themeDisplay.isThemeJsFastLoad()` and the `javascript.log.enabled` property, in order to return `'raw'`, `'min'` or `'debug'` as a filter type. Now, we only ever return `'raw'` or `'min'`.

If you're curious, how these filter types are used can be seen in [the loader source](https://alloyui.com/api/files/yui3_src_loader_js_loader.js.html).