### PR TITLE
LPS-122873 [Content Dashboard] Put none categories at the end

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
@@ -58,6 +58,14 @@ export default function AuditBarChart({rtl, vocabularies}) {
 			return acc.concat(newBar);
 		}, []);
 
+		const noneBarIndex = bars.findIndex((bar) => bar.dataKey === 'none');
+
+		if (noneBarIndex !== -1) {
+			const noneBar = bars.splice(noneBarIndex, 1)[0];
+
+			bars.push(noneBar);
+		}
+
 		const data = vocabularies.map((category) => {
 			if (!category.categories) {
 				if (Number(category.value) > maxValue) {


### PR DESCRIPTION
**Description**

On top of https://github.com/brianchandotcom/liferay-portal/pull/98104.

The none category is displayed when we found an asset with that category. In the image below, the "No Stage Specified" will be displayed in the second position of the checkboxes.

New commit:
* LPS-122873 Put none category at the end: https://github.com/liferay-frontend/liferay-portal/commit/8acff23aae8445db656e869e493c1ae4a5dc0ab2

**Solution**

When we generate the bars for the graph, the none category is not at the end of the bars. So I search for this category at put at the end. With this change, the checkboxes above the chart, the grey bars and the X-Axis none category are displayed always at the end.

![Screenshot 2021-01-27 at 13 29 21](https://user-images.githubusercontent.com/15845466/105991093-accd3f00-60a3-11eb-8b6b-8a2569bb2916.png)
