### PR TITLE
LPS-125671 - Use of tabs

### DIFF
--- a/portal-web/docroot/html/taglib/ui/tabs/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/tabs/start.jsp
@@ -91,7 +91,7 @@ String onClick = GetterUtil.getString((String)request.getAttribute("liferay-ui:t
 
 // Type
 
-String type = GetterUtil.getString((String)request.getAttribute("liferay-ui:tabs:type"), "underline");
+String type = GetterUtil.getString((String)request.getAttribute("liferay-ui:tabs:type"), "tabs");
 %>
 
 <c:if test="<%= names.length > 0 %>">


### PR DESCRIPTION
Example of changing `underline` for `tabs`.

IMHO It needs a deeper change (it is old markup). starting with asking design what they want for that tabs, or even if they are not so important we could avoid touching them.

Visual example:

![image](https://user-images.githubusercontent.com/7963804/105205169-3bdad400-5b45-11eb-81f2-31fb97099d2e.png)
---
![image](https://user-images.githubusercontent.com/7963804/105205129-31203f00-5b45-11eb-9b5d-841fb7a325a6.png)

