### PR TITLE
LPS-125708

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
@@ -240,7 +240,7 @@ AUI.add(
 
 					if (field) {
 						var fieldWrapper = field.ancestor(
-							'form > fieldset > div'
+							'form > fieldset > div, form > div'
 						);
 
 						var formTabs = formNode.one('.lfr-nav');


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-125708

## Steps to reproduce

1. Create a widget page
2. Add a Knowledge Base Section widget to the created page
3. Open the Knowledge Base Section widget's configuration
4. Move to the "Display Settings" tab
5. Hit the Save button

Expected behavior is that it switches back to the General tab to show you the validation error.

Actual behavior is that it stays on the Display Settings tab.

## Solution concept

Updates the solution to [LPS-103247](https://issues.liferay.com/browse/LPS-103247) so that it still includes the old selector.