### PR TITLE
LPS-126675 Create propsTransformer and propsTransformerSevletContext parameters in <react:component>

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-react/src/main/java/com/liferay/frontend/taglib/react/servlet/taglib/ComponentTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/src/main/java/com/liferay/frontend/taglib/react/servlet/taglib/ComponentTag.java
@@ -48,7 +48,8 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 			prepareProps(props);
 
 			ComponentDescriptor componentDescriptor = new ComponentDescriptor(
-				getModule(), getComponentId(), null, isPositionInLine());
+				getModule(), getComponentId(), null, isPositionInLine(),
+				_getPropsTransformerModule());
 
 			ReactRenderer reactRenderer =
 				ReactRendererProvider.getReactRenderer();
@@ -76,16 +77,7 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 	}
 
 	public String getModule() {
-		if (_setServletContext) {
-			String namespace = NPMResolvedPackageNameUtil.get(servletContext);
-
-			return StringBundler.concat(namespace, "/", _module);
-		}
-
-		String namespace = NPMResolvedPackageNameUtil.get(
-			pageContext.getServletContext());
-
-		return StringBundler.concat(namespace, "/", _module);
+		return StringBundler.concat(_getNamespace(), "/", _module);
 	}
 
 	@Override
@@ -115,6 +107,16 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 		_props = props;
 	}
 
+	public void setPropsTransformer(String propsTransformer) {
+		_propsTransformer = propsTransformer;
+	}
+
+	public void setPropsTransformerServletContext(
+		ServletContext servletContext) {
+
+		_propsTransformerServletContext = servletContext;
+	}
+
 	@Override
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
@@ -126,6 +128,8 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 		_componentId = null;
 		_module = null;
 		_props = Collections.emptyMap();
+		_propsTransformer = null;
+		_propsTransformerServletContext = null;
 		_setServletContext = false;
 	}
 
@@ -184,9 +188,33 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 	protected void prepareProps(Map<String, Object> props) {
 	}
 
+	private String _getNamespace() {
+		if (_setServletContext) {
+			return NPMResolvedPackageNameUtil.get(servletContext);
+		}
+
+		return NPMResolvedPackageNameUtil.get(pageContext.getServletContext());
+	}
+
+	private String _getPropsTransformerModule() {
+		if (Validator.isBlank(_propsTransformer)) {
+			return null;
+		}
+
+		if (_propsTransformerServletContext != null) {
+			return StringBundler.concat(
+				NPMResolvedPackageNameUtil.get(_propsTransformerServletContext),
+				"/", _propsTransformer);
+		}
+
+		return StringBundler.concat(_getNamespace(), "/", _propsTransformer);
+	}
+
 	private String _componentId;
 	private String _module;
 	private Map<String, Object> _props = Collections.emptyMap();
+	private String _propsTransformer;
+	private ServletContext _propsTransformerServletContext;
 	private boolean _setServletContext;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/META-INF/resources/react.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/META-INF/resources/react.tld
@@ -38,6 +38,18 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>Optional name of an AMD module exporting a function to transform the properties before they are passed to the component</description>
+			<name>propsTransformer</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>propsTransformerServletContext</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>The servlet context used to resolve JS packages. The default value is the current portlet's servlet context.</description>
 			<name>servletContext</name>
 			<required>false</required>

--- a/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/com/liferay/frontend/taglib/react/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/com/liferay/frontend/taglib/react/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
Hello :)

In this PR i'm creating two parameters for the <react:component> taglib.

### Context/Use Case
Data Engine has a[ builder taglib](https://github.com/liferay/liferay-portal/blob/master/modules/apps/data-engine/data-engine-taglib/src/main/java/com/liferay/data/engine/taglib/servlet/taglib/DataLayoutBuilderTag.java) that creates a react components builder for general purpose. Nowadays, three products use this taglib: [App builder](https://github.com/liferay/liferay-portal/blob/37360aa819a399af55b83604302f74ad4b076d12/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_form_view.jsp#L74), [WEM](https://github.com/liferay/liferay-portal/blob/37360aa819a399af55b83604302f74ad4b076d12/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp#L104) and [DL](https://github.com/liferay/liferay-portal/blob/37360aa819a399af55b83604302f74ad4b076d12/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure.jsp#L94). 

A lot of the props that are passed to the component taglib are fetched by the server side taglib code so the client doesn't have access to it and can't do any specific business logic transformation with them. This leads to situations like [this](https://github.com/liferay/liferay-portal/blob/37360aa819a399af55b83604302f74ad4b076d12/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/AppContext.es.js#L217).

That's why I'm creating these two parameters in the react component itself, for cases where there is a taglib( or some other server side component) being used to render some react component, kinda like we are already doing in (some?) clay taglibs.


### Testing 

On top of [this PR](https://github.com/liferay-app-builder/liferay-portal/pull/167)  i created a file under `app-builder/app-builder-web/src/main/resources/META-INF/resources/js` called `transformProps.js` with the content more or less like this: 

``` javascript
export default function transformProps(props){
      console.log(props);
      return props;
}
```
Then, [in here](https://github.com/liferay/liferay-portal/blob/37360aa819a399af55b83604302f74ad4b076d12/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_form_view.jsp#L74) i sent the values like this:

``` html
<liferay-data-engine:data-layout-builder
        componentId="<%= componentId %>"
        contentType="app-builder"
        dataDefinitionId="<%= dataDefinitionId %>"
        dataLayoutId="<%= dataLayoutId %>"
        fieldSetContentType="app-builder-fieldset"
        namespace="<%= liferayPortletResponse.getNamespace() %>"
        scopes='<%= SetUtil.fromCollection(Arrays.asList("app-builder")) %>'
        propsTransformer="<%=js/propsTransformer.js%>"
        propsTransfomerServletContext="<%= application %>"
  />
```

And then, to check if the propsTransfomer was working as intended i navigated to Applications > App Builder > Objects > New Object > new Form Builder and i asserted that the props were logged in the browser's console.

Let me know if you need more information :)