### PR TITLE
LPS-126065 Pages with info-panel aren't laid out correctly

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/view.jsp
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/view.jsp
@@ -31,10 +31,7 @@ AMManagementToolbarDisplayContext amManagementToolbarDisplayContext = new AMMana
 	showSearch="<%= false %>"
 />
 
-<clay:container-fluid
-	cssClass="closed sidenav-container sidenav-right"
-	id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
->
+<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/adaptive_media/info_panel" var="sidebarPanelURL" />
 
 	<liferay-frontend:sidebar-panel
@@ -45,168 +42,170 @@ AMManagementToolbarDisplayContext amManagementToolbarDisplayContext = new AMMana
 	</liferay-frontend:sidebar-panel>
 
 	<div class="sidenav-content">
-		<liferay-util:include page="/adaptive_media/success_messages.jsp" servletContext="<%= application %>" />
+		<clay:container-fluid>
+			<liferay-util:include page="/adaptive_media/success_messages.jsp" servletContext="<%= application %>" />
 
-		<c:choose>
-			<c:when test='<%= SessionMessages.contains(request, "configurationEntryUpdated") %>'>
-
-				<%
-				AMImageConfigurationEntry amImageConfigurationEntry = (AMImageConfigurationEntry)SessionMessages.get(request, "configurationEntryUpdated");
-				%>
-
-				<div class="alert alert-success">
-					<liferay-ui:message arguments="<%= HtmlUtil.escape(amImageConfigurationEntry.getName()) %>" key="x-saved-successfully" translateArguments="<%= false %>" />
-				</div>
-			</c:when>
-		</c:choose>
-
-		<portlet:actionURL name="/adaptive_media/delete_image_configuration_entry" var="deleteImageConfigurationEntryURL" />
-
-		<%
-		int optimizeImagesAllConfigurationsBackgroundTasksCount = BackgroundTaskManagerUtil.getBackgroundTasksCount(CompanyConstants.SYSTEM, OptimizeImagesAllConfigurationsBackgroundTaskExecutor.class.getName(), false);
-
-		List<BackgroundTask> optimizeImageSingleBackgroundTasks = BackgroundTaskManagerUtil.getBackgroundTasks(CompanyConstants.SYSTEM, OptimizeImagesSingleConfigurationBackgroundTaskExecutor.class.getName(), BackgroundTaskConstants.STATUS_IN_PROGRESS);
-
-		request.setAttribute("view.jsp-optimizeImageSingleBackgroundTasks", optimizeImageSingleBackgroundTasks);
-
-		List<String> currentBackgroundTaskConfigurationEntryUuids = new ArrayList<>();
-
-		for (BackgroundTask optimizeImageSingleBackgroundTask : optimizeImageSingleBackgroundTasks) {
-			Map<String, Serializable> taskContextMap = optimizeImageSingleBackgroundTask.getTaskContextMap();
-
-			String configurationEntryUuid = (String)taskContextMap.get("configurationEntryUuid");
-
-			currentBackgroundTaskConfigurationEntryUuids.add(configurationEntryUuid);
-		}
-
-		List<AMImageConfigurationEntry> selectedConfigurationEntries = amManagementToolbarDisplayContext.getSelectedConfigurationEntries();
-		%>
-
-		<aui:form action="<%= deleteImageConfigurationEntryURL.toString() %>" method="post" name="fm">
-			<liferay-ui:search-container
-				emptyResultsMessage="there-are-no-image-resolutions"
-				id="imageConfigurationEntries"
-				iteratorURL="<%= renderResponse.createRenderURL() %>"
-				rowChecker="<%= new ImageConfigurationEntriesChecker(liferayPortletResponse) %>"
-				total="<%= selectedConfigurationEntries.size() %>"
-			>
-				<liferay-ui:search-container-results
-					results="<%= ListUtil.subList(selectedConfigurationEntries, searchContainer.getStart(), searchContainer.getEnd()) %>"
-				/>
-
-				<liferay-ui:search-container-row
-					className="com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry"
-					modelVar="amImageConfigurationEntry"
-				>
+			<c:choose>
+				<c:when test='<%= SessionMessages.contains(request, "configurationEntryUpdated") %>'>
 
 					<%
-					row.setPrimaryKey(String.valueOf(amImageConfigurationEntry.getUUID()));
+					AMImageConfigurationEntry amImageConfigurationEntry = (AMImageConfigurationEntry)SessionMessages.get(request, "configurationEntryUpdated");
 					%>
 
-					<liferay-portlet:renderURL varImpl="rowURL">
-						<portlet:param name="mvcRenderCommandName" value="/adaptive_media/edit_image_configuration_entry" />
-						<portlet:param name="redirect" value="<%= currentURL %>" />
-						<portlet:param name="entryUuid" value="<%= String.valueOf(amImageConfigurationEntry.getUUID()) %>" />
-					</liferay-portlet:renderURL>
+					<div class="alert alert-success">
+						<liferay-ui:message arguments="<%= HtmlUtil.escape(amImageConfigurationEntry.getName()) %>" key="x-saved-successfully" translateArguments="<%= false %>" />
+					</div>
+				</c:when>
+			</c:choose>
 
-					<liferay-ui:search-container-column-text
-						cssClass="table-cell-expand table-cell-minw-200 table-title"
-						href="<%= rowURL %>"
-						name="name"
-						orderable="<%= false %>"
-						value="<%= HtmlUtil.escape(amImageConfigurationEntry.getName()) %>"
+			<portlet:actionURL name="/adaptive_media/delete_image_configuration_entry" var="deleteImageConfigurationEntryURL" />
+
+			<%
+			int optimizeImagesAllConfigurationsBackgroundTasksCount = BackgroundTaskManagerUtil.getBackgroundTasksCount(CompanyConstants.SYSTEM, OptimizeImagesAllConfigurationsBackgroundTaskExecutor.class.getName(), false);
+
+			List<BackgroundTask> optimizeImageSingleBackgroundTasks = BackgroundTaskManagerUtil.getBackgroundTasks(CompanyConstants.SYSTEM, OptimizeImagesSingleConfigurationBackgroundTaskExecutor.class.getName(), BackgroundTaskConstants.STATUS_IN_PROGRESS);
+
+			request.setAttribute("view.jsp-optimizeImageSingleBackgroundTasks", optimizeImageSingleBackgroundTasks);
+
+			List<String> currentBackgroundTaskConfigurationEntryUuids = new ArrayList<>();
+
+			for (BackgroundTask optimizeImageSingleBackgroundTask : optimizeImageSingleBackgroundTasks) {
+				Map<String, Serializable> taskContextMap = optimizeImageSingleBackgroundTask.getTaskContextMap();
+
+				String configurationEntryUuid = (String)taskContextMap.get("configurationEntryUuid");
+
+				currentBackgroundTaskConfigurationEntryUuids.add(configurationEntryUuid);
+			}
+
+			List<AMImageConfigurationEntry> selectedConfigurationEntries = amManagementToolbarDisplayContext.getSelectedConfigurationEntries();
+			%>
+
+			<aui:form action="<%= deleteImageConfigurationEntryURL.toString() %>" method="post" name="fm">
+				<liferay-ui:search-container
+					emptyResultsMessage="there-are-no-image-resolutions"
+					id="imageConfigurationEntries"
+					iteratorURL="<%= renderResponse.createRenderURL() %>"
+					rowChecker="<%= new ImageConfigurationEntriesChecker(liferayPortletResponse) %>"
+					total="<%= selectedConfigurationEntries.size() %>"
+				>
+					<liferay-ui:search-container-results
+						results="<%= ListUtil.subList(selectedConfigurationEntries, searchContainer.getStart(), searchContainer.getEnd()) %>"
 					/>
 
-					<liferay-ui:search-container-column-text
-						cssClass="table-cell-expand-smallest table-cell-ws-nowrap"
-						name="state"
-						orderable="<%= false %>"
-						value='<%= LanguageUtil.get(request, amImageConfigurationEntry.isEnabled() ? "enabled" : "disabled") %>'
-					/>
-
-					<liferay-ui:search-container-column-text
-						cssClass="table-cell-expand table-cell-minw-200"
-						name="adapted-images"
+					<liferay-ui:search-container-row
+						className="com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry"
+						modelVar="amImageConfigurationEntry"
 					>
 
 						<%
-						String rowId = row.getRowId();
-						String uuid = String.valueOf(amImageConfigurationEntry.getUUID());
-
-						int adaptedImages = AMImageEntryLocalServiceUtil.getAMImageEntriesCount(themeDisplay.getCompanyId(), amImageConfigurationEntry.getUUID());
-
-						int totalImages = AMImageEntryLocalServiceUtil.getExpectedAMImageEntriesCount(themeDisplay.getCompanyId());
+						row.setPrimaryKey(String.valueOf(amImageConfigurationEntry.getUUID()));
 						%>
 
-						<div id="<portlet:namespace />AdaptRemainingContainer_<%= rowId %>">
-							<portlet:resourceURL id="/adaptive_media/adapted_images_percentage" var="adaptedImagesPercentageURL">
-								<portlet:param name="entryUuid" value="<%= uuid %>" />
-							</portlet:resourceURL>
+						<liferay-portlet:renderURL varImpl="rowURL">
+							<portlet:param name="mvcRenderCommandName" value="/adaptive_media/edit_image_configuration_entry" />
+							<portlet:param name="redirect" value="<%= currentURL %>" />
+							<portlet:param name="entryUuid" value="<%= String.valueOf(amImageConfigurationEntry.getUUID()) %>" />
+						</liferay-portlet:renderURL>
 
-							<react:component
-								module="adaptive_media/js/AdaptiveMediaProgress"
-								props='<%=
-									HashMapBuilder.<String, Object>put(
-										"adaptedImages", Math.min(adaptedImages, totalImages)
-									).put(
-										"adaptiveMediaProgressComponentId", liferayPortletResponse.getNamespace() + "AdaptRemaining" + uuid
-									).put(
-										"autoStartProgress", ((optimizeImagesAllConfigurationsBackgroundTasksCount > 0) && amImageConfigurationEntry.isEnabled()) || currentBackgroundTaskConfigurationEntryUuids.contains(uuid)
-									).put(
-										"disabled", !amImageConfigurationEntry.isEnabled()
-									).put(
-										"namespace", liferayPortletResponse.getNamespace()
-									).put(
-										"percentageUrl", adaptedImagesPercentageURL.toString()
-									).put(
-										"totalImages", totalImages
-									).put(
-										"uuid", uuid
-									).build()
-								%>'
-							/>
-						</div>
-					</liferay-ui:search-container-column-text>
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand table-cell-minw-200 table-title"
+							href="<%= rowURL %>"
+							name="name"
+							orderable="<%= false %>"
+							value="<%= HtmlUtil.escape(amImageConfigurationEntry.getName()) %>"
+						/>
 
-					<%
-					Map<String, String> properties = amImageConfigurationEntry.getProperties();
-					%>
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand-smallest table-cell-ws-nowrap"
+							name="state"
+							orderable="<%= false %>"
+							value='<%= LanguageUtil.get(request, amImageConfigurationEntry.isEnabled() ? "enabled" : "disabled") %>'
+						/>
 
-					<%
-					String maxWidth = properties.get("max-width");
-					%>
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand table-cell-minw-200"
+							name="adapted-images"
+						>
 
-					<liferay-ui:search-container-column-text
-						cssClass="table-cell-ws-nowrap"
-						name="max-width"
-						orderable="<%= false %>"
-						value='<%= (Validator.isNull(maxWidth) || maxWidth.equals("0")) ? LanguageUtil.get(request, "auto") : maxWidth + "px" %>'
+							<%
+							String rowId = row.getRowId();
+							String uuid = String.valueOf(amImageConfigurationEntry.getUUID());
+
+							int adaptedImages = AMImageEntryLocalServiceUtil.getAMImageEntriesCount(themeDisplay.getCompanyId(), amImageConfigurationEntry.getUUID());
+
+							int totalImages = AMImageEntryLocalServiceUtil.getExpectedAMImageEntriesCount(themeDisplay.getCompanyId());
+							%>
+
+							<div id="<portlet:namespace />AdaptRemainingContainer_<%= rowId %>">
+								<portlet:resourceURL id="/adaptive_media/adapted_images_percentage" var="adaptedImagesPercentageURL">
+									<portlet:param name="entryUuid" value="<%= uuid %>" />
+								</portlet:resourceURL>
+
+								<react:component
+									module="adaptive_media/js/AdaptiveMediaProgress"
+									props='<%=
+										HashMapBuilder.<String, Object>put(
+											"adaptedImages", Math.min(adaptedImages, totalImages)
+										).put(
+											"adaptiveMediaProgressComponentId", liferayPortletResponse.getNamespace() + "AdaptRemaining" + uuid
+										).put(
+											"autoStartProgress", ((optimizeImagesAllConfigurationsBackgroundTasksCount > 0) && amImageConfigurationEntry.isEnabled()) || currentBackgroundTaskConfigurationEntryUuids.contains(uuid)
+										).put(
+											"disabled", !amImageConfigurationEntry.isEnabled()
+										).put(
+											"namespace", liferayPortletResponse.getNamespace()
+										).put(
+											"percentageUrl", adaptedImagesPercentageURL.toString()
+										).put(
+											"totalImages", totalImages
+										).put(
+											"uuid", uuid
+										).build()
+									%>'
+								/>
+							</div>
+						</liferay-ui:search-container-column-text>
+
+						<%
+						Map<String, String> properties = amImageConfigurationEntry.getProperties();
+						%>
+
+						<%
+						String maxWidth = properties.get("max-width");
+						%>
+
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-ws-nowrap"
+							name="max-width"
+							orderable="<%= false %>"
+							value='<%= (Validator.isNull(maxWidth) || maxWidth.equals("0")) ? LanguageUtil.get(request, "auto") : maxWidth + "px" %>'
+						/>
+
+						<%
+						String maxHeight = properties.get("max-height");
+						%>
+
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-ws-nowrap"
+							name="max-height"
+							orderable="<%= false %>"
+							value='<%= (Validator.isNull(maxHeight) || maxHeight.equals("0")) ? LanguageUtil.get(request, "auto") : maxHeight + "px" %>'
+						/>
+
+						<liferay-ui:search-container-column-jsp
+							path="/adaptive_media/image_configuration_entry_action.jsp"
+						/>
+					</liferay-ui:search-container-row>
+
+					<liferay-ui:search-iterator
+						displayStyle="list"
+						markupView="lexicon"
 					/>
