### PR TITLE
LPS-125066 Fix <clay:management-toolbar-v2> not rendering the component

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_template.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_template.jsp
@@ -36,6 +36,7 @@ if ((classPK > 0) && (structureClassNameId == classNameId)) {
 
 <clay:management-toolbar-v2
 	clearResultsURL="<%= ddmDisplayContext.getClearResultsURL() %>"
+	componentId="ddmTemplateManagementToolbar"
 	creationMenu="<%= ddmDisplayContext.getTemplateCreationMenu() %>"
 	disabled="<%= ddmDisplayContext.isDisabledManagementBar(DDMWebKeys.DYNAMIC_DATA_MAPPING_TEMPLATE) %>"
 	filterDropdownItems="<%= ddmDisplayContext.getFilterItemsDropdownItems() %>"
@@ -115,9 +116,11 @@ if ((classPK > 0) && (structureClassNameId == classNameId)) {
 </aui:form>
 
 <aui:script>
-	Liferay.Util.focusFormField(
-		document.<portlet:namespace />searchForm.<portlet:namespace />keywords
-	);
+	Liferay.componentReady('ddmTemplateManagementToolbar').then(function () {
+		Liferay.Util.focusFormField(
+			document.<portlet:namespace />searchForm.<portlet:namespace />keywords
+		);
+	});
 </aui:script>
 
 <aui:script>


### PR DESCRIPTION
Based on repro:

1. Content & Data > Kaleo Forms Admin
2. Create a new Process
3. Create and Choose a FieldSet
4. Choose a Workflow Definition
5. Assign a form to any workflow task

You can see this error in the console:

    Uncaught TypeError: Cannot read property '_com_liferay_dynamic_data_mapping_web_portlet_DDMPortlet_keywords' of undefined

It seems that we need to wait for the component to be rendered client-side before trying to focus the field. So, register a component ID and wait for it, using the [same pattern as in the neighboring `select_structure.jsp`](https://github.com/liferay/liferay-portal/blob/9c0936516180b28b6db2830e6b7fcac3ea3de1a9/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_structure.jsp#L110-L116), which was added in [liferay-frontend/liferay-portal#614](https://github.com/liferay-frontend/liferay-portal/pull/614/files#diff-16b5273d20da4f6733a2d2aedd18f086b57bc183d9df0b355965d9425eddfe54).

Here's proof of the management toolbar rendering after this fix:

<img width="958" alt="Screenshot 2020-12-18 -111047-aC80aeOa@2x" src="https://user-images.githubusercontent.com/7074/102602350-b4530d00-4121-11eb-82fa-8c8fe3e6486f.png">
