### PR TITLE
LPS-125126 - Remove references to metal-debounce as a dependency

### DIFF
--- a/modules/apps/commerce/commerce-cart-taglib/package.json
+++ b/modules/apps/commerce/commerce-cart-taglib/package.json
@@ -3,7 +3,6 @@
 		"clay-icon": "2.22.0",
 		"metal": "2.16.8",
 		"metal-component": "2.16.8",
-		"metal-debounce": "^2.0.2",
 		"metal-soy": "2.16.9",
 		"metal-state": "2.16.8"
 	},

--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-impl/package.json
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-impl/package.json
@@ -7,7 +7,6 @@
 		"clay-table": "2.22.0",
 		"metal": "2.16.8",
 		"metal-component": "2.16.8",
-		"metal-debounce": "^2.0.2",
 		"metal-soy": "2.16.9",
 		"metal-state": "2.16.8"
 	},

--- a/modules/apps/frontend-js/frontend-js-metal-web/bnd.bnd
+++ b/modules/apps/frontend-js/frontend-js-metal-web/bnd.bnd
@@ -12,7 +12,6 @@ Liferay-JS-Submodules-Bridge:\
 	metal-assertions,\
 	metal-clipboard,\
 	metal-component,\
-	metal-debounce,\
 	metal-dom,\
 	metal-drag-drop,\
 	metal-events,\

--- a/modules/apps/frontend-js/frontend-js-metal-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-metal-web/package.json
@@ -8,7 +8,6 @@
 		"metal-assertions": "2.16.8",
 		"metal-clipboard": "2.0.1",
 		"metal-component": "2.16.8",
-		"metal-debounce": "^2.0.2",
 		"metal-dom": "2.16.8",
 		"metal-drag-drop": "3.3.1",
 		"metal-events": "2.16.8",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -10290,7 +10290,7 @@ metal-component@2.16.8, metal-component@^2.0.0, metal-component@^2.13.2, metal-c
     metal-events "^2.16.8"
     metal-state "^2.16.8"
 
-metal-debounce@^2.0.0, metal-debounce@^2.0.1, metal-debounce@^2.0.2:
+metal-debounce@^2.0.0, metal-debounce@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/metal-debounce/-/metal-debounce-2.0.2.tgz#e5cbe97e76bf0e57a09df927de8b65a47c1f2fc5"
   integrity sha512-BFAVzGDN50drx6cV88JgI1pyI2z4awQZejMgefxpwJgcvsFXMQyymDFRzuEtecYARSHWyGPjfB5BYrpaKY8uKQ==


### PR DESCRIPTION
Removes metal-debounce as a dependency. Note that it still exists in a .npmbundlerrc file, but those will be addressed in a separate task. https://issues.liferay.com/browse/LPS-125126