### PR TITLE
LPS-125607 Fix select any element from the highlighted ones and delete click target

### DIFF
--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -53,6 +53,8 @@ const THROTTLE_INTERVAL_MS = 100;
 
 const DispatchContext = React.createContext();
 
+const OVERLAY_TARGET_CLASS = 'lfr-segments-experiment-click-goal-target';
+
 /**
  * Top-level entry point for displaying, selecting, editing and removing click
  * goal targets.
@@ -376,9 +378,11 @@ function OverlayContainer({allowEdit, root}) {
 
 	const handleMouseUp = useCallback(
 		(event) => {
-			if (mousedownRef.current === true) {
-				event.preventDefault();
-				stopImmediatePropagation(event);
+			const overlayTarget = event.target.closest(
+				`.${OVERLAY_TARGET_CLASS}`
+			);
+
+			if (mousedownRef.current === true && !overlayTarget) {
 				dispatch({type: 'deactivate'});
 			}
 
@@ -515,7 +519,7 @@ function Target({allowEdit, element, geometry, mode, selector}) {
 
 	return (
 		<div
-			className="lfr-segments-experiment-click-goal-target"
+			className={OVERLAY_TARGET_CLASS}
 			style={{
 				alignItems: align === 'left' ? 'flex-start' : 'flex-end',
 				left: align === 'left' ? spaceOnLeft : null,


### PR DESCRIPTION
**Description**

When we create an AB Test with Click goal, we want to let the user enter the element ID (click goal target). Otherwise, the user can always select the click goal target from the UI (with the highlighted ones).

**Impedibug**

With this commit https://github.com/liferay-frontend/liferay-portal/pull/650/commits/fc06def393307e7b3a1d852f9373207f99fd6ff3 (already merged in master) we lose two functionalities:

- Select the click goal target with the UI (from the highlighted ones)
- Remove the selected click goal target (to be empty again)

**Screenshot**

![LPS-125607](https://user-images.githubusercontent.com/15845466/104314006-1ad90a00-54d9-11eb-8756-81e28c788808.gif)