### PR TITLE
LPS-125733 Asset Publisher scrolls up when clicking on Info button on further documents

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -154,7 +154,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 													skipEditorLoading="<%= skipEditorLoading %>"
 												/>
 
-												<aui:input name="postReplyBody0" type="hidden" />
+												<aui:input name='<%= randomNamespace + "postReplyBody0" %>' type="hidden" />
 
 												<aui:button-row>
 													<aui:button cssClass="btn-comment btn-primary btn-sm" disabled="<%= true %>" id="postReplyButton0" onClick='<%= randomNamespace + "postReply(0);" %>' value='<%= themeDisplay.isSignedIn() ? "reply" : "reply-as" %>' />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -19,6 +19,7 @@
 <%
 FileEntry fileEntry = (FileEntry)request.getAttribute("info_panel.jsp-fileEntry");
 FileVersion fileVersion = (FileVersion)request.getAttribute("info_panel.jsp-fileVersion");
+String randomNamespace = GetterUtil.getString(request.getAttribute("info_panel.jsp-randomNamespace"), liferayPortletResponse.getNamespace());
 boolean hideActions = GetterUtil.getBoolean(request.getAttribute("info_panel_file_entry.jsp-hideActions"));
 
 DLPortletInstanceSettings dlPortletInstanceSettings = dlRequestHelper.getDLPortletInstanceSettings();
@@ -243,8 +244,6 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 					else {
 						urlLabel = LanguageUtil.format(request, "version-x-url", fileVersion.getVersion());
 					}
-
-					String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 
 					String urlInputId = liferayPortletResponse.getNamespace() + randomNamespace + "urlInput";
 					%>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -84,6 +84,7 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 		cssClass="navbar-no-collapse"
 		names="<%= tabsNames %>"
 		refresh="<%= false %>"
+		param='<%= "tabs" + StringPool.UNDERLINE + fileEntry.getFileEntryId() %>'
 	>
 		<liferay-ui:section>
 
@@ -453,7 +454,7 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 									cssClass="metadata"
 									defaultState="closed"
 									extended="<%= true %>"
-									id='<%= "documentLibraryMetadataPanel" + StringPool.UNDERLINE + ddmStructure.getStructureId() %>'
+									id='<%= "documentLibraryMetadataPanel" + StringPool.UNDERLINE + fileEntry.getFileEntryId() %>'
 									markupView="lexicon"
 									persistState="<%= true %>"
 									title="<%= HtmlUtil.escape(ddmStructure.getName(locale)) %>"
@@ -520,7 +521,7 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 								collapsible="<%= true %>"
 								cssClass="lfr-asset-metadata"
 								defaultState="closed"
-								id='<%= "documentLibraryMetadataPanel" + StringPool.UNDERLINE + ddmStructure.getStructureId() %>'
+								id='<%= "documentLibraryMetadataPanel" + StringPool.UNDERLINE + fileEntry.getFileEntryId() %>'
 								markupView="lexicon"
 								persistState="<%= true %>"
 								title='<%= "metadata." + ddmStructure.getStructureKey() %>'

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -243,7 +243,9 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 						urlLabel = LanguageUtil.format(request, "version-x-url", fileVersion.getVersion());
 					}
 
-					String urlInputId = liferayPortletResponse.getNamespace() + "urlInput";
+					String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
+
+					String urlInputId = liferayPortletResponse.getNamespace() + randomNamespace + "urlInput";
 					%>
 
 					<div class="form-group">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -19,7 +19,7 @@
 <%
 FileEntry fileEntry = (FileEntry)request.getAttribute("info_panel.jsp-fileEntry");
 FileVersion fileVersion = (FileVersion)request.getAttribute("info_panel.jsp-fileVersion");
-String randomNamespace = GetterUtil.getString(request.getAttribute("info_panel.jsp-randomNamespace"), liferayPortletResponse.getNamespace());
+String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 boolean hideActions = GetterUtil.getBoolean(request.getAttribute("info_panel_file_entry.jsp-hideActions"));
 
 DLPortletInstanceSettings dlPortletInstanceSettings = dlRequestHelper.getDLPortletInstanceSettings();

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -84,8 +84,8 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 	<liferay-ui:tabs
 		cssClass="navbar-no-collapse"
 		names="<%= tabsNames %>"
-		refresh="<%= false %>"
 		param='<%= "tabs" + StringPool.UNDERLINE + fileEntry.getFileEntryId() %>'
+		refresh="<%= false %>"
 	>
 		<liferay-ui:section>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -41,7 +41,7 @@ if (portletTitleBasedNavigation) {
 }
 %>
 
