### PR TITLE
LPS-125139 - Add metal dependencies back in for backwards compatability

### DIFF
--- a/modules/apps/frontend-js/frontend-js-metal-web/bnd.bnd
+++ b/modules/apps/frontend-js/frontend-js-metal-web/bnd.bnd
@@ -5,12 +5,14 @@ Liferay-JS-Submodules-Bridge:\
 	incremental-dom,\
 	incremental-dom-string,\
 	metal,\
+	metal-affix,\
 	metal-ajax,\
 	metal-anim,\
 	metal-aop,\
 	metal-assertions,\
 	metal-clipboard,\
 	metal-component,\
+	metal-debounce,\
 	metal-dom,\
 	metal-drag-drop,\
 	metal-events,\
@@ -21,6 +23,8 @@ Liferay-JS-Submodules-Bridge:\
 	metal-multimap,\
 	metal-pagination,\
 	metal-path-parser,\
+	metal-position,\
+	metal-promise,\
 	metal-router,\
 	metal-scrollspy,\
 	metal-soy,\
@@ -28,6 +32,7 @@ Liferay-JS-Submodules-Bridge:\
 	metal-state,\
 	metal-storage,\
 	metal-structs,\
+	metal-throttle,\
 	metal-toggler,\
 	metal-uri,\
 	metal-useragent

--- a/modules/apps/frontend-js/frontend-js-metal-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-metal-web/package.json
@@ -20,6 +20,7 @@
 		"metal-pagination": "2.0.1",
 		"metal-path-parser": "1.0.4",
 		"metal-position": "2.1.2",
+		"metal-promise": "3.0.5",
 		"metal-router": "3.6.3",
 		"metal-scrollspy": "2.1.1",
 		"metal-soy": "2.16.9",

--- a/modules/apps/frontend-js/frontend-js-metal-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-metal-web/package.json
@@ -8,6 +8,7 @@
 		"metal-assertions": "2.16.8",
 		"metal-clipboard": "2.0.1",
 		"metal-component": "2.16.8",
+		"metal-debounce": "^2.0.2",
 		"metal-dom": "2.16.8",
 		"metal-drag-drop": "3.3.1",
 		"metal-events": "2.16.8",

--- a/modules/apps/frontend-js/frontend-js-metal-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-metal-web/package.json
@@ -28,6 +28,7 @@
 		"metal-state": "2.16.8",
 		"metal-storage": "2.0.1",
 		"metal-structs": "1.0.2",
+		"metal-throttle": "3.0.1",
 		"metal-toggler": "2.3.0",
 		"metal-uri": "2.4.0",
 		"metal-useragent": "3.0.1",

--- a/modules/apps/frontend-js/frontend-js-metal-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-metal-web/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"metal": "2.16.8",
+		"metal-affix": "2.0.0",
 		"metal-ajax": "2.1.1",
 		"metal-anim": "2.0.1",
 		"metal-aop": "3.0.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -10251,6 +10251,17 @@ merge@^1.2.0, merge@^1.2.1:
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
+metal-affix@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/metal-affix/-/metal-affix-2.0.0.tgz#16c4d914a627d15232a22776691bf2ab1b0cde37"
+  integrity sha1-FsTZFKYn0VIyoid2aRvyqxsM3jc=
+  dependencies:
+    metal "^2.0.0"
+    metal-dom "^2.0.0"
+    metal-events "^2.0.0"
+    metal-position "^2.0.0"
+    metal-state "^2.0.0"
+
 metal-ajax@2.1.1, metal-ajax@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/metal-ajax/-/metal-ajax-2.1.1.tgz#f715dd98fb38bc2ad2269eb960f3318ff8a4e543"
@@ -10300,7 +10311,7 @@ metal-component@2.16.8, metal-component@^2.0.0, metal-component@^2.13.2, metal-c
     metal-events "^2.16.8"
     metal-state "^2.16.8"
 
-metal-debounce@^2.0.0, metal-debounce@^2.0.1:
+metal-debounce@^2.0.0, metal-debounce@^2.0.1, metal-debounce@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/metal-debounce/-/metal-debounce-2.0.2.tgz#e5cbe97e76bf0e57a09df927de8b65a47c1f2fc5"
   integrity sha512-BFAVzGDN50drx6cV88JgI1pyI2z4awQZejMgefxpwJgcvsFXMQyymDFRzuEtecYARSHWyGPjfB5BYrpaKY8uKQ==
@@ -10401,13 +10412,20 @@ metal-path-parser@1.0.4, metal-path-parser@^1.0.3:
   dependencies:
     metal "^2.16.6"
 
-metal-position@2.1.2, metal-position@^2.1.0, metal-position@^2.1.2:
+metal-position@2.1.2, metal-position@^2.0.0, metal-position@^2.1.0, metal-position@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/metal-position/-/metal-position-2.1.2.tgz#3643a7f83a6b5a39061841858b058935390bd13c"
   integrity sha512-XvE1AQoySYFGG0sc3unZWfK97UKOvHvg/asq2k1Oh+vs1NGD9PhhGBQKiD0/Rix85ICHEeLUVzS0WGQr5wdapQ==
   dependencies:
     metal "^2.16.6"
     metal-dom "^2.16.6"
+
+metal-promise@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/metal-promise/-/metal-promise-3.0.5.tgz#03d8fb40579e5b97a4e44356e00042f2d34844de"
+  integrity sha512-9LRn5oPcv439xCiNvmKBWVopFBaJ5zBV75lkZMydufJX17YJ8J6+EVrL2ctlrxxxyF/hFhiEGVGPvxNjY9kwxg==
+  dependencies:
+    metal "^2.16.6"
 
 metal-promise@^2.0.0, metal-promise@^2.0.1:
   version "2.0.1"
@@ -10485,6 +10503,11 @@ metal-structs@1.0.2, metal-structs@^1.0.0:
   integrity sha512-LoGpcDtHvheGrG0e3eTPlb1vG52M06LbYtD4Oyb1EkVSMUvxpAjwuzVh4eUTkCLH9facAgoLlwkO2j07NBrdeA==
   dependencies:
     metal "^2.16.6"
+
+metal-throttle@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/metal-throttle/-/metal-throttle-3.0.1.tgz#d9b976c0d4fef11e08cc9d72ff5478f1998805e2"
+  integrity sha512-aigicXXWzpllJGWdLaCQVVFSDLfLlVAyG0LRuzwrVToWVJpdDL0RJ5nWad30X/p0Fa3IuewEMD55UuWkT4TNqw==
 
 metal-toggler@2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Follow up from conversation at https://docs.google.com/spreadsheets/d/1gPuEUpPkzpAz5Lm7k2rOLETcoC-c7ix_o2cKR28Qjpc/edit?ts=600b25af#gid=984768550

In order to keep backwards compatability for metal, we shouldn't remove these dependencies from the package.json.