### PR TITLE
LPS-126675 Add propsTransformer parameter to the react component taglib

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-react/src/main/java/com/liferay/frontend/taglib/react/servlet/taglib/ComponentTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/src/main/java/com/liferay/frontend/taglib/react/servlet/taglib/ComponentTag.java
@@ -48,7 +48,8 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 			prepareProps(props);
 
 			ComponentDescriptor componentDescriptor = new ComponentDescriptor(
-				getModule(), getComponentId(), null, isPositionInLine());
+				getNamespacedModule(_module), getComponentId(), null,
+				isPositionInLine(), getNamespacedModule(_propsTransformer));
 
 			ReactRenderer reactRenderer =
 				ReactRendererProvider.getReactRenderer();
@@ -75,17 +76,21 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 		return _componentId;
 	}
 
-	public String getModule() {
+	public String getNamespacedModule(String module) {
+		if (Validator.isBlank(module)) {
+			return null;
+		}
+
 		if (_setServletContext) {
 			String namespace = NPMResolvedPackageNameUtil.get(servletContext);
 
-			return StringBundler.concat(namespace, "/", _module);
+			return StringBundler.concat(namespace, "/", module);
 		}
 
 		String namespace = NPMResolvedPackageNameUtil.get(
 			pageContext.getServletContext());
 
-		return StringBundler.concat(namespace, "/", _module);
+		return StringBundler.concat(namespace, "/", module);
 	}
 
 	@Override
@@ -115,6 +120,10 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 		_props = props;
 	}
 
+	public void setPropsTransformer(String propsTransformer) {
+		_propsTransformer = propsTransformer;
+	}
+
 	@Override
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
@@ -126,6 +135,7 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 		_componentId = null;
 		_module = null;
 		_props = Collections.emptyMap();
+		_propsTransformer = null;
 		_setServletContext = false;
 	}
 
@@ -139,6 +149,10 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 
 	protected Map<String, Object> getProps() {
 		return _props;
+	}
+
+	protected String getPropsTransformer() {
+		return _propsTransformer;
 	}
 
 	protected boolean isPositionInLine() {
@@ -187,6 +201,7 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 	private String _componentId;
 	private String _module;
 	private Map<String, Object> _props = Collections.emptyMap();
+	private String _propsTransformer;
 	private boolean _setServletContext;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/META-INF/resources/react.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/META-INF/resources/react.tld
@@ -38,6 +38,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>Optional name of an AMD module exporting a function to transform the properties before they are passed to the component</description>
+			<name>propsTransformer</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>The servlet context used to resolve JS packages. The default value is the current portlet's servlet context.</description>
 			<name>servletContext</name>
 			<required>false</required>

--- a/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/com/liferay/frontend/taglib/react/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/com/liferay/frontend/taglib/react/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0


### PR DESCRIPTION
Hello.

In this PR I'm just creating a propsTransfomer parameter for the <react:component> taglib since we will need it in Data Engine.

Tests:

For testing i just  passed a value for this new property in [here](https://github.com/liferay/liferay-portal/blob/9d429565e2539fa00b639a033740ed21b194dee5/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/end.jsp#L68) and asserted that the value was getting in the taglib correctly.

Since this should work exactly as the component module i didn't really tested it with a real module and that also why I'm reusing the `getNamespacedModule` method.

Let me know if you need more info :)