### PR TITLE
LPS-126057 Remove default sticker icon value from VerticalCardTag and set showSticker to false as default

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/servlet/taglib/clay/DepotEntryVerticalCard.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/servlet/taglib/clay/DepotEntryVerticalCard.java
@@ -154,11 +154,6 @@ public class DepotEntryVerticalCard
 		return true;
 	}
 
-	@Override
-	public Boolean isStickerShown() {
-		return false;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		DepotEntryVerticalCard.class);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/FileCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/FileCardTag.java
@@ -27,6 +27,14 @@ public class FileCardTag extends VerticalCardTag {
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
 
+		if (getIcon() == null) {
+			setIcon("documents-and-media");
+		}
+
+		if (getStickerIcon() == null) {
+			setStickerIcon("document-default");
+		}
+
 		return super.doStartTag();
 	}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
@@ -43,10 +43,6 @@ public class VerticalCardTag extends BaseCardTag {
 			setIcon("documents-and-media");
 		}
 
-		if (getStickerIcon() == null) {
-			setStickerIcon("document-default");
-		}
-
 		return super.doStartTag();
 	}
 
@@ -239,11 +235,18 @@ public class VerticalCardTag extends BaseCardTag {
 		if (_showSticker == null) {
 			VerticalCard verticalCard = getVerticalCard();
 
-			if (verticalCard != null) {
+			if ((verticalCard != null) &&
+				(verticalCard.isStickerShown() != null)) {
+
 				return verticalCard.isStickerShown();
 			}
+			else if (Validator.isNotNull(getStickerImageSrc()) ||
+					 Validator.isNotNull(getStickerIcon())) {
 
-			return true;
+				return true;
+			}
+
+			return false;
 		}
 
 		return _showSticker;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/VerticalCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/VerticalCard.java
@@ -91,7 +91,7 @@ public interface VerticalCard extends BaseClayCard {
 	}
 
 	public default Boolean isStickerShown() {
-		return true;
+		return null;
 	}
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/DefaultStylebookLayoutVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/DefaultStylebookLayoutVerticalCard.java
@@ -94,11 +94,6 @@ public class DefaultStylebookLayoutVerticalCard implements VerticalCard {
 		return false;
 	}
 
-	@Override
-	public Boolean isStickerShown() {
-		return false;
-	}
-
 	private final String _name;
 	private final ResourceBundle _resourceBundle;
 	private final StyleBookEntry _styleBookEntry;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectStylebookLayoutVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectStylebookLayoutVerticalCard.java
@@ -80,11 +80,6 @@ public class SelectStylebookLayoutVerticalCard implements VerticalCard {
 		return false;
 	}
 
-	@Override
-	public Boolean isStickerShown() {
-		return false;
-	}
-
 	private final StyleBookEntry _styleBookEntry;
 	private final ThemeDisplay _themeDisplay;
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-126057

- Removes the default sticker icon value from `VerticalCardTag` and adds it to `FileCardTag` instead.
- Set `isStickerShown` default value to `null` (in `VerticalCard` interface) and to `false` in `VerticalCardTag`.
- Set `isStickerShown` as true in case `stickerImageSrc` or `stickerIcon` are not `null`.

Before
![image](https://user-images.githubusercontent.com/5803434/105199674-4f833c00-5b3f-11eb-81fa-31428df4f82d.png)

After
![image](https://user-images.githubusercontent.com/5803434/105199710-58740d80-5b3f-11eb-98c5-5c03d43d5ac0.png)

Testing plan

Use case with no sticker:
- Go to Stylebooks
- Create a new one
- Change the view type to card view
- No sticker should appear since no `isStickerShown` is implemented in the model nor `stickerIcon` or `stickerImageSrc` are set.

Use case with sticker
- Go to Content & Data / Web Content
- Create a new Basic Web Content
- Change the view type to card view
- A sticker should appear since `stickerIcon` and `stickerImageSrc` are implemented in the model.