-<div class="<%= portletTitleBasedNavigation ? StringPool.BLANK : "closed sidenav-container sidenav-right" %>" id="<%= liferayPortletResponse.getNamespace() + (portletTitleBasedNavigation ? "FileEntry" : "infoPanelId") %>">
+<div class="<%= portletTitleBasedNavigation ? StringPool.BLANK : "closed sidenav-container sidenav-right" %>" id="<%= liferayPortletResponse.getNamespace() + (portletTitleBasedNavigation ? "FileEntry" : ("infoPanelId" + StringPool.UNDERLINE + fileEntry.getFileEntryId())) %>">
 	<c:if test="<%= portletTitleBasedNavigation %>">
 		<liferay-util:include page="/document_library/file_entry_upper_tbar.jsp" servletContext="<%= application %>" />
 	</c:if>
@@ -100,6 +100,7 @@ if (portletTitleBasedNavigation) {
 				<div class="file-entry-actions">
 					<liferay-frontend:management-bar-sidenav-toggler-button
 						label="info"
+						sidenavId='<%= liferayPortletResponse.getNamespace() + "infoPanelId" + StringPool.UNDERLINE + fileEntry.getFileEntryId() %>'
 					/>
 
 					<%

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -39,6 +39,9 @@ if (portletTitleBasedNavigation) {
 
 	renderResponse.setTitle(fileVersion.getTitle());
 }
+
+String portletNamespace = liferayPortletResponse.getNamespace();
+String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 %>
 
 <div class="<%= portletTitleBasedNavigation ? StringPool.BLANK : "closed sidenav-container sidenav-right" %>" id="<%= liferayPortletResponse.getNamespace() + (portletTitleBasedNavigation ? "FileEntry" : ("infoPanelId" + StringPool.UNDERLINE + fileEntry.getFileEntryId())) %>">
@@ -48,7 +51,7 @@ if (portletTitleBasedNavigation) {
 
 	<portlet:actionURL name="/document_library/edit_file_entry" var="editFileEntry" />
 
-	<aui:form action="<%= editFileEntry %>" method="post" name="fm">
+	<aui:form action="<%= editFileEntry %>" method="post" name="fm" portletNamespace="<%= portletNamespace + randomNamespace %>">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 		<aui:input name="fileEntryId" type="hidden" value="<%= String.valueOf(fileEntry.getFileEntryId()) %>" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -40,8 +40,7 @@ if (portletTitleBasedNavigation) {
 	renderResponse.setTitle(fileVersion.getTitle());
 }
 
-String portletNamespace = liferayPortletResponse.getNamespace();
-String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
+String randomNamespace = PortalUtil.generateRandomKey(request, liferayPortletResponse.getNamespace());
 %>
 
 <div class="<%= portletTitleBasedNavigation ? StringPool.BLANK : "closed sidenav-container sidenav-right" %>" id="<%= liferayPortletResponse.getNamespace() + (portletTitleBasedNavigation ? "FileEntry" : ("infoPanelId" + StringPool.UNDERLINE + fileEntry.getFileEntryId())) %>">
@@ -51,7 +50,7 @@ String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 
 	<portlet:actionURL name="/document_library/edit_file_entry" var="editFileEntry" />
 
-	<aui:form action="<%= editFileEntry %>" method="post" name="fm" portletNamespace="<%= portletNamespace + randomNamespace %>">
+	<aui:form action="<%= editFileEntry %>" method="post" name="fm" portletNamespace="<%= randomNamespace %>">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 		<aui:input name="fileEntryId" type="hidden" value="<%= String.valueOf(fileEntry.getFileEntryId()) %>" />
@@ -76,6 +75,7 @@ String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 				<%
 				request.setAttribute("info_panel.jsp-fileEntry", dlViewFileEntryDisplayContext.getFileEntry());
 				request.setAttribute("info_panel.jsp-fileVersion", dlViewFileEntryDisplayContext.getFileVersion());
+				request.setAttribute("info_panel.jsp-randomNamespace", randomNamespace);
 				request.setAttribute("info_panel_file_entry.jsp-hideActions", true);
 				%>
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ManagementBarSidenavTogglerButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ManagementBarSidenavTogglerButtonTag.java
@@ -29,6 +29,10 @@ public class ManagementBarSidenavTogglerButtonTag
 		return _position;
 	}
 
+	public String getSidenavId() {
+		return _sidenavId;
+	}
+
 	public String getType() {
 		return _type;
 	}
@@ -50,6 +54,10 @@ public class ManagementBarSidenavTogglerButtonTag
 		_position = position;
 	}
 
+	public void setSidenavId(String sidenavId) {
+		_sidenavId = sidenavId;
+	}
+
 	public void setType(String type) {
 		_type = type;
 	}
@@ -68,6 +76,7 @@ public class ManagementBarSidenavTogglerButtonTag
 
 		_href = null;
 		_position = null;
