### PR TITLE
[Only-7.4] LPS-125761 and LPS-125859: - Fix compat management-bar

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/css/main.scss
@@ -645,4 +645,5 @@ $management-bar-default-btn-secondary-active-color: $management-bar-default-btn-
 .management-bar-secondary-bar {
 	background-color: #f0f5ff;
 	border-bottom: 1px solid $primary;
+	position: absolute;
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/css/main.scss
@@ -200,7 +200,7 @@ $management-bar-default-btn-secondary-active-color: $management-bar-default-btn-
 	padding-right: 0;
 	padding-top: (
 		(
-				$management-bar-height - 1.5rem -
+				$management-bar-height - 0.65rem -
 					$management-bar-border-bottom-width -
 					$management-bar-border-top-width
 			) / 2
@@ -208,7 +208,7 @@ $management-bar-default-btn-secondary-active-color: $management-bar-default-btn-
 
 	@media (min-width: 768px) {
 		padding-bottom: 18px;
-		padding-top: 18px;
+		padding-top: 24px;
 	}
 }
 
@@ -632,7 +632,7 @@ $management-bar-default-btn-secondary-active-color: $management-bar-default-btn-
 }
 
 .management-bar-header .form-inline input[type='checkbox'] {
-	margin-left: -1.25rem;
+	margin-left: 1.25rem;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
This PR fixes two issues with compat management bar:

- LPS-125761: Fix the checkbox
- LPS-125859: Fix the super extra space

https://user-images.githubusercontent.com/7963804/104601519-a211b380-567a-11eb-89bb-dd0eb6fead3c.mov

Mobile:
![image](https://user-images.githubusercontent.com/7963804/104602954-37617780-567c-11eb-960f-4abdcfb5e07e.png)


---

How to test it?

 - Product menu > configuration > mobile device families
 - Create a new one
 - See the pretty and awesome old management bar

