### PR TITLE
LPS-125269 Fix grid/container spacing in modules

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/details.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/details.jsp
@@ -31,6 +31,7 @@ renderResponse.setTitle((accountEntryDisplay.getAccountEntryId() == 0) ? Languag
 
 <liferay-frontend:edit-form
 	action="<%= editAccountURL %>"
+	cssClass="container-form-lg"
 >
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= (accountEntryDisplay.getAccountEntryId() == 0) ? Constants.ADD : Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/view_valid_domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/view_valid_domains.jsp
@@ -29,9 +29,7 @@ else {
 }
 %>
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<clay:alert
 		message="<%= message %>"
 	/>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
@@ -45,9 +45,7 @@ BlogEntriesManagementToolbarDisplayContext blogEntriesManagementToolbarDisplayCo
 	portletURL="<%= restoreTrashEntriesURL %>"
 />
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<aui:form action="<%= portletURL.toString() %>" method="get" name="fm">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
@@ -67,9 +67,7 @@ String displayStyle = blogImagesManagementToolbarDisplayContext.getDisplayStyle(
 	viewTypeItems="<%= blogImagesManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<portlet:actionURL name="/blogs/edit_image" var="editImageURL" />
 
 	<aui:form action="<%= editImageURL %>" name="fm">

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -22,254 +22,253 @@ ContentDashboardAdminDisplayContext contentDashboardAdminDisplayContext = (Conte
 ContentDashboardAdminManagementToolbarDisplayContext contentDashboardAdminManagementToolbarDisplayContext = (ContentDashboardAdminManagementToolbarDisplayContext)request.getAttribute(ContentDashboardWebKeys.CONTENT_DASHBOARD_ADMIN_MANAGEMENT_TOOLBAR_DISPLAY_CONTEXT);
 %>
 
-<clay:row
-	cssClass="no-gutters sidebar-wrapper"
->
-	<clay:container-fluid>
-		<div class="main-content-body">
-			<clay:sheet
-				size="<%= StringPool.BLANK %>"
-			>
-				<h2 class="sheet-title">
-					<clay:content-row>
-						<clay:content-col
-							expand="<%= true %>"
-						>
+<div class="sidebar-wrapper">
+	<clay:container-fluid
+		cssClass="container-form-lg"
+	>
+		<clay:sheet
+			size="<%= StringPool.BLANK %>"
+		>
+			<h2 class="sheet-title">
+				<clay:content-row
+					noGutters="true"
+				>
+					<clay:content-col
+						expand="<%= true %>"
+					>
+						<span class="component-title">
 							<%= contentDashboardAdminDisplayContext.getAuditGraphTitle() %>
-						</clay:content-col>
+						</span>
+					</clay:content-col>
 
-						<clay:content-col
-							cssClass="c-mr-4"
-						>
-							<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "flip-axes") %>">
-								<form action="<%= contentDashboardAdminDisplayContext.getSwapConfigurationURL() %>" method="post">
-									<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+					<clay:content-col>
+						<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "flip-axes") %>">
+							<form action="<%= contentDashboardAdminDisplayContext.getSwapConfigurationURL() %>" method="post">
+								<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
-									<clay:button
-										borderless="<%= true %>"
-										cssClass="component-action"
-										disabled="<%= !contentDashboardAdminDisplayContext.isSwapConfigurationEnabled() %>"
-										displayType="secondary"
-										icon="change"
-										small="<%= true %>"
-										type="submit"
-									/>
-								</form>
-							</span>
-						</clay:content-col>
-
-						<clay:content-col>
-							<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "configure-chart") %>">
 								<clay:button
 									borderless="<%= true %>"
 									cssClass="component-action"
+									disabled="<%= !contentDashboardAdminDisplayContext.isSwapConfigurationEnabled() %>"
 									displayType="secondary"
-									icon="cog"
-									onClick="<%= contentDashboardAdminDisplayContext.getOnClickConfiguration() %>"
+									icon="change"
 									small="<%= true %>"
+									type="submit"
+								/>
+							</form>
+						</span>
+					</clay:content-col>
+
+					<clay:content-col>
+						<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "configure-chart") %>">
+							<clay:button
+								borderless="<%= true %>"
+								cssClass="component-action"
+								displayType="secondary"
+								icon="cog"
+								onClick="<%= contentDashboardAdminDisplayContext.getOnClickConfiguration() %>"
+								small="<%= true %>"
+							/>
+						</span>
+					</clay:content-col>
+				</clay:content-row>
+			</h2>
+
+			<div class="audit-graph">
+				<div class="c-my-5 c-p-5 inline-item w-100">
+					<span aria-hidden="true" class="loading-animation"></span>
+				</div>
+
+				<react:component
+					module="js/AuditGraphApp"
+					props="<%= contentDashboardAdminDisplayContext.getData() %>"
+				/>
+			</div>
+		</clay:sheet>
+
+		<clay:sheet
+			cssClass="c-mt-5"
+			size="<%= StringPool.BLANK %>"
+		>
+			<h2 class="sheet-title">
+				<span class="component-title">
+					<%= LanguageUtil.format(request, "content-x", contentDashboardAdminDisplayContext.getSearchContainer().getTotal(), false) %>
+				</span>
+			</h2>
+
+			<clay:management-toolbar-v2
+				displayContext="<%= contentDashboardAdminManagementToolbarDisplayContext %>"
+				elementClasses="content-dashboard-management-toolbar"
+			/>
+
+			<liferay-ui:search-container
+				cssClass="table-hover"
+				id="content"
+				searchContainer="<%= contentDashboardAdminDisplayContext.getSearchContainer() %>"
+			>
+				<liferay-ui:search-container-row
+					className="com.liferay.content.dashboard.web.internal.item.ContentDashboardItem"
+					keyProperty="id"
+					modelVar="contentDashboardItem"
+				>
+
+					<%
+					InfoItemReference infoItemReference = contentDashboardItem.getInfoItemReference();
+
+					String rowId = String.valueOf(infoItemReference.getClassPK());
+
+					row.setData(Collections.singletonMap("rowId", rowId));
+					row.setRowId(rowId);
+
+					ContentDashboardItemAction contentDashboardItemAction = contentDashboardItem.getDefaultContentDashboardItemAction(request);
+					%>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand table-title"
+						name="title"
+					>
+						<c:choose>
+							<c:when test="<%= contentDashboardItemAction != null %>">
+								<a class="lfr-portal-tooltip" href="<%= contentDashboardItemAction.getURL() %>" title="<%= HtmlUtil.escape(contentDashboardItem.getTitle(locale)) %>">
+									<span class="text-truncate-inline">
+										<span class="text-truncate"><%= HtmlUtil.escape(contentDashboardItem.getTitle(locale)) %></span>
+									</span>
+								</a>
+							</c:when>
+							<c:otherwise>
+								<span class="lfr-portal-tooltip text-truncate-inline" title="<%= HtmlUtil.escape(contentDashboardItem.getTitle(locale)) %>">
+									<span class="text-truncate"><%= HtmlUtil.escape(contentDashboardItem.getTitle(locale)) %></span>
+								</span>
+							</c:otherwise>
+						</c:choose>
+					</liferay-ui:search-container-column-text>
+
+					<liferay-ui:search-container-column-text
+						cssClass="text-center"
+						name=""
+					>
+						<c:if test="<%= contentDashboardItem.isViewable(request) %>">
+							<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "this-content-has-a-display-page") %>">
+								<clay:icon
+									cssClass="text-secondary"
+									symbol="page"
 								/>
 							</span>
-						</clay:content-col>
-					</clay:content-row>
-				</h2>
+						</c:if>
+					</liferay-ui:search-container-column-text>
 
-				<div class="audit-graph">
-					<div class="c-my-5 c-p-5 inline-item w-100">
-						<span aria-hidden="true" class="loading-animation"></span>
-					</div>
-
-					<react:component
-						module="js/AuditGraphApp"
-						props="<%= contentDashboardAdminDisplayContext.getData() %>"
-					/>
-				</div>
-			</clay:sheet>
-		</div>
-
-		<div class="main-content-body">
-			<clay:sheet
-				size="<%= StringPool.BLANK %>"
-			>
-				<h2 class="sheet-title">
-					<%= LanguageUtil.format(request, "content-x", contentDashboardAdminDisplayContext.getSearchContainer().getTotal(), false) %>
-				</h2>
-
-				<clay:management-toolbar-v2
-					displayContext="<%= contentDashboardAdminManagementToolbarDisplayContext %>"
-					elementClasses="content-dashboard-management-toolbar"
-				/>
-
-				<div class="sheet-section">
-					<liferay-ui:search-container
-						cssClass="table-hover"
-						id="content"
-						searchContainer="<%= contentDashboardAdminDisplayContext.getSearchContainer() %>"
+					<liferay-ui:search-container-column-text
+						cssClass="text-center"
+						name="author"
 					>
-						<liferay-ui:search-container-row
-							className="com.liferay.content.dashboard.web.internal.item.ContentDashboardItem"
-							keyProperty="id"
-							modelVar="contentDashboardItem"
+						<span class="lfr-portal-tooltip" title="<%= HtmlUtil.escape(contentDashboardItem.getUserName()) %>">
+							<liferay-ui:user-portrait
+								userId="<%= contentDashboardItem.getUserId() %>"
+							/>
+						</span>
+					</liferay-ui:search-container-column-text>
+
+					<%
+					ContentDashboardItemType contentDashboardItemType = contentDashboardItem.getContentDashboardItemType();
+					%>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand-smaller"
+						name="subtype"
+						value="<%= HtmlUtil.escape(contentDashboardItemType.getLabel(locale)) %>"
+					/>
+
+					<liferay-ui:search-container-column-text
+						name="site-or-asset-library"
+						value="<%= HtmlUtil.escape(contentDashboardItem.getScopeName(locale)) %>"
+					/>
+
+					<liferay-ui:search-container-column-text
+						cssClass="text-nowrap"
+						name="status"
+					>
+
+						<%
+						List<ContentDashboardItem.Version> versions = contentDashboardItem.getVersions(locale);
+
+						for (ContentDashboardItem.Version version : versions) {
+						%>
+
+							<clay:label
+								label="<%= StringUtil.toUpperCase(version.getLabel()) %>"
+								style="<%= version.getStyle() %>"
+							/>
+
+						<%
+						}
+						%>
+
+					</liferay-ui:search-container-column-text>
+
+					<%
+					for (AssetVocabulary assetVocabulary : contentDashboardAdminDisplayContext.getAssetVocabularies()) {
+					%>
+
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand-smaller"
+							name="<%= assetVocabulary.getTitle(locale) %>"
 						>
 
 							<%
-							InfoItemReference infoItemReference = contentDashboardItem.getInfoItemReference();
-
-							String rowId = String.valueOf(infoItemReference.getClassPK());
-
-							row.setData(Collections.singletonMap("rowId", rowId));
-							row.setRowId(rowId);
-
-							ContentDashboardItemAction contentDashboardItemAction = contentDashboardItem.getDefaultContentDashboardItemAction(request);
+							List<String> assetCategories = contentDashboardAdminDisplayContext.getAssetCategoryTitles(contentDashboardItem, assetVocabulary.getVocabularyId());
 							%>
 
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand table-title"
-								name="title"
-							>
-								<c:choose>
-									<c:when test="<%= contentDashboardItemAction != null %>">
-										<a class="lfr-portal-tooltip" href="<%= contentDashboardItemAction.getURL() %>" title="<%= HtmlUtil.escape(contentDashboardItem.getTitle(locale)) %>">
-											<span class="text-truncate-inline">
-												<span class="text-truncate"><%= HtmlUtil.escape(contentDashboardItem.getTitle(locale)) %></span>
-											</span>
-										</a>
-									</c:when>
-									<c:otherwise>
-										<span class="lfr-portal-tooltip text-truncate-inline" title="<%= HtmlUtil.escape(contentDashboardItem.getTitle(locale)) %>">
-											<span class="text-truncate"><%= HtmlUtil.escape(contentDashboardItem.getTitle(locale)) %></span>
-										</span>
-									</c:otherwise>
-								</c:choose>
-							</liferay-ui:search-container-column-text>
-
-							<liferay-ui:search-container-column-text
-								cssClass="text-center"
-								name=""
-							>
-								<c:if test="<%= contentDashboardItem.isViewable(request) %>">
-									<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "this-content-has-a-display-page") %>">
-										<clay:icon
-											cssClass="text-secondary"
-											symbol="page"
-										/>
-									</span>
-								</c:if>
-							</liferay-ui:search-container-column-text>
-
-							<liferay-ui:search-container-column-text
-								cssClass="text-center"
-								name="author"
-							>
-								<span class="lfr-portal-tooltip" title="<%= HtmlUtil.escape(contentDashboardItem.getUserName()) %>">
-									<liferay-ui:user-portrait
-										userId="<%= contentDashboardItem.getUserId() %>"
-									/>
-								</span>
-							</liferay-ui:search-container-column-text>
-
-							<%
-							ContentDashboardItemType contentDashboardItemType = contentDashboardItem.getContentDashboardItemType();
-							%>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand-smaller"
-								name="subtype"
-								value="<%= HtmlUtil.escape(contentDashboardItemType.getLabel(locale)) %>"
-							/>
-
-							<liferay-ui:search-container-column-text
-								name="site-or-asset-library"
-								value="<%= HtmlUtil.escape(contentDashboardItem.getScopeName(locale)) %>"
-							/>
-
-							<liferay-ui:search-container-column-text
-								cssClass="text-nowrap"
-								name="status"
-							>
-
-								<%
-								List<ContentDashboardItem.Version> versions = contentDashboardItem.getVersions(locale);
-
-								for (ContentDashboardItem.Version version : versions) {
-								%>
-
-									<clay:label
-										label="<%= StringUtil.toUpperCase(version.getLabel()) %>"
-										style="<%= version.getStyle() %>"
-									/>
-
-								<%
-								}
-								%>
-
-							</liferay-ui:search-container-column-text>
-
-							<%
-							for (AssetVocabulary assetVocabulary : contentDashboardAdminDisplayContext.getAssetVocabularies()) {
-							%>
-
-								<liferay-ui:search-container-column-text
-									cssClass="table-cell-expand-smaller"
-									name="<%= assetVocabulary.getTitle(locale) %>"
+							<c:if test="<%= !assetCategories.isEmpty() %>">
+								<clay:label
+									displayType="secondary"
+									large="<%= true %>"
 								>
+									<clay:label-item-expand><%= assetCategories.get(0) %></clay:label-item-expand>
+								</clay:label>
+							</c:if>
 
-									<%
-									List<String> assetCategories = contentDashboardAdminDisplayContext.getAssetCategoryTitles(contentDashboardItem, assetVocabulary.getVocabularyId());
-									%>
+							<c:if test="<%= assetCategories.size() > 1 %>">
 
-									<c:if test="<%= !assetCategories.isEmpty() %>">
-										<clay:label
-											displayType="secondary"
-											large="<%= true %>"
-										>
-											<clay:label-item-expand><%= assetCategories.get(0) %></clay:label-item-expand>
-										</clay:label>
-									</c:if>
+								<%
+								String assetCategoriesSummary = StringUtil.merge(assetCategories.subList(1, assetCategories.size()), "\n");
+								%>
 
-									<c:if test="<%= assetCategories.size() > 1 %>">
+								<span class="lfr-portal-tooltip" title="<%= assetCategoriesSummary %>">
+									<clay:label
+										aria-title="<%= assetCategoriesSummary %>"
+										displayType="secondary"
+										large="<%= true %>"
+									>
+										<span>...</span>
+									</clay:label>
+								</span>
+							</c:if>
+						</liferay-ui:search-container-column-text>
 
-										<%
-										String assetCategoriesSummary = StringUtil.merge(assetCategories.subList(1, assetCategories.size()), "\n");
-										%>
+					<%
+					}
+					%>
 
