### PR TITLE
LPS-127008 [Content Dashboard] Audit Tool graph crashes because it is accessing to a non-existent array value

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
@@ -348,7 +348,7 @@ function CustomTooltip(props) {
 		return null;
 	}
 
-	for (var i = 0; i <= payload.length; i++) {
+	for (var i = 0; i < payload.length; i++) {
 		if (payload[i].dataKey === tooltip.dataKey) {
 			return (
 				<ClayLayout.ContentRow


### PR DESCRIPTION
**Description**

When the Audit Tool graph shows several categories (this means several bars in the graph), the user can hover over them to see the tooltip.

**Steps to reproduce**

* Create some Categories in the Global Site (for example for Audience and Stage)
* Create some Web Contents categorized with previously created categories
* Go to Applications Menu > Content > Content Dashboard
* Hover over the bars for a few seconds

**Solution**

Update the `for` loop because we were accessing a non-existent element in the array. For example, one category has two bars, so `payload` is an Array[2] and we were accessing 3 positions (with the `i` variable).

**Error screenshot**

![Screenshot 2021-01-28 at 12 24 21](https://user-images.githubusercontent.com/15845466/106132107-ccc43780-6163-11eb-816a-80312b0d3739.png)
