### PR TITLE
LPS-102105 Adds classes `nav-item` and `nav-link` to `li` and `a` ele…

### DIFF
--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_app/page.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_app/page.jsp
@@ -24,8 +24,8 @@ String url = (String)request.getAttribute("liferay-application-list:panel-app:ur
 %>
 
 <c:if test="<%= Validator.isNotNull(url) %>">
-	<li class="<%= active ? "active" : StringPool.BLANK %>" role="presentation">
-		<aui:a ariaRole="menuitem" data='<%= (Map<String, Object>)request.getAttribute("liferay-application-list:panel-app:data") %>' href="<%= url %>" id='<%= (String)request.getAttribute("liferay-application-list:panel-app:id") %>'>
+	<li class="<%= active ? "active" : StringPool.BLANK %> nav-item" role="presentation">
+		<aui:a ariaRole="menuitem" cssClass="nav-link" data='<%= (Map<String, Object>)request.getAttribute("liferay-application-list:panel-app:data") %>' href="<%= url %>" id='<%= (String)request.getAttribute("liferay-application-list:panel-app:id") %>'>
 			<%= label %>
 
 			<c:if test="<%= notificationsCount > 0 %>">

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_category/start.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_category/start.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/panel_category/init.jsp" %>
 
 <c:if test="<%= !panelApps.isEmpty() && showHeader %>">
-	<a aria-expanded="<%= active %>" class="<%= headerActive ? "active" : "" %> collapse-icon collapse-icon-middle <%= active ? StringPool.BLANK : "collapsed" %> list-group-heading panel-header" data-qa-id="appGroup" data-toggle="liferay-collapse" href="#<%= id %>">
+	<a aria-expanded="<%= active %>" class="<%= headerActive ? "active" : "" %> collapse-icon collapse-icon-middle nav-link <%= active ? StringPool.BLANK : "collapsed" %> list-group-heading panel-header" data-qa-id="appGroup" data-toggle="liferay-collapse" href="#<%= id %>">
 		<c:if test="<%= !panelCategory.includeHeader(request, PipingServletResponse.createPipingServletResponse(pageContext)) %>">
 			<%= panelCategory.getLabel(themeDisplay.getLocale()) %>
 


### PR DESCRIPTION
…ments in product menu due to removal of compat nav styles

Caused by https://issues.liferay.com/browse/LPS-102105. This updates product menu `li` and `a` elements to use Clay 3 classes. Removing styled theme compat nav layer caused links to be too small.