-										<span class="lfr-portal-tooltip" title="<%= assetCategoriesSummary %>">
-											<clay:label
-												aria-title="<%= assetCategoriesSummary %>"
-												displayType="secondary"
-												large="<%= true %>"
-											>
-												<span>...</span>
-											</clay:label>
-										</span>
-									</c:if>
-								</liferay-ui:search-container-column-text>
+					<liferay-ui:search-container-column-date
+						name="modified-date"
+						value="<%= contentDashboardItem.getModifiedDate() %>"
+					/>
 
-							<%
-							}
-							%>
-
-							<liferay-ui:search-container-column-date
-								name="modified-date"
-								value="<%= contentDashboardItem.getModifiedDate() %>"
-							/>
-
-							<liferay-ui:search-container-column-text>
-								<clay:dropdown-actions
-									dropdownItems="<%= contentDashboardAdminDisplayContext.getDropdownItems(contentDashboardItem) %>"
-									propsTransformer="js/transformers/ActionsComponentPropsTransformer"
-								/>
-							</liferay-ui:search-container-column-text>
-						</liferay-ui:search-container-row>
-
-						<liferay-ui:search-iterator
-							markupView="lexicon"
+					<liferay-ui:search-container-column-text>
+						<clay:dropdown-actions
+							dropdownItems="<%= contentDashboardAdminDisplayContext.getDropdownItems(contentDashboardItem) %>"
+							propsTransformer="js/transformers/ActionsComponentPropsTransformer"
 						/>
-					</liferay-ui:search-container>
-				</div>
-			</clay:sheet>
-		</div>
+					</liferay-ui:search-container-column-text>
+				</liferay-ui:search-container-row>
+
+				<liferay-ui:search-iterator
+					markupView="lexicon"
+				/>
+			</liferay-ui:search-container>
+		</clay:sheet>
 	</clay:container-fluid>
-</clay:row>
+</div>
 
 <liferay-frontend:component
 	componentId="<%= contentDashboardAdminManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view.jsp
@@ -26,111 +26,111 @@ DepotAdminManagementToolbarDisplayContext depotAdminManagementToolbarDisplayCont
 	displayContext="<%= depotAdminManagementToolbarDisplayContext %>"
 />
 
-<clay:container-fluid
-	cssClass="closed sidenav-container sidenav-right"
->
+<div class="closed sidenav-container sidenav-right">
 	<div class="sidenav-content">
-		<portlet:actionURL name="deleteGroups" var="deleteGroupsURL" />
+		<clay:container-fluid>
+			<portlet:actionURL name="deleteGroups" var="deleteGroupsURL" />
 
-		<aui:form action="<%= depotAdminDisplayContext.getIteratorURL() %>" cssClass="container-fluid container-fluid-max-xl" name="fm">
-			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+			<aui:form action="<%= depotAdminDisplayContext.getIteratorURL() %>" name="fm">
+				<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
-			<liferay-ui:search-container
-				id="<%= depotAdminDisplayContext.getSearchContainerId() %>"
-				searchContainer="<%= depotAdminDisplayContext.searchContainer() %>"
-			>
-				<liferay-ui:search-container-row
-					className="com.liferay.depot.model.DepotEntry"
-					cssClass="entry-display-style"
-					escapedModel="<%= true %>"
-					keyProperty="depotEntryId"
-					rowIdProperty="depotEntryId"
+				<liferay-ui:search-container
+					id="<%= depotAdminDisplayContext.getSearchContainerId() %>"
+					searchContainer="<%= depotAdminDisplayContext.searchContainer() %>"
 				>
+					<liferay-ui:search-container-row
+						className="com.liferay.depot.model.DepotEntry"
+						cssClass="entry-display-style"
+						escapedModel="<%= true %>"
+						keyProperty="depotEntryId"
+						rowIdProperty="depotEntryId"
+					>
 
-					<%
-					DepotEntry depotEntry = (DepotEntry)row.getObject();
+						<%
+						DepotEntry depotEntry = (DepotEntry)row.getObject();
 
-					Group depotEntryGroup = depotEntry.getGroup();
+						Group depotEntryGroup = depotEntry.getGroup();
 
-					row.setData(depotAdminManagementToolbarDisplayContext.getRowData(depotEntry));
-					%>
+						row.setData(depotAdminManagementToolbarDisplayContext.getRowData(depotEntry));
+						%>
 
-					<c:choose>
-						<c:when test="<%= depotAdminDisplayContext.isDisplayStyleDescriptive() %>">
-							<liferay-ui:search-container-column-text>
-								<liferay-ui:search-container-column-icon
-									icon="books"
-									toggleRowChecker="<%= true %>"
+						<c:choose>
+							<c:when test="<%= depotAdminDisplayContext.isDisplayStyleDescriptive() %>">
+								<liferay-ui:search-container-column-text>
+									<liferay-ui:search-container-column-icon
+										icon="books"
+										toggleRowChecker="<%= true %>"
+									/>
+								</liferay-ui:search-container-column-text>
+
+								<liferay-ui:search-container-column-text
+									colspan="<%= 2 %>"
+								>
+									<h5>
+										<aui:a cssClass="selector-button" href="<%= depotAdminDisplayContext.getViewDepotURL(depotEntry) %>">
+											<%= HtmlUtil.escape(depotEntryGroup.getDescriptiveName(locale)) %>
+										</aui:a>
+									</h5>
+
+									<h6>
+
+										<%
+										int depotEntryConnectedGroupsCount = depotAdminDisplayContext.getDepotEntryConnectedGroupsCount(depotEntry);
+										%>
+
+										<liferay-ui:message arguments="<%= depotEntryConnectedGroupsCount %>" key='<%= (depotEntryConnectedGroupsCount != 1) ? "x-connected-sites" : "x-connected-site" %>' />
+									</h6>
+								</liferay-ui:search-container-column-text>
+
+								<liferay-ui:search-container-column-text>
+									<clay:dropdown-actions
+										defaultEventHandler="<%= DepotAdminWebKeys.DEPOT_ENTRY_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
+										dropdownItems="<%= depotAdminDisplayContext.getActionDropdownItems(depotEntry) %>"
+									/>
+								</liferay-ui:search-container-column-text>
+							</c:when>
+							<c:when test="<%= depotAdminDisplayContext.isDisplayStyleIcon() %>">
+								<liferay-ui:search-container-column-text>
+									<clay:vertical-card
+										verticalCard="<%= depotAdminDisplayContext.getDepotEntryVerticalCard(depotEntry) %>"
+									/>
+								</liferay-ui:search-container-column-text>
+							</c:when>
+							<c:otherwise>
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand table-cell-minw-200 table-title"
+									name="name"
+									orderable="<%= true %>"
+								>
+									<aui:a href="<%= depotAdminDisplayContext.getViewDepotURL(depotEntry) %>" label="<%= HtmlUtil.escape(depotEntryGroup.getDescriptiveName(locale)) %>" localizeLabel="<%= false %>" />
+								</liferay-ui:search-container-column-text>
+
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand table-cell-minw-200"
+									name="num-of-connections"
+									value="<%= String.valueOf(depotAdminDisplayContext.getDepotEntryConnectedGroupsCount(depotEntry)) %>"
 								/>
-							</liferay-ui:search-container-column-text>
 
-							<liferay-ui:search-container-column-text
-								colspan="<%= 2 %>"
-							>
-								<h5>
-									<aui:a cssClass="selector-button" href="<%= depotAdminDisplayContext.getViewDepotURL(depotEntry) %>">
-										<%= HtmlUtil.escape(depotEntryGroup.getDescriptiveName(locale)) %>
-									</aui:a>
-								</h5>
+								<liferay-ui:search-container-column-text>
+									<clay:dropdown-actions
+										defaultEventHandler="<%= DepotAdminWebKeys.DEPOT_ENTRY_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
+										dropdownItems="<%= depotAdminDisplayContext.getActionDropdownItems(depotEntry) %>"
+									/>
+								</liferay-ui:search-container-column-text>
+							</c:otherwise>
+						</c:choose>
+					</liferay-ui:search-container-row>
 
-								<h6>
-
-									<%
-									int depotEntryConnectedGroupsCount = depotAdminDisplayContext.getDepotEntryConnectedGroupsCount(depotEntry);
-									%>
-
-									<liferay-ui:message arguments="<%= depotEntryConnectedGroupsCount %>" key='<%= (depotEntryConnectedGroupsCount != 1) ? "x-connected-sites" : "x-connected-site" %>' />
-								</h6>
-							</liferay-ui:search-container-column-text>
-
-							<liferay-ui:search-container-column-text>
-								<clay:dropdown-actions
-									defaultEventHandler="<%= DepotAdminWebKeys.DEPOT_ENTRY_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
-									dropdownItems="<%= depotAdminDisplayContext.getActionDropdownItems(depotEntry) %>"
-								/>
-							</liferay-ui:search-container-column-text>
-						</c:when>
-						<c:when test="<%= depotAdminDisplayContext.isDisplayStyleIcon() %>">
-							<liferay-ui:search-container-column-text>
-								<clay:vertical-card
-									verticalCard="<%= depotAdminDisplayContext.getDepotEntryVerticalCard(depotEntry) %>"
-								/>
-							</liferay-ui:search-container-column-text>
-						</c:when>
-						<c:otherwise>
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand table-cell-minw-200 table-title"
-								name="name"
-								orderable="<%= true %>"
-							>
-								<aui:a href="<%= depotAdminDisplayContext.getViewDepotURL(depotEntry) %>" label="<%= HtmlUtil.escape(depotEntryGroup.getDescriptiveName(locale)) %>" localizeLabel="<%= false %>" />
-							</liferay-ui:search-container-column-text>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand table-cell-minw-200"
-								name="num-of-connections"
-								value="<%= String.valueOf(depotAdminDisplayContext.getDepotEntryConnectedGroupsCount(depotEntry)) %>"
-							/>
-
-							<liferay-ui:search-container-column-text>
-								<clay:dropdown-actions
-									defaultEventHandler="<%= DepotAdminWebKeys.DEPOT_ENTRY_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
-									dropdownItems="<%= depotAdminDisplayContext.getActionDropdownItems(depotEntry) %>"
-								/>
-							</liferay-ui:search-container-column-text>
-						</c:otherwise>
-					</c:choose>
-				</liferay-ui:search-container-row>
-
-				<liferay-ui:search-iterator
-					displayStyle="<%= depotAdminDisplayContext.getDisplayStyle() %>"
-					markupView="lexicon"
-					searchContainer="<%= searchContainer %>"
-				/>
-			</liferay-ui:search-container>
-		</aui:form>
+					<liferay-ui:search-iterator
+						displayStyle="<%= depotAdminDisplayContext.getDisplayStyle() %>"
+						markupView="lexicon"
+						searchContainer="<%= searchContainer %>"
+					/>
+				</liferay-ui:search-container>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
-</clay:container-fluid>
+</div>
 
 <liferay-frontend:component
 	componentId="<%= DepotAdminWebKeys.DEPOT_ENTRY_DROPDOWN_DEFAULT_EVENT_HANDLER %>"

