### PR TITLE
LPS-126171 - Update LabelTag markup to be the same as @clayui/label

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
@@ -229,7 +229,7 @@ public class LabelTag extends BaseContainerTag {
 
 				IconTag iconTag = new IconTag();
 
-				iconTag.setSymbol("times");
+				iconTag.setSymbol("times-small");
 
 				iconTag.doTag(pageContext);
 


### PR DESCRIPTION
Fixes https://issues.liferay.com/browse/LPS-126171

Updates markup to use the same icon as @clayui/label