### PR TITLE
[7.4-only] LPS-125256 Remove deprecated tag attributes

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
@@ -94,7 +94,7 @@ renderResponse.setTitle(title);
 														<div class="input-group-item">
 															<c:if test="<%= parentCategory != null %>">
 																<clay:label
-																	closeable="<%= true %>"
+																	dismissible="<%= true %>"
 																	label="<%= parentCategory.getTitle(locale) %>"
 																/>
 

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/InfoListProviderDropdownDefaultPropsTransformer.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/InfoListProviderDropdownDefaultPropsTransformer.js
@@ -12,20 +12,33 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
+import {openModal} from 'frontend-js-web';
 
-class SiteDropdownDefaultEventHandler extends DefaultEventHandler {
-	joinSite(itemData) {
-		this._send(itemData.joinSiteURL);
-	}
+const ACTIONS = {
+	viewInfoListProviderItems(itemData) {
+		openModal({
+			title: itemData.infoListProviderTitle,
+			url: itemData.viewInfoListProviderItemsURL,
+		});
+	},
+};
 
-	leaveSite(itemData) {
-		this._send(itemData.leaveSiteURL);
-	}
+export default function propsTransformer({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
 
-	_send(url) {
-		submitForm(document.hrefFm, url);
-	}
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
 }
-
-export default SiteDropdownDefaultEventHandler;

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/ListItemsDropdownPropsTransformer.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/ListItemsDropdownPropsTransformer.js
@@ -12,31 +12,42 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
-import {Config} from 'metal-state';
-
-class ListItemsDropdownDefaultEventHandler extends DefaultEventHandler {
+const ACTIONS = {
 	editContent(itemData) {
-		this._navigate(itemData.editContentURL);
-	}
+		this.navigate(itemData.editContentURL);
+	},
 
 	editDisplayPageTemplate(itemData) {
-		this._navigate(itemData.editDisplayPageTemplateURL);
-	}
+		this.navigate(itemData.editDisplayPageTemplateURL);
+	},
 
-	viewDisplayPage(itemData) {
-		this._navigate(itemData.viewDisplayPageURL);
-	}
-
-	_navigate(url) {
+	navigate(url) {
 		const openerWindow = Liferay.Util.getTop();
 
 		openerWindow.Liferay.Util.navigate(url);
-	}
-}
+	},
 
-ListItemsDropdownDefaultEventHandler.STATE = {
-	spritemap: Config.string(),
+	viewDisplayPage(itemData) {
+		this.navigate(itemData.viewDisplayPageURL);
+	},
 };
 
-export default ListItemsDropdownDefaultEventHandler;
+export default function propsTransformer({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view.jsp
@@ -124,8 +124,8 @@ AssetListManagementToolbarDisplayContext assetListManagementToolbarDisplayContex
 
 					<liferay-ui:search-container-column-text>
 						<clay:dropdown-actions
-							defaultEventHandler="assetEntryListDropdownDefaultEventHandler"
 							dropdownItems="<%= assetEntryListActionDropdownItems.getActionDropdownItems() %>"
+							propsTransformer="js/AssetEntryListDropdownDefaultPropsTransformer"
 						/>
 					</liferay-ui:search-container-column-text>
 				</liferay-ui:search-container-row>
@@ -154,11 +154,6 @@ AssetListManagementToolbarDisplayContext assetListManagementToolbarDisplayContex
 		module="js/EmptyResultMessageDefaultEventHandler.es"
 	/>
 </c:if>
-
-<liferay-frontend:component
-	componentId="assetEntryListDropdownDefaultEventHandler"
-	module="js/AssetEntryListDropdownDefaultEventHandler.es"
-/>
 
 <liferay-frontend:component
 	componentId="<%= assetListManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_items.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_items.jsp
@@ -87,8 +87,8 @@ ListItemsActionDropdownItems listItemsActionDropdownItems = (ListItemsActionDrop
 			<c:if test="<%= assetListItemsDisplayContext.isShowActions() %>">
 				<liferay-ui:search-container-column-text>
 					<clay:dropdown-actions
-						defaultEventHandler="<%= AssetListWebKeys.LIST_ITEMS_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 						dropdownItems="<%= listItemsActionDropdownItems.getActionDropdownItems(AssetEntry.class.getName(), assetEntry) %>"
+						propsTransformer="js/ListItemsDropdownPropsTransformer"
 					/>
 				</liferay-ui:search-container-column-text>
 			</c:if>
@@ -99,11 +99,6 @@ ListItemsActionDropdownItems listItemsActionDropdownItems = (ListItemsActionDrop
 		/>
 	</liferay-ui:search-container>
 </clay:container-fluid>
-
-<liferay-frontend:component
-	componentId="<%= AssetListWebKeys.LIST_ITEMS_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
-	module="js/ListItemsDropdownDefaultEventHandler.es"
-/>
 
 <liferay-frontend:component
 	module="js/TopLinkEventHandler.es"

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_info_list_provider_items.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_info_list_provider_items.jsp
@@ -103,8 +103,8 @@ String infoListProviderClassName = infoListProviderItemsDisplayContext.getInfoLi
 				<c:if test="<%= infoListProviderItemsDisplayContext.isShowActions() %>">
 					<liferay-ui:search-container-column-text>
 						<clay:dropdown-actions
-							defaultEventHandler="<%= AssetListWebKeys.LIST_ITEMS_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 							dropdownItems="<%= listItemsActionDropdownItems.getActionDropdownItems(infoListProviderClassName, result) %>"
+							propsTransformer="js/ListItemsDropdownPropsTransformer"
 						/>
 					</liferay-ui:search-container-column-text>
 				</c:if>
@@ -116,11 +116,6 @@ String infoListProviderClassName = infoListProviderItemsDisplayContext.getInfoLi
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<liferay-frontend:component
-	componentId="<%= AssetListWebKeys.LIST_ITEMS_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
-	module="js/ListItemsDropdownDefaultEventHandler.es"
-/>
 
 <liferay-frontend:component
 	module="js/TopLinkEventHandler.es"

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_info_list_providers.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_info_list_providers.jsp
@@ -62,8 +62,8 @@ InfoListProviderDisplayContext infoListProviderDisplayContext = (InfoListProvide
 
 			<liferay-ui:search-container-column-text>
 				<clay:dropdown-actions
-					defaultEventHandler="infoListProviderDropdownDefaultEventHandler"
 					dropdownItems="<%= infoListProviderActionDropdownItems.getActionDropdownItems() %>"
+					propsTransformer="js/InfoListProviderDropdownDefaultPropsTransformer"
 				/>
 			</liferay-ui:search-container-column-text>
 		</liferay-ui:search-container-row>
@@ -74,8 +74,3 @@ InfoListProviderDisplayContext infoListProviderDisplayContext = (InfoListProvide
 		/>
 	</liferay-ui:search-container>
 </div>
-
-<liferay-frontend:component
-	componentId="infoListProviderDropdownDefaultEventHandler"
-	module="js/InfoListProviderDropdownDefaultEventHandler.es"
-/>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/entry_search_columns.jspf
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/entry_search_columns.jspf
@@ -60,8 +60,13 @@
 			%>
 
 			<clay:dropdown-actions
-				defaultEventHandler="<%= BlogsWebConstants.BLOGS_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+				additionalProps='<%=
+					HashMapBuilder.<String, Object>put(
+						"trashEnabled", trashHelper.isTrashEnabled(themeDisplay.getScopeGroupId())
+					).build()
+				%>'
 				dropdownItems="<%= blogsEntryActionDropdownItemsProvider.getActionDropdownItems() %>"
+				propsTransformer="blogs_admin/js/ElementsPropsTransformer"
 			/>
 		</liferay-ui:search-container-column-text>
 	</c:when>
@@ -124,8 +129,13 @@
 			%>
 
 			<clay:dropdown-actions
-				defaultEventHandler="<%= BlogsWebConstants.BLOGS_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+				additionalProps='<%=
+					HashMapBuilder.<String, Object>put(
+						"trashEnabled", trashHelper.isTrashEnabled(themeDisplay.getScopeGroupId())
+					).build()
+				%>'
 				dropdownItems="<%= blogsEntryActionDropdownItemsProvider.getActionDropdownItems() %>"
+				propsTransformer="blogs_admin/js/ElementsPropsTransformer"
 			/>
 		</liferay-ui:search-container-column-text>
 	</c:otherwise>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/ElementsPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/ElementsPropsTransformer.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const ACTIONS = {
+	delete(itemData, trashEnabled) {
+		const message = Liferay.Language.get(
+			'are-you-sure-you-want-to-delete-this'
+		);
+
+		if (trashEnabled || confirm(message)) {
+			this.send(itemData.deleteURL);
+		}
+	},
+
+	permissions(itemData) {
+		Liferay.Util.openWindow({
+			dialog: {
+				destroyOnHide: true,
+				modal: true,
+			},
+			dialogIframe: {
+				bodyCssClass: 'dialog-with-footer',
+			},
+			title: Liferay.Language.get('permissions'),
+			uri: itemData.permissionsURL,
+		});
+	},
+
+	publishToLive(itemData) {
+		if (
+			confirm(
+				Liferay.Language.get('are-you-sure-you-want-to-publish-to-live')
+			)
+		) {
+			this.send(itemData.publishEntryURL);
+		}
+	},
+
+	send(url) {
+		submitForm(document.hrefFm, url);
+	},
+};
+
+export default function propsTransformer({
+	additionalProps: {trashEnabled},
+	items,
+	...props
+}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data, trashEnabled);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
@@ -122,7 +122,7 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 									</liferay-util:buffer>
 
 									<clay:link
-										ariaLabel='<%= LanguageUtil.format(request, "in-reply-to-x", HtmlUtil.escape(parentDiscussionComment.getUserName()), false) %>'
+										aria-label='<%= LanguageUtil.format(request, "in-reply-to-x", HtmlUtil.escape(parentDiscussionComment.getUserName()), false) %>'
 										cssClass="lfr-discussion-parent-link"
 										data-inreply-content="<%= HtmlUtil.escapeAttribute(parentDiscussionComment.getBody()) %>"
 										data-inreply-title="<%= HtmlUtil.escapeAttribute(parentCommentUserBuffer) %>"

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
@@ -159,11 +159,11 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 						<div class="dropdown-menu dropdown-menu-right" id="<portlet:namespace />commerce-dropdown-assigned-to">
 							<c:if test="<%= !assignedToCurrentUser %>">
 								<clay:button
-									elementClasses="dropdown-item transition-link"
+									cssClass="dropdown-item transition-link"
+									displayType="secondary"
 									id='<%= liferayPortletResponse.getNamespace() + "assign-to-me-modal-opener" %>'
 									label='<%= LanguageUtil.get(request, "assign-to-me") %>'
-									size="lg"
-									style="secondary"
+									small="<%= false %>"
 								/>
 
 								<liferay-portlet:renderURL portletName="<%= PortletKeys.MY_WORKFLOW_TASK %>" var="assignToMeURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
@@ -196,11 +196,11 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 							</c:if>
 
 							<clay:button
-								elementClasses="dropdown-item transition-link"
+								cssClass="dropdown-item transition-link"
+								displayType="secondary"
 								id='<%= liferayPortletResponse.getNamespace() + "assign-to-modal-opener" %>'
 								label='<%= LanguageUtil.get(request, "assign-to-...") %>'
-								size="lg"
-								style="secondary"
+								small="<%= false %>"
 							/>
 
 							<liferay-portlet:renderURL portletName="<%= PortletKeys.MY_WORKFLOW_TASK %>" var="assignToURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
@@ -272,7 +272,7 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 						%>
 
 							<clay:link
-								elementClasses="<%= buttonCssClasses %>"
+								cssClass="<%= buttonCssClasses %>"
 								href="<%= Validator.isNotNull(action.getHref()) ? action.getHref() : StringPool.POUND %>"
 								id="<%= actionId %>"
 								label="<%= LanguageUtil.get(request, action.getLabel()) %>"
@@ -328,7 +328,7 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 
 					<c:if test="<%= Validator.isNotNull(previewUrl) %>">
 						<clay:link
-							elementClasses="btn btn-outline-borderless btn-outline-secondary btn-sm text-primary"
+							cssClass="btn btn-outline-borderless btn-outline-secondary btn-sm text-primary"
 							href="<%= previewUrl %>"
 							icon="shortcut"
 						/>

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/panel/start.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/panel/start.jsp
@@ -50,7 +50,7 @@ String collapseSwitchId = Validator.isNotNull(collapseSwitchName) ? collapseSwit
 				</c:when>
 				<c:when test="<%= Validator.isNotNull(actionIcon) %>">
 					<clay:link
-						elementClasses="btn btn-monospaced btn-primary btn-sm text-white"
+						cssClass="btn btn-monospaced btn-primary btn-sm text-white"
 						href='<%= (Validator.isNotNull(actionUrl) && Validator.isNull(actionTargetId)) ? actionUrl : "#" %>'
 						icon="<%= actionIcon %>"
 						id="<%= linkId %>"

--- a/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/pending_orders/b2b/view.jsp
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/pending_orders/b2b/view.jsp
@@ -55,11 +55,11 @@ CommerceAccount commerceAccount = commerceOrderContentDisplayContext.getCommerce
 				<aui:input name="deleteCommerceOrderIds" type="hidden" />
 
 				<clay:button
+					cssClass="btn-fixed btn-primary"
 					disabled="<%= commerceAccount == null %>"
-					elementClasses="btn-fixed btn-primary"
+					displayType="primary"
 					label='<%= LanguageUtil.get(request, "add-order") %>'
-					size="lg"
-					style="primary"
+					small="<%= false %>"
 					type="submit"
 				/>
 			</aui:form>

--- a/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/pending_orders/edit_order.jsp
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/pending_orders/edit_order.jsp
@@ -285,10 +285,10 @@ List<CommerceAddress> billingAddresses = commerceOrderContentDisplayContext.getB
 	<div class="commerce-cta is-visible">
 		<c:if test="<%= commerceOrderContentDisplayContext.hasModelPermission(commerceOrder, ActionKeys.UPDATE) %>">
 			<clay:button
-				elementClasses="btn-fixed btn-secondary"
+				cssClass="btn-fixed btn-secondary"
+				displayType="secondary"
 				label='<%= LanguageUtil.get(request, "save") %>'
-				size="lg"
-				style="secondary"
+				small="<%= false %>"
 				type="submit"
 			/>
 		</c:if>

--- a/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/order/payments.jsp
+++ b/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/order/payments.jsp
@@ -98,10 +98,10 @@ CommerceOrder commerceOrder = commerceOrderEditDisplayContext.getCommerceOrder()
 			<div class="row">
 				<div class="col d-flex">
 					<clay:label
-						elementClasses="align-self-center"
+						cssClass="align-self-center"
+						displayType="<%= CommerceOrderPaymentConstants.getOrderPaymentLabelStyle(commerceOrder.getPaymentStatus()) %>"
 						label="<%= LanguageUtil.get(request, CommerceOrderPaymentConstants.getOrderPaymentStatusLabel(commerceOrder.getPaymentStatus())) %>"
-						size="lg"
-						style="<%= CommerceOrderPaymentConstants.getOrderPaymentLabelStyle(commerceOrder.getPaymentStatus()) %>"
+						large="<%= true %>"
 					/>
 				</div>
 			</div>

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/sort/view.jsp
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/sort/view.jsp
@@ -49,7 +49,7 @@ SearchContainer<CPCatalogEntry> cpCatalogEntrySearchContainer = cpSearchResultsD
 			%>
 
 				<clay:link
-					elementClasses="dropdown-item transition-link"
+					cssClass="dropdown-item transition-link"
 					href="#"
 					id="<%= liferayPortletResponse.getNamespace() + sortOption %>"
 					label="<%= LanguageUtil.get(request, sortOption) %>"

--- a/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/my_subscriptions/view.jsp
+++ b/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/my_subscriptions/view.jsp
@@ -116,7 +116,7 @@ CommerceSubscriptionContentDisplayContext commerceSubscriptionContentDisplayCont
 											%>
 
 											<clay:link
-												buttonStyle="secondary"
+												displayType="secondary"
 												href='<%= String.valueOf(dropdownItem.get("href")) %>'
 												label='<%= String.valueOf(dropdownItem.get("label")) %>'
 											/>

--- a/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/subscription_entry/general.jsp
+++ b/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/subscription_entry/general.jsp
@@ -103,8 +103,8 @@ if (deliveryMaxSubscriptionCycles > 0) {
 			title='<%= LanguageUtil.get(request, "payment-status") %>'
 		>
 			<clay:label
+				displayType="<%= CommerceOrderPaymentConstants.getOrderPaymentLabelStyle(orderPaymentStatus) %>"
 				label="<%= LanguageUtil.get(request, CommerceOrderPaymentConstants.getOrderPaymentStatusLabel(orderPaymentStatus)) %>"
-				style="<%= CommerceOrderPaymentConstants.getOrderPaymentLabelStyle(orderPaymentStatus) %>"
 			/>
 		</commerce-ui:info-box>
 	</div>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/init.jsp
@@ -81,7 +81,8 @@ page import="com.liferay.sharing.configuration.SharingConfiguration" %>
 page import="java.util.Collections" %><%@
 page import="java.util.List" %>
 
-<%@ page import="javax.portlet.ActionRequest" %>
+<%@ page import="javax.portlet.ActionRequest" %><%@
+page import="javax.portlet.PortletURL" %>
 
 <liferay-frontend:defineObjects />
 

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/AddConnectedSitesButtonPropsTransformer.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/AddConnectedSitesButtonPropsTransformer.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {openSelectionModal} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps,
+	portletNamespace,
+	...props
+}) {
+	return {
+		...props,
+		onClick() {
+			const {currentURL, itemSelectorURL} = additionalProps;
+
+			openSelectionModal({
+				customSelectEvent: true,
+				id: `${portletNamespace}selectSite`,
+				onSelect: (event) => {
+					const toGroupIdInput = document.getElementById(
+						`${portletNamespace}toGroupId`
+					);
+
+					toGroupIdInput.value = event.groupid;
+
+					const redirectInput = document.getElementById(
+						`${portletNamespace}redirect`
+					);
+
+					redirectInput.value = currentURL;
+
+					submitForm(toGroupIdInput.form);
+				},
+				selectEventName: `${portletNamespace}selectSite`,
+				title: Liferay.Language.get('select-site'),
+				url: `${itemSelectorURL}`,
+			});
+		},
+	};
+}

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotEntryDropdownPropsTransformer.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotEntryDropdownPropsTransformer.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import confirmDepotEntryDeletion from './confirmDepotEntryDeletion.es';
+
+const ACTIONS = {
+	deleteDepotEntry(itemData) {
+		if (confirmDepotEntryDeletion()) {
+			submitForm(document.hrefFm, itemData.deleteDepotEntryURL);
+		}
+	},
+
+	openWindow(label, url) {
+		Liferay.Util.openWindow({
+			dialog: {
+				destroyOnHide: true,
+				modal: true,
+			},
+			dialogIframe: {
+				bodyCssClass: 'dialog-with-footer',
+			},
+			title: Liferay.Language.get(label),
+			uri: url,
+		});
+	},
+
+	permissionsDepotEntry(itemData) {
+		this.openWindow(
+			Liferay.Language.get('permissions'),
+			itemData.permissionsDepotEntryURL
+		);
+	},
+};
+
+export default function propsTransformer({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
@@ -36,10 +36,25 @@ List<DepotEntryGroupRel> depotEntryGroupRels = depotAdminSitesDisplayContext.get
 		<c:if test="<%= !depotAdminSitesDisplayContext.isLiveDepotEntry() %>">
 			<clay:content-col>
 				<span class="heading-end">
+
+					<%
+					PortletURL itemSelectorURL = depotAdminSitesDisplayContext.getItemSelectorURL();
+
+					String itemSelectorURLString = itemSelectorURL.toString();
+					%>
+
 					<clay:button
+						additionalProps='<%=
+							HashMapBuilder.<String, Object>put(
+								"currentURL", currentURL
+							).put(
+								"itemSelectorURL", itemSelectorURLString
+							).build()
+						%>'
 						displayType="secondary"
 						id='<%= liferayPortletResponse.getNamespace() + "addConnectedSiteButton" %>'
 						label="add"
+						propsTransformer="js/AddConnectedSitesButtonPropsTransformer"
 						small="<%= true %>"
 						title="connect-to-a-site"
 					/>
@@ -133,39 +148,4 @@ List<DepotEntryGroupRel> depotEntryGroupRels = depotAdminSitesDisplayContext.get
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-
-	<aui:script sandbox="<%= true %>">
-		var addConnectedSiteButton = document.querySelector(
-			'#<portlet:namespace />addConnectedSiteButton'
-		);
-
-		if (addConnectedSiteButton) {
-			addConnectedSiteButton.addEventListener('click', function (event) {
-				Liferay.Util.openSelectionModal({
-					customSelectEvent: true,
-					id: '<portlet:namespace />selectSite',
-					onSelect: function (event) {
-						var toGroupIdInput = document.querySelector(
-							'#<portlet:namespace />toGroupId'
-						);
-
-						toGroupIdInput.value = event.groupid;
-
-						var redirectInput = document.querySelector(
-							'#<portlet:namespace />redirect'
-						);
-
-						redirectInput.value = '<%= currentURL %>';
-
-						submitForm(toGroupIdInput.form);
-					},
-					selectEventName:
-						'<%= liferayPortletResponse.getNamespace() + "selectSite" %>',
-					title: '<liferay-ui:message key="select-site" />',
-					url:
-						'<%= String.valueOf(depotAdminSitesDisplayContext.getItemSelectorURL()) %>',
-				});
-			});
-		}
-	</aui:script>
 </clay:sheet-section>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view.jsp
@@ -83,8 +83,8 @@ DepotAdminManagementToolbarDisplayContext depotAdminManagementToolbarDisplayCont
 
 								<liferay-ui:search-container-column-text>
 									<clay:dropdown-actions
-										defaultEventHandler="<%= DepotAdminWebKeys.DEPOT_ENTRY_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 										dropdownItems="<%= depotAdminDisplayContext.getActionDropdownItems(depotEntry) %>"
+										propsTransformer="js/DepotEntryDropdownPropsTransformer"
 									/>
 								</liferay-ui:search-container-column-text>
 							</c:when>
@@ -112,8 +112,8 @@ DepotAdminManagementToolbarDisplayContext depotAdminManagementToolbarDisplayCont
 
 								<liferay-ui:search-container-column-text>
 									<clay:dropdown-actions
-										defaultEventHandler="<%= DepotAdminWebKeys.DEPOT_ENTRY_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 										dropdownItems="<%= depotAdminDisplayContext.getActionDropdownItems(depotEntry) %>"
+										propsTransformer="js/DepotEntryDropdownPropsTransformer"
 									/>
 								</liferay-ui:search-container-column-text>
 							</c:otherwise>

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -88,7 +88,10 @@ public class FragmentDisplayContext {
 			WebKeys.THEME_DISPLAY);
 	}
 
-	public List<DropdownItem> getActionDropdownItems() {
+	public List<DropdownItem> getActionDropdownItems() throws Exception {
+		Map<String, Object> fragmentCollectionsViewContext =
+			getFragmentCollectionsViewContext();
+
 		return DropdownItemListBuilder.add(
 			dropdownItem -> {
 				dropdownItem.setHref(
@@ -101,6 +104,10 @@ public class FragmentDisplayContext {
 		).add(
 			dropdownItem -> {
 				dropdownItem.putData("action", "openImportView");
+				dropdownItem.putData(
+					"viewImportURL",
+					(String)fragmentCollectionsViewContext.get(
+						"viewImportURL"));
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "import"));
 			}

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionViewButtonPropsTransformer.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionViewButtonPropsTransformer.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ACTIONS} from './actions';
+
+export default function propsTransformer({
+	additionalProps: {action, viewImportURL},
+	portletNamespace,
+	...props
+}) {
+	return {
+		...props,
+		onClick() {
+			ACTIONS[action]({
+				portletNamespace,
+				viewImportURL,
+			});
+		},
+	};
+}

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionViewDefaultPropsTransformer.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionViewDefaultPropsTransformer.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ACTIONS} from './actions';
+
+export default function propsTransformer({
+	additionalProps: {
+		deleteFragmentCollectionURL,
+		exportFragmentCollectionsURL,
+		viewDeleteFragmentCollectionsURL,
+		viewExportFragmentCollectionsURL,
+		viewImportURL,
+	},
+	items,
+	portletNamespace,
+	...props
+}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action]({
+							deleteFragmentCollectionURL,
+							exportFragmentCollectionsURL,
+							portletNamespace,
+							viewDeleteFragmentCollectionsURL,
+							viewExportFragmentCollectionsURL,
+							viewImportURL,
+						});
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/actions.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/actions.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {
+	normalizeFriendlyURL,
+	openModal,
+	openSelectionModal,
+} from 'frontend-js-web';
+
+export const ACTIONS = {
+	deleteCollections({
+		deleteFragmentCollectionURL,
+		portletNamespace,
+		viewDeleteFragmentCollectionsURL,
+	}) {
+		this.openFragmentCollectionsItemSelector(
+			Liferay.Language.get('delete'),
+			Liferay.Language.get('delete-collection'),
+			viewDeleteFragmentCollectionsURL,
+			(selectedItems) => {
+				const fragmentCollectionsForm = document.getElementById(
+					normalizeFriendlyURL(
+						portletNamespace,
+						'fragmentCollectionsFm'
+					)
+				);
+
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-the-selected-entries'
+						)
+					)
+				) {
+					selectedItems.forEach((item) => {
+						fragmentCollectionsForm.appendChild(
+							item.cloneNode(true)
+						);
+					});
+				}
+
+				submitForm(
+					fragmentCollectionsForm,
+					deleteFragmentCollectionURL
+				);
+			},
+			null,
+			portletNamespace
+		);
+	},
+
+	exportCollections({
+		exportFragmentCollectionsURL,
+		portletNamespace,
+		viewExportFragmentCollectionsURL,
+	}) {
+		let processed = false;
+
+		this.openFragmentCollectionsItemSelector(
+			Liferay.Language.get('export'),
+			Liferay.Language.get('export-collection'),
+			viewExportFragmentCollectionsURL,
+			(selectedItems) => {
+				const fragmentCollectionsForm = document.getElementById(
+					normalizeFriendlyURL(
+						portletNamespace,
+						'fragmentCollectionsFm'
+					)
+				);
+
+				selectedItems.forEach((item) => {
+					fragmentCollectionsForm.appendChild(item.cloneNode(true));
+				});
+
+				submitForm(
+					fragmentCollectionsForm,
+					exportFragmentCollectionsURL
+				);
+
+				processed = true;
+			},
+			() => {
+				if (processed) {
+					Liferay.Util.openToast({
+						message: Liferay.Language.get(
+							'your-request-processed-successfully'
+						),
+						toastProps: {
+							autoClose: 5000,
+						},
+						type: 'success',
+					});
+				}
+			},
+			portletNamespace
+		);
+	},
+
+	openFragmentCollectionsItemSelector(
+		dialogButtonLabel,
+		dialogTitle,
+		dialogURL,
+		callback,
+		onClose,
+		portletNamespace
+	) {
+		openSelectionModal({
+			buttonAddLabel: dialogButtonLabel,
+			multiple: true,
+			onClose,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					callback(selectedItem);
+				}
+			},
+			selectEventName: normalizeFriendlyURL(
+				portletNamespace,
+				'selectCollections'
+			),
+			title: dialogTitle,
+			url: dialogURL,
+		});
+	},
+
+	openImportView({portletNamespace, viewImportURL}) {
+		openModal({
+			buttons: [
+				{
+					displayType: 'secondary',
+					label: Liferay.Language.get('cancel'),
+					type: 'cancel',
+				},
+				{
+					label: Liferay.Language.get('import'),
+					type: 'submit',
+				},
+			],
+			id: normalizeFriendlyURL(portletNamespace, 'openImportView'),
+			onClose: () => {
+				window.location.reload();
+			},
+			title: Liferay.Language.get('import'),
+			url: viewImportURL,
+		});
+	},
+};

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -67,9 +67,33 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 												</c:if>
 											</li>
 											<li>
+
+												<%
+												Map<String, Object> fragmentCollectionsViewContext = fragmentDisplayContext.getFragmentCollectionsViewContext();
+
+												String deleteFragmentCollectionURL = (String)fragmentCollectionsViewContext.get("deleteFragmentCollectionURL");
+												String exportFragmentCollectionsURL = (String)fragmentCollectionsViewContext.get("exportFragmentCollectionsURL");
+												String viewDeleteFragmentCollectionsURL = (String)fragmentCollectionsViewContext.get("viewDeleteFragmentCollectionsURL");
+												String viewExportFragmentCollectionsURL = (String)fragmentCollectionsViewContext.get("viewExportFragmentCollectionsURL");
+												String viewImportURL = (String)fragmentCollectionsViewContext.get("viewImportURL");
+												%>
+
 												<clay:dropdown-actions
-													defaultEventHandler="FragmentCollectionsViewDefaultEventHandler"
+													additionalProps='<%=
+														HashMapBuilder.<String, Object>put(
+															"deleteFragmentCollectionURL", deleteFragmentCollectionURL
+														).put(
+															"exportFragmentCollectionsURL", exportFragmentCollectionsURL
+														).put(
+															"viewDeleteFragmentCollectionsURL", viewDeleteFragmentCollectionsURL
+														).put(
+															"viewExportFragmentCollectionsURL", viewExportFragmentCollectionsURL
+														).put(
+															"viewImportURL", viewImportURL
+														).build()
+													%>'
 													dropdownItems="<%= fragmentDisplayContext.getCollectionsDropdownItems() %>"
+													propsTransformer="js/FragmentCollectionViewDefaultPropsTransformer"
 												/>
 											</li>
 										</ul>
@@ -224,10 +248,14 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 
 								<liferay-frontend:empty-result-message
 									actionDropdownItems="<%= FragmentPermission.contains(permissionChecker, scopeGroupId, FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES) ? fragmentDisplayContext.getActionDropdownItems() : null %>"
+									additionalProps="<%= fragmentDisplayContext.getFragmentCollectionsViewContext() %>"
 									animationType="<%= EmptyResultMessageKeys.AnimationType.NONE %>"
+									buttonPropsTransformer="js/FragmentCollectionViewButtonPropsTransformer"
 									defaultEventHandler="FragmentCollectionsViewDefaultEventHandler"
 									description='<%= LanguageUtil.get(request, "collections-are-needed-to-create-fragments") %>'
 									elementType='<%= LanguageUtil.get(request, "collections") %>'
+									propsTransformer="js/FragmentCollectionViewDefaultPropsTransformer"
+									propsTransformerServletContext="<%= application %>"
 								/>
 							</c:otherwise>
 						</c:choose>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/badges.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/badges.jsp
@@ -37,8 +37,8 @@
 		md="1"
 	>
 		<clay:badge
+			displayType="secondary"
 			label="87"
-			style="secondary"
 		/>
 
 		<div>Secondary</div>
@@ -48,8 +48,8 @@
 		md="1"
 	>
 		<clay:badge
+			displayType="info"
 			label="91"
-			style="info"
 		/>
 
 		<div>Info</div>
@@ -59,8 +59,8 @@
 		md="1"
 	>
 		<clay:badge
+			displayType="danger"
 			label="130"
-			style="danger"
 		/>
 
 		<div>Error</div>
@@ -70,8 +70,8 @@
 		md="1"
 	>
 		<clay:badge
+			displayType="success"
 			label="1111"
-			style="success"
 		/>
 
 		<div>Success</div>
@@ -81,8 +81,8 @@
 		md="1"
 	>
 		<clay:badge
+			displayType="warning"
 			label="21"
-			style="warning"
 		/>
 
 		<div>Warning</div>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/buttons.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/buttons.jsp
@@ -37,14 +37,14 @@
 					cssClass="flex-md-nowrap mb-2"
 				>
 					<clay:col><clay:button label="Primary" /></clay:col>
-					<clay:col><clay:button ariaLabel="Workflow" icon="workflow" /></clay:col>
+					<clay:col><clay:button aria-label="Workflow" icon="workflow" /></clay:col>
 				</clay:row>
 
 				<clay:row
 					cssClass="flex-md-nowrap"
 				>
 					<clay:col><clay:button disabled="<%= true %>" label="Primary" /></clay:col>
-					<clay:col><clay:button ariaLabel="Workflow" disabled="<%= true %>" icon="workflow" /></clay:col>
+					<clay:col><clay:button aria-label="Workflow" disabled="<%= true %>" icon="workflow" /></clay:col>
 				</clay:row>
 			</td>
 			<td>
@@ -56,15 +56,15 @@
 				<clay:row
 					cssClass="flex-md-nowrap mb-2"
 				>
-					<clay:col><clay:button label="Secondary" style="secondary" /></clay:col>
-					<clay:col><clay:button ariaLabel="Wiki" icon="wiki" style="secondary" /></clay:col>
+					<clay:col><clay:button displayType="secondary" label="Secondary" /></clay:col>
+					<clay:col><clay:button aria-label="Wiki" displayType="secondary" icon="wiki" /></clay:col>
 				</clay:row>
 
 				<clay:row
 					cssClass="flex-md-nowrap"
 				>
-					<clay:col><clay:button disabled="<%= true %>" label="Secondary" style="secondary" /></clay:col>
-					<clay:col><clay:button ariaLabel="Wiki" disabled="<%= true %>" icon="wiki" style="secondary" /></clay:col>
+					<clay:col><clay:button disabled="<%= true %>" displayType="secondary" label="Secondary" /></clay:col>
+					<clay:col><clay:button aria-label="Wiki" disabled="<%= true %>" displayType="secondary" icon="wiki" /></clay:col>
 				</clay:row>
 			</td>
 			<td>
@@ -76,15 +76,15 @@
 				<clay:row
 					cssClass="flex-md-nowrap mb-2"
 				>
-					<clay:col><clay:button label="Borderless" style="borderless" /></clay:col>
-					<clay:col><clay:button ariaLabel="Page Template" icon="page-template" style="borderless" /></clay:col>
+					<clay:col><clay:button displayType="borderless" label="Borderless" /></clay:col>
+					<clay:col><clay:button aria-label="Page Template" displayType="borderless" icon="page-template" /></clay:col>
 				</clay:row>
 
 				<clay:row
 					cssClass="flex-md-nowrap"
 				>
-					<clay:col><clay:button disabled="<%= true %>" label="Borderless" style="borderless" /></clay:col>
-					<clay:col><clay:button ariaLabel="Page Template" disabled="<%= true %>" icon="page-template" style="borderless" /></clay:col>
+					<clay:col><clay:button disabled="<%= true %>" displayType="borderless" label="Borderless" /></clay:col>
+					<clay:col><clay:button aria-label="Page Template" disabled="<%= true %>" displayType="borderless" icon="page-template" /></clay:col>
 				</clay:row>
 			</td>
 			<td>
@@ -96,15 +96,15 @@
 				<clay:row
 					cssClass="flex-md-nowrap mb-2"
 				>
-					<clay:col><clay:button label="Link" style="link" /></clay:col>
-					<clay:col><clay:button ariaLabel="Add Role" icon="add-role" style="link" /></clay:col>
+					<clay:col><clay:button displayType="link" label="Link" /></clay:col>
+					<clay:col><clay:button aria-label="Add Role" displayType="link" icon="add-role" /></clay:col>
 				</clay:row>
 
 				<clay:row
 					cssClass="flex-md-nowrap"
 				>
-					<clay:col><clay:button disabled="<%= true %>" label="Link" style="link" /></clay:col>
-					<clay:col><clay:button ariaLabel="Add Role" disabled="<%= true %>" icon="add-role" style="link" /></clay:col>
+					<clay:col><clay:button disabled="<%= true %>" displayType="link" label="Link" /></clay:col>
+					<clay:col><clay:button aria-label="Add Role" disabled="<%= true %>" displayType="link" icon="add-role" /></clay:col>
 				</clay:row>
 			</td>
 			<td>
@@ -134,9 +134,9 @@
 		md="2"
 	>
 		<clay:button
+			displayType="secondary"
 			icon="indent-less"
 			monospaced="<%= true %>"
-			style="secondary"
 		/>
 
 		<div>Monospaced Button</div>
@@ -157,9 +157,9 @@
 		md="2"
 	>
 		<clay:button
+			displayType="secondary"
 			icon="plus"
 			monospaced="<%= true %>"
-			style="secondary"
 		/>
 
 		<div>Plus Button</div>
@@ -169,9 +169,9 @@
 		md="2"
 	>
 		<clay:button
+			displayType="borderless"
 			icon="ellipsis-v"
 			monospaced="<%= true %>"
-			style="borderless"
 		/>
 
 		<div>Action Button</div>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/dropdowns.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/dropdowns.jsp
@@ -47,7 +47,6 @@
 		<clay:dropdown-menu
 			dropdownItems="<%= dropdownsDisplayContext.getDefaultDropdownItems() %>"
 			label="<%= userSticker %>"
-			showToggleIcon="<%= false %>"
 		/>
 	</clay:col>
 
@@ -64,10 +63,8 @@
 		md="2"
 	>
 		<clay:dropdown-menu
-			buttonLabel="Done"
 			dropdownItems="<%= dropdownsDisplayContext.getInputDropdownItems() %>"
-			label="Inputs"
-			searchable="<%= true %>"
+			label="Done"
 		/>
 	</clay:col>
 
@@ -86,7 +83,6 @@
 	>
 		<clay:dropdown-menu
 			dropdownItems="<%= dropdownsDisplayContext.getIconDropdownItems() %>"
-			itemsIconAlignment="left"
 			label="Icons"
 		/>
 	</clay:col>
@@ -97,11 +93,10 @@
 		md="4"
 	>
 		<clay:dropdown-menu
+			cssClass="btn-outline-borderless"
+			displayType="secondary"
 			dropdownItems="<%= dropdownsDisplayContext.getDefaultDropdownItems() %>"
-			itemsIconAlignment="left"
 			label="Secondary Borderless"
-			style="secondary"
-			triggerCssClasses="btn-outline-borderless"
 		/>
 	</clay:col>
 
@@ -117,11 +112,11 @@
 		md="2"
 	>
 		<clay:dropdown-actions
-			buttonLabel="More"
-			buttonStyle="secondary"
 			caption="Showing 4 of 32 Options"
+			displayType="secondary"
 			dropdownItems="<%= dropdownsDisplayContext.getDefaultDropdownItems() %>"
 			helpText="You can customize this menu or see all you have by pressing \"more\"."
+			label="More"
 		/>
 	</clay:col>
 
@@ -129,12 +124,12 @@
 		md="2"
 	>
 		<clay:dropdown-actions
-			buttonLabel="More"
-			buttonStyle="secondary"
 			caption="Showing 4 of 32 Options"
+			cssClass="btn-outline-borderless"
+			displayType="secondary"
 			dropdownItems="<%= dropdownsDisplayContext.getDefaultDropdownItems() %>"
 			helpText="You can customize this menu or see all you have by pressing \"more\"."
-			triggerCssClasses="btn-outline-borderless"
+			label="More"
 		/>
 	</clay:col>
 </clay:row>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/links.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/links.jsp
@@ -30,7 +30,7 @@
 	data-custom-property="customValue"
 	href="#"
 	label="link text"
-	target="blank"
+	target="_blank"
 />
 
 <clay:link
@@ -38,6 +38,6 @@
 	href="#"
 	label="a button link"
 	rel="nofollow"
-	target="blank"
+	target="_blank"
 	type="button"
 />

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/stickers.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/stickers.jsp
@@ -78,9 +78,9 @@
 			<img class="aspect-ratio-item-fluid" src="https://claycss.com/images/thumbnail_hot_air_ballon.jpg" />
 
 			<clay:sticker
+				displayType="danger"
 				label="PDF"
 				position="top-left"
-				style="danger"
 			/>
 		</div>
 	</clay:col>
@@ -92,9 +92,9 @@
 			<img class="aspect-ratio-item-fluid" src="https://claycss.com/images/thumbnail_hot_air_ballon.jpg" />
 
 			<clay:sticker
+				displayType="danger"
 				label="PDF"
 				position="bottom-left"
-				style="danger"
 			/>
 		</clay:col>
 	</div>
@@ -106,9 +106,9 @@
 			<img class="aspect-ratio-item-fluid" src="https://claycss.com/images/thumbnail_hot_air_ballon.jpg" />
 
 			<clay:sticker
+				displayType="danger"
 				label="PDF"
 				position="top-right"
-				style="danger"
 			/>
 		</div>
 	</clay:col>
@@ -120,9 +120,9 @@
 			<img class="aspect-ratio-item-fluid" src="https://claycss.com/images/thumbnail_hot_air_ballon.jpg" />
 
 			<clay:sticker
+				displayType="danger"
 				label="PDF"
 				position="bottom-right"
-				style="danger"
 			/>
 		</div>
 	</clay:col>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
@@ -43,23 +43,6 @@ public class AlertTag extends BaseContainerTag {
 		return _autoClose;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getDismissible()}
-	 */
-	@Deprecated
-	public boolean getCloseable() {
-		return _dismissible;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public boolean getDestroyOnHide() {
-		return _destroyOnHide;
-	}
-
 	public boolean getDismissible() {
 		return _dismissible;
 	}
@@ -72,25 +55,8 @@ public class AlertTag extends BaseContainerTag {
 		return _message;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getDisplayType()}
-	 */
-	@Deprecated
-	public String getStyle() {
-		return getDisplayType();
-	}
-
 	public String getTitle() {
 		return _title;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getType() {
-		return _type;
 	}
 
 	public String getVariant() {
@@ -99,18 +65,6 @@ public class AlertTag extends BaseContainerTag {
 
 	public void setAutoClose(boolean autoClose) {
 		_autoClose = autoClose;
-	}
-
-	public void setCloseable(boolean closeable) {
-		setDismissible(closeable);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setDestroyOnHide(boolean destroyOnHide) {
-		_destroyOnHide = destroyOnHide;
 	}
 
 	public void setDismissible(boolean dismissible) {
@@ -125,27 +79,10 @@ public class AlertTag extends BaseContainerTag {
 		_message = message;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setDisplayType(String)}
-	 */
-	@Deprecated
-	public void setStyle(String style) {
-		setDisplayType(style);
-	}
-
 	public void setTitle(String title) {
 		_title = title;
 	}
 
-	public void setType(String type) {
-		_type = type;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
 	public void setVariant(String variant) {
 		_variant = variant;
 	}
@@ -155,12 +92,10 @@ public class AlertTag extends BaseContainerTag {
 		super.cleanUp();
 
 		_autoClose = false;
-		_destroyOnHide = false;
 		_dismissible = false;
 		_displayType = "info";
 		_message = null;
 		_title = null;
-		_type = null;
 		_variant = null;
 	}
 
@@ -283,12 +218,10 @@ public class AlertTag extends BaseContainerTag {
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:alert:";
 
 	private boolean _autoClose;
-	private boolean _destroyOnHide;
 	private boolean _dismissible;
 	private String _displayType = "info";
 	private String _message;
 	private String _title;
-	private String _type;
 	private String _variant;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BadgeTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BadgeTag.java
@@ -45,15 +45,6 @@ public class BadgeTag extends BaseContainerTag {
 		return _label;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getDisplayType()}
-	 */
-	@Deprecated
-	public String getStyle() {
-		return getDisplayType();
-	}
-
 	public void setDisplayType(String displayType) {
 		_displayType = displayType;
 	}
@@ -62,22 +53,12 @@ public class BadgeTag extends BaseContainerTag {
 		_label = label;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setDisplayType(String)}
-	 */
-	@Deprecated
-	public void setStyle(String style) {
-		setDisplayType(style);
-	}
-
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
 
 		_displayType = "primary";
 		_label = null;
-		_style = null;
 	}
 
 	@Override
@@ -107,6 +88,5 @@ public class BadgeTag extends BaseContainerTag {
 
 	private String _displayType = "primary";
 	private String _label;
-	private String _style;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -39,23 +39,17 @@ public class ButtonTag extends BaseContainerTag {
 
 		setContainerElement("button");
 
-		if (Validator.isNotNull(_ariaLabel)) {
-			setDynamicAttribute(StringPool.BLANK, "aria-label", _ariaLabel);
-		}
+		Map<String, Object> dynamicAttributes = getDynamicAttributes();
 
-		if (_disabled) {
-			setDynamicAttribute(StringPool.BLANK, "disabled", _disabled);
-		}
+		if (dynamicAttributes.get("title") != null) {
+			String title = (String)dynamicAttributes.get("title");
 
-		if (Validator.isNotNull(_title)) {
 			setDynamicAttribute(
 				StringPool.BLANK, "title",
 				LanguageUtil.get(
 					TagResourceBundleUtil.getResourceBundle(pageContext),
-					_title));
+					title));
 		}
-
-		setDynamicAttribute(StringPool.BLANK, "type", _type);
 
 		return super.doStartTag();
 	}
@@ -64,28 +58,12 @@ public class ButtonTag extends BaseContainerTag {
 		return _alert;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getAriaLabel() {
-		return _ariaLabel;
-	}
-
 	public boolean getBlock() {
 		return _block;
 	}
 
 	public boolean getBorderless() {
 		return _borderless;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public boolean getDisabled() {
-		return _disabled;
 	}
 
 	public String getDisplayType() {
@@ -108,57 +86,12 @@ public class ButtonTag extends BaseContainerTag {
 		return _outline;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getLarge()}
-	 */
-	@Deprecated
-	public String getSize() {
-		if (_small) {
-			return "sm";
-		}
-
-		return null;
-	}
-
 	public boolean getSmall() {
 		return _small;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getDisplayType()}
-	 */
-	@Deprecated
-	public String getStyle() {
-		return getDisplayType();
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getTitle() {
-		return _title;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getType() {
-		return _type;
-	}
-
 	public void setAlert(boolean alert) {
 		_alert = alert;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setAriaLabel(String ariaLabel) {
-		_ariaLabel = ariaLabel;
 	}
 
 	public void setBlock(boolean block) {
@@ -167,14 +100,6 @@ public class ButtonTag extends BaseContainerTag {
 
 	public void setBorderless(boolean borderless) {
 		_borderless = borderless;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setDisabled(boolean disabled) {
-		_disabled = disabled;
 	}
 
 	public void setDisplayType(String displayType) {
@@ -197,42 +122,8 @@ public class ButtonTag extends BaseContainerTag {
 		_outline = outline;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setLarge(boolean)}
-	 */
-	@Deprecated
-	public void setSize(String size) {
-		setSmall(size.equals("sm"));
-	}
-
 	public void setSmall(boolean small) {
 		_small = small;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setDisplayType(String)}
-	 */
-	@Deprecated
-	public void setStyle(String style) {
-		setDisplayType(style);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setTitle(String title) {
-		_title = title;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setType(String type) {
-		_type = type;
 	}
 
 	@Override
@@ -240,18 +131,14 @@ public class ButtonTag extends BaseContainerTag {
 		super.cleanUp();
 
 		_alert = false;
-		_ariaLabel = null;
 		_block = false;
 		_borderless = false;
-		_disabled = false;
 		_displayType = "primary";
 		_icon = null;
 		_label = null;
 		_monospaced = false;
 		_outline = false;
 		_small = false;
-		_title = null;
-		_type = "button";
 	}
 
 	@Override
@@ -281,7 +168,6 @@ public class ButtonTag extends BaseContainerTag {
 		props.put("monospaced", _monospaced);
 		props.put("outline", _outline);
 		props.put("small", _small);
-		props.put("type", _type);
 
 		return super.prepareProps(props);
 	}
@@ -373,17 +259,13 @@ public class ButtonTag extends BaseContainerTag {
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:button:";
 
 	private boolean _alert;
-	private String _ariaLabel;
 	private boolean _block;
 	private boolean _borderless;
-	private boolean _disabled;
 	private String _displayType = "primary";
 	private String _icon;
 	private String _label;
 	private boolean _monospaced;
 	private boolean _outline;
 	private boolean _small;
-	private String _title;
-	private String _type = "button";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
@@ -33,160 +33,12 @@ public class DropdownMenuTag extends ButtonTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getLabel()}
-	 */
-	@Deprecated
-	public String getButtonLabel() {
-		return getLabel();
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getDisplayType()}
-	 */
-	@Deprecated
-	public String getButtonStyle() {
-		return getDisplayType();
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getButtonType() {
-		return _buttonType;
-	}
-
 	public List<DropdownItem> getDropdownItems() {
 		return _dropdownItems;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public boolean getExpanded() {
-		return _expanded;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getItemsIconAlignment() {
-		return _itemsIconAlignment;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public boolean getSearchable() {
-		return _searchable;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public boolean getShowToggleIcon() {
-		return _showToggleIcon;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getCssClass()}
-	 */
-	@Deprecated
-	public String getTriggerCssClasses() {
-		return getCssClass();
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getTriggerTitle() {
-		return _triggerTitle;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setLabel(String)}
-	 */
-	@Deprecated
-	public void setButtonLabel(String buttonLabel) {
-		setLabel(buttonLabel);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setDisplayType(String)}
-	 */
-	@Deprecated
-	public void setButtonStyle(String buttonStyle) {
-		setDisplayType(buttonStyle);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setButtonType(String buttonType) {
-		_buttonType = buttonType;
-	}
-
 	public void setDropdownItems(List<DropdownItem> dropdownItems) {
 		_dropdownItems = dropdownItems;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setExpanded(boolean expanded) {
-		_expanded = expanded;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setItemsIconAlignment(String itemsIconAlignment) {
-		_itemsIconAlignment = itemsIconAlignment;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setSearchable(boolean searchable) {
-		_searchable = searchable;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setShowToggleIcon(boolean showToggleIcon) {
-		_showToggleIcon = showToggleIcon;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setCssClas(String)}
-	 */
-	@Deprecated
-	public void setTriggerCssClasses(String triggerCssClasses) {
-		setCssClass(triggerCssClasses);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setTriggerTitle(String triggerTitle) {
-		_triggerTitle = triggerTitle;
 	}
 
 	@Override
@@ -195,11 +47,6 @@ public class DropdownMenuTag extends ButtonTag {
 
 		_buttonType = null;
 		_dropdownItems = null;
-		_expanded = false;
-		_itemsIconAlignment = null;
-		_searchable = false;
-		_showToggleIcon = false;
-		_triggerTitle = null;
 	}
 
 	@Override
@@ -218,10 +65,5 @@ public class DropdownMenuTag extends ButtonTag {
 
 	private String _buttonType;
 	private List<DropdownItem> _dropdownItems;
-	private boolean _expanded;
-	private String _itemsIconAlignment;
-	private boolean _searchable;
-	private boolean _showToggleIcon;
-	private String _triggerTitle;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
@@ -48,40 +48,8 @@ public class IconTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public boolean getMonospaced() {
-		return _monospaced;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getSpritemap() {
-		return _spritemap;
-	}
-
 	public String getSymbol() {
 		return _symbol;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setMonospaced(boolean monospaced) {
-		_monospaced = monospaced;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setSpritemap(String spritemap) {
-		_spritemap = spritemap;
 	}
 
 	public void setSymbol(String symbol) {
@@ -92,7 +60,6 @@ public class IconTag extends BaseContainerTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
-		_monospaced = false;
 		_spritemap = null;
 		_symbol = null;
 	}
@@ -122,7 +89,6 @@ public class IconTag extends BaseContainerTag {
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:icon:";
 
-	private boolean _monospaced;
 	private String _spritemap;
 	private String _symbol;
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
@@ -40,29 +40,12 @@ public class LabelTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getDismissible()}
-	 */
-	@Deprecated
-	public boolean getCloseable() {
-		return getDismissible();
-	}
-
 	public boolean getDismissible() {
 		return _dismissible;
 	}
 
 	public String getDisplayType() {
 		return _displayType;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getHref() {
-		return _href;
 	}
 
 	public String getLabel() {
@@ -73,66 +56,12 @@ public class LabelTag extends BaseContainerTag {
 		return _large;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getMessage() {
-		return _message;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getLarge()}
-	 */
-	@Deprecated
-	public String getSize() {
-		if (_large) {
-			return "lg";
-		}
-
-		return null;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getSpritemap() {
-		return _spritemap;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getDisplayType()}
-	 */
-	@Deprecated
-	public String getStyle() {
-		return getDisplayType();
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setDismissible(boolean)}
-	 */
-	@Deprecated
-	public void setCloseable(boolean closeable) {
-		setDismissible(closeable);
-	}
-
 	public void setDismissible(boolean dismissible) {
 		_dismissible = dismissible;
 	}
 
 	public void setDisplayType(String displayType) {
 		_displayType = displayType;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setHref(String href) {
-		_href = href;
 	}
 
 	public void setLabel(String label) {
@@ -143,51 +72,14 @@ public class LabelTag extends BaseContainerTag {
 		_large = large;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setMessage(String message) {
-		_message = message;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setLarge(boolean)}
-	 */
-	@Deprecated
-	public void setSize(String size) {
-		setLarge(size.equals("lg"));
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setSpritemap(String spritemap) {
-		_spritemap = spritemap;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setDisplayType(String)}
-	 */
-	@Deprecated
-	public void setStyle(String style) {
-		setDisplayType(style);
-	}
-
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
 
 		_dismissible = false;
 		_displayType = "secondary";
-		_href = null;
 		_label = null;
 		_large = false;
-		_message = null;
-		_spritemap = null;
 	}
 
 	@Override
@@ -247,10 +139,7 @@ public class LabelTag extends BaseContainerTag {
 
 	private boolean _dismissible;
 	private String _displayType = "secondary";
-	private String _href;
 	private String _label;
 	private boolean _large;
-	private String _message;
-	private String _spritemap;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
@@ -38,31 +38,16 @@ public class LinkTag extends BaseContainerTag {
 
 		setContainerElement("a");
 
-		if (Validator.isNotNull(_ariaLabel)) {
-			setDynamicAttribute(StringPool.BLANK, "aria-label", _ariaLabel);
-		}
-
 		if (Validator.isNotNull(_href)) {
 			setDynamicAttribute(StringPool.BLANK, "href", _href);
 		}
 
-		if (Validator.isNotNull(_target)) {
-			Map<String, Object> dynamicAttributes = getDynamicAttributes();
+		Map<String, Object> dynamicAttributes = getDynamicAttributes();
 
-			if (dynamicAttributes.get("rel") == null) {
-				setDynamicAttribute(
-					StringPool.BLANK, "rel", "noreferrer noopener");
-			}
+		if ((dynamicAttributes.get("target") != null) &&
+			(dynamicAttributes.get("rel") == null)) {
 
-			setDynamicAttribute(StringPool.BLANK, "target", _target);
-		}
-
-		if (Validator.isNotNull(_title)) {
-			setDynamicAttribute(
-				StringPool.BLANK, "title",
-				LanguageUtil.get(
-					TagResourceBundleUtil.getResourceBundle(pageContext),
-					_title));
+			setDynamicAttribute(StringPool.BLANK, "rel", "noreferrer noopener");
 		}
 
 		if (Validator.isNotNull(_type) &&
@@ -74,25 +59,8 @@ public class LinkTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getAriaLabel() {
-		return _ariaLabel;
-	}
-
 	public boolean getBorderless() {
 		return _borderless;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getDisplayType()}
-	 */
-	@Deprecated
-	public String getButtonStyle() {
-		return getDisplayType();
 	}
 
 	public String getDisplayType() {
@@ -111,14 +79,6 @@ public class LinkTag extends BaseContainerTag {
 		return _icon;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getIconAlignment() {
-		return _iconAlignment;
-	}
-
 	public String getLabel() {
 		return _label;
 	}
@@ -135,55 +95,12 @@ public class LinkTag extends BaseContainerTag {
 		return _small;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getDisplayType()}
-	 */
-	@Deprecated
-	public String getStyle() {
-		return getDisplayType();
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getTarget() {
-		return _target;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getTitle() {
-		return _title;
-	}
-
 	public String getType() {
 		return _type;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setAriaLabel(String ariaLabel) {
-		_ariaLabel = ariaLabel;
-	}
-
 	public void setBorderless(boolean borderless) {
 		_borderless = borderless;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setDisplayType(String)}
-	 */
-	@Deprecated
-	public void setButtonStyle(String buttonStyle) {
-		setDisplayType(buttonStyle);
-		setType("button");
 	}
 
 	public void setDisplayType(String displayType) {
@@ -202,14 +119,6 @@ public class LinkTag extends BaseContainerTag {
 		_icon = icon;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setIconAlignment(String iconAlignment) {
-		_iconAlignment = iconAlignment;
-	}
-
 	public void setLabel(String label) {
 		_label = label;
 	}
@@ -226,31 +135,6 @@ public class LinkTag extends BaseContainerTag {
 		_small = small;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setDisplayType(String)}
-	 */
-	@Deprecated
-	public void setStyle(String style) {
-		setDisplayType(style);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setTarget(String target) {
-		_target = target;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setTitle(String title) {
-		_title = title;
-	}
-
 	public void setType(String type) {
 		_type = type;
 	}
@@ -259,19 +143,15 @@ public class LinkTag extends BaseContainerTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
-		_ariaLabel = null;
 		_borderless = false;
 		_displayType = null;
 		_download = null;
 		_href = null;
 		_icon = null;
-		_iconAlignment = null;
 		_label = null;
 		_monospaced = false;
 		_outline = false;
 		_small = false;
-		_target = null;
-		_title = null;
 		_type = "link";
 	}
 
@@ -344,19 +224,15 @@ public class LinkTag extends BaseContainerTag {
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:link:";
 
-	private String _ariaLabel;
 	private boolean _borderless;
 	private String _displayType;
 	private String _download;
 	private String _href;
 	private String _icon;
-	private String _iconAlignment;
 	private String _label;
 	private boolean _monospaced;
 	private boolean _outline;
 	private boolean _small;
-	private String _target;
-	private String _title;
 	private String _type = "link";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/MultiselectTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/MultiselectTag.java
@@ -17,6 +17,7 @@ package com.liferay.frontend.taglib.clay.servlet.taglib;
 import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.MultiselectItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.MultiselectLocator;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -311,7 +312,8 @@ public class MultiselectTag extends BaseContainerTag {
 					TagResourceBundleUtil.getResourceBundle(pageContext),
 					_clearAllTitle);
 
-				buttonTag.setTitle(HtmlUtil.escape(clearAllTitle));
+				buttonTag.setDynamicAttribute(
+					StringPool.BLANK, "title", HtmlUtil.escape(clearAllTitle));
 			}
 
 			buttonTag.doTag(pageContext);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
@@ -47,14 +47,6 @@ public class NavigationBarTag extends BaseContainerTag {
 		return _navigationItems;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getSpritemap() {
-		return _spritemap;
-	}
-
 	public void setInverted(boolean inverted) {
 		_inverted = inverted;
 	}
@@ -63,21 +55,12 @@ public class NavigationBarTag extends BaseContainerTag {
 		_navigationItems = navigationItems;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setSpritemap(String spritemap) {
-		_spritemap = spritemap;
-	}
-
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
 
 		_inverted = false;
 		_navigationItems = null;
-		_spritemap = null;
 	}
 
 	@Override
@@ -160,6 +143,5 @@ public class NavigationBarTag extends BaseContainerTag {
 
 	private boolean _inverted;
 	private List<NavigationItem> _navigationItems;
-	private String _spritemap;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
@@ -78,23 +78,6 @@ public class StickerTag extends BaseContainerTag {
 		return _size;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getSpritemap() {
-		return _spritemap;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getDisplayType()}
-	 */
-	@Deprecated
-	public String getStyle() {
-		return getDisplayType();
-	}
-
 	public void setDisplayType(String displayType) {
 		_displayType = displayType;
 	}
@@ -135,23 +118,6 @@ public class StickerTag extends BaseContainerTag {
 		_size = size;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setSpritemap(String spritemap) {
-		_spritemap = spritemap;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setDisplayType(String)}
-	 */
-	@Deprecated
-	public void setStyle(String style) {
-		setDisplayType(style);
-	}
-
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
@@ -166,7 +132,6 @@ public class StickerTag extends BaseContainerTag {
 		_position = null;
 		_shape = "rounded";
 		_size = null;
-		_spritemap = null;
 	}
 
 	@Override
@@ -258,6 +223,5 @@ public class StickerTag extends BaseContainerTag {
 	private String _position;
 	private String _shape = "rounded";
 	private String _size;
-	private String _spritemap;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -22,44 +22,8 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>dismissible</code>]]>.</description>
-			<name>closeable</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>cssClass</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>destroyOnHide</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -76,12 +40,6 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>id</name>
 			<required>false</required>
@@ -94,26 +52,8 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>spritemap</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>style</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>title</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>type</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -125,20 +65,8 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.BadgeTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>containerElement</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -149,26 +77,8 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>displayType</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -181,12 +91,6 @@
 		<attribute>
 			<name>label</name>
 			<required>true</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>style</name>
-			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<dynamic-attributes>true</dynamic-attributes>
@@ -203,12 +107,6 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>ariaLabel</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>block</name>
 			<required>false</required>
@@ -221,38 +119,8 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>cssClass</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>disabled</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -263,20 +131,8 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>icon</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>iconAlignment</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -299,56 +155,20 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>name</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>propsTransformer</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>small</code>]]>.</description>
-			<name>size</name>
+			<description></description>
+			<name>propsTransformerServletContext</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
 			<name>small</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>spritemap</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>style</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>title</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>type</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>value</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -781,50 +601,8 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>label</code>]]>.</description>
-			<name>buttonLabel</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>buttonStyle</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>buttonType</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>cssClass</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -835,26 +613,8 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>expanded</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>id</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>itemsIconAlignment</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -867,48 +627,6 @@
 		<attribute>
 			<description></description>
 			<name>propsTransformerServletContext</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>searchable</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>showToggleIcon</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>spritemap</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>style</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>triggerCssClasses</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>triggerTitle</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>type</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -938,50 +656,8 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>label</code>]]>.</description>
-			<name>buttonLabel</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>buttonStyle</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>buttonType</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>cssClass</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -998,18 +674,6 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>expanded</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>icon</name>
 			<required>false</required>
@@ -1018,12 +682,6 @@
 		<attribute>
 			<description></description>
 			<name>id</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>itemsIconAlignment</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1052,50 +710,8 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>searchable</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>showToggleIcon</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>small</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>spritemap</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>style</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>triggerCssClasses</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>triggerTitle</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>type</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1555,55 +1171,13 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.IconTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<name>cssClass</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
 			<name>id</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>monospaced</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1838,56 +1412,14 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.LabelTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>dismissible</code>]]>.</description>
-			<name>closeable</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>displayType</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>href</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1906,30 +1438,6 @@
 		<attribute>
 			<description></description>
 			<name>large</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>message</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>large</code>]]>.</description>
-			<name>size</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>spritemap</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>style</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1995,12 +1503,6 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.LinkTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>ariaLabel</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>borderless</name>
 			<required>false</required>
@@ -2013,38 +1515,8 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>buttonStyle</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>cssClass</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -2061,12 +1533,6 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>href</name>
 			<required>true</required>
@@ -2075,12 +1541,6 @@
 		<attribute>
 			<description></description>
 			<name>icon</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>iconAlignment</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -2111,30 +1571,6 @@
 		<attribute>
 			<description></description>
 			<name>small</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>spritemap</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>style</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>target</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>title</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -2890,38 +2326,8 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.NavigationBarTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>cssClass</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -2941,12 +2347,6 @@
 			<description></description>
 			<name>navigationItems</name>
 			<required>true</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>spritemap</name>
-			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 	</tag>
@@ -3041,44 +2441,14 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.ProgressBarTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>cssClass</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -3097,12 +2467,6 @@
 		<attribute>
 			<description></description>
 			<name>minValue</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -3132,44 +2496,14 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>disabled</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -3409,44 +2743,14 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.StickerTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>displayType</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -3510,18 +2814,6 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>spritemap</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>style</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
 		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
@@ -3532,42 +2824,6 @@
 		<attribute>
 			<description></description>
 			<name>autoClose</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>dismissible</code>]]>.</description>
-			<name>closeable</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>contributorKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>data</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>defaultEventHandler</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>destroyOnHide</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -3584,12 +2840,6 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
-			<name>elementClasses</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>id</name>
 			<required>false</required>
@@ -3602,26 +2852,8 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>spritemap</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
-			<name>style</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>title</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
-			<name>type</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 4.0.0

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/EmptyResultMessageTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/EmptyResultMessageTag.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.util.IncludeTag;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -36,12 +37,20 @@ public class EmptyResultMessageTag extends IncludeTag {
 		return _actionDropdownItems;
 	}
 
+	public Map<String, Object> getAdditionalProps() {
+		return _additionalProps;
+	}
+
 	public EmptyResultMessageKeys.AnimationType getAnimationType() {
 		return _animationType;
 	}
 
 	public String getButtonCssClass() {
 		return _buttonCssClass;
+	}
+
+	public String getButtonPropsTransformer() {
+		return _buttonPropsTransformer;
 	}
 
 	public String getComponentId() {
@@ -72,6 +81,10 @@ public class EmptyResultMessageTag extends IncludeTag {
 		_actionDropdownItems = actionDropdownItems;
 	}
 
+	public void setAdditionalProps(Map<String, Object> additionalProps) {
+		_additionalProps = additionalProps;
+	}
+
 	public void setAnimationType(
 		EmptyResultMessageKeys.AnimationType animationType) {
 
@@ -80,6 +93,10 @@ public class EmptyResultMessageTag extends IncludeTag {
 
 	public void setButtonCssClass(String buttonCssClass) {
 		_buttonCssClass = buttonCssClass;
+	}
+
+	public void setButtonPropsTransformer(String buttonPropsTransformer) {
+		_buttonPropsTransformer = buttonPropsTransformer;
 	}
 
 	public void setComponentId(String componentId) {
@@ -124,8 +141,10 @@ public class EmptyResultMessageTag extends IncludeTag {
 		super.cleanUp();
 
 		_actionDropdownItems = null;
+		_additionalProps = null;
 		_animationType = EmptyResultMessageKeys.AnimationType.EMPTY;
 		_buttonCssClass = "primary";
+		_buttonPropsTransformer = null;
 		_componentId = null;
 		_defaultEventHandler = null;
 		_description = null;
@@ -154,11 +173,17 @@ public class EmptyResultMessageTag extends IncludeTag {
 			"liferay-frontend:empty-result-message:actionDropdownItems",
 			_actionDropdownItems);
 		httpServletRequest.setAttribute(
+			"liferay-frontend:empty-result-message:additionalProps",
+			_additionalProps);
+		httpServletRequest.setAttribute(
 			"liferay-frontend:empty-result-message:animationTypeCssClass",
 			EmptyResultMessageKeys.getAnimationTypeCssClass(_animationType));
 		httpServletRequest.setAttribute(
 			"liferay-frontend:empty-result-message:buttonCssClass",
 			_buttonCssClass);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:empty-result-message:buttonPropsTransformer",
+			_buttonPropsTransformer);
 		httpServletRequest.setAttribute(
 			"liferay-frontend:empty-result-message:componentId", _componentId);
 		httpServletRequest.setAttribute(
@@ -188,9 +213,11 @@ public class EmptyResultMessageTag extends IncludeTag {
 	private static final String _PAGE = "/empty_result_message/page.jsp";
 
 	private List<DropdownItem> _actionDropdownItems;
+	private Map<String, Object> _additionalProps;
 	private EmptyResultMessageKeys.AnimationType _animationType =
 		EmptyResultMessageKeys.AnimationType.EMPTY;
 	private String _buttonCssClass = "primary";
+	private String _buttonPropsTransformer;
 	private String _componentId;
 	private String _defaultEventHandler;
 	private String _description;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -361,12 +361,22 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>additionalProps</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>animationType</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<name>buttonCssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>buttonPropsTransformer</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/init.jsp
@@ -20,10 +20,10 @@
 
 <%
 List<DropdownItem> actionDropdownItems = (List<DropdownItem>)request.getAttribute("liferay-frontend:empty-result-message:actionDropdownItems");
+Map<String, Object> additionalProps = (Map<String, Object>)request.getAttribute("liferay-frontend:empty-result-message:additionalProps");
 String animationTypeCssClass = GetterUtil.getString((String)request.getAttribute("liferay-frontend:empty-result-message:animationTypeCssClass"));
 String buttonCssClass = GetterUtil.getString((String)request.getAttribute("liferay-frontend:empty-result-message:buttonCssClass"));
-String componentId = GetterUtil.getString((String)request.getAttribute("liferay-frontend:empty-result-message:componentId"));
-String defaultEventHandler = GetterUtil.getString((String)request.getAttribute("liferay-frontend:empty-result-message:defaultEventHandler"));
+String buttonPropsTransformer = GetterUtil.getString((String)request.getAttribute("liferay-frontend:empty-result-message:buttonPropsTransformer"));
 String description = (String)request.getAttribute("liferay-frontend:empty-result-message:description");
 String elementType = (String)request.getAttribute("liferay-frontend:empty-result-message:elementType");
 String propsTransformer = (String)request.getAttribute("liferay-frontend:empty-result-message:propsTransformer");

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
@@ -41,8 +41,7 @@
 			<c:choose>
 				<c:when test="<%= actionDropdownItems.size() > 1 %>">
 					<clay:dropdown-menu
-						componentId="<%= componentId %>"
-						defaultEventHandler="<%= defaultEventHandler %>"
+						additionalProps="<%= additionalProps %>"
 						displayType="<%= buttonCssClass %>"
 						dropdownItems="<%= actionDropdownItems %>"
 						label="new"
@@ -60,25 +59,19 @@
 					<c:choose>
 						<c:when test='<%= Validator.isNotNull(actionDropdownItem.get("href")) %>'>
 							<clay:link
-								buttonStyle="<%= buttonCssClass %>"
-								componentId="<%= componentId %>"
-								data='<%= (HashMap)actionDropdownItem.get("data") %>'
-								defaultEventHandler="<%= defaultEventHandler %>"
+								displayType="<%= buttonCssClass %>"
 								href='<%= String.valueOf(actionDropdownItem.get("href")) %>'
 								label='<%= String.valueOf(actionDropdownItem.get("label")) %>'
-								propsTransformer="<%= propsTransformer %>"
-								servletContext="<%= application %>"
+								type="button"
 							/>
 						</c:when>
 						<c:otherwise>
 							<clay:button
-								componentId="<%= componentId %>"
-								data='<%= (HashMap)actionDropdownItem.get("data") %>'
-								defaultEventHandler="<%= defaultEventHandler %>"
+								additionalProps='<%= (HashMap)actionDropdownItem.get("data") %>'
 								displayType="<%= buttonCssClass %>"
 								label='<%= String.valueOf(actionDropdownItem.get("label")) %>'
-								propsTransformer="<%= propsTransformer %>"
-								servletContext="<%= application %>"
+								propsTransformer="<%= buttonPropsTransformer %>"
+								propsTransformerServletContext="<%= propsTransformerServletContext %>"
 							/>
 						</c:otherwise>
 					</c:choose>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/action_button_preview.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/action_button_preview.jsp
@@ -18,8 +18,8 @@
 
 <clay:button
 	borderless="<%= true %>"
+	cssClass="component-action icon-view"
 	displayType="secondary"
-	elementClasses="component-action icon-view"
 	icon="view"
 	monospaced="<%= true %>"
 />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -37,6 +37,8 @@ if (ListUtil.isEmpty(folders) && ListUtil.isEmpty(articles)) {
 		folders.add(null);
 	}
 }
+
+Map<String, Object> componentContext = journalDisplayContext.getComponentContext();
 %>
 
 <c:choose>
@@ -69,8 +71,13 @@ if (ListUtil.isEmpty(folders) && ListUtil.isEmpty(articles)) {
 						</li>
 						<li class="autofit-col">
 							<clay:dropdown-actions
-								defaultEventHandler="<%= JournalWebConstants.JOURNAL_INFO_PANEL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+								additionalProps='<%=
+									HashMapBuilder.<String, Object>put(
+										"trashEnabled", componentContext.get("trashEnabled")
+									).build()
+								%>'
 								dropdownItems="<%= journalDisplayContext.getFolderInfoPanelDropdownItems(folder) %>"
+								propsTransformer="js/ElementsDefaultPropsTransformer"
 							/>
 						</li>
 					</ul>
@@ -139,8 +146,13 @@ if (ListUtil.isEmpty(folders) && ListUtil.isEmpty(articles)) {
 						</li>
 						<li class="autofit-col">
 							<clay:dropdown-actions
-								defaultEventHandler="<%= JournalWebConstants.JOURNAL_INFO_PANEL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+								additionalProps='<%=
+									HashMapBuilder.<String, Object>put(
+										"trashEnabled", componentContext.get("trashEnabled")
+									).build()
+								%>'
 								dropdownItems="<%= journalDisplayContext.getArticleInfoPanelDropdownItems(article) %>"
+								propsTransformer="js/ElementsDefaultPropsTransformer"
 							/>
 						</li>
 					</ul>
@@ -283,9 +295,3 @@ if (ListUtil.isEmpty(folders) && ListUtil.isEmpty(articles)) {
 		</div>
 	</c:otherwise>
 </c:choose>
-
-<liferay-frontend:component
-	componentId="<%= JournalWebConstants.JOURNAL_INFO_PANEL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
-	context="<%= journalDisplayContext.getComponentContext() %>"
-	module="js/ElementsDefaultEventHandler.es"
-/>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMTemplateElementsDefaultPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMTemplateElementsDefaultPropsTransformer.js
@@ -12,18 +12,43 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
+import {openModal} from 'frontend-js-web';
 
-class OrganizationDropdownDefaultEventHandler extends DefaultEventHandler {
-	deleteGroupOrganizations(itemData) {
+const ACTIONS = {
+	deleteDDMTemplate(itemData) {
 		if (
 			confirm(
 				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
 			)
 		) {
-			submitForm(document.hrefFm, itemData.deleteGroupOrganizationsURL);
+			submitForm(document.hrefFm, itemData.deleteDDMTemplateURL);
 		}
-	}
-}
+	},
 
-export default OrganizationDropdownDefaultEventHandler;
+	permissionsDDMTemplate(itemData) {
+		openModal({
+			title: Liferay.Language.get('permissions'),
+			url: itemData.permissionsDDMTemplateURL,
+		});
+	},
+};
+
+export default function propsTransformer({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {
+	addParams,
+	normalizeFriendlyURL,
+	openModal,
+	openSelectionModal,
+} from 'frontend-js-web';
+
+const ACTIONS = {
+	compareVersions({itemData, portletNamespace}) {
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				let url = itemData.redirectURL;
+
+				url = addParams(
+					`${portletNamespace}sourceVersion=${selectedItem.sourceversion}`,
+					url
+				);
+				url = addParams(
+					`${portletNamespace}targetVersion=${selectedItem.targetversion}`,
+					url
+				);
+
+				location.href = url;
+			},
+			selectEventName: normalizeFriendlyURL(
+				`${portletNamespace}selectVersionFm`
+			),
+			title: Liferay.Language.get('compare-versions'),
+			url: itemData.compareVersionsURL,
+		});
+	},
+
+	copyArticle({itemData}) {
+		this.send(itemData.copyArticleURL);
+	},
+
+	delete({itemData, trashEnabled}) {
+		let message = Liferay.Language.get(
+			'are-you-sure-you-want-to-delete-this'
+		);
+
+		if (trashEnabled) {
+			message = Liferay.Language.get(
+				'are-you-sure-you-want-to-move-this-to-the-recycle-bin'
+			);
+		}
+
+		if (confirm(message)) {
+			this.send(itemData.deleteURL);
+		}
+	},
+
+	deleteArticleTranslations({itemData, portletNamespace}) {
+		openSelectionModal({
+			buttonAddLabel: Liferay.Language.get('delete'),
+			multiple: true,
+			onSelect: (selectedItems) => {
+				if (selectedItems) {
+					if (
+						confirm(
+							Liferay.Language.get(
+								'are-you-sure-you-want-to-delete-the-selected-entries'
+							)
+						)
+					) {
+						selectedItems.forEach((item) => {
+							document.hrefFm.appendChild(item);
+						});
+
+						submitForm(
+							document.hrefFm,
+							itemData.deleteArticleTranslationsURL
+						);
+					}
+				}
+			},
+			selectEventName: normalizeFriendlyURL(
+				`${portletNamespace}selectTranslations`
+			),
+			title: Liferay.Language.get('delete-translations'),
+			url: itemData.selectArticleTranslationsURL,
+		});
+	},
+
+	expireArticles({itemData}) {
+		this.send(itemData.expireURL);
+	},
+
+	exportTranslation({itemData, portletNamespace}) {
+		Liferay.componentReady(
+			`${portletNamespace}ExportForTranslationComponent`
+		).then((exportTranslationComponent) => {
+			exportTranslationComponent.open([itemData.articleEntryId]);
+		});
+	},
+
+	permissions({itemData}) {
+		openModal({
+			title: Liferay.Language.get('permissions'),
+			url: itemData.permissionsURL,
+		});
+	},
+
+	preview({itemData}) {
+		openModal({
+			title: itemData.title,
+			url: itemData.previewURL,
+		});
+	},
+
+	publishArticleToLive({itemData}) {
+		if (
+			confirm(
+				Liferay.Language.get(
+					'are-you-sure-you-want-to-publish-the-selected-web-content'
+				)
+			)
+		) {
+			this.send(itemData.publishArticleURL);
+		}
+	},
+
+	publishFolderToLive({itemData}) {
+		if (
+			confirm(
+				Liferay.Language.get(
+					'are-you-sure-you-want-to-publish-the-selected-folder'
+				)
+			)
+		) {
+			this.send(itemData.publishFolderURL);
+		}
+	},
+
+	send(url) {
+		submitForm(document.hrefFm, url);
+	},
+
+	subscribeArticle({itemData}) {
+		this.send(itemData.subscribeArticleURL);
+	},
+
+	unsubscribeArticle({itemData}) {
+		this.send(itemData.unsubscribeArticleURL);
+	},
+};
+
+export default function propsTransformer({
+	additionalProps: {trashEnabled},
+	items,
+	portletNamespace,
+	...props
+}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action]({
+							itemData: item.data,
+							portletNamespace,
+							trashEnabled,
+						});
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_article_history.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_article_history.jsp
@@ -18,6 +18,8 @@
 
 <%
 JournalArticle article = journalDisplayContext.getArticle();
+
+Map<String, Object> componentContext = journalDisplayContext.getComponentContext();
 %>
 
 <c:choose>
@@ -107,8 +109,13 @@ JournalArticle article = journalDisplayContext.getArticle();
 
 							<liferay-ui:search-container-column-text>
 								<clay:dropdown-actions
-									defaultEventHandler="<%= JournalWebConstants.JOURNAL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+									additionalProps='<%=
+										HashMapBuilder.<String, Object>put(
+											"trashEnabled", componentContext.get("trashEnabled")
+										).build()
+									%>'
 									dropdownItems="<%= journalDisplayContext.getArticleHistoryActionDropdownItems(articleVersion) %>"
+									propsTransformer="js/ElementsDefaultPropsTransformer"
 								/>
 							</liferay-ui:search-container-column-text>
 						</c:when>
@@ -165,8 +172,13 @@ JournalArticle article = journalDisplayContext.getArticle();
 
 							<liferay-ui:search-container-column-text>
 								<clay:dropdown-actions
-									defaultEventHandler="<%= JournalWebConstants.JOURNAL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+									additionalProps='<%=
+										HashMapBuilder.<String, Object>put(
+											"trashEnabled", componentContext.get("trashEnabled")
+										).build()
+									%>'
 									dropdownItems="<%= journalDisplayContext.getArticleHistoryActionDropdownItems(articleVersion) %>"
+									propsTransformer="js/ElementsDefaultPropsTransformer"
 								/>
 							</liferay-ui:search-container-column-text>
 						</c:when>
@@ -179,11 +191,6 @@ JournalArticle article = journalDisplayContext.getArticle();
 				/>
 			</liferay-ui:search-container>
 		</aui:form>
-
-		<liferay-frontend:component
-			componentId="<%= JournalWebConstants.JOURNAL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
-			module="js/ElementsDefaultEventHandler.es"
-		/>
 
 		<liferay-frontend:component
 			componentId="<%= journalHistoryManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_templates.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_templates.jsp
@@ -149,8 +149,8 @@ if (ddmStructure != null) {
 
 					<liferay-ui:search-container-column-text>
 						<clay:dropdown-actions
-							defaultEventHandler="<%= JournalWebConstants.JOURNAL_DDM_TEMPLATE_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
 							dropdownItems="<%= journalDDMTemplateDisplayContext.getDDMTemplateActionDropdownItems(ddmTemplate) %>"
+							propsTransformer="js/DDMTemplateElementsDefaultPropsTransformer"
 						/>
 					</liferay-ui:search-container-column-text>
 				</c:otherwise>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -17,6 +17,8 @@
 <%@ include file="/init.jsp" %>
 
 <%
+Map<String, Object> componentContext = journalDisplayContext.getComponentContext();
+
 String referringPortletResource = ParamUtil.getString(request, "referringPortletResource");
 %>
 
@@ -140,8 +142,13 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 
 						<liferay-ui:search-container-column-text>
 							<clay:dropdown-actions
-								defaultEventHandler="<%= JournalWebConstants.JOURNAL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+								additionalProps='<%=
+									HashMapBuilder.<String, Object>put(
+										"trashEnabled", componentContext.get("trashEnabled")
+									).build()
+								%>'
 								dropdownItems="<%= journalDisplayContext.getArticleActionDropdownItems(curArticle) %>"
+								propsTransformer="js/ElementsDefaultPropsTransformer"
 							/>
 						</liferay-ui:search-container-column-text>
 					</c:when>
@@ -240,8 +247,13 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 
 						<liferay-ui:search-container-column-text>
 							<clay:dropdown-actions
-								defaultEventHandler="<%= JournalWebConstants.JOURNAL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+								additionalProps='<%=
+									HashMapBuilder.<String, Object>put(
+										"trashEnabled", componentContext.get("trashEnabled")
+									).build()
+								%>'
 								dropdownItems="<%= journalDisplayContext.getArticleActionDropdownItems(curArticle) %>"
+								propsTransformer="js/ElementsDefaultPropsTransformer"
 							/>
 						</liferay-ui:search-container-column-text>
 					</c:otherwise>
@@ -311,8 +323,13 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 
 						<liferay-ui:search-container-column-text>
 							<clay:dropdown-actions
-								defaultEventHandler="<%= JournalWebConstants.JOURNAL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+								additionalProps='<%=
+									HashMapBuilder.<String, Object>put(
+										"trashEnabled", componentContext.get("trashEnabled")
+									).build()
+								%>'
 								dropdownItems="<%= journalDisplayContext.getFolderActionDropdownItems(curFolder) %>"
+								propsTransformer="js/ElementsDefaultPropsTransformer"
 							/>
 						</liferay-ui:search-container-column-text>
 					</c:when>
@@ -390,8 +407,13 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 
 						<liferay-ui:search-container-column-text>
 							<clay:dropdown-actions
-								defaultEventHandler="<%= JournalWebConstants.JOURNAL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+								additionalProps='<%=
+									HashMapBuilder.<String, Object>put(
+										"trashEnabled", componentContext.get("trashEnabled")
+									).build()
+								%>'
 								dropdownItems="<%= journalDisplayContext.getFolderActionDropdownItems(curFolder) %>"
+								propsTransformer="js/ElementsDefaultPropsTransformer"
 							/>
 						</liferay-ui:search-container-column-text>
 					</c:otherwise>
@@ -407,12 +429,6 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 		searchContainer="<%= searchContainer %>"
 	/>
 </liferay-ui:search-container>
-
-<liferay-frontend:component
-	componentId="<%= JournalWebConstants.JOURNAL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
-	context="<%= journalDisplayContext.getComponentContext() %>"
-	module="js/ElementsDefaultEventHandler.es"
-/>
 
 <aui:script use="liferay-journal-navigation">
 	var journalNavigation = new Liferay.Portlet.JournalNavigation({

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_versions.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_versions.jsp
@@ -16,6 +16,10 @@
 
 <%@ include file="/init.jsp" %>
 
+<%
+Map<String, Object> componentContext = journalDisplayContext.getComponentContext();
+%>
+
 <liferay-ui:search-container
 	emptyResultsMessage="no-web-content-was-found"
 	searchContainer="<%= journalDisplayContext.getSearchContainer() %>"
@@ -62,8 +66,13 @@
 
 				<liferay-ui:search-container-column-text>
 					<clay:dropdown-actions
-						defaultEventHandler="<%= JournalWebConstants.JOURNAL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+						additionalProps='<%=
+							HashMapBuilder.<String, Object>put(
+								"trashEnabled", componentContext.get("trashEnabled")
+							).build()
+						%>'
 						dropdownItems="<%= journalDisplayContext.getArticleVersionActionDropdownItems(articleVersion) %>"
+						propsTransformer="js/ElementsDefaultPropsTransformer"
 					/>
 				</liferay-ui:search-container-column-text>
 			</c:when>
@@ -116,8 +125,13 @@
 
 				<liferay-ui:search-container-column-text>
 					<clay:dropdown-actions
-						defaultEventHandler="<%= JournalWebConstants.JOURNAL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
+						additionalProps='<%=
+							HashMapBuilder.<String, Object>put(
+								"trashEnabled", componentContext.get("trashEnabled")
+							).build()
+						%>'
 						dropdownItems="<%= journalDisplayContext.getArticleVersionActionDropdownItems(articleVersion) %>"
+						propsTransformer="js/ElementsDefaultPropsTransformer"
 					/>
 				</liferay-ui:search-container-column-text>
 			</c:when>
@@ -130,9 +144,3 @@
 		searchContainer="<%= searchContainer %>"
 	/>
 </liferay-ui:search-container>
-
-<liferay-frontend:component
-	componentId="<%= JournalWebConstants.JOURNAL_ELEMENTS_DEFAULT_EVENT_HANDLER %>"
-	context="<%= journalDisplayContext.getComponentContext() %>"
-	module="js/ElementsDefaultEventHandler.es"
-/>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
@@ -107,8 +107,8 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 			/>
 
 			<clay:button
+				cssClass="btn-cancel"
 				displayType="secondary"
-				elementClasses="btn-cancel"
 				label="cancel"
 			/>
 		</liferay-frontend:edit-form-footer>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/ChangeMasterLayoutButtonPropsTransformer.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/ChangeMasterLayoutButtonPropsTransformer.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {openSelectionModal} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps,
+	portletNamespace,
+	...props
+}) {
+	return {
+		...props,
+		onClick() {
+			const {url} = additionalProps;
+
+			openSelectionModal({
+				buttonAddLabel: Liferay.Language.get('done'),
+				multiple: true,
+				onSelect(selectedItem) {
+					if (selectedItem) {
+						const editMasterLayoutButton = document.getElementById(
+							`${portletNamespace}editMasterLayoutButton`
+						);
+
+						const masterLayoutName = document.getElementById(
+							`${portletNamespace}masterLayoutName`
+						);
+
+						const masterLayoutPlid = document.getElementById(
+							`${portletNamespace}masterLayoutPlid`
+						);
+
+						const oldMasterLayoutPlid = masterLayoutPlid.value;
+
+						const themeContainer = document.getElementById(
+							`${portletNamespace}themeContainer`
+						);
+
+						masterLayoutName.innerHTML = selectedItem.name;
+
+						masterLayoutPlid.value = selectedItem.plid;
+
+						if (masterLayoutPlid.value === '0') {
+							themeContainer.classList.remove('hide');
+						}
+						else {
+							themeContainer.classList.add('hide');
+						}
+
+						if (
+							masterLayoutPlid.value === oldMasterLayoutPlid &&
+							masterLayoutPlid.value !== '0'
+						) {
+							editMasterLayoutButton.classList.remove('hide');
+						}
+						else {
+							editMasterLayoutButton.classList.add('hide');
+						}
+					}
+				},
+				selectEventName: `${portletNamespace}selectMasterLayout`,
+				title: Liferay.Language.get('select-master'),
+				url,
+			});
+		},
+	};
+}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/ChangeStyleBookButtonPropsTransformer.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/ChangeStyleBookButtonPropsTransformer.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {openSelectionModal} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps,
+	portletNamespace,
+	...props
+}) {
+	return {
+		...props,
+		onClick() {
+			const {url} = additionalProps;
+
+			openSelectionModal({
+				buttonAddLabel: Liferay.Language.get('done'),
+				multiple: true,
+				onSelect(selectedItem) {
+					if (selectedItem) {
+						const styleBookName = document.getElementById(
+							`${portletNamespace}styleBookName`
+						);
+
+						styleBookName.innerHTML = selectedItem.name;
+
+						const styleBookEntryId = document.getElementById(
+							`${portletNamespace}styleBookEntryId`
+						);
+
+						styleBookEntryId.value = selectedItem.stylebookentryid;
+					}
+				},
+				selectEventName: `${portletNamespace}selectStyleBook`,
+				title: Liferay.Language.get('select-style-book'),
+				url,
+			});
+		},
+	};
+}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/EditMasterLayoutButtonPropsTransformer.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/EditMasterLayoutButtonPropsTransformer.js
@@ -12,20 +12,19 @@
  * details.
  */
 
-import {DefaultEventHandler, openModal} from 'frontend-js-web';
-import {Config} from 'metal-state';
+import {navigate} from 'frontend-js-web';
 
-class InfoListProviderDropdownDefaultEventHandler extends DefaultEventHandler {
-	viewInfoListProviderItems(itemData) {
-		openModal({
-			title: itemData.infoListProviderTitle,
-			url: itemData.viewInfoListProviderItemsURL,
-		});
-	}
+export default function propsTransformer({additionalProps, ...props}) {
+	return {
+		...props,
+		onClick() {
+			const {editMasterLayoutURL, editableMasterLayout} = additionalProps;
+
+			if (!editableMasterLayout) {
+				return;
+			}
+
+			navigate(editMasterLayoutURL);
+		},
+	};
 }
-
-InfoListProviderDropdownDefaultEventHandler.STATE = {
-	spritemap: Config.string(),
-};
-
-export default InfoListProviderDropdownDefaultEventHandler;

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
@@ -73,21 +73,51 @@ if ((layoutPageTemplateEntry == null) || !Objects.equals(layoutPageTemplateEntry
 		</p>
 
 		<div class="button-holder">
+
+			<%
+			String editMasterLayoutURL = StringPool.BLANK;
+
+			if (selLayout.getMasterLayoutPlid() > 0) {
+				Layout masterLayout = LayoutLocalServiceUtil.getLayout(selLayout.getMasterLayoutPlid());
+
+				String editLayoutURL = HttpUtil.addParameter(HttpUtil.addParameter(PortalUtil.getLayoutFullURL(selLayout, themeDisplay), "p_l_mode", Constants.EDIT), "p_l_back_url", ParamUtil.getString(request, "redirect"));
+
+				editMasterLayoutURL = HttpUtil.addParameter(HttpUtil.addParameter(PortalUtil.getLayoutFullURL(masterLayout.fetchDraftLayout(), themeDisplay), "p_l_mode", Constants.EDIT), "p_l_back_url", editLayoutURL);
+			}
+			%>
+
 			<clay:button
+				additionalProps='<%=
+					HashMapBuilder.<String, Object>put(
+						"editableMasterLayout", editableMasterLayout
+					).put(
+						"editMasterLayoutURL", editMasterLayoutURL
+					).build()
+				%>'
 				cssClass='<%= (masterLayoutPageTemplateEntry == null) ? "hide" : StringPool.BLANK %>'
-				displayType="secondary"
 				id='<%= liferayPortletResponse.getNamespace() + "editMasterLayoutButton" %>'
 				label="edit-master"
+				propsTransformer="js/layout/EditMasterLayoutButtonPropsTransformer"
 				small="<%= true %>"
 			/>
 
+			<portlet:renderURL var="changeMasterLayoutURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+				<portlet:param name="mvcPath" value="/select_master_layout.jsp" />
+			</portlet:renderURL>
+
 			<clay:button
-				displaytype="secondary"
+				additionalProps='<%=
+					HashMapBuilder.<String, Object>put(
+						"url", changeMasterLayoutURL.toString()
+					).build()
+				%>'
 				id='<%= liferayPortletResponse.getNamespace() + "changeMasterLayoutButton" %>'
 				label="change-master"
+				propsTransformer="js/layout/ChangeMasterLayoutButtonPropsTransformer"
 				small="<%= true %>"
 			/>
-		</div>
+		</div
+	>
 	</clay:sheet-section>
 </c:if>
 
@@ -112,11 +142,22 @@ if (hasStyleBooks && (selLayout.getStyleBookEntryId() > 0)) {
 		<b><liferay-ui:message key="style-book-name" />:</b> <span id="<portlet:namespace />styleBookName"><%= (styleBookEntry != null) ? styleBookEntry.getName() : LanguageUtil.get(request, "inherited") %></span>
 	</p>
 
+	<portlet:renderURL var="changeStyleBookURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+		<portlet:param name="mvcPath" value="/select_style_book.jsp" />
+		<portlet:param name="selPlid" value="<%= String.valueOf(selLayout.getPlid()) %>" />
+		<portlet:param name="editableMasterLayout" value="<%= String.valueOf(editableMasterLayout) %>" />
+	</portlet:renderURL>
+
 	<div class="button-holder">
 		<clay:button
-			displaytype="secondary"
+			additionalProps='<%=
+				HashMapBuilder.<String, Object>put(
+					"url", changeStyleBookURL.toString()
+				).build()
+			%>'
 			id='<%= liferayPortletResponse.getNamespace() + "changeStyleBookButton" %>'
 			label="change-style-book"
+			propsTransformer="js/layout/ChangeStyleBookButtonPropsTransformer"
 			small="<%= true %>"
 		/>
 	</div>
@@ -211,121 +252,3 @@ else {
 		});
 	</aui:script>
 </c:if>
-
-<c:if test="<%= editableMasterLayout %>">
-	<aui:script sandbox="<%= true %>">
-		var changeMasterLayoutButton = document.getElementById(
-			'<portlet:namespace />changeMasterLayoutButton'
-		);
-
-		var editMasterLayoutButton = document.getElementById(
-			'<portlet:namespace />editMasterLayoutButton'
-		);
-
-		var masterLayoutPlid = document.getElementById(
-			'<portlet:namespace />masterLayoutPlid'
-		);
-
-		var oldMasterLayoutPlid = masterLayoutPlid.value;
-
-		var themeContainer = document.getElementById(
-			'<portlet:namespace />themeContainer'
-		);
-
-		var changeMasterLayoutButtonEventListener = changeMasterLayoutButton.addEventListener(
-			'click',
-			function (event) {
-				Liferay.Util.openSelectionModal({
-					buttonAddLabel: '<liferay-ui:message key="done" />',
-					multiple: true,
-					onSelect: function (selectedItem) {
-						if (selectedItem) {
-							var masterLayoutName = document.getElementById(
-								'<portlet:namespace />masterLayoutName'
-							);
-
-							masterLayoutName.innerHTML = selectedItem.name;
-
-							masterLayoutPlid.value = selectedItem.plid;
-
-							if (masterLayoutPlid.value == 0) {
-								themeContainer.classList.remove('hide');
-							}
-							else {
-								themeContainer.classList.add('hide');
-							}
-
-							if (
-								masterLayoutPlid.value == oldMasterLayoutPlid &&
-								masterLayoutPlid.value != 0
-							) {
-								editMasterLayoutButton.classList.remove('hide');
-							}
-							else {
-								editMasterLayoutButton.classList.add('hide');
-							}
-						}
-					},
-					selectEventName: '<portlet:namespace />selectMasterLayout',
-					title: '<liferay-ui:message key="select-master" />',
-					url:
-						'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_master_layout.jsp" /></portlet:renderURL>',
-				});
-			}
-		);
-
-		<%
-		String editMasterLayoutURL = StringPool.BLANK;
-
-		if (selLayout.getMasterLayoutPlid() > 0) {
-			Layout masterLayout = LayoutLocalServiceUtil.getLayout(selLayout.getMasterLayoutPlid());
-
-			String editLayoutURL = HttpUtil.addParameter(HttpUtil.addParameter(PortalUtil.getLayoutFullURL(selLayout, themeDisplay), "p_l_mode", Constants.EDIT), "p_l_back_url", ParamUtil.getString(request, "redirect"));
-
-			editMasterLayoutURL = HttpUtil.addParameter(HttpUtil.addParameter(PortalUtil.getLayoutFullURL(masterLayout.fetchDraftLayout(), themeDisplay), "p_l_mode", Constants.EDIT), "p_l_back_url", editLayoutURL);
-		}
-		%>
-
-		var editMasterLayoutButtonEventListener = editMasterLayoutButton.addEventListener(
-			'click',
-			function (event) {
-				Liferay.Util.navigate('<%= editMasterLayoutURL %>');
-			}
-		);
-	</aui:script>
-</c:if>
-
-<aui:script sandbox="<%= true %>">
-	var changeStyleBookButton = document.getElementById(
-		'<portlet:namespace />changeStyleBookButton'
-	);
-
-	var changeStyleBookButtonEventListener = changeStyleBookButton.addEventListener(
-		'click',
-		function (event) {
-			Liferay.Util.openSelectionModal({
-				buttonAddLabel: '<liferay-ui:message key="done" />',
-				multiple: true,
-				onSelect: function (selectedItem) {
-					if (selectedItem) {
-						var styleBookName = document.getElementById(
-							'<portlet:namespace />styleBookName'
-						);
-
-						styleBookName.innerHTML = selectedItem.name;
-
-						var styleBookEntryId = document.getElementById(
-							'<portlet:namespace />styleBookEntryId'
-						);
-
-						styleBookEntryId.value = selectedItem.stylebookentryid;
-					}
-				},
-				selectEventName: '<portlet:namespace />selectStyleBook',
-				title: '<liferay-ui:message key="select-style-book" />',
-				url:
-					'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_style_book.jsp" /><portlet:param name="selPlid" value="<%= String.valueOf(selLayout.getPlid()) %>" /><portlet:param name="editableMasterLayout" value="<%= String.valueOf(editableMasterLayout) %>" /></portlet:renderURL>',
-			});
-		}
-	);
-</aui:script>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration_templates.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration_templates.jsp
@@ -78,8 +78,8 @@ PortletConfigurationTemplatesManagementToolbarDisplayContext portletConfiguratio
 
 								<liferay-ui:search-container-column-text>
 									<clay:dropdown-actions
-										defaultEventHandler="<%= PortletConfigurationWebKeys.ARCHIVED_SETUPS_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 										dropdownItems="<%= portletConfigurationTemplatesDisplayContext.getActionDropdownItems(archivedSettings) %>"
+										propsTransformer="js/ArchivedSetuptsDropdownDefaultPropsTransformer"
 									/>
 								</liferay-ui:search-container-column-text>
 							</c:when>
@@ -112,8 +112,8 @@ PortletConfigurationTemplatesManagementToolbarDisplayContext portletConfiguratio
 
 								<liferay-ui:search-container-column-text>
 									<clay:dropdown-actions
-										defaultEventHandler="<%= PortletConfigurationWebKeys.ARCHIVED_SETUPS_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 										dropdownItems="<%= portletConfigurationTemplatesDisplayContext.getActionDropdownItems(archivedSettings) %>"
+										propsTransformer="js/ArchivedSetuptsDropdownDefaultPropsTransformer"
 									/>
 								</liferay-ui:search-container-column-text>
 							</c:when>
@@ -129,19 +129,6 @@ PortletConfigurationTemplatesManagementToolbarDisplayContext portletConfiguratio
 		</div>
 	</aui:form>
 </div>
-
-<aui:script require='<%= portletConfigurationTemplatesDisplayContext.getModuleName() + "/js/ArchivedSetuptsDropdownDefaultEventHandler.es as ArchivedSetuptsDropdownDefaultEventHandler" %>'>
-	Liferay.component(
-		'<%= PortletConfigurationWebKeys.ARCHIVED_SETUPS_DROPDOWN_DEFAULT_EVENT_HANDLER %>',
-		new ArchivedSetuptsDropdownDefaultEventHandler.default({
-			namespace: '<portlet:namespace />',
-		}),
-		{
-			destroyOnNavigate: true,
-			portletId: '<%= HtmlUtil.escapeJS(portletDisplay.getId()) %>',
-		}
-	);
-</aui:script>
 
 <aui:script require='<%= portletConfigurationTemplatesDisplayContext.getModuleName() + "/js/ManagementToolbarDefaultEventHandler.es as ManagementToolbarDefaultEventHandler" %>'>
 	Liferay.component(

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/init.jsp
@@ -65,7 +65,6 @@ page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
 page import="com.liferay.portal.util.ResourcePermissionUtil" %><%@
 page import="com.liferay.portlet.configuration.kernel.util.PortletConfigurationUtil" %><%@
-page import="com.liferay.portlet.configuration.web.internal.constants.PortletConfigurationWebKeys" %><%@
 page import="com.liferay.portlet.configuration.web.internal.display.context.PortletConfigurationPermissionsDisplayContext" %><%@
 page import="com.liferay.portlet.configuration.web.internal.display.context.PortletConfigurationTemplatesDisplayContext" %><%@
 page import="com.liferay.portlet.configuration.web.internal.display.context.PortletConfigurationTemplatesManagementToolbarDisplayContext" %><%@

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/ArchivedSetuptsDropdownDefaultPropsTransformer.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/ArchivedSetuptsDropdownDefaultPropsTransformer.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const ACTIONS = {
+	deleteArchivedSetups(itemData) {
+		if (
+			confirm(
+				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
+			)
+		) {
+			this.send(itemData.deleteArchivedSetupsURL);
+		}
+	},
+
+	restoreArchivedSetup(itemData) {
+		this.send(itemData.restoreArchivedSetupURL);
+	},
+
+	send(url) {
+		submitForm(document.hrefFm, url);
+	},
+};
+
+export default function propsTransformer({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -101,8 +101,8 @@ request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 							<ul class="autofit-padded-no-gutters autofit-row">
 								<li class="autofit-col">
 									<clay:dropdown-actions
-										defaultEventHandler="<%= SiteAdminWebKeys.SITE_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 										dropdownItems="<%= siteAdminDisplayContext.getActionDropdownItems(group) %>"
+										propsTransformer="js/SiteDropdownDefaultPropsTransformer"
 									/>
 								</li>
 							</ul>
@@ -247,8 +247,3 @@ request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 		</div>
 	</c:otherwise>
 </c:choose>
-
-<liferay-frontend:component
-	componentId="<%= SiteAdminWebKeys.SITE_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
-	module="js/SiteDropdownDefaultEventHandler.es"
-/>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/SiteDropdownDefaultPropsTransformer.js
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/SiteDropdownDefaultPropsTransformer.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const ACTIONS = {
+	activateSite(itemData) {
+		this.send(itemData.activateSiteURL);
+	},
+
+	deactivateSite(itemData) {
+		if (
+			confirm(
+				Liferay.Language.get('are-you-sure-you-want-to-deactivate-this')
+			)
+		) {
+			this.send(itemData.deactivateSiteURL);
+		}
+	},
+
+	deleteSite(itemData) {
+		if (
+			confirm(
+				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
+			)
+		) {
+			this.send(itemData.deleteSiteURL);
+		}
+	},
+
+	leaveSite(itemData) {
+		this.send(itemData.leaveSiteURL);
+	},
+
+	send(url) {
+		submitForm(document.hrefFm, url);
+	},
+};
+
+export default function propsTransformer({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -84,8 +84,8 @@
 
 				<liferay-ui:search-container-column-text>
 					<clay:dropdown-actions
-						defaultEventHandler="<%= SiteAdminWebKeys.SITE_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 						dropdownItems="<%= siteAdminDisplayContext.getActionDropdownItems(curGroup) %>"
+						propsTransformer="js/SiteDropdownDefaultPropsTransformer"
 					/>
 				</liferay-ui:search-container-column-text>
 			</c:when>
@@ -216,9 +216,8 @@
 
 				<liferay-ui:search-container-column-text>
 					<clay:dropdown-actions
-						defaultEventHandler="<%= SiteAdminWebKeys.SITE_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 						dropdownItems="<%= siteAdminDisplayContext.getActionDropdownItems(curGroup) %>"
-						itemsIconAlignment="right"
+						propsTransformer="js/SiteDropdownDefaultPropsTransformer"
 					/>
 				</liferay-ui:search-container-column-text>
 			</c:otherwise>
@@ -230,8 +229,3 @@
 		markupView="lexicon"
 	/>
 </liferay-ui:search-container>
-
-<liferay-frontend:component
-	componentId="<%= SiteAdminWebKeys.SITE_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
-	module="js/SiteDropdownDefaultEventHandler.es"
-/>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationDropdownDefaultPropsTransformer.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationDropdownDefaultPropsTransformer.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const ACTIONS = {
+	deleteGroupOrganizations(itemData) {
+		if (
+			confirm(
+				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
+			)
+		) {
+			submitForm(document.hrefFm, itemData.deleteGroupOrganizationsURL);
+		}
+	},
+};
+
+export default function propsTransformer({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserCardPropsTransformer.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserCardPropsTransformer.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ACTIONS} from './actions';
+
+export default function propsTransformer({
+	actions,
+	portletNamespace,
+	...props
+}) {
+	return {
+		...props,
+		actions: actions.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data, portletNamespace);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserDropdownDefaultPropsTransformer.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserDropdownDefaultPropsTransformer.js
@@ -12,18 +12,24 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
+import {ACTIONS} from './actions';
 
-class UserDropdownDefaultEventHandler extends DefaultEventHandler {
-	deleteTeamUsers(itemData) {
-		if (
-			confirm(
-				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
-			)
-		) {
-			submitForm(document.hrefFm, itemData.deleteTeamUsersURL);
-		}
-	}
+export default function propsTransformer({items, portletNamespace, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data, portletNamespace);
+					}
+				},
+			};
+		}),
+	};
 }
-
-export default UserDropdownDefaultEventHandler;

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/actions.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/actions.js
@@ -12,27 +12,17 @@
  * details.
  */
 
-import {DefaultEventHandler, openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-web';
 
-class UserDropdownDefaultEventHandler extends DefaultEventHandler {
-	deleteGroupUsers(itemData) {
-		if (
-			confirm(
-				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
-			)
-		) {
-			submitForm(document.hrefFm, itemData.deleteGroupUsersURL);
-		}
-	}
-
-	assignRoles(itemData) {
+export const ACTIONS = {
+	assignRoles(itemData, portletNamespace) {
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
 			multiple: true,
 			onSelect: (selectedItem) => {
 				if (selectedItem) {
-					const editUserGroupRoleFm = this.one(
-						'#editUserGroupRoleFm'
+					const editUserGroupRoleFm = document.getElementById(
+						`${portletNamespace}editUserGroupRoleFm`
 					);
 
 					selectedItem.forEach((item) => {
@@ -45,11 +35,19 @@ class UserDropdownDefaultEventHandler extends DefaultEventHandler {
 					);
 				}
 			},
-			selectEventName: this.ns('selectUsersRoles'),
+			selectEventName: `${portletNamespace}selectUsersRoles`,
 			title: Liferay.Language.get('assign-roles'),
 			url: itemData.assignRolesURL,
 		});
-	}
-}
+	},
 
-export default UserDropdownDefaultEventHandler;
+	deleteGroupUsers(itemData) {
+		if (
+			confirm(
+				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
+			)
+		) {
+			submitForm(document.hrefFm, itemData.deleteGroupUsersURL);
+		}
+	},
+};

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organization_columns.jspf
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organization_columns.jspf
@@ -56,8 +56,8 @@
 
 			<liferay-ui:search-container-column-text>
 				<clay:dropdown-actions
-					defaultEventHandler="<%= SiteMembershipWebKeys.ORGANIZATION_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 					dropdownItems="<%= organizationActionDropdownItemsProvider.getActionDropdownItems() %>"
+					propsTransformer="js/OrganizationDropdownDefaultPropsTransformer"
 				/>
 			</liferay-ui:search-container-column-text>
 		</c:if>
@@ -109,8 +109,8 @@
 
 			<liferay-ui:search-container-column-text>
 				<clay:dropdown-actions
-					defaultEventHandler="<%= SiteMembershipWebKeys.ORGANIZATION_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 					dropdownItems="<%= organizationActionDropdownItemsProvider.getActionDropdownItems() %>"
+					propsTransformer="js/OrganizationDropdownDefaultPropsTransformer"
 				/>
 			</liferay-ui:search-container-column-text>
 		</c:if>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organizations.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organizations.jsp
@@ -99,8 +99,3 @@ OrganizationsManagementToolbarDisplayContext organizationsManagementToolbarDispl
 	componentId="<%= organizationsManagementToolbarDisplayContext.getDefaultEventHandler() %>"
 	module="js/OrganizationsManagementToolbarDefaultEventHandler.es"
 />
-
-<liferay-frontend:component
-	componentId="<%= SiteMembershipWebKeys.ORGANIZATION_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
-	module="js/OrganizationDropdownDefaultEventHandler.es"
-/>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_columns.jspf
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_columns.jspf
@@ -30,6 +30,7 @@ names.addAll(ListUtil.toList(teams, Team.NAME_ACCESSOR));
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 		<liferay-ui:search-container-column-text>
 			<clay:user-card
+				propsTransformer="js/UserCardPropsTransformer"
 				userCard="<%= new UsersUserCard(user2, !selectUsers, renderRequest, renderResponse, searchContainer.getRowChecker()) %>"
 				userColorClass='<%= "sticker-user-icon " + LexiconUtil.getUserColorCssClass(user2) %>'
 			/>
@@ -66,8 +67,8 @@ names.addAll(ListUtil.toList(teams, Team.NAME_ACCESSOR));
 
 			<liferay-ui:search-container-column-text>
 				<clay:dropdown-actions
-					defaultEventHandler="<%= SiteMembershipWebKeys.USER_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 					dropdownItems="<%= userActionDropdownItemsProvider.getActionDropdownItems() %>"
+					propsTransformer="js/UserDropdownDefaultPropsTransformer"
 				/>
 			</liferay-ui:search-container-column-text>
 		</c:if>
@@ -99,8 +100,8 @@ names.addAll(ListUtil.toList(teams, Team.NAME_ACCESSOR));
 
 			<liferay-ui:search-container-column-text>
 				<clay:dropdown-actions
-					defaultEventHandler="<%= SiteMembershipWebKeys.USER_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 					dropdownItems="<%= userActionDropdownItemsProvider.getActionDropdownItems() %>"
+					propsTransformer="js/UserDropdownDefaultPropsTransformer"
 				/>
 			</liferay-ui:search-container-column-text>
 		</c:if>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
@@ -117,8 +117,3 @@ Role role = usersDisplayContext.getRole();
 	componentId="<%= usersManagementToolbarDisplayContext.getDefaultEventHandler() %>"
 	module="js/UsersManagementToolbarDefaultEventHandler.es"
 />
-
-<liferay-frontend:component
-	componentId="<%= SiteMembershipWebKeys.USER_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
-	module="js/UserDropdownDefaultEventHandler.es"
-/>

--- a/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/init.jsp
@@ -39,7 +39,6 @@ page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.liveusers.LiveUsers" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
-page import="com.liferay.site.my.sites.web.internal.constants.MySitesWebKeys" %><%@
 page import="com.liferay.site.my.sites.web.internal.display.context.SiteMySitesDisplayContext" %><%@
 page import="com.liferay.site.my.sites.web.internal.display.context.SiteMySitesManagementToolbarDisplayContext" %><%@
 page import="com.liferay.site.my.sites.web.internal.servlet.taglib.clay.SiteVerticalCard" %>

--- a/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/js/SiteDropdownDefaultPropsTransformer.js
+++ b/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/js/SiteDropdownDefaultPropsTransformer.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const ACTIONS = {
+	joinSite(itemData) {
+		this.send(itemData.joinSiteURL);
+	},
+
+	leaveSite(itemData) {
+		this.send(itemData.leaveSiteURL);
+	},
+
+	send(url) {
+		submitForm(document.hrefFm, url);
+	},
+};
+
+export default function propsTransformer({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/view.jsp
@@ -112,8 +112,8 @@
 					<c:if test="<%= ListUtil.isNotEmpty(dropdownItems) %>">
 						<liferay-ui:search-container-column-text>
 							<clay:dropdown-actions
-								defaultEventHandler="<%= MySitesWebKeys.SITES_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 								dropdownItems="<%= dropdownItems %>"
+								propsTransformer="js/SiteDropdownDefaultPropsTransformer"
 							/>
 						</liferay-ui:search-container-column-text>
 					</c:if>
@@ -173,8 +173,8 @@
 					<c:if test="<%= ListUtil.isNotEmpty(dropdownItems) %>">
 						<liferay-ui:search-container-column-text>
 							<clay:dropdown-actions
-								defaultEventHandler="<%= MySitesWebKeys.SITES_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 								dropdownItems="<%= dropdownItems %>"
+								propsTransformer="js/SiteDropdownDefaultPropsTransformer"
 							/>
 						</liferay-ui:search-container-column-text>
 					</c:if>
@@ -188,8 +188,3 @@
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<liferay-frontend:component
-	componentId="<%= MySitesWebKeys.SITES_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
-	module="js/SiteDropdownDefaultEventHandler.es"
-/>

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/edit_team_assignments_users.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/edit_team_assignments_users.jsp
@@ -82,8 +82,8 @@ EditSiteTeamAssignmentsUsersManagementToolbarDisplayContext editSiteTeamAssignme
 						%>
 
 						<clay:dropdown-actions
-							defaultEventHandler="<%= SiteTeamsWebKeys.USER_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 							dropdownItems="<%= userActionDropdownItemsProvider.getActionDropdownItems() %>"
+							propsTransformer="js/UserDropdownDefaultPropsTransformer"
 						/>
 					</liferay-ui:search-container-column-text>
 				</c:when>
@@ -107,8 +107,8 @@ EditSiteTeamAssignmentsUsersManagementToolbarDisplayContext editSiteTeamAssignme
 						%>
 
 						<clay:dropdown-actions
-							defaultEventHandler="<%= SiteTeamsWebKeys.USER_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
 							dropdownItems="<%= userActionDropdownItemsProvider.getActionDropdownItems() %>"
+							propsTransformer="js/UserDropdownDefaultPropsTransformer"
 						/>
 					</liferay-ui:search-container-column-text>
 				</c:otherwise>
@@ -133,9 +133,4 @@ EditSiteTeamAssignmentsUsersManagementToolbarDisplayContext editSiteTeamAssignme
 <liferay-frontend:component
 	componentId="<%= editSiteTeamAssignmentsUsersManagementToolbarDisplayContext.getDefaultEventHandler() %>"
 	module="js/EditTeamAssignmentsUsersManagementToolbarDefaultEventHandler.es"
-/>
-
-<liferay-frontend:component
-	componentId="<%= SiteTeamsWebKeys.USER_DROPDOWN_DEFAULT_EVENT_HANDLER %>"
-	module="js/UserDropdownDefaultEventHandler.es"
 />

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/init.jsp
@@ -51,7 +51,6 @@ page import="com.liferay.portal.kernel.util.UnicodeProperties" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowConstants" %><%@
-page import="com.liferay.site.teams.web.internal.constants.SiteTeamsWebKeys" %><%@
 page import="com.liferay.site.teams.web.internal.display.context.EditSiteTeamAssignmentsDisplayContext" %><%@
 page import="com.liferay.site.teams.web.internal.display.context.EditSiteTeamAssignmentsUserGroupsDisplayContext" %><%@
 page import="com.liferay.site.teams.web.internal.display.context.EditSiteTeamAssignmentsUserGroupsManagementToolbarDisplayContext" %><%@

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/UserDropdownDefaultPropsTransformer.js
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/UserDropdownDefaultPropsTransformer.js
@@ -12,40 +12,34 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
-
-class SiteDropdownDefaultEventHandler extends DefaultEventHandler {
-	activateSite(itemData) {
-		this._send(itemData.activateSiteURL);
-	}
-
-	deactivateSite(itemData) {
-		if (
-			confirm(
-				Liferay.Language.get('are-you-sure-you-want-to-deactivate-this')
-			)
-		) {
-			this._send(itemData.deactivateSiteURL);
-		}
-	}
-
-	deleteSite(itemData) {
+const ACTIONS = {
+	deleteTeamUsers(itemData) {
 		if (
 			confirm(
 				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
 			)
 		) {
-			this._send(itemData.deleteSiteURL);
+			submitForm(document.hrefFm, itemData.deleteTeamUsersURL);
 		}
-	}
+	},
+};
 
-	leaveSite(itemData) {
-		this._send(itemData.leaveSiteURL);
-	}
+export default function propsTransformer({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
 
-	_send(url) {
-		submitForm(document.hrefFm, url);
-	}
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
 }
-
-export default SiteDropdownDefaultEventHandler;

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/ElementsDefaultPropsTransformer.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/ElementsDefaultPropsTransformer.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const ACTIONS = {
+	delete(itemData) {
+		const message = Liferay.Language.get(
+			'are-you-sure-you-want-to-delete-this'
+		);
+
+		if (confirm(message)) {
+			submitForm(document.hrefFm, itemData.deleteURL);
+		}
+	},
+};
+
+export default function propsTransformer({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
@@ -74,8 +74,8 @@ ViewDisplayContext viewDisplayContext = (ViewDisplayContext)request.getAttribute
 
 				<liferay-ui:search-container-column-text>
 					<clay:dropdown-actions
-						defaultEventHandler="<%= viewDisplayContext.getElementsDefaultEventHandler() %>"
 						dropdownItems="<%= viewDisplayContext.getActionDropdownItems(translationEntry) %>"
+						propsTransformer="js/translate/ElementsDefaultPropsTransformer"
 					/>
 				</liferay-ui:search-container-column-text>
 			</liferay-ui:search-container-row>
@@ -91,9 +91,4 @@ ViewDisplayContext viewDisplayContext = (ViewDisplayContext)request.getAttribute
 	componentId="<%= viewDisplayContext.getManagementToolbarDefaultEventHandler() %>"
 	context="<%= viewDisplayContext.getComponentContext() %>"
 	module="js/translate/TranslationManagementToolbarDefaultEventHandler.es"
-/>
-
-<liferay-frontend:component
-	componentId="<%= viewDisplayContext.getElementsDefaultEventHandler() %>"
-	module="js/translate/ElementsDefaultEventHandler.es"
 />

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -53,14 +53,24 @@ List<TrashEntry> trashEntries = (List<TrashEntry>)request.getAttribute(TrashWebK
 									<c:choose>
 										<c:when test="<%= trashEntry.getRootEntry() == null %>">
 											<clay:dropdown-actions
-												defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
+												additionalProps='<%=
+													HashMapBuilder.<String, Object>put(
+														"portletNamespace", liferayPortletResponse.getNamespace()
+													).build()
+												%>'
 												dropdownItems="<%= trashDisplayContext.getTrashEntryActionDropdownItems(trashEntry) %>"
+												propsTransformer="js/EntriesPropsTransformer"
 											/>
 										</c:when>
 										<c:otherwise>
 											<clay:dropdown-actions
-												defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
+												additionalProps='<%=
+													HashMapBuilder.<String, Object>put(
+														"portletNamespace", liferayPortletResponse.getNamespace()
+													).build()
+												%>'
 												dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(trashRenderer.getClassName(), trashRenderer.getClassPK()) %>"
+												propsTransformer="js/EntriesPropsTransformer"
 											/>
 										</c:otherwise>
 									</c:choose>

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/js/EntriesPropsTransformer.js
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/js/EntriesPropsTransformer.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {normalizeFriendlyURL, openSelectionModal} from 'frontend-js-web';
+
+const ACTIONS = {
+	deleteEntry(itemData) {
+		if (
+			confirm(
+				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
+			)
+		) {
+			submitForm(document.hrefFm, itemData.deleteEntryURL);
+		}
+	},
+
+	moveEntry(itemData, portletNamespace) {
+		openSelectionModal({
+			onSelect: (event) => {
+				const selectContainerForm = document.getElementById(
+					`${portletNamespace}selectContainerForm`
+				);
+
+				if (selectContainerForm) {
+					const className = selectContainerForm.querySelector(
+						`#${portletNamespace}className`
+					);
+
+					if (className) {
+						className.setAttribute('value', event.classname);
+					}
+
+					const classPK = selectContainerForm.querySelector(
+						`#${portletNamespace}classPK`
+					);
+
+					if (classPK) {
+						classPK.setAttribute('value', event.classpk);
+					}
+
+					const containerModelId = selectContainerForm.querySelector(
+						`#${portletNamespace}containerModelId`
+					);
+
+					if (containerModelId) {
+						containerModelId.setAttribute(
+							'value',
+							event.containermodelid
+						);
+					}
+
+					const redirect = selectContainerForm.querySelector(
+						`#${portletNamespace}redirect`
+					);
+
+					if (redirect) {
+						redirect.setAttribute('value', event.redirect);
+					}
+
+					submitForm(selectContainerForm);
+				}
+			},
+			selectEventName: normalizeFriendlyURL(
+				portletNamespace,
+				'selectContainer'
+			),
+			title: Liferay.Language.get('warning'),
+			url: itemData.moveEntryURL,
+		});
+	},
+
+	restoreEntry(itemData) {
+		submitForm(document.hrefFm, itemData.restoreEntryURL);
+	},
+};
+
+export default function propsTransformer({items, portletNamespace, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data, portletNamespace);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
@@ -172,14 +172,14 @@ TrashManagementToolbarDisplayContext trashManagementToolbarDisplayContext = new 
 									<c:choose>
 										<c:when test="<%= trashEntry.getRootEntry() == null %>">
 											<clay:dropdown-actions
-												defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
 												dropdownItems="<%= trashDisplayContext.getTrashEntryActionDropdownItems(trashEntry) %>"
+												propsTransformer="js/EntriesPropsTransformer"
 											/>
 										</c:when>
 										<c:otherwise>
 											<clay:dropdown-actions
-												defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
 												dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(trashRenderer.getClassName(), trashRenderer.getClassPK()) %>"
+												propsTransformer="js/EntriesPropsTransformer"
 											/>
 										</c:otherwise>
 									</c:choose>
@@ -259,14 +259,14 @@ TrashManagementToolbarDisplayContext trashManagementToolbarDisplayContext = new 
 									<c:choose>
 										<c:when test="<%= trashEntry.getRootEntry() == null %>">
 											<clay:dropdown-actions
-												defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
 												dropdownItems="<%= trashDisplayContext.getTrashEntryActionDropdownItems(trashEntry) %>"
+												propsTransformer="js/EntriesPropsTransformer"
 											/>
 										</c:when>
 										<c:otherwise>
 											<clay:dropdown-actions
-												defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
 												dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(trashRenderer.getClassName(), trashRenderer.getClassPK()) %>"
+												propsTransformer="js/EntriesPropsTransformer"
 											/>
 										</c:otherwise>
 									</c:choose>
@@ -287,6 +287,6 @@ TrashManagementToolbarDisplayContext trashManagementToolbarDisplayContext = new 
 </div>
 
 <liferay-frontend:component
-	componentId="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
-	module="js/EntriesDefaultEventHandler.es"
+	componentId="<%= trashManagementToolbarDisplayContext.getDefaultEventHandler() %>"
+	module="js/ManagementToolbarDefaultEventHandler.es"
 />

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -91,8 +91,8 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 
 									<liferay-ui:search-container-column-text>
 										<clay:dropdown-actions
-											defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
 											dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(modelClassName, curTrashedModel.getTrashEntryClassPK()) %>"
+											propsTransformer="js/EntriesPropsTransformer"
 										/>
 									</liferay-ui:search-container-column-text>
 								</c:when>
@@ -131,8 +131,8 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 
 									<liferay-ui:search-container-column-text>
 										<clay:dropdown-actions
-											defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
 											dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(modelClassName, curTrashedModel.getTrashEntryClassPK()) %>"
+											propsTransformer="js/EntriesPropsTransformer"
 										/>
 									</liferay-ui:search-container-column-text>
 								</c:when>
@@ -171,8 +171,3 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 		</clay:container-fluid>
 	</c:otherwise>
 </c:choose>
-
-<liferay-frontend:component
-	componentId="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
-	module="js/EntriesDefaultEventHandler.es"
-/>

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content_info_panel.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content_info_panel.jsp
@@ -44,8 +44,13 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 						%>
 
 						<clay:dropdown-actions
-							defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
+							additionalProps='<%=
+								HashMapBuilder.<String, Object>put(
+									"portletNamespace", liferayPortletResponse.getNamespace()
+								).build()
+							%>'
 							dropdownItems="<%= trashContainerActionDropdownItemsProvider.getActionDropdownItems() %>"
+							propsTransformer="js/EntriesPropsTransformer"
 						/>
 					</li>
 				</ul>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/SynonymSetsDropdownDefaultPropsTransformer.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/SynonymSetsDropdownDefaultPropsTransformer.js
@@ -9,22 +9,38 @@
  * distribution rights of the Software.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
-
-class SynonymSetsDropdownDefaultEventHandler extends DefaultEventHandler {
+const ACTIONS = {
 	delete(itemData) {
 		const message = Liferay.Language.get(
 			'are-you-sure-you-want-to-delete-this'
 		);
 
 		if (confirm(message)) {
-			this._send(itemData.deleteURL);
+			this.send(itemData.deleteURL);
 		}
-	}
+	},
 
-	_send(url) {
+	send(url) {
 		submitForm(document.hrefFm, url);
-	}
-}
+	},
+};
 
-export default SynonymSetsDropdownDefaultEventHandler;
+export default function ({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				onClick(event) {
+					const action = item.data?.action;
+
+					if (action) {
+						event.preventDefault();
+
+						ACTIONS[action](item.data);
+					}
+				},
+			};
+		}),
+	};
+}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/view.jsp
@@ -73,8 +73,8 @@ SynonymsDisplayContext synonymsDisplayContext = (SynonymsDisplayContext)request.
 
 			<liferay-ui:search-container-column-text>
 				<clay:dropdown-actions
-					defaultEventHandler="SynonymSetsDropdownDefaultEventHandler"
 					dropdownItems="<%= synonymSetDisplayContext.getDropdownItems() %>"
+					propsTransformer="js/SynonymSetsDropdownDefaultPropsTransformer"
 				/>
 			</liferay-ui:search-container-column-text>
 		</liferay-ui:search-container-row>
@@ -89,8 +89,3 @@ SynonymsDisplayContext synonymsDisplayContext = (SynonymsDisplayContext)request.
 <aui:script require='<%= npmResolvedPackageName + "/js/MultipleCheckboxAction.es as MultipleCheckboxAction" %>'>
 	new MultipleCheckboxAction.default('<portlet:namespace />');
 </aui:script>
-
-<liferay-frontend:component
-	componentId="SynonymSetsDropdownDefaultEventHandler"
-	module="js/SynonymSetsDropdownDefaultEventHandler.es"
-/>

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -461,3 +461,23 @@ Remove `@spi.id@` from log4j xml definition file.
 The support of SPI has been removed by LPS-110758.
 
 ---------------------------------------
+### Deprecated attributes have been removed from the frontend-taglib-clay tags
+- **Date:** 2021-Jan-26
+- **JIRA Ticket:** [LPS-125256](https://issues.liferay.com/browse/LPS-125256)
+
+#### What changed?
+
+The deprecated attributes have been removed from the `frontend-taglib-clay`
+taglib.
+
+#### Who is affected?
+
+Anyone using deprecated attributes for `<clay:*>` tags.
+
+#### Why was this change made?
+
+The `frontend-taglib-clay` module is now using components from
+[`Clay v3`](https://github.com/liferay/clay), which doesn't support the
+previous attributes.
+
+---------------------------------------


### PR DESCRIPTION
Deprecated attributes have been removed from the following tags and
there usages:

- `<clay:alert />`
- `<clay:badge />`
- `<clay:button />`
- `<clay:checkbox />`
- `<clay:dropdown-actions />`
- `<clay:dropdown-menu />`
- `<clay:icon />`
- `<clay:label />`
- `<clay:link />`
- `<clay:navigation-bar />`
- `<clay:progressbar />`
- `<clay:radio />`
- `<clay:sticker />`
- `<clay:stripe />`

/cc @liferay-lima, @liferay-echo, @liferay-commerce