--- a/modules/apps/dispatch/dispatch-talend-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dispatch/dispatch-talend-web/src/main/resources/META-INF/resources/view.jsp
@@ -23,9 +23,9 @@ String fileEntryName = (String)request.getAttribute(DispatchWebKeys.FILE_ENTRY_N
 
 <liferay-portlet:actionURL name="/dispatch_talend/edit_dispatch_talend_job_archive" portletName="<%= DispatchPortletKeys.DISPATCH %>" var="editDispatchTalendJobArchiveActionURL" />
 
-<div class="closed container-fluid container-fluid-max-xl" id="<portlet:namespace />editDispatchTriggerId">
-	<div class="container main-content-body sheet">
-		<aui:form action="<%= editDispatchTalendJobArchiveActionURL %>" cssClass="container-fluid container-fluid-max-xl" enctype="multipart/form-data" method="post" name="fm">
+<div class="closed container-view" id="<portlet:namespace />editDispatchTriggerId">
+	<div class="sheet">
+		<aui:form action="<%= editDispatchTalendJobArchiveActionURL %>" enctype="multipart/form-data" method="post" name="fm">
 			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 			<aui:input name="dispatchTriggerId" type="hidden" value="<%= String.valueOf(dispatchTrigger.getDispatchTriggerId()) %>" />
 
@@ -50,11 +50,11 @@ String fileEntryName = (String)request.getAttribute(DispatchWebKeys.FILE_ENTRY_N
 				</div>
 			</c:if>
 
-			<aui:button-row>
-				<aui:button cssClass="btn-lg" type="submit" value="save" />
+			<div class="sheet-footer">
+				<aui:button type="submit" value="save" />
 
-				<aui:button cssClass="btn-lg" href="<%= currentURL %>" type="cancel" />
-			</aui:button-row>
+				<aui:button href="<%= currentURL %>" type="cancel" />
+			<div>
 		</aui:form>
 	</div>
 </div>

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/buttons.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/buttons.jsp
@@ -27,7 +27,7 @@ String runNowButton = "runNowButton" + row.getRowId();
 <span aria-hidden="true" class="<%= "hide icon-spinner icon-spin dispatch-check-row-icon-spinner" + row.getRowId() %>"></span>
 
 <c:if test="<%= DispatchTriggerPermission.contains(permissionChecker, dispatchTrigger, ActionKeys.UPDATE) %>">
-	<aui:button cssClass="btn-lg" name="<%= runNowButton %>" type="cancel" value="run-now" />
+	<aui:button name="<%= runNowButton %>" value="run-now" />
 </c:if>
 
 <aui:script use="aui-io-request,aui-parse-content,liferay-notification">

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/details.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/details.jsp
@@ -35,8 +35,8 @@ if (dispatchTrigger != null) {
 
 <portlet:actionURL name="/dispatch/edit_dispatch_trigger" var="editDispatchTriggerActionURL" />
 
-<div class="closed container-fluid container-fluid-max-xl" id="<portlet:namespace />editDispatchTriggerId">
-	<div class="container main-content-body sheet">
+<div class="closed container-view" id="<portlet:namespace />editDispatchTriggerId">
+	<div class="sheet">
 		<liferay-ui:error exception="<%= NoSuchLogException.class %>" message="the-log-could-not-be-found" />
 		<liferay-ui:error exception="<%= NoSuchTriggerException.class %>" message="the-trigger-could-not-be-found" />
 
@@ -58,16 +58,16 @@ if (dispatchTrigger != null) {
 
 				<div id="<portlet:namespace />dispatchTaskSettingsEditor"></div>
 
-				<aui:button-row>
+				<div class="sheet-footer">
 
 					<%
 					String taglibSaveOnClick = "Liferay.fire('" + liferayPortletResponse.getNamespace() + "saveTrigger');";
 					%>
 
-					<aui:button onClick="<%= taglibSaveOnClick %>" value="save" />
+					<aui:button onClick="<%= taglibSaveOnClick %>" primary="<%= true %>" value="save" />
 
-					<aui:button cssClass="btn-lg" href="<%= backURL %>" type="cancel" />
-				</aui:button-row>
+					<aui:button href="<%= backURL %>" type="cancel" />
+				</div>
 			</div>
 		</aui:form>
 	</div>

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/dispatch_trigger.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/dispatch_trigger.jsp
@@ -50,7 +50,7 @@ if ((dispatchTrigger != null) && (dispatchTrigger.getEndDate() != null)) {
 
 <portlet:actionURL name="/dispatch/edit_dispatch_trigger" var="editDispatchTriggerActionURL" />
 
-<aui:form action="<%= editDispatchTriggerActionURL %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm">
+<aui:form action="<%= editDispatchTriggerActionURL %>" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="schedule" />
 	<aui:input name="dispatchTriggerId" type="hidden" value="<%= String.valueOf(dispatchTrigger.getDispatchTriggerId()) %>" />
@@ -152,11 +152,11 @@ if ((dispatchTrigger != null) && (dispatchTrigger.getEndDate() != null)) {
 					</aui:field-wrapper>
 				</aui:fieldset>
 
-				<aui:button-row>
-					<aui:button cssClass="btn-lg" type="submit" value="save" />
+				<div class="sheet-footer">
+					<aui:button type="submit" value="save" />
 
-					<aui:button cssClass="btn-lg" href="<%= backURL %>" type="cancel" />
-				</aui:button-row>
+					<aui:button href="<%= backURL %>" type="cancel" />
+				</div>
 			</div>
 		</aui:fieldset>
 	</aui:fieldset-group>

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/dispatch_trigger_logs.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/dispatch_trigger_logs.jsp
@@ -33,7 +33,7 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 </liferay-util:include>
 
 <div id="<portlet:namespace />triggerLogsContainer">
-	<div class="closed container-fluid container-fluid-max-xl" id="<portlet:namespace />infoPanelId">
+	<div class="closed" id="<portlet:namespace />infoPanelId">
 		<aui:form action="<%= portletURL.toString() %>" method="post" name="fm">
 			<aui:input name="<%= Constants.CMD %>" type="hidden" />
 			<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/view.jsp
@@ -31,75 +31,73 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 </liferay-util:include>
 
 <div id="<portlet:namespace />dispatchTriggerContainer">
-	<div class="closed container-fluid container-fluid-max-xl" id="<portlet:namespace />infoPanelId">
-		<div class="container">
-			<aui:form action="<%= portletURL.toString() %>" method="post" name="fm">
-				<aui:input name="<%= Constants.CMD %>" type="hidden" />
-				<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
-				<aui:input name="deleteDispatchTriggerIds" type="hidden" />
+	<div class="closed container" id="<portlet:namespace />infoPanelId">
+		<aui:form action="<%= portletURL.toString() %>" method="post" name="fm">
+			<aui:input name="<%= Constants.CMD %>" type="hidden" />
+			<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
+			<aui:input name="deleteDispatchTriggerIds" type="hidden" />
 
-				<div class="dispatch-trigger-lists-container" id="<portlet:namespace />entriesContainer">
-					<liferay-ui:search-container
-						id="dispatchTriggers"
-						searchContainer="<%= dispatchTriggerDisplayContext.getSearchContainer() %>"
+			<div class="dispatch-trigger-lists-container" id="<portlet:namespace />entriesContainer">
+				<liferay-ui:search-container
+					id="dispatchTriggers"
+					searchContainer="<%= dispatchTriggerDisplayContext.getSearchContainer() %>"
+				>
+					<liferay-ui:search-container-row
+						className="com.liferay.dispatch.model.DispatchTrigger"
+						cssClass="entry-display-style"
+						keyProperty="dispatchTriggerId"
+						modelVar="dispatchTrigger"
 					>
-						<liferay-ui:search-container-row
-							className="com.liferay.dispatch.model.DispatchTrigger"
-							cssClass="entry-display-style"
-							keyProperty="dispatchTriggerId"
-							modelVar="dispatchTrigger"
-						>
 
-							<%
-							PortletURL rowURL = renderResponse.createRenderURL();
+						<%
+						PortletURL rowURL = renderResponse.createRenderURL();
 
-							rowURL.setParameter("mvcRenderCommandName", "/dispatch/edit_dispatch_trigger");
-							rowURL.setParameter("redirect", currentURL);
-							rowURL.setParameter("dispatchTriggerId", String.valueOf(dispatchTrigger.getDispatchTriggerId()));
-							%>
+						rowURL.setParameter("mvcRenderCommandName", "/dispatch/edit_dispatch_trigger");
+						rowURL.setParameter("redirect", currentURL);
+						rowURL.setParameter("dispatchTriggerId", String.valueOf(dispatchTrigger.getDispatchTriggerId()));
+						%>
 
-							<liferay-ui:search-container-column-text
-								cssClass="important table-cell-expand"
-								href="<%= rowURL %>"
-								property="name"
-							/>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand"
-								name="task-executor-type"
-								property="dispatchTaskExecutorType"
-							/>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand"
-								name="system"
-								value='<%= dispatchTrigger.isSystem() ? LanguageUtil.get(request, "yes") : LanguageUtil.get(request, "no") %>'
-							/>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand"
-								name="next-fire-date"
-								value="<%= dispatchTriggerDisplayContext.getNextFireDateString(dispatchTrigger.getDispatchTriggerId()) %>"
-							/>
-
-							<liferay-ui:search-container-column-jsp
-								cssClass="table-cell-expand"
-								path="/trigger/buttons.jsp"
-							/>
-
-							<liferay-ui:search-container-column-jsp
-								cssClass="entry-action-column"
-								path="/dispatch_trigger_action.jsp"
-							/>
-						</liferay-ui:search-container-row>
-
-						<liferay-ui:search-iterator
-							displayStyle="list"
-							markupView="lexicon"
+						<liferay-ui:search-container-column-text
+							cssClass="important table-cell-expand"
+							href="<%= rowURL %>"
+							property="name"
 						/>
-					</liferay-ui:search-container>
-				</div>
-			</aui:form>
-		</div>
+
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand"
+							name="task-executor-type"
+							property="dispatchTaskExecutorType"
+						/>
+
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand"
+							name="system"
+							value='<%= dispatchTrigger.isSystem() ? LanguageUtil.get(request, "yes") : LanguageUtil.get(request, "no") %>'
+						/>
+
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand"
+							name="next-fire-date"
+							value="<%= dispatchTriggerDisplayContext.getNextFireDateString(dispatchTrigger.getDispatchTriggerId()) %>"
+						/>
+
+						<liferay-ui:search-container-column-jsp
+							cssClass="table-cell-expand"
+							path="/trigger/buttons.jsp"
+						/>
+
+						<liferay-ui:search-container-column-jsp
+							cssClass="entry-action-column"
+							path="/dispatch_trigger_action.jsp"
+						/>
+					</liferay-ui:search-container-row>
+
+					<liferay-ui:search-iterator
+						displayStyle="list"
+						markupView="lexicon"
+					/>
+				</liferay-ui:search-container>
+			</div>
+		</aui:form>
 	</div>
 </div>

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/view_dispatch_log.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/view_dispatch_log.jsp
@@ -24,32 +24,34 @@ DispatchLog dispatchLog = dispatchLogDisplayContext.getDispatchLog();
 
 <portlet:actionURL name="/dispatch/edit_dispatch_log" var="editDispatchLogActionURL" />
 
-<div class="container-fluid container-fluid-max-xl sheet">
-	<aui:form action="<%= editDispatchLogActionURL %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm">
-		<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
-		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
-		<aui:input name="dispatchLogId" type="hidden" value="<%= String.valueOf(dispatchLog.getDispatchLogId()) %>" />
+<div class="container-fluid container-fluid-max-xl container-view">
+	<div class="sheet">
+		<aui:form action="<%= editDispatchLogActionURL %>" method="post" name="fm">
+			<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
+			<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
+			<aui:input name="dispatchLogId" type="hidden" value="<%= String.valueOf(dispatchLog.getDispatchLogId()) %>" />
 
-		<div class="lfr-form-content">
-			<aui:fieldset>
-				<aui:input disabled="<%= true %>" label="start-date" name="startDate" value="<%= dispatchLogDisplayContext.getDateString(dispatchLog.getStartDate()) %>" />
+			<div class="lfr-form-content">
+				<aui:fieldset>
+					<aui:input disabled="<%= true %>" label="start-date" name="startDate" value="<%= dispatchLogDisplayContext.getDateString(dispatchLog.getStartDate()) %>" />
 
-				<%
-				DispatchTaskStatus dispatchTaskStatus = DispatchTaskStatus.valueOf(dispatchLog.getStatus());
-				%>
+					<%
+					DispatchTaskStatus dispatchTaskStatus = DispatchTaskStatus.valueOf(dispatchLog.getStatus());
+					%>
 
-				<aui:input disabled="<%= true %>" name="status" value="<%= LanguageUtil.get(request, dispatchTaskStatus.getLabel()) %>" />
+					<aui:input disabled="<%= true %>" name="status" value="<%= LanguageUtil.get(request, dispatchTaskStatus.getLabel()) %>" />
 
-				<aui:input disabled="<%= true %>" label="runtime" name="runTime" value='<%= dispatchLogDisplayContext.getExecutionTimeMills() + " ms" %>' />
+					<aui:input disabled="<%= true %>" label="runtime" name="runTime" value='<%= dispatchLogDisplayContext.getExecutionTimeMills() + " ms" %>' />
 
-				<aui:input disabled="<%= true %>" label="error" name="error" type="textarea" value="<%= dispatchLog.getError() %>" />
+					<aui:input disabled="<%= true %>" label="error" name="error" type="textarea" value="<%= dispatchLog.getError() %>" />
 
-				<aui:input disabled="<%= true %>" label="output" name="output" type="textarea" value="<%= dispatchLog.getOutput() %>" />
-			</aui:fieldset>
+					<aui:input disabled="<%= true %>" label="output" name="output" type="textarea" value="<%= dispatchLog.getOutput() %>" />
+				</aui:fieldset>
 
-			<aui:button-row>
-				<aui:button cssClass="btn-lg" href="<%= backURL %>" type="cancel" />
-			</aui:button-row>
-		</div>
-	</aui:form>
+				<div class="sheet-footer">
+					<aui:button href="<%= backURL %>" type="cancel" />
+				</div>
+			</div>
+		</aui:form>
+	</div>
 </div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -75,7 +75,7 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 			boolean portletTitleBasedNavigation = GetterUtil.getBoolean(portletConfig.getInitParameter("portlet-title-based-navigation"));
 			%>
 
-			<div class="closed <%= portletTitleBasedNavigation ? "container-fluid container-fluid-max-xl" : StringPool.BLANK %> sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+			<div class="closed sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
 				<liferay-frontend:sidebar-panel
 					resourceURL="<%= dlViewDisplayContext.getSidebarPanelURL() %>"
 					searchContainerId="entries"
@@ -84,99 +84,101 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 				</liferay-frontend:sidebar-panel>
 
 				<div class="sidenav-content">
-					<div class="document-library-breadcrumb" id="<portlet:namespace />breadcrumbContainer">
-						<c:if test="<%= !dlViewDisplayContext.isSearch() %>">
-
-							<%
-							DLBreadcrumbUtil.addPortletBreadcrumbEntries(dlViewDisplayContext.getFolder(), request, liferayPortletResponse);
-							%>
-
-							<liferay-ui:breadcrumb
-								showCurrentGroup="<%= false %>"
-								showGuestGroup="<%= false %>"
-								showLayout="<%= false %>"
-								showParentGroups="<%= false %>"
-							/>
-						</c:if>
-					</div>
-
-					<c:if test="<%= dlViewDisplayContext.isOpenInMSOfficeEnabled() %>">
-						<div class="alert alert-danger hide" id="<portlet:namespace />openMSOfficeError"></div>
-					</c:if>
-
-					<aui:form action="<%= dlViewDisplayContext.getEditFileEntryURL() %>" method="get" name="fm2">
-						<aui:input name="<%= Constants.CMD %>" type="hidden" />
-						<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
-						<aui:input name="repositoryId" type="hidden" value="<%= dlViewDisplayContext.getRepositoryId() %>" />
-						<aui:input name="newFolderId" type="hidden" />
-						<aui:input name="folderId" type="hidden" value="<%= dlViewDisplayContext.getFolderId() %>" />
-						<aui:input name="changeLog" type="hidden" />
-						<aui:input name="versionIncrease" type="hidden" />
-						<aui:input name="selectAll" type="hidden" value="<%= false %>" />
-
-						<liferay-util:dynamic-include key="com.liferay.document.library.web#/document_library/view.jsp#errors" />
-
-						<liferay-ui:error exception="<%= AuthenticationRepositoryException.class %>" message="you-cannot-access-the-repository-because-you-are-not-allowed-to-or-it-is-unavailable" />
-						<liferay-ui:error exception="<%= DuplicateFileEntryException.class %>" message="the-folder-you-selected-already-has-an-entry-with-this-name.-please-select-a-different-folder" />
-						<liferay-ui:error exception="<%= FileEntryLockException.MustBeUnlocked.class %>" message="you-cannot-perform-this-operation-on-checked-out-documents-.please-check-it-in-or-cancel-the-checkout-first" />
-						<liferay-ui:error exception="<%= FileEntryLockException.MustOwnLock.class %>" message="you-can-only-checkin-documents-you-have-checked-out-yourself" />
-						<liferay-ui:error key="externalServiceFailed" message="you-cannot-access-external-service-because-you-are-not-allowed-to-or-it-is-unavailable" />
-
-						<div class="document-container">
-							<c:choose>
-								<c:when test="<%= dlViewDisplayContext.isSearch() %>">
-									<liferay-util:include page="/document_library/search_resources.jsp" servletContext="<%= application %>" />
-								</c:when>
-								<c:otherwise>
-									<liferay-util:include page="/document_library/view_entries.jsp" servletContext="<%= application %>" />
-								</c:otherwise>
-							</c:choose>
-
-							<div class="lfr-template" id="<portlet:namespace />appViewEntryTemplates">
+					<div class="<%= portletTitleBasedNavigation ? "container-fluid container-fluid-max-xl container-view" : StringPool.BLANK %>">
+						<div class="document-library-breadcrumb" id="<portlet:namespace />breadcrumbContainer">
+							<c:if test="<%= !dlViewDisplayContext.isSearch() %>">
 
 								<%
-								String thumbnailSrc = themeDisplay.getPathThemeImages() + "/file_system/large/default.png";
+								DLBreadcrumbUtil.addPortletBreadcrumbEntries(dlViewDisplayContext.getFolder(), request, liferayPortletResponse);
 								%>
 
-								<liferay-frontend:vertical-card
-									cssClass="display-icon entry-display-style"
-									imageUrl="<%= thumbnailSrc %>"
-									title="{title}"
-									url="<%= dlViewDisplayContext.getUploadURL() %>"
-								>
-									<liferay-frontend:vertical-card-header>
-										<liferay-ui:message arguments="<%= HtmlUtil.escape(user.getFullName()) %>" key="right-now-by-x" />
-									</liferay-frontend:vertical-card-header>
-								</liferay-frontend:vertical-card>
+								<liferay-ui:breadcrumb
+									showCurrentGroup="<%= false %>"
+									showGuestGroup="<%= false %>"
+									showLayout="<%= false %>"
+									showParentGroups="<%= false %>"
+								/>
+							</c:if>
+						</div>
 
-								<li class="display-descriptive entry-display-style list-group-item">
-									<div class="autofit-col"></div>
+						<c:if test="<%= dlViewDisplayContext.isOpenInMSOfficeEnabled() %>">
+							<div class="alert alert-danger hide" id="<portlet:namespace />openMSOfficeError"></div>
+						</c:if>
 
-									<div class="autofit-col">
-										<div class="click-selector sticker sticker-user-icon sticker-xl">
-											<div class="sticker-overlay">
-												<img alt="thumbnail" class="sticker-img" src="<%= thumbnailSrc %>" />
+						<aui:form action="<%= dlViewDisplayContext.getEditFileEntryURL() %>" method="get" name="fm2">
+							<aui:input name="<%= Constants.CMD %>" type="hidden" />
+							<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+							<aui:input name="repositoryId" type="hidden" value="<%= dlViewDisplayContext.getRepositoryId() %>" />
+							<aui:input name="newFolderId" type="hidden" />
+							<aui:input name="folderId" type="hidden" value="<%= dlViewDisplayContext.getFolderId() %>" />
+							<aui:input name="changeLog" type="hidden" />
+							<aui:input name="versionIncrease" type="hidden" />
+							<aui:input name="selectAll" type="hidden" value="<%= false %>" />
+
+							<liferay-util:dynamic-include key="com.liferay.document.library.web#/document_library/view.jsp#errors" />
+
+							<liferay-ui:error exception="<%= AuthenticationRepositoryException.class %>" message="you-cannot-access-the-repository-because-you-are-not-allowed-to-or-it-is-unavailable" />
+							<liferay-ui:error exception="<%= DuplicateFileEntryException.class %>" message="the-folder-you-selected-already-has-an-entry-with-this-name.-please-select-a-different-folder" />
+							<liferay-ui:error exception="<%= FileEntryLockException.MustBeUnlocked.class %>" message="you-cannot-perform-this-operation-on-checked-out-documents-.please-check-it-in-or-cancel-the-checkout-first" />
+							<liferay-ui:error exception="<%= FileEntryLockException.MustOwnLock.class %>" message="you-can-only-checkin-documents-you-have-checked-out-yourself" />
+							<liferay-ui:error key="externalServiceFailed" message="you-cannot-access-external-service-because-you-are-not-allowed-to-or-it-is-unavailable" />
+
+							<div class="document-container">
+								<c:choose>
+									<c:when test="<%= dlViewDisplayContext.isSearch() %>">
+										<liferay-util:include page="/document_library/search_resources.jsp" servletContext="<%= application %>" />
+									</c:when>
+									<c:otherwise>
+										<liferay-util:include page="/document_library/view_entries.jsp" servletContext="<%= application %>" />
+									</c:otherwise>
+								</c:choose>
+
+								<div class="lfr-template" id="<portlet:namespace />appViewEntryTemplates">
+
+									<%
+									String thumbnailSrc = themeDisplay.getPathThemeImages() + "/file_system/large/default.png";
+									%>
+
+									<liferay-frontend:vertical-card
+										cssClass="display-icon entry-display-style"
+										imageUrl="<%= thumbnailSrc %>"
+										title="{title}"
+										url="<%= dlViewDisplayContext.getUploadURL() %>"
+									>
+										<liferay-frontend:vertical-card-header>
+											<liferay-ui:message arguments="<%= HtmlUtil.escape(user.getFullName()) %>" key="right-now-by-x" />
+										</liferay-frontend:vertical-card-header>
+									</liferay-frontend:vertical-card>
+
+									<li class="display-descriptive entry-display-style list-group-item">
+										<div class="autofit-col"></div>
+
+										<div class="autofit-col">
+											<div class="click-selector sticker sticker-user-icon sticker-xl">
+												<div class="sticker-overlay">
+													<img alt="thumbnail" class="sticker-img" src="<%= thumbnailSrc %>" />
+												</div>
 											</div>
 										</div>
-									</div>
 
-									<div class="autofit-col autofit-col-expand">
-										<h5 class="text-default">
-											<liferay-ui:message arguments="<%= HtmlUtil.escape(user.getFullName()) %>" key="right-now-by-x" />
-										</h5>
+										<div class="autofit-col autofit-col-expand">
+											<h5 class="text-default">
+												<liferay-ui:message arguments="<%= HtmlUtil.escape(user.getFullName()) %>" key="right-now-by-x" />
+											</h5>
 
-										<h4>
-											<aui:a href="<%= dlViewDisplayContext.getUploadURL() %>">
-												{title}
-											</aui:a>
-										</h4>
-									</div>
+											<h4>
+												<aui:a href="<%= dlViewDisplayContext.getUploadURL() %>">
+													{title}
+												</aui:a>
+											</h4>
+										</div>
 
-									<div class="autofit-col"></div>
-								</li>
+										<div class="autofit-col"></div>
+									</li>
+								</div>
 							</div>
-						</div>
-					</aui:form>
+						</aui:form>
+					</div>
 				</div>
 			</div>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
@@ -26,9 +26,7 @@ DLViewFileEntryMetadataSetsDisplayContext dLViewFileEntryMetadataSetsDisplayCont
 	displayContext="<%= new DLViewFileEntryMetadataSetsManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, dLViewFileEntryMetadataSetsDisplayContext) %>"
 />
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByStructureLinks.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-structure-links" />
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByTemplates.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-templates" />
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureThatHasChild.class %>" message="the-structure-cannot-be-deleted-because-it-has-one-or-more-substructures" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
@@ -32,9 +32,7 @@ DLViewFileEntryTypesDisplayContext dlViewFileEntryTypesDisplayContext = new DLVi
 	selectable="<%= false %>"
 />
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<liferay-ui:breadcrumb
 		showLayout="<%= false %>"
 	/>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
@@ -29,7 +29,7 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 %>
 
 <clay:container-fluid
-	cssClass="lfr-spreadsheet-container"
+	cssClass="container-view lfr-spreadsheet-container"
 >
 	<div id="<portlet:namespace />spreadsheet">
 		<div class="table-striped yui3-datatable yui3-widget" id="<portlet:namespace />dataTable">

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/expando.jsp
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/expando.jsp
@@ -115,57 +115,59 @@ else {
 	<portlet:param name="mvcPath" value="/edit/expando.jsp" />
 </portlet:actionURL>
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-view"
+>
 	<liferay-ui:breadcrumb
 		showCurrentGroup="<%= false %>"
 		showGuestGroup="<%= false %>"
 		showLayout="<%= false %>"
 		showPortletBreadcrumb="<%= true %>"
 	/>
+
+	<liferay-frontend:edit-form
+		action="<%= editExpandoURL %>"
+	>
+		<aui:input name="redirect" type="hidden" value="<%= portletURL %>" />
+		<aui:input name="columnId" type="hidden" value="<%= columnId %>" />
+		<aui:input name="modelResource" type="hidden" value="<%= modelResource %>" />
+		<aui:input name="type" type="hidden" value="<%= type %>" />
+
+		<aui:input name="Property--display-type--" type="hidden" value="<%= propertyDisplayType %>" />
+
+		<liferay-frontend:edit-form-body>
+			<h2 class="sheet-title">
+				<%= LanguageUtil.format(request, expandoColumn != null ? "edit-x" : "new-x", new Object[] {propertyDisplayType}) %>
+			</h2>
+
+			<liferay-frontend:fieldset-group>
+				<aui:field-wrapper cssClass="form-group lfr-input-text-container">
+					<c:choose>
+						<c:when test="<%= expandoColumn != null %>">
+							<aui:input name="name" type="hidden" value="<%= expandoColumn.getName() %>" />
+
+							<aui:input label="field-name" name="key" type="resource" value="<%= expandoColumn.getName() %>" />
+						</c:when>
+						<c:otherwise>
+							<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>" label="field-name" maxlength='<%= ModelHintsUtil.getMaxLength(ExpandoColumn.class.getName(), "name") %>' name="name" required="<%= true %>" />
+						</c:otherwise>
+					</c:choose>
+
+					<div class="form-text">
+						<liferay-ui:message arguments="&lt;liferay-expando:custom-attribute /&gt;" key="custom-field-key-help" translateArguments="<%= false %>" />
+					</div>
+				</aui:field-wrapper>
+
+				<%@ include file="/edit/default_value_input.jspf" %>
+
+				<%@ include file="/edit/advanced_properties.jspf" %>
+			</liferay-frontend:fieldset-group>
+		</liferay-frontend:edit-form-body>
+
+		<liferay-frontend:edit-form-footer>
+			<aui:button type="submit" />
+
+			<aui:button href="<%= redirect %>" type="cancel" />
+		</liferay-frontend:edit-form-footer>
+	</liferay-frontend:edit-form>
 </clay:container-fluid>
-
-<liferay-frontend:edit-form
-	action="<%= editExpandoURL %>"
->
-	<aui:input name="redirect" type="hidden" value="<%= portletURL %>" />
-	<aui:input name="columnId" type="hidden" value="<%= columnId %>" />
-	<aui:input name="modelResource" type="hidden" value="<%= modelResource %>" />
-	<aui:input name="type" type="hidden" value="<%= type %>" />
-
-	<aui:input name="Property--display-type--" type="hidden" value="<%= propertyDisplayType %>" />
-
-	<liferay-frontend:edit-form-body>
-		<h2 class="sheet-title">
-			<%= LanguageUtil.format(request, expandoColumn != null ? "edit-x" : "new-x", new Object[] {propertyDisplayType}) %>
-		</h2>
-
-		<liferay-frontend:fieldset-group>
-			<aui:field-wrapper cssClass="form-group lfr-input-text-container">
-				<c:choose>
-					<c:when test="<%= expandoColumn != null %>">
-						<aui:input name="name" type="hidden" value="<%= expandoColumn.getName() %>" />
-
-						<aui:input label="field-name" name="key" type="resource" value="<%= expandoColumn.getName() %>" />
-					</c:when>
-					<c:otherwise>
-						<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>" label="field-name" maxlength='<%= ModelHintsUtil.getMaxLength(ExpandoColumn.class.getName(), "name") %>' name="name" required="<%= true %>" />
-					</c:otherwise>
-				</c:choose>
-
-				<div class="form-text">
-					<liferay-ui:message arguments="&lt;liferay-expando:custom-attribute /&gt;" key="custom-field-key-help" translateArguments="<%= false %>" />
-				</div>
-			</aui:field-wrapper>
-
-			<%@ include file="/edit/default_value_input.jspf" %>
-
-			<%@ include file="/edit/advanced_properties.jspf" %>
-		</liferay-frontend:fieldset-group>
-	</liferay-frontend:edit-form-body>
-
-	<liferay-frontend:edit-form-footer>
-		<aui:button type="submit" />
-
-		<aui:button href="<%= redirect %>" type="cancel" />
-	</liferay-frontend:edit-form-footer>
-</liferay-frontend:edit-form>

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/select_field_type.jsp
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/select_field_type.jsp
@@ -49,254 +49,256 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "view-at
 PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "new-custom-field"), null);
 %>
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-view"
+>
 	<liferay-ui:breadcrumb
 		showCurrentGroup="<%= false %>"
 		showGuestGroup="<%= false %>"
 		showLayout="<%= false %>"
 		showPortletBreadcrumb="<%= true %>"
 	/>
-</clay:container-fluid>
 
-<liferay-frontend:edit-form>
-	<liferay-frontend:edit-form-body>
-		<clay:sheet-header>
-			<h2 class="sheet-title">
-				<liferay-ui:message key="new-custom-field" />
-			</h2>
-		</clay:sheet-header>
+	<liferay-frontend:edit-form>
+		<liferay-frontend:edit-form-body>
+			<clay:sheet-header>
+				<h2 class="sheet-title">
+					<liferay-ui:message key="new-custom-field" />
+				</h2>
+			</clay:sheet-header>
 
-		<clay:row
-			cssClass="clay-site-row-spacer"
-		>
-			<clay:col
-				size="12"
+			<clay:row
+				cssClass="clay-site-row-spacer"
 			>
-				<h3 class="sheet-subtitle">
-					<liferay-ui:message key="text-and-numbers" />
-				</h3>
-			</clay:col>
+				<clay:col
+					size="12"
+				>
+					<h3 class="sheet-subtitle">
+						<liferay-ui:message key="text-and-numbers" />
+					</h3>
+				</clay:col>
 
-			<clay:col
-				md="4"
-			>
-				<portlet:renderURL var="createTextAreaURL">
-					<portlet:param name="mvcPath" value="/edit/expando.jsp" />
-					<portlet:param name="redirect" value="<%= currentURL %>" />
-					<portlet:param name="modelResource" value="<%= modelResource %>" />
-					<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_TEXT_BOX %>" />
-					<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.STRING) %>" />
-				</portlet:renderURL>
+				<clay:col
+					md="4"
+				>
+					<portlet:renderURL var="createTextAreaURL">
+						<portlet:param name="mvcPath" value="/edit/expando.jsp" />
+						<portlet:param name="redirect" value="<%= currentURL %>" />
+						<portlet:param name="modelResource" value="<%= modelResource %>" />
+						<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_TEXT_BOX %>" />
+						<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.STRING) %>" />
+					</portlet:renderURL>
 
-				<a class="card card-interactive card-interactive-secondary" href="<%= createTextAreaURL %>">
-					<div class="card-body">
-						<label>
-							<liferay-ui:message key="text-area" />
-						</label>
-
-						<span class="form-control form-control-textarea"></span>
-					</div>
-				</a>
-			</clay:col>
-
-			<clay:col
-				md="4"
-			>
-				<portlet:renderURL var="createInputFieldURL">
-					<portlet:param name="mvcPath" value="/edit/expando.jsp" />
-					<portlet:param name="redirect" value="<%= currentURL %>" />
-					<portlet:param name="modelResource" value="<%= modelResource %>" />
-					<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_INPUT_FIELD %>" />
-					<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.STRING) %>" />
-				</portlet:renderURL>
-
-				<a class="card card-interactive card-interactive-secondary" href="<%= createInputFieldURL %>">
-					<div class="card-body">
-						<label>
-							<liferay-ui:message key="input-field" />
-						</label>
-
-						<span class="form-control"></span>
-					</div>
-				</a>
-			</clay:col>
-
-			<clay:col
-				size="12"
-			>
-				<h3 class="sheet-subtitle">
-					<liferay-ui:message key="selection" />
-				</h3>
-			</clay:col>
-
-			<clay:col
-				md="4"
-			>
-				<portlet:renderURL var="createDropdownURL">
-					<portlet:param name="mvcPath" value="/edit/expando.jsp" />
-					<portlet:param name="redirect" value="<%= currentURL %>" />
-					<portlet:param name="modelResource" value="<%= modelResource %>" />
-					<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST %>" />
-					<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.STRING_ARRAY) %>" />
-				</portlet:renderURL>
-
-				<a class="card card-interactive card-interactive-secondary" href="<%= createDropdownURL %>">
-					<div class="card-body">
-						<label>
-							<liferay-ui:message key="dropdown" />
-						</label>
-
-						<span class="form-control form-control-select">Option 1</span>
-					</div>
-				</a>
-			</clay:col>
-
-			<clay:col
-				md="4"
-			>
-				<portlet:renderURL var="createCheckboxURL">
-					<portlet:param name="mvcPath" value="/edit/expando.jsp" />
-					<portlet:param name="redirect" value="<%= currentURL %>" />
-					<portlet:param name="modelResource" value="<%= modelResource %>" />
-					<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_CHECKBOX %>" />
-					<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.STRING_ARRAY) %>" />
-				</portlet:renderURL>
-
-				<a class="card card-interactive card-interactive-secondary" href="<%= createCheckboxURL %>">
-					<div class="card-body">
-						<span class="custom-checkbox custom-control">
+					<a class="card card-interactive card-interactive-secondary" href="<%= createTextAreaURL %>">
+						<div class="card-body">
 							<label>