-
-					<%
-					String maxHeight = properties.get("max-height");
-					%>
-
-					<liferay-ui:search-container-column-text
-						cssClass="table-cell-ws-nowrap"
-						name="max-height"
-						orderable="<%= false %>"
-						value='<%= (Validator.isNull(maxHeight) || maxHeight.equals("0")) ? LanguageUtil.get(request, "auto") : maxHeight + "px" %>'
-					/>
-
-					<liferay-ui:search-container-column-jsp
-						path="/adaptive_media/image_configuration_entry_action.jsp"
-					/>
-				</liferay-ui:search-container-row>
-
-				<liferay-ui:search-iterator
-					displayStyle="list"
-					markupView="lexicon"
-				/>
-			</liferay-ui:search-container>
-		</aui:form>
+				</liferay-ui:search-container>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
-</clay:container-fluid>
+</div>
 
 <aui:script>
 	function <portlet:namespace />adaptRemaining(uuid, backgroundTaskUrl) {

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view.jsp
@@ -180,10 +180,7 @@ BookmarksUtil.addPortletBreadcrumbEntries(folder, request, renderResponse);
 	<liferay-util:param name="searchContainerId" value="entries" />
 </liferay-util:include>
 
-<clay:container-fluid
-	cssClass="closed sidenav-container sidenav-right"
-	id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
->
+<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/bookmarks/info_panel" var="sidebarPanelURL">
 		<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
 	</liferay-portlet:resourceURL>
@@ -196,32 +193,36 @@ BookmarksUtil.addPortletBreadcrumbEntries(folder, request, renderResponse);
 	</liferay-frontend:sidebar-panel>
 
 	<div class="sidenav-content">
-		<div class="bookmakrs-breadcrumb" id="<portlet:namespace />breadcrumbContainer">
-			<c:if test='<%= !navigation.equals("recent") && !navigation.equals("mine") %>'>
-				<liferay-ui:breadcrumb
-					showCurrentGroup="<%= false %>"
-					showGuestGroup="<%= false %>"
-					showLayout="<%= false %>"
-					showParentGroups="<%= false %>"
-				/>
-			</c:if>
-		</div>
+		<clay:container-fluid
+			cssClass="container-view"
+		>
+			<div class="bookmarks-breadcrumb" id="<portlet:namespace />breadcrumbContainer">
+				<c:if test='<%= !navigation.equals("recent") && !navigation.equals("mine") %>'>
+					<liferay-ui:breadcrumb
+						showCurrentGroup="<%= false %>"
+						showGuestGroup="<%= false %>"
+						showLayout="<%= false %>"
+						showParentGroups="<%= false %>"
+					/>
+				</c:if>
+			</div>
 
-		<liferay-portlet:actionURL varImpl="editEntryURL">
-			<portlet:param name="mvcRenderCommandName" value="/bookmarks/edit_entry" />
-		</liferay-portlet:actionURL>
+			<liferay-portlet:actionURL varImpl="editEntryURL">
+				<portlet:param name="mvcRenderCommandName" value="/bookmarks/edit_entry" />
+			</liferay-portlet:actionURL>
 
-		<aui:form action="<%= editEntryURL.toString() %>" method="get" name="fm">
-			<aui:input name="<%= Constants.CMD %>" type="hidden" />
-			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
-			<aui:input name="newFolderId" type="hidden" />
+			<aui:form action="<%= editEntryURL.toString() %>" method="get" name="fm">
+				<aui:input name="<%= Constants.CMD %>" type="hidden" />
+				<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+				<aui:input name="newFolderId" type="hidden" />
 
-			<liferay-util:include page="/bookmarks/view_entries.jsp" servletContext="<%= application %>">
-				<liferay-util:param name="searchContainerId" value="entries" />
-			</liferay-util:include>
-		</aui:form>
+				<liferay-util:include page="/bookmarks/view_entries.jsp" servletContext="<%= application %>">
+					<liferay-util:param name="searchContainerId" value="entries" />
+				</liferay-util:include>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
-</clay:container-fluid>
+</div>
 
 <%
 if (navigation.equals("all") && !defaultFolderView && (folder != null) && (portletName.equals(BookmarksPortletKeys.BOOKMARKS) || portletName.equals(BookmarksPortletKeys.BOOKMARKS_ADMIN))) {

--- a/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/view_cp_option_categories.jsp
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/view_cp_option_categories.jsp
@@ -100,7 +100,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "specifications"));
 </liferay-frontend:management-bar>
 
 <div id="<portlet:namespace />productOptionCategoriesContainer">
-	<div class="closed container-fluid container-fluid-max-xl sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+	<div class="closed sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
 		<c:if test="<%= cpOptionCategoryDisplayContext.isShowInfoPanel() %>">
 			<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/cp_specification_options/cp_option_category_info_panel" var="sidebarPanelURL" />
 
@@ -113,62 +113,64 @@ renderResponse.setTitle(LanguageUtil.get(request, "specifications"));
 		</c:if>
 
 		<div class="sidenav-content">
-			<aui:form action="<%= portletURL.toString() %>" method="post" name="fm">
-				<aui:input name="<%= Constants.CMD %>" type="hidden" />
-				<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
-				<aui:input name="deleteCPOptionCategoryIds" type="hidden" />
+			<clay:container-fluid>
+				<aui:form action="<%= portletURL.toString() %>" method="post" name="fm">
+					<aui:input name="<%= Constants.CMD %>" type="hidden" />
+					<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
+					<aui:input name="deleteCPOptionCategoryIds" type="hidden" />
 
-				<div class="product-option-categories-container" id="<portlet:namespace />entriesContainer">
-					<liferay-ui:search-container
-						id="cpOptionCategories"
-						iteratorURL="<%= portletURL %>"
-						searchContainer="<%= cpOptionCategoryDisplayContext.getSearchContainer() %>"
-					>
-						<liferay-ui:search-container-row
-							className="com.liferay.commerce.product.model.CPOptionCategory"
-							keyProperty="CPOptionCategoryId"
-							modelVar="cpOptionCategory"
+					<div class="product-option-categories-container" id="<portlet:namespace />entriesContainer">
+						<liferay-ui:search-container
+							id="cpOptionCategories"
+							iteratorURL="<%= portletURL %>"
+							searchContainer="<%= cpOptionCategoryDisplayContext.getSearchContainer() %>"
 						>
+							<liferay-ui:search-container-row
+								className="com.liferay.commerce.product.model.CPOptionCategory"
+								keyProperty="CPOptionCategoryId"
+								modelVar="cpOptionCategory"
+							>
 
-							<%
-							PortletURL rowURL = renderResponse.createRenderURL();
+								<%
+								PortletURL rowURL = renderResponse.createRenderURL();
 
-							rowURL.setParameter("mvcRenderCommandName", "/cp_specification_options/edit_cp_option_category");
-							rowURL.setParameter("redirect", currentURL);
-							rowURL.setParameter("cpOptionCategoryId", String.valueOf(cpOptionCategory.getCPOptionCategoryId()));
-							%>
+								rowURL.setParameter("mvcRenderCommandName", "/cp_specification_options/edit_cp_option_category");
+								rowURL.setParameter("redirect", currentURL);
+								rowURL.setParameter("cpOptionCategoryId", String.valueOf(cpOptionCategory.getCPOptionCategoryId()));
+								%>
 
-							<liferay-ui:search-container-column-text
-								cssClass="important table-cell-expand"
-								href="<%= rowURL %>"
-								name="group"
-								value="<%= HtmlUtil.escape(cpOptionCategory.getTitle(locale)) %>"
+								<liferay-ui:search-container-column-text
+									cssClass="important table-cell-expand"
+									href="<%= rowURL %>"
+									name="group"
+									value="<%= HtmlUtil.escape(cpOptionCategory.getTitle(locale)) %>"
+								/>
+
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand"
+									property="priority"
+								/>
+
+								<liferay-ui:search-container-column-date
+									cssClass="table-cell-expand"
+									name="modified-date"
+									property="modifiedDate"
+								/>
+
+								<liferay-ui:search-container-column-jsp
+									cssClass="entry-action-column"
+									path="/option_category_action.jsp"
+								/>
+							</liferay-ui:search-container-row>
+
+							<liferay-ui:search-iterator
+								displayStyle="<%= displayStyle %>"
+								markupView="lexicon"
 							/>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand"
-								property="priority"
-							/>
-
-							<liferay-ui:search-container-column-date
-								cssClass="table-cell-expand"
-								name="modified-date"
-								property="modifiedDate"
-							/>
-
-							<liferay-ui:search-container-column-jsp
-								cssClass="entry-action-column"
-								path="/option_category_action.jsp"
-							/>
-						</liferay-ui:search-container-row>
-
-						<liferay-ui:search-iterator
-							displayStyle="<%= displayStyle %>"
-							markupView="lexicon"
-						/>
-					</liferay-ui:search-container>
-				</div>
-			</aui:form>
+						</liferay-ui:search-container>
+					</div>
+				</aui:form>
+			</clay:container-fluid>
 		</div>
 	</div>
 </div>

--- a/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/view_specification_options.jsp
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/view_specification_options.jsp
@@ -107,7 +107,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "specifications"));
 </liferay-frontend:management-bar>
 
 <div id="<portlet:namespace />productSpecificationOptionsContainer">
-	<div class="closed container-fluid container-fluid-max-xl sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+	<div class="closed sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
 		<c:if test="<%= cpSpecificationOptionDisplayContext.isShowInfoPanel() %>">
 			<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/cp_specification_options/cp_specification_option_info_panel" var="sidebarPanelURL" />
 
@@ -120,69 +120,71 @@ renderResponse.setTitle(LanguageUtil.get(request, "specifications"));
 		</c:if>
 
 		<div class="sidenav-content">
-			<aui:form action="<%= portletURL.toString() %>" method="post" name="fm">
-				<aui:input name="<%= Constants.CMD %>" type="hidden" />
-				<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
-				<aui:input name="deleteCPSpecificationOptionIds" type="hidden" />
+			<clay:container-fluid>
+				<aui:form action="<%= portletURL.toString() %>" method="post" name="fm">
+					<aui:input name="<%= Constants.CMD %>" type="hidden" />
+					<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
+					<aui:input name="deleteCPSpecificationOptionIds" type="hidden" />
 
-				<div class="product-specification-options-container" id="<portlet:namespace />entriesContainer">
-					<liferay-ui:search-container
-						id="cpSpecificationOptions"
-						iteratorURL="<%= portletURL %>"
-						searchContainer="<%= cpSpecificationOptionDisplayContext.getSearchContainer() %>"
-					>
-						<liferay-ui:search-container-row
-							className="com.liferay.commerce.product.model.CPSpecificationOption"
-							keyProperty="CPSpecificationOptionId"
-							modelVar="cpSpecificationOption"
+					<div class="product-specification-options-container" id="<portlet:namespace />entriesContainer">
+						<liferay-ui:search-container
+							id="cpSpecificationOptions"
+							iteratorURL="<%= portletURL %>"
+							searchContainer="<%= cpSpecificationOptionDisplayContext.getSearchContainer() %>"
 						>
+							<liferay-ui:search-container-row
+								className="com.liferay.commerce.product.model.CPSpecificationOption"
+								keyProperty="CPSpecificationOptionId"
+								modelVar="cpSpecificationOption"
+							>
 
-							<%
-							PortletURL rowURL = renderResponse.createRenderURL();
+								<%
+								PortletURL rowURL = renderResponse.createRenderURL();
 
-							rowURL.setParameter("mvcRenderCommandName", "/cp_specification_options/edit_cp_specification_option");
-							rowURL.setParameter("redirect", currentURL);
-							rowURL.setParameter("cpSpecificationOptionId", String.valueOf(cpSpecificationOption.getCPSpecificationOptionId()));
-							%>
+								rowURL.setParameter("mvcRenderCommandName", "/cp_specification_options/edit_cp_specification_option");
+								rowURL.setParameter("redirect", currentURL);
+								rowURL.setParameter("cpSpecificationOptionId", String.valueOf(cpSpecificationOption.getCPSpecificationOptionId()));
+								%>
 
-							<liferay-ui:search-container-column-text
-								cssClass="important table-cell-expand"
-								href="<%= rowURL %>"
-								name="label"
-								value="<%= HtmlUtil.escape(cpSpecificationOption.getTitle(locale)) %>"
+								<liferay-ui:search-container-column-text
+									cssClass="important table-cell-expand"
+									href="<%= rowURL %>"
+									name="label"
+									value="<%= HtmlUtil.escape(cpSpecificationOption.getTitle(locale)) %>"
+								/>
+
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand"
+									name="default-group"
+									value="<%= HtmlUtil.escape(cpSpecificationOptionDisplayContext.getCPOptionCategoryTitle(cpSpecificationOption)) %>"
+								/>
+
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand"
+									name="use-in-faceted-navigation"
+									value='<%= LanguageUtil.get(request, cpSpecificationOption.isFacetable() ? "yes" : "no") %>'
+								/>
+
+								<liferay-ui:search-container-column-date
+									cssClass="table-cell-expand"
+									name="modified-date"
+									property="modifiedDate"
+								/>
+
+								<liferay-ui:search-container-column-jsp
+									cssClass="entry-action-column"
+									path="/specification_option_action.jsp"
+								/>
+							</liferay-ui:search-container-row>
+
+							<liferay-ui:search-iterator
+								displayStyle="<%= displayStyle %>"
+								markupView="lexicon"
 							/>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand"
-								name="default-group"
-								value="<%= HtmlUtil.escape(cpSpecificationOptionDisplayContext.getCPOptionCategoryTitle(cpSpecificationOption)) %>"
-							/>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand"
-								name="use-in-faceted-navigation"
-								value='<%= LanguageUtil.get(request, cpSpecificationOption.isFacetable() ? "yes" : "no") %>'
-							/>
-
-							<liferay-ui:search-container-column-date
-								cssClass="table-cell-expand"
-								name="modified-date"
-								property="modifiedDate"
-							/>
-
-							<liferay-ui:search-container-column-jsp
-								cssClass="entry-action-column"
-								path="/specification_option_action.jsp"
-							/>
-						</liferay-ui:search-container-row>
-
-						<liferay-ui:search-iterator
-							displayStyle="<%= displayStyle %>"
-							markupView="lexicon"
-						/>
-					</liferay-ui:search-container>
-				</div>
-			</aui:form>
+						</liferay-ui:search-container>
+					</div>
+				</aui:form>
+			</clay:container-fluid>
 		</div>
 	</div>
 </div>

--- a/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/view_cp_definition_grouped_entries.jsp
+++ b/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/view_cp_definition_grouped_entries.jsp
@@ -103,7 +103,7 @@ renderResponse.setTitle(cpDefinition.getName(themeDisplay.getLanguageId()));
 </liferay-frontend:management-bar>
 
 <div id="<portlet:namespace />cpDefinitionGroupedEntriesContainer">
