### PR TITLE
LPS-125509 Replaces metal-dom's closest function with native closest on commerce-product-options-web

### DIFF
--- a/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/CPOptionValueList.es.js
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/CPOptionValueList.es.js
@@ -32,11 +32,11 @@ class CPOptionValueList extends Component {
 	}
 
 	_handleSelectOptionValueClick(event) {
-		var target = event.target;
+		const target = event.target;
 
-		var row = target.closest('tr');
+		const row = target.closest('tr');
 
-		var cpOptionValueId = row.getAttribute('data-id');
+		const cpOptionValueId = row.getAttribute('data-id');
 
 		this.emit('optionValueSelected', cpOptionValueId);
 	}

--- a/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/CPOptionValueList.es.js
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/CPOptionValueList.es.js
@@ -13,7 +13,6 @@
  */
 
 import Component from 'metal-component';
-import dom from 'metal-dom';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';
 
@@ -35,7 +34,7 @@ class CPOptionValueList extends Component {
 	_handleSelectOptionValueClick(event) {
 		var target = event.target;
 
-		var row = dom.closest(target, 'tr');
+		var row = target.closest('tr');
 
 		var cpOptionValueId = row.getAttribute('data-id');
 


### PR DESCRIPTION
It was a leftover from:

https://github.com/liferay-frontend/liferay-portal/pull/462
https://issues.liferay.com/browse/LPS-122392

I need help for finding the use case commerce. Could you guys help me?

/cc @marco-leo @FabioDiegoMastrorilli @john-co 