-								<span class="custom-control-label">
-									<span class="custom-control-label-text">
-										<liferay-ui:message key="checkbox" />
-									</span>
-								</span>
+								<liferay-ui:message key="text-area" />
 							</label>
-						</span>
-					</div>
-				</a>
-			</clay:col>
 
-			<clay:col
-				md="4"
-			>
-				<portlet:renderURL var="createRadioURL">
-					<portlet:param name="mvcPath" value="/edit/expando.jsp" />
-					<portlet:param name="redirect" value="<%= currentURL %>" />
-					<portlet:param name="modelResource" value="<%= modelResource %>" />
-					<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_RADIO %>" />
-					<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.STRING_ARRAY) %>" />
-				</portlet:renderURL>
-
-				<a class="card card-interactive card-interactive-secondary" href="<%= createRadioURL %>">
-					<div class="card-body">
-						<span class="custom-control custom-radio">
-							<label>
-								<span class="custom-control-label">
-									<span class="custom-control-label-text">
-										<liferay-ui:message key="radio" />
-									</span>
-								</span>
-							</label>
-						</span>
-					</div>
-				</a>
-			</clay:col>
-
-			<clay:col
-				size="12"
-			>
-				<h3 class="sheet-subtitle">
-					<liferay-ui:message key="others" />
-				</h3>
-			</clay:col>
-
-			<clay:col
-				md="4"
-			>
-				<portlet:renderURL var="createGeolocationURL">
-					<portlet:param name="mvcPath" value="/edit/expando.jsp" />
-					<portlet:param name="redirect" value="<%= currentURL %>" />
-					<portlet:param name="modelResource" value="<%= modelResource %>" />
-					<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_GEOLOCATION %>" />
-					<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.GEOLOCATION) %>" />
-				</portlet:renderURL>
-
-				<a class="card card-interactive card-interactive-secondary" href="<%= createGeolocationURL %>">
-					<div class="card-body">
-						<label>
-							<liferay-ui:message key="geolocation" />
-						</label>
-
-						<div class="aspect-ratio custom-aspect-ratio-geolocation">
-							<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-flush" src="<%= PortalUtil.getPathContext(request) %>/images/map.svg" />
+							<span class="form-control form-control-textarea"></span>
 						</div>
