### PR TITLE
LPS-126011 Migrate 'show more' feature in management toolbar creation menu

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleManagementToolbarsDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleManagementToolbarsDisplayContext.java
@@ -94,9 +94,41 @@ public class ClaySampleManagementToolbarsDisplayContext
 		).addFavoriteDropdownItem(
 			dropdownItem -> {
 				dropdownItem.setHref("#4");
-				dropdownItem.setLabel("Other item");
+				dropdownItem.setLabel("Favorite 2");
+			}
+		).addRestDropdownItem(
+			dropdownItem -> {
+				dropdownItem.setHref("#5");
+				dropdownItem.setLabel("Secondary 1");
+			}
+		).addRestDropdownItem(
+			dropdownItem -> {
+				dropdownItem.setHref("#6");
+				dropdownItem.setLabel("Secondary 2");
+			}
+		).addRestDropdownItem(
+			dropdownItem -> {
+				dropdownItem.setHref("#7");
+				dropdownItem.setLabel("Secondary 3");
+			}
+		).addRestDropdownItem(
+			dropdownItem -> {
+				dropdownItem.setHref("#8");
+				dropdownItem.setLabel("Secondary 4");
+			}
+		).addRestDropdownItem(
+			dropdownItem -> {
+				dropdownItem.setHref("#9");
+				dropdownItem.setLabel("Secondary 5");
+			}
+		).addRestDropdownItem(
+			dropdownItem -> {
+				dropdownItem.setHref("#10");
+				dropdownItem.setLabel("Secondary 6");
 			}
 		).build();
+
+		_creationMenu.put("maxTotalItems", 8);
 
 		return _creationMenu;
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleManagementToolbarPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleManagementToolbarPropsTransformer.js
@@ -30,5 +30,8 @@ export default function propsTransformer(props) {
 		onSelectAllButtonClick: () => {
 			alert('Select all button clicked');
 		},
+		onShowMoreButtonClick: () => {
+			alert('Show more button clicked');
+		},
 	};
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -12,14 +12,75 @@
  * details.
  */
 
-import {ClayButtonWithIcon} from '@clayui/button';
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
-import React, {useState} from 'react';
+import React, {useRef, useState} from 'react';
 
