### PR TITLE
LPS-124914 Migrate instances of AlloyEditor in Commerce commerce-product-definitions-web

### DIFF
--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
@@ -111,7 +111,6 @@ if ((cpDefinition != null) && (cpDefinition.getExpirationDate() != null)) {
 					<div class="entry-content form-group">
 						<liferay-ui:input-localized
 							defaultLanguageId="<%= defaultLanguageId %>"
-							editorName="alloyeditor"
 							name="descriptionMapAsXML"
 							type="editor"
 							xml="<%= descriptionMapAsXML %>"


### PR DESCRIPTION
The `editorName` attribute has been removed from the
`<liferay-ui:input-localized>` tag instance, so that it uses
`_EDITOR_WYSIWYG_DEFAULT`, which is `ckeditor`.

**Test plan**

- Deploy the `commerce-product-definitions-web` module
- From the global menu, select the **Control Panel** tab
- Navigate to **Sites**
- Create a new site based on the **Speedwell** template
- From the global menu, select the **Commerce** tab
- Select **Products**
- Edit an existing product
- Assert that a ckeditor instance is visible under **Full Description**


**Before**

![](https://user-images.githubusercontent.com/5572/102495568-84026480-4076-11eb-8d4c-2c4ed7dff727.png)

**After**

![](https://user-images.githubusercontent.com/5572/102495576-8795eb80-4076-11eb-9ef0-e195ae4490ba.png)

**PS**
Sending this for an internal review, before sending it @liferay-commerce