-					</div>
-				</a>
-			</clay:col>
+					</a>
+				</clay:col>
 
-			<clay:col
-				md="4"
-			>
-				<portlet:renderURL var="createDateURL">
-					<portlet:param name="mvcPath" value="/edit/expando.jsp" />
-					<portlet:param name="redirect" value="<%= currentURL %>" />
-					<portlet:param name="modelResource" value="<%= modelResource %>" />
-					<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_DATE %>" />
-					<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.DATE) %>" />
-				</portlet:renderURL>
+				<clay:col
+					md="4"
+				>
+					<portlet:renderURL var="createInputFieldURL">
+						<portlet:param name="mvcPath" value="/edit/expando.jsp" />
+						<portlet:param name="redirect" value="<%= currentURL %>" />
+						<portlet:param name="modelResource" value="<%= modelResource %>" />
+						<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_INPUT_FIELD %>" />
+						<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.STRING) %>" />
+					</portlet:renderURL>
 
-				<a class="card card-interactive card-interactive-secondary" href="<%= createDateURL %>">
-					<div class="card-body">
-						<label>
-							<liferay-ui:message key="date" />
-						</label>
+					<a class="card card-interactive card-interactive-secondary" href="<%= createInputFieldURL %>">
+						<div class="card-body">
+							<label>
+								<liferay-ui:message key="input-field" />
+							</label>
 
-						<div class="input-group">
-							<div class="input-group-item">
-								<div class="form-control input-group-inset input-group-inset-after">YYYY-MM-DD</div>
+							<span class="form-control"></span>
+						</div>
+					</a>
+				</clay:col>
 
-								<div class="input-group-inset-item input-group-inset-item-after">
-									<div class="align-items-center btn btn-unstyled d-flex">
-										<clay:icon
-											symbol="calendar"
-										/>
+				<clay:col
+					size="12"
+				>
+					<h3 class="sheet-subtitle">
+						<liferay-ui:message key="selection" />
+					</h3>
+				</clay:col>
+
+				<clay:col
+					md="4"
+				>
+					<portlet:renderURL var="createDropdownURL">
+						<portlet:param name="mvcPath" value="/edit/expando.jsp" />
+						<portlet:param name="redirect" value="<%= currentURL %>" />
+						<portlet:param name="modelResource" value="<%= modelResource %>" />
+						<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST %>" />
+						<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.STRING_ARRAY) %>" />
+					</portlet:renderURL>
+
+					<a class="card card-interactive card-interactive-secondary" href="<%= createDropdownURL %>">
+						<div class="card-body">
+							<label>
+								<liferay-ui:message key="dropdown" />
+							</label>
+
+							<span class="form-control form-control-select">Option 1</span>
+						</div>
+					</a>
+				</clay:col>
+
+				<clay:col
+					md="4"
+				>
+					<portlet:renderURL var="createCheckboxURL">
+						<portlet:param name="mvcPath" value="/edit/expando.jsp" />
+						<portlet:param name="redirect" value="<%= currentURL %>" />
+						<portlet:param name="modelResource" value="<%= modelResource %>" />
+						<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_CHECKBOX %>" />
+						<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.STRING_ARRAY) %>" />
+					</portlet:renderURL>
+
+					<a class="card card-interactive card-interactive-secondary" href="<%= createCheckboxURL %>">
+						<div class="card-body">
+							<span class="custom-checkbox custom-control">
+								<label>
+									<span class="custom-control-label">
+										<span class="custom-control-label-text">
+											<liferay-ui:message key="checkbox" />
+										</span>
+									</span>
+								</label>
+							</span>
+						</div>
+					</a>
+				</clay:col>
+
+				<clay:col
+					md="4"
+				>
+					<portlet:renderURL var="createRadioURL">
+						<portlet:param name="mvcPath" value="/edit/expando.jsp" />
+						<portlet:param name="redirect" value="<%= currentURL %>" />
+						<portlet:param name="modelResource" value="<%= modelResource %>" />
+						<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_RADIO %>" />
+						<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.STRING_ARRAY) %>" />
+					</portlet:renderURL>
+
+					<a class="card card-interactive card-interactive-secondary" href="<%= createRadioURL %>">
+						<div class="card-body">
+							<span class="custom-control custom-radio">
+								<label>
+									<span class="custom-control-label">
+										<span class="custom-control-label-text">
+											<liferay-ui:message key="radio" />
+										</span>
+									</span>
+								</label>
+							</span>
+						</div>
+					</a>
+				</clay:col>
+
+				<clay:col
+					size="12"
+				>
+					<h3 class="sheet-subtitle">
+						<liferay-ui:message key="others" />
+					</h3>
+				</clay:col>
+
+				<clay:col
+					md="4"
+				>
+					<portlet:renderURL var="createGeolocationURL">
+						<portlet:param name="mvcPath" value="/edit/expando.jsp" />
+						<portlet:param name="redirect" value="<%= currentURL %>" />
+						<portlet:param name="modelResource" value="<%= modelResource %>" />
+						<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_GEOLOCATION %>" />
+						<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.GEOLOCATION) %>" />
+					</portlet:renderURL>
+
+					<a class="card card-interactive card-interactive-secondary" href="<%= createGeolocationURL %>">
+						<div class="card-body">
+							<label>
+								<liferay-ui:message key="geolocation" />
+							</label>
+
+							<div class="aspect-ratio custom-aspect-ratio-geolocation">
+								<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-flush" src="<%= PortalUtil.getPathContext(request) %>/images/map.svg" />
+							</div>
+						</div>
+					</a>
+				</clay:col>
+
+				<clay:col
+					md="4"
+				>
+					<portlet:renderURL var="createDateURL">
+						<portlet:param name="mvcPath" value="/edit/expando.jsp" />
+						<portlet:param name="redirect" value="<%= currentURL %>" />
+						<portlet:param name="modelResource" value="<%= modelResource %>" />
+						<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_DATE %>" />
+						<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.DATE) %>" />
+					</portlet:renderURL>
+
+					<a class="card card-interactive card-interactive-secondary" href="<%= createDateURL %>">
+						<div class="card-body">
+							<label>
+								<liferay-ui:message key="date" />
+							</label>
+
+							<div class="input-group">
+								<div class="input-group-item">
+									<div class="form-control input-group-inset input-group-inset-after">YYYY-MM-DD</div>
+
+									<div class="input-group-inset-item input-group-inset-item-after">
+										<div class="align-items-center btn btn-unstyled d-flex">
+											<clay:icon
+												symbol="calendar"
+											/>
+										</div>
 									</div>
 								</div>
 							</div>
 						</div>
-					</div>
-				</a>
-			</clay:col>
+					</a>
+				</clay:col>
 
-			<clay:col
-				md="4"
-			>
-				<portlet:renderURL var="createBooleanURL">
-					<portlet:param name="mvcPath" value="/edit/expando.jsp" />
-					<portlet:param name="redirect" value="<%= currentURL %>" />
-					<portlet:param name="modelResource" value="<%= modelResource %>" />
-					<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_BOOLEAN %>" />
-					<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.BOOLEAN) %>" />
-				</portlet:renderURL>
+				<clay:col
+					md="4"
+				>
+					<portlet:renderURL var="createBooleanURL">
+						<portlet:param name="mvcPath" value="/edit/expando.jsp" />
+						<portlet:param name="redirect" value="<%= currentURL %>" />
+						<portlet:param name="modelResource" value="<%= modelResource %>" />
+						<portlet:param name="displayType" value="<%= ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_BOOLEAN %>" />
+						<portlet:param name="type" value="<%= String.valueOf(ExpandoColumnConstants.BOOLEAN) %>" />
+					</portlet:renderURL>
 
-				<a class="card card-interactive card-interactive-secondary" href="<%= createBooleanURL %>">
-					<div class="card-body custom-card-body-boolean">
-						<span class="simple-toggle-switch toggle-switch">
-							<span class="toggle-switch-check-bar">
-								<span class="toggle-switch-check"></span>
-								<span aria-hidden="true" class="toggle-switch-bar">
-									<span class="toggle-switch-handle"></span>
+					<a class="card card-interactive card-interactive-secondary" href="<%= createBooleanURL %>">
+						<div class="card-body custom-card-body-boolean">
+							<span class="simple-toggle-switch toggle-switch">
+								<span class="toggle-switch-check-bar">
+									<span class="toggle-switch-check"></span>
+									<span aria-hidden="true" class="toggle-switch-bar">
+										<span class="toggle-switch-handle"></span>
+									</span>
 								</span>
-							</span>
 
-							<label>
-								<liferay-ui:message key="true-or-false" />
-							</label>
-						</span>
-					</div>
-				</a>
-			</clay:col>
-		</clay:row>
-	</liferay-frontend:edit-form-body>
-</liferay-frontend:edit-form>
+								<label>
+									<liferay-ui:message key="true-or-false" />
+								</label>
+							</span>
+						</div>
+					</a>
+				</clay:col>
+			</clay:row>
+		</liferay-frontend:edit-form-body>
+	</liferay-frontend:edit-form>
+</clay:container-fluid>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/start.jsp
@@ -20,7 +20,7 @@
 String fullName = namespace.concat(HtmlUtil.escapeAttribute(name));
 %>
 
