### PR TITLE
LPS-124187 Fix style of form validation

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
@@ -490,6 +490,8 @@ AUI.add(
 					if (formNode) {
 						var formValidator = new A.FormValidator({
 							boundingBox: formNode,
+							stackErrorContainer:
+								'<div class="form-feedback-item form-validator-stack help-block"></div>',
 							validateOnBlur: instance.get('validateOnBlur'),
 						});
 


### PR DESCRIPTION
This PR fixes an error caused by the compat-layer removal. 

We had the CSS class `.help-block` that simulated the new `.form-feedback-item` from Clay

We added the new class using the AUI API

![image](https://user-images.githubusercontent.com/46778114/106164060-e11b2b00-6189-11eb-91a7-c19da157fd53.png)