-const CreationMenu = ({primaryItems, secondaryItems}) => {
+const CreationMenu = ({
+	maxPrimaryItems,
+	maxSecondaryItems,
+	maxTotalItems = 15,
+	onShowMoreButtonClick,
+	primaryItems,
+	secondaryItems,
+	viewMoreURL,
+}) => {
 	const [active, setActive] = useState(false);
+
+	const secondaryItemsCountRef = useRef(
+		secondaryItems?.reduce((acc, cur) => {
+			return acc + cur.items.length;
+		}, 0) ?? 0
+	);
+
+	const totalItemsCountRef = useRef(
+		primaryItems.length + secondaryItemsCountRef.current
+	);
+
+	const getVisibleItemsCount = () => {
+		const primaryItemsCount = primaryItems.length;
+		const secondaryItemsCount = secondaryItemsCountRef.current;
+
+		const defaultMaxPrimaryItems = maxPrimaryItems
+			? primaryItemsCount > maxPrimaryItems
+				? maxPrimaryItems
+				: primaryItemsCount
+			: primaryItemsCount > 8
+			? 8
+			: primaryItemsCount;
+
+		const tempDefaultMaxSecondaryItems = maxSecondaryItems
+			? secondaryItemsCount > maxSecondaryItems
+				? maxSecondaryItems
+				: secondaryItemsCount
+			: secondaryItemsCount > 7
+			? 7
+			: secondaryItemsCount;
+
+		const defaultMaxSecondaryItems =
+			tempDefaultMaxSecondaryItems >
+			maxTotalItems - defaultMaxPrimaryItems
+				? maxTotalItems - defaultMaxPrimaryItems
+				: tempDefaultMaxSecondaryItems;
+
+		return secondaryItemsCount === 0
+			? primaryItemsCount > maxTotalItems
+				? maxTotalItems
+				: primaryItemsCount
+			: primaryItemsCount > defaultMaxPrimaryItems
+			? secondaryItemsCount > defaultMaxSecondaryItems
+				? defaultMaxPrimaryItems + defaultMaxSecondaryItems
+				: defaultMaxPrimaryItems + secondaryItemsCount
+			: secondaryItemsCount > defaultMaxSecondaryItems
+			? primaryItemsCount + defaultMaxSecondaryItems
+			: primaryItemsCount + secondaryItemsCount;
+	};
+
+	const [visibleItemsCount, setVisibleItemsCount] = useState(
+		getVisibleItemsCount()
+	);
 
 	return (
 		<>
@@ -34,31 +95,63 @@ const CreationMenu = ({primaryItems, secondaryItems}) => {
 						/>
 					}
 				>
-					<ClayDropDown.ItemList>
-						{primaryItems?.map((item, index) => (
-							<ClayDropDown.Item href={item.href} key={index}>
-								{item.label}
-							</ClayDropDown.Item>
-						))}
+					{visibleItemsCount < totalItemsCountRef.current ? (
+						<>
+							<div className="inline-scroller">
+								<ItemList
+									primaryItems={primaryItems}
+									secondaryItems={secondaryItems}
+									visibleItemsCount={visibleItemsCount}
+								/>
+							</div>
 
-						{secondaryItems?.map((secondaryItemsGroup, index) => (
-							<ClayDropDown.Group
-								header={secondaryItemsGroup.label}
-								key={index}
-							>
-								{secondaryItemsGroup.items.map(
-									(item, index) => (
-										<ClayDropDown.Item
-											href={item.href}
-											key={index}
-										>
-											{item.label}
-										</ClayDropDown.Item>
-									)
+							<div className="dropdown-caption">
+								{Liferay.Util.sub(
+									Liferay.Language.get(
+										'showing-x-of-x-elements'
+									),
+									visibleItemsCount,
+									totalItemsCountRef.current
 								)}
-							</ClayDropDown.Group>
-						))}
-					</ClayDropDown.ItemList>
+							</div>
+
+							<div className="dropdown-section">
+								{viewMoreURL ? (
+									<ClayLink
+										button={{block: true}}
+										displayType="secondary"
+										href={viewMoreURL}
+									>
+										{Liferay.Language.get('more')}
+									</ClayLink>
+								) : (
+									<ClayButton
+										block={true}
+										displayType="secondary"
+										onClick={() => {
+											if (onShowMoreButtonClick) {
+												onShowMoreButtonClick();
+
+												return;
+											}
+
+											setVisibleItemsCount(
+												totalItemsCountRef.current
+											);
+										}}
+									>
+										{Liferay.Language.get('more')}
+									</ClayButton>
+								)}
+							</div>
+						</>
+					) : (
+						<ItemList
+							primaryItems={primaryItems}
+							secondaryItems={secondaryItems}
+							visibleItemsCount={totalItemsCountRef.current}
+						/>
+					)}
 				</ClayDropDown>
 			) : (
 				<ClayLink
@@ -71,6 +164,53 @@ const CreationMenu = ({primaryItems, secondaryItems}) => {
 				</ClayLink>
 			)}
 		</>
+	);
+};
+
+const ItemList = ({primaryItems, secondaryItems, visibleItemsCount}) => {
+	let currentItemCount = 0;
+
+	return (
+		<ClayDropDown.ItemList>
+			{primaryItems?.map((item, index) => {
+				currentItemCount++;
+
+				if (currentItemCount > visibleItemsCount) {
+					return false;
+				}
+
+				return (
+					<ClayDropDown.Item href={item.href} key={index}>
+						{item.label}
+					</ClayDropDown.Item>
+				);
+			})}
+
+			{secondaryItems?.map((secondaryItemsGroup, index) => (
+				<ClayDropDown.Group
+					header={secondaryItemsGroup.label}
+					key={index}
+				>
+					{secondaryItemsGroup.items.map((item, index) => {
+						currentItemCount++;
+
+						if (currentItemCount > visibleItemsCount) {
+							return false;
+						}
+
+						return (
+							<ClayDropDown.Item href={item.href} key={index}>
+								{item.label}
+							</ClayDropDown.Item>
+						);
+					})}
+
+					{secondaryItemsGroup.separator && (
+						<ClayDropDown.Item className="dropdown-divider" />
+					)}
+				</ClayDropDown.Group>
+			))}
+		</ClayDropDown.ItemList>
 	);
 };
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -44,6 +44,7 @@ function ManagementToolbar({
 	onClearSelectionButtonClick = () => {},
 	onInfoButtonClick = () => {},
 	onSelectAllButtonClick = () => {},
+	onShowMoreButtonClick,
 	searchActionURL,
 	searchContainerId,
 	searchData,
@@ -161,7 +162,12 @@ function ManagementToolbar({
 
 							{showCreationMenu && creationMenu && (
 								<ClayManagementToolbar.Item>
-									<CreationMenu {...creationMenu} />
+									<CreationMenu
+										{...creationMenu}
+										onShowMoreButtonClick={
+											onShowMoreButtonClick
+										}
+									/>
 								</ClayManagementToolbar.Item>
 							)}
 						</ClayManagementToolbar.ItemList>


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-126011

In this PR we are adding the 'More' button in the management toolbar creation menu, and extending `sample-web` to showcase the behavior.

Test plan:
- Place `frontend-taglib-clay-sample-web` on a page and open `Management Toolbars` tab.
- See gif on bottom.

Notes:
- The button will show if there are more than `maxTotalItems` items in the menu. By default, this is 15, taken from the [v2 implementation](https://github.com/liferay/clay/blob/2.x/packages/clay-dropdown/src/ClayCreationMenuDropdown.soy#L93).
- Menu items can be primary and secondary. There can be any number of secondary item groups. v2 implementation supported only two groups, in practice it was 'Favorites' and 'Other'. New tag supports any number of groups. I found this cleaner than duplicated code for two groups in v2 implementation, for example [here](https://github.com/liferay/clay/blob/2.x/packages/clay-dropdown/src/ClayCreationMenuDropdown.soy#L50-L62).
- Number of primary and secondary items can be limited with `maxPrimaryItems` and `maxSecondaryItems`. These along with `maxTotalItems` results in [complicated resolution](https://github.com/liferay/clay/blob/2.x/packages/clay-dropdown/src/ClayCreationMenuDropdown.soy#L50-L118) of how many items should be visible. I copied, but did not test all of the many branching cases. I tested only `maxTotalItems` setting, and it works as expected.
- By default, clicking on 'More' button shows all the items in the extended menu. See this in gif.
- If `onShowMoreButtonClick` is defined, clicking on 'More' invokes it, instead of extending menu. See this in gif, only bottom toolbar has it defined. For usages in Web Content and Documents and Media, this would open a modal with full selection.

@jbalsas Please confirm that the behavior described in last two notes matches the required behavior.

@julien @jonmak08 @carloslancha 

![after](https://user-images.githubusercontent.com/5435511/106168250-57219100-618e-11eb-8b31-8924ec342e54.gif)