-<form action="<%= HtmlUtil.escapeAttribute(action) %>" class="container-lg container-no-gutters-sm-down container-view form <%= cssClass %> <%= inlineLabels ? "field-labels-inline" : StringPool.BLANK %>" data-fm-namespace="<%= namespace %>" id="<%= fullName %>" method="<%= method %>" name="<%= fullName %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
+<form action="<%= HtmlUtil.escapeAttribute(action) %>" class="container-fluid container-fluid-max-xl container-no-gutters form <%= cssClass %> <%= inlineLabels ? "field-labels-inline" : StringPool.BLANK %>" data-fm-namespace="<%= namespace %>" id="<%= fullName %>" method="<%= method %>" name="<%= fullName %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
 	<c:if test="<%= !themeDisplay.isStatePopUp() %>">
 		<div class="sheet <%= fluid ? StringPool.BLANK : "sheet-lg" %>">
 	</c:if>

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_dialog.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_dialog.scss
@@ -19,7 +19,7 @@
 	}
 
 	.lfr-form-content {
-		padding: 15px;
+		padding: 24px 12px;
 	}
 
 	.portlet-body,

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_misc.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_misc.scss
@@ -23,7 +23,7 @@
 }
 
 .main-content-body {
-	margin-top: 20px;
+	margin-top: 24px;
 }
 
 .restricted {

--- a/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view_invite.jsp
+++ b/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view_invite.jsp
@@ -36,9 +36,7 @@ Group group = GroupLocalServiceUtil.getGroup(scopeGroupId);
 		<aui:input name="invitedTeamId" type="hidden" value="" />
 
 		<div class="dialog-body">
-			<clay:container-fluid
-				cssClass="main-content-body"
-			>
+			<clay:container-fluid>
 				<aui:fieldset-group markupView="lexicon">
 					<aui:fieldset>
 						<label><liferay-ui:message key="find-members" /></label>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -68,10 +68,7 @@ if (parentResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 	sortingURL="<%= String.valueOf(kbAdminManagementToolbarDisplayContext.getSortingURL()) %>"
 />
 
-<clay:container-fluid
-	cssClass="closed sidenav-container sidenav-right"
-	id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
->
+<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="infoPanel" var="sidebarPanelURL">
 		<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(parentResourceClassNameId) %>" />
 		<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(parentResourcePrimKey) %>" />
@@ -91,233 +88,237 @@ if (parentResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 	</liferay-frontend:sidebar-panel>
 
 	<div class="sidenav-content">
+		<clay:container-fluid
+			cssClass="container-view"
+		>
 
-		<%
-		KBAdminViewDisplayContext kbAdminViewDisplayContext = new KBAdminViewDisplayContext(parentResourceClassNameId, parentResourcePrimKey, request, liferayPortletResponse);
+			<%
+			KBAdminViewDisplayContext kbAdminViewDisplayContext = new KBAdminViewDisplayContext(parentResourceClassNameId, parentResourcePrimKey, request, liferayPortletResponse);
 
-		kbAdminViewDisplayContext.populatePortletBreadcrumbEntries(currentURLObj);
-		%>
+			kbAdminViewDisplayContext.populatePortletBreadcrumbEntries(currentURLObj);
+			%>
 
-		<liferay-ui:breadcrumb
-			showCurrentGroup="<%= false %>"
-			showGuestGroup="<%= false %>"
-			showLayout="<%= false %>"
-			showParentGroups="<%= false %>"
-		/>
+			<liferay-ui:breadcrumb
+				showCurrentGroup="<%= false %>"
+				showGuestGroup="<%= false %>"
+				showLayout="<%= false %>"
+				showParentGroups="<%= false %>"
+			/>
 
-		<liferay-portlet:actionURL name="deleteKBArticlesAndFolders" varImpl="deleteKBArticlesAndFoldersURL" />
+			<liferay-portlet:actionURL name="deleteKBArticlesAndFolders" varImpl="deleteKBArticlesAndFoldersURL" />
 
-		<aui:form action="<%= deleteKBArticlesAndFoldersURL %>" name="fm">
-			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+			<aui:form action="<%= deleteKBArticlesAndFoldersURL %>" name="fm">
+				<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
-			<liferay-ui:error exception="<%= KBArticlePriorityException.class %>" message='<%= LanguageUtil.format(request, "please-enter-a-priority-that-is-greater-than-x", "0", false) %>' translateMessage="<%= false %>" />
+				<liferay-ui:error exception="<%= KBArticlePriorityException.class %>" message='<%= LanguageUtil.format(request, "please-enter-a-priority-that-is-greater-than-x", "0", false) %>' translateMessage="<%= false %>" />
 
-			<c:if test='<%= SessionMessages.contains(renderRequest, "importedKBArticlesCount") %>'>
+				<c:if test='<%= SessionMessages.contains(renderRequest, "importedKBArticlesCount") %>'>
 
-				<%
-				int importedKBArticlesCount = GetterUtil.getInteger(SessionMessages.get(renderRequest, "importedKBArticlesCount"));
-				%>
+					<%
+					int importedKBArticlesCount = GetterUtil.getInteger(SessionMessages.get(renderRequest, "importedKBArticlesCount"));
+					%>
 
-				<c:choose>
-					<c:when test="<%= importedKBArticlesCount > 0 %>">
-						<div class="alert alert-success">
-							<liferay-ui:message key="your-request-completed-successfully" />
-
-							<liferay-ui:message arguments="<%= importedKBArticlesCount %>" key="a-total-of-x-articles-have-been-imported" />
-						</div>
-					</c:when>
-					<c:otherwise>
-						<div class="alert alert-warning">
-							<liferay-ui:message arguments="<%= HtmlUtil.escape(StringUtil.merge(kbGroupServiceConfiguration.markdownImporterArticleExtensions(), StringPool.COMMA_AND_SPACE)) %>" key="nothing-was-imported-no-articles-were-found-with-one-of-the-supported-extensions-x" />
-						</div>
-					</c:otherwise>
-				</c:choose>
-			</c:if>
-
-			<liferay-ui:search-container
-				id="kbObjects"
-				searchContainer="<%= kbAdminManagementToolbarDisplayContext.getSearchContainer() %>"
-			>
-				<liferay-ui:search-container-row
-					className="Object"
-					modelVar="kbObject"
-				>
 					<c:choose>
-						<c:when test="<%= kbObject instanceof KBFolder %>">
+						<c:when test="<%= importedKBArticlesCount > 0 %>">
+							<div class="alert alert-success">
+								<liferay-ui:message key="your-request-completed-successfully" />
 
-							<%
-							KBFolder kbFolder = (KBFolder)kbObject;
-
-							row.setData(
-								HashMapBuilder.<String, Object>put(
-									"actions", StringUtil.merge(kbAdminManagementToolbarDisplayContext.getAvailableActions(kbFolder))
-								).build());
-
-							row.setPrimaryKey(String.valueOf(kbFolder.getKbFolderId()));
-							%>
-
-							<liferay-ui:search-container-column-icon
-								icon="folder"
-								toggleRowChecker="<%= true %>"
-							/>
-
-							<liferay-ui:search-container-column-text
-								colspan="<%= 2 %>"
-							>
-								<span class="text-default">
-
-									<%
-									Date modifiedDate = kbFolder.getModifiedDate();
-
-									String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
-									%>
-
-									<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(kbFolder.getUserName()), modifiedDateDescription} %>" key="x-modified-x-ago" />
-								</span>
-
-								<liferay-portlet:renderURL varImpl="rowURL">
-									<portlet:param name="mvcPath" value="/admin/view_folders.jsp" />
-									<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(kbFolder.getClassNameId()) %>" />
-									<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(kbFolder.getKbFolderId()) %>" />
-									<portlet:param name="redirect" value="<%= currentURL %>" />
-								</liferay-portlet:renderURL>
-
-								<h2 class="h5">
-									<aui:a href="<%= rowURL.toString() %>">
-										<%= HtmlUtil.escape(kbFolder.getName()) %>
-									</aui:a>
-								</h2>
-
-								<span class="text-default">
-									<span>
-
-										<%
-										int kbFoldersCount = KBFolderServiceUtil.getKBFoldersCount(kbFolder.getGroupId(), kbFolder.getKbFolderId());
-										%>
-
-										<c:choose>
-											<c:when test="<%= kbFoldersCount == 1 %>">
-												<liferay-ui:message arguments="<%= kbFoldersCount %>" key="x-folder" />
-											</c:when>
-											<c:otherwise>
-												<liferay-ui:message arguments="<%= kbFoldersCount %>" key="x-folders" />
-											</c:otherwise>
-										</c:choose>
-									</span>
-									<span class="kb-descriptive-details">
-
-										<%
-										int kbArticlesCount = KBArticleServiceUtil.getKBArticlesCount(kbFolder.getGroupId(), kbFolder.getKbFolderId(), WorkflowConstants.STATUS_ANY);
-										%>
-
-										<c:choose>
-											<c:when test="<%= kbArticlesCount == 1 %>">
-												<liferay-ui:message arguments="<%= kbArticlesCount %>" key="x-article" />
-											</c:when>
-											<c:otherwise>
-												<liferay-ui:message arguments="<%= kbArticlesCount %>" key="x-articles" />
-											</c:otherwise>
-										</c:choose>
-									</span>
-								</span>
-							</liferay-ui:search-container-column-text>
-
-							<liferay-ui:search-container-column-jsp
-								path="/admin/folder_action.jsp"
-							/>
+								<liferay-ui:message arguments="<%= importedKBArticlesCount %>" key="a-total-of-x-articles-have-been-imported" />
+							</div>
 						</c:when>
 						<c:otherwise>
-
-							<%
-							KBArticle kbArticle = (KBArticle)kbObject;
-
-							row.setData(
-								HashMapBuilder.<String, Object>put(
-									"actions", StringUtil.merge(kbAdminManagementToolbarDisplayContext.getAvailableActions(kbArticle))
-								).build());
-
-							row.setPrimaryKey(String.valueOf(kbArticle.getResourcePrimKey()));
-							%>
-
-							<liferay-ui:search-container-column-user
-								showDetails="<%= false %>"
-								userId="<%= kbArticle.getUserId() %>"
-							/>
-
-							<liferay-ui:search-container-column-text
-								colspan="<%= 2 %>"
-							>
-								<span class="text-default">
-
-									<%
-									Date modifiedDate = kbArticle.getModifiedDate();
-
-									String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
-									%>
-
-									<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(kbArticle.getUserName()), modifiedDateDescription} %>" key="x-modified-x-ago" />
-								</span>
-
-								<h2 class="h5">
-
-									<%
-									PortletURL viewURL = kbArticleURLHelper.createViewWithRedirectURL(kbArticle, currentURL);
-									%>
-
-									<aui:a href="<%= viewURL.toString() %>">
-										<%= HtmlUtil.escape(kbArticle.getTitle()) %>
-									</aui:a>
-								</h2>
-
-								<span class="text-default">
-									<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" />
-
-									<%
-									int childKBArticlesCount = KBArticleServiceUtil.getKBArticlesCount(scopeGroupId, kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_ANY);
-									%>
-
-									<c:if test="<%= childKBArticlesCount > 0 %>">
-										<liferay-portlet:renderURL varImpl="childKBArticlesURL">
-											<portlet:param name="mvcPath" value="/admin/view_articles.jsp" />
-											<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(kbArticle.getClassNameId()) %>" />
-											<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(kbArticle.getResourcePrimKey()) %>" />
-											<portlet:param name="redirect" value="<%= currentURL %>" />
-										</liferay-portlet:renderURL>
-
-										<span class="kb-descriptive-details">
-											<aui:a href="<%= childKBArticlesURL.toString() %>">
-												<liferay-ui:message arguments="<%= childKBArticlesCount %>" key="x-child-articles" />
-											</aui:a>
-										</span>
-									</c:if>
-
-									<span class="kb-descriptive-details">
-										<liferay-ui:message arguments="<%= BigDecimal.valueOf(kbArticle.getPriority()).toPlainString() %>" key="priority-x" />
-									</span>
-									<span class="kb-descriptive-details">
-										<liferay-ui:message arguments="<%= kbArticle.getViewCount() %>" key="x-views" />
-									</span>
-								</span>
-							</liferay-ui:search-container-column-text>
-
-							<liferay-ui:search-container-column-jsp
-								align="right"
-								cssClass="entry-action"
-								path="/admin/article_action.jsp"
-							/>
+							<div class="alert alert-warning">
+								<liferay-ui:message arguments="<%= HtmlUtil.escape(StringUtil.merge(kbGroupServiceConfiguration.markdownImporterArticleExtensions(), StringPool.COMMA_AND_SPACE)) %>" key="nothing-was-imported-no-articles-were-found-with-one-of-the-supported-extensions-x" />
+							</div>
 						</c:otherwise>
 					</c:choose>
-				</liferay-ui:search-container-row>
+				</c:if>
 
-				<liferay-ui:search-iterator
-					displayStyle="descriptive"
-					markupView="lexicon"
-					resultRowSplitter="<%= kbFolderView ? new KBResultRowSplitter() : null %>"
-				/>
-			</liferay-ui:search-container>
-		</aui:form>
+				<liferay-ui:search-container
+					id="kbObjects"
+					searchContainer="<%= kbAdminManagementToolbarDisplayContext.getSearchContainer() %>"
+				>
+					<liferay-ui:search-container-row
+						className="Object"
+						modelVar="kbObject"
+					>
+						<c:choose>
+							<c:when test="<%= kbObject instanceof KBFolder %>">
+
+								<%
+								KBFolder kbFolder = (KBFolder)kbObject;
+
+								row.setData(
+									HashMapBuilder.<String, Object>put(
+										"actions", StringUtil.merge(kbAdminManagementToolbarDisplayContext.getAvailableActions(kbFolder))
+									).build());
+
+								row.setPrimaryKey(String.valueOf(kbFolder.getKbFolderId()));
+								%>
+
+								<liferay-ui:search-container-column-icon
+									icon="folder"
+									toggleRowChecker="<%= true %>"
+								/>
+
+								<liferay-ui:search-container-column-text
+									colspan="<%= 2 %>"
+								>
+									<span class="text-default">
+
+										<%
+										Date modifiedDate = kbFolder.getModifiedDate();
+
+										String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
+										%>
+
+										<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(kbFolder.getUserName()), modifiedDateDescription} %>" key="x-modified-x-ago" />
+									</span>
+
+									<liferay-portlet:renderURL varImpl="rowURL">
+										<portlet:param name="mvcPath" value="/admin/view_folders.jsp" />
+										<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(kbFolder.getClassNameId()) %>" />
+										<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(kbFolder.getKbFolderId()) %>" />
+										<portlet:param name="redirect" value="<%= currentURL %>" />
+									</liferay-portlet:renderURL>
+
+									<h2 class="h5">
+										<aui:a href="<%= rowURL.toString() %>">
+											<%= HtmlUtil.escape(kbFolder.getName()) %>
+										</aui:a>
+									</h2>
+
+									<span class="text-default">
+										<span>
+
+											<%
+											int kbFoldersCount = KBFolderServiceUtil.getKBFoldersCount(kbFolder.getGroupId(), kbFolder.getKbFolderId());
+											%>
+
+											<c:choose>
+												<c:when test="<%= kbFoldersCount == 1 %>">
+													<liferay-ui:message arguments="<%= kbFoldersCount %>" key="x-folder" />
+												</c:when>
+												<c:otherwise>
+													<liferay-ui:message arguments="<%= kbFoldersCount %>" key="x-folders" />
+												</c:otherwise>
+											</c:choose>
+										</span>
+										<span class="kb-descriptive-details">
+
+											<%
+											int kbArticlesCount = KBArticleServiceUtil.getKBArticlesCount(kbFolder.getGroupId(), kbFolder.getKbFolderId(), WorkflowConstants.STATUS_ANY);
+											%>
+
+											<c:choose>
+												<c:when test="<%= kbArticlesCount == 1 %>">
+													<liferay-ui:message arguments="<%= kbArticlesCount %>" key="x-article" />
+												</c:when>
+												<c:otherwise>
+													<liferay-ui:message arguments="<%= kbArticlesCount %>" key="x-articles" />
+												</c:otherwise>
+											</c:choose>
+										</span>
+									</span>
+								</liferay-ui:search-container-column-text>
+
+								<liferay-ui:search-container-column-jsp
+									path="/admin/folder_action.jsp"
+								/>
+							</c:when>
+							<c:otherwise>
+
+								<%
+								KBArticle kbArticle = (KBArticle)kbObject;
+
+								row.setData(
+									HashMapBuilder.<String, Object>put(
+										"actions", StringUtil.merge(kbAdminManagementToolbarDisplayContext.getAvailableActions(kbArticle))
+									).build());
+
+								row.setPrimaryKey(String.valueOf(kbArticle.getResourcePrimKey()));
+								%>
+
+								<liferay-ui:search-container-column-user
+									showDetails="<%= false %>"
+									userId="<%= kbArticle.getUserId() %>"
+								/>
+
+								<liferay-ui:search-container-column-text
+									colspan="<%= 2 %>"
+								>
+									<span class="text-default">
+
+										<%
+										Date modifiedDate = kbArticle.getModifiedDate();
+
+										String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
+										%>
+
+										<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(kbArticle.getUserName()), modifiedDateDescription} %>" key="x-modified-x-ago" />
+									</span>
+
+									<h2 class="h5">
+
+										<%
+										PortletURL viewURL = kbArticleURLHelper.createViewWithRedirectURL(kbArticle, currentURL);
+										%>
+
+										<aui:a href="<%= viewURL.toString() %>">
+											<%= HtmlUtil.escape(kbArticle.getTitle()) %>
+										</aui:a>
+									</h2>
+
+									<span class="text-default">
+										<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" />
+
+										<%
+										int childKBArticlesCount = KBArticleServiceUtil.getKBArticlesCount(scopeGroupId, kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_ANY);
+										%>
+
+										<c:if test="<%= childKBArticlesCount > 0 %>">
+											<liferay-portlet:renderURL varImpl="childKBArticlesURL">
+												<portlet:param name="mvcPath" value="/admin/view_articles.jsp" />
+												<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(kbArticle.getClassNameId()) %>" />
+												<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(kbArticle.getResourcePrimKey()) %>" />
+												<portlet:param name="redirect" value="<%= currentURL %>" />
+											</liferay-portlet:renderURL>
+
+											<span class="kb-descriptive-details">
+												<aui:a href="<%= childKBArticlesURL.toString() %>">
+													<liferay-ui:message arguments="<%= childKBArticlesCount %>" key="x-child-articles" />
+												</aui:a>
+											</span>
+										</c:if>
+
+										<span class="kb-descriptive-details">
+											<liferay-ui:message arguments="<%= BigDecimal.valueOf(kbArticle.getPriority()).toPlainString() %>" key="priority-x" />
+										</span>
+										<span class="kb-descriptive-details">
+											<liferay-ui:message arguments="<%= kbArticle.getViewCount() %>" key="x-views" />
+										</span>
+									</span>
+								</liferay-ui:search-container-column-text>
+
+								<liferay-ui:search-container-column-jsp
+									align="right"
+									cssClass="entry-action"
+									path="/admin/article_action.jsp"
+								/>
+							</c:otherwise>
+						</c:choose>
+					</liferay-ui:search-container-row>
+
+					<liferay-ui:search-iterator
+						displayStyle="descriptive"
+						markupView="lexicon"
+						resultRowSplitter="<%= kbFolderView ? new KBResultRowSplitter() : null %>"
+					/>
+				</liferay-ui:search-container>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
-</clay:container-fluid>
+</div>
 
 <script>
 	var deleteEntries = function () {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestion.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/admin/init.jsp" %>
 
 <clay:container-fluid
-	cssClass="main-content-body"
+	cssClass="container-form-lg"
 >
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
 </clay:container-fluid>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/view_suggestion.jsp
@@ -16,8 +16,6 @@
 
 <%@ include file="/admin/init.jsp" %>
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
 </clay:container-fluid>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/view_suggestion.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/admin/init.jsp" %>
 
 <clay:container-fluid
-	cssClass="main-content-body"
+	cssClass="container-view"
 >
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
 </clay:container-fluid>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/search/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/search/view_suggestion.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/admin/init.jsp" %>
 
 <clay:container-fluid
-	cssClass="main-content-body"
+	cssClass="container-view"
 >
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
 </clay:container-fluid>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/section/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/section/view_suggestion.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/admin/init.jsp" %>
 
 <clay:container-fluid
-	cssClass="main-content-body"
+	cssClass="container-view"
 >
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
 </clay:container-fluid>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
@@ -22,9 +22,7 @@ long sourcePlid = ParamUtil.getLong(request, "sourcePlid");
 List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.getAutoSiteNavigationMenus();
 %>
 
-<clay:container-fluid
-	cssClass="pb-9 pt-2"
->
+<clay:container-fluid>
 	<liferay-frontend:edit-form
 		action="<%= (sourcePlid <= 0) ? layoutsAdminDisplayContext.getAddLayoutURL() : layoutsAdminDisplayContext.getCopyLayoutURL(sourcePlid) %>"
 		method="post"

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_entries.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_entries.jspf
@@ -18,7 +18,7 @@
 MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, categoryId);
 %>
 
-<div class="container-fluid container-fluid-max-xl view-entries-container">
+<div class="container-fluid container-fluid-max-xl container-view view-entries-container">
 	<c:if test="<%= category != null %>">
 
 		<%

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -84,9 +84,7 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 	sortingURL="<%= String.valueOf(notificationsManagementToolbarDisplayContext.getSortingURL()) %>"
 />
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<aui:form action="<%= currentURL %>" method="get" name="fm">
 		<div class="user-notifications">
 			<liferay-ui:search-container

--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/view.jsp
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/view.jsp
@@ -20,9 +20,7 @@
 
 <liferay-util:include page="/polls/management_bar.jsp" servletContext="<%= application %>" />
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<aui:form method="post" name="fm">
 		<aui:input name="deleteQuestionIds" type="hidden" />
 

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view.jsp
@@ -26,8 +26,6 @@ portletDisplay.setShowBackIcon(false);
 
 <liferay-util:include page="/toolbar.jsp" servletContext="<%= application %>" />
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<%@ include file="/workflow_tasks.jspf" %>
 </clay:container-fluid>

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -41,9 +41,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(assetRenderer.getTitle(workflowTaskDisplayContext.getTaskContentLocale()));
 %>
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<clay:col
 		cssClass="lfr-asset-column lfr-asset-column-details"
 		md="12"

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view.jsp
@@ -29,7 +29,7 @@ PortletURL portletURL = workflowInstanceViewDisplayContext.getViewPortletURL();
 </aui:form>
 
 <clay:container-fluid