-	<div class="closed container-fluid container-fluid-max-xl sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+	<div class="closed sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
 		<c:if test="<%= cpDefinitionGroupedEntriesDisplayContext.isShowInfoPanel() %>">
 			<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/cp_definitions/cp_definition_grouped_entry_info_panel" var="sidebarPanelURL" />
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -54,10 +54,7 @@ else {
 	module="js/ManagementToolbarDefaultEventHandler.es"
 />
 
-<clay:container-fluid
-	cssClass="closed sidenav-container sidenav-right"
-	id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
->
+<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 	<c:if test="<%= journalDisplayContext.isShowInfoButton() %>">
 		<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/journal/info_panel" var="sidebarPanelURL">
 			<portlet:param name="folderId" value="<%= String.valueOf(journalDisplayContext.getFolderId()) %>" />
@@ -72,76 +69,80 @@ else {
 	</c:if>
 
 	<div class="sidenav-content">
-		<c:if test="<%= !journalDisplayContext.isNavigationMine() && !journalDisplayContext.isNavigationRecent() %>">
-			<liferay-site-navigation:breadcrumb
-				breadcrumbEntries="<%= JournalPortletUtil.getPortletBreadcrumbEntries(journalDisplayContext.getFolder(), request, journalDisplayContext.getPortletURL()) %>"
-			/>
-		</c:if>
+		<clay:container-fluid
+			cssClass="container-view"
+		>
+			<c:if test="<%= !journalDisplayContext.isNavigationMine() && !journalDisplayContext.isNavigationRecent() %>">
+				<liferay-site-navigation:breadcrumb
+					breadcrumbEntries="<%= JournalPortletUtil.getPortletBreadcrumbEntries(journalDisplayContext.getFolder(), request, journalDisplayContext.getPortletURL()) %>"
+				/>
+			</c:if>
 
-		<aui:form action="<%= journalDisplayContext.getPortletURL() %>" method="get" name="fm">
-			<aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" />
-			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
-			<aui:input name="groupId" type="hidden" value="<%= scopeGroupId %>" />
-			<aui:input name="newFolderId" type="hidden" />
+			<aui:form action="<%= journalDisplayContext.getPortletURL() %>" method="get" name="fm">
+				<aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" />
+				<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+				<aui:input name="groupId" type="hidden" value="<%= scopeGroupId %>" />
+				<aui:input name="newFolderId" type="hidden" />
 
-			<c:choose>
-				<c:when test="<%= !journalDisplayContext.isSearch() %>">
-					<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
-				</c:when>
-				<c:otherwise>
+				<c:choose>
+					<c:when test="<%= !journalDisplayContext.isSearch() %>">
+						<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
+					</c:when>
+					<c:otherwise>
 
-					<%
-					String[] tabsNames = new String[0];
-					String[] tabsValues = new String[0];
+						<%
+						String[] tabsNames = new String[0];
+						String[] tabsValues = new String[0];
 
-					if (journalDisplayContext.hasResults()) {
-						String tabName = StringUtil.appendParentheticalSuffix(LanguageUtil.get(request, "web-content"), journalDisplayContext.getTotalItems());
+						if (journalDisplayContext.hasResults()) {
+							String tabName = StringUtil.appendParentheticalSuffix(LanguageUtil.get(request, "web-content"), journalDisplayContext.getTotalItems());
 
-						tabsNames = ArrayUtil.append(tabsNames, tabName);
+							tabsNames = ArrayUtil.append(tabsNames, tabName);
 
-						tabsValues = ArrayUtil.append(tabsValues, "web-content");
-					}
+							tabsValues = ArrayUtil.append(tabsValues, "web-content");
+						}
 
-					if (journalDisplayContext.hasVersionsResults()) {
-						String tabName = StringUtil.appendParentheticalSuffix(LanguageUtil.get(request, "versions"), journalDisplayContext.getVersionsTotal());
+						if (journalDisplayContext.hasVersionsResults()) {
+							String tabName = StringUtil.appendParentheticalSuffix(LanguageUtil.get(request, "versions"), journalDisplayContext.getVersionsTotal());
 
-						tabsNames = ArrayUtil.append(tabsNames, tabName);
+							tabsNames = ArrayUtil.append(tabsNames, tabName);
 
-						tabsValues = ArrayUtil.append(tabsValues, "versions");
-					}
+							tabsValues = ArrayUtil.append(tabsValues, "versions");
+						}
 
-					if (journalDisplayContext.hasCommentsResults()) {
-						String tabName = StringUtil.appendParentheticalSuffix(LanguageUtil.get(request, "comments"), journalDisplayContext.getCommentsTotal());
+						if (journalDisplayContext.hasCommentsResults()) {
+							String tabName = StringUtil.appendParentheticalSuffix(LanguageUtil.get(request, "comments"), journalDisplayContext.getCommentsTotal());
 
-						tabsNames = ArrayUtil.append(tabsNames, tabName);
+							tabsNames = ArrayUtil.append(tabsNames, tabName);
 
-						tabsValues = ArrayUtil.append(tabsValues, "comments");
-					}
-					%>
+							tabsValues = ArrayUtil.append(tabsValues, "comments");
+						}
+						%>
 
-					<liferay-ui:tabs
-						names="<%= StringUtil.merge(tabsNames) %>"
-						portletURL="<%= journalDisplayContext.getPortletURL() %>"
-						tabsValues="<%= StringUtil.merge(tabsValues) %>"
-					/>
+						<liferay-ui:tabs
+							names="<%= StringUtil.merge(tabsNames) %>"
+							portletURL="<%= journalDisplayContext.getPortletURL() %>"
+							tabsValues="<%= StringUtil.merge(tabsValues) %>"
+						/>
 
-					<c:choose>
-						<c:when test="<%= journalDisplayContext.isWebContentTabSelected() %>">
-							<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
-						</c:when>
-						<c:when test="<%= journalDisplayContext.isVersionsTabSelected() %>">
-							<liferay-util:include page="/view_versions.jsp" servletContext="<%= application %>" />
-						</c:when>
-						<c:when test="<%= journalDisplayContext.isCommentsTabSelected() %>">
-							<liferay-util:include page="/view_comments.jsp" servletContext="<%= application %>" />
-						</c:when>
-						<c:otherwise>
-							<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
-						</c:otherwise>
-					</c:choose>
-				</c:otherwise>
-			</c:choose>
-		</aui:form>
+						<c:choose>
+							<c:when test="<%= journalDisplayContext.isWebContentTabSelected() %>">
+								<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
+							</c:when>
+							<c:when test="<%= journalDisplayContext.isVersionsTabSelected() %>">
+								<liferay-util:include page="/view_versions.jsp" servletContext="<%= application %>" />
+							</c:when>
+							<c:when test="<%= journalDisplayContext.isCommentsTabSelected() %>">
+								<liferay-util:include page="/view_comments.jsp" servletContext="<%= application %>" />
+							</c:when>
+							<c:otherwise>
+								<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
+							</c:otherwise>
+						</c:choose>
+					</c:otherwise>
+				</c:choose>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
 
 	<div>
@@ -150,4 +151,4 @@ else {
 			props="<%= journalDisplayContext.getExportTranslationData() %>"
 		/>
 	</div>
-</clay:container-fluid>
+</div>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_article.jsp
@@ -59,7 +59,7 @@ if (portletTitleBasedNavigation) {
 	</liferay-frontend:info-bar>
 </c:if>
 
-<div <%= portletTitleBasedNavigation ? "class=\"closed container-fluid container-fluid-max-xl kb-article sidenav-container sidenav-right\" id=\"" + liferayPortletResponse.getNamespace() + "infoPanelId\"" : StringPool.BLANK %>>
+<div <%= portletTitleBasedNavigation ? "class=\"closed kb-article sidenav-container sidenav-right\" id=\"" + liferayPortletResponse.getNamespace() + "infoPanelId\"" : StringPool.BLANK %>>
 	<c:if test="<%= portletTitleBasedNavigation %>">
 		<liferay-frontend:sidebar-panel>
 
@@ -72,95 +72,97 @@ if (portletTitleBasedNavigation) {
 	</c:if>
 
 	<div class="sidenav-content">
-		<c:if test="<%= !portletTitleBasedNavigation %>">
-			<liferay-ui:header
-				title="<%= kbArticle.getTitle() %>"
-			/>
-		</c:if>
+		<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl\"" : StringPool.BLANK %>>
+			<c:if test="<%= !portletTitleBasedNavigation %>">
+				<liferay-ui:header
+					title="<%= kbArticle.getTitle() %>"
+				/>
+			</c:if>
 
-		<div class="kb-tools">
-			<liferay-util:include page="/admin/common/article_tools.jsp" servletContext="<%= application %>" />
-		</div>
-
-		<div <%= portletTitleBasedNavigation ? "class=\"main-content-card panel\"" : StringPool.BLANK %>>
-			<div class="kb-entity-body <%= portletTitleBasedNavigation ? "panel-body" : StringPool.BLANK %>">
-				<c:if test="<%= portletTitleBasedNavigation %>">
-					<h1>
-						<%= HtmlUtil.escape(kbArticle.getTitle()) %>
-					</h1>
-				</c:if>
-
-				<div id="<portlet:namespace /><%= kbArticle.getResourcePrimKey() %>">
-					<%= kbArticle.getContent() %>
-				</div>
-
-				<liferay-util:include page="/admin/common/article_social_bookmarks.jsp" servletContext="<%= application %>" />
-
-				<liferay-expando:custom-attributes-available
-					className="<%= KBArticle.class.getName() %>"
-				>
-					<liferay-expando:custom-attribute-list
-						className="<%= KBArticle.class.getName() %>"
-						classPK="<%= kbArticle.getKbArticleId() %>"
-						editable="<%= false %>"
-						label="<%= true %>"
-					/>
-				</liferay-expando:custom-attributes-available>
-
-				<liferay-util:include page="/admin/common/article_assets.jsp" servletContext="<%= application %>" />
-
-				<c:if test="<%= showKBArticleAttachments %>">
-					<liferay-util:include page="/admin/common/article_attachments.jsp" servletContext="<%= application %>" />
-				</c:if>
-
-				<liferay-util:include page="/admin/common/article_asset_links.jsp" servletContext="<%= application %>" />
-
-				<c:if test="<%= !portletTitleBasedNavigation %>">
-					<liferay-util:include page="/admin/common/article_asset_entries.jsp" servletContext="<%= application %>" />
-				</c:if>
-
-				<c:if test="<%= enableKBArticleRatings %>">
-					<div class="kb-article-ratings">
-						<liferay-ratings:ratings
-							className="<%= KBArticle.class.getName() %>"
-							classPK="<%= kbArticle.getResourcePrimKey() %>"
-							inTrash="<%= false %>"
-						/>
-					</div>
-				</c:if>
-
-				<c:if test="<%= !portletTitleBasedNavigation && !rootPortletId.equals(KBPortletKeys.KNOWLEDGE_BASE_ARTICLE) %>">
-					<liferay-util:include page="/admin/common/article_siblings.jsp" servletContext="<%= application %>" />
-				</c:if>
+			<div class="kb-tools">
+				<liferay-util:include page="/admin/common/article_tools.jsp" servletContext="<%= application %>" />
 			</div>
 
-			<c:if test="<%= enableKBArticleSuggestions %>">
-				<c:choose>
-					<c:when test="<%= portletTitleBasedNavigation %>">
-						<liferay-ui:panel-container
-							extended="<%= false %>"
-							markupView="lexicon"
-							persistState="<%= true %>"
-						>
-							<liferay-ui:panel
-								collapsible="<%= true %>"
+			<div <%= portletTitleBasedNavigation ? "class=\"main-content-card panel\"" : StringPool.BLANK %>>
+				<div class="kb-entity-body <%= portletTitleBasedNavigation ? "panel-body" : StringPool.BLANK %>">
+					<c:if test="<%= portletTitleBasedNavigation %>">
+						<h1>
+							<%= HtmlUtil.escape(kbArticle.getTitle()) %>
+						</h1>
+					</c:if>
+
+					<div id="<portlet:namespace /><%= kbArticle.getResourcePrimKey() %>">
+						<%= kbArticle.getContent() %>
+					</div>
+
+					<liferay-util:include page="/admin/common/article_social_bookmarks.jsp" servletContext="<%= application %>" />
+
+					<liferay-expando:custom-attributes-available
+						className="<%= KBArticle.class.getName() %>"
+					>
+						<liferay-expando:custom-attribute-list
+							className="<%= KBArticle.class.getName() %>"
+							classPK="<%= kbArticle.getKbArticleId() %>"
+							editable="<%= false %>"
+							label="<%= true %>"
+						/>
+					</liferay-expando:custom-attributes-available>
+
+					<liferay-util:include page="/admin/common/article_assets.jsp" servletContext="<%= application %>" />
+
+					<c:if test="<%= showKBArticleAttachments %>">
+						<liferay-util:include page="/admin/common/article_attachments.jsp" servletContext="<%= application %>" />
+					</c:if>
+
+					<liferay-util:include page="/admin/common/article_asset_links.jsp" servletContext="<%= application %>" />
+
+					<c:if test="<%= !portletTitleBasedNavigation %>">
+						<liferay-util:include page="/admin/common/article_asset_entries.jsp" servletContext="<%= application %>" />
+					</c:if>
+
+					<c:if test="<%= enableKBArticleRatings %>">
+						<div class="kb-article-ratings">
+							<liferay-ratings:ratings
+								className="<%= KBArticle.class.getName() %>"
+								classPK="<%= kbArticle.getResourcePrimKey() %>"
+								inTrash="<%= false %>"
+							/>
+						</div>
+					</c:if>
+
+					<c:if test="<%= !portletTitleBasedNavigation && !rootPortletId.equals(KBPortletKeys.KNOWLEDGE_BASE_ARTICLE) %>">
+						<liferay-util:include page="/admin/common/article_siblings.jsp" servletContext="<%= application %>" />
+					</c:if>
+				</div>
+
+				<c:if test="<%= enableKBArticleSuggestions %>">
+					<c:choose>
+						<c:when test="<%= portletTitleBasedNavigation %>">
+							<liferay-ui:panel-container
 								extended="<%= false %>"
 								markupView="lexicon"
 								persistState="<%= true %>"
-								title="suggestions"
 							>
-								<liferay-util:include page="/admin/common/article_suggestions.jsp" servletContext="<%= application %>" />
-							</liferay-ui:panel>
-						</liferay-ui:panel-container>
-					</c:when>
-					<c:otherwise>
-						<liferay-util:include page="/admin/common/article_suggestions.jsp" servletContext="<%= application %>" />
-					</c:otherwise>
-				</c:choose>
-			</c:if>
-		</div>
+								<liferay-ui:panel
+									collapsible="<%= true %>"
+									extended="<%= false %>"
+									markupView="lexicon"
+									persistState="<%= true %>"
+									title="suggestions"
+								>
+									<liferay-util:include page="/admin/common/article_suggestions.jsp" servletContext="<%= application %>" />
+								</liferay-ui:panel>
+							</liferay-ui:panel-container>
+						</c:when>
+						<c:otherwise>
+							<liferay-util:include page="/admin/common/article_suggestions.jsp" servletContext="<%= application %>" />
+						</c:otherwise>
+					</c:choose>
+				</c:if>
+			</div>
 
-		<liferay-util:include page="/admin/common/article_child.jsp" servletContext="<%= application %>" />
+			<liferay-util:include page="/admin/common/article_child.jsp" servletContext="<%= application %>" />
+		</div>
 	</div>
 </div>
 

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
@@ -197,8 +197,8 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 		</div>
 	</c:if>
 
-	<clay:container-fluid>
-		<div class="sidenav-content">
+	<div class="sidenav-content">
+		<clay:container-fluid>
 			<aui:form method="post" name="fm">
 				<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 				<aui:input name="name" type="hidden" value="<%= name %>" />
@@ -290,8 +290,8 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 					</c:if>
 				</aui:button-row>
 			</aui:form>
-		</div>
-	</clay:container-fluid>
+		</clay:container-fluid>
+	</div>
 </div>
 
 <div class="hide" id="<%= randomNamespace %>titleInputLocalized">

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
@@ -34,10 +34,7 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 	/>
 </c:if>
 
-<clay:container-fluid
-	cssClass="closed redirect-entries sidenav-container sidenav-right"
-	id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
->
+<div class="closed redirect-entries sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/redirect/info_panel" var="sidebarPanelURL" />
 
 	<liferay-frontend:sidebar-panel
@@ -48,108 +45,110 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 	</liferay-frontend:sidebar-panel>
 
 	<div class="sidenav-content">
-		<c:if test="<%= stagingGroup %>">
-			<div class="lfr-search-container">
-				<clay:alert
-					displayType="info"
-					message="redirections-are-unavailable-in-staged-sites"
-				/>
-			</div>
-		</c:if>
+		<clay:container-fluid>
+			<c:if test="<%= stagingGroup %>">
+				<div class="lfr-search-container">
+					<clay:alert
+						displayType="info"
+						message="redirections-are-unavailable-in-staged-sites"
+					/>
+				</div>
+			</c:if>
 
-		<aui:form action="<%= redirectSearchContainer.getIteratorURL() %>" cssClass="container-fluid container-fluid-max-xl" name="fm">
-			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+			<aui:form action="<%= redirectSearchContainer.getIteratorURL() %>" cssClass="container-fluid container-fluid-max-xl" name="fm">
+				<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
-			<liferay-ui:search-container
-				id="<%= redirectDisplayContext.getSearchContainerId() %>"
-				searchContainer="<%= redirectSearchContainer %>"
-			>
-				<liferay-ui:search-container-row
-					className="com.liferay.redirect.model.RedirectEntry"
-					keyProperty="redirectEntryId"
-					modelVar="redirectEntry"
-				>
-
-					<%
-					row.setData(
-						HashMapBuilder.<String, Object>put(
-							"actions", redirectManagementToolbarDisplayContext.getAvailableActions(redirectEntry)
-						).build());
-					%>
-
-					<liferay-ui:search-container-column-text
-						cssClass="table-cell-expand"
-						name="source-url"
-					>
-
-						<%
-						String sourceURL = HtmlUtil.escape(RedirectUtil.getGroupBaseURL(themeDisplay) + StringPool.SLASH + redirectEntry.getSourceURL());
-						%>
-
-						<span data-title="<%= HtmlUtil.escapeAttribute(sourceURL) %>">
-							<%= sourceURL %>
-						</span>
-					</liferay-ui:search-container-column-text>
-
-					<liferay-ui:search-container-column-text
-						cssClass="table-cell-expand"
-						name="destination-url"
-					>
-
-						<%
-						String destinationURL = HtmlUtil.escape(redirectEntry.getDestinationURL());
-						%>
-
-						<span data-title="<%= HtmlUtil.escapeAttribute(destinationURL) %>">
-							<%= destinationURL %>
-						</span>
-					</liferay-ui:search-container-column-text>
-
-					<liferay-ui:search-container-column-text
-						cssClass="table-cell-expand-smallest"
-						name="type"
-					>
-						<liferay-ui:message key='<%= redirectEntry.isPermanent() ? "permanent" : "temporary" %>' />
-					</liferay-ui:search-container-column-text>
-
-					<liferay-ui:search-container-column-text
-						cssClass="table-cell-expand-smallest"
-						name="expiration"
-					>
-						<c:choose>
-							<c:when test="<%= Validator.isNull(redirectEntry.getExpirationDate()) %>">
-								<%= StringPool.DASH %>
-							</c:when>
-							<c:when test="<%= DateUtil.compareTo(redirectEntry.getExpirationDate(), DateUtil.newDate()) <= 0 %>">
-								<strong><liferay-ui:message key="expired" /></strong>
-							</c:when>
-							<c:otherwise>
-								<%= redirectDisplayContext.formatExpirationDate(redirectEntry.getExpirationDate()) %>
-							</c:otherwise>
-						</c:choose>
-					</liferay-ui:search-container-column-text>
-
-					<%
-					List<DropdownItem> dropdownItems = redirectDisplayContext.getActionDropdownItems(redirectEntry);
-					%>
-
-					<c:if test="<%= ListUtil.isNotEmpty(dropdownItems) %>">
-						<liferay-ui:search-container-column-text>
-							<clay:dropdown-actions
-								dropdownItems="<%= dropdownItems %>"
-							/>
-						</liferay-ui:search-container-column-text>
-					</c:if>
-				</liferay-ui:search-container-row>
-
-				<liferay-ui:search-iterator
-					markupView="lexicon"
+				<liferay-ui:search-container
+					id="<%= redirectDisplayContext.getSearchContainerId() %>"
 					searchContainer="<%= redirectSearchContainer %>"
-				/>
-			</liferay-ui:search-container>
-		</aui:form>
+				>
+					<liferay-ui:search-container-row
+						className="com.liferay.redirect.model.RedirectEntry"
+						keyProperty="redirectEntryId"
+						modelVar="redirectEntry"
+					>
+
+						<%
+						row.setData(
+							HashMapBuilder.<String, Object>put(
+								"actions", redirectManagementToolbarDisplayContext.getAvailableActions(redirectEntry)
+							).build());
+						%>
+
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand"
+							name="source-url"
+						>
+
+							<%
+							String sourceURL = HtmlUtil.escape(RedirectUtil.getGroupBaseURL(themeDisplay) + StringPool.SLASH + redirectEntry.getSourceURL());
+							%>
+
+							<span data-title="<%= HtmlUtil.escapeAttribute(sourceURL) %>">
+								<%= sourceURL %>
+							</span>
+						</liferay-ui:search-container-column-text>
+
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand"
+							name="destination-url"
+						>
+
+							<%
+							String destinationURL = HtmlUtil.escape(redirectEntry.getDestinationURL());
+							%>
+
+							<span data-title="<%= HtmlUtil.escapeAttribute(destinationURL) %>">
+								<%= destinationURL %>
+							</span>
+						</liferay-ui:search-container-column-text>
+
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand-smallest"
+							name="type"
+						>
+							<liferay-ui:message key='<%= redirectEntry.isPermanent() ? "permanent" : "temporary" %>' />
+						</liferay-ui:search-container-column-text>
+
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand-smallest"
+							name="expiration"
+						>
+							<c:choose>
+								<c:when test="<%= Validator.isNull(redirectEntry.getExpirationDate()) %>">
+									<%= StringPool.DASH %>
+								</c:when>
+								<c:when test="<%= DateUtil.compareTo(redirectEntry.getExpirationDate(), DateUtil.newDate()) <= 0 %>">
+									<strong><liferay-ui:message key="expired" /></strong>
+								</c:when>
+								<c:otherwise>
+									<%= redirectDisplayContext.formatExpirationDate(redirectEntry.getExpirationDate()) %>
+								</c:otherwise>
+							</c:choose>
+						</liferay-ui:search-container-column-text>
+
+						<%
+						List<DropdownItem> dropdownItems = redirectDisplayContext.getActionDropdownItems(redirectEntry);
+						%>
+
+						<c:if test="<%= ListUtil.isNotEmpty(dropdownItems) %>">
+							<liferay-ui:search-container-column-text>
+								<clay:dropdown-actions
+									dropdownItems="<%= dropdownItems %>"
+								/>
+							</liferay-ui:search-container-column-text>
+						</c:if>
+					</liferay-ui:search-container-row>
+
+					<liferay-ui:search-iterator
+						markupView="lexicon"
+						searchContainer="<%= redirectSearchContainer %>"
+					/>
+				</liferay-ui:search-container>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
-</clay:container-fluid>
+</div>
 
 <liferay-frontend:component
 	componentId="<%= redirectManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -37,10 +37,7 @@ if (group != null) {
 	displayContext="<%= siteAdminManagementToolbarDisplayContext %>"
 />
 
-<clay:container-fluid
-	cssClass="closed sidenav-container sidenav-right"
-	id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
->
+<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/site_admin/info_panel" var="sidebarPanelURL" />
 
 	<liferay-frontend:sidebar-panel
@@ -51,46 +48,48 @@ if (group != null) {
 	</liferay-frontend:sidebar-panel>
 
 	<div class="sidenav-content">
-		<portlet:actionURL name="/site_admin/delete_groups" var="deleteGroupsURL" />
+		<clay:container-fluid>
+			<portlet:actionURL name="/site_admin/delete_groups" var="deleteGroupsURL" />
 
-		<aui:form action="<%= deleteGroupsURL %>" name="fm">
-			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+			<aui:form action="<%= deleteGroupsURL %>" name="fm">
+				<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
-			<liferay-site-navigation:breadcrumb
-				breadcrumbEntries="<%= siteAdminDisplayContext.getBreadcrumbEntries() %>"
-			/>
+				<liferay-site-navigation:breadcrumb
+					breadcrumbEntries="<%= siteAdminDisplayContext.getBreadcrumbEntries() %>"
+				/>
 
-			<liferay-ui:error exception="<%= NoSuchLayoutSetException.class %>">
+				<liferay-ui:error exception="<%= NoSuchLayoutSetException.class %>">
 
-				<%
-				Group curGroup = GroupLocalServiceUtil.fetchGroup(scopeGroupId);
+					<%
+					Group curGroup = GroupLocalServiceUtil.fetchGroup(scopeGroupId);
 
-				NoSuchLayoutSetException nslse = (NoSuchLayoutSetException)errorException;
+					NoSuchLayoutSetException nslse = (NoSuchLayoutSetException)errorException;
 
-				String message = nslse.getMessage();
+					String message = nslse.getMessage();
 
-				int index = message.indexOf("{");
+					int index = message.indexOf("{");
 
-				if (index > 0) {
-					JSONObject jsonObject = JSONFactoryUtil.createJSONObject(message.substring(index));
+					if (index > 0) {
+						JSONObject jsonObject = JSONFactoryUtil.createJSONObject(message.substring(index));
 
-					curGroup = GroupLocalServiceUtil.fetchGroup(jsonObject.getLong("groupId"));
-				}
-				%>
+						curGroup = GroupLocalServiceUtil.fetchGroup(jsonObject.getLong("groupId"));
+					}
+					%>
 
-				<c:if test="<%= curGroup != null %>">
-					<liferay-ui:message arguments="<%= HtmlUtil.escape(curGroup.getDescriptiveName(locale)) %>" key="site-x-does-not-have-any-private-pages" translateArguments="<%= false %>" />
-				</c:if>
-			</liferay-ui:error>
+					<c:if test="<%= curGroup != null %>">
+						<liferay-ui:message arguments="<%= HtmlUtil.escape(curGroup.getDescriptiveName(locale)) %>" key="site-x-does-not-have-any-private-pages" translateArguments="<%= false %>" />
+					</c:if>
+				</liferay-ui:error>
 
-			<liferay-ui:error exception="<%= RequiredGroupException.MustNotDeleteCurrentGroup.class %>" message="the-site-cannot-be-deleted-or-deactivated-because-you-are-accessing-the-site" />
-			<liferay-ui:error exception="<%= RequiredGroupException.MustNotDeleteGroupThatHasChild.class %>" message="you-cannot-delete-sites-that-have-subsites" />
-			<liferay-ui:error exception="<%= RequiredGroupException.MustNotDeleteSystemGroup.class %>" message="the-site-cannot-be-deleted-or-deactivated-because-it-is-a-required-system-site" />
+				<liferay-ui:error exception="<%= RequiredGroupException.MustNotDeleteCurrentGroup.class %>" message="the-site-cannot-be-deleted-or-deactivated-because-you-are-accessing-the-site" />
+				<liferay-ui:error exception="<%= RequiredGroupException.MustNotDeleteGroupThatHasChild.class %>" message="you-cannot-delete-sites-that-have-subsites" />
+				<liferay-ui:error exception="<%= RequiredGroupException.MustNotDeleteSystemGroup.class %>" message="the-site-cannot-be-deleted-or-deactivated-because-it-is-a-required-system-site" />
 
-			<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
-		</aui:form>
+				<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
+			</aui:form>
+		</clay:container-fluid>
 	</div>
-</clay:container-fluid>
+</div>
 
 <liferay-frontend:component
 	componentId="<%= siteAdminManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organizations.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organizations.jsp
@@ -31,10 +31,7 @@ OrganizationsManagementToolbarDisplayContext organizationsManagementToolbarDispl
 	displayContext="<%= organizationsManagementToolbarDisplayContext %>"
 />
 
-<clay:container-fluid
-	cssClass="closed sidenav-container sidenav-right"
-	id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
->
+<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 	<liferay-ui:breadcrumb
 		showLayout="<%= false %>"
 	/>
@@ -51,42 +48,44 @@ OrganizationsManagementToolbarDisplayContext organizationsManagementToolbarDispl
 	</liferay-frontend:sidebar-panel>
 
 	<div class="sidenav-content">
-		<portlet:actionURL name="deleteGroupOrganizations" var="deleteGroupOrganizationsURL">
-			<portlet:param name="redirect" value="<%= currentURL %>" />
-		</portlet:actionURL>
+		<clay:container-fluid>
+			<portlet:actionURL name="deleteGroupOrganizations" var="deleteGroupOrganizationsURL">
+				<portlet:param name="redirect" value="<%= currentURL %>" />
+			</portlet:actionURL>
 
-		<aui:form action="<%= deleteGroupOrganizationsURL %>" method="post" name="fm">
-			<aui:input name="tabs1" type="hidden" value="organizations" />
-			<aui:input name="groupId" type="hidden" value="<%= String.valueOf(siteMembershipsDisplayContext.getGroupId()) %>" />
+			<aui:form action="<%= deleteGroupOrganizationsURL %>" method="post" name="fm">
+				<aui:input name="tabs1" type="hidden" value="organizations" />
+				<aui:input name="groupId" type="hidden" value="<%= String.valueOf(siteMembershipsDisplayContext.getGroupId()) %>" />
 
-			<liferay-ui:search-container
-				id="organizations"
-				searchContainer="<%= organizationsDisplayContext.getOrganizationSearchContainer() %>"
-			>
-				<liferay-ui:search-container-row
-					className="com.liferay.portal.kernel.model.Organization"
-					escapedModel="<%= true %>"
-					keyProperty="organizationId"
-					modelVar="organization"
+				<liferay-ui:search-container
+					id="organizations"
+					searchContainer="<%= organizationsDisplayContext.getOrganizationSearchContainer() %>"
 				>
+					<liferay-ui:search-container-row
+						className="com.liferay.portal.kernel.model.Organization"
+						escapedModel="<%= true %>"
+						keyProperty="organizationId"
+						modelVar="organization"
+					>
 
-					<%
-					String displayStyle = organizationsDisplayContext.getDisplayStyle();
+						<%
+						String displayStyle = organizationsDisplayContext.getDisplayStyle();
 
-					boolean selectOrganizations = false;
-					%>
+						boolean selectOrganizations = false;
+						%>
 
-					<%@ include file="/organization_columns.jspf" %>
-				</liferay-ui:search-container-row>
+						<%@ include file="/organization_columns.jspf" %>
+					</liferay-ui:search-container-row>
 
-				<liferay-ui:search-iterator
-					displayStyle="<%= organizationsDisplayContext.getDisplayStyle() %>"
-					markupView="lexicon"
-				/>
-			</liferay-ui:search-container>
-		</aui:form>
+					<liferay-ui:search-iterator
+						displayStyle="<%= organizationsDisplayContext.getDisplayStyle() %>"
+						markupView="lexicon"
+					/>
+				</liferay-ui:search-container>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
-</clay:container-fluid>
+</div>
 
 <portlet:actionURL name="addGroupOrganizations" var="addGroupOrganizationsURL">
 	<portlet:param name="redirect" value="<%= currentURL %>" />

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
@@ -35,10 +35,7 @@ Role role = usersDisplayContext.getRole();
 
 <liferay-ui:error embed="<%= false %>" exception="<%= RequiredUserException.class %>" message="one-or-more-users-were-not-removed-since-they-belong-to-a-user-group" />
 
-<clay:container-fluid
-	cssClass="closed sidenav-container sidenav-right"
-	id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
->
+<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/site_memberships/users_info_panel" var="sidebarPanelURL">
 		<portlet:param name="groupId" value="<%= String.valueOf(siteMembershipsDisplayContext.getGroupId()) %>" />
 	</liferay-portlet:resourceURL>
@@ -51,56 +48,58 @@ Role role = usersDisplayContext.getRole();
 	</liferay-frontend:sidebar-panel>
 
 	<div class="sidenav-content">
-		<portlet:actionURL name="deleteGroupUsers" var="deleteGroupUsersURL">
-			<portlet:param name="redirect" value="<%= currentURL %>" />
-		</portlet:actionURL>
+		<clay:container-fluid>
+			<portlet:actionURL name="deleteGroupUsers" var="deleteGroupUsersURL">
+				<portlet:param name="redirect" value="<%= currentURL %>" />
+			</portlet:actionURL>
 
-		<aui:form action="<%= deleteGroupUsersURL %>" cssClass="portlet-site-memberships-users" method="post" name="fm">
-			<aui:input name="tabs1" type="hidden" value="users" />
-			<aui:input name="navigation" type="hidden" value="<%= usersDisplayContext.getNavigation() %>" />
-			<aui:input name="addUserIds" type="hidden" />
-			<aui:input name="roleId" type="hidden" value="<%= (role != null) ? role.getRoleId() : 0 %>" />
+			<aui:form action="<%= deleteGroupUsersURL %>" cssClass="portlet-site-memberships-users" method="post" name="fm">
+				<aui:input name="tabs1" type="hidden" value="users" />
+				<aui:input name="navigation" type="hidden" value="<%= usersDisplayContext.getNavigation() %>" />
+				<aui:input name="addUserIds" type="hidden" />
+				<aui:input name="roleId" type="hidden" value="<%= (role != null) ? role.getRoleId() : 0 %>" />
 
-			<liferay-ui:breadcrumb
-				showLayout="<%= false %>"
-			/>
-
-			<liferay-ui:membership-policy-error />
-
-			<liferay-ui:search-container
-				id="users"
-				searchContainer="<%= usersDisplayContext.getUserSearchContainer() %>"
-			>
-				<liferay-ui:search-container-row
-					className="com.liferay.portal.kernel.model.User"
-					escapedModel="<%= true %>"
-					keyProperty="userId"
-					modelVar="user2"
-					rowIdProperty="screenName"
-				>
-
-					<%
-					String displayStyle = usersDisplayContext.getDisplayStyle();
-
-					boolean selectUsers = false;
-
-					row.setData(
-						HashMapBuilder.<String, Object>put(
-							"actions", usersManagementToolbarDisplayContext.getAvailableActions(user2)
-						).build());
-					%>
-
-					<%@ include file="/user_columns.jspf" %>
-				</liferay-ui:search-container-row>
-
-				<liferay-ui:search-iterator
-					displayStyle="<%= usersDisplayContext.getDisplayStyle() %>"
-					markupView="lexicon"
+				<liferay-ui:breadcrumb
+					showLayout="<%= false %>"
 				/>
-			</liferay-ui:search-container>
-		</aui:form>
+
+				<liferay-ui:membership-policy-error />
+
+				<liferay-ui:search-container
+					id="users"
+					searchContainer="<%= usersDisplayContext.getUserSearchContainer() %>"
+				>
+					<liferay-ui:search-container-row
+						className="com.liferay.portal.kernel.model.User"
+						escapedModel="<%= true %>"
+						keyProperty="userId"
+						modelVar="user2"
+						rowIdProperty="screenName"
+					>
+
+						<%
+						String displayStyle = usersDisplayContext.getDisplayStyle();
+
+						boolean selectUsers = false;
+
+						row.setData(
+							HashMapBuilder.<String, Object>put(
+								"actions", usersManagementToolbarDisplayContext.getAvailableActions(user2)
+							).build());
+						%>
+
+						<%@ include file="/user_columns.jspf" %>
+					</liferay-ui:search-container-row>
+
+					<liferay-ui:search-iterator
+						displayStyle="<%= usersDisplayContext.getDisplayStyle() %>"
+						markupView="lexicon"
+					/>
+				</liferay-ui:search-container>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
-</clay:container-fluid>
+</div>
 
 <portlet:actionURL name="addGroupUsers" var="addGroupUsersURL">
 	<portlet:param name="redirect" value="<%= currentURL %>" />

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
@@ -26,10 +26,7 @@ TrashManagementToolbarDisplayContext trashManagementToolbarDisplayContext = new 
 
 <liferay-util:include page="/restore_path.jsp" servletContext="<%= application %>" />
 
-<clay:container-fluid
-	cssClass="closed sidenav-container sidenav-right"
-	id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
->
+<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/trash/info_panel" var="sidebarPanelURL" />
 
 	<liferay-frontend:sidebar-panel
@@ -40,250 +37,252 @@ TrashManagementToolbarDisplayContext trashManagementToolbarDisplayContext = new 
 	</liferay-frontend:sidebar-panel>
 
 	<div class="sidenav-content">
-		<c:if test="<%= Validator.isNull(trashDisplayContext.getKeywords()) %>">
-			<liferay-site-navigation:breadcrumb
-				breadcrumbEntries="<%= trashDisplayContext.getPortletBreadcrumbEntries() %>"
-			/>
-		</c:if>
+		<clay:container-fluid>
+			<c:if test="<%= Validator.isNull(trashDisplayContext.getKeywords()) %>">
+				<liferay-site-navigation:breadcrumb
+					breadcrumbEntries="<%= trashDisplayContext.getPortletBreadcrumbEntries() %>"
+				/>
+			</c:if>
 
-		<portlet:actionURL name="deleteEntries" var="deleteTrashEntriesURL">
-			<portlet:param name="redirect" value="<%= currentURL %>" />
-		</portlet:actionURL>
+			<portlet:actionURL name="deleteEntries" var="deleteTrashEntriesURL">
+				<portlet:param name="redirect" value="<%= currentURL %>" />
+			</portlet:actionURL>
 
-		<aui:form action="<%= deleteTrashEntriesURL %>" name="fm">
-			<liferay-ui:error exception="<%= RestoreEntryException.class %>">
-
-				<%
-				RestoreEntryException ree = (RestoreEntryException)errorException;
-				%>
-
-				<c:if test="<%= ree.getType() == RestoreEntryException.DUPLICATE %>">
-					<liferay-ui:message key="unable-to-move-this-item-to-the-selected-destination" />
-				</c:if>
-
-				<c:if test="<%= ree.getType() == RestoreEntryException.INVALID_CONTAINER %>">
-					<liferay-ui:message key="the-destination-you-selected-is-an-invalid-container.-please-select-a-different-destination" />
-				</c:if>
-
-				<c:if test="<%= ree.getType() == RestoreEntryException.INVALID_STATUS %>">
-					<liferay-ui:message key="unable-to-restore-this-item" />
-				</c:if>
-			</liferay-ui:error>
-
-			<liferay-ui:error exception="<%= TrashEntryException.class %>" message="unable-to-move-this-item-to-the-recycle-bin" />
-
-			<liferay-ui:error exception="<%= TrashPermissionException.class %>">
-
-				<%
-				TrashPermissionException tpe = (TrashPermissionException)errorException;
-				%>
-
-				<c:if test="<%= tpe.getType() == TrashPermissionException.DELETE %>">
-					<liferay-ui:message key="you-do-not-have-permission-to-delete-this-item" />
-				</c:if>
-
-				<c:if test="<%= tpe.getType() == TrashPermissionException.EMPTY_TRASH %>">
-					<liferay-ui:message key="unable-to-completely-empty-trash-you-do-not-have-permission-to-delete-one-or-more-items" />
-				</c:if>
-
-				<c:if test="<%= tpe.getType() == TrashPermissionException.MOVE %>">
-					<liferay-ui:message key="you-do-not-have-permission-to-move-this-item-to-the-selected-destination" />
-				</c:if>
-
-				<c:if test="<%= tpe.getType() == TrashPermissionException.RESTORE %>">
-					<liferay-ui:message key="you-do-not-have-permission-to-restore-this-item" />
-				</c:if>
-
-				<c:if test="<%= tpe.getType() == TrashPermissionException.RESTORE_OVERWRITE %>">
-					<liferay-ui:message key="you-do-not-have-permission-to-replace-an-existing-item-with-the-selected-one" />
-				</c:if>
-
-				<c:if test="<%= tpe.getType() == TrashPermissionException.RESTORE_RENAME %>">
-					<liferay-ui:message key="you-do-not-have-permission-to-rename-this-item" />
-				</c:if>
-			</liferay-ui:error>
-
-			<liferay-ui:search-container
-				id="trash"
-				searchContainer="<%= trashDisplayContext.getEntrySearch() %>"
-			>
-				<liferay-ui:search-container-row
-					className="com.liferay.trash.model.TrashEntry"
-					keyProperty="entryId"
-					modelVar="trashEntry"
-					rowVar="row"
-				>
+			<aui:form action="<%= deleteTrashEntriesURL %>" name="fm">
+				<liferay-ui:error exception="<%= RestoreEntryException.class %>">
 
 					<%
-					TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(trashEntry.getClassName());
-
-					TrashRenderer trashRenderer = trashHandler.getTrashRenderer(trashEntry.getClassPK());
-
-					String viewContentURLString = null;
-
-					if (trashRenderer != null) {
-						PortletURL viewContentURL = renderResponse.createRenderURL();
-
-						viewContentURL.setParameter("mvcPath", "/view_content.jsp");
-
-						if (trashEntry.getRootEntry() != null) {
-							viewContentURL.setParameter("classNameId", String.valueOf(trashEntry.getClassNameId()));
-							viewContentURL.setParameter("classPK", String.valueOf(trashEntry.getClassPK()));
-						}
-						else {
-							viewContentURL.setParameter("trashEntryId", String.valueOf(trashEntry.getEntryId()));
-						}
-
-						viewContentURLString = viewContentURL.toString();
-					}
-
-					row.setData(
-						HashMapBuilder.<String, Object>put(
-							"actions", trashManagementToolbarDisplayContext.getAvailableActions(trashEntry)
-						).build());
+					RestoreEntryException ree = (RestoreEntryException)errorException;
 					%>
 
-					<c:choose>
-						<c:when test="<%= trashDisplayContext.isDescriptiveView() %>">
-							<liferay-ui:search-container-column-icon
-								icon="<%= trashRenderer.getIconCssClass() %>"
-								toggleRowChecker="<%= true %>"
-							/>
+					<c:if test="<%= ree.getType() == RestoreEntryException.DUPLICATE %>">
+						<liferay-ui:message key="unable-to-move-this-item-to-the-selected-destination" />
+					</c:if>
 
-							<liferay-ui:search-container-column-text
-								colspan="<%= 2 %>"
-							>
-								<h6 class="text-default">
-									<liferay-ui:message arguments="<%= dateFormatDateTime.format(trashEntry.getCreateDate()) %>" key="removed-x" />
-								</h6>
+					<c:if test="<%= ree.getType() == RestoreEntryException.INVALID_CONTAINER %>">
+						<liferay-ui:message key="the-destination-you-selected-is-an-invalid-container.-please-select-a-different-destination" />
+					</c:if>
 
-								<h5>
+					<c:if test="<%= ree.getType() == RestoreEntryException.INVALID_STATUS %>">
+						<liferay-ui:message key="unable-to-restore-this-item" />
+					</c:if>
+				</liferay-ui:error>
+
+				<liferay-ui:error exception="<%= TrashEntryException.class %>" message="unable-to-move-this-item-to-the-recycle-bin" />
+
+				<liferay-ui:error exception="<%= TrashPermissionException.class %>">
+
+					<%
+					TrashPermissionException tpe = (TrashPermissionException)errorException;
+					%>
+
+					<c:if test="<%= tpe.getType() == TrashPermissionException.DELETE %>">
+						<liferay-ui:message key="you-do-not-have-permission-to-delete-this-item" />
+					</c:if>
+
+					<c:if test="<%= tpe.getType() == TrashPermissionException.EMPTY_TRASH %>">
+						<liferay-ui:message key="unable-to-completely-empty-trash-you-do-not-have-permission-to-delete-one-or-more-items" />
+					</c:if>
+
+					<c:if test="<%= tpe.getType() == TrashPermissionException.MOVE %>">
+						<liferay-ui:message key="you-do-not-have-permission-to-move-this-item-to-the-selected-destination" />
+					</c:if>
+
+					<c:if test="<%= tpe.getType() == TrashPermissionException.RESTORE %>">
+						<liferay-ui:message key="you-do-not-have-permission-to-restore-this-item" />
+					</c:if>
+
+					<c:if test="<%= tpe.getType() == TrashPermissionException.RESTORE_OVERWRITE %>">
+						<liferay-ui:message key="you-do-not-have-permission-to-replace-an-existing-item-with-the-selected-one" />
+					</c:if>
+
+					<c:if test="<%= tpe.getType() == TrashPermissionException.RESTORE_RENAME %>">
+						<liferay-ui:message key="you-do-not-have-permission-to-rename-this-item" />
+					</c:if>
+				</liferay-ui:error>
+
+				<liferay-ui:search-container
+					id="trash"
+					searchContainer="<%= trashDisplayContext.getEntrySearch() %>"
+				>
+					<liferay-ui:search-container-row
+						className="com.liferay.trash.model.TrashEntry"
+						keyProperty="entryId"
+						modelVar="trashEntry"
+						rowVar="row"
+					>
+
+						<%
+						TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(trashEntry.getClassName());
+
+						TrashRenderer trashRenderer = trashHandler.getTrashRenderer(trashEntry.getClassPK());
+
+						String viewContentURLString = null;
+
+						if (trashRenderer != null) {
+							PortletURL viewContentURL = renderResponse.createRenderURL();
+
+							viewContentURL.setParameter("mvcPath", "/view_content.jsp");
+
+							if (trashEntry.getRootEntry() != null) {
+								viewContentURL.setParameter("classNameId", String.valueOf(trashEntry.getClassNameId()));
+								viewContentURL.setParameter("classPK", String.valueOf(trashEntry.getClassPK()));
+							}
+							else {
+								viewContentURL.setParameter("trashEntryId", String.valueOf(trashEntry.getEntryId()));
+							}
+
+							viewContentURLString = viewContentURL.toString();
+						}
+
+						row.setData(
+							HashMapBuilder.<String, Object>put(
+								"actions", trashManagementToolbarDisplayContext.getAvailableActions(trashEntry)
+							).build());
+						%>
+
+						<c:choose>
+							<c:when test="<%= trashDisplayContext.isDescriptiveView() %>">
+								<liferay-ui:search-container-column-icon
+									icon="<%= trashRenderer.getIconCssClass() %>"
+									toggleRowChecker="<%= true %>"
+								/>
+
+								<liferay-ui:search-container-column-text
+									colspan="<%= 2 %>"
+								>
+									<h6 class="text-default">
+										<liferay-ui:message arguments="<%= dateFormatDateTime.format(trashEntry.getCreateDate()) %>" key="removed-x" />
+									</h6>
+
+									<h5>
+										<aui:a href="<%= viewContentURLString %>">
+											<%= HtmlUtil.escape(trashRenderer.getTitle(locale)) %>
+										</aui:a>
+									</h5>
+
+									<h6 class="text-default">
+										<strong><liferay-ui:message key="type" />:</strong> <%= ResourceActionsUtil.getModelResource(locale, trashEntry.getClassName()) %>
+									</h6>
+								</liferay-ui:search-container-column-text>
+
+								<liferay-ui:search-container-column-text>
+									<c:choose>
+										<c:when test="<%= trashEntry.getRootEntry() == null %>">
+											<clay:dropdown-actions
+												defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
+												dropdownItems="<%= trashDisplayContext.getTrashEntryActionDropdownItems(trashEntry) %>"
+											/>
+										</c:when>
+										<c:otherwise>
+											<clay:dropdown-actions
+												defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
+												dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(trashRenderer.getClassName(), trashRenderer.getClassPK()) %>"
+											/>
+										</c:otherwise>
+									</c:choose>
+								</liferay-ui:search-container-column-text>
+							</c:when>
+							<c:when test="<%= trashDisplayContext.isIconView() %>">
+								<liferay-ui:search-container-column-text>
+									<clay:vertical-card
+										verticalCard="<%= new TrashEntryVerticalCard(trashEntry, trashRenderer, liferayPortletResponse, renderRequest, searchContainer.getRowChecker(), viewContentURLString) %>"
+									/>
+								</liferay-ui:search-container-column-text>
+							</c:when>
+							<c:when test="<%= trashDisplayContext.isListView() %>">
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand table-cell-minw-200 table-title"
+									name="name"
+								>
 									<aui:a href="<%= viewContentURLString %>">
 										<%= HtmlUtil.escape(trashRenderer.getTitle(locale)) %>
 									</aui:a>
-								</h5>
 
-								<h6 class="text-default">
-									<strong><liferay-ui:message key="type" />:</strong> <%= ResourceActionsUtil.getModelResource(locale, trashEntry.getClassName()) %>
-								</h6>
-							</liferay-ui:search-container-column-text>
+									<c:if test="<%= trashEntry.getRootEntry() != null %>">
 
-							<liferay-ui:search-container-column-text>
-								<c:choose>
-									<c:when test="<%= trashEntry.getRootEntry() == null %>">
-										<clay:dropdown-actions
-											defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
-											dropdownItems="<%= trashDisplayContext.getTrashEntryActionDropdownItems(trashEntry) %>"
-										/>
-									</c:when>
-									<c:otherwise>
-										<clay:dropdown-actions
-											defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
-											dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(trashRenderer.getClassName(), trashRenderer.getClassPK()) %>"
-										/>
-									</c:otherwise>
-								</c:choose>
-							</liferay-ui:search-container-column-text>
-						</c:when>
-						<c:when test="<%= trashDisplayContext.isIconView() %>">
-							<liferay-ui:search-container-column-text>
-								<clay:vertical-card
-									verticalCard="<%= new TrashEntryVerticalCard(trashEntry, trashRenderer, liferayPortletResponse, renderRequest, searchContainer.getRowChecker(), viewContentURLString) %>"
+										<%
+										TrashEntry rootEntry = trashEntry.getRootEntry();
+
+										TrashHandler rootTrashHandler = TrashHandlerRegistryUtil.getTrashHandler(rootEntry.getClassName());
+
+										TrashRenderer rootTrashRenderer = rootTrashHandler.getTrashRenderer(rootEntry.getClassPK());
+
+										String viewRootContentURLString = null;
+
+										if (rootTrashRenderer != null) {
+											PortletURL viewContentURL = renderResponse.createRenderURL();
+
+											viewContentURL.setParameter("mvcPath", "/view_content.jsp");
+											viewContentURL.setParameter("trashEntryId", String.valueOf(rootEntry.getEntryId()));
+
+											viewRootContentURLString = viewContentURL.toString();
+										}
+										%>
+
+										<liferay-util:buffer
+											var="rootEntryIcon"
+										>
+											<liferay-ui:icon
+												label="<%= true %>"
+												message="<%= HtmlUtil.escape(rootTrashRenderer.getTitle(locale)) %>"
+												method="get"
+												url="<%= viewRootContentURLString %>"
+											/>
+										</liferay-util:buffer>
+
+										<span class="trash-root-entry">(<liferay-ui:message arguments="<%= rootEntryIcon %>" key="<%= rootTrashHandler.getDeleteMessage() %>" translateArguments="<%= false %>" />)</span>
+									</c:if>
+								</liferay-ui:search-container-column-text>
+
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand-smaller table-cell-minw-150"
+									name="type"
+									value="<%= ResourceActionsUtil.getModelResource(locale, trashEntry.getClassName()) %>"
 								/>
-							</liferay-ui:search-container-column-text>
-						</c:when>
-						<c:when test="<%= trashDisplayContext.isListView() %>">
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand table-cell-minw-200 table-title"
-								name="name"
-							>
-								<aui:a href="<%= viewContentURLString %>">
-									<%= HtmlUtil.escape(trashRenderer.getTitle(locale)) %>
-								</aui:a>
 
-								<c:if test="<%= trashEntry.getRootEntry() != null %>">
+								<liferay-ui:search-container-column-date
+									cssClass="table-cell-expand-smaller table-cell-ws-nowrap"
+									name="removed-date"
+									value="<%= trashEntry.getCreateDate() %>"
+								/>
 
-									<%
-									TrashEntry rootEntry = trashEntry.getRootEntry();
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand-smallest table-cell-minw-150"
+									name="removed-by"
+									value="<%= HtmlUtil.escape(trashEntry.getUserName()) %>"
+								/>
 
-									TrashHandler rootTrashHandler = TrashHandlerRegistryUtil.getTrashHandler(rootEntry.getClassName());
+								<liferay-ui:search-container-column-text>
+									<c:choose>
+										<c:when test="<%= trashEntry.getRootEntry() == null %>">
+											<clay:dropdown-actions
+												defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
+												dropdownItems="<%= trashDisplayContext.getTrashEntryActionDropdownItems(trashEntry) %>"
+											/>
+										</c:when>
+										<c:otherwise>
+											<clay:dropdown-actions
+												defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
+												dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(trashRenderer.getClassName(), trashRenderer.getClassPK()) %>"
+											/>
+										</c:otherwise>
+									</c:choose>
+								</liferay-ui:search-container-column-text>
+							</c:when>
+						</c:choose>
+					</liferay-ui:search-container-row>
 
-									TrashRenderer rootTrashRenderer = rootTrashHandler.getTrashRenderer(rootEntry.getClassPK());
-
-									String viewRootContentURLString = null;
-
-									if (rootTrashRenderer != null) {
-										PortletURL viewContentURL = renderResponse.createRenderURL();
-
-										viewContentURL.setParameter("mvcPath", "/view_content.jsp");
-										viewContentURL.setParameter("trashEntryId", String.valueOf(rootEntry.getEntryId()));
-
-										viewRootContentURLString = viewContentURL.toString();
-									}
-									%>
-
-									<liferay-util:buffer
-										var="rootEntryIcon"
-									>
-										<liferay-ui:icon
-											label="<%= true %>"
-											message="<%= HtmlUtil.escape(rootTrashRenderer.getTitle(locale)) %>"
-											method="get"
-											url="<%= viewRootContentURLString %>"
-										/>
-									</liferay-util:buffer>
-
-									<span class="trash-root-entry">(<liferay-ui:message arguments="<%= rootEntryIcon %>" key="<%= rootTrashHandler.getDeleteMessage() %>" translateArguments="<%= false %>" />)</span>
-								</c:if>
-							</liferay-ui:search-container-column-text>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand-smaller table-cell-minw-150"
-								name="type"
-								value="<%= ResourceActionsUtil.getModelResource(locale, trashEntry.getClassName()) %>"
-							/>
-
-							<liferay-ui:search-container-column-date
-								cssClass="table-cell-expand-smaller table-cell-ws-nowrap"
-								name="removed-date"
-								value="<%= trashEntry.getCreateDate() %>"
-							/>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand-smallest table-cell-minw-150"
-								name="removed-by"
-								value="<%= HtmlUtil.escape(trashEntry.getUserName()) %>"
-							/>
-
-							<liferay-ui:search-container-column-text>
-								<c:choose>
-									<c:when test="<%= trashEntry.getRootEntry() == null %>">
-										<clay:dropdown-actions
-											defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
-											dropdownItems="<%= trashDisplayContext.getTrashEntryActionDropdownItems(trashEntry) %>"
-										/>
-									</c:when>
-									<c:otherwise>
-										<clay:dropdown-actions
-											defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
-											dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(trashRenderer.getClassName(), trashRenderer.getClassPK()) %>"
-										/>
-									</c:otherwise>
-								</c:choose>
-							</liferay-ui:search-container-column-text>
-						</c:when>
-					</c:choose>
-				</liferay-ui:search-container-row>
-
-				<liferay-ui:search-iterator
-					displayStyle="<%= trashDisplayContext.getDisplayStyle() %>"
-					markupView="lexicon"
-					type='<%= trashDisplayContext.isApproximate() ? "more" : "regular" %>'
-				/>
-			</liferay-ui:search-container>
-		</aui:form>
+					<liferay-ui:search-iterator
+						displayStyle="<%= trashDisplayContext.getDisplayStyle() %>"
+						markupView="lexicon"
+						type='<%= trashDisplayContext.isApproximate() ? "more" : "regular" %>'
+					/>
+				</liferay-ui:search-container>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
-</clay:container-fluid>
+</div>
 
 <liferay-frontend:component
 	componentId="<%= trashManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -28,10 +28,7 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 			displayContext="<%= new TrashContainerManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, trashDisplayContext) %>"
 		/>
 
-		<clay:container-fluid
-			cssClass="closed sidenav-container sidenav-right"
-			id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
-		>
+		<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 			<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/trash/info_panel" var="sidebarPanelURL" />
 
 			<liferay-frontend:sidebar-panel
@@ -41,114 +38,116 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 			</liferay-frontend:sidebar-panel>
 
 			<div class="sidenav-content">
-				<liferay-site-navigation:breadcrumb
-					breadcrumbEntries="<%= trashDisplayContext.getBaseModelBreadcrumbEntries() %>"
-				/>
+				<clay:container-fluid>
+					<liferay-site-navigation:breadcrumb
+						breadcrumbEntries="<%= trashDisplayContext.getBaseModelBreadcrumbEntries() %>"
+					/>
 
-				<liferay-ui:search-container
-					id="trash"
-					searchContainer="<%= trashDisplayContext.getTrashContainerSearchContainer() %>"
-				>
-					<liferay-ui:search-container-row
-						className="com.liferay.portal.kernel.model.TrashedModel"
-						modelVar="curTrashedModel"
+					<liferay-ui:search-container
+						id="trash"
+						searchContainer="<%= trashDisplayContext.getTrashContainerSearchContainer() %>"
 					>
+						<liferay-ui:search-container-row
+							className="com.liferay.portal.kernel.model.TrashedModel"
+							modelVar="curTrashedModel"
+						>
 
-						<%
-						ClassedModel classedModel = (ClassedModel)curTrashedModel;
+							<%
+							ClassedModel classedModel = (ClassedModel)curTrashedModel;
 
-						String modelClassName = classedModel.getModelClassName();
+							String modelClassName = classedModel.getModelClassName();
 
-						TrashHandler curTrashHandler = TrashHandlerRegistryUtil.getTrashHandler(modelClassName);
+							TrashHandler curTrashHandler = TrashHandlerRegistryUtil.getTrashHandler(modelClassName);
 
-						TrashRenderer curTrashRenderer = curTrashHandler.getTrashRenderer(curTrashedModel.getTrashEntryClassPK());
+							TrashRenderer curTrashRenderer = curTrashHandler.getTrashRenderer(curTrashedModel.getTrashEntryClassPK());
 
-						PortletURL rowURL = renderResponse.createRenderURL();
+							PortletURL rowURL = renderResponse.createRenderURL();
 
-						rowURL.setParameter("mvcPath", "/view_content.jsp");
-						rowURL.setParameter("classNameId", String.valueOf(PortalUtil.getClassNameId(curTrashRenderer.getClassName())));
-						rowURL.setParameter("classPK", String.valueOf(curTrashRenderer.getClassPK()));
-						%>
+							rowURL.setParameter("mvcPath", "/view_content.jsp");
+							rowURL.setParameter("classNameId", String.valueOf(PortalUtil.getClassNameId(curTrashRenderer.getClassName())));
+							rowURL.setParameter("classPK", String.valueOf(curTrashRenderer.getClassPK()));
+							%>
 
-						<c:choose>
-							<c:when test="<%= trashDisplayContext.isDescriptiveView() %>">
-								<liferay-ui:search-container-column-icon
-									icon="<%= curTrashRenderer.getIconCssClass() %>"
-									toggleRowChecker="<%= false %>"
-								/>
+							<c:choose>
+								<c:when test="<%= trashDisplayContext.isDescriptiveView() %>">
+									<liferay-ui:search-container-column-icon
+										icon="<%= curTrashRenderer.getIconCssClass() %>"
+										toggleRowChecker="<%= false %>"
+									/>
 
-								<liferay-ui:search-container-column-text
-									colspan="<%= 2 %>"
-								>
-									<h5>
+									<liferay-ui:search-container-column-text
+										colspan="<%= 2 %>"
+									>
+										<h5>
+											<aui:a href="<%= rowURL.toString() %>">
+												<%= HtmlUtil.escape(curTrashRenderer.getTitle(locale)) %>
+											</aui:a>
+										</h5>
+
+										<h6 class="text-default">
+											<liferay-ui:message key="type" /> <%= ResourceActionsUtil.getModelResource(locale, curTrashRenderer.getClassName()) %>
+										</h6>
+									</liferay-ui:search-container-column-text>
+
+									<liferay-ui:search-container-column-text>
+										<clay:dropdown-actions
+											defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
+											dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(modelClassName, curTrashedModel.getTrashEntryClassPK()) %>"
+										/>
+									</liferay-ui:search-container-column-text>
+								</c:when>
+								<c:when test="<%= trashDisplayContext.isIconView() %>">
+									<c:choose>
+										<c:when test="<%= !curTrashHandler.isContainerModel() %>">
+											<liferay-ui:search-container-column-text>
+												<clay:vertical-card
+													verticalCard="<%= new TrashContentVerticalCard(curTrashedModel, curTrashRenderer, liferayPortletResponse, renderRequest, rowURL.toString()) %>"
+												/>
+											</liferay-ui:search-container-column-text>
+										</c:when>
+										<c:otherwise>
+											<liferay-ui:search-container-column-text>
+
+												<%
+												row.setCssClass("card-page-item card-page-item-directory");
+												%>
+
+												<clay:horizontal-card
+													horizontalCard="<%= new TrashContentHorizontalCard(curTrashedModel, curTrashRenderer, liferayPortletResponse, renderRequest, rowURL.toString()) %>"
+												/>
+											</liferay-ui:search-container-column-text>
+										</c:otherwise>
+									</c:choose>
+								</c:when>
+								<c:when test="<%= trashDisplayContext.isListView() %>">
+									<liferay-ui:search-container-column-text
+										name="name"
+										truncate="<%= true %>"
+									>
 										<aui:a href="<%= rowURL.toString() %>">
 											<%= HtmlUtil.escape(curTrashRenderer.getTitle(locale)) %>
 										</aui:a>
-									</h5>
+									</liferay-ui:search-container-column-text>
 
-									<h6 class="text-default">
-										<liferay-ui:message key="type" /> <%= ResourceActionsUtil.getModelResource(locale, curTrashRenderer.getClassName()) %>
-									</h6>
-								</liferay-ui:search-container-column-text>
+									<liferay-ui:search-container-column-text>
+										<clay:dropdown-actions
+											defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
+											dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(modelClassName, curTrashedModel.getTrashEntryClassPK()) %>"
+										/>
+									</liferay-ui:search-container-column-text>
+								</c:when>
+							</c:choose>
+						</liferay-ui:search-container-row>
 
-								<liferay-ui:search-container-column-text>
-									<clay:dropdown-actions
-										defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
-										dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(modelClassName, curTrashedModel.getTrashEntryClassPK()) %>"
-									/>
-								</liferay-ui:search-container-column-text>
-							</c:when>
-							<c:when test="<%= trashDisplayContext.isIconView() %>">
-								<c:choose>
-									<c:when test="<%= !curTrashHandler.isContainerModel() %>">
-										<liferay-ui:search-container-column-text>
-											<clay:vertical-card
-												verticalCard="<%= new TrashContentVerticalCard(curTrashedModel, curTrashRenderer, liferayPortletResponse, renderRequest, rowURL.toString()) %>"
-											/>
-										</liferay-ui:search-container-column-text>
-									</c:when>
-									<c:otherwise>
-										<liferay-ui:search-container-column-text>
-
-											<%
-											row.setCssClass("card-page-item card-page-item-directory");
-											%>
-
-											<clay:horizontal-card
-												horizontalCard="<%= new TrashContentHorizontalCard(curTrashedModel, curTrashRenderer, liferayPortletResponse, renderRequest, rowURL.toString()) %>"
-											/>
-										</liferay-ui:search-container-column-text>
-									</c:otherwise>
-								</c:choose>
-							</c:when>
-							<c:when test="<%= trashDisplayContext.isListView() %>">
-								<liferay-ui:search-container-column-text
-									name="name"
-									truncate="<%= true %>"
-								>
-									<aui:a href="<%= rowURL.toString() %>">
-										<%= HtmlUtil.escape(curTrashRenderer.getTitle(locale)) %>
-									</aui:a>
-								</liferay-ui:search-container-column-text>
-
-								<liferay-ui:search-container-column-text>
-									<clay:dropdown-actions
-										defaultEventHandler="<%= TrashWebKeys.TRASH_ENTRIES_DEFAULT_EVENT_HANDLER %>"
-										dropdownItems="<%= trashDisplayContext.getTrashViewContentActionDropdownItems(modelClassName, curTrashedModel.getTrashEntryClassPK()) %>"
-									/>
-								</liferay-ui:search-container-column-text>
-							</c:when>
-						</c:choose>
-					</liferay-ui:search-container-row>
-
-					<liferay-ui:search-iterator
-						displayStyle="<%= trashDisplayContext.getDisplayStyle() %>"
-						markupView="lexicon"
-						resultRowSplitter="<%= new TrashResultRowSplitter() %>"
-					/>
-				</liferay-ui:search-container>
+						<liferay-ui:search-iterator
+							displayStyle="<%= trashDisplayContext.getDisplayStyle() %>"
+							markupView="lexicon"
+							resultRowSplitter="<%= new TrashResultRowSplitter() %>"
+						/>
+					</liferay-ui:search-container>
+				</clay:container-fluid>
 			</div>
-		</clay:container-fluid>
+		</div>
 	</c:when>
 	<c:otherwise>
 

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
@@ -70,10 +70,7 @@ long[] groupIds = viewUADEntitiesDisplay.getGroupIds();
 		</c:otherwise>
 	</c:choose>
 
-	<clay:container-fluid
-		cssClass="closed sidenav-container sidenav-right"
-		id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
-	>
+	<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 		<div id="breadcrumb">
 			<liferay-ui:breadcrumb
 				showCurrentGroup="<%= false %>"
@@ -102,83 +99,85 @@ long[] groupIds = viewUADEntitiesDisplay.getGroupIds();
 		</c:if>
 
 		<div class="sidenav-content">
-			<liferay-ui:search-container
-				searchContainer="<%= viewUADEntitiesDisplay.getSearchContainer() %>"
-			>
-				<liferay-ui:search-container-row
-					className="com.liferay.user.associated.data.web.internal.display.UADEntity"
-					escapedModel="<%= true %>"
-					keyProperty="primaryKey"
-					modelVar="uadEntity"
+			<clay:container-fluid>
+				<liferay-ui:search-container
+					searchContainer="<%= viewUADEntitiesDisplay.getSearchContainer() %>"
 				>
+					<liferay-ui:search-container-row
+						className="com.liferay.user.associated.data.web.internal.display.UADEntity"
+						escapedModel="<%= true %>"
+						keyProperty="primaryKey"
+						modelVar="uadEntity"
+					>
 
-					<%
-					List<KeyValuePair> columnEntries = uadEntity.getColumnEntries();
+						<%
+						List<KeyValuePair> columnEntries = uadEntity.getColumnEntries();
 
-					String uadEntityHref = uadEntity.getViewURL();
+						String uadEntityHref = uadEntity.getViewURL();
 
-					if (uadEntityHref == null) {
-						uadEntityHref = uadEntity.getEditURL();
-					}
-
-					boolean showUserIcon = false;
-
-					if ((uadEntity.getViewURL() != null) && !uadEntity.isUserOwned()) {
-						showUserIcon = true;
-					}
-
-					for (KeyValuePair columnEntry : columnEntries) {
-						String columnEntryKey = columnEntry.getKey();
-
-						String cssClass = "table-cell-expand";
-
-						if (columnEntry.equals(columnEntries.get(0))) {
-							cssClass = "table-cell-expand table-list-title";
+						if (uadEntityHref == null) {
+							uadEntityHref = uadEntity.getEditURL();
 						}
-					%>
 
-						<liferay-ui:search-container-column-text
-							cssClass="<%= cssClass %>"
-							name="<%= columnEntryKey %>"
-						>
-							<aui:a href="<%= uadEntityHref %>"><%= StringUtil.shorten(columnEntry.getValue(), 200) %></aui:a>
+						boolean showUserIcon = false;
 
-							<c:if test='<%= columnEntryKey.equals("name") || columnEntryKey.equals("title") %>'>
-								<c:if test="<%= uadEntity.isInTrash() %>">
-									<clay:label
-										label="in-trash"
-									/>
+						if ((uadEntity.getViewURL() != null) && !uadEntity.isUserOwned()) {
+							showUserIcon = true;
+						}
+
+						for (KeyValuePair columnEntry : columnEntries) {
+							String columnEntryKey = columnEntry.getKey();
+
+							String cssClass = "table-cell-expand";
+
+							if (columnEntry.equals(columnEntries.get(0))) {
+								cssClass = "table-cell-expand table-list-title";
+							}
+						%>
+
+							<liferay-ui:search-container-column-text
+								cssClass="<%= cssClass %>"
+								name="<%= columnEntryKey %>"
+							>
+								<aui:a href="<%= uadEntityHref %>"><%= StringUtil.shorten(columnEntry.getValue(), 200) %></aui:a>
+
+								<c:if test='<%= columnEntryKey.equals("name") || columnEntryKey.equals("title") %>'>
+									<c:if test="<%= uadEntity.isInTrash() %>">
+										<clay:label
+											label="in-trash"
+										/>
+									</c:if>
+
+									<c:if test="<%= showUserIcon %>">
+										<liferay-ui:icon
+											cssClass="disabled"
+											icon="user"
+											markupView="lexicon"
+											message="this-parent-item-does-not-belong-to-the-user-but-contains-children-items-belonging-to-the-user"
+											toolTip="<%= true %>"
+										/>
+									</c:if>
 								</c:if>
+							</liferay-ui:search-container-column-text>
 
-								<c:if test="<%= showUserIcon %>">
-									<liferay-ui:icon
-										cssClass="disabled"
-										icon="user"
-										markupView="lexicon"
-										message="this-parent-item-does-not-belong-to-the-user-but-contains-children-items-belonging-to-the-user"
-										toolTip="<%= true %>"
-									/>
-								</c:if>
-							</c:if>
-						</liferay-ui:search-container-column-text>
+						<%
+						}
+						%>
 
-					<%
-					}
-					%>
+						<liferay-ui:search-container-column-jsp
+							cssClass="entry-action-column"
+							path="/uad_entity_action.jsp"
+						/>
+					</liferay-ui:search-container-row>
 
-					<liferay-ui:search-container-column-jsp
-						cssClass="entry-action-column"
-						path="/uad_entity_action.jsp"
+					<liferay-ui:search-iterator
+						markupView="lexicon"
+						resultRowSplitter="<%= viewUADEntitiesDisplay.getResultRowSplitter() %>"
 					/>
-				</liferay-ui:search-container-row>
-
-				<liferay-ui:search-iterator
-					markupView="lexicon"
-					resultRowSplitter="<%= viewUADEntitiesDisplay.getResultRowSplitter() %>"
-				/>
-			</liferay-ui:search-container>
+				</liferay-ui:search-container>
+			</clay:container-fluid>
 		</div>
-	</clay:container-fluid>
+	</div>
 </aui:form>
 
 <aui:script>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
@@ -149,7 +149,7 @@ if (portletTitleBasedNavigation) {
 	</c:if>
 
 	<div class="sidenav-content">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container-fluid>
 			<div <%= portletTitleBasedNavigation ? "class=\"panel main-content-card\"" : StringPool.BLANK %>>
 				<div <%= portletTitleBasedNavigation ? "class=\"panel-body\"" : StringPool.BLANK %>>
 					<c:if test="<%= !portletTitleBasedNavigation %>">
@@ -485,6 +485,6 @@ if (portletTitleBasedNavigation) {
 					</ul>
 				</div>
 			</c:if>
-		</div>
+		</clay:container-fluid>
 	</div>
 </div>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view.jsp
@@ -93,10 +93,7 @@ WikiNodesManagementToolbarDisplayContext wikiNodesManagementToolbarDisplayContex
 	viewTypeItems="<%= wikiNodesManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
-<clay:container-fluid
-	cssClass="closed sidenav-container sidenav-right"
-	id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
->
+<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/wiki/node_info_panel" var="sidebarPanelURL" />
 
 	<liferay-frontend:sidebar-panel
@@ -112,123 +109,127 @@ WikiNodesManagementToolbarDisplayContext wikiNodesManagementToolbarDisplayContex
 	</liferay-frontend:sidebar-panel>
 
 	<div class="sidenav-content">
+		<clay:container-fluid
+			cssClass="container-view"
+		>
 
-		<%
-		PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "wiki"), portletURL.toString());
-		%>
+			<%
+			PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "wiki"), portletURL.toString());
+			%>
 
-		<liferay-ui:breadcrumb
-			showCurrentGroup="<%= false %>"
-			showGuestGroup="<%= false %>"
-			showLayout="<%= false %>"
-			showParentGroups="<%= false %>"
-		/>
+			<liferay-ui:breadcrumb
+				showCurrentGroup="<%= false %>"
+				showGuestGroup="<%= false %>"
+				showLayout="<%= false %>"
+				showParentGroups="<%= false %>"
+			/>
 
-		<liferay-trash:undo
-			portletURL="<%= restoreTrashEntriesURL %>"
-		/>
+			<liferay-trash:undo
+				portletURL="<%= restoreTrashEntriesURL %>"
+			/>
 
-		<liferay-ui:error exception="<%= RequiredNodeException.class %>" message="the-last-main-node-is-required-and-cannot-be-deleted" />
+			<liferay-ui:error exception="<%= RequiredNodeException.class %>" message="the-last-main-node-is-required-and-cannot-be-deleted" />
 
-		<aui:form action="<%= wikiURLHelper.getSearchURL() %>" method="get" name="fm">
-			<aui:input name="<%= Constants.CMD %>" type="hidden" />
-			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+			<aui:form action="<%= wikiURLHelper.getSearchURL() %>" method="get" name="fm">
+				<aui:input name="<%= Constants.CMD %>" type="hidden" />
+				<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
-			<liferay-ui:search-container
-				id="wikiNodes"
-				searchContainer="<%= wikiNodesSearchContainer %>"
-				total="<%= wikiNodesSearchContainer.getTotal() %>"
-			>
-				<liferay-ui:search-container-row
-					className="com.liferay.wiki.model.WikiNode"
-					keyProperty="nodeId"
-					modelVar="node"
+				<liferay-ui:search-container
+					id="wikiNodes"
+					searchContainer="<%= wikiNodesSearchContainer %>"
+					total="<%= wikiNodesSearchContainer.getTotal() %>"
 				>
+					<liferay-ui:search-container-row
+						className="com.liferay.wiki.model.WikiNode"
+						keyProperty="nodeId"
+						modelVar="node"
+					>
 
-					<%
-					row.setData(
-						HashMapBuilder.<String, Object>put(
-							"actions", StringUtil.merge(wikiNodesManagementToolbarDisplayContext.getAvailableActions(node))
-						).build());
+						<%
+						row.setData(
+							HashMapBuilder.<String, Object>put(
+								"actions", StringUtil.merge(wikiNodesManagementToolbarDisplayContext.getAvailableActions(node))
+							).build());
 
-					PortletURL rowURL = renderResponse.createRenderURL();
+						PortletURL rowURL = renderResponse.createRenderURL();
 
-					rowURL.setParameter("mvcRenderCommandName", "/wiki/view_pages");
-					rowURL.setParameter("navigation", "all-pages");
-					rowURL.setParameter("redirect", currentURL);
-					rowURL.setParameter("nodeId", String.valueOf(node.getNodeId()));
-					%>
+						rowURL.setParameter("mvcRenderCommandName", "/wiki/view_pages");
+						rowURL.setParameter("navigation", "all-pages");
+						rowURL.setParameter("redirect", currentURL);
+						rowURL.setParameter("nodeId", String.valueOf(node.getNodeId()));
+						%>
 
-					<c:choose>
-						<c:when test='<%= displayStyle.equals("descriptive") %>'>
-							<liferay-ui:search-container-column-icon
-								icon="wiki"
-								toggleRowChecker="<%= true %>"
-							/>
+						<c:choose>
+							<c:when test='<%= displayStyle.equals("descriptive") %>'>
+								<liferay-ui:search-container-column-icon
+									icon="wiki"
+									toggleRowChecker="<%= true %>"
+								/>
 
-							<liferay-ui:search-container-column-text
-								colspan="<%= 2 %>"
-							>
-								<p class="h5">
-									<aui:a href="<%= rowURL.toString() %>">
-										<%= HtmlUtil.escape(node.getName()) %>
-									</aui:a>
-								</p>
+								<liferay-ui:search-container-column-text
+									colspan="<%= 2 %>"
+								>
+									<p class="h5">
+										<aui:a href="<%= rowURL.toString() %>">
+											<%= HtmlUtil.escape(node.getName()) %>
+										</aui:a>
+									</p>
 
-								<%
-								Date lastPostDate = node.getLastPostDate();
-								%>
+									<%
+									Date lastPostDate = node.getLastPostDate();
+									%>
 
-								<c:if test="<%= lastPostDate != null %>">
+									<c:if test="<%= lastPostDate != null %>">
+										<span class="text-default">
+											<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - lastPostDate.getTime(), true) %>" key="last-post-x-ago" />
+										</span>
+									</c:if>
+
 									<span class="text-default">
-										<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - lastPostDate.getTime(), true) %>" key="last-post-x-ago" />
+										<liferay-ui:message arguments="<%= String.valueOf(WikiPageServiceUtil.getPagesCount(scopeGroupId, node.getNodeId(), true)) %>" key="x-pages" />
 									</span>
-								</c:if>
+								</liferay-ui:search-container-column-text>
 
-								<span class="text-default">
-									<liferay-ui:message arguments="<%= String.valueOf(WikiPageServiceUtil.getPagesCount(scopeGroupId, node.getNodeId(), true)) %>" key="x-pages" />
-								</span>
-							</liferay-ui:search-container-column-text>
+								<liferay-ui:search-container-column-jsp
+									path="/wiki/node_action.jsp"
+								/>
+							</c:when>
+							<c:otherwise>
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand table-cell-minw-200 table-title"
+									href="<%= rowURL %>"
+									name="wiki"
+									value="<%= HtmlUtil.escape(node.getName()) %>"
+								/>
 
-							<liferay-ui:search-container-column-jsp
-								path="/wiki/node_action.jsp"
-							/>
-						</c:when>
-						<c:otherwise>
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand table-cell-minw-200 table-title"
-								href="<%= rowURL %>"
-								name="wiki"
-								value="<%= HtmlUtil.escape(node.getName()) %>"
-							/>
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand-small"
+									name="num-of-pages"
+									value="<%= String.valueOf(WikiPageServiceUtil.getPagesCount(scopeGroupId, node.getNodeId(), true)) %>"
+								/>
 
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand-small"
-								name="num-of-pages"
-								value="<%= String.valueOf(WikiPageServiceUtil.getPagesCount(scopeGroupId, node.getNodeId(), true)) %>"
-							/>
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand-smaller table-cell-ws-nowrap"
+									name="last-post-date"
+									value='<%= (node.getLastPostDate() == null) ? LanguageUtil.get(request, "never") : dateFormatDateTime.format(node.getLastPostDate()) %>'
+								/>
 
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand-smaller table-cell-ws-nowrap"
-								name="last-post-date"
-								value='<%= (node.getLastPostDate() == null) ? LanguageUtil.get(request, "never") : dateFormatDateTime.format(node.getLastPostDate()) %>'
-							/>
+								<liferay-ui:search-container-column-jsp
+									path="/wiki/node_action.jsp"
+								/>
+							</c:otherwise>
+						</c:choose>
+					</liferay-ui:search-container-row>
 
-							<liferay-ui:search-container-column-jsp
-								path="/wiki/node_action.jsp"
-							/>
-						</c:otherwise>
-					</c:choose>
-				</liferay-ui:search-container-row>
-
-				<liferay-ui:search-iterator
-					displayStyle="<%= displayStyle %>"
-					markupView="lexicon"
-				/>
-			</liferay-ui:search-container>
-		</aui:form>
+					<liferay-ui:search-iterator
+						displayStyle="<%= displayStyle %>"
+						markupView="lexicon"
+					/>
+				</liferay-ui:search-container>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
-</clay:container-fluid>
+</div>
 
 <script>
 	var deleteNodes = function () {

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp
@@ -102,10 +102,7 @@ WikiPagesManagementToolbarDisplayContext wikiPagesManagementToolbarDisplayContex
 	viewTypeItems="<%= wikiPagesManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
-<clay:container-fluid
-	cssClass="closed sidenav-container sidenav-right"
-	id='<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>'
->
+<div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/wiki/page_info_panel" var="sidebarPanelURL">
 		<portlet:param name="nodeId" value="<%= String.valueOf(node.getNodeId()) %>" />
 		<portlet:param name="showSidebarHeader" value="<%= Boolean.TRUE.toString() %>" />
@@ -125,176 +122,180 @@ WikiPagesManagementToolbarDisplayContext wikiPagesManagementToolbarDisplayContex
 	</liferay-frontend:sidebar-panel>
 
 	<div class="sidenav-content">
-
-		<%
-		PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "wiki"), backToNodeURL.toString());
-
-		PortalUtil.addPortletBreadcrumbEntry(request, node.getName(), portletURL.toString());
-		%>
-
-		<liferay-ui:breadcrumb
-			showCurrentGroup="<%= false %>"
-			showGuestGroup="<%= false %>"
-			showLayout="<%= false %>"
-			showParentGroups="<%= false %>"
-		/>
-
-		<%
-		WikiVisualizationHelper wikiVisualizationHelper = new WikiVisualizationHelper(wikiRequestHelper, wikiPortletInstanceSettingsHelper, wikiGroupServiceConfiguration);
-		%>
-
-		<c:if test="<%= wikiVisualizationHelper.isUndoTrashControlVisible() %>">
+		<clay:container-fluid
+			cssClass="container-view"
+		>
 
 			<%
-			PortletURL undoTrashURL = wikiURLHelper.getUndoTrashURL();
+			PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "wiki"), backToNodeURL.toString());
+
+			PortalUtil.addPortletBreadcrumbEntry(request, node.getName(), portletURL.toString());
 			%>
 
