### PR TITLE
LPS-127013 Required date should be populated with current date

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_date/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_date/page.jsp
@@ -46,7 +46,18 @@ String monthParamId = namespace + HtmlUtil.getAUICompatibleId(monthParam);
 String nameId = namespace + HtmlUtil.getAUICompatibleId(name);
 String yearParamId = namespace + HtmlUtil.getAUICompatibleId(yearParam);
 
-Calendar calendar = CalendarFactoryUtil.getCalendar(yearValue, monthValue, dayValue);
+Calendar calendar = null;
+
+if (required && (yearValue == 0) && (monthValue == -1) && (dayValue == 0)) {
+	calendar = CalendarFactoryUtil.getCalendar(timeZone);
+
+	yearValue = calendar.get(Calendar.YEAR);
+	monthValue = calendar.get(Calendar.MONTH);
+	dayValue = calendar.get(Calendar.DAY_OF_MONTH);
+}
+else {
+	calendar = CalendarFactoryUtil.getCalendar(yearValue, monthValue, dayValue);
+}
 
 String mask = _MASK_YMD;
 String simpleDateFormatPattern = _SIMPLE_DATE_FORMAT_PATTERN_HTML5;


### PR DESCRIPTION
See [LPS-127013](https://issues.liferay.com/browse/LPS-127013)

**Steps to Reproduce:** 

1. Create a JSP usign liferay-ui:input-date with required attribute set to true. 
2. Check default date.

 **Actual Results:**
The default date is 11/30/1902

**Expected Results:**
Default date should be now.