+		_sidenavId = null;
 		_type = null;
 		_typeMobile = null;
 		_width = null;
@@ -90,6 +99,7 @@ public class ManagementBarSidenavTogglerButtonTag
 
 		setNamespacedAttribute(httpServletRequest, "href", _href);
 		setNamespacedAttribute(httpServletRequest, "position", _position);
+		setNamespacedAttribute(httpServletRequest, "sidenavId", _sidenavId);
 		setNamespacedAttribute(httpServletRequest, "type", _type);
 		setNamespacedAttribute(httpServletRequest, "typeMobile", _typeMobile);
 		setNamespacedAttribute(httpServletRequest, "width", _width);
@@ -105,6 +115,7 @@ public class ManagementBarSidenavTogglerButtonTag
 
 	private String _href;
 	private String _position;
+	private String _sidenavId;
 	private String _type;
 	private String _typeMobile;
 	private String _width;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -1331,6 +1331,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>sidenavId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>type</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/management_bar_sidenav_toggler_button/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/management_bar_sidenav_toggler_button/init.jsp
@@ -26,11 +26,14 @@ String iconCssClass = (String)request.getAttribute("liferay-frontend:management-
 String id = (String)request.getAttribute("liferay-frontend:management-bar-sidenav-toggler-button:id");
 String label = (String)request.getAttribute("liferay-frontend:management-bar-sidenav-toggler-button:label");
 String position = (String)request.getAttribute("liferay-frontend:management-bar-sidenav-toggler-button:position");
+String sidenavId = (String)request.getAttribute("liferay-frontend:management-bar-sidenav-toggler-button:sidenavId");
 String type = (String)request.getAttribute("liferay-frontend:management-bar-sidenav-toggler-button:type");
 String typeMobile = (String)request.getAttribute("liferay-frontend:management-bar-sidenav-toggler-button:typeMobile");
 String width = (String)request.getAttribute("liferay-frontend:management-bar-sidenav-toggler-button:width");
 
-String sidenavId = liferayPortletResponse.getNamespace() + "infoPanelId";
+if (Validator.isNull(sidenavId)) {
+	sidenavId = liferayPortletResponse.getNamespace() + "infoPanelId";
+}
 
 if (Validator.isNull(href)) {
 	href = "#" + sidenavId;

--- a/portal-web/docroot/html/taglib/aui/form/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/form/start.jsp
@@ -18,8 +18,6 @@
 
 <%
 String fullName = namespace.concat(HtmlUtil.escapeAttribute(name));
-
-String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 %>
 
 <form action="<%= HtmlUtil.escapeAttribute(action) %>" class="form <%= cssClass %> <%= inlineLabels ? "field-labels-inline" : StringPool.BLANK %>" data-fm-namespace="<%= namespace %>" id="<%= fullName %>" method="<%= method %>" name="<%= fullName %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
@@ -27,4 +25,4 @@ String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 		<fieldset class="input-container" disabled="disabled">
 	</c:if>
 
-	<aui:input name='<%= randomNamespace + "formDate" %>' type="hidden" value="<%= System.currentTimeMillis() %>" />
+	<aui:input name='<%= portletNamespace + "formDate" %>' type="hidden" value="<%= System.currentTimeMillis() %>" />

--- a/portal-web/docroot/html/taglib/aui/form/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/form/start.jsp
@@ -18,6 +18,8 @@
 
 <%
 String fullName = namespace.concat(HtmlUtil.escapeAttribute(name));
+
+String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 %>
 
 <form action="<%= HtmlUtil.escapeAttribute(action) %>" class="form <%= cssClass %> <%= inlineLabels ? "field-labels-inline" : StringPool.BLANK %>" data-fm-namespace="<%= namespace %>" id="<%= fullName %>" method="<%= method %>" name="<%= fullName %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
@@ -25,4 +27,4 @@ String fullName = namespace.concat(HtmlUtil.escapeAttribute(name));
 		<fieldset class="input-container" disabled="disabled">
 	</c:if>
 
-	<aui:input name="formDate" type="hidden" value="<%= System.currentTimeMillis() %>" />
+	<aui:input name='<%= randomNamespace + "formDate" %>' type="hidden" value="<%= System.currentTimeMillis() %>" />


### PR DESCRIPTION
See https://issues.liferay.com/browse/LPS-125733

Currently it was not possible to have several info panels inside a portlet. They had to add a `sidenavId` attribute in the `management-bar-sidenav-toggler-button` taglib for this, but in other to make it work properly, several other id's have to be changed. 

Although right now it works and bug would be fixed, I wanted you to have a look to the changes and to check if you approve this or we may need to do this otherwise. 

Thanks in advance for youur feedback. 