### PR TITLE
LPS-125077 Senna attempts to navigate for href="#" links

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
@@ -372,7 +372,7 @@ class App extends EventEmitter {
 
 			// Prevents navigation if it's a hash change on the same url.
 
-			if (uri.hash && isCurrentBrowserPath(path)) {
+			if ((uri.hash || url.endsWith('#')) && isCurrentBrowserPath(path)) {
 				return false;
 			}
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/app/App.js
@@ -523,7 +523,7 @@ describe('App', function () {
 			host: 'localhost',
 			hostname: 'localhost',
 			origin: 'http://localhost',
-			pathname: '/path',
+			pathname: '/base/path',
 			search: '',
 		});
 
@@ -536,6 +536,10 @@ describe('App', function () {
 		expect(this.app.canNavigate('http://localhost/base/')).toBe(true);
 		expect(this.app.canNavigate('http://localhost/base')).toBe(true);
 		expect(this.app.canNavigate('http://localhost/base/path')).toBe(true);
+		expect(this.app.canNavigate('http://localhost/base/path#')).toBe(false);
+		expect(this.app.canNavigate('http://localhost/base/path#foo')).toBe(
+			false
+		);
 		expect(this.app.canNavigate('http://localhost/base/path1')).toBe(false);
 		expect(this.app.canNavigate('http://localhost/path')).toBe(false);
 		expect(this.app.canNavigate('http://external/path')).toBe(false);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-125077

Steps are roundabout using web content templates, because regular web content doesn't accept the HTML in my testing on master.

1. Create a web content template for the Basic Web Content structure with the following content
``` html
<p><a href="#">click me</a></p>
<p><input type="text" /></p>
```
2. Add a web content using the web content template created in step 1
3. Add the web content display portlet to page and configure it to use the web content created in step 2
4. Publish the page
5. Type something into the input field
6. Click on the "click me" link

Expected behavior is that the link brings you to the top of the page, but whatever is typed into the input field remains.

Actual behavior is that the page refreshes and whatever is typed into the input field is lost.