### PR TITLE
LPS-123965 Migrate instances of AlloyEditor in Commerce commerce-payment-method-money-order

### DIFF
--- a/modules/apps/commerce/commerce-payment-method-money-order/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/commerce/commerce-payment-method-money-order/src/main/resources/META-INF/resources/configuration.jsp
@@ -41,7 +41,6 @@ if (messageLocalizedValuesMap != null) {
 		<div id="<portlet:namespace />message">
 			<aui:field-wrapper label="message">
 				<liferay-ui:input-localized
-					editorName="alloyeditor"
 					fieldPrefix="settings"
 					fieldPrefixSeparator="--"
 					name="message"


### PR DESCRIPTION
The `editorName` attribute has been removed from the
`<liferay-ui:input-localized>` tag instance, so that it uses
`_EDITOR_WYSIWYG_DEFAULT`, which is `ckeditor`.

**Test plan**

- Deploy the `commerce-payment-method-money-order` module
- From the global menu, select the **Control Panel** tab
- Navigate to **Sites**
- Create a new site based on the **Speedwell** template
- From the global menu, select the **Commerce** tab
- Under **Store management** select **Channels**
- Select **Commerce Portal**
- Scroll down the **Payment Methods** panel
- Click the **Edit** button next to **Money Order**
- Toggle the **Active** check box
- Click on **Save**
- Select the **Configuration** tab
- Toggle the **Show Message Page** check box

**Before**

![](https://user-images.githubusercontent.com/5572/102495294-35ed6100-4076-11eb-9e9c-22c490e38887.png)

**After**

![](https://user-images.githubusercontent.com/5572/102495352-456caa00-4076-11eb-8b2b-34b6240a440d.png)

**PS**
Sending this for an internal review, before sending it @liferay-commerce