### PR TITLE
LPS-124597 [7.4 only] Image resize function not working in ItemSelector

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -13,8 +13,6 @@
  */
 
 (function () {
-	var IE9AndLater = AUI.Env.UA.ie >= 9;
-
 	var STR_FILE_ENTRY_RETURN_TYPE =
 		'com.liferay.item.selector.criteria.FileEntryItemSelectorReturnType';
 
@@ -218,7 +216,7 @@
 
 			return (
 				selection.getType() === CKEDITOR.SELECTION_NONE ||
-				(ranges.length === 1 && (ranges[0].collapsed || IE9AndLater))
+				(ranges.length === 1 && ranges[0].collapsed)
 			);
 		},
 
@@ -250,33 +248,13 @@
 						callback(imageSrc, selectedItem);
 					}
 					else {
-						var imageElement = new CKEDITOR.dom.element.createFromHtml(
-							'<img src="' + imageSrc + '">'
-						);
+						var elementOuterHtml = '<img src="' + imageSrc + '">';
 
-						editor.insertElement(imageElement);
-
-						if (IE9AndLater) {
-							if (!editor.window.$.AlloyEditor) {
-								editor.insertHtml('&nbsp;');
-							}
-
-							var element = new CKEDITOR.dom.element('br');
-
-							editor.insertElement(element);
-							editor.getSelection();
-
-							editor.fire('editorInteraction', {
-								nativeEvent: {},
-								selectionData: {
-									element,
-									region: element.getClientRect(),
-								},
-							});
+						if (instance._isEmptySelection(editor)) {
+							elementOuterHtml += '<br />';
 						}
-						else {
-							editor.execCommand('enter');
-						}
+
+						editor.insertHtml(elementOuterHtml);
 
 						editor.focus();
 					}


### PR DESCRIPTION
This commit fix resizing functionality broken in commit fb3d12c8032e242708661b59b41d035847c08c75. The cause is the use of `insertElement()` that seems to not add the selection outer element on the image.

The [original fix proposed here](https://github.com/liferay-frontend/liferay-portal/pull/720) was careful to preserve the IE-specific behavior, but given that we no longer need to support IE in 7.4 we take the opportunity to simplify the code instead, using `insertHtml()`.