-			<liferay-trash:undo
-				portletURL="<%= undoTrashURL.toString() %>"
+			<liferay-ui:breadcrumb
+				showCurrentGroup="<%= false %>"
+				showGuestGroup="<%= false %>"
+				showLayout="<%= false %>"
+				showParentGroups="<%= false %>"
 			/>
-		</c:if>
 
-		<aui:form action="<%= wikiURLHelper.getSearchURL() %>" method="get" name="fm">
-			<aui:input name="nodeId" type="hidden" value="<%= String.valueOf(node.getNodeId()) %>" />
-			<aui:input name="<%= Constants.CMD %>" type="hidden" />
-			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+			<%
+			WikiVisualizationHelper wikiVisualizationHelper = new WikiVisualizationHelper(wikiRequestHelper, wikiPortletInstanceSettingsHelper, wikiGroupServiceConfiguration);
+			%>
 
-			<liferay-ui:search-container
-				id="wikiPages"
-				searchContainer="<%= wikiPagesSearchContainer %>"
-				total="<%= wikiPagesSearchContainer.getTotal() %>"
-			>
-				<liferay-ui:search-container-results
-					results="<%= wikiPagesSearchContainer.getResults() %>"
+			<c:if test="<%= wikiVisualizationHelper.isUndoTrashControlVisible() %>">
+
+				<%
+				PortletURL undoTrashURL = wikiURLHelper.getUndoTrashURL();
+				%>
+
+				<liferay-trash:undo
+					portletURL="<%= undoTrashURL.toString() %>"
 				/>
