### PR TITLE
[Only 7.4] LPS-125795 - Fix Simulation panel styles

### DIFF
--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
@@ -69,7 +69,7 @@
 
 	.panel {
 		.simulation-app-panel-body {
-			padding-top: 20px;
+			padding: 12px 0 4px;
 		}
 	}
 }

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -31,21 +31,19 @@ PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(panelAppRegist
 		for (PanelApp panelApp : panelCategoryHelper.getAllPanelApps(panelCategory.getKey())) {
 		%>
 
-			<div class="panel panel-secondary">
-				<div class="panel-header panel-heading" id="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Header" role="tab">
-					<div class="panel-title">
-						<div aria-controls="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" aria-expanded="<%= true %>" class="collapse-icon collapse-icon-middle panel-toggler" data-toggle="liferay-collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" role="button">
-							<span class="category-name text-truncate"><%= panelApp.getLabel(locale) %></span>
+			<div class="panel">
+				<div class="panel-heading" id="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Header" role="tab">
+					<div aria-controls="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" aria-expanded="<%= true %>" class="collapse-icon collapse-icon-middle list-group-heading panel-header" data-toggle="liferay-collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" role="button">
+						<span class="category-name text-truncate"><%= panelApp.getLabel(locale) %></span>
 
-							<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
+						<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
 
-							<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
-						</div>
+						<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
 					</div>
 				</div>
 
 				<div aria-expanded="<%= true %>" aria-labelledby="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Header" class="collapse panel-collapse show" id="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" role="tabpanel">
-					<div class="simulation-app-panel-body">
+					<div class="list-group-item simulation-app-panel-body">
 						<liferay-application-list:panel-app
 							panelApp="<%= panelApp %>"
 						/>

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -33,13 +33,13 @@ PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(panelAppRegist
 
 			<div class="panel">
 				<div class="panel-heading" id="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Header" role="tab">
-					<div aria-controls="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" aria-expanded="<%= true %>" class="collapse-icon collapse-icon-middle list-group-heading panel-header" data-toggle="liferay-collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" role="button">
+					<a aria-controls="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" aria-expanded="<%= true %>" class="collapse-icon collapse-icon-middle list-group-heading panel-header" data-toggle="liferay-collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" role="button">
 						<span class="category-name text-truncate"><%= panelApp.getLabel(locale) %></span>
 
 						<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
 
 						<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
-					</div>
+					</a>
 				</div>
 
 				<div aria-expanded="<%= true %>" aria-labelledby="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Header" class="collapse panel-collapse show" id="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" role="tabpanel">


### PR DESCRIPTION
This PR fixes the chaos of problems in the simulation panel:

- Alignment
- Padding and spaces
- Bg colors
- The uppercase
- Improves accessibility

![image](https://user-images.githubusercontent.com/7963804/104459075-8c35bd00-55ac-11eb-91d1-252fbe66d538.png)


- Now the visual design is the same as the Product menu, with states on panels opened or closed, same sizes/spaces, etc:

![image](https://user-images.githubusercontent.com/7963804/104459534-2269e300-55ad-11eb-8b26-bd73e7d6d3e1.png)

- https://github.com/liferay-frontend/liferay-portal/pull/694/commits/b3869853e77b5632492be383de1fa2f5dfc3b8dd fixes an accessibility issue, now we have focus state on panels an they can be managed by keyboard:

![image](https://user-images.githubusercontent.com/7963804/104459858-9efcc180-55ad-11eb-9b68-18f4ec291de7.png)

**How to test the PR:**

- Open simulation panel
