### PR TITLE
LPS-124406 Fix input-group style

### DIFF
--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -206,8 +206,12 @@ boolean choiceField = checkboxField || radioField;
 <c:if test="<%= Validator.isNotNull(prefix) || Validator.isNotNull(suffix) %>">
 	<div class="<%= addOnCssClass %>">
 		<c:if test="<%= Validator.isNotNull(prefix) %>">
-			<span class="<%= helpTextCssClass %>"><liferay-ui:message key="<%= prefix %>" /></span>
+			<div class="input-group-item input-group-item-shrink input-group-prepend">
+				<span class="input-group-text <%= helpTextCssClass %>"><liferay-ui:message key="<%= prefix %>" /></span>
+			</div>
 		</c:if>
+
+		<div class="input-group-item input-group-prepend">
 </c:if>
 
 <c:choose>
@@ -444,8 +448,12 @@ boolean choiceField = checkboxField || radioField;
 </c:choose>
 
 <c:if test="<%= Validator.isNotNull(prefix) || Validator.isNotNull(suffix) %>">
+		</div>
+
 		<c:if test="<%= Validator.isNotNull(suffix) %>">
-			<span class="<%= helpTextCssClass %>"><liferay-ui:message key="<%= suffix %>" /></span>
+			<div class="input-group-append input-group-item-shrink">
+				<span class="input-group-text <%= helpTextCssClass %>"><liferay-ui:message key="<%= suffix %>" /></span>
+			</div>
 		</c:if>
 	</div>
 </c:if>


### PR DESCRIPTION
Fixing the input-group style after the compat-layer removal.

The ideal change would have been to replace the original class `input-group-addon` with the Clay one `input-group-text` but since it's used in several places and scripts I preferred to keep it.

![blog](https://user-images.githubusercontent.com/46778114/103341098-2c0c2a80-4a86-11eb-99b5-a120a1100483.jpg)