+			</c:if>
 
-				<liferay-ui:search-container-row
-					className="com.liferay.wiki.model.WikiPage"
-					keyProperty="pageId"
-					modelVar="curPage"
+			<aui:form action="<%= wikiURLHelper.getSearchURL() %>" method="get" name="fm">
+				<aui:input name="nodeId" type="hidden" value="<%= String.valueOf(node.getNodeId()) %>" />
+				<aui:input name="<%= Constants.CMD %>" type="hidden" />
+				<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+
+				<liferay-ui:search-container
+					id="wikiPages"
+					searchContainer="<%= wikiPagesSearchContainer %>"
+					total="<%= wikiPagesSearchContainer.getTotal() %>"
 				>
+					<liferay-ui:search-container-results
+						results="<%= wikiPagesSearchContainer.getResults() %>"
+					/>
 
-					<%
-					row.setData(
-						HashMapBuilder.<String, Object>put(
-							"actions", StringUtil.merge(wikiPagesManagementToolbarDisplayContext.getAvailableActions(curPage))
-						).build());
+					<liferay-ui:search-container-row
+						className="com.liferay.wiki.model.WikiPage"
+						keyProperty="pageId"
+						modelVar="curPage"
+					>
 
-					PortletURL rowURL = renderResponse.createRenderURL();
+						<%
+						row.setData(
+							HashMapBuilder.<String, Object>put(
+								"actions", StringUtil.merge(wikiPagesManagementToolbarDisplayContext.getAvailableActions(curPage))
+							).build());
 
