### PR TITLE
LPS-126069 - Check for cdn.host rather than dynamic.resources.enabled

### DIFF
--- a/modules/apps/frontend-js/frontend-js-svg4everybody-web/src/main/java/com/liferay/frontend/js/svg4everybody/web/internal/servlet/taglib/SVG4EverybodyTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-svg4everybody-web/src/main/java/com/liferay/frontend/js/svg4everybody/web/internal/servlet/taglib/SVG4EverybodyTopHeadDynamicInclude.java
@@ -64,7 +64,22 @@ public class SVG4EverybodyTopHeadDynamicInclude extends BaseDynamicInclude {
 			}
 		}
 
-		if (!cdnDynamicResourcesEnabled) {
+		boolean cdnHostEnabled = false;
+
+		try {
+			String cdnHost = _portal.getCDNHost(httpServletRequest);
+
+			cdnHostEnabled = !cdnHost.isEmpty();
+		}
+		catch (PortalException portalException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to gather property from configuration",
+					portalException);
+			}
+		}
+
+		if (cdnHostEnabled) {
 			PrintWriter printWriter = httpServletResponse.getWriter();
 
 			AbsolutePortalURLBuilder absolutePortalURLBuilder =


### PR DESCRIPTION
Fixes https://issues.liferay.com/browse/LPS-126069

We had made the wrong assumption in that checking against the dynamic resources field would be enough for this. [However, we obviously weren't totally sure](https://github.com/liferay-frontend/liferay-portal/pull/220/files#r471694447). This changes makes it so that svg4everybody is included on the page anytime the cdn.host is set.

Note, this should be backported as well.