### PR TITLE
LPS-125139 - Remove metal-throttle dependency

### DIFF
--- a/modules/apps/frontend-js/frontend-js-metal-web/bnd.bnd
+++ b/modules/apps/frontend-js/frontend-js-metal-web/bnd.bnd
@@ -32,7 +32,6 @@ Liferay-JS-Submodules-Bridge:\
 	metal-state,\
 	metal-storage,\
 	metal-structs,\
-	metal-throttle,\
 	metal-toggler,\
 	metal-uri,\
 	metal-useragent

--- a/modules/apps/frontend-js/frontend-js-metal-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-metal-web/package.json
@@ -28,7 +28,6 @@
 		"metal-state": "2.16.8",
 		"metal-storage": "2.0.1",
 		"metal-structs": "1.0.2",
-		"metal-throttle": "3.0.1",
 		"metal-toggler": "2.3.0",
 		"metal-uri": "2.4.0",
 		"metal-useragent": "3.0.1",

--- a/modules/apps/layout/layout-admin-web/package.json
+++ b/modules/apps/layout/layout-admin-web/package.json
@@ -19,7 +19,6 @@
 		"metal-events": "2.16.8",
 		"metal-position": "2.1.2",
 		"metal-state": "2.16.8",
-		"metal-throttle": "3.0.1",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
 		"react-dnd": "11.1.1",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -10483,11 +10483,6 @@ metal-structs@1.0.2, metal-structs@^1.0.0:
   dependencies:
     metal "^2.16.6"
 
-metal-throttle@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/metal-throttle/-/metal-throttle-3.0.1.tgz#d9b976c0d4fef11e08cc9d72ff5478f1998805e2"
-  integrity sha512-aigicXXWzpllJGWdLaCQVVFSDLfLlVAyG0LRuzwrVToWVJpdDL0RJ5nWad30X/p0Fa3IuewEMD55UuWkT4TNqw==
-
 metal-toggler@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/metal-toggler/-/metal-toggler-2.3.0.tgz#16805424dd06adf499ac3e19a53b412ccd13acec"


### PR DESCRIPTION
Removes all references to metal-throttle and gets rid of the dependency in dxp. https://issues.liferay.com/browse/LPS-125139