-					if (!navigation.equals("draft-pages") || Validator.isNotNull(keywords)) {
-						rowURL.setParameter("mvcRenderCommandName", "/wiki/view");
-						rowURL.setParameter("redirect", currentURL);
+						PortletURL rowURL = renderResponse.createRenderURL();
 
-						WikiNode wikiNode = curPage.getNode();
+						if (!navigation.equals("draft-pages") || Validator.isNotNull(keywords)) {
+							rowURL.setParameter("mvcRenderCommandName", "/wiki/view");
+							rowURL.setParameter("redirect", currentURL);
 
-						rowURL.setParameter("nodeName", wikiNode.getName());
-					}
-					else {
-						rowURL.setParameter("mvcRenderCommandName", "/wiki/edit_page");
-						rowURL.setParameter("redirect", currentURL);
-						rowURL.setParameter("nodeId", String.valueOf(curPage.getNodeId()));
-					}
+							WikiNode wikiNode = curPage.getNode();
 
-					rowURL.setParameter("title", curPage.getTitle());
-					%>
+							rowURL.setParameter("nodeName", wikiNode.getName());
+						}
+						else {
+							rowURL.setParameter("mvcRenderCommandName", "/wiki/edit_page");
+							rowURL.setParameter("redirect", currentURL);
+							rowURL.setParameter("nodeId", String.valueOf(curPage.getNodeId()));
+						}
 
