### PR TITLE
LPS-125188 Update CKEditor scayt and wcs plugin versions

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
@@ -6,7 +6,7 @@ task buildCKEditor(type: Copy)
 task buildCKEditorBBCode(type: ConcatenateTask)
 task buildCKEditorPlugins(type: Copy)
 
-String ckEditorVersion = "4.13.1"
+String ckEditorVersion = "4.14.1"
 
 String ckEditorScaytUrl = "https://ckeditor.com/cke4/sites/default/files/scayt/releases/scayt_${ckEditorVersion}.zip"
 String ckEditorWscUrl = "https://ckeditor.com/cke4/sites/default/files/wsc/releases/wsc_${ckEditorVersion}.zip"


### PR DESCRIPTION
Both of these plugins should use the same ckeditor version,
as [liferay-ckeditor](https://github.com/liferay/liferay-ckeditor), which is currently [`4.14.1`](https://github.com/ckeditor/ckeditor4/blob/eb2d11644a796cd13cd047cd55541430359f9317/package.json#L3)