### PR TITLE
LPS-124915 Migrate instances of AlloyEditor in Commerce commerce-product-type-virtual-web

### DIFF
--- a/modules/apps/commerce/commerce-payment-method-money-order/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/commerce/commerce-payment-method-money-order/src/main/resources/META-INF/resources/configuration.jsp
@@ -41,7 +41,6 @@ if (messageLocalizedValuesMap != null) {
 		<div id="<portlet:namespace />message">
 			<aui:field-wrapper label="message">
 				<liferay-ui:input-localized
-					editorName="alloyeditor"
 					fieldPrefix="settings"
 					fieldPrefixSeparator="--"
 					name="message"

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
@@ -111,7 +111,6 @@ if ((cpDefinition != null) && (cpDefinition.getExpirationDate() != null)) {
 					<div class="entry-content form-group">
 						<liferay-ui:input-localized
 							defaultLanguageId="<%= defaultLanguageId %>"
-							editorName="alloyeditor"
 							name="descriptionMapAsXML"
 							type="editor"
 							xml="<%= descriptionMapAsXML %>"

--- a/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/terms_of_use.jspf
+++ b/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/terms_of_use.jspf
@@ -61,7 +61,6 @@
 					<liferay-ui:input-localized
 						cssClass="form-control"
 						disabled="<%= useTermsOfUseJournal %>"
-						editorName="alloyeditor"
 						name="termsOfUseContent"
 						type="editor"
 						xml='<%= BeanPropertiesUtil.getString(cpDefinitionVirtualSetting, "termsOfUseContent") %>'


### PR DESCRIPTION
The `editorName` attribute has been removed from the
`<liferay-ui:input-localized>` tag instance, so that it uses
`_EDITOR_WYSIWYG_DEFAULT`, which is ckeditor.

**Test plan**

- Deploy the `commerce-product-type-virtual-web` module
- From the global menu, select the **Control Panel** tab
- Navigate to **Sites**
- Create a new site based on the **Speedwell** template
- From the global menu, select the **Commerce** tab
- Select **Products**
- Create a new **virtual** product
- Select the **Virtual** tab
- Toggle the **Enable Terms of Use** check box
- Assert that a ckeditor instance is visible and usable

**Before**

![](https://user-images.githubusercontent.com/5572/102504076-ac8f5c00-4080-11eb-8587-b150f94891fa.png)

**After**

![](https://user-images.githubusercontent.com/5572/102504113-b618c400-4080-11eb-82ee-0680b5e63198.png)


**PS**

Submitting this for an internal review before sending to @liferay-commerce