-					<c:choose>
-						<c:when test='<%= displayStyle.equals("descriptive") %>'>
-							<liferay-ui:search-container-column-icon
-								icon="wiki-page"
-								toggleRowChecker="<%= true %>"
-							/>
+						rowURL.setParameter("title", curPage.getTitle());
+						%>
 
-							<liferay-ui:search-container-column-text
-								colspan="<%= 2 %>"
-							>
-								<h2 class="h5">
-									<aui:a href="<%= rowURL.toString() %>">
-										<%= curPage.getTitle() %>
-									</aui:a>
-								</h2>
+						<c:choose>
+							<c:when test='<%= displayStyle.equals("descriptive") %>'>
+								<liferay-ui:search-container-column-icon
+									icon="wiki-page"
+									toggleRowChecker="<%= true %>"
+								/>
+
+								<liferay-ui:search-container-column-text
+									colspan="<%= 2 %>"
+								>
+									<h2 class="h5">
+										<aui:a href="<%= rowURL.toString() %>">
+											<%= curPage.getTitle() %>
+										</aui:a>
+									</h2>
+
+									<%
+									Date modifiedDate = curPage.getModifiedDate();
+
+									String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
+									%>
+
+									<span class="text-default">
+										<c:choose>
+											<c:when test="<%= Validator.isNotNull(curPage.getUserName()) %>">
+												<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(curPage.getUserName()), modifiedDateDescription} %>" key="x-modified-x-ago" />
+											</c:when>
+											<c:otherwise>
+												<liferay-ui:message arguments="<%= modifiedDateDescription %>" key="modified-x-ago" />
+											</c:otherwise>
+										</c:choose>
+									</span>
+									<span class="text-default">
+										<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= curPage.getStatus() %>" />
+									</span>
+								</liferay-ui:search-container-column-text>
+
+								<liferay-ui:search-container-column-jsp
+									path="/wiki/page_action.jsp"
+								/>
+							</c:when>
+							<c:otherwise>
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand table-cell-minw-200 table-title"
+									href="<%= rowURL %>"
+									name="title"
+									value="<%= curPage.getTitle() %>"
+								/>
+
+								<liferay-ui:search-container-column-status
+									cssClass="table-cell-expand-smaller"
+									name="status"
+									status="<%= curPage.getStatus() %>"
+								/>
 
 								<%
