### PR TITLE
[7.4-Only] - LPS-126201 and LPS-125963 - Panels update

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -198,11 +198,6 @@
 		text-transform: capitalize;
 	}
 
-	.portlet-body .panel {
-		margin-top: 1rem;
-		padding: 1rem;
-	}
-
 	.scheduler-event-content,
 	.scheduler-event-title {
 		font-family: inherit;

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -299,12 +299,14 @@ while (manageableCalendarsIterator.hasNext()) {
 
 			<aui:fieldset markupView="lexicon">
 				<liferay-ui:panel-container
+					cssClass="panel-group-flush panel-group-sm"
 					extended="<%= true %>"
 					id="calendarBookingDetailsPanelContainer"
 					persistState="<%= true %>"
 				>
 					<liferay-ui:panel
 						collapsible="<%= true %>"
+						cssClass="panel-unstyled"
 						defaultState="closed"
 						extended="<%= false %>"
 						id="calendarBookingDetailsPanel"
@@ -362,6 +364,7 @@ while (manageableCalendarsIterator.hasNext()) {
 
 					<liferay-ui:panel
 						collapsible="<%= true %>"
+						cssClass="panel-unstyled"
 						defaultState="closed"
 						extended="<%= false %>"
 						id="calendarBookingInvitationPanel"
@@ -450,6 +453,7 @@ while (manageableCalendarsIterator.hasNext()) {
 
 					<liferay-ui:panel
 						collapsible="<%= true %>"
+						cssClass="panel-unstyled"
 						defaultState="closed"
 						extended="<%= false %>"
 						id="calendarBookingReminderPanel"
@@ -462,6 +466,7 @@ while (manageableCalendarsIterator.hasNext()) {
 
 					<liferay-ui:panel
 						collapsible="<%= true %>"
+						cssClass="panel-unstyled"
 						defaultState="closed"
 						extended="<%= false %>"
 						id="calendarBookingCategorizationPanel"
@@ -483,6 +488,7 @@ while (manageableCalendarsIterator.hasNext()) {
 
 					<liferay-ui:panel
 						collapsible="<%= true %>"
+						cssClass="panel-unstyled"
 						defaultState="closed"
 						extended="<%= false %>"
 						id="calendarBookingAssetLinksPanel"

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_resource.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_resource.jsp
@@ -59,12 +59,14 @@ if (calendarResource != null) {
 		<aui:input name="name" />
 
 		<liferay-ui:panel-container
+			cssClass="panel-group-flush panel-group-sm"
 			extended="<%= true %>"
 			id="calendarResourceDetailsPanelContainer"
 			persistState="<%= true %>"
 		>
 			<liferay-ui:panel
 				collapsible="<%= true %>"
+				cssClass="panel-unstyled"
 				defaultState="closed"
 				extended="<%= false %>"
 				id="calendarResourceDetailsPanel"
@@ -106,6 +108,7 @@ if (calendarResource != null) {
 
 			<liferay-ui:panel
 				collapsible="<%= true %>"
+				cssClass="panel-unstyled"
 				defaultState="closed"
 				extended="<%= false %>"
 				id="calendarResourceCategorizationPanel"
@@ -128,6 +131,7 @@ if (calendarResource != null) {
 			<c:if test="<%= calendarResource == null %>">
 				<liferay-ui:panel
 					collapsible="<%= true %>"
+					cssClass="panel-unstyled"
 					defaultState="closed"
 					extended="<%= false %>"
 					id="calendarResourcePermissionsPanel"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -516,7 +516,7 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 
 							<liferay-ui:panel
 								collapsible="<%= true %>"
-								cssClass="lfr-asset-metadata"
+								cssClass="lfr-asset-metadata panel-unstyled"
 								defaultState="closed"
 								id='<%= "documentLibraryMetadataPanel" + StringPool.UNDERLINE + ddmStructure.getStructureId() %>'
 								markupView="lexicon"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -424,7 +424,7 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 			</c:if>
 
 			<liferay-ui:panel-container
-				cssClass="metadata-panel-container"
+				cssClass="metadata-panel-container panel-group-flush panel-group-sm"
 				extended="<%= true %>"
 				markupView="lexicon"
 				persistState="<%= true %>"

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_panel.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_panel.scss
@@ -1,8 +1,3 @@
-.info-panel .panel-group {
-	margin-left: -$sidebar-padding-left;
-	margin-right: -$sidebar-padding-right;
-}
-
 .lfr-panel-container {
 	background: #fff;
 }

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/resources.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/resources.jsp
@@ -121,7 +121,7 @@ long usedMemory = totalMemory - runtime.freeMemory();
 
 	<liferay-ui:panel
 		collapsible="<%= true %>"
-		cssClass="server-admin-actions-panel"
+		cssClass="panel-secondary server-admin-actions-panel"
 		extended="<%= true %>"
 		id="adminServerAdministrationSystemActionsPanel"
 		markupView="lexicon"
@@ -152,7 +152,7 @@ long usedMemory = totalMemory - runtime.freeMemory();
 
 	<liferay-ui:panel
 		collapsible="<%= true %>"
-		cssClass="server-admin-actions-panel"
+		cssClass="panel-secondary server-admin-actions-panel"
 		extended="<%= true %>"
 		id="adminServerAdministrationCacheActionsPanel"
 		markupView="lexicon"
@@ -201,7 +201,7 @@ long usedMemory = totalMemory - runtime.freeMemory();
 
 	<liferay-ui:panel
 		collapsible="<%= true %>"
-		cssClass="server-admin-actions-panel"
+		cssClass="panel-secondary server-admin-actions-panel"
 		extended="<%= true %>"
 		id="adminServerAdministrationVerificationActionsPanel"
 		markupView="lexicon"
@@ -232,7 +232,7 @@ long usedMemory = totalMemory - runtime.freeMemory();
 
 	<liferay-ui:panel
 		collapsible="<%= true %>"
-		cssClass="server-admin-actions-panel"
+		cssClass="panel-secondary server-admin-actions-panel"
 		extended="<%= true %>"
 		id="adminServerAdministrationCleanUpActionsPanel"
 		markupView="lexicon"

--- a/portal-web/docroot/html/taglib/ui/panel/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/panel/lexicon/start.jsp
@@ -33,30 +33,11 @@ if (persistState) {
 }
 %>
 
-<div class="panel <%= cssClass %>" id="<%= id %>">
-	<div class="panel panel-unstyled" id="<%= id %>Header" role="tab">
-		<c:choose>
-			<c:when test="<%= collapsible %>">
-				<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapsed panel-header panel-header-link <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-parent="#<%= id %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
-					<span class="panel-title">
-						<c:if test="<%= Validator.isNotNull(iconCssClass) %>">
-							<i class="<%= iconCssClass %>"></i>
-						</c:if>
-
-						<liferay-ui:message key="<%= title %>" />
-
-						<c:if test="<%= Validator.isNotNull(helpMessage) %>">
-							<liferay-ui:icon-help message="<%= helpMessage %>" />
-						</c:if>
-					</span>
-
-					<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
-
-					<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
-				</a>
-			</c:when>
-			<c:otherwise>
-				<span class="panel-title">
+<div class="panel panel-unstyled <%= cssClass %>" id="<%= id %>">
+	<c:choose>
+		<c:when test="<%= collapsible %>">
+			<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapsed panel-header panel-header-link <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-parent="#<%= id %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
+				<span class="panel-title" id="<%= id %>Header">
 					<c:if test="<%= Validator.isNotNull(iconCssClass) %>">
 						<i class="<%= iconCssClass %>"></i>
 					</c:if>
@@ -67,9 +48,26 @@ if (persistState) {
 						<liferay-ui:icon-help message="<%= helpMessage %>" />
 					</c:if>
 				</span>
-			</c:otherwise>
-		</c:choose>
-	</div>
+
+				<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
+
+				<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
+			</a>
+		</c:when>
+		<c:otherwise>
+			<span class="panel-title" id="<%= id %>Header">
+				<c:if test="<%= Validator.isNotNull(iconCssClass) %>">
+					<i class="<%= iconCssClass %>"></i>
+				</c:if>
+
+				<liferay-ui:message key="<%= title %>" />
+
+				<c:if test="<%= Validator.isNotNull(helpMessage) %>">
+					<liferay-ui:icon-help message="<%= helpMessage %>" />
+				</c:if>
+			</span>
+		</c:otherwise>
+	</c:choose>
 
 	<div aria-labelledby="<%= id %>Header" class="<%= collapsible ? "collapse panel-collapse" : StringPool.BLANK %> <%= !collapsed ? "show" : StringPool.BLANK %>" <%= accordion ? "data-parent='#" + parentId + "'" : StringPool.BLANK %> id="<%= id %>Content" role="tabpanel">
 		<div class="panel-body">

--- a/portal-web/docroot/html/taglib/ui/panel/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/panel/lexicon/start.jsp
@@ -33,7 +33,7 @@ if (persistState) {
 }
 %>
 
-<div class="panel panel-unstyled <%= cssClass %>" id="<%= id %>">
+<div class="panel <%= cssClass %>" id="<%= id %>">
 	<c:choose>
 		<c:when test="<%= collapsible %>">
 			<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapsed panel-header panel-header-link <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-parent="#<%= id %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">

--- a/portal-web/docroot/html/taglib/ui/panel/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/panel/lexicon/start.jsp
@@ -33,29 +33,12 @@ if (persistState) {
 }
 %>
 
-<div class="panel panel-secondary <%= cssClass %>" id="<%= id %>">
-	<div class="panel-heading" id="<%= id %>Header" role="tab">
-		<div class="h4 panel-title">
-			<c:choose>
-				<c:when test="<%= collapsible %>">
-					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapse-icon-middle <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-parent="#<%= id %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
-						<c:if test="<%= Validator.isNotNull(iconCssClass) %>">
-							<i class="<%= iconCssClass %>"></i>
-						</c:if>
-
-						<liferay-ui:message key="<%= title %>" />
-
-						<c:if test="<%= Validator.isNotNull(helpMessage) %>">
-							<liferay-ui:icon-help message="<%= helpMessage %>" />
-						</c:if>
-
-						<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
-
-						<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
-					</a>
-				</c:when>
-				<c:otherwise>
-					<span>
+<div class="panel <%= cssClass %>" id="<%= id %>">
+	<div class="panel panel-unstyled" id="<%= id %>Header" role="tab">
+		<c:choose>
+			<c:when test="<%= collapsible %>">
+				<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapsed panel-header panel-header-link <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-parent="#<%= id %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
+					<span class="panel-title">
 						<c:if test="<%= Validator.isNotNull(iconCssClass) %>">
 							<i class="<%= iconCssClass %>"></i>
 						</c:if>
@@ -66,9 +49,26 @@ if (persistState) {
 							<liferay-ui:icon-help message="<%= helpMessage %>" />
 						</c:if>
 					</span>
-				</c:otherwise>
-			</c:choose>
-		</div>
+
+					<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
+
+					<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
+				</a>
+			</c:when>
+			<c:otherwise>
+				<span class="panel-title">
+					<c:if test="<%= Validator.isNotNull(iconCssClass) %>">
+						<i class="<%= iconCssClass %>"></i>
+					</c:if>
+
+					<liferay-ui:message key="<%= title %>" />
+
+					<c:if test="<%= Validator.isNotNull(helpMessage) %>">
+						<liferay-ui:icon-help message="<%= helpMessage %>" />
+					</c:if>
+				</span>
+			</c:otherwise>
+		</c:choose>
 	</div>
 
 	<div aria-labelledby="<%= id %>Header" class="<%= collapsible ? "collapse panel-collapse" : StringPool.BLANK %> <%= !collapsed ? "show" : StringPool.BLANK %>" <%= accordion ? "data-parent='#" + parentId + "'" : StringPool.BLANK %> id="<%= id %>Content" role="tabpanel">


### PR DESCRIPTION
This PR updates the markup for panel headers:

Issue:
![image](https://user-images.githubusercontent.com/7963804/105491089-0ef9fe80-5cb6-11eb-8bc0-22d740f4ecae.png)

Fixed (based on Lexicon visual design):
![image](https://user-images.githubusercontent.com/7963804/105741097-35c86700-5f3a-11eb-8419-604e967acf44.png)

---

How to test the PR:

- Go to Site Menu > Content & data > Documents and media
- Select a document with metadata (ex: jpg) and upload! 
- Show info bar
- Go scroll down and see the toggle header