### PR TITLE
LPS-125241 Remove unneeded lines in `frontend-editor-ckeditor-web/build.gradle`

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
@@ -6,11 +6,6 @@ task buildCKEditor(type: Copy)
 task buildCKEditorBBCode(type: ConcatenateTask)
 task buildCKEditorPlugins(type: Copy)
 
-String ckEditorVersion = "4.14.1"
-
-String ckEditorScaytUrl = "https://ckeditor.com/cke4/sites/default/files/scayt/releases/scayt_${ckEditorVersion}.zip"
-String ckEditorWscUrl = "https://ckeditor.com/cke4/sites/default/files/wsc/releases/wsc_${ckEditorVersion}.zip"
-
 File editorDestinationDir = file("tmp/META-INF/resources")
 File editorSrcDir = file("src/main/resources/META-INF/resources")
 


### PR DESCRIPTION
In [LPS-125188](https://issues.liferay.com/browse/LPS-125188),we updated the CKEditor version 
for the `scayt` and `wcs` plugins, but later realized that 
these were bundled with our [`liferay-ckeditor`](https://github.com/liferay/liferay-ckeditor/blob/8e1423af268c05d65c6998d68ebec808f2519120/ck.sh#L279-L280) package 
since [LPS-108652](https://issues.liferay.com/browse/LPS-108652).

**Test plan**:

- Deploy the `frontend-editor-ckeditor-web` module
- Make sure that editors work as expected