-								Date modifiedDate = curPage.getModifiedDate();
+								String revision = String.valueOf(curPage.getVersion());
 
-								String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
+								if (curPage.isMinorEdit()) {
+									revision += " (" + LanguageUtil.get(request, "minor-edit") + ")";
+								}
 								%>
 
-								<span class="text-default">
-									<c:choose>
-										<c:when test="<%= Validator.isNotNull(curPage.getUserName()) %>">
-											<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(curPage.getUserName()), modifiedDateDescription} %>" key="x-modified-x-ago" />
-										</c:when>
-										<c:otherwise>
-											<liferay-ui:message arguments="<%= modifiedDateDescription %>" key="modified-x-ago" />
-										</c:otherwise>
-									</c:choose>
-								</span>
-								<span class="text-default">
-									<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= curPage.getStatus() %>" />
-								</span>
-							</liferay-ui:search-container-column-text>
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand-smaller table-cell-minw-150"
+									name="revision"
+									value="<%= revision %>"
+								/>
 
-							<liferay-ui:search-container-column-jsp
-								path="/wiki/page_action.jsp"
-							/>
-						</c:when>
-						<c:otherwise>
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand table-cell-minw-200 table-title"
-								href="<%= rowURL %>"
-								name="title"
-								value="<%= curPage.getTitle() %>"
-							/>
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-expand-smaller table-cell-minw-150"
+									name="user"
+									value="<%= HtmlUtil.escape(PortalUtil.getUserName(curPage)) %>"
+								/>
 
-							<liferay-ui:search-container-column-status
-								cssClass="table-cell-expand-smaller"
-								name="status"
-								status="<%= curPage.getStatus() %>"
-							/>
+								<liferay-ui:search-container-column-date
+									cssClass="table-cell-ws-nowrap"
+									name="modified-date"
+									value="<%= curPage.getModifiedDate() %>"
+								/>
 
-							<%
-							String revision = String.valueOf(curPage.getVersion());
+								<liferay-ui:search-container-column-jsp
+									path="/wiki/page_action.jsp"
+								/>
+							</c:otherwise>
+						</c:choose>
+					</liferay-ui:search-container-row>
 
-							if (curPage.isMinorEdit()) {
-								revision += " (" + LanguageUtil.get(request, "minor-edit") + ")";
-							}
-							%>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand-smaller table-cell-minw-150"
-								name="revision"
-								value="<%= revision %>"
-							/>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand-smaller table-cell-minw-150"
-								name="user"
-								value="<%= HtmlUtil.escape(PortalUtil.getUserName(curPage)) %>"
-							/>
-
-							<liferay-ui:search-container-column-date
-								cssClass="table-cell-ws-nowrap"
-								name="modified-date"
-								value="<%= curPage.getModifiedDate() %>"
-							/>
-
-							<liferay-ui:search-container-column-jsp
-								path="/wiki/page_action.jsp"
-							/>
-						</c:otherwise>
-					</c:choose>
-				</liferay-ui:search-container-row>
-
-				<liferay-ui:search-iterator
-					displayStyle="<%= displayStyle %>"
-					markupView="lexicon"
-				/>
-			</liferay-ui:search-container>
-		</aui:form>
+					<liferay-ui:search-iterator
+						displayStyle="<%= displayStyle %>"
+						markupView="lexicon"
+					/>
+				</liferay-ui:search-container>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
-</clay:container-fluid>
+</div>
 
 <script>
 	var deletePages = function () {

--- a/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/message_boards.jspf
+++ b/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/message_boards.jspf
@@ -14,77 +14,79 @@
  */
 --%>
 
-<div class="closed container-fluid container-fluid-max-xl sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<div class="closed sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
 	<div class="sidenav-content">
-		<aui:form method="post" name="fm">
-			<aui:input name="deleteMBMessageIds" type="hidden" />
-			<aui:input name="notSpamMBMessageIds" type="hidden" />
+		<clay:container-fluid>
+			<aui:form method="post" name="fm">
+				<aui:input name="deleteMBMessageIds" type="hidden" />
+				<aui:input name="notSpamMBMessageIds" type="hidden" />
 
-			<liferay-ui:search-container
-				emptyResultsMessage="there-are-no-posts"
-				headerNames="subject,preview,posted-by"
-				iteratorURL="<%= portletURL %>"
-				rowChecker="<%= new RowChecker(renderResponse) %>"
-				total="<%= ModerationUtil.getMBMessagesCount(scopeGroupId) %>"
-			>
-				<liferay-ui:search-container-results
-					results="<%= ModerationUtil.getMBMessages(scopeGroupId, searchContainer.getStart(), searchContainer.getEnd()) %>"
-				/>
-
-				<c:if test="<%= !results.isEmpty() %>">
-					<aui:button-row>
-						<aui:button cssClass="btn-lg" onClick='<%= liferayPortletResponse.getNamespace() + "notSpamMBMessages();" %>' value="not-spam" />
-
-						<aui:button cssClass="btn-lg" onClick='<%= liferayPortletResponse.getNamespace() + "deleteMBMessages(false);" %>' value="delete" />
-					</aui:button-row>
-				</c:if>
-
-				<liferay-ui:search-container-row
-					className="com.liferay.message.boards.model.MBMessage"
-					escapedModel="<%= true %>"
-					keyProperty="messageId"
-					modelVar="message"
+				<liferay-ui:search-container
+					emptyResultsMessage="there-are-no-posts"
+					headerNames="subject,preview,posted-by"
+					iteratorURL="<%= portletURL %>"
+					rowChecker="<%= new RowChecker(renderResponse) %>"
+					total="<%= ModerationUtil.getMBMessagesCount(scopeGroupId) %>"
 				>
-					<liferay-portlet:renderURL varImpl="rowURL">
-						<portlet:param name="mvcPath" value="/view_thread_message.jsp" />
-						<portlet:param name="messageId" value="<%= String.valueOf(message.getMessageId()) %>" />
-					</liferay-portlet:renderURL>
-
-					<liferay-ui:search-container-column-text
-						href="<%= rowURL %>"
-						name="subject"
-						value="<%= message.getSubject() %>"
+					<liferay-ui:search-container-results
+						results="<%= ModerationUtil.getMBMessages(scopeGroupId, searchContainer.getStart(), searchContainer.getEnd()) %>"
 					/>
 
-					<liferay-ui:search-container-column-text
-						href="<%= rowURL %>"
-						name="preview"
-						value="<%= StringUtil.shorten(message.getBody(), 100) %>"
-					/>
+					<c:if test="<%= !results.isEmpty() %>">
+						<aui:button-row>
+							<aui:button cssClass="btn-lg" onClick='<%= liferayPortletResponse.getNamespace() + "notSpamMBMessages();" %>' value="not-spam" />
 
-					<liferay-ui:search-container-column-text
-						href="<%= rowURL %>"
-						name="posted-by"
+							<aui:button cssClass="btn-lg" onClick='<%= liferayPortletResponse.getNamespace() + "deleteMBMessages(false);" %>' value="delete" />
+						</aui:button-row>
+					</c:if>
+
+					<liferay-ui:search-container-row
+						className="com.liferay.message.boards.model.MBMessage"
+						escapedModel="<%= true %>"
+						keyProperty="messageId"
+						modelVar="message"
 					>
-						<div>
-							<%= message.isAnonymous() ? LanguageUtil.get(portletConfig.getResourceBundle(locale), "anonymous") : HtmlUtil.escape(PortalUtil.getUserName(message.getUserId(), message.getUserName())) %>
-						</div>
+						<liferay-portlet:renderURL varImpl="rowURL">
+							<portlet:param name="mvcPath" value="/view_thread_message.jsp" />
+							<portlet:param name="messageId" value="<%= String.valueOf(message.getMessageId()) %>" />
+						</liferay-portlet:renderURL>
 
-						<div>
-							<%= longDateFormatDate.format(message.getCreateDate()) %>
-						</div>
-					</liferay-ui:search-container-column-text>
+						<liferay-ui:search-container-column-text
+							href="<%= rowURL %>"
+							name="subject"
+							value="<%= message.getSubject() %>"
+						/>
 
-					<liferay-ui:search-container-column-jsp
-						align="right"
-						path="/message_boards_action.jsp"
+						<liferay-ui:search-container-column-text
+							href="<%= rowURL %>"
+							name="preview"
+							value="<%= StringUtil.shorten(message.getBody(), 100) %>"
+						/>
+
+						<liferay-ui:search-container-column-text
+							href="<%= rowURL %>"
+							name="posted-by"
+						>
+							<div>
+								<%= message.isAnonymous() ? LanguageUtil.get(portletConfig.getResourceBundle(locale), "anonymous") : HtmlUtil.escape(PortalUtil.getUserName(message.getUserId(), message.getUserName())) %>
+							</div>
+
+							<div>
+								<%= longDateFormatDate.format(message.getCreateDate()) %>
+							</div>
+						</liferay-ui:search-container-column-text>
+
+						<liferay-ui:search-container-column-jsp
+							align="right"
+							path="/message_boards_action.jsp"
+						/>
+					</liferay-ui:search-container-row>
+
+					<liferay-ui:search-iterator
+						markupView="lexicon"
 					/>
-				</liferay-ui:search-container-row>
-
-				<liferay-ui:search-iterator
-					markupView="lexicon"
-				/>
-			</liferay-ui:search-container>
-		</aui:form>
+				</liferay-ui:search-container>
+			</aui:form>
+		</clay:container-fluid>
 	</div>
 </div>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -233,10 +233,10 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 				</div>
 			</c:if>
 
-			<clay:container-fluid
-				size='<%= Objects.equals(renderRequest.getWindowState(), LiferayWindowState.POP_UP) ? "xl" : "lg" %>'
-			>
-				<div class="sidenav-content">
+			<div class="sidenav-content">
+				<clay:container-fluid
+					size='<%= Objects.equals(renderRequest.getWindowState(), LiferayWindowState.POP_UP) ? "xl" : "lg" %>'
+				>
 					<aui:form cssClass="full-width-content" method="post" name="fm" onSubmit="event.preventDefault();">
 						<aui:model-context bean="<%= kaleoDefinitionVersion %>" model="<%= KaleoDefinitionVersion.class %>" />
 						<aui:input name="mvcPath" type="hidden" value="<%= mvcPath %>" />
@@ -769,8 +769,8 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 							</c:when>
 						</c:choose>
 					</aui:form>
-				</div>
-			</clay:container-fluid>
+				</clay:container-fluid>
+			</div>
 		</div>
 
 		<c:if test="<%= kaleoDefinition != null %>">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-126065

Move container-fluid inside sidenav-content so the Info Panel isn't rendered right against the content. There are vertical gaps between info panel and navigation in Documents and Media and Knowledge Base view_article.jsp that are not related to this pr.

- Adaptive Media Web
- Bookmarks Web
   - change typo on css class bookmakrs-breadcrumb to bookmarks-breadcrumb
- Commerce Product Options Web
- Commerce Product Type Grouped Web
- Journal Web
- Knowledge Base Web
- Portal Workflow Web
- Redirect Web
- Site Admin Web
- Site Memberships Web
- Trash Web
- User Associated Data Web
- Wiki Web
- Askimet Web

What it looks like now:
<img width="1424" alt="info-panel-fix" src="https://user-images.githubusercontent.com/788266/105568381-d2e29000-5ced-11eb-899b-ce97472315e6.png">
