### PR TITLE
LPS-126201 - Panels heading update

### DIFF
--- a/portal-web/docroot/html/taglib/ui/panel/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/panel/lexicon/start.jsp
@@ -35,40 +35,40 @@ if (persistState) {
 
 <div class="panel panel-secondary <%= cssClass %>" id="<%= id %>">
 	<div class="panel-heading" id="<%= id %>Header" role="tab">
-		<div class="h4 panel-title">
-			<c:choose>
-				<c:when test="<%= collapsible %>">
-					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapse-icon-middle <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-parent="#<%= id %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
-						<c:if test="<%= Validator.isNotNull(iconCssClass) %>">
-							<i class="<%= iconCssClass %>"></i>
-						</c:if>
+		<c:choose>
+			<c:when test="<%= collapsible %>">
+				<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon panel-header panel-header-link <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-parent="#<%= id %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
+					<c:if test="<%= Validator.isNotNull(iconCssClass) %>">
+						<i class="<%= iconCssClass %>"></i>
+					</c:if>
 
+					<span class="h5">
 						<liferay-ui:message key="<%= title %>" />
-
-						<c:if test="<%= Validator.isNotNull(helpMessage) %>">
-							<liferay-ui:icon-help message="<%= helpMessage %>" />
-						</c:if>
-
-						<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
-
-						<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
-					</a>
-				</c:when>
-				<c:otherwise>
-					<span>
-						<c:if test="<%= Validator.isNotNull(iconCssClass) %>">
-							<i class="<%= iconCssClass %>"></i>
-						</c:if>
-
-						<liferay-ui:message key="<%= title %>" />
-
-						<c:if test="<%= Validator.isNotNull(helpMessage) %>">
-							<liferay-ui:icon-help message="<%= helpMessage %>" />
-						</c:if>
 					</span>
-				</c:otherwise>
-			</c:choose>
-		</div>
+
+					<c:if test="<%= Validator.isNotNull(helpMessage) %>">
+						<liferay-ui:icon-help message="<%= helpMessage %>" />
+					</c:if>
+
+					<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
+
+					<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
+				</a>
+			</c:when>
+			<c:otherwise>
+				<span>
+					<c:if test="<%= Validator.isNotNull(iconCssClass) %>">
+						<i class="<%= iconCssClass %>"></i>
+					</c:if>
+
+					<liferay-ui:message key="<%= title %>" />
+
+					<c:if test="<%= Validator.isNotNull(helpMessage) %>">
+						<liferay-ui:icon-help message="<%= helpMessage %>" />
+					</c:if>
+				</span>
+			</c:otherwise>
+		</c:choose>
 	</div>
 
 	<div aria-labelledby="<%= id %>Header" class="<%= collapsible ? "collapse panel-collapse" : StringPool.BLANK %> <%= !collapsed ? "show" : StringPool.BLANK %>" <%= accordion ? "data-parent='#" + parentId + "'" : StringPool.BLANK %> id="<%= id %>Content" role="tabpanel">


### PR DESCRIPTION
This PR updates the markup for panel headers:

Issue:
![image](https://user-images.githubusercontent.com/7963804/105491089-0ef9fe80-5cb6-11eb-8bc0-22d740f4ecae.png)

Fixed (based on the original format):
![image](https://user-images.githubusercontent.com/7963804/105491008-ef62d600-5cb5-11eb-8e62-9758b81c1ba5.png)

---

How to test the PR:

- Go to Site Menu > Content & data > Documents and media
- Select a document with metadata (ex: jpg) and upload! 
- Show info bar
- Go scroll down and see the toggle header