### PR TITLE
LPS-125411 - Use correct nav-underline

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf
@@ -56,7 +56,7 @@ if (Validator.isNotNull(script)) {
 				<div class="diagram-builder-content" id="<portlet:namespace />formBuilderContent">
 					<div class="tabbable">
 						<div class="tabbable-content">
-							<ul class="lfr-nav nav nav-tabs">
+							<ul class="lfr-nav nav nav-underline">
 								<li class="nav-item">
 									<a class="active nav-link" href="javascript:;">
 										<liferay-ui:message key="fields" />


### PR DESCRIPTION
This PR fix an incorrect tab style.

With bg-white we use the correct `nav-underline` with a blue line to make active visible:

![image](https://user-images.githubusercontent.com/7963804/105163418-2e592600-5b14-11eb-85a6-fe7840d622a0.png)

---

**How to test this PR:**

 - Got to: Product Menu > Content & Data > Kaleo forms admin
 - Create a new one with name/description and press Next
 - Click on `New Field Set`
 - Wow! is that a wonderful underline tab?!!!
