### PR TITLE
LPS-125728 Fix render of empty accordions in Forms

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
@@ -1083,65 +1083,69 @@ class Sidebar extends Component {
 				id="accordion03"
 				role="tablist"
 			>
-				{group.map((key, index) => (
-					<div
-						class="panel panel-secondary"
-						key={`fields-group-${key}-${index}`}
-					>
-						<a
-							aria-controls="collapseTwo"
-							aria-expanded="true"
-							class="collapse-icon panel-header panel-header-link"
-							data-parent="#accordion03"
-							data-toggle="liferay-collapse"
-							href={`#ddm-field-types-${key}-body`}
-							id={`ddm-field-types-${key}-header`}
-							role="tab"
-						>
-							<span class="panel-title">
-								{fieldTypesGroup[key].label}
-							</span>
-							<span class="collapse-icon-closed">
-								<svg
-									aria-hidden="true"
-									class="lexicon-icon lexicon-icon-angle-right"
+				{group.map((key, index) => {
+					const fields = fieldTypesGroup[key].fields;
+
+					return (
+						!!fields.length && (
+							<div
+								class="panel panel-secondary"
+								key={`fields-group-${key}-${index}`}
+							>
+								<a
+									aria-controls="collapseTwo"
+									aria-expanded="true"
+									class="collapse-icon panel-header panel-header-link"
+									data-parent="#accordion03"
+									data-toggle="liferay-collapse"
+									href={`#ddm-field-types-${key}-body`}
+									id={`ddm-field-types-${key}-header`}
+									role="tab"
 								>
-									<use
-										xlink:href={`${spritemap}#angle-right`}
-									/>
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg
-									aria-hidden="true"
-									class="lexicon-icon lexicon-icon-angle-down"
+									<span class="panel-title">
+										{fieldTypesGroup[key].label}
+									</span>
+									<span class="collapse-icon-closed">
+										<svg
+											aria-hidden="true"
+											class="lexicon-icon lexicon-icon-angle-right"
+										>
+											<use
+												xlink:href={`${spritemap}#angle-right`}
+											/>
+										</svg>
+									</span>
+									<span class="collapse-icon-open">
+										<svg
+											aria-hidden="true"
+											class="lexicon-icon lexicon-icon-angle-down"
+										>
+											<use
+												xlink:href={`${spritemap}#angle-down`}
+											/>
+										</svg>
+									</span>
+								</a>
+								<div
+									aria-labelledby={`#ddm-field-types-${key}-header`}
+									class="panel-collapse show"
+									id={`ddm-field-types-${key}-body`}
+									role="tabpanel"
 								>
-									<use
-										xlink:href={`${spritemap}#angle-down`}
-									/>
-								</svg>
-							</span>
-						</a>
-						<div
-							aria-labelledby={`#ddm-field-types-${key}-header`}
-							class="panel-collapse show"
-							id={`ddm-field-types-${key}-body`}
-							role="tabpanel"
-						>
-							<div class="panel-body p-0 m-0 list-group">
-								{fieldTypesGroup[key].fields.map(
-									(fieldType) => (
-										<FieldTypeBox
-											fieldType={fieldType}
-											key={fieldType.name}
-											spritemap={spritemap}
-										/>
-									)
-								)}
+									<div class="panel-body p-0 m-0 list-group">
+										{fields.map((fieldType) => (
+											<FieldTypeBox
+												fieldType={fieldType}
+												key={fieldType.name}
+												spritemap={spritemap}
+											/>
+										))}
+									</div>
+								</div>
 							</div>
-						</div>
-					</div>
-				))}
+						)
+					);
+				})}
 			</div>
 		);
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Sidebar/Sidebar.es.js
@@ -20,6 +20,13 @@ import withContextMock from '../../__mock__/withContextMock.es';
 
 const mockFieldTypes = [
 	{
+		description: 'Custom field description.',
+		group: 'customized',
+		icon: 'icon',
+		label: 'Custom Field',
+		name: 'custom_field',
+	},
+	{
 		description: 'Select date from a Datepicker.',
 		group: 'basic',
 		icon: 'calendar',
@@ -190,15 +197,6 @@ describe('Sidebar', () => {
 
 		expect(basicTab).toEqual(expect.anything());
 		expect(basicTab.classList.value).toEqual(
-			'collapse-icon panel-header panel-header-link'
-		);
-
-		const customizedTab = document.querySelector(
-			'#ddm-field-types-customized-header'
-		);
-
-		expect(customizedTab).toEqual(expect.anything());
-		expect(customizedTab.classList.value).toEqual(
 			'collapse-icon panel-header panel-header-link'
 		);
 	});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Sidebar/__snapshots__/Sidebar.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Sidebar/__snapshots__/Sidebar.es.js.snap
@@ -98,7 +98,17 @@ exports[`Sidebar closes the sidebar in edition mode 1`] = `
                   <use xlink:href="icons.svg#angle-down"></use>
                 </svg></span></a>
             <div aria-labelledby="#ddm-field-types-customized-header" id="ddm-field-types-customized-body" class="panel-collapse show" role="tabpanel">
-              <div class="panel-body p-0 m-0 list-group"></div>
+              <div class="panel-body p-0 m-0 list-group">
+                <div class="ddm-drag-item list-group-item list-group-item-flex" data-field-type-name="custom_field" ref="fieldType_custom_field">
+                  <div class="autofit-col"><span class="sticker sticker-secondary"><span class="inline-item"><svg class="lexicon-icon lexicon-icon-icon" aria-hidden="true">
+                          <use xlink:href="icons.svg#icon"></use>
+                        </svg></span></span></div>
+                  <div class="autofit-col autofit-col-expand">
+                    <h4 class="list-group-title text-truncate"><span>Custom Field</span></h4>
+                    <p class="list-group-subtitle text-truncate">Custom field description.</p>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -255,7 +265,17 @@ exports[`Sidebar renders a Sidebar with fieldTypes 1`] = `
                   <use xlink:href="icons.svg#angle-down"></use>
                 </svg></span></a>
             <div aria-labelledby="#ddm-field-types-customized-header" id="ddm-field-types-customized-body" class="panel-collapse show" role="tabpanel">
-              <div class="panel-body p-0 m-0 list-group"></div>
+              <div class="panel-body p-0 m-0 list-group">
+                <div class="ddm-drag-item list-group-item list-group-item-flex" data-field-type-name="custom_field" ref="fieldType_custom_field">
+                  <div class="autofit-col"><span class="sticker sticker-secondary"><span class="inline-item"><svg class="lexicon-icon lexicon-icon-icon" aria-hidden="true">
+                          <use xlink:href="icons.svg#icon"></use>
+                        </svg></span></span></div>
+                  <div class="autofit-col autofit-col-expand">
+                    <h4 class="list-group-title text-truncate"><span>Custom Field</span></h4>
+                    <p class="list-group-subtitle text-truncate">Custom field description.</p>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR fixes the accordion bug in Forms https://issues.liferay.com/browse/LPS-125728

The bug was caused by the empty tab, probably because [the responsible script](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.js) is trying to get an height size.

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/46778114/105027706-6008b900-5a50-11eb-98c0-6426e3482ab8.gif)

Since keeping the empty tab it's actually an UX error, I preferred to remove it instead of adjusting the script for this corner case.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/46778114/105028058-d5748980-5a50-11eb-9e9f-6c4b86aa9054.gif)

