### PR TITLE
LPS-125131 Remove usage of {EventHandler} from metal-events

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/package.json
@@ -5,7 +5,6 @@
 		"clay-icon": "2.22.0",
 		"clay-modal": "2.22.0",
 		"metal-drag-drop": "3.3.1",
-		"metal-events": "2.16.8",
 		"metal-jsx": "2.16.8",
 		"metal-state": "2.16.8"
 	},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
@@ -27,7 +27,6 @@ import {
 import {makeFetch} from 'dynamic-data-mapping-form-renderer/js/util/fetch.es';
 import {openModal} from 'frontend-js-web';
 import {Drag, DragDrop} from 'metal-drag-drop';
-import {EventHandler} from 'metal-events';
 import Component, {Fragment} from 'metal-jsx';
 import {Config} from 'metal-state';
 
@@ -105,7 +104,6 @@ class Sidebar extends Component {
 	}
 
 	created() {
-		this._eventHandler = new EventHandler();
 		const transitionEnd = this._getTransitionEndEvent();
 
 		this.supportsTransitionEnd = transitionEnd !== false;
@@ -155,13 +153,6 @@ class Sidebar extends Component {
 	disposeInternal() {
 		super.disposeInternal();
 
-		document.removeEventListener(
-			'mousedown',
-			this._handleDocumentMouseDown,
-			false
-		);
-
-		this._eventHandler.removeAllListeners();
 		this.disposeDragAndDrop();
 	}
 
@@ -385,17 +376,15 @@ class Sidebar extends Component {
 			useShim: false,
 		});
 
-		this._eventHandler.add(
-			this._dragAndDrop.on(Drag.Events.START, this._handleDragStarted),
-			this._dragAndDrop.on(DragDrop.Events.END, this._handleDragEnded),
-			this._dragAndDrop.on(
-				DragDrop.Events.TARGET_ENTER,
-				this._handleDragTargetEnter
-			),
-			this._dragAndDrop.on(
-				DragDrop.Events.TARGET_LEAVE,
-				this._handleDragTargetLeave
-			)
+		this._dragAndDrop.on(Drag.Events.START, this._handleDragStarted);
+		this._dragAndDrop.on(DragDrop.Events.END, this._handleDragEnded);
+		this._dragAndDrop.on(
+			DragDrop.Events.TARGET_ENTER,
+			this._handleDragTargetEnter
+		);
+		this._dragAndDrop.on(
+			DragDrop.Events.TARGET_LEAVE,
+			this._handleDragTargetLeave
 		);
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
@@ -7,7 +7,6 @@
 		"clay-multi-select": "2.22.0",
 		"clipboard": "2.0.4",
 		"metal-drag-drop": "3.3.1",
-		"metal-events": "2.16.8",
 		"metal-jsx": "2.16.8",
 		"metal-state": "2.16.8",
 		"object-hash": "^1.3.0"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -29,7 +29,6 @@ import {
 import {sub} from 'dynamic-data-mapping-form-builder/js/util/strings.es';
 import {PagesVisitor, compose} from 'dynamic-data-mapping-form-renderer';
 import {delegate} from 'frontend-js-web';
-import {EventHandler} from 'metal-events';
 import Component from 'metal-jsx';
 import {Config} from 'metal-state';
 
@@ -62,8 +61,6 @@ class Form extends Component {
 		} = this.props;
 
 		const {activeNavItem, paginationMode} = this.state;
-
-		this._eventHandler = new EventHandler();
 
 		const nameEditor = document.getElementById(`${namespace}nameEditor`);
 
@@ -155,9 +152,7 @@ class Form extends Component {
 					this.element
 				);
 
-				this._eventHandler.add(
-					this._autoSave.on('autosaved', this._updateAutoSaveMessage)
-				);
+				this._autoSave.on('autosaved', this._updateAutoSaveMessage);
 			}
 		);
 
@@ -325,8 +320,6 @@ class Form extends Component {
 
 		this._backButtonClickEventHandler.dispose();
 		this._formNavClickEventHandler.dispose();
-
-		this._eventHandler.removeAllListeners();
 
 		const addFieldButton = document.getElementById('addFieldButton');
 

--- a/modules/apps/item-selector/item-selector-taglib/package.json
+++ b/modules/apps/item-selector/item-selector-taglib/package.json
@@ -7,7 +7,6 @@
 		"@clayui/tabs": "3.3.3",
 		"clay-alert": "2.22.0",
 		"frontend-js-web": "*",
-		"metal-events": "2.16.8",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -15,7 +15,6 @@
 import {ClayAlert} from 'clay-alert';
 import {render} from 'frontend-js-react-web';
 import {PortletBase, delegate} from 'frontend-js-web';
-import {EventHandler} from 'metal-events';
 import {Config} from 'metal-state';
 import ReactDOM from 'react-dom';
 
@@ -33,13 +32,6 @@ const statusCode = Liferay.STATUS_CODE;
  * @extends {PortletBase}
  */
 class ItemSelectorRepositoryEntryBrowser extends PortletBase {
-
-	/**
-	 * @inheritDoc
-	 */
-	created() {
-		this._eventHandler = new EventHandler();
-	}
 
 	/**
 	 * @inheritDoc
@@ -105,7 +97,28 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 
 		this._itemSelectorUploader.destroy();
 
-		this._eventHandler.removeAllListeners();
+		if (this._itemPreviewClickHandle) {
+			this._itemPreviewClickHandle.dispose();
+		}
+
+		if (this._inputFileNode) {
+			this._inputFileNode.removeEventListener(
+				'change',
+				this._handleInputFileNodeChange
+			);
+		}
+
+		if (this.rootNode) {
+			this.rootNode.removeEventListener(STR_DRAG_OVER, (event) =>
+				this._ddEventHandler(event)
+			);
+			this.rootNode.removeEventListener(STR_DRAG_LEAVE, (event) =>
+				this._ddEventHandler(event)
+			);
+			this.rootNode.removeEventListener(STR_DROP, (event) =>
+				this._ddEventHandler(event)
+			);
+		}
 	}
 
 	/**
@@ -114,19 +127,23 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 	 * @private
 	 */
 	_bindEvents() {
-		this._eventHandler.add(
-			delegate(this.rootNode, 'click', '.item-preview', (event) =>
-				this._onItemSelected(event.delegateTarget.dataset)
-			)
+		this._itemPreviewClickHandle = delegate(
+			this.rootNode,
+			'click',
+			'.item-preview',
+			(event) => this._onItemSelected(event.delegateTarget.dataset)
 		);
 
-		const inputFileNode = this.one('input[type="file"]');
+		this._inputFileNode = document.querySelector('input[type="file"]');
 
-		if (inputFileNode) {
-			this._eventHandler.add(
-				inputFileNode.addEventListener('change', (event) => {
-					this._validateFile(event.target.files[0]);
-				})
+		this._handleInputFileNodeChange = (event) => {
+			this._validateFile(event.target.files[0]);
+		};
+
+		if (this._inputFileNode) {
+			this._inputFileNode.addEventListener(
+				'change',
+				this._handleInputFileNodeChange
 			);
 		}
 
@@ -134,47 +151,50 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 			const itemSelectorUploader = this._itemSelectorUploader;
 			const rootNode = this.rootNode;
 
-			this._eventHandler.add(
-				itemSelectorUploader.after('itemUploadCancel', () => {
-					this.closeItemSelectorPreview();
-				}),
-				itemSelectorUploader.after('itemUploadComplete', (itemData) => {
-					const itemFile = itemData.file;
-					const itemFileUrl = itemFile.url;
-					let itemFileValue = itemFile.resolvedValue;
+			itemSelectorUploader.after('itemUploadCancel', () => {
+				this.closeItemSelectorPreview();
+			});
 
-					if (!itemFileValue) {
-						const imageValue = {
-							fileEntryId: itemFile.fileEntryId,
-							groupId: itemFile.groupId,
-							title: itemFile.title,
-							type: itemFile.type,
-							url: itemFileUrl,
-							uuid: itemFile.uuid,
-						};
+			itemSelectorUploader.after('itemUploadComplete', (itemData) => {
+				const itemFile = itemData.file;
+				const itemFileUrl = itemFile.url;
+				let itemFileValue = itemFile.resolvedValue;
 
-						itemFileValue = JSON.stringify(imageValue);
-					}
+				if (!itemFileValue) {
+					const imageValue = {
+						fileEntryId: itemFile.fileEntryId,
+						groupId: itemFile.groupId,
+						title: itemFile.title,
+						type: itemFile.type,
+						url: itemFileUrl,
+						uuid: itemFile.uuid,
+					};
 
-					Liferay.componentReady('ItemSelectorPreview').then(() => {
-						Liferay.fire('updateCurrentItem', {
-							url: itemFileUrl,
-							value: itemFileValue,
-						});
+					itemFileValue = JSON.stringify(imageValue);
+				}
+
+				Liferay.componentReady('ItemSelectorPreview').then(() => {
+					Liferay.fire('updateCurrentItem', {
+						url: itemFileUrl,
+						value: itemFileValue,
 					});
-				}),
-				itemSelectorUploader.after('itemUploadError', (event) => {
-					this._onItemUploadError(event);
-				}),
-				rootNode.addEventListener(STR_DRAG_OVER, (event) =>
-					this._ddEventHandler(event)
-				),
-				rootNode.addEventListener(STR_DRAG_LEAVE, (event) =>
-					this._ddEventHandler(event)
-				),
-				rootNode.addEventListener(STR_DROP, (event) =>
-					this._ddEventHandler(event)
-				)
+				});
+			});
+
+			itemSelectorUploader.after('itemUploadError', (event) => {
+				this._onItemUploadError(event);
+			});
+
+			rootNode.addEventListener(STR_DRAG_OVER, (event) =>
+				this._ddEventHandler(event)
+			);
+
+			rootNode.addEventListener(STR_DRAG_LEAVE, (event) =>
+				this._ddEventHandler(event)
+			);
+
+			rootNode.addEventListener(STR_DROP, (event) =>
+				this._ddEventHandler(event)
 			);
 		}
 	}

--- a/modules/apps/layout/layout-admin-web/package.json
+++ b/modules/apps/layout/layout-admin-web/package.json
@@ -15,7 +15,6 @@
 		"frontend-js-web": "*",
 		"metal-component": "2.16.8",
 		"metal-drag-drop": "3.3.1",
-		"metal-events": "2.16.8",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",

--- a/modules/apps/layout/layout-content-page-editor-web/package.json
+++ b/modules/apps/layout/layout-content-page-editor-web/package.json
@@ -20,7 +20,6 @@
 		"classnames": "2.2.6",
 		"frontend-js-react-web": "*",
 		"frontend-js-web": "*",
-		"metal-events": "2.16.8",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
 		"react-dnd": "11.1.1",

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/Editor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/Editor.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import {EventHandler} from 'metal-events';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
 
@@ -44,28 +43,20 @@ export default function Editor({
 	}, [editor, initialValue]);
 
 	useEffect(() => {
-		const editorEventHandler = new EventHandler();
-
 		if (editor && onChange) {
 			const nativeEditor = editor.get('nativeEditor');
 
-			editorEventHandler.add(
-				nativeEditor.on('change', () =>
-					onChange(nativeEditor.getData())
-				)
+			nativeEditor.on('change', () => onChange(nativeEditor.getData()));
+
+			nativeEditor.on('actionPerformed', () =>
+				onChange(nativeEditor.getData())
 			);
 
-			editorEventHandler.add(
-				nativeEditor.on('actionPerformed', () =>
-					onChange(nativeEditor.getData())
-				)
-			);
+			return () => {
+				nativeEditor._.events.change = null;
+				nativeEditor._.events.actionPerformed = null;
+			};
 		}
-
-		return () => {
-			editorEventHandler.removeAllListeners();
-			editorEventHandler.dispose();
-		};
 	}, [editor, onChange]);
 
 	useEffect(() => {

--- a/modules/apps/message-boards/message-boards-web/package.json
+++ b/modules/apps/message-boards/message-boards-web/package.json
@@ -1,7 +1,6 @@
 {
 	"dependencies": {
-		"frontend-js-web": "*",
-		"metal-events": "2.16.8"
+		"frontend-js-web": "*"
 	},
 	"name": "message-boards-web",
 	"scripts": {

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/package.json
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/package.json
@@ -5,7 +5,6 @@
 		"@clayui/icon": "3.1.0",
 		"@clayui/loading-indicator": "3.2.0",
 		"frontend-js-web": "*",
-		"metal-events": "2.16.8",
 		"metal-state": "2.16.8",
 		"react": "16.12.0",
 		"react-dom": "16.12.0"

--- a/modules/apps/wiki/wiki-web/package.json
+++ b/modules/apps/wiki/wiki-web/package.json
@@ -1,7 +1,6 @@
 {
 	"dependencies": {
-		"frontend-js-web": "*",
-		"metal-events": "2.16.8"
+		"frontend-js-web": "*"
 	},
 	"name": "wiki-web",
 	"scripts": {


### PR DESCRIPTION
### Overview of the PR
In this PR I removed the `EventHandler` part of the `metal-events` package. 
I've done this by manually adding event handlers and manually removing them, similar to what we did in #466 

### Testing
I've manually tested all of my changes except the one in `item-selector-taglib` where I couldn't get `detach()` to trigger, therefore unable to test if the event listeners I created were getting properly detached from the DOM.

### Future
Remaining parts of `metal-events` are `EventEmitter` and `EventEmitterProxy` which, as proposed by @wincent in https://github.com/liferay-frontend/liferay-portal/pull/684#issuecomment-766656500, will be split into a PR separate from this one and handled on their own as this PR can remain independent and get merged without doing anything to the emitters.