### PR TITLE
LPS-125807 Update liferay-ckeditor to v4.14.1-liferay.16

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"ckeditor4-react": "1.3.0",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.14.1-liferay.15",
+		"liferay-ckeditor": "4.14.1-liferay.16",
 		"prop-types": "15.7.2"
 	},
 	"main": "index.js",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -9429,10 +9429,10 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
-liferay-ckeditor@4.14.1-liferay.15:
-  version "4.14.1-liferay.15"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.14.1-liferay.15.tgz#fab308dbcb637ce0cff9f2a8b294a7183cbd4c52"
-  integrity sha512-gRBUy13UZHZoCde6FQ425mERUZFq8uWruWL94d82af9rGFjwb/dlZBfi7OWxiycx/cTjaBBH21ShgtOAvBv8Og==
+liferay-ckeditor@4.14.1-liferay.16:
+  version "4.14.1-liferay.16"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.14.1-liferay.16.tgz#cae6421d684745de477cded2c3ff1458488e60a3"
+  integrity sha512-/R7KjFnyNEgW+PfgO2MW6gpvEHS7Has8b1FGGiPNJx2Kl4jifN8fYSp4LHQX6Xfaa1IZAhwKtaQ9ASUaUEIC5g==
 
 liferay-font-awesome@3.4.0:
   version "3.4.0"


### PR DESCRIPTION
**Release notes:**

[Full changelog](https://github.com/liferay/liferay-ckeditor/compare/v4.14.1-liferay.15...v4.14.1-liferay.16)

-   fix: LPS-125441 CKEditor font size selector flickers on mouse over ([\#148](https://github.com/liferay/liferay-ckeditor/pull/148))

Additionally this fixes [LPS-125441](https://issues.liferay.com/browse/LPS-125441)