### PR TITLE
[LRQA-62224 | LPS-126081] Remove false positive sikuli assertions from theme tests and ignore failing test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Theme.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Theme.macro
@@ -99,6 +99,15 @@ definition {
 		}
 	}
 
+	macro viewClassicThemeBackgroundColor {
+		AssertCssValue(
+			locator1 = "//body",
+			locator2 = "background-color",
+			value1 = "rgba(255, 255, 255, 1)");
+
+		takeScreenshot();
+	}
+
 	macro viewMaxPortletOption {
 		AssertTextEquals(
 			key_menuItem = "Maximize",
@@ -122,6 +131,15 @@ definition {
 		// Refresh step is a workaround for LPS-91762
 
 		Refresh();
+	}
+
+	macro viewTestThemeBackgroundColor {
+		AssertCssValue(
+			locator1 = "//body",
+			locator2 = "background-color",
+			value1 = "rgba(255, 165, 0, 1)");
+
+		takeScreenshot();
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
@@ -53,9 +53,9 @@ definition {
 
 		Navigator.openStagingSiteURL(defaultSite = "true");
 
-		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
 		// Workaround for LPS-110206
+
+		//SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
 
 		//AssertCssValue(
 		//	locator1 = "//body",
@@ -212,9 +212,9 @@ definition {
 
 		Button.clickPublish();
 
-		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
 		// Workaround for LPS-110206
+
+		//SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
 
 		//AssertCssValue(
 		//	locator1 = "//body",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
@@ -166,6 +166,9 @@ definition {
 			themeName = "test-theme-7-4");
 	}
 
+	// Ignore test until LPS-126081 is resolved
+
+	@ignore = "true"
 	@priority = "5"
 	test PublishThemeFromStagedToLive {
 		property test.name.skip.portal.instance = "Theme#PublishThemeFromStagedToLive";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
@@ -104,6 +104,11 @@ definition {
 
 		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
 
+		AssertCssValue(
+			locator1 = "//body",
+			locator2 = "background-color",
+			value1 = "rgba(255, 165, 0, 1)");
+
 		takeScreenshot();
 	}
 
@@ -136,6 +141,11 @@ definition {
 			siteName = "Guest");
 
 		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
+
+		AssertCssValue(
+			locator1 = "//body",
+			locator2 = "background-color",
+			value1 = "rgba(255, 165, 0, 1)");
 
 		ApplicationsMenu.gotoPortlet(
 			category = "System",
@@ -177,6 +187,11 @@ definition {
 			siteName = "Guest");
 
 		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
+
+		AssertCssValue(
+			locator1 = "//body",
+			locator2 = "background-color",
+			value1 = "rgba(255, 165, 0, 1)");
 
 		takeScreenshot();
 
@@ -309,6 +324,11 @@ definition {
 			siteName = "Guest");
 
 		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
+
+		AssertCssValue(
+			locator1 = "//body",
+			locator2 = "background-color",
+			value1 = "rgba(255, 165, 0, 1)");
 
 		ApplicationsMenu.gotoPortlet(
 			category = "System",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
@@ -55,25 +55,11 @@ definition {
 
 		// Workaround for LPS-110206
 
-		//SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		//AssertCssValue(
-		//	locator1 = "//body",
-		//	locator2 = "background-color",
-		//	value1 = "rgba(255, 165, 0, 1)");
-
-		takeScreenshot();
+		//Theme.viewTestThemeBackgroundColor();
 
 		Navigator.openURL();
 
-		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		AssertCssValue(
-			locator1 = "//body",
-			locator2 = "background-color",
-			value1 = "rgba(255, 165, 0, 1)");
-
-		takeScreenshot();
+		Theme.viewTestThemeBackgroundColor();
 	}
 
 	@description = "This test validates that a theme can be applied to a single page."
@@ -102,14 +88,7 @@ definition {
 
 		ProductMenuHelper.closeProductMenu();
 
-		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		AssertCssValue(
-			locator1 = "//body",
-			locator2 = "background-color",
-			value1 = "rgba(255, 165, 0, 1)");
-
-		takeScreenshot();
+		Theme.viewTestThemeBackgroundColor();
 	}
 
 	@priority = "5"
@@ -140,12 +119,7 @@ definition {
 			pageName = "Theme Test Page",
 			siteName = "Guest");
 
-		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		AssertCssValue(
-			locator1 = "//body",
-			locator2 = "background-color",
-			value1 = "rgba(255, 165, 0, 1)");
+		Theme.viewTestThemeBackgroundColor();
 
 		ApplicationsMenu.gotoPortlet(
 			category = "System",
@@ -164,9 +138,7 @@ definition {
 
 		AssertConsoleTextPresent(value1 = "No theme found for specified theme id testtheme74_WAR_testtheme. Returning the default theme.");
 
-		SikuliAssertElementNotPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		takeScreenshot();
+		Theme.viewClassicThemeBackgroundColor();
 
 		Page.viewCurrentTheme(
 			page = "Public Pages",
@@ -186,14 +158,7 @@ definition {
 			pageName = "Theme Test Page",
 			siteName = "Guest");
 
-		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		AssertCssValue(
-			locator1 = "//body",
-			locator2 = "background-color",
-			value1 = "rgba(255, 165, 0, 1)");
-
-		takeScreenshot();
+		Theme.viewTestThemeBackgroundColor();
 
 		Page.viewCurrentTheme(
 			page = "Public Pages",
@@ -229,25 +194,11 @@ definition {
 
 		// Workaround for LPS-110206
 
-		//SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		//AssertCssValue(
-		//	locator1 = "//body",
-		//	locator2 = "background-color",
-		//	value1 = "rgba(255, 165, 0, 1)");
-
-		takeScreenshot();
+		//Theme.viewTestThemeBackgroundColor();
 
 		Navigator.openURL();
 
-		SikuliAssertElementNotPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		AssertCssValue(
-			locator1 = "//body",
-			locator2 = "background-color",
-			value1 = "rgba(255, 255, 255, 1)");
-
-		takeScreenshot();
+		Theme.viewClassicThemeBackgroundColor();
 
 		Navigator.openStagingSiteURL(defaultSite = "true");
 
@@ -257,14 +208,7 @@ definition {
 
 		Navigator.openURL();
 
-		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		AssertCssValue(
-			locator1 = "//body",
-			locator2 = "background-color",
-			value1 = "rgba(255, 165, 0, 1)");
-
-		takeScreenshot();
+		Theme.viewTestThemeBackgroundColor();
 	}
 
 	@priority = "5"
@@ -323,12 +267,7 @@ definition {
 			pageName = "Theme Test Page",
 			siteName = "Guest");
 
-		SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		AssertCssValue(
-			locator1 = "//body",
-			locator2 = "background-color",
-			value1 = "rgba(255, 165, 0, 1)");
+		Theme.viewTestThemeBackgroundColor();
 
 		ApplicationsMenu.gotoPortlet(
 			category = "System",
@@ -347,9 +286,7 @@ definition {
 
 		AssertConsoleTextPresent(value1 = "No theme found for specified theme id testtheme74_WAR_testtheme. Returning the default theme.");
 
-		SikuliAssertElementNotPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		takeScreenshot();
+		Theme.viewClassicThemeBackgroundColor();
 
 		Page.viewCurrentTheme(
 			page = "Public Pages",
@@ -372,9 +309,7 @@ definition {
 			pageName = "Theme Test Page",
 			siteName = "Guest");
 
-		SikuliAssertElementNotPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG");
-
-		takeScreenshot();
+		Theme.viewClassicThemeBackgroundColor();
 
 		Page.viewCurrentTheme(
 			page = "Public Pages",


### PR DESCRIPTION
Not a clean cherry pick to 7.3.x. Once this is approved, will follow up with backport.

**Description**
Assert sikuli image alone is a false positive due to a sikuli bug on background color https://answers.launchpad.net/sikuli/+question/271019, but when paired with assert css backround color it is a full assertion. Therefore, we will remove the sikuli image assertion temporarily until LPS-110206 is fixed. This also exposes that other theme tests could potentially have false positives so will probably want the css background color assertion whenever there is a sikuli image is present assertion to cover that.

**Test Plan**
* Theme test cases pass
* SikuliAssertElementPresent(locator1 = "Theme#TEST_THEME_HOME_PAGE_PNG"); is always followed by assertCSSValue on background color

**JIRA Ticket**
https://issues.liferay.com/browse/LRQA-62224