-	cssClass="main-content-body workflow-instance-container"
+	cssClass="workflow-instance-container"
 >
 	<%@ include file="/instance/workflow_instance.jspf" %>
 </clay:container-fluid>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/preview_segments_entry_users.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/preview_segments_entry_users.jsp
@@ -20,9 +20,7 @@
 PreviewSegmentsEntryUsersDisplayContext previewSegmentsEntryUsersDisplayContext = (PreviewSegmentsEntryUsersDisplayContext)request.getAttribute(SegmentsWebKeys.PREVIEW_SEGMENTS_ENTRY_USERS_DISPLAY_CONTEXT);
 %>
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<liferay-ui:search-container
 		searchContainer="<%= previewSegmentsEntryUsersDisplayContext.getSearchContainer() %>"
 	>

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view.jsp
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view.jsp
@@ -44,9 +44,7 @@ SearchContainer<SharingEntry> sharingEntriesSearchContainer = new SearchContaine
 viewSharedAssetsDisplayContext.populateResults(sharingEntriesSearchContainer);
 %>
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<liferay-ui:search-container
 		id="sharingEntries"
 		searchContainer="<%= sharingEntriesSearchContainer %>"

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
@@ -24,10 +24,8 @@ ViewDisplayContext viewDisplayContext = (ViewDisplayContext)request.getAttribute
 	displayContext="<%= viewDisplayContext.getTranslationEntryManagementToolbarDisplayContext() %>"
 />
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
-	<aui:form action="<%= viewDisplayContext.getActionURL() %>" cssClass="container-fluid container-fluid-max-xl" name="fm">
+<clay:container-fluid>
+	<aui:form action="<%= viewDisplayContext.getActionURL() %>" name="fm">
 		<liferay-ui:search-container
 			id="searchContainer"
 			searchContainer="<%= viewDisplayContext.getSearchContainer() %>"

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -58,7 +58,7 @@ PortletURL portletURL = viewUserGroupsManagementToolbarDisplayContext.getPortlet
 	viewTypeItems="<%= viewUserGroupsManagementToolbarDisplayContext.getViewTypeItems() %>"
 />
 
