### PR TITLE
LRQA-63724 - Add a base workflow metrics test to environment acceptance

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetrics.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetrics.testcase
@@ -2968,6 +2968,7 @@ definition {
 	@description = "LRQA-53659 Automate LPS-86652 [Reports] View all items for a certain process"
 	@priority = "5"
 	test ViewReports {
+		property environment.acceptance = "true";
 		property test.name.skip.portal.instance = "WorkflowMetrics#ViewReports";
 
 		var siteName = TestCase.getSiteName(siteName = "${siteName}");


### PR DESCRIPTION
Ok to backport in 7.x branches.

**Description**
This aims to fix a regression test gap between workflow metrics and FI modules. Since some FI modules target only environment.acceptance tests and no workflow metrics test cases had set that property, it allowed a FP5 regression to get past `ci:test:relevant` testing. I contacted @rodrigocunhaa (Workflow QA) and we agreed that WorfklowMetrics#ViewReports would be a good smoke test to include in environment.acceptance.

**Test Plan**
1. Edit some code in frontend-js directory
2. Run ci:test:relevant in PR
3. Assert that a base workflow metrics test was included in test result

**JIra Ticket**
https://issues.liferay.com/browse/LRQA-63724