### PR TITLE
LPS-125214 Make sure the header and the body are set to the initial width

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -463,10 +463,25 @@ SideNavigation.prototype = {
 		const options = instance.options;
 
 		const container = document.querySelector(options.container);
+		const body = container.querySelector('.sidebar-body');
+		const header = container.querySelector('.sidebar-header');
 		const toggler = instance.toggler;
 
 		const mobile = instance.mobile;
 		const type = mobile ? options.typeMobile : options.type;
+		const width = instance._getSidenavWidth();
+
+		if (body) {
+			setStyles(body, {
+				width: px(width),
+			});
+		}
+
+		if (header) {
+			setStyles(header, {
+				width: px(width),
+			});
+		}
 
 		if (!instance.useDataAttribute) {
 			if (mobile) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-125214

## Steps to reproduce

1. Go to Content & Data -> Web Content and add a basic new web content
2. Choose to add an image to the web content and upload a new image using the file selector.
3. Select the info button for the image to open it, then again to close it

**Expected Results**:
You get a sliding behavior (all text slides into view, as originally formatted)

**Actual Results**:
You get an accordion-like behavior, where at lower widths, the text wraps extremely early, and only fixes itself at higher widths.
