### PR TITLE
LPS-125950 liferay-frontend:screen-navigation causes horizontal scroll bar to show

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_role/details.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_role/details.jsp
@@ -34,6 +34,7 @@ if (accountRole != null) {
 
 <liferay-frontend:edit-form
 	action="<%= editAccountRoleURL %>"
+	cssClass="container-form-lg"
 >
 	<portlet:renderURL var="redirect">
 		<portlet:param name="mvcPath" value="/account_entries_admin/edit_account_role.jsp" />

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/add_account_user.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/add_account_user.jsp
@@ -41,6 +41,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "add-new-user-to-x", accoun
 
 <liferay-frontend:edit-form
 	action="<%= addAccountUsersURL %>"
+	cssClass="container-form-lg"
 >
 	<liferay-frontend:edit-form-body>
 		<portlet:renderURL var="defaultRedirect">

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/edit_account_entry.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/edit_account_entry.jsp
@@ -26,9 +26,7 @@ portletURL.setParameter("accountEntryId", String.valueOf(accountEntryDisplay.get
 %>
 
 <liferay-frontend:screen-navigation
-	containerWrapperCssClass=""
 	context="<%= accountEntryDisplay %>"
-	headerContainerCssClass=""
 	key="<%= AccountScreenNavigationEntryConstants.SCREEN_NAVIGATION_KEY_ACCOUNT_ENTRY %>"
 	portletURL="<%= portletURL %>"
 />

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/edit_account_entry_address.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/edit_account_entry_address.jsp
@@ -35,6 +35,7 @@ renderResponse.setTitle((accountEntryAddressId == 0) ? LanguageUtil.get(request,
 
 <liferay-frontend:edit-form
 	action="<%= editAccountEntryAddressURL %>"
+	cssClass="container-form-lg"
 >
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= (accountEntryAddressId == 0) ? Constants.ADD : Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= backURL %>" />

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/edit_account_role.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/edit_account_role.jsp
@@ -54,9 +54,7 @@ renderResponse.setTitle((role == null) ? LanguageUtil.get(request, "add-new-role
 %>
 
 <liferay-frontend:screen-navigation
-	containerWrapperCssClass=""
 	context="<%= accountRole %>"
-	headerContainerCssClass=""
 	key="<%= AccountScreenNavigationEntryConstants.SCREEN_NAVIGATION_KEY_ACCOUNT_ROLE %>"
 	portletURL="<%= portletURL %>"
 />

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/account_group/details.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/account_group/details.jsp
@@ -34,6 +34,7 @@ renderResponse.setTitle((accountGroupDisplay.getAccountGroupId() == 0) ? Languag
 
 <liferay-frontend:edit-form
 	action="<%= editAccountGroupURL %>"
+	cssClass="container-form-lg"
 >
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= (accountGroupDisplay.getAccountGroupId() == 0) ? Constants.ADD : Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/edit_account_group.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/edit_account_group.jsp
@@ -26,9 +26,7 @@ portletURL.setParameter("accountGroupId", String.valueOf(accountGroupDisplay.get
 %>
 
 <liferay-frontend:screen-navigation
-	containerWrapperCssClass=""
 	context="<%= accountGroupDisplay %>"
-	headerContainerCssClass=""
 	key="<%= AccountScreenNavigationEntryConstants.SCREEN_NAVIGATION_KEY_ACCOUNT_GROUP %>"
 	portletURL="<%= portletURL %>"
 />

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/edit_account_user.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/edit_account_user.jsp
@@ -29,7 +29,6 @@ portletURL.setParameter("mvcPath", "/account_users_admin/edit_account_user.jsp")
 	containerCssClass="col-lg-8"
 	containerWrapperCssClass="container-fluid container-fluid-max-xl container-form-lg"
 	context="<%= selUser %>"
-	headerContainerCssClass=""
 	key="<%= AccountScreenNavigationEntryConstants.SCREEN_NAVIGATION_KEY_ACCOUNT_USER %>"
 	menubarCssClass="menubar menubar-transparent menubar-vertical-expand-lg"
 	navCssClass="col-lg-3"

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/edit_vocabulary.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/edit_vocabulary.jsp
@@ -39,6 +39,7 @@ renderResponse.setTitle((vocabulary == null) ? LanguageUtil.get(request, "add-vo
 
 <liferay-frontend:edit-form
 	action="<%= editVocabularyURL %>"
+	cssClass="container-form-lg"
 	name="fm"
 	onSubmit='<%= liferayPortletResponse.getNamespace() + "confirmation(event);" %>'
 >

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/edit_tag.jsp
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/edit_tag.jsp
@@ -37,6 +37,7 @@ renderResponse.setTitle(assetTagsDisplayContext.getAssetTitle());
 
 <liferay-frontend:edit-form
 	action="<%= editTagURL %>"
+	cssClass="container-form-lg"
 	method="post"
 	name="fm"
 >

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/edit_depot_entry.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/edit_depot_entry.jsp
@@ -27,9 +27,7 @@
 
 	<liferay-frontend:screen-navigation
 		containerCssClass="col-lg-8"
-		containerWrapperCssClass=""
 		context="<%= (DepotEntry)request.getAttribute(DepotAdminWebKeys.DEPOT_ENTRY) %>"
-		headerContainerCssClass=""
 		key="<%= DepotScreenNavigationEntryConstants.SCREEN_NAVIGATION_KEY_DEPOT %>"
 		menubarCssClass="menubar menubar-transparent menubar-vertical-expand-lg"
 		navCssClass="col-lg-3"

--- a/modules/apps/dispatch/dispatch-talend-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dispatch/dispatch-talend-web/src/main/resources/META-INF/resources/view.jsp
@@ -23,7 +23,7 @@ String fileEntryName = (String)request.getAttribute(DispatchWebKeys.FILE_ENTRY_N
 
 <liferay-portlet:actionURL name="/dispatch_talend/edit_dispatch_talend_job_archive" portletName="<%= DispatchPortletKeys.DISPATCH %>" var="editDispatchTalendJobArchiveActionURL" />
 
-<div class="closed container-view" id="<portlet:namespace />editDispatchTriggerId">
+<div class="closed container-fluid container-fluid-max-xl container-form-lg" id="<portlet:namespace />editDispatchTriggerId">
 	<div class="sheet">
 		<aui:form action="<%= editDispatchTalendJobArchiveActionURL %>" enctype="multipart/form-data" method="post" name="fm">
 			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/details.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/details.jsp
@@ -35,7 +35,7 @@ if (dispatchTrigger != null) {
 
 <portlet:actionURL name="/dispatch/edit_dispatch_trigger" var="editDispatchTriggerActionURL" />
 
-<div class="closed container-view" id="<portlet:namespace />editDispatchTriggerId">
+<div class="closed container-fluid container-fluid-max-xl container-form-lg" id="<portlet:namespace />editDispatchTriggerId">
 	<div class="sheet">
 		<liferay-ui:error exception="<%= NoSuchLogException.class %>" message="the-log-could-not-be-found" />
 		<liferay-ui:error exception="<%= NoSuchTriggerException.class %>" message="the-trigger-could-not-be-found" />

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/details.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/details.jsp
@@ -35,7 +35,10 @@ if (dispatchTrigger != null) {
 
 <portlet:actionURL name="/dispatch/edit_dispatch_trigger" var="editDispatchTriggerActionURL" />
 
-<div class="closed container-fluid container-fluid-max-xl container-form-lg" id="<portlet:namespace />editDispatchTriggerId">
+<clay:container-fluid
+	cssClass="closed container-form-lg"
+	id='<%= liferayPortletResponse.getNamespace() + "editDispatchTriggerId" %>'
+>
 	<div class="sheet">
 		<liferay-ui:error exception="<%= NoSuchLogException.class %>" message="the-log-could-not-be-found" />
 		<liferay-ui:error exception="<%= NoSuchTriggerException.class %>" message="the-trigger-could-not-be-found" />
@@ -71,7 +74,7 @@ if (dispatchTrigger != null) {
 			</div>
 		</aui:form>
 	</div>
-</div>
+</clay:container-fluid>
 
 <aui:script>
 	Liferay.provide(

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/dispatch_trigger.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/dispatch_trigger.jsp
@@ -50,7 +50,7 @@ if ((dispatchTrigger != null) && (dispatchTrigger.getEndDate() != null)) {
 
 <portlet:actionURL name="/dispatch/edit_dispatch_trigger" var="editDispatchTriggerActionURL" />
 
-<aui:form action="<%= editDispatchTriggerActionURL %>" method="post" name="fm">
+<aui:form action="<%= editDispatchTriggerActionURL %>" cssClass="container-fluid container-fluid-max-xl container-form-lg" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="schedule" />
 	<aui:input name="dispatchTriggerId" type="hidden" value="<%= String.valueOf(dispatchTrigger.getDispatchTriggerId()) %>" />

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/dispatch_trigger_logs.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/dispatch_trigger_logs.jsp
@@ -33,7 +33,7 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 </liferay-util:include>
 
 <div id="<portlet:namespace />triggerLogsContainer">
-	<div class="closed" id="<portlet:namespace />infoPanelId">
+	<div class="closed container-fluid container-fluid-max-xl" id="<portlet:namespace />infoPanelId">
 		<aui:form action="<%= portletURL.toString() %>" method="post" name="fm">
 			<aui:input name="<%= Constants.CMD %>" type="hidden" />
 			<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_collection.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_collection.jsp
@@ -33,6 +33,7 @@ renderResponse.setTitle((fragmentCollection != null) ? fragmentCollection.getNam
 
 <liferay-frontend:edit-form
 	action="<%= editFragmentCollectionURL %>"
+	cssClass="container-form-lg"
 	name="fm"
 >
 	<aui:input name="redirect" type="hidden" value="<%= fragmentDisplayContext.getRedirect() %>" />

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ScreenNavigationTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ScreenNavigationTag.java
@@ -181,10 +181,10 @@ public class ScreenNavigationTag extends IncludeTag {
 		super.cleanUp();
 
 		_containerCssClass = "col-md-9";
-		_containerWrapperCssClass = "container";
+		_containerWrapperCssClass = StringPool.BLANK;
 		_context = null;
-		_fullContainerCssClass = "col-md-12";
-		_headerContainerCssClass = "container";
+		_fullContainerCssClass = StringPool.BLANK;
+		_headerContainerCssClass = StringPool.BLANK;
 		_id = null;
 		_inverted = false;
 		_key = null;
@@ -366,10 +366,10 @@ public class ScreenNavigationTag extends IncludeTag {
 	private static final String _PAGE = "/screen_navigation/page.jsp";
 
 	private String _containerCssClass = "col-md-9";
-	private String _containerWrapperCssClass = "container";
+	private String _containerWrapperCssClass = StringPool.BLANK;
 	private Object _context;
-	private String _fullContainerCssClass = "col-md-12";
-	private String _headerContainerCssClass = "container";
+	private String _fullContainerCssClass = StringPool.BLANK;
+	private String _headerContainerCssClass = StringPool.BLANK;
 	private String _id;
 	private boolean _inverted;
 	private String _key;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
@@ -36,7 +36,10 @@ LiferayPortletResponse finalLiferayPortletResponse = liferayPortletResponse;
 
 <c:if test="<%= ListUtil.isNotEmpty(screenNavigationCategories) && (screenNavigationCategories.size() > 1) %>">
 	<div class="page-header">
-		<div class="<%= headerContainerCssClass %>">
+		<c:if test="<%= Validator.isNotNull(headerContainerCssClass) %>">
+			<div class="<%= headerContainerCssClass %>">
+		</c:if>
+
 			<clay:navigation-bar
 				inverted="<%= inverted %>"
 				navigationItems='<%=
@@ -56,54 +59,69 @@ LiferayPortletResponse finalLiferayPortletResponse = liferayPortletResponse;
 					}
 				%>'
 			/>
-		</div>
+
+		<c:if test="<%= Validator.isNotNull(headerContainerCssClass) %>">
+			</div>
+		</c:if>
 	</div>
 </c:if>
 
 <c:if test="<%= (selectedScreenNavigationEntry != null) && ListUtil.isNotEmpty(screenNavigationEntries) %>">
-	<div class="<%= containerWrapperCssClass %>">
-		<clay:row>
-			<c:if test="<%= screenNavigationEntries.size() > 1 %>">
-				<div class="<%= navCssClass %>">
-					<nav class="<%= menubarCssClass %>">
-						<a aria-controls="<%= id %>" aria-expanded="false" class="menubar-toggler" data-toggle="liferay-collapse" href="#<%= id %>" role="button">
-							<%= selectedScreenNavigationEntry.getLabel(locale) %>
+	<c:if test="<%= Validator.isNotNull(containerWrapperCssClass) %>">
+		<div class="<%= containerWrapperCssClass %>">
+	</c:if>
 
-							<aui:icon image="caret-bottom" markupView="lexicon" />
-						</a>
+		<c:if test="<%= screenNavigationEntries.size() > 1 %>">
+			<div class="row">
+		</c:if>
 
-						<div class="collapse menubar-collapse" id="<%= id %>">
-							<ul class="nav nav-nested">
+		<c:if test="<%= screenNavigationEntries.size() > 1 %>">
+			<div class="<%= navCssClass %>">
+				<nav class="<%= menubarCssClass %>">
+					<a aria-controls="<%= id %>" aria-expanded="false" class="menubar-toggler" data-toggle="liferay-collapse" href="#<%= id %>" role="button">
+						<%= selectedScreenNavigationEntry.getLabel(locale) %>
 
-								<%
-								for (ScreenNavigationEntry<Object> screenNavigationEntry : screenNavigationEntries) {
-									PortletURL screenNavigationEntryURL = PortletURLUtil.clone(portletURL, liferayPortletResponse);
+						<aui:icon image="caret-bottom" markupView="lexicon" />
+					</a>
 
-									screenNavigationEntryURL.setParameter("screenNavigationCategoryKey", screenNavigationEntry.getCategoryKey());
-									screenNavigationEntryURL.setParameter("screenNavigationEntryKey", screenNavigationEntry.getEntryKey());
-								%>
+					<div class="collapse menubar-collapse" id="<%= id %>">
+						<ul class="nav nav-nested">
 
-									<li class="nav-item">
-										<a class="nav-link <%= Objects.equals(selectedScreenNavigationEntry.getEntryKey(), screenNavigationEntry.getEntryKey()) ? "active" : StringPool.BLANK %>" href="<%= screenNavigationEntryURL %>"><%= screenNavigationEntry.getLabel(themeDisplay.getLocale()) %></a>
-									</li>
+							<%
+							for (ScreenNavigationEntry<Object> screenNavigationEntry : screenNavigationEntries) {
+								PortletURL screenNavigationEntryURL = PortletURLUtil.clone(portletURL, liferayPortletResponse);
 
-								<%
-								}
-								%>
+								screenNavigationEntryURL.setParameter("screenNavigationCategoryKey", screenNavigationEntry.getCategoryKey());
+								screenNavigationEntryURL.setParameter("screenNavigationEntryKey", screenNavigationEntry.getEntryKey());
+							%>
 
-							</ul>
-						</div>
-					</nav>
-				</div>
-			</c:if>
+								<li class="nav-item">
+									<a class="nav-link <%= Objects.equals(selectedScreenNavigationEntry.getEntryKey(), screenNavigationEntry.getEntryKey()) ? "active" : StringPool.BLANK %>" href="<%= screenNavigationEntryURL %>"><%= screenNavigationEntry.getLabel(themeDisplay.getLocale()) %></a>
+								</li>
 
-			<div class="<%= (screenNavigationEntries.size() > 1) ? containerCssClass : fullContainerCssClass %>">
+							<%
+							}
+							%>
 
-				<%
-				selectedScreenNavigationEntry.render(request, PipingServletResponse.createPipingServletResponse(pageContext));
-				%>
-
+						</ul>
+					</div>
+				</nav>
 			</div>
-		</clay:row>
-	</div>
+		</c:if>
+
+		<div class="<%= (screenNavigationEntries.size() > 1) ? containerCssClass : fullContainerCssClass %>">
+
+			<%
+			selectedScreenNavigationEntry.render(request, PipingServletResponse.createPipingServletResponse(pageContext));
+			%>
+
+		</div>
+
+		<c:if test="<%= screenNavigationEntries.size() > 1 %>">
+			</div>
+		</c:if>
+
+	<c:if test="<%= Validator.isNotNull(containerWrapperCssClass) %>">
+		</div>
+	</c:if>
 </c:if>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -73,6 +73,7 @@ renderResponse.setTitle(title);
 
 <liferay-frontend:edit-form
 	action="<%= editFolderURL %>"
+	cssClass="container-form-lg"
 	method="post"
 	name="fm"
 >

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/edit_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/edit_layout.jsp
@@ -49,7 +49,6 @@ renderResponse.setTitle(selLayout.getName(locale));
 	containerCssClass="col-lg-8"
 	containerWrapperCssClass="container-fluid container-fluid-max-xl container-form-lg"
 	context="<%= selLayout %>"
-	headerContainerCssClass=""
 	inverted="<%= true %>"
 	key="<%= LayoutScreenNavigationEntryConstants.SCREEN_NAVIGATION_KEY_LAYOUT %>"
 	menubarCssClass="menubar menubar-transparent menubar-vertical-expand-lg"

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_collection.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_collection.jsp
@@ -36,6 +36,7 @@ renderResponse.setTitle((layoutPageTemplateCollection != null) ? layoutPageTempl
 
 <liferay-frontend:edit-form
 	action="<%= editLayoutPageTemplateCollectionURL %>"
+	cssClass="container-form-lg"
 	name="fm"
 >
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
@@ -27,8 +27,6 @@ serverURL.setParameter("delta", String.valueOf(delta));
 %>
 
 <liferay-frontend:screen-navigation
-	containerWrapperCssClass=""
-	headerContainerCssClass=""
 	key="<%= ServerAdminNavigationEntryConstants.SCREEN_NAVIGATION_KEY_PROPERTIES %>"
 	portletURL="<%= serverURL %>"
 />

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/edit_site.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/edit_site.jsp
@@ -90,6 +90,7 @@ if (layoutSetPrototypeId > 0) {
 
 <liferay-frontend:edit-form
 	action="<%= editGroupURL %>"
+	cssClass="container-form-lg"
 	method="post"
 	name="fm"
 	onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveGroup();" %>'

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization.jsp
@@ -72,7 +72,6 @@ renderResponse.setTitle(headerTitle);
 	containerCssClass="col-lg-8"
 	containerWrapperCssClass="container-fluid container-fluid-max-xl container-form-lg"
 	context="<%= organization %>"
-	headerContainerCssClass=""
 	key="<%= UserScreenNavigationEntryConstants.SCREEN_NAVIGATION_KEY_ORGANIZATIONS %>"
 	menubarCssClass="menubar menubar-transparent menubar-vertical-expand-lg"
 	navCssClass="col-lg-3"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_user.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_user.jsp
@@ -38,7 +38,6 @@ if (Validator.isNotNull(backURL)) {
 	containerCssClass="col-lg-8"
 	containerWrapperCssClass="container-fluid container-fluid-max-xl container-form-lg"
 	context="<%= selUser %>"
-	headerContainerCssClass=""
 	key="<%= UserScreenNavigationEntryConstants.SCREEN_NAVIGATION_KEY_USERS %>"
 	menubarCssClass="menubar menubar-transparent menubar-vertical-expand-lg"
 	navCssClass="col-lg-3"


### PR DESCRIPTION
This pr prevents the `row` from being output by default if there is only 1 screen navigation entry. This was causing the horizontal overflow because there was no container around the row.

Some additional changes:
- Don't output empty divs if there is no CSS class passed to `headerContainerCssClass` and `containerWrapperCssClass`.
- Add `container-fluid container-fluid-max-xl` in places where it depended on screen navigation for the `container`
- Fix no vertical spacing between nav and sheet

Fixed:
<img width="1054" alt="add-account-fixed" src="https://user-images.githubusercontent.com/788266/104970171-70149000-599f-11eb-8b96-ca8d0950c47b.png">