-<aui:form action="<%= portletURL.toString() %>" cssClass="container-fluid container-fluid-max-xl" method="get" name="fm">
+<aui:form action="<%= portletURL.toString() %>" cssClass="container-fluid container-fluid-max-xl container-view" method="get" name="fm">
 	<liferay-portlet:renderURLParams varImpl="portletURL" />
 	<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
 	<aui:input name="deleteUserGroupIds" type="hidden" />

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
@@ -141,7 +141,7 @@ if (portletTitleBasedNavigation) {
 	</liferay-frontend:info-bar>
 </c:if>
 
-<div <%= portletTitleBasedNavigation ? "class=\"closed container-fluid container-fluid-max-xl sidenav-container sidenav-right\" id=\"" + liferayPortletResponse.getNamespace() + "infoPanelId\"" : StringPool.BLANK %>>
+<div <%= portletTitleBasedNavigation ? "class=\"closed sidenav-container sidenav-right\" id=\"" + liferayPortletResponse.getNamespace() + "infoPanelId\"" : StringPool.BLANK %>>
 	<c:if test="<%= portletTitleBasedNavigation %>">
 		<liferay-frontend:sidebar-panel>
 			<liferay-util:include page="/wiki_admin/page_info_panel.jsp" servletContext="<%= application %>" />
@@ -149,340 +149,342 @@ if (portletTitleBasedNavigation) {
 	</c:if>
 
 	<div class="sidenav-content">
-		<div <%= portletTitleBasedNavigation ? "class=\"panel main-content-card\"" : StringPool.BLANK %>>
-			<div <%= portletTitleBasedNavigation ? "class=\"panel-body\"" : StringPool.BLANK %>>
-				<c:if test="<%= !portletTitleBasedNavigation %>">
-					<c:choose>
-						<c:when test="<%= print %>">
-							<aui:script>
-								window.onafterprint = function () {
-									window.close();
-								};
-
-								window.onfocus = function () {
-									window.close();
-								};
-
-								print();
-							</aui:script>
-						</c:when>
-						<c:otherwise>
-							<aui:script>
-								function <portlet:namespace />printPage() {
-									window.open(
-										'<%= printPageURL %>',
-										'',
-										'directories=0,height=480,left=80,location=1,menubar=1,resizable=1,scrollbars=yes,status=0,toolbar=0,top=180,width=640'
-									);
-								}
-							</aui:script>
-						</c:otherwise>
-					</c:choose>
-
-					<liferay-util:include page="/wiki/top_links.jsp" servletContext="<%= application %>" />
-				</c:if>
-
-				<%
-				List<WikiPage> entries = new ArrayList<>();
-
-				entries.add(wikiPage);
-
-				String formattedContent = null;
-
-				WikiEngineRenderer wikiEngineRenderer = (WikiEngineRenderer)request.getAttribute(WikiWebKeys.WIKI_ENGINE_RENDERER);
-
-				try {
-					formattedContent = WikiUtil.getFormattedContent(wikiEngineRenderer, renderRequest, renderResponse, wikiPage, viewPageURL, editPageURL, title, preview);
-				}
-				catch (Exception e) {
-					formattedContent = wikiPage.getContent();
-				}
-				%>
-
-				<c:if test="<%= !portletTitleBasedNavigation %>">
-					<div class="lfr-alert-container"></div>
-				</c:if>
-
-				<liferay-ddm:template-renderer
-					className="<%= WikiPage.class.getName() %>"
-					contextObjects='<%=
-						HashMapBuilder.<String, Object>put(
-							"assetEntry", layoutAssetEntry
-						).put(
-							"formattedContent", formattedContent
-						).put(
-							"viewURL", viewPageURL.toString()
-						).put(
-							"wikiPortletInstanceConfiguration", wikiPortletInstanceConfiguration
-						).put(
-							"wikiPortletInstanceOverriddenConfiguration", wikiPortletInstanceConfiguration
-						).build()
-					%>'
-					displayStyle="<%= wikiPortletInstanceSettingsHelper.getDisplayStyle() %>"
-					displayStyleGroupId="<%= wikiPortletInstanceSettingsHelper.getDisplayStyleGroupId() %>"
-					entries="<%= entries %>"
-				>
-					<div class="main-content-body">
+		<div class="container-fluid container-fluid-max-xl">
+			<div <%= portletTitleBasedNavigation ? "class=\"panel main-content-card\"" : StringPool.BLANK %>>
+				<div <%= portletTitleBasedNavigation ? "class=\"panel-body\"" : StringPool.BLANK %>>
+					<c:if test="<%= !portletTitleBasedNavigation %>">
 						<c:choose>
-							<c:when test="<%= !portletTitleBasedNavigation %>">
-								<liferay-ui:header
-									backLabel="<%= parentTitle %>"
-									backURL="<%= (viewParentPageURL != null) ? viewParentPageURL.toString() : null %>"
-									localizeTitle="<%= false %>"
-									title="<%= title %>"
-								/>
+							<c:when test="<%= print %>">
+								<aui:script>
+									window.onafterprint = function () {
+										window.close();
+									};
+
+									window.onfocus = function () {
+										window.close();
+									};
+
+									print();
+								</aui:script>
 							</c:when>
 							<c:otherwise>
-								<h2><%= title %></h2>
+								<aui:script>
+									function <portlet:namespace />printPage() {
+										window.open(
+											'<%= printPageURL %>',
+											'',
+											'directories=0,height=480,left=80,location=1,menubar=1,resizable=1,scrollbars=yes,status=0,toolbar=0,top=180,width=640'
+										);
+									}
+								</aui:script>
 							</c:otherwise>
 						</c:choose>
 
-						<c:if test="<%= !print && !portletTitleBasedNavigation %>">
-							<div class="page-actions top-actions">
-								<c:if test="<%= followRedirect || (redirectPage == null) %>">
-									<c:if test="<%= Validator.isNotNull(formattedContent) && WikiNodePermission.contains(permissionChecker, node, ActionKeys.ADD_PAGE) %>">
-										<liferay-ui:icon
-											icon="plus"
-											label="<%= true %>"
-											markupView="lexicon"
-											message="add-child-page"
-											method="get"
-											url="<%= addPageURL.toString() %>"
-										/>
+						<liferay-util:include page="/wiki/top_links.jsp" servletContext="<%= application %>" />
+					</c:if>
+
+					<%
+					List<WikiPage> entries = new ArrayList<>();
+
+					entries.add(wikiPage);
+
+					String formattedContent = null;
+
+					WikiEngineRenderer wikiEngineRenderer = (WikiEngineRenderer)request.getAttribute(WikiWebKeys.WIKI_ENGINE_RENDERER);
+
+					try {
+						formattedContent = WikiUtil.getFormattedContent(wikiEngineRenderer, renderRequest, renderResponse, wikiPage, viewPageURL, editPageURL, title, preview);
+					}
+					catch (Exception e) {
+						formattedContent = wikiPage.getContent();
+					}
+					%>
+
+					<c:if test="<%= !portletTitleBasedNavigation %>">
+						<div class="lfr-alert-container"></div>
+					</c:if>
+
+					<liferay-ddm:template-renderer
+						className="<%= WikiPage.class.getName() %>"
+						contextObjects='<%=
+							HashMapBuilder.<String, Object>put(
+								"assetEntry", layoutAssetEntry
+							).put(
+								"formattedContent", formattedContent
+							).put(
+								"viewURL", viewPageURL.toString()
+							).put(
+								"wikiPortletInstanceConfiguration", wikiPortletInstanceConfiguration
+							).put(
+								"wikiPortletInstanceOverriddenConfiguration", wikiPortletInstanceConfiguration
+							).build()
+						%>'
+						displayStyle="<%= wikiPortletInstanceSettingsHelper.getDisplayStyle() %>"
+						displayStyleGroupId="<%= wikiPortletInstanceSettingsHelper.getDisplayStyleGroupId() %>"
+						entries="<%= entries %>"
+					>
+						<div class="main-content-body">
+							<c:choose>
+								<c:when test="<%= !portletTitleBasedNavigation %>">
+									<liferay-ui:header
+										backLabel="<%= parentTitle %>"
+										backURL="<%= (viewParentPageURL != null) ? viewParentPageURL.toString() : null %>"
+										localizeTitle="<%= false %>"
+										title="<%= title %>"
+									/>
+								</c:when>
+								<c:otherwise>
+									<h2><%= title %></h2>
+								</c:otherwise>
+							</c:choose>
+
+							<c:if test="<%= !print && !portletTitleBasedNavigation %>">
+								<div class="page-actions top-actions">
+									<c:if test="<%= followRedirect || (redirectPage == null) %>">
+										<c:if test="<%= Validator.isNotNull(formattedContent) && WikiNodePermission.contains(permissionChecker, node, ActionKeys.ADD_PAGE) %>">
+											<liferay-ui:icon
+												icon="plus"
+												label="<%= true %>"
+												markupView="lexicon"
+												message="add-child-page"
+												method="get"
+												url="<%= addPageURL.toString() %>"
+											/>
+										</c:if>
+
+										<c:if test="<%= WikiPagePermission.contains(permissionChecker, wikiPage, ActionKeys.UPDATE) %>">
+											<liferay-ui:icon
+												icon="pencil"
+												label="<%= true %>"
+												markupView="lexicon"
+												message="edit"
+												url="<%= editPageURL.toString() %>"
+											/>
+										</c:if>
 									</c:if>
-
-									<c:if test="<%= WikiPagePermission.contains(permissionChecker, wikiPage, ActionKeys.UPDATE) %>">
-										<liferay-ui:icon
-											icon="pencil"
-											label="<%= true %>"
-											markupView="lexicon"
-											message="edit"
-											url="<%= editPageURL.toString() %>"
-										/>
-									</c:if>
-								</c:if>
-
-								<%
-								PortletURL viewPageDetailsURL = PortletURLUtil.clone(viewPageURL, renderResponse);
-
-								viewPageDetailsURL.setParameter("mvcRenderCommandName", "/wiki/view_page_details");
-								viewPageDetailsURL.setParameter("redirect", currentURL);
-								%>
-
-								<liferay-ui:icon
-									icon="document"
-									label="<%= true %>"
-									markupView="lexicon"
-									message="details"
-									method="get"
-									url="<%= viewPageDetailsURL.toString() %>"
-								/>
-
-								<liferay-ui:icon
-									icon="print"
-									label="<%= true %>"
-									markupView="lexicon"
-									message="print"
-									url='<%= "javascript:" + liferayPortletResponse.getNamespace() + "printPage();" %>'
-								/>
-							</div>
-						</c:if>
-
-						<c:if test="<%= originalPage != null %>">
-
-							<%
-							PortletURL originalViewPageURL = renderResponse.createRenderURL();
-
-							originalViewPageURL.setParameter("mvcRenderCommandName", "/wiki/view");
-							originalViewPageURL.setParameter("nodeName", node.getName());
-							originalViewPageURL.setParameter("title", originalPage.getTitle());
-							originalViewPageURL.setParameter("followRedirect", "false");
-							%>
-
-							<div class="page-redirect" onClick="location.href = '<%= originalViewPageURL.toString() %>';">
-								(<liferay-ui:message arguments="<%= originalPage.getTitle() %>" key="redirected-from-x" translateArguments="<%= false %>" />)
-							</div>
-						</c:if>
-
-						<c:if test="<%= !wikiPage.isHead() %>">
-							<div class="page-old-version">
-								(<liferay-ui:message key="you-are-viewing-an-archived-version-of-this-page" /> (<%= wikiPage.getVersion() %>), <aui:a href="<%= viewPageURL.toString() %>" label="go-to-the-latest-version" />)
-							</div>
-						</c:if>
-
-						<%@ include file="/wiki/view_page_content.jspf" %>
-
-						<liferay-expando:custom-attributes-available
-							className="<%= WikiPage.class.getName() %>"
-						>
-							<liferay-expando:custom-attribute-list
-								className="<%= WikiPage.class.getName() %>"
-								classPK="<%= wikiPage.getPrimaryKey() %>"
-								editable="<%= false %>"
-								label="<%= true %>"
-							/>
-						</liferay-expando:custom-attributes-available>
-
-						<c:if test="<%= followRedirect || (redirectPage == null) %>">
-							<div class="page-actions">
-								<div class="stats">
 
 									<%
-									AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(WikiPage.class.getName(), wikiPage.getResourcePrimKey());
+									PortletURL viewPageDetailsURL = PortletURLUtil.clone(viewPageURL, renderResponse);
+
+									viewPageDetailsURL.setParameter("mvcRenderCommandName", "/wiki/view_page_details");
+									viewPageDetailsURL.setParameter("redirect", currentURL);
 									%>
 
-									<c:choose>
-										<c:when test="<%= assetEntry.getViewCount() == 1 %>">
-											<%= assetEntry.getViewCount() %> <liferay-ui:message key="view" />
-										</c:when>
-										<c:when test="<%= assetEntry.getViewCount() > 1 %>">
-											<%= assetEntry.getViewCount() %> <liferay-ui:message key="views" />
-										</c:when>
-									</c:choose>
-								</div>
+									<liferay-ui:icon
+										icon="document"
+										label="<%= true %>"
+										markupView="lexicon"
+										message="details"
+										method="get"
+										url="<%= viewPageDetailsURL.toString() %>"
+									/>
 
-								<div class="page-categorization">
-									<div class="page-categories">
-										<liferay-asset:asset-categories-summary
-											className="<%= WikiPage.class.getName() %>"
-											classPK="<%= wikiPage.getResourcePrimKey() %>"
-											portletURL="<%= PortletURLUtil.clone(categorizedPagesURL, renderResponse) %>"
-										/>
-									</div>
-
-									<div class="page-tags">
-										<liferay-asset:asset-tags-available
-											className="<%= WikiPage.class.getName() %>"
-											classPK="<%= wikiPage.getResourcePrimKey() %>"
-										>
-											<h5><liferay-ui:message key="tags" /></h5>
-
-											<liferay-asset:asset-tags-summary
-												className="<%= WikiPage.class.getName() %>"
-												classPK="<%= wikiPage.getResourcePrimKey() %>"
-												portletURL="<%= PortletURLUtil.clone(taggedPagesURL, renderResponse) %>"
-											/>
-										</liferay-asset:asset-tags-available>
-									</div>
-								</div>
-
-								<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnablePageRatings() %>">
-									<div class="page-ratings">
-										<liferay-ratings:ratings
-											className="<%= WikiPage.class.getName() %>"
-											classPK="<%= wikiPage.getResourcePrimKey() %>"
-											inTrash="<%= wikiPage.isInTrash() %>"
-										/>
-									</div>
-								</c:if>
-
-								<liferay-util:include page="/wiki/view_attachments.jsp" servletContext="<%= application %>" />
-
-								<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnableRelatedAssets() %>">
-									<div class="entry-links">
-										<liferay-asset:asset-links
-											assetEntryId="<%= assetEntry.getEntryId() %>"
-										/>
-									</div>
-								</c:if>
-							</div>
-
-							<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnableComments() %>">
-								<div id="<portlet:namespace />wikiCommentsPanel">
-									<liferay-comment:discussion
-										className="<%= WikiPage.class.getName() %>"
-										classPK="<%= wikiPage.getResourcePrimKey() %>"
-										formName="fm2"
-										ratingsEnabled="<%= wikiPortletInstanceSettingsHelper.isEnableCommentRatings() %>"
-										redirect="<%= currentURL %>"
-										userId="<%= wikiPage.getUserId() %>"
+									<liferay-ui:icon
+										icon="print"
+										label="<%= true %>"
+										markupView="lexicon"
+										message="print"
+										url='<%= "javascript:" + liferayPortletResponse.getNamespace() + "printPage();" %>'
 									/>
 								</div>
 							</c:if>
-						</c:if>
-					</div>
-				</liferay-ddm:template-renderer>
 
-				<%
-				if (!Objects.equals(wikiPage.getTitle(), wikiGroupServiceConfiguration.frontPageName())) {
-					if (!portletName.equals(WikiPortletKeys.WIKI_DISPLAY)) {
-						PortalUtil.setPageSubtitle(wikiPage.getTitle(), request);
-
-						String description = wikiPage.getContent();
-
-						if (Objects.equals(wikiPage.getFormat(), "html")) {
-							description = HtmlUtil.stripHtml(description);
-						}
-
-						description = StringUtil.shorten(description, 200);
-
-						PortalUtil.setPageDescription(description, request);
-
-						PortalUtil.setPageKeywords(assetHelper.getAssetKeywords(WikiPage.class.getName(), wikiPage.getResourcePrimKey()), request);
-					}
-
-					List<WikiPage> parentPages = wikiPage.getViewableParentPages();
-
-					for (WikiPage curParentPage : parentPages) {
-						viewPageURL.setParameter("title", curParentPage.getTitle());
-
-						PortalUtil.addPortletBreadcrumbEntry(request, curParentPage.getTitle(), viewPageURL.toString());
-					}
-
-					viewPageURL.setParameter("title", wikiPage.getTitle());
-
-					PortalUtil.addPortletBreadcrumbEntry(request, wikiPage.getTitle(), viewPageURL.toString());
-				}
-				%>
-
-				<liferay-util:dynamic-include key="com.liferay.wiki.web#/wiki/view.jsp#post" />
-			</div>
-		</div>
-
-		<c:if test="<%= Validator.isNotNull(formattedContent) && (followRedirect || (redirectPage == null)) && !childPages.isEmpty() %>">
-			<h4 class="text-default">
-				<liferay-ui:message arguments="<%= childPages.size() %>" key="child-pages-x" translateArguments="<%= false %>" />
-			</h4>
-
-			<div>
-				<ul class="list-group">
-
-					<%
-					for (WikiPage childPage : childPages) {
-					%>
-
-						<li class="list-group-item">
-							<h3>
+							<c:if test="<%= originalPage != null %>">
 
 								<%
-								PortletURL rowURL = PortletURLUtil.clone(viewPageURL, renderResponse);
+								PortletURL originalViewPageURL = renderResponse.createRenderURL();
 
-								rowURL.setParameter("title", childPage.getTitle());
+								originalViewPageURL.setParameter("mvcRenderCommandName", "/wiki/view");
+								originalViewPageURL.setParameter("nodeName", node.getName());
+								originalViewPageURL.setParameter("title", originalPage.getTitle());
+								originalViewPageURL.setParameter("followRedirect", "false");
 								%>
 
-								<aui:a href="<%= rowURL.toString() %>"><%= childPage.getTitle() %></aui:a>
-							</h3>
+								<div class="page-redirect" onClick="location.href = '<%= originalViewPageURL.toString() %>';">
+									(<liferay-ui:message arguments="<%= originalPage.getTitle() %>" key="redirected-from-x" translateArguments="<%= false %>" />)
+								</div>
+							</c:if>
 
-							<%
-							String childPageFormattedContent = null;
+							<c:if test="<%= !wikiPage.isHead() %>">
+								<div class="page-old-version">
+									(<liferay-ui:message key="you-are-viewing-an-archived-version-of-this-page" /> (<%= wikiPage.getVersion() %>), <aui:a href="<%= viewPageURL.toString() %>" label="go-to-the-latest-version" />)
+								</div>
+							</c:if>
 
-							try {
-								childPageFormattedContent = WikiUtil.getFormattedContent(wikiEngineRenderer, renderRequest, renderResponse, childPage, viewPageURL, editPageURL, childPage.getTitle(), false);
-							}
-							catch (Exception e) {
-								childPageFormattedContent = childPage.getContent();
-							}
-							%>
+							<%@ include file="/wiki/view_page_content.jspf" %>
 
-							<p class="text-default"><%= StringUtil.shorten(HtmlUtil.extractText(childPageFormattedContent), 200) %></p>
-						</li>
+							<liferay-expando:custom-attributes-available
+								className="<%= WikiPage.class.getName() %>"
+							>
+								<liferay-expando:custom-attribute-list
+									className="<%= WikiPage.class.getName() %>"
+									classPK="<%= wikiPage.getPrimaryKey() %>"
+									editable="<%= false %>"
+									label="<%= true %>"
+								/>
+							</liferay-expando:custom-attributes-available>
+
+							<c:if test="<%= followRedirect || (redirectPage == null) %>">
+								<div class="page-actions">
+									<div class="stats">
+
+										<%
+										AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(WikiPage.class.getName(), wikiPage.getResourcePrimKey());
+										%>
+
+										<c:choose>
+											<c:when test="<%= assetEntry.getViewCount() == 1 %>">
+												<%= assetEntry.getViewCount() %> <liferay-ui:message key="view" />
+											</c:when>
+											<c:when test="<%= assetEntry.getViewCount() > 1 %>">
+												<%= assetEntry.getViewCount() %> <liferay-ui:message key="views" />
+											</c:when>
+										</c:choose>
+									</div>
+
+									<div class="page-categorization">
+										<div class="page-categories">
+											<liferay-asset:asset-categories-summary
+												className="<%= WikiPage.class.getName() %>"
+												classPK="<%= wikiPage.getResourcePrimKey() %>"
+												portletURL="<%= PortletURLUtil.clone(categorizedPagesURL, renderResponse) %>"
+											/>
+										</div>
+
+										<div class="page-tags">
+											<liferay-asset:asset-tags-available
+												className="<%= WikiPage.class.getName() %>"
+												classPK="<%= wikiPage.getResourcePrimKey() %>"
+											>
+												<h5><liferay-ui:message key="tags" /></h5>
+
+												<liferay-asset:asset-tags-summary
+													className="<%= WikiPage.class.getName() %>"
+													classPK="<%= wikiPage.getResourcePrimKey() %>"
+													portletURL="<%= PortletURLUtil.clone(taggedPagesURL, renderResponse) %>"
+												/>
+											</liferay-asset:asset-tags-available>
+										</div>
+									</div>
+
+									<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnablePageRatings() %>">
+										<div class="page-ratings">
+											<liferay-ratings:ratings
+												className="<%= WikiPage.class.getName() %>"
+												classPK="<%= wikiPage.getResourcePrimKey() %>"
+												inTrash="<%= wikiPage.isInTrash() %>"
+											/>
+										</div>
+									</c:if>
+
+									<liferay-util:include page="/wiki/view_attachments.jsp" servletContext="<%= application %>" />
+
+									<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnableRelatedAssets() %>">
+										<div class="entry-links">
+											<liferay-asset:asset-links
+												assetEntryId="<%= assetEntry.getEntryId() %>"
+											/>
+										</div>
+									</c:if>
+								</div>
+
+								<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnableComments() %>">
+									<div id="<portlet:namespace />wikiCommentsPanel">
+										<liferay-comment:discussion
+											className="<%= WikiPage.class.getName() %>"
+											classPK="<%= wikiPage.getResourcePrimKey() %>"
+											formName="fm2"
+											ratingsEnabled="<%= wikiPortletInstanceSettingsHelper.isEnableCommentRatings() %>"
+											redirect="<%= currentURL %>"
+											userId="<%= wikiPage.getUserId() %>"
+										/>
+									</div>
+								</c:if>
+							</c:if>
+						</div>
+					</liferay-ddm:template-renderer>
 
 					<%
+					if (!Objects.equals(wikiPage.getTitle(), wikiGroupServiceConfiguration.frontPageName())) {
+						if (!portletName.equals(WikiPortletKeys.WIKI_DISPLAY)) {
+							PortalUtil.setPageSubtitle(wikiPage.getTitle(), request);
+
+							String description = wikiPage.getContent();
+
+							if (Objects.equals(wikiPage.getFormat(), "html")) {
+								description = HtmlUtil.stripHtml(description);
+							}
+
+							description = StringUtil.shorten(description, 200);
+
+							PortalUtil.setPageDescription(description, request);
+
+							PortalUtil.setPageKeywords(assetHelper.getAssetKeywords(WikiPage.class.getName(), wikiPage.getResourcePrimKey()), request);
+						}
+
+						List<WikiPage> parentPages = wikiPage.getViewableParentPages();
+
+						for (WikiPage curParentPage : parentPages) {
+							viewPageURL.setParameter("title", curParentPage.getTitle());
+
+							PortalUtil.addPortletBreadcrumbEntry(request, curParentPage.getTitle(), viewPageURL.toString());
+						}
+
+						viewPageURL.setParameter("title", wikiPage.getTitle());
+
+						PortalUtil.addPortletBreadcrumbEntry(request, wikiPage.getTitle(), viewPageURL.toString());
 					}
 					%>
 
-				</ul>
+					<liferay-util:dynamic-include key="com.liferay.wiki.web#/wiki/view.jsp#post" />
+				</div>
 			</div>
-		</c:if>
+
+			<c:if test="<%= Validator.isNotNull(formattedContent) && (followRedirect || (redirectPage == null)) && !childPages.isEmpty() %>">
+				<h4 class="text-default">
+					<liferay-ui:message arguments="<%= childPages.size() %>" key="child-pages-x" translateArguments="<%= false %>" />
+				</h4>
+
+				<div>
+					<ul class="list-group">
+
+						<%
+						for (WikiPage childPage : childPages) {
+						%>
+
+							<li class="list-group-item">
+								<h3>
+
+									<%
+									PortletURL rowURL = PortletURLUtil.clone(viewPageURL, renderResponse);
+
+									rowURL.setParameter("title", childPage.getTitle());
+									%>
+
+									<aui:a href="<%= rowURL.toString() %>"><%= childPage.getTitle() %></aui:a>
+								</h3>
+
+								<%
+								String childPageFormattedContent = null;
+
+								try {
+									childPageFormattedContent = WikiUtil.getFormattedContent(wikiEngineRenderer, renderRequest, renderResponse, childPage, viewPageURL, editPageURL, childPage.getTitle(), false);
+								}
+								catch (Exception e) {
+									childPageFormattedContent = childPage.getContent();
+								}
+								%>
+
+								<p class="text-default"><%= StringUtil.shorten(HtmlUtil.extractText(childPageFormattedContent), 200) %></p>
+							</li>
+
+						<%
+						}
+						%>
+
+					</ul>
+				</div>
+			</c:if>
+		</div>
 	</div>
 </div>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -18,9 +18,7 @@
 
 <liferay-util:include page="/admin/toolbar.jsp" servletContext="<%= application %>" />
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<c:choose>
 		<c:when test="<%= hasAddSourcePermission && reportsEngineDisplayContext.isSourcesTabSelected() %>">
 			<liferay-util:include page="/admin/data_source/sources.jsp" servletContext="<%= application %>" />

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_workflow_definitions.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_workflow_definitions.jsp
@@ -24,9 +24,7 @@ KaleoDefinitionVersionSearch kaleoDefinitionVersionSearch = kaleoDesignerDisplay
 
 <liferay-util:include page="/designer/management_bar.jsp" servletContext="<%= application %>" />
 
-<clay:container-fluid
-	cssClass="main-content-body"
->
+<clay:container-fluid>
 	<liferay-ui:error exception="<%= RequiredWorkflowDefinitionException.class %>">
 		<liferay-ui:message arguments="<%= kaleoDesignerDisplayContext.getMessageArguments((RequiredWorkflowDefinitionException)errorException) %>" key="<%= kaleoDesignerDisplayContext.getMessageKey((RequiredWorkflowDefinitionException)errorException) %>" translateArguments="<%= false %>" />
 	</liferay-ui:error>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/top.jspf
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/top.jspf
@@ -23,7 +23,7 @@ if ((rowChecker != null) && (headerNames != null)) {
 %>
 
 <c:if test="<%= emptyResultsMessage != null %>">
-	<div class="<%= resultRows.isEmpty() ? StringPool.BLANK : "hide" %> main-content-body" id="<%= namespace + id %>EmptyResultsMessage">
+	<div class="<%= resultRows.isEmpty() ? StringPool.BLANK : "hide" %> container-view" id="<%= namespace + id %>EmptyResultsMessage">
 		<liferay-ui:empty-result-message
 			compact="<%= compactEmptyResultsMessage %>"
 			cssClass="<%= emptyResultsMessageCssClass %>"
@@ -33,5 +33,5 @@ if ((rowChecker != null) && (headerNames != null)) {
 	</div>
 </c:if>
 
-<div class="<%= resultRows.isEmpty() ? "hide" : StringPool.BLANK %> <%= searchContainer.getCssClass() %> lfr-search-container-wrapper <%= displayStyle.equals(SearchIteratorTag.DEFAULT_DISPLAY_STYLE) ? StringPool.BLANK : "main-content-body" %> <%= fixedHeader ? "lfr-search-container-fixed-first-column" : StringPool.BLANK %>">
+<div class="<%= resultRows.isEmpty() ? "hide" : StringPool.BLANK %> <%= searchContainer.getCssClass() %> container-view lfr-search-container-wrapper <%= fixedHeader ? "lfr-search-container-fixed-first-column" : StringPool.BLANK %>">
 	<div id="<%= namespace + id %>SearchContainer">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-125269

Combing through portal trying to unify container classes and removing old container related css. I rearranged a lot of container classes using `container-view` and `container-form-lg` where applicable. There were so many odd uses of containers that I couldn't catch them all.

I also tried to fix the info panels not aligning all the way to the right in admin view, but I'm sure I missed some.

- liferay-ui:search-iterator use container-view to space tables, cards, and list always
- Content Dashboard Web update container classes to properly space tables and sheets according to Lexicon specs
- liferay-frontend:edit-form use container-fluid container-fluid-max-xl and remove container-view. Spacing gets really inconsistent since this tag is used in modals and regular pages. This tag should be spaced using the class lfr-form-content inside modals.
- Account Admin details should have space between sheet and navigation-bar