### PR TITLE
LPS-126737 Replace legacy markup card main-content-card classes with Clay 3 sheet pattern

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/details.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/details.jsp
@@ -31,7 +31,6 @@ renderResponse.setTitle((accountEntryDisplay.getAccountEntryId() == 0) ? Languag
 
 <liferay-frontend:edit-form
 	action="<%= editAccountURL %>"
-	cssClass="container-form-lg"
 >
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= (accountEntryDisplay.getAccountEntryId() == 0) ? Constants.ADD : Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_role/details.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_role/details.jsp
@@ -34,7 +34,6 @@ if (accountRole != null) {
 
 <liferay-frontend:edit-form
 	action="<%= editAccountRoleURL %>"
-	cssClass="container-form-lg"
 >
 	<portlet:renderURL var="redirect">
 		<portlet:param name="mvcPath" value="/account_entries_admin/edit_account_role.jsp" />

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/add_account_user.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/add_account_user.jsp
@@ -41,7 +41,6 @@ renderResponse.setTitle(LanguageUtil.format(request, "add-new-user-to-x", accoun
 
 <liferay-frontend:edit-form
 	action="<%= addAccountUsersURL %>"
-	cssClass="container-form-lg"
 >
 	<liferay-frontend:edit-form-body>
 		<portlet:renderURL var="defaultRedirect">

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/edit_account_entry_address.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/edit_account_entry_address.jsp
@@ -35,7 +35,6 @@ renderResponse.setTitle((accountEntryAddressId == 0) ? LanguageUtil.get(request,
 
 <liferay-frontend:edit-form
 	action="<%= editAccountEntryAddressURL %>"
-	cssClass="container-form-lg"
 >
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= (accountEntryAddressId == 0) ? Constants.ADD : Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= backURL %>" />

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/account_group/details.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/account_group/details.jsp
@@ -34,7 +34,6 @@ renderResponse.setTitle((accountGroupDisplay.getAccountGroupId() == 0) ? Languag
 
 <liferay-frontend:edit-form
 	action="<%= editAccountGroupURL %>"
-	cssClass="container-form-lg"
 >
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= (accountGroupDisplay.getAccountGroupId() == 0) ? Constants.ADD : Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/css/main.scss
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/css/main.scss
@@ -1,14 +1,6 @@
 .portlet-announcements,
 .portlet-alerts {
-	.entry-content {
-		padding: 1em;
-	}
-
 	.important {
 		font-weight: normal;
-	}
-
-	.panel-body img {
-		max-width: 100%;
 	}
 }

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/edit_entry.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/edit_entry.jsp
@@ -153,13 +153,13 @@ if (portletTitleBasedNavigation) {
 
 				<aui:input name="expirationDate" />
 			</aui:fieldset>
+
+			<div class="sheet-footer">
+				<aui:button primary="<%= true %>" type="submit" />
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button primary="<%= true %>" type="submit" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </div>
 

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/entry_scope.jspf
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/entry_scope.jspf
@@ -77,8 +77,8 @@ scopeName = HtmlUtil.escape(scopeName);
 		</c:choose>
 	</c:when>
 	<c:otherwise>
-		<h5 class="text-default" title="<%= scopeName %>">
+		<div class="component-subtitle entry-scope" title="<%= scopeName %>">
 			<%= scopeName %>
-		</h5>
+		</div>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view.jsp
@@ -31,14 +31,16 @@ portletURL.setParameter("tabs1", announcementsRequestHelper.getTabs1());
 </c:if>
 
 <c:if test="<%= PortletPermissionUtil.hasControlPanelAccessPermission(permissionChecker, scopeGroupId, AnnouncementsPortletKeys.ANNOUNCEMENTS_ADMIN) %>">
-	<div class="button-holder">
+	<div class="btn-group c-mb-4">
 		<portlet:renderURL var="addEntryURL">
 			<portlet:param name="mvcRenderCommandName" value="/announcements/edit_entry" />
 			<portlet:param name="redirect" value="<%= currentURL %>" />
 			<portlet:param name="alert" value="<%= String.valueOf(portletName.equals(AnnouncementsPortletKeys.ALERTS)) %>" />
 		</portlet:renderURL>
 
-		<aui:button href="<%= addEntryURL %>" icon="icon-plus" value='<%= portletName.equals(AnnouncementsPortletKeys.ALERTS) ? "add-alert" : "add-announcement" %>' />
+		<div class="btn-group-item">
+			<aui:button href="<%= addEntryURL %>" icon="icon-plus" value='<%= portletName.equals(AnnouncementsPortletKeys.ALERTS) ? "add-alert" : "add-announcement" %>' />
+		</div>
 	</div>
 </c:if>
 

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view_entry.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view_entry.jsp
@@ -99,7 +99,7 @@ if (portletTitleBasedNavigation) {
 					</div>
 				</div>
 
-				<div class="entry-content c-mt-3">
+				<div class="c-mt-3 entry-content">
 					<%= entry.getContent() %>
 				</div>
 			</div>

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view_entry.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view_entry.jsp
@@ -50,57 +50,59 @@ if (portletTitleBasedNavigation) {
 </c:if>
 
 <div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl\"" : StringPool.BLANK %>>
-	<div class="main-content-card panel" id="<portlet:namespace /><%= entry.getEntryId() %>">
-		<div class="panel-heading">
-			<div class="card-row">
-				<div class="card-col-field">
-					<div class="list-group-card-icon">
-						<liferay-ui:user-portrait
-							userId="<%= entry.getUserId() %>"
-						/>
+	<div id="<portlet:namespace /><%= entry.getEntryId() %>">
+		<div class="autofit-padded autofit-row">
+			<div class="autofit-col">
+				<liferay-ui:user-portrait
+					userId="<%= entry.getUserId() %>"
+				/>
+			</div>
+
+			<div class="autofit-col autofit-col-expand">
+
+				<%
+				String userDisplayText = PortalUtil.getUserName(entry) + StringPool.COMMA_AND_SPACE + Time.getRelativeTimeDescription(entry.getDisplayDate(), locale, timeZone, announcementsDisplayContext.getDateFormatDate());
+				%>
+
+				<div class="autofit-row">
+					<div class="autofit-col autofit-col-expand">
+						<div class="autofit-section">
+							<div class="component-title entry-user-display-text" title="<%= userDisplayText %>">
+								<%= userDisplayText %>
+							</div>
+
+							<div class="component-title entry-title" title="<%= HtmlUtil.escape(entry.getTitle()) %>">
+								<c:choose>
+									<c:when test="<%= Validator.isNotNull(entry.getUrl()) %>">
+										<a href="<%= HtmlUtil.escapeHREF(entry.getUrl()) %>">
+											<%= HtmlUtil.escape(entry.getTitle()) %>
+										</a>
+									</c:when>
+									<c:otherwise>
+										<%= HtmlUtil.escape(entry.getTitle()) %>
+									</c:otherwise>
+								</c:choose>
+
+								<c:if test="<%= entry.isAlert() || (entry.getPriority() > 0) %>">
+									<span class="badge badge-danger">
+										<liferay-ui:message key="important" />
+									</span>
+								</c:if>
+							</div>
+
+							<%@ include file="/announcements/entry_scope.jspf" %>
+						</div>
+					</div>
+
+					<div class="autofit-col">
+						<%@ include file="/announcements/entry_action.jspf" %>
 					</div>
 				</div>
 
-				<div class="card-col-content card-col-gutters">
-
-					<%
-					String userDisplayText = PortalUtil.getUserName(entry) + StringPool.COMMA_AND_SPACE + Time.getRelativeTimeDescription(entry.getDisplayDate(), locale, timeZone, announcementsDisplayContext.getDateFormatDate());
-					%>
-
-					<h5 class="text-default" title="<%= userDisplayText %>">
-						<%= userDisplayText %>
-					</h5>
-
-					<h4 title="<%= HtmlUtil.escape(entry.getTitle()) %>">
-						<c:choose>
-							<c:when test="<%= Validator.isNotNull(entry.getUrl()) %>">
-								<a href="<%= HtmlUtil.escapeHREF(entry.getUrl()) %>">
-									<%= HtmlUtil.escape(entry.getTitle()) %>
-								</a>
-							</c:when>
-							<c:otherwise>
-								<%= HtmlUtil.escape(entry.getTitle()) %>
-							</c:otherwise>
-						</c:choose>
-
-						<c:if test="<%= entry.isAlert() || (entry.getPriority() > 0) %>">
-							<span class="badge badge-danger badge-sm">
-								<liferay-ui:message key="important" />
-							</span>
-						</c:if>
-					</h4>
-
-					<%@ include file="/announcements/entry_scope.jspf" %>
-				</div>
-
-				<div class="card-col-field">
-					<%@ include file="/announcements/entry_action.jspf" %>
+				<div class="entry-content c-mt-3">
+					<%= entry.getContent() %>
 				</div>
 			</div>
-		</div>
-
-		<div class="entry-content panel-body">
-			<%= entry.getContent() %>
 		</div>
 	</div>
 </div>

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/edit_vocabulary.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/edit_vocabulary.jsp
@@ -39,7 +39,6 @@ renderResponse.setTitle((vocabulary == null) ? LanguageUtil.get(request, "add-vo
 
 <liferay-frontend:edit-form
 	action="<%= editVocabularyURL %>"
-	cssClass="container-form-lg"
 	name="fm"
 	onSubmit='<%= liferayPortletResponse.getNamespace() + "confirmation(event);" %>'
 >

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/edit_tag.jsp
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/edit_tag.jsp
@@ -37,7 +37,6 @@ renderResponse.setTitle(assetTagsDisplayContext.getAssetTitle());
 
 <liferay-frontend:edit-form
 	action="<%= editTagURL %>"
-	cssClass="container-form-lg"
 	method="post"
 	name="fm"
 >

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
@@ -57,7 +57,7 @@ renderResponse.setTitle((entry != null) ? BlogsEntryUtil.getDisplayTitle(resourc
 <portlet:actionURL name="/blogs/edit_entry" var="editEntryURL" />
 
 <clay:container-fluid
-	cssClass="entry-body"
+	cssClass="container-form-lg entry-body"
 >
 	<aui:form action="<%= editEntryURL %>" cssClass="edit-entry" enctype="multipart/form-data" method="post" name="fm" onSubmit="event.preventDefault();">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
@@ -360,51 +360,51 @@ renderResponse.setTitle((entry != null) ? BlogsEntryUtil.getDisplayTitle(resourc
 						/>
 					</aui:fieldset>
 				</c:if>
+
+				<%
+				boolean pending = false;
+
+				if (entry != null) {
+					pending = entry.isPending();
+				}
+				%>
+
+				<c:if test="<%= pending %>">
+					<div class="alert alert-info">
+						<liferay-ui:message key="there-is-a-publication-workflow-in-process" />
+					</div>
+				</c:if>
+
+				<div class="blog-article-button-row sheet-footer">
+
+					<%
+					String saveButtonLabel = "save";
+
+					if ((entry == null) || entry.isDraft() || entry.isApproved()) {
+						saveButtonLabel = "save-as-draft";
+					}
+
+					String publishButtonLabel = "publish";
+
+					if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(themeDisplay.getCompanyId(), scopeGroupId, BlogsEntry.class.getName())) {
+						publishButtonLabel = "submit-for-publication";
+					}
+					%>
+
+					<c:if test="<%= (entry != null) && entry.isApproved() && WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(entry.getCompanyId(), entry.getGroupId(), BlogsEntry.class.getName()) %>">
+						<div class="alert alert-info">
+							<liferay-ui:message arguments="<%= ResourceActionsUtil.getModelResource(locale, BlogsEntry.class.getName()) %>" key="this-x-is-approved.-publishing-these-changes-will-cause-it-to-be-unpublished-and-go-through-the-approval-process-again" translateArguments="<%= false %>" />
+						</div>
+					</c:if>
+
+					<aui:button disabled="<%= pending %>" name="publishButton" type="submit" value="<%= publishButtonLabel %>" />
+
+					<aui:button name="saveButton" primary="<%= false %>" type="submit" value="<%= saveButtonLabel %>" />
+
+					<aui:button href="<%= redirect %>" name="cancelButton" type="cancel" />
+				</div>
 			</aui:fieldset-group>
-
-			<%
-			boolean pending = false;
-
-			if (entry != null) {
-				pending = entry.isPending();
-			}
-			%>
-
-			<c:if test="<%= pending %>">
-				<div class="alert alert-info">
-					<liferay-ui:message key="there-is-a-publication-workflow-in-process" />
-				</div>
-			</c:if>
 		</div>
-
-		<aui:button-row cssClass="blog-article-button-row">
-
-			<%
-			String saveButtonLabel = "save";
-
-			if ((entry == null) || entry.isDraft() || entry.isApproved()) {
-				saveButtonLabel = "save-as-draft";
-			}
-
-			String publishButtonLabel = "publish";
-
-			if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(themeDisplay.getCompanyId(), scopeGroupId, BlogsEntry.class.getName())) {
-				publishButtonLabel = "submit-for-publication";
-			}
-			%>
-
-			<c:if test="<%= (entry != null) && entry.isApproved() && WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(entry.getCompanyId(), entry.getGroupId(), BlogsEntry.class.getName()) %>">
-				<div class="alert alert-info">
-					<liferay-ui:message arguments="<%= ResourceActionsUtil.getModelResource(locale, BlogsEntry.class.getName()) %>" key="this-x-is-approved.-publishing-these-changes-will-cause-it-to-be-unpublished-and-go-through-the-approval-process-again" translateArguments="<%= false %>" />
-				</div>
-			</c:if>
-
-			<aui:button disabled="<%= pending %>" name="publishButton" type="submit" value="<%= publishButtonLabel %>" />
-
-			<aui:button name="saveButton" primary="<%= false %>" type="submit" value="<%= saveButtonLabel %>" />
-
-			<aui:button href="<%= redirect %>" name="cancelButton" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
@@ -53,7 +53,9 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(headerTitle);
 %>
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<portlet:actionURL name="/bookmarks/edit_entry" var="editEntryURL">
 		<portlet:param name="mvcRenderCommandName" value="/bookmarks/edit_entry" />
 	</portlet:actionURL>
@@ -182,14 +184,14 @@ renderResponse.setTitle(headerTitle);
 						/>
 					</aui:fieldset>
 				</c:if>
+
+				<div class="sheet-footer">
+					<aui:button type="submit" />
+
+					<aui:button href="<%= redirect %>" type="cancel" />
+				</div>
 			</aui:fieldset-group>
 		</div>
-
-		<aui:button-row>
-			<aui:button type="submit" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
@@ -55,7 +55,9 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(headerTitle);
 %>
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<portlet:actionURL name="/bookmarks/edit_folder" var="editFolderURL">
 		<portlet:param name="mvcRenderCommandName" value="/bookmarks/edit_folder" />
 	</portlet:actionURL>
@@ -168,13 +170,13 @@ renderResponse.setTitle(headerTitle);
 					</aui:field-wrapper>
 				</aui:fieldset>
 			</c:if>
+
+			<div class="sheet-footer">
+				<aui:button type="submit" />
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button type="submit" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -139,7 +139,9 @@ renderResponse.setTitle(headerTitle);
 	</liferay-frontend:info-bar>
 </c:if>
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<c:if test="<%= checkedOut %>">
 
 		<%
@@ -531,32 +533,32 @@ renderResponse.setTitle(headerTitle);
 						<liferay-ui:message key="there-is-a-publication-workflow-in-process" />
 					</div>
 				</c:if>
+
+				<div class="sheet-footer">
+					<c:if test="<%= dlEditFileEntryDisplayContext.isSaveButtonVisible() %>">
+						<aui:button disabled="<%= dlEditFileEntryDisplayContext.isSaveButtonDisabled() %>" name="saveButton" onClick='<%= liferayPortletResponse.getNamespace() + "saveFileEntry(true);" %>' value="<%= dlEditFileEntryDisplayContext.getSaveButtonLabel() %>" />
+					</c:if>
+
+					<c:if test="<%= dlEditFileEntryDisplayContext.isPublishButtonVisible() %>">
+						<aui:button disabled="<%= dlEditFileEntryDisplayContext.isPublishButtonDisabled() %>" name="publishButton" type="submit" value="<%= dlEditFileEntryDisplayContext.getPublishButtonLabel() %>" />
+					</c:if>
+
+					<c:if test="<%= dlEditFileEntryDisplayContext.isCheckoutDocumentButtonVisible() %>">
+						<aui:button disabled="<%= dlEditFileEntryDisplayContext.isCheckoutDocumentButtonDisabled() %>" onClick='<%= liferayPortletResponse.getNamespace() + "checkOut();" %>' value="checkout[document]" />
+					</c:if>
+
+					<c:if test="<%= dlEditFileEntryDisplayContext.isCheckinButtonVisible() %>">
+						<aui:button disabled="<%= dlEditFileEntryDisplayContext.isCheckinButtonDisabled() %>" onClick='<%= liferayPortletResponse.getNamespace() + "checkIn();" %>' value="save-and-checkin" />
+					</c:if>
+
+					<c:if test="<%= dlEditFileEntryDisplayContext.isCancelCheckoutDocumentButtonVisible() %>">
+						<aui:button disabled="<%= dlEditFileEntryDisplayContext.isCancelCheckoutDocumentButtonDisabled() %>" onClick='<%= liferayPortletResponse.getNamespace() + "cancelCheckOut();" %>' value="cancel-checkout[document]" />
+					</c:if>
+
+					<aui:button href="<%= redirect %>" type="cancel" />
+				</div>
 			</aui:fieldset-group>
 		</div>
-
-		<aui:button-row>
-			<c:if test="<%= dlEditFileEntryDisplayContext.isSaveButtonVisible() %>">
-				<aui:button disabled="<%= dlEditFileEntryDisplayContext.isSaveButtonDisabled() %>" name="saveButton" onClick='<%= liferayPortletResponse.getNamespace() + "saveFileEntry(true);" %>' value="<%= dlEditFileEntryDisplayContext.getSaveButtonLabel() %>" />
-			</c:if>
-
-			<c:if test="<%= dlEditFileEntryDisplayContext.isPublishButtonVisible() %>">
-				<aui:button disabled="<%= dlEditFileEntryDisplayContext.isPublishButtonDisabled() %>" name="publishButton" type="submit" value="<%= dlEditFileEntryDisplayContext.getPublishButtonLabel() %>" />
-			</c:if>
-
-			<c:if test="<%= dlEditFileEntryDisplayContext.isCheckoutDocumentButtonVisible() %>">
-				<aui:button disabled="<%= dlEditFileEntryDisplayContext.isCheckoutDocumentButtonDisabled() %>" onClick='<%= liferayPortletResponse.getNamespace() + "checkOut();" %>' value="checkout[document]" />
-			</c:if>
-
-			<c:if test="<%= dlEditFileEntryDisplayContext.isCheckinButtonVisible() %>">
-				<aui:button disabled="<%= dlEditFileEntryDisplayContext.isCheckinButtonDisabled() %>" onClick='<%= liferayPortletResponse.getNamespace() + "checkIn();" %>' value="save-and-checkin" />
-			</c:if>
-
-			<c:if test="<%= dlEditFileEntryDisplayContext.isCancelCheckoutDocumentButtonVisible() %>">
-				<aui:button disabled="<%= dlEditFileEntryDisplayContext.isCancelCheckoutDocumentButtonDisabled() %>" onClick='<%= liferayPortletResponse.getNamespace() + "cancelCheckOut();" %>' value="cancel-checkout[document]" />
-			</c:if>
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 
 	<liferay-ui:upload-progress

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
@@ -24,7 +24,9 @@ DLEditFileShortcutDisplayContext dlEditFileShortcutDisplayContext = (DLEditFileS
 renderResponse.setTitle(dlEditFileShortcutDisplayContext.getTitle());
 %>
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<aui:form action="<%= dlEditFileShortcutDisplayContext.getEditFileShortcutURL() %>" method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 		<aui:input name="fileShortcutId" type="hidden" value="<%= dlEditFileShortcutDisplayContext.getFileShortcutId() %>" />
@@ -55,13 +57,13 @@ renderResponse.setTitle(dlEditFileShortcutDisplayContext.getTitle());
 					/>
 				</aui:fieldset>
 			</c:if>
+
+			<div class="sheet-footer">
+				<aui:button type="submit" />
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button type="submit" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
@@ -38,7 +38,9 @@ renderResponse.setTitle(dlEditFolderDisplayContext.getHeaderTitle());
 	/>
 </liferay-util:buffer>
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<portlet:actionURL name="/document_library/edit_folder" var="editFolderURL">
 		<portlet:param name="mvcRenderCommandName" value="/document_library/edit_folder" />
 	</portlet:actionURL>
@@ -226,13 +228,13 @@ renderResponse.setTitle(dlEditFolderDisplayContext.getHeaderTitle());
 					</aui:fieldset>
 				</c:if>
 			</c:if>
+
+			<div class="sheet-footer">
+				<aui:button type="submit" />
+
+				<aui:button href="<%= dlEditFolderDisplayContext.getRedirect() %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button type="submit" />
-
-			<aui:button href="<%= dlEditFolderDisplayContext.getRedirect() %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
@@ -33,7 +33,9 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(headerTitle);
 %>
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<portlet:actionURL name="/document_library/edit_repository" var="editRepositoryURL">
 		<portlet:param name="mvcRenderCommandName" value="/document_library/edit_repository" />
 	</portlet:actionURL>
@@ -127,13 +129,13 @@ renderResponse.setTitle(headerTitle);
 					/>
 				</aui:fieldset>
 			</c:if>
+
+			<div class="sheet-footer">
+				<aui:button type="submit" />
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button type="submit" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 
 	<div class="hide" id="<portlet:namespace />settingsSupported">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries.jsp
@@ -42,7 +42,7 @@ if (portletTitleBasedNavigation) {
 }
 %>
 
-<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl\"" : StringPool.BLANK %>>
+<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl container-form-lg\"" : StringPool.BLANK %>>
 	<c:if test="<%= !portletTitleBasedNavigation %>">
 		<liferay-ui:header
 			backURL="<%= redirect %>"
@@ -51,225 +51,223 @@ if (portletTitleBasedNavigation) {
 		/>
 	</c:if>
 
-	<div class="card main-content-card">
-		<div class="card-body">
-			<c:choose>
-				<c:when test="<%= DLFolderPermission.contains(permissionChecker, scopeGroupId, folderId, ActionKeys.ADD_DOCUMENT) %>">
-					<clay:row>
-						<clay:col
-							md="6"
-						>
-							<aui:form name="fm1">
-								<div class="lfr-dynamic-uploader">
-									<div class="lfr-upload-container" id="<portlet:namespace />fileUpload"></div>
-								</div>
-							</aui:form>
-
-							<aui:script use="liferay-upload">
-								new Liferay.Upload({
-									boundingBox: '#<portlet:namespace />fileUpload',
-
-									<%
-									DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance(locale);
-									%>
-
-									decimalSeparator: '<%= decimalFormatSymbols.getDecimalSeparator() %>',
-
-									deleteFile:
-										'<liferay-portlet:actionURL name="/document_library/upload_multiple_file_entries"><portlet:param name="<%= Constants.CMD %>" value="<%= Constants.DELETE_TEMP %>" /><portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" /></liferay-portlet:actionURL>',
-									fileDescription:
-										'<%= StringUtil.merge(dlConfiguration.fileExtensions()) %>',
-									maxFileSize: '<%= dlConfiguration.fileMaxSize() %> B',
-									metadataContainer: '#<portlet:namespace />commonFileMetadataContainer',
-									metadataExplanationContainer:
-										'#<portlet:namespace />metadataExplanationContainer',
-									namespace: '<portlet:namespace />',
-									tempFileURL: {
-										method: Liferay.Service.bind('/dlapp/get-temp-file-names'),
-										params: {
-											folderId: <%= folderId %>,
-											folderName: '<%= EditFileEntryMVCActionCommand.TEMP_FOLDER_NAME %>',
-											groupId: <%= scopeGroupId %>,
-										},
-									},
-									tempRandomSuffix: '<%= TempFileEntryUtil.TEMP_RANDOM_SUFFIX %>',
-									uploadFile:
-										'<liferay-portlet:actionURL name="/document_library/upload_multiple_file_entries"><portlet:param name="<%= Constants.CMD %>" value="<%= Constants.ADD_TEMP %>" /><portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" /></liferay-portlet:actionURL>',
-								});
-							</aui:script>
-						</clay:col>
-
-						<clay:col
-							md="6"
-						>
-							<div class="common-file-metadata-container hide selected" id="<portlet:namespace />commonFileMetadataContainer">
-								<liferay-util:include page="/document_library/upload_multiple_file_entries_resources.jsp" servletContext="<%= application %>" />
+	<div class="sheet">
+		<c:choose>
+			<c:when test="<%= DLFolderPermission.contains(permissionChecker, scopeGroupId, folderId, ActionKeys.ADD_DOCUMENT) %>">
+				<clay:row>
+					<clay:col
+						md="6"
+					>
+						<aui:form name="fm1">
+							<div class="lfr-dynamic-uploader">
+								<div class="lfr-upload-container" id="<portlet:namespace />fileUpload"></div>
 							</div>
+						</aui:form>
 
-							<%
-							DLBreadcrumbUtil.addPortletBreadcrumbEntries(folderId, request, renderResponse);
+						<aui:script use="liferay-upload">
+							new Liferay.Upload({
+								boundingBox: '#<portlet:namespace />fileUpload',
 
-							PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "add-multiple-file-entries"), currentURL);
-							%>
+								<%
+								DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance(locale);
+								%>
 
-							<aui:script use="aui-base,aui-loading-mask-deprecated,node-load">
-								Liferay.on('tempFileRemoved', function () {
-									Liferay.Util.openToast({
-										message:
-											'<%= LanguageUtil.get(request, "your-request-completed-successfully") %>',
-									});
+								decimalSeparator: '<%= decimalFormatSymbols.getDecimalSeparator() %>',
+
+								deleteFile:
+									'<liferay-portlet:actionURL name="/document_library/upload_multiple_file_entries"><portlet:param name="<%= Constants.CMD %>" value="<%= Constants.DELETE_TEMP %>" /><portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" /></liferay-portlet:actionURL>',
+								fileDescription:
+									'<%= StringUtil.merge(dlConfiguration.fileExtensions()) %>',
+								maxFileSize: '<%= dlConfiguration.fileMaxSize() %> B',
+								metadataContainer: '#<portlet:namespace />commonFileMetadataContainer',
+								metadataExplanationContainer:
+									'#<portlet:namespace />metadataExplanationContainer',
+								namespace: '<portlet:namespace />',
+								tempFileURL: {
+									method: Liferay.Service.bind('/dlapp/get-temp-file-names'),
+									params: {
+										folderId: <%= folderId %>,
+										folderName: '<%= EditFileEntryMVCActionCommand.TEMP_FOLDER_NAME %>',
+										groupId: <%= scopeGroupId %>,
+									},
+								},
+								tempRandomSuffix: '<%= TempFileEntryUtil.TEMP_RANDOM_SUFFIX %>',
+								uploadFile:
+									'<liferay-portlet:actionURL name="/document_library/upload_multiple_file_entries"><portlet:param name="<%= Constants.CMD %>" value="<%= Constants.ADD_TEMP %>" /><portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" /></liferay-portlet:actionURL>',
+							});
+						</aui:script>
+					</clay:col>
+
+					<clay:col
+						md="6"
+					>
+						<div class="common-file-metadata-container hide selected" id="<portlet:namespace />commonFileMetadataContainer">
+							<liferay-util:include page="/document_library/upload_multiple_file_entries_resources.jsp" servletContext="<%= application %>" />
+						</div>
+
+						<%
+						DLBreadcrumbUtil.addPortletBreadcrumbEntries(folderId, request, renderResponse);
+
+						PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "add-multiple-file-entries"), currentURL);
+						%>
+
+						<aui:script use="aui-base,aui-loading-mask-deprecated,node-load">
+							Liferay.on('tempFileRemoved', function () {
+								Liferay.Util.openToast({
+									message:
+										'<%= LanguageUtil.get(request, "your-request-completed-successfully") %>',
 								});
+							});
 
-								window['<portlet:namespace />updateMultipleFiles'] = function () {
-									var Lang = A.Lang;
+							window['<portlet:namespace />updateMultipleFiles'] = function () {
+								var Lang = A.Lang;
 
-									var commonFileMetadataContainer = A.one(
-										'#<portlet:namespace />commonFileMetadataContainer'
-									);
-									var selectedFileNameContainer = A.one(
-										'#<portlet:namespace />selectedFileNameContainer'
-									);
+								var commonFileMetadataContainer = A.one(
+									'#<portlet:namespace />commonFileMetadataContainer'
+								);
+								var selectedFileNameContainer = A.one(
+									'#<portlet:namespace />selectedFileNameContainer'
+								);
 
-									var inputTpl =
-										'<input id="<portlet:namespace />selectedFileName{0}" name="<portlet:namespace />selectedFileName" type="hidden" value="{1}" />';
+								var inputTpl =
+									'<input id="<portlet:namespace />selectedFileName{0}" name="<portlet:namespace />selectedFileName" type="hidden" value="{1}" />';
 
-									var values = A.all(
-										'input[name=<portlet:namespace />selectUploadedFile]:checked'
-									).val();
+								var values = A.all(
+									'input[name=<portlet:namespace />selectUploadedFile]:checked'
+								).val();
 
-									var buffer = [];
-									var dataBuffer = [];
-									var length = values.length;
+								var buffer = [];
+								var dataBuffer = [];
+								var length = values.length;
 
-									for (var i = 0; i < length; i++) {
-										dataBuffer[0] = i;
-										dataBuffer[1] = values[i];
+								for (var i = 0; i < length; i++) {
+									dataBuffer[0] = i;
+									dataBuffer[1] = values[i];
 
-										buffer[i] = Lang.sub(inputTpl, dataBuffer);
-									}
+									buffer[i] = Lang.sub(inputTpl, dataBuffer);
+								}
 
-									selectedFileNameContainer.html(buffer.join(''));
+								selectedFileNameContainer.html(buffer.join(''));
 
-									commonFileMetadataContainer.plug(A.LoadingMask);
+								commonFileMetadataContainer.plug(A.LoadingMask);
 
-									commonFileMetadataContainer.loadingmask.show();
+								commonFileMetadataContainer.loadingmask.show();
 
-									Liferay.Util.fetch(document.<portlet:namespace />fm2.action, {
-										body: new FormData(document.<portlet:namespace />fm2),
-										method: 'POST',
+								Liferay.Util.fetch(document.<portlet:namespace />fm2.action, {
+									body: new FormData(document.<portlet:namespace />fm2),
+									method: 'POST',
+								})
+									.then(function (response) {
+										return response.json();
 									})
-										.then(function (response) {
-											return response.json();
-										})
-										.then(function (response) {
-											var itemFailed = false;
+									.then(function (response) {
+										var itemFailed = false;
 
-											for (var i = 0; i < response.length; i++) {
-												var item = response[i];
+										for (var i = 0; i < response.length; i++) {
+											var item = response[i];
 
-												var checkBox = A.one(
-													'input[data-fileName="' + item.originalFileName + '"]'
+											var checkBox = A.one(
+												'input[data-fileName="' + item.originalFileName + '"]'
+											);
+
+											var li = checkBox.ancestor();
+
+											checkBox.remove(true);
+
+											li.removeClass('selectable').removeClass('selected');
+
+											var cssClass = null;
+											var childHTML = null;
+
+											if (item.added) {
+												cssClass = 'file-saved';
+
+												var originalFileName = item.originalFileName;
+
+												var pos = originalFileName.indexOf(
+													'<%= TempFileEntryUtil.TEMP_RANDOM_SUFFIX %>'
 												);
 
-												var li = checkBox.ancestor();
+												if (pos != -1) {
+													originalFileName = originalFileName.substr(0, pos);
+												}
 
-												checkBox.remove(true);
-
-												li.removeClass('selectable').removeClass('selected');
-
-												var cssClass = null;
-												var childHTML = null;
-
-												if (item.added) {
-													cssClass = 'file-saved';
-
-													var originalFileName = item.originalFileName;
-
-													var pos = originalFileName.indexOf(
-														'<%= TempFileEntryUtil.TEMP_RANDOM_SUFFIX %>'
-													);
-
-													if (pos != -1) {
-														originalFileName = originalFileName.substr(0, pos);
-													}
-
-													if (originalFileName === item.fileName) {
-														childHTML =
-															'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %></span>';
-													}
-													else {
-														childHTML =
-															'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %> (' +
-															item.fileName +
-															')</span>';
-													}
+												if (originalFileName === item.fileName) {
+													childHTML =
+														'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %></span>';
 												}
 												else {
-													cssClass = 'upload-error';
-
 													childHTML =
-														'<span class="card-bottom error-message">' +
-														item.errorMessage +
-														'</span>';
-
-													itemFailed = true;
+														'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %> (' +
+														item.fileName +
+														')</span>';
 												}
-
-												li.addClass(cssClass);
-												li.append(childHTML);
-											}
-
-											<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/document_library/upload_multiple_file_entries" var="uploadMultipleFileEntries">
-												<portlet:param name="repositoryId" value="<%= String.valueOf(repositoryId) %>" />
-												<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
-											</liferay-portlet:resourceURL>
-
-											if (commonFileMetadataContainer.io) {
-												commonFileMetadataContainer.io.start();
 											}
 											else {
-												commonFileMetadataContainer.load(
-													'<%= uploadMultipleFileEntries %>'
-												);
+												cssClass = 'upload-error';
+
+												childHTML =
+													'<span class="card-bottom error-message">' +
+													item.errorMessage +
+													'</span>';
+
+												itemFailed = true;
 											}
 
-											Liferay.fire('filesSaved');
+											li.addClass(cssClass);
+											li.append(childHTML);
+										}
 
-											commonFileMetadataContainer.unplug(A.LoadingMask);
+										<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/document_library/upload_multiple_file_entries" var="uploadMultipleFileEntries">
+											<portlet:param name="repositoryId" value="<%= String.valueOf(repositoryId) %>" />
+											<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
+										</liferay-portlet:resourceURL>
 
-											if (!itemFailed) {
-												location.href = '<%= HtmlUtil.escapeJS(redirect) %>';
-											}
-										})
-										.catch(function (error) {
-											var selectedItems = A.all(
-												'#<portlet:namespace />fileUpload li.selected'
+										if (commonFileMetadataContainer.io) {
+											commonFileMetadataContainer.io.start();
+										}
+										else {
+											commonFileMetadataContainer.load(
+												'<%= uploadMultipleFileEntries %>'
 											);
+										}
 
-											selectedItems
-												.removeClass('selectable')
-												.removeClass('selected')
-												.addClass('upload-error');
+										Liferay.fire('filesSaved');
 
-											selectedItems.append(
-												'<span class="card-bottom error-message"><%= UnicodeLanguageUtil.get(request, "an-unexpected-error-occurred-while-deleting-the-file") %></span>'
-											);
+										commonFileMetadataContainer.unplug(A.LoadingMask);
 
-											selectedItems.all('input').remove(true);
+										if (!itemFailed) {
+											location.href = '<%= HtmlUtil.escapeJS(redirect) %>';
+										}
+									})
+									.catch(function (error) {
+										var selectedItems = A.all(
+											'#<portlet:namespace />fileUpload li.selected'
+										);
 
-											commonFileMetadataContainer.loadingmask.hide();
-										});
-								};
-							</aui:script>
-						</clay:col>
-					</clay:row>
-				</c:when>
-				<c:otherwise>
-					<div class="alert alert-danger">
-						<liferay-ui:message key="you-do-not-have-the-required-permissions-to-access-this-application" />
-					</div>
-				</c:otherwise>
-			</c:choose>
-		</div>
+										selectedItems
+											.removeClass('selectable')
+											.removeClass('selected')
+											.addClass('upload-error');
+
+										selectedItems.append(
+											'<span class="card-bottom error-message"><%= UnicodeLanguageUtil.get(request, "an-unexpected-error-occurred-while-deleting-the-file") %></span>'
+										);
+
+										selectedItems.all('input').remove(true);
+
+										commonFileMetadataContainer.loadingmask.hide();
+									});
+							};
+						</aui:script>
+					</clay:col>
+				</clay:row>
+			</c:when>
+			<c:otherwise>
+				<div class="alert alert-danger">
+					<liferay-ui:message key="you-do-not-have-the-required-permissions-to-access-this-application" />
+				</div>
+			</c:otherwise>
+		</c:choose>
 	</div>
 </div>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record_set.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record_set.jsp
@@ -68,98 +68,102 @@ if (ddlDisplayContext.isAdminPortlet()) {
 	<portlet:param name="mvcPath" value="/edit_record_set.jsp" />
 </portlet:actionURL>
 
-<aui:form action="<%= (recordSet == null) ? addRecordSetURL : updateRecordSetURL %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveRecordSet();" %>'>
-	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
-	<aui:input name="closeRedirect" type="hidden" value="<%= closeRedirect %>" />
-	<aui:input name="portletResource" type="hidden" value="<%= portletResource %>" />
-	<aui:input name="groupId" type="hidden" value="<%= groupId %>" />
-	<aui:input name="recordSetId" type="hidden" value="<%= recordSetId %>" />
-	<aui:input name="ddmStructureId" type="hidden" value="<%= ddmStructureId %>" />
-	<aui:input name="scope" type="hidden" value="<%= DDLRecordSetConstants.SCOPE_DYNAMIC_DATA_LISTS %>" />
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
+	<aui:form action="<%= (recordSet == null) ? addRecordSetURL : updateRecordSetURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveRecordSet();" %>'>
+		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
+		<aui:input name="closeRedirect" type="hidden" value="<%= closeRedirect %>" />
+		<aui:input name="portletResource" type="hidden" value="<%= portletResource %>" />
+		<aui:input name="groupId" type="hidden" value="<%= groupId %>" />
+		<aui:input name="recordSetId" type="hidden" value="<%= recordSetId %>" />
+		<aui:input name="ddmStructureId" type="hidden" value="<%= ddmStructureId %>" />
+		<aui:input name="scope" type="hidden" value="<%= DDLRecordSetConstants.SCOPE_DYNAMIC_DATA_LISTS %>" />
 
-	<liferay-ui:error exception="<%= RecordSetDDMStructureIdException.class %>" message="please-enter-a-valid-definition" />
-	<liferay-ui:error exception="<%= RecordSetNameException.class %>" message="please-enter-a-valid-name" />
+		<liferay-ui:error exception="<%= RecordSetDDMStructureIdException.class %>" message="please-enter-a-valid-definition" />
+		<liferay-ui:error exception="<%= RecordSetNameException.class %>" message="please-enter-a-valid-name" />
 
-	<liferay-asset:asset-categories-error />
+		<liferay-asset:asset-categories-error />
 
-	<liferay-asset:asset-tags-error />
+		<liferay-asset:asset-tags-error />
 
-	<aui:model-context bean="<%= recordSet %>" model="<%= DDLRecordSet.class %>" />
+		<aui:model-context bean="<%= recordSet %>" model="<%= DDLRecordSet.class %>" />
 
-	<aui:fieldset-group markupView="lexicon">
-		<aui:fieldset>
-			<c:if test="<%= (recordSet != null) && (DDMStorageLinkLocalServiceUtil.getStructureStorageLinksCount(recordSet.getDDMStructureId()) > 0) %>">
-				<div class="alert alert-warning">
-					<liferay-ui:message key="updating-the-data-definition-may-cause-data-loss" />
+		<aui:fieldset-group markupView="lexicon">
+			<aui:fieldset>
+				<c:if test="<%= (recordSet != null) && (DDMStorageLinkLocalServiceUtil.getStructureStorageLinksCount(recordSet.getDDMStructureId()) > 0) %>">
+					<div class="alert alert-warning">
+						<liferay-ui:message key="updating-the-data-definition-may-cause-data-loss" />
+					</div>
+				</c:if>
+
+				<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>" name="name" />
+
+				<aui:input name="description" />
+
+				<div class="form-group">
+					<aui:input label="data-definition" name="ddmStructureNameDisplay" required="<%= true %>" type="resource" value="<%= ddmStructureName %>" />
+
+					<liferay-ui:icon
+						label="<%= true %>"
+						linkCssClass="btn btn-secondary"
+						message="select"
+						url='<%= "javascript:" + liferayPortletResponse.getNamespace() + "openDDMStructureSelector();" %>'
+					/>
 				</div>
-			</c:if>
 
-			<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>" name="name" />
+				<c:if test="<%= WorkflowEngineManagerUtil.isDeployed() && (WorkflowHandlerRegistryUtil.getWorkflowHandler(DDLRecord.class.getName()) != null) && !scopeGroup.isLayoutSetPrototype() %>">
+					<aui:select label="workflow" name="workflowDefinition">
 
-			<aui:input name="description" />
+						<%
+						WorkflowDefinitionLink workflowDefinitionLink = null;
 
-			<div class="form-group">
-				<aui:input label="data-definition" name="ddmStructureNameDisplay" required="<%= true %>" type="resource" value="<%= ddmStructureName %>" />
-
-				<liferay-ui:icon
-					label="<%= true %>"
-					linkCssClass="btn btn-secondary"
-					message="select"
-					url='<%= "javascript:" + liferayPortletResponse.getNamespace() + "openDDMStructureSelector();" %>'
-				/>
-			</div>
-
-			<c:if test="<%= WorkflowEngineManagerUtil.isDeployed() && (WorkflowHandlerRegistryUtil.getWorkflowHandler(DDLRecord.class.getName()) != null) && !scopeGroup.isLayoutSetPrototype() %>">
-				<aui:select label="workflow" name="workflowDefinition">
-
-					<%
-					WorkflowDefinitionLink workflowDefinitionLink = null;
-
-					try {
-						workflowDefinitionLink = WorkflowDefinitionLinkLocalServiceUtil.getWorkflowDefinitionLink(company.getCompanyId(), themeDisplay.getScopeGroupId(), DDLRecordSet.class.getName(), recordSetId, 0, true);
-					}
-					catch (NoSuchWorkflowDefinitionLinkException nswdle) {
-					}
-					%>
-
-					<aui:option><liferay-ui:message key="no-workflow" /></aui:option>
-
-					<%
-					List<WorkflowDefinition> workflowDefinitions = WorkflowDefinitionManagerUtil.getActiveWorkflowDefinitions(company.getCompanyId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-
-					for (WorkflowDefinition workflowDefinition : workflowDefinitions) {
-						boolean selected = false;
-
-						if ((workflowDefinitionLink != null) && Objects.equals(workflowDefinitionLink.getWorkflowDefinitionName(), workflowDefinition.getName()) && (workflowDefinitionLink.getWorkflowDefinitionVersion() == workflowDefinition.getVersion())) {
-							selected = true;
+						try {
+							workflowDefinitionLink = WorkflowDefinitionLinkLocalServiceUtil.getWorkflowDefinitionLink(company.getCompanyId(), themeDisplay.getScopeGroupId(), DDLRecordSet.class.getName(), recordSetId, 0, true);
 						}
-					%>
+						catch (NoSuchWorkflowDefinitionLinkException nswdle) {
+						}
+						%>
 
-						<aui:option label="<%= HtmlUtil.escape(workflowDefinition.getTitle(languageId)) %>" selected="<%= selected %>" value="<%= HtmlUtil.escapeAttribute(workflowDefinition.getName()) + StringPool.AT + workflowDefinition.getVersion() %>" />
+						<aui:option><liferay-ui:message key="no-workflow" /></aui:option>
 
-					<%
-					}
-					%>
+						<%
+						List<WorkflowDefinition> workflowDefinitions = WorkflowDefinitionManagerUtil.getActiveWorkflowDefinitions(company.getCompanyId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
-				</aui:select>
-			</c:if>
-		</aui:fieldset>
+						for (WorkflowDefinition workflowDefinition : workflowDefinitions) {
+							boolean selected = false;
 
-		<c:if test="<%= recordSet == null %>">
-			<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="permissions">
-				<liferay-ui:input-permissions
-					modelName="<%= DDLRecordSet.class.getName() %>"
-				/>
+							if ((workflowDefinitionLink != null) && Objects.equals(workflowDefinitionLink.getWorkflowDefinitionName(), workflowDefinition.getName()) && (workflowDefinitionLink.getWorkflowDefinitionVersion() == workflowDefinition.getVersion())) {
+								selected = true;
+							}
+						%>
+
+							<aui:option label="<%= HtmlUtil.escape(workflowDefinition.getTitle(languageId)) %>" selected="<%= selected %>" value="<%= HtmlUtil.escapeAttribute(workflowDefinition.getName()) + StringPool.AT + workflowDefinition.getVersion() %>" />
+
+						<%
+						}
+						%>
+
+					</aui:select>
+				</c:if>
 			</aui:fieldset>
-		</c:if>
-	</aui:fieldset-group>
 
-	<aui:button-row>
-		<aui:button name="saveButton" type="submit" value="save" />
+			<c:if test="<%= recordSet == null %>">
+				<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="permissions">
+					<liferay-ui:input-permissions
+						modelName="<%= DDLRecordSet.class.getName() %>"
+					/>
+				</aui:fieldset>
+			</c:if>
 
-		<aui:button href="<%= redirect %>" name="cancelButton" type="cancel" />
-	</aui:button-row>
-</aui:form>
+			<div class="sheet-footer">
+				<aui:button name="saveButton" type="submit" value="save" />
+
+				<aui:button href="<%= redirect %>" name="cancelButton" type="cancel" />
+			</div>
+		</aui:fieldset-group>
+	</aui:form>
+</clay:container-fluid>
 
 <aui:script>
 	var form = document.<portlet:namespace />fm;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/edit_data_provider.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/edit_data_provider.jsp
@@ -50,7 +50,7 @@ renderResponse.setTitle((ddmDataProviderInstance == null) ? LanguageUtil.get(req
 	<%@ include file="/exceptions.jspf" %>
 
 	<clay:container-fluid
-		cssClass="lfr-ddm-edit-data-provider"
+		cssClass="container-form-lg lfr-ddm-edit-data-provider"
 	>
 		<aui:fieldset-group markupView="lexicon">
 			<aui:fieldset>
@@ -84,18 +84,16 @@ renderResponse.setTitle((ddmDataProviderInstance == null) ? LanguageUtil.get(req
 					/>
 				</aui:fieldset>
 			</c:if>
+
+			<c:if test="<%= !windowState.equals(LiferayWindowState.POP_UP) %>">
+				<div class="sheet-footer">
+					<aui:button id="submit" label="save" type="submit" />
+
+					<aui:button href="<%= redirect %>" name="cancelButton" type="cancel" />
+				</div>
+			</c:if>
 		</aui:fieldset-group>
 	</clay:container-fluid>
-
-	<c:if test="<%= !windowState.equals(LiferayWindowState.POP_UP) %>">
-		<clay:container-fluid>
-			<aui:button-row>
-				<aui:button id="submit" label="save" type="submit" />
-
-				<aui:button href="<%= redirect %>" name="cancelButton" type="cancel" />
-			</aui:button-row>
-		</clay:container-fluid>
-	</c:if>
 
 	<aui:button cssClass="hide" type="submit" />
 </aui:form>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/edit_export_configuration.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/edit_export_configuration.jsp
@@ -82,7 +82,9 @@ portletDisplay.setURLBack(portletURL.toString());
 renderResponse.setTitle((exportImportConfiguration == null) ? LanguageUtil.get(request, "new-export-template") : exportImportConfiguration.getName());
 %>
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<portlet:actionURL name="/export_import/edit_export_configuration" var="updateExportConfigurationURL">
 		<portlet:param name="mvcRenderCommandName" value="/export_import/edit_export_configuration" />
 	</portlet:actionURL>
@@ -139,13 +141,13 @@ renderResponse.setTitle((exportImportConfiguration == null) ? LanguageUtil.get(r
 					labelCSSClass="permissions-label"
 				/>
 			</aui:fieldset-group>
+
+			<div class="sheet-footer">
+				<aui:button type="submit" value="save" />
+
+				<aui:button href="<%= portletURL.toString() %>" type="cancel" />
+			</div>
 		</div>
-
-		<aui:button-row>
-			<aui:button type="submit" value="save" />
-
-			<aui:button href="<%= portletURL.toString() %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/new_export/export_layouts.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/new_export/export_layouts.jsp
@@ -88,7 +88,9 @@ portletDisplay.setURLBack(backURL);
 renderResponse.setTitle(!configuredExport ? LanguageUtil.get(request, "new-custom-export") : LanguageUtil.format(request, "new-export-based-on-x", exportImportConfiguration.getName(), false));
 %>
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<portlet:actionURL name="/export_import/edit_export_configuration" var="restoreTrashEntriesURL">
 		<portlet:param name="mvcRenderCommandName" value="/export_import/export_layouts" />
 		<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.RESTORE %>" />
@@ -173,14 +175,14 @@ renderResponse.setTitle(!configuredExport ? LanguageUtil.get(request, "new-custo
 					global="<%= group.isCompany() %>"
 					labelCSSClass="permissions-label"
 				/>
+
+				<div class="sheet-footer">
+					<aui:button type="submit" value="export" />
+
+					<aui:button href="<%= backURL %>" type="cancel" />
+				</div>
 			</aui:fieldset-group>
 		</div>
-
-		<aui:button-row>
-			<aui:button type="submit" value="export" />
-
-			<aui:button href="<%= backURL %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts.jsp
@@ -34,7 +34,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "new-import-process"));
 %>
 
 <clay:container-fluid
-	cssClass="container-view"
+	cssClass="container-form-lg"
 	id='<%= liferayPortletResponse.getNamespace() + "exportImportOptions" %>'
 >
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_validation.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_validation.jsp
@@ -21,7 +21,7 @@ long groupId = ParamUtil.getLong(request, "groupId");
 boolean privateLayout = ParamUtil.getBoolean(request, "privateLayout");
 %>
 
-<aui:form cssClass="lfr-export-dialog" method="post" name="fm1">
+<aui:form cssClass="lfr-export-dialog sheet" method="post" name="fm1">
 	<div class="lfr-dynamic-uploader">
 		<clay:container-fluid>
 			<div class="lfr-upload-container" id="<portlet:namespace />fileUpload"></div>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_collection.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_collection.jsp
@@ -33,7 +33,6 @@ renderResponse.setTitle((fragmentCollection != null) ? fragmentCollection.getNam
 
 <liferay-frontend:edit-form
 	action="<%= editFragmentCollectionURL %>"
-	cssClass="container-form-lg"
 	name="fm"
 >
 	<aui:input name="redirect" type="hidden" value="<%= fragmentDisplayContext.getRedirect() %>" />

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_logo_selector.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_logo_selector.scss
@@ -19,10 +19,6 @@
 			width: fit-content;
 		}
 	}
-
-	.main-content-card {
-		margin-top: 2px;
-	}
 }
 
 .taglib-logo-selector .avatar {

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/index.js
@@ -149,7 +149,7 @@ function Comparator({
 	return (
 		<form
 			action={portletURL}
-			className="container-fluid-1280 diff-version-comparator"
+			className="container-fluid container-fluid-max-xl container-view diff-version-comparator"
 			method="post"
 			name={`${portletNamespace}diffVersionFm`}
 			ref={formRef}
@@ -166,7 +166,7 @@ function Comparator({
 				value={targetVersion}
 			/>
 
-			<ClayCard className="main-content-card" horizontal>
+			<ClayCard horizontal>
 				<ClayCard.Body>
 					<ClayCard.Description displayType="title">
 						{Liferay.Language.get(

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/start.jsp
@@ -20,7 +20,7 @@
 String fullName = namespace.concat(HtmlUtil.escapeAttribute(name));
 %>
 
-<form action="<%= HtmlUtil.escapeAttribute(action) %>" class="container-fluid container-fluid-max-xl container-no-gutters form <%= cssClass %> <%= inlineLabels ? "field-labels-inline" : StringPool.BLANK %>" data-fm-namespace="<%= namespace %>" id="<%= fullName %>" method="<%= method %>" name="<%= fullName %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
+<form action="<%= HtmlUtil.escapeAttribute(action) %>" class="container-fluid container-fluid-max-xl container-form-lg container-no-gutters form <%= cssClass %> <%= inlineLabels ? "field-labels-inline" : StringPool.BLANK %>" data-fm-namespace="<%= namespace %>" id="<%= fullName %>" method="<%= method %>" name="<%= fullName %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
 	<c:if test="<%= !themeDisplay.isStatePopUp() %>">
 		<div class="sheet <%= fluid ? StringPool.BLANK : "sheet-lg" %>">
 	</c:if>

--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/_custom.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/_custom.scss
@@ -33,12 +33,6 @@ body {
 		}
 	}
 
-	.main-content-card {
-		box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
-		margin-top: 20px;
-		min-height: 200px;
-	}
-
 	.main-content-nav {
 		margin-left: -($grid-gutter-width / 2);
 		margin-top: 20px;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -73,7 +73,6 @@ renderResponse.setTitle(title);
 
 <liferay-frontend:edit-form
 	action="<%= editFolderURL %>"
-	cssClass="container-form-lg"
 	method="post"
 	name="fm"
 >

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_article.jsp
@@ -73,7 +73,7 @@ if (portletTitleBasedNavigation) {
 	/>
 </c:if>
 
-<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl\"" : StringPool.BLANK %>>
+<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl container-form-lg\"" : StringPool.BLANK %>>
 	<liferay-portlet:actionURL name="updateKBArticle" var="updateKBArticleURL" />
 
 	<aui:form action="<%= updateKBArticleURL %>" method="post" name="fm">
@@ -254,37 +254,37 @@ if (portletTitleBasedNavigation) {
 						/>
 					</aui:fieldset>
 				</c:if>
+
+				<div class="kb-submit-buttons sheet-footer">
+
+					<%
+					boolean pending = false;
+
+					if (kbArticle != null) {
+						pending = kbArticle.isPending();
+					}
+
+					String saveButtonLabel = "save";
+
+					if ((kbArticle == null) || kbArticle.isDraft() || kbArticle.isApproved()) {
+						saveButtonLabel = "save-as-draft";
+					}
+
+					String publishButtonLabel = "publish";
+
+					if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(themeDisplay.getCompanyId(), scopeGroupId, KBArticle.class.getName())) {
+						publishButtonLabel = "submit-for-publication";
+					}
+					%>
+
+					<aui:button disabled="<%= pending %>" name="publishButton" type="submit" value="<%= publishButtonLabel %>" />
+
+					<aui:button primary="<%= false %>" type="submit" value="<%= saveButtonLabel %>" />
+
+					<aui:button href="<%= redirect %>" type="cancel" />
+				</div>
 			</aui:fieldset-group>
 		</div>
-
-		<aui:button-row cssClass="kb-submit-buttons">
-
-			<%
-			boolean pending = false;
-
-			if (kbArticle != null) {
-				pending = kbArticle.isPending();
-			}
-
-			String saveButtonLabel = "save";
-
-			if ((kbArticle == null) || kbArticle.isDraft() || kbArticle.isApproved()) {
-				saveButtonLabel = "save-as-draft";
-			}
-
-			String publishButtonLabel = "publish";
-
-			if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(themeDisplay.getCompanyId(), scopeGroupId, KBArticle.class.getName())) {
-				publishButtonLabel = "submit-for-publication";
-			}
-			%>
-
-			<aui:button disabled="<%= pending %>" name="publishButton" type="submit" value="<%= publishButtonLabel %>" />
-
-			<aui:button primary="<%= false %>" type="submit" value="<%= saveButtonLabel %>" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </div>
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_folder.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_folder.jsp
@@ -41,7 +41,9 @@ renderResponse.setTitle((kbFolder == null) ? LanguageUtil.get(resourceBundle, "n
 
 <liferay-portlet:actionURL name="updateKBFolder" var="updateKBFolderURL" />
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<aui:form action="<%= updateKBFolderURL %>" method="post" name="fm">
 		<aui:input name="mvcPath" type="hidden" value="/admin/common/edit_folder.jsp" />
 		<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= (kbFolder == null) ? Constants.ADD : Constants.UPDATE %>" />
@@ -84,12 +86,12 @@ renderResponse.setTitle((kbFolder == null) ? LanguageUtil.get(resourceBundle, "n
 					</aui:field-wrapper>
 				</aui:fieldset>
 			</c:if>
+
+			<div class="sheet-footer">
+				<aui:button type="submit" value="save" />
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button type="submit" value="save" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </clay:container-fluid>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_template.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_template.jsp
@@ -32,7 +32,9 @@ renderResponse.setTitle((kbTemplate == null) ? LanguageUtil.get(request, "new-te
 
 <liferay-portlet:actionURL name="updateKBTemplate" var="updateKBTemplateURL" />
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<aui:form action="<%= updateKBTemplateURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "updateKBTemplate();" %>'>
 		<aui:input name="mvcPath" type="hidden" value='<%= templatePath + "edit_template.jsp" %>' />
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
@@ -46,9 +48,7 @@ renderResponse.setTitle((kbTemplate == null) ? LanguageUtil.get(request, "new-te
 
 		<aui:fieldset-group markupView="lexicon">
 			<aui:fieldset>
-				<h1 class="kb-title">
-					<aui:input autocomplete="off" label='<%= LanguageUtil.get(request, "title") %>' name="title" required="<%= true %>" type="text" value="<%= HtmlUtil.escape(title) %>" />
-				</h1>
+				<aui:input autocomplete="off" label='<%= LanguageUtil.get(request, "title") %>' name="title" required="<%= true %>" type="text" value="<%= HtmlUtil.escape(title) %>" />
 
 				<liferay-editor:editor
 					contents="<%= content %>"
@@ -67,13 +67,13 @@ renderResponse.setTitle((kbTemplate == null) ? LanguageUtil.get(request, "new-te
 					/>
 				</aui:fieldset>
 			</c:if>
+
+			<div class="sheet-footer">
+				<aui:button type="submit" value="publish" />
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button type="submit" value="publish" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
@@ -45,7 +45,7 @@ if (portletTitleBasedNavigation) {
 	/>
 </c:if>
 
-<aui:fieldset cssClass='<%= portletTitleBasedNavigation ? "container-fluid container-fluid-max-xl main-content-card panel" : StringPool.BLANK %>' markupView="lexicon">
+<aui:fieldset cssClass='<%= portletTitleBasedNavigation ? "container-fluid container-fluid-max-xl panel" : StringPool.BLANK %>' markupView="lexicon">
 
 	<%
 	RowChecker rowChecker = new RowChecker(renderResponse);

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/move_object.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/move_object.jsp
@@ -67,7 +67,7 @@ if (portletTitleBasedNavigation) {
 	/>
 </c:if>
 
-<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl\"" : StringPool.BLANK %>>
+<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl container-form-lg\"" : StringPool.BLANK %>>
 	<liferay-portlet:actionURL name="moveKBObject" var="moveKBObjectURL" />
 
 	<aui:form action="<%= moveKBObjectURL %>" method="post" name="fm">
@@ -99,13 +99,13 @@ if (portletTitleBasedNavigation) {
 					<aui:button name="selectKBObjectButton" value="select" />
 				</aui:field-wrapper>
 			</aui:fieldset>
+
+			<div class="sheet-footer">
+				<aui:button type="submit" value="move" />
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button type="submit" value="move" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </div>
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_article.jsp
@@ -72,7 +72,7 @@ if (portletTitleBasedNavigation) {
 	</c:if>
 
 	<div class="sidenav-content">
-		<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl\"" : StringPool.BLANK %>>
+		<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl container-form-lg\"" : StringPool.BLANK %>>
 			<c:if test="<%= !portletTitleBasedNavigation %>">
 				<liferay-ui:header
 					title="<%= kbArticle.getTitle() %>"
@@ -83,7 +83,7 @@ if (portletTitleBasedNavigation) {
 				<liferay-util:include page="/admin/common/article_tools.jsp" servletContext="<%= application %>" />
 			</div>
 
-			<div <%= portletTitleBasedNavigation ? "class=\"main-content-card panel\"" : StringPool.BLANK %>>
+			<div <%= portletTitleBasedNavigation ? "class=\"panel\"" : StringPool.BLANK %>>
 				<div class="kb-entity-body <%= portletTitleBasedNavigation ? "panel-body" : StringPool.BLANK %>">
 					<c:if test="<%= portletTitleBasedNavigation %>">
 						<h1>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/common.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/common.scss
@@ -319,10 +319,6 @@
 	}
 }
 
-#wrapper .knowledge-base-portlet .card-horizontal.main-content-card {
-	min-height: 0;
-}
-
 // ---------- Skin ----------
 
 .knowledge-base-portlet {

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_edit.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_edit.jsp
@@ -30,9 +30,9 @@ else {
 }
 %>
 
-<h1 class="h4 text-default"><liferay-ui:message key="current-theme" /></h1>
+<h1 class="c-mb-4 h4 text-default"><liferay-ui:message key="current-theme" /></h1>
 
-<div class="card-horizontal main-content-card">
+<div class="card">
 	<div class="card-body">
 		<div id="<portlet:namespace />currentThemeContainer">
 			<liferay-util:include page="/look_and_feel_theme_details.jsp" servletContext="<%= application %>" />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_info.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_info.jsp
@@ -34,9 +34,9 @@ else if (selLayout == null) {
 PluginPackage selPluginPackage = selTheme.getPluginPackage();
 %>
 
-<h1 class="h4 text-default"><liferay-ui:message key="current-theme" /></h1>
+<h1 class="c-mb-4 h4 text-default"><liferay-ui:message key="current-theme" /></h1>
 
-<div class="card-horizontal main-content-card">
+<div class="card">
 	<div class="card-body">
 		<clay:row>
 			<clay:col

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_collection.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_collection.jsp
@@ -36,7 +36,6 @@ renderResponse.setTitle((layoutPageTemplateCollection != null) ? layoutPageTempl
 
 <liferay-frontend:edit-form
 	action="<%= editLayoutPageTemplateCollectionURL %>"
-	cssClass="container-form-lg"
 	name="fm"
 >
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_category.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_category.jsp
@@ -74,7 +74,7 @@ if (portletTitleBasedNavigation) {
 }
 %>
 
-<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl\"" : StringPool.BLANK %>>
+<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl container-form-lg\"" : StringPool.BLANK %>>
 	<c:if test="<%= !portletTitleBasedNavigation %>">
 		<h3><%= LanguageUtil.get(request, mbHomeDisplayContext.getTitle()) %></h3>
 	</c:if>
@@ -222,13 +222,13 @@ if (portletTitleBasedNavigation) {
 					/>
 				</aui:fieldset>
 			</c:if>
+
+			<div class="sheet-footer">
+				<aui:button type="submit" />
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button type="submit" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </div>
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
@@ -117,6 +117,7 @@ if (portletTitleBasedNavigation) {
 %>
 
 <clay:container-fluid
+	cssClass="container-form-lg"
 	id='<%= liferayPortletResponse.getNamespace() + "mbEditPageContainer" %>'
 >
 	<c:if test="<%= !portletTitleBasedNavigation %>">
@@ -411,52 +412,52 @@ if (portletTitleBasedNavigation) {
 			<c:if test="<%= (message == null) && captchaConfiguration.messageBoardsEditMessageCaptchaEnabled() %>">
 				<liferay-captcha:captcha />
 			</c:if>
-		</aui:fieldset-group>
-
-		<%
-		boolean pending = false;
-
-		if (message != null) {
-			pending = message.isPending();
-		}
-		%>
-
-		<c:if test="<%= pending %>">
-			<div class="alert alert-info">
-				<liferay-ui:message key="there-is-a-publication-workflow-in-process" />
-			</div>
-		</c:if>
-
-		<aui:button-row>
 
 			<%
-			String saveButtonLabel = "save";
+			boolean pending = false;
 
-			if ((message == null) || message.isDraft() || message.isApproved()) {
-				saveButtonLabel = "save-as-draft";
-			}
-
-			String publishButtonLabel = "publish";
-
-			if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(themeDisplay.getCompanyId(), scopeGroupId, MBMessage.class.getName())) {
-				publishButtonLabel = "submit-for-publication";
+			if (message != null) {
+				pending = message.isPending();
 			}
 			%>
 
-			<c:if test="<%= (message != null) && message.isApproved() && WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(message.getCompanyId(), message.getGroupId(), MBMessage.class.getName()) %>">
+			<c:if test="<%= pending %>">
 				<div class="alert alert-info">
-					<liferay-ui:message arguments="<%= ResourceActionsUtil.getModelResource(locale, MBMessage.class.getName()) %>" key="this-x-is-approved.-publishing-these-changes-will-cause-it-to-be-unpublished-and-go-through-the-approval-process-again" translateArguments="<%= false %>" />
+					<liferay-ui:message key="there-is-a-publication-workflow-in-process" />
 				</div>
 			</c:if>
 
-			<aui:button disabled="<%= pending %>" name="publishButton" type="submit" value="<%= publishButtonLabel %>" />
+			<div class="sheet-footer">
 
-			<c:if test="<%= themeDisplay.isSignedIn() %>">
-				<aui:button name="saveButton" value="<%= saveButtonLabel %>" />
-			</c:if>
+				<%
+				String saveButtonLabel = "save";
 
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
+				if ((message == null) || message.isDraft() || message.isApproved()) {
+					saveButtonLabel = "save-as-draft";
+				}
+
+				String publishButtonLabel = "publish";
+
+				if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(themeDisplay.getCompanyId(), scopeGroupId, MBMessage.class.getName())) {
+					publishButtonLabel = "submit-for-publication";
+				}
+				%>
+
+				<c:if test="<%= (message != null) && message.isApproved() && WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(message.getCompanyId(), message.getGroupId(), MBMessage.class.getName()) %>">
+					<div class="alert alert-info">
+						<liferay-ui:message arguments="<%= ResourceActionsUtil.getModelResource(locale, MBMessage.class.getName()) %>" key="this-x-is-approved.-publishing-these-changes-will-cause-it-to-be-unpublished-and-go-through-the-approval-process-again" translateArguments="<%= false %>" />
+					</div>
+				</c:if>
+
+				<aui:button disabled="<%= pending %>" name="publishButton" type="submit" value="<%= publishButtonLabel %>" />
+
+				<c:if test="<%= themeDisplay.isSignedIn() %>">
+					<aui:button name="saveButton" value="<%= saveButtonLabel %>" />
+				</c:if>
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
+		</aui:fieldset-group>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
@@ -74,7 +74,7 @@ class MBPortlet {
 
 	_attachEvents() {
 		const publishButton = this.rootNode.querySelector(
-			'.button-holder button[type="submit"]'
+			'.sheet-footer button[type="submit"]'
 		);
 
 		if (publishButton) {

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_category.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_category.jsp
@@ -37,7 +37,7 @@ if (portletTitleBasedNavigation) {
 }
 %>
 
-<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl\"" : StringPool.BLANK %>>
+<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl container-form-lg\"" : StringPool.BLANK %>>
 	<c:if test="<%= !portletTitleBasedNavigation %>">
 		<h3><%= LanguageUtil.format(request, "move-x", category.getName(), false) %></h3>
 	</c:if>
@@ -80,13 +80,13 @@ if (portletTitleBasedNavigation) {
 
 				<aui:input label="merge-with-parent-category" name="mergeWithParentCategory" type="checkbox" />
 			</aui:fieldset>
+
+			<div class="sheet-footer">
+				<aui:button type="submit" value="move" />
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button type="submit" value="move" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </div>
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_rule.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_rule.jsp
@@ -52,7 +52,7 @@ renderResponse.setTitle(title);
 	<portlet:param name="mvcRenderCommandName" value="/mobile_device_rules/edit_rule" />
 </portlet:actionURL>
 
-<aui:form action="<%= editRuleURL %>" cssClass="container-fluid container-fluid-max-xl" enctype="multipart/form-data" method="post" name="fm">
+<aui:form action="<%= editRuleURL %>" cssClass="container-fluid container-fluid-max-xl container-form-lg" enctype="multipart/form-data" method="post" name="fm">
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= (rule == null) ? Constants.ADD : Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 	<aui:input name="ruleGroupId" type="hidden" value="<%= ruleGroupId %>" />
@@ -108,12 +108,13 @@ renderResponse.setTitle(title);
 				<liferay-util:include page="<%= editorJSP %>" servletContext="<%= application %>" />
 			</c:if>
 		</div>
-	</aui:fieldset-group>
 
-	<aui:button-row>
-		<aui:button type="submit" />
-		<aui:button href="<%= redirect %>" value="cancel" />
-	</aui:button-row>
+		<div class="sheet-footer">
+			<aui:button type="submit" />
+
+			<aui:button href="<%= redirect %>" value="cancel" />
+		</div>
+	</aui:fieldset-group>
 </aui:form>
 
 <portlet:resourceURL id="/mobile_device_rules/edit_rule" var="editorURL" />

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_rule_group.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_rule_group.jsp
@@ -34,7 +34,7 @@ renderResponse.setTitle((ruleGroup == null) ? LanguageUtil.get(resourceBundle, "
 	<portlet:param name="mvcRenderCommandName" value="/mobile_device_rules/edit_rule_group" />
 </portlet:actionURL>
 
-<aui:form action="<%= editRuleGroupURL %>" cssClass="container-fluid container-fluid-max-xl" enctype="multipart/form-data" method="post" name="fm">
+<aui:form action="<%= editRuleGroupURL %>" cssClass="container-fluid container-fluid-max-xl container-form-lg" enctype="multipart/form-data" method="post" name="fm">
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= (ruleGroup == null) ? Constants.ADD : Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 	<aui:input name="backURL" type="hidden" value="<%= backURL %>" />
@@ -57,11 +57,11 @@ renderResponse.setTitle((ruleGroup == null) ? LanguageUtil.get(resourceBundle, "
 
 			<aui:input name="description" placeholder="description" />
 		</aui:fieldset>
+
+		<div class="sheet-footer">
+			<aui:button type="submit" />
+
+			<aui:button href="<%= redirect %>" value="cancel" />
+		</div>
 	</aui:fieldset-group>
-
-	<aui:button-row>
-		<aui:button type="submit" />
-
-		<aui:button href="<%= redirect %>" value="cancel" />
-	</aui:button-row>
 </aui:form>

--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/edit_question.jsp
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/edit_question.jsp
@@ -71,7 +71,7 @@ portletDisplay.setURLBack(redirect);
 	<portlet:param name="mvcPath" value="/polls/edit_question.jsp" />
 </liferay-portlet:actionURL>
 
-<aui:form action="<%= editQuestionURL %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveQuestion();" %>'>
+<aui:form action="<%= editQuestionURL %>" cssClass="container-fluid container-fluid-max-xl container-form-lg" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveQuestion();" %>'>
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="" />
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 	<aui:input name="referringPortletResource" type="hidden" value="<%= referringPortletResource %>" />
@@ -142,8 +142,10 @@ portletDisplay.setURLBack(redirect);
 				}
 				%>
 
-				<div class="button-holder">
-					<aui:button cssClass="add-choice" onClick='<%= liferayPortletResponse.getNamespace() + "addPollChoice();" %>' value="add-choice" />
+				<div class="btn-group">
+					<div class="btn-group-item">
+						<aui:button cssClass="add-choice" onClick='<%= liferayPortletResponse.getNamespace() + "addPollChoice();" %>' value="add-choice" />
+					</div>
 				</div>
 			</aui:field-wrapper>
 		</aui:fieldset>
@@ -155,13 +157,13 @@ portletDisplay.setURLBack(redirect);
 				/>
 			</aui:fieldset>
 		</c:if>
+
+		<div class="sheet-footer">
+			<aui:button type="submit" />
+
+			<aui:button href="<%= redirect %>" type="cancel" />
+		</div>
 	</aui:fieldset-group>
-
-	<aui:button-row>
-		<aui:button type="submit" />
-
-		<aui:button href="<%= redirect %>" type="cancel" />
-	</aui:button-row>
 </aui:form>
 
 <aui:script use="aui-char-counter">

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -41,12 +41,14 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(assetRenderer.getTitle(workflowTaskDisplayContext.getTaskContentLocale()));
 %>
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-view"
+>
 	<clay:col
 		cssClass="lfr-asset-column lfr-asset-column-details"
 		md="12"
 	>
-		<div class="card-horizontal main-content-card">
+		<div class="card">
 			<div class="panel-body">
 				<c:if test="<%= assetEntry != null %>">
 					<c:if test="<%= assetRenderer.isLocalizable() %>">

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/css/_definition.scss
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/css/_definition.scss
@@ -2,10 +2,6 @@
 	margin: 0 !important;
 }
 
-#wrapper .main-content-card {
-	margin: 0 !important;
-}
-
 .portal.popup {
 	background: #fff;
 }

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
@@ -198,7 +198,9 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 	</c:if>
 
 	<div class="sidenav-content">
-		<clay:container-fluid>
+		<clay:container-fluid
+			cssClass="container-form-lg"
+		>
 			<aui:form method="post" name="fm">
 				<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 				<aui:input name="name" type="hidden" value="<%= name %>" />
@@ -206,89 +208,87 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 				<aui:input name="content" type="hidden" value="<%= content %>" />
 				<aui:input name="successMessage" type="hidden" value='<%= active ? LanguageUtil.get(request, "workflow-updated-successfully") : LanguageUtil.get(request, "workflow-published-successfully") %>' />
 
-				<div class="card-horizontal main-content-card">
-					<div class="card-row-padded">
-						<liferay-ui:error exception="<%= IllegalArgumentException.class %>">
+				<div class="sheet">
+					<liferay-ui:error exception="<%= IllegalArgumentException.class %>">
+
+						<%
+						IllegalArgumentException iae = (IllegalArgumentException)errorException;
+						%>
+
+						<liferay-ui:message key="<%= iae.getMessage() %>" />
+					</liferay-ui:error>
+
+					<liferay-ui:error exception="<%= NoSuchRoleException.class %>" message="the-role-could-not-be-found" />
+
+					<liferay-ui:error exception="<%= RequiredWorkflowDefinitionException.class %>">
+						<liferay-ui:message arguments="<%= workflowDefinitionDisplayContext.getMessageArguments((RequiredWorkflowDefinitionException)errorException) %>" key="<%= workflowDefinitionDisplayContext.getMessageKey((RequiredWorkflowDefinitionException)errorException) %>" translateArguments="<%= false %>" />
+					</liferay-ui:error>
+
+					<liferay-ui:error exception="<%= WorkflowDefinitionFileException.class %>" message="please-enter-valid-content" />
+
+					<liferay-ui:error exception="<%= WorkflowDefinitionTitleException.class %>" message="please-add-a-workflow-title-before-publishing" />
+
+					<liferay-ui:error exception="<%= WorkflowException.class %>" message="an-error-occurred-in-the-workflow-engine" />
+
+					<aui:fieldset cssClass="workflow-definition-content">
+						<clay:col
+							size="12"
+						>
+							<aui:field-wrapper label="title">
+								<liferay-ui:input-localized
+									name="title"
+									placeholder="untitled-workflow"
+									xml='<%= BeanPropertiesUtil.getString(workflowDefinition, "title") %>'
+								/>
+							</aui:field-wrapper>
+						</clay:col>
+
+						<clay:col
+							cssClass="workflow-definition-upload"
+							size="12"
+						>
+							<liferay-util:buffer
+								var="importFileMark"
+							>
+								<aui:a href="#" id="uploadLink">
+									<%= StringUtil.toLowerCase(LanguageUtil.get(request, "import-a-file")) %>
+								</aui:a>
+							</liferay-util:buffer>
+
+							<liferay-ui:message arguments="<%= importFileMark %>" key="write-your-definition-or-x" translateArguments="<%= false %>" />
+
+							<input accept="application/xml" class="workflow-definition-upload-source" id="<portlet:namespace />upload" type="file" />
+						</clay:col>
+
+						<clay:col
+							cssClass="workflow-definition-content-source-wrapper"
+							id='<%= liferayPortletResponse.getNamespace() + "contentSourceWrapper" %>'
+							size="12"
+						>
+							<div class="workflow-definition-content-source" id="<portlet:namespace />contentEditor"></div>
+						</clay:col>
+					</aui:fieldset>
+
+					<div class="sheet-footer">
+						<c:if test="<%= workflowDefinitionDisplayContext.canPublishWorkflowDefinition() %>">
 
 							<%
-							IllegalArgumentException iae = (IllegalArgumentException)errorException;
+							String taglibUpdateOnClick = "Liferay.fire('" + liferayPortletResponse.getNamespace() + "publishDefinition');";
 							%>
 
-							<liferay-ui:message key="<%= iae.getMessage() %>" />
-						</liferay-ui:error>
+							<aui:button onClick="<%= taglibUpdateOnClick %>" primary="<%= true %>" value='<%= ((workflowDefinition == null) || !active) ? "publish" : "update" %>' />
+						</c:if>
 
-						<liferay-ui:error exception="<%= NoSuchRoleException.class %>" message="the-role-could-not-be-found" />
+						<c:if test="<%= (workflowDefinition == null) || !active %>">
 
-						<liferay-ui:error exception="<%= RequiredWorkflowDefinitionException.class %>">
-							<liferay-ui:message arguments="<%= workflowDefinitionDisplayContext.getMessageArguments((RequiredWorkflowDefinitionException)errorException) %>" key="<%= workflowDefinitionDisplayContext.getMessageKey((RequiredWorkflowDefinitionException)errorException) %>" translateArguments="<%= false %>" />
-						</liferay-ui:error>
+							<%
+							String taglibSaveOnClick = "Liferay.fire('" + liferayPortletResponse.getNamespace() + "saveDefinition');";
+							%>
 
-						<liferay-ui:error exception="<%= WorkflowDefinitionFileException.class %>" message="please-enter-valid-content" />
-
-						<liferay-ui:error exception="<%= WorkflowDefinitionTitleException.class %>" message="please-add-a-workflow-title-before-publishing" />
-
-						<liferay-ui:error exception="<%= WorkflowException.class %>" message="an-error-occurred-in-the-workflow-engine" />
-
-						<aui:fieldset cssClass="workflow-definition-content">
-							<clay:col
-								size="12"
-							>
-								<aui:field-wrapper label="title">
-									<liferay-ui:input-localized
-										name="title"
-										placeholder="untitled-workflow"
-										xml='<%= BeanPropertiesUtil.getString(workflowDefinition, "title") %>'
-									/>
-								</aui:field-wrapper>
-							</clay:col>
-
-							<clay:col
-								cssClass="workflow-definition-upload"
-								size="12"
-							>
-								<liferay-util:buffer
-									var="importFileMark"
-								>
-									<aui:a href="#" id="uploadLink">
-										<%= StringUtil.toLowerCase(LanguageUtil.get(request, "import-a-file")) %>
-									</aui:a>
-								</liferay-util:buffer>
-
-								<liferay-ui:message arguments="<%= importFileMark %>" key="write-your-definition-or-x" translateArguments="<%= false %>" />
-
-								<input accept="application/xml" class="workflow-definition-upload-source" id="<portlet:namespace />upload" type="file" />
-							</clay:col>
-
-							<clay:col
-								cssClass="workflow-definition-content-source-wrapper"
-								id='<%= liferayPortletResponse.getNamespace() + "contentSourceWrapper" %>'
-								size="12"
-							>
-								<div class="workflow-definition-content-source" id="<portlet:namespace />contentEditor"></div>
-							</clay:col>
-						</aui:fieldset>
+							<aui:button onClick="<%= taglibSaveOnClick %>" value="save" />
+						</c:if>
 					</div>
 				</div>
-
-				<aui:button-row>
-					<c:if test="<%= workflowDefinitionDisplayContext.canPublishWorkflowDefinition() %>">
-
-						<%
-						String taglibUpdateOnClick = "Liferay.fire('" + liferayPortletResponse.getNamespace() + "publishDefinition');";
-						%>
-
-						<aui:button onClick="<%= taglibUpdateOnClick %>" primary="<%= true %>" value='<%= ((workflowDefinition == null) || !active) ? "publish" : "update" %>' />
-					</c:if>
-
-					<c:if test="<%= (workflowDefinition == null) || !active %>">
-
-						<%
-						String taglibSaveOnClick = "Liferay.fire('" + liferayPortletResponse.getNamespace() + "saveDefinition');";
-						%>
-
-						<aui:button onClick="<%= taglibSaveOnClick %>" value="save" />
-					</c:if>
-				</aui:button-row>
 			</aui:form>
 		</clay:container-fluid>
 	</div>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view_workflow_definition.jsp
@@ -82,43 +82,41 @@ boolean previewBeforeRestore = WorkflowWebKeys.WORKFLOW_PREVIEW_BEFORE_RESTORE_S
 	</clay:container-fluid>
 </liferay-frontend:info-bar>
 
-<div class="<%= previewBeforeRestore ? "" : "container-fluid container-fluid-max-xl" %>" id="container">
+<div class="<%= previewBeforeRestore ? "" : "container-fluid container-fluid-max-xl container-form-lg" %>" id="container">
 	<aui:model-context bean="<%= workflowDefinition %>" model="<%= WorkflowDefinition.class %>" />
 
 	<aui:input name="content" type="hidden" value="<%= content %>" />
 
 	<aui:form method="post" name="form">
-		<div class="card-horizontal main-content-card">
-			<div class="card-row-padded">
-				<aui:fieldset cssClass="workflow-definition-content">
-					<clay:col>
-						<aui:field-wrapper label="title">
-							<liferay-ui:input-localized
-								disabled="<%= true %>"
-								name=" <%= workflowDefinition.getName() %>_title"
-								xml='<%= BeanPropertiesUtil.getString(workflowDefinition, "title") %>'
-							/>
-						</aui:field-wrapper>
-					</clay:col>
+		<div class="sheet">
+			<aui:fieldset cssClass="workflow-definition-content">
+				<clay:col>
+					<aui:field-wrapper label="title">
+						<liferay-ui:input-localized
+							disabled="<%= true %>"
+							name=" <%= workflowDefinition.getName() %>_title"
+							xml='<%= BeanPropertiesUtil.getString(workflowDefinition, "title") %>'
+						/>
+					</aui:field-wrapper>
+				</clay:col>
 
-					<clay:col
-						cssClass="workflow-definition-content-source-wrapper"
-						id='<%= liferayPortletResponse.getNamespace() + "contentSourceWrapper" %>'
-					>
-						<div class="workflow-definition-content-source" id="<portlet:namespace />contentEditor"></div>
-					</clay:col>
-				</aui:fieldset>
-			</div>
+				<clay:col
+					cssClass="workflow-definition-content-source-wrapper"
+					id='<%= liferayPortletResponse.getNamespace() + "contentSourceWrapper" %>'
+				>
+					<div class="workflow-definition-content-source" id="<portlet:namespace />contentEditor"></div>
+				</clay:col>
+			</aui:fieldset>
+
+			<c:choose>
+				<c:when test="<%= !previewBeforeRestore %>">
+					<div class="sheet-footer">
+						<aui:button href="<%= editWorkflowDefinitionURL %>" primary="<%= true %>" value="edit" />
+					</div>
+				</c:when>
+			</c:choose>
 		</div>
 	</aui:form>
-
-	<c:choose>
-		<c:when test="<%= !previewBeforeRestore %>">
-			<aui:button-row>
-				<aui:button href="<%= editWorkflowDefinitionURL %>" primary="<%= true %>" value="edit" />
-			</aui:button-row>
-		</c:when>
-	</c:choose>
 </div>
 
 <aui:script use="aui-ace-editor">

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/edit_site.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/edit_site.jsp
@@ -90,7 +90,6 @@ if (layoutSetPrototypeId > 0) {
 
 <liferay-frontend:edit-form
 	action="<%= editGroupURL %>"
-	cssClass="container-form-lg"
 	method="post"
 	name="fm"
 	onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveGroup();" %>'

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page.jsp
@@ -132,7 +132,7 @@ if (portletTitleBasedNavigation) {
 	<portlet:param name="mvcRenderCommandName" value="/wiki/edit_page" />
 </portlet:renderURL>
 
-<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl\"" : StringPool.BLANK %> id='<%= liferayPortletResponse.getNamespace() + "wikiEditPageContainer" %>'>
+<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl container-form-lg\"" : StringPool.BLANK %> id='<%= liferayPortletResponse.getNamespace() + "wikiEditPageContainer" %>'>
 	<aui:form action="<%= editPageActionURL %>" method="post" name="fm">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -205,7 +205,7 @@ if (portletTitleBasedNavigation) {
 							</c:when>
 							<c:otherwise>
 								<div class="entry-title">
-									<h1><%= HtmlUtil.escape(title) %></h1>
+									<h1 class="sheet-title"><%= HtmlUtil.escape(title) %></h1>
 								</div>
 
 								<aui:input name="title" type="hidden" value="<%= title %>" />
@@ -356,43 +356,43 @@ if (portletTitleBasedNavigation) {
 							/>
 						</aui:fieldset>
 					</c:if>
-				</aui:fieldset-group>
 
-				<%
-				boolean pending = false;
+					<%
+					boolean pending = false;
 
-				if (wikiPage != null) {
-					pending = wikiPage.isPending();
-				}
-				%>
+					if (wikiPage != null) {
+						pending = wikiPage.isPending();
+					}
+					%>
 
-				<c:if test="<%= pending %>">
-					<div class="alert alert-info">
-						<liferay-ui:message key="there-is-a-publication-workflow-in-process" />
+					<c:if test="<%= pending %>">
+						<div class="alert alert-info">
+							<liferay-ui:message key="there-is-a-publication-workflow-in-process" />
+						</div>
+					</c:if>
+
+					<%
+					String saveButtonLabel = "save";
+
+					if ((wikiPage == null) || wikiPage.isDraft() || wikiPage.isApproved()) {
+						saveButtonLabel = "save-as-draft";
+					}
+
+					String publishButtonLabel = "publish";
+
+					if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(themeDisplay.getCompanyId(), scopeGroupId, WikiPage.class.getName())) {
+						publishButtonLabel = "submit-for-publication";
+					}
+					%>
+
+					<div class="sheet-footer">
+						<aui:button disabled="<%= pending %>" name="publishButton" primary="<%= true %>" value="<%= publishButtonLabel %>" />
+
+						<aui:button name="saveButton" primary="<%= false %>" type="submit" value="<%= saveButtonLabel %>" />
+
+						<aui:button href="<%= redirect %>" type="cancel" />
 					</div>
-				</c:if>
-
-				<%
-				String saveButtonLabel = "save";
-
-				if ((wikiPage == null) || wikiPage.isDraft() || wikiPage.isApproved()) {
-					saveButtonLabel = "save-as-draft";
-				}
-
-				String publishButtonLabel = "publish";
-
-				if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(themeDisplay.getCompanyId(), scopeGroupId, WikiPage.class.getName())) {
-					publishButtonLabel = "submit-for-publication";
-				}
-				%>
-
-				<aui:button-row>
-					<aui:button disabled="<%= pending %>" name="publishButton" primary="<%= true %>" value="<%= publishButtonLabel %>" />
-
-					<aui:button name="saveButton" primary="<%= false %>" type="submit" value="<%= saveButtonLabel %>" />
-
-					<aui:button href="<%= redirect %>" type="cancel" />
-				</aui:button-row>
+				</aui:fieldset-group>
 			</c:otherwise>
 		</c:choose>
 	</aui:form>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/error.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/error.jsp
@@ -73,27 +73,25 @@ if (portletTitleBasedNavigation) {
 	searchURL.setParameter("keywords", title);
 	%>
 
-	<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl\"" : StringPool.BLANK %>>
-		<div class="main-content-card panel">
-			<div class="panel-body">
-				<div class="alert alert-info">
-					<liferay-ui:message key="this-page-is-empty.-use-the-buttons-below-to-create-it-or-to-search-for-the-words-in-the-title" />
-				</div>
+	<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl container-form-lg\"" : StringPool.BLANK %>>
+		<div class="sheet">
+			<div class="alert alert-info">
+				<liferay-ui:message key="this-page-is-empty.-use-the-buttons-below-to-create-it-or-to-search-for-the-words-in-the-title" />
+			</div>
 
-				<div class="btn-toolbar">
+			<div class="btn-toolbar">
 
-					<%
-					String taglibEditPage = "location.href = '" + editPageURL.toString() + "';";
-					%>
+				<%
+				String taglibEditPage = "location.href = '" + editPageURL.toString() + "';";
+				%>
 
-					<aui:button onClick="<%= taglibEditPage %>" primary="<%= true %>" value='<%= LanguageUtil.format(request, "create-page-x", HtmlUtil.escapeAttribute(title), false) %>' />
+				<aui:button onClick="<%= taglibEditPage %>" primary="<%= true %>" value='<%= LanguageUtil.format(request, "create-page-x", HtmlUtil.escapeAttribute(title), false) %>' />
 
-					<%
-					String taglibSearch = "location.href = '" + searchURL.toString() + "';";
-					%>
+				<%
+				String taglibSearch = "location.href = '" + searchURL.toString() + "';";
+				%>
 
-					<aui:button cssClass="btn-secondary" onClick="<%= taglibSearch %>" value='<%= LanguageUtil.format(request, "search-for-x", HtmlUtil.escapeAttribute(title), false) %>' />
-				</div>
+				<aui:button cssClass="btn-secondary" onClick="<%= taglibSearch %>" value='<%= LanguageUtil.format(request, "search-for-x", HtmlUtil.escapeAttribute(title), false) %>' />
 			</div>
 		</div>
 	</div>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
@@ -150,8 +150,8 @@ if (portletTitleBasedNavigation) {
 
 	<div class="sidenav-content">
 		<clay:container-fluid>
-			<div <%= portletTitleBasedNavigation ? "class=\"panel main-content-card\"" : StringPool.BLANK %>>
-				<div <%= portletTitleBasedNavigation ? "class=\"panel-body\"" : StringPool.BLANK %>>
+			<div <%= portletTitleBasedNavigation ? "class=\"container-form-lg\"" : StringPool.BLANK %>>
+				<div <%= portletTitleBasedNavigation ? "class=\"sheet\"" : StringPool.BLANK %>>
 					<c:if test="<%= !portletTitleBasedNavigation %>">
 						<c:choose>
 							<c:when test="<%= print %>">
@@ -223,185 +223,183 @@ if (portletTitleBasedNavigation) {
 						displayStyleGroupId="<%= wikiPortletInstanceSettingsHelper.getDisplayStyleGroupId() %>"
 						entries="<%= entries %>"
 					>
-						<div class="main-content-body">
-							<c:choose>
-								<c:when test="<%= !portletTitleBasedNavigation %>">
-									<liferay-ui:header
-										backLabel="<%= parentTitle %>"
-										backURL="<%= (viewParentPageURL != null) ? viewParentPageURL.toString() : null %>"
-										localizeTitle="<%= false %>"
-										title="<%= title %>"
-									/>
-								</c:when>
-								<c:otherwise>
-									<h2><%= title %></h2>
-								</c:otherwise>
-							</c:choose>
+						<c:choose>
+							<c:when test="<%= !portletTitleBasedNavigation %>">
+								<liferay-ui:header
+									backLabel="<%= parentTitle %>"
+									backURL="<%= (viewParentPageURL != null) ? viewParentPageURL.toString() : null %>"
+									localizeTitle="<%= false %>"
+									title="<%= title %>"
+								/>
+							</c:when>
+							<c:otherwise>
+								<h2 class="sheet-title"><%= title %></h2>
+							</c:otherwise>
+						</c:choose>
 
-							<c:if test="<%= !print && !portletTitleBasedNavigation %>">
-								<div class="page-actions top-actions">
-									<c:if test="<%= followRedirect || (redirectPage == null) %>">
-										<c:if test="<%= Validator.isNotNull(formattedContent) && WikiNodePermission.contains(permissionChecker, node, ActionKeys.ADD_PAGE) %>">
-											<liferay-ui:icon
-												icon="plus"
-												label="<%= true %>"
-												markupView="lexicon"
-												message="add-child-page"
-												method="get"
-												url="<%= addPageURL.toString() %>"
-											/>
-										</c:if>
-
-										<c:if test="<%= WikiPagePermission.contains(permissionChecker, wikiPage, ActionKeys.UPDATE) %>">
-											<liferay-ui:icon
-												icon="pencil"
-												label="<%= true %>"
-												markupView="lexicon"
-												message="edit"
-												url="<%= editPageURL.toString() %>"
-											/>
-										</c:if>
+						<c:if test="<%= !print && !portletTitleBasedNavigation %>">
+							<div class="page-actions top-actions">
+								<c:if test="<%= followRedirect || (redirectPage == null) %>">
+									<c:if test="<%= Validator.isNotNull(formattedContent) && WikiNodePermission.contains(permissionChecker, node, ActionKeys.ADD_PAGE) %>">
+										<liferay-ui:icon
+											icon="plus"
+											label="<%= true %>"
+											markupView="lexicon"
+											message="add-child-page"
+											method="get"
+											url="<%= addPageURL.toString() %>"
+										/>
 									</c:if>
 
-									<%
-									PortletURL viewPageDetailsURL = PortletURLUtil.clone(viewPageURL, renderResponse);
-
-									viewPageDetailsURL.setParameter("mvcRenderCommandName", "/wiki/view_page_details");
-									viewPageDetailsURL.setParameter("redirect", currentURL);
-									%>
-
-									<liferay-ui:icon
-										icon="document"
-										label="<%= true %>"
-										markupView="lexicon"
-										message="details"
-										method="get"
-										url="<%= viewPageDetailsURL.toString() %>"
-									/>
-
-									<liferay-ui:icon
-										icon="print"
-										label="<%= true %>"
-										markupView="lexicon"
-										message="print"
-										url='<%= "javascript:" + liferayPortletResponse.getNamespace() + "printPage();" %>'
-									/>
-								</div>
-							</c:if>
-
-							<c:if test="<%= originalPage != null %>">
+									<c:if test="<%= WikiPagePermission.contains(permissionChecker, wikiPage, ActionKeys.UPDATE) %>">
+										<liferay-ui:icon
+											icon="pencil"
+											label="<%= true %>"
+											markupView="lexicon"
+											message="edit"
+											url="<%= editPageURL.toString() %>"
+										/>
+									</c:if>
+								</c:if>
 
 								<%
-								PortletURL originalViewPageURL = renderResponse.createRenderURL();
+								PortletURL viewPageDetailsURL = PortletURLUtil.clone(viewPageURL, renderResponse);
 
-								originalViewPageURL.setParameter("mvcRenderCommandName", "/wiki/view");
-								originalViewPageURL.setParameter("nodeName", node.getName());
-								originalViewPageURL.setParameter("title", originalPage.getTitle());
-								originalViewPageURL.setParameter("followRedirect", "false");
+								viewPageDetailsURL.setParameter("mvcRenderCommandName", "/wiki/view_page_details");
+								viewPageDetailsURL.setParameter("redirect", currentURL);
 								%>
 
-								<div class="page-redirect" onClick="location.href = '<%= originalViewPageURL.toString() %>';">
-									(<liferay-ui:message arguments="<%= originalPage.getTitle() %>" key="redirected-from-x" translateArguments="<%= false %>" />)
-								</div>
-							</c:if>
-
-							<c:if test="<%= !wikiPage.isHead() %>">
-								<div class="page-old-version">
-									(<liferay-ui:message key="you-are-viewing-an-archived-version-of-this-page" /> (<%= wikiPage.getVersion() %>), <aui:a href="<%= viewPageURL.toString() %>" label="go-to-the-latest-version" />)
-								</div>
-							</c:if>
-
-							<%@ include file="/wiki/view_page_content.jspf" %>
-
-							<liferay-expando:custom-attributes-available
-								className="<%= WikiPage.class.getName() %>"
-							>
-								<liferay-expando:custom-attribute-list
-									className="<%= WikiPage.class.getName() %>"
-									classPK="<%= wikiPage.getPrimaryKey() %>"
-									editable="<%= false %>"
+								<liferay-ui:icon
+									icon="document"
 									label="<%= true %>"
+									markupView="lexicon"
+									message="details"
+									method="get"
+									url="<%= viewPageDetailsURL.toString() %>"
 								/>
-							</liferay-expando:custom-attributes-available>
 
-							<c:if test="<%= followRedirect || (redirectPage == null) %>">
-								<div class="page-actions">
-									<div class="stats">
+								<liferay-ui:icon
+									icon="print"
+									label="<%= true %>"
+									markupView="lexicon"
+									message="print"
+									url='<%= "javascript:" + liferayPortletResponse.getNamespace() + "printPage();" %>'
+								/>
+							</div>
+						</c:if>
 
-										<%
-										AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(WikiPage.class.getName(), wikiPage.getResourcePrimKey());
-										%>
+						<c:if test="<%= originalPage != null %>">
 
-										<c:choose>
-											<c:when test="<%= assetEntry.getViewCount() == 1 %>">
-												<%= assetEntry.getViewCount() %> <liferay-ui:message key="view" />
-											</c:when>
-											<c:when test="<%= assetEntry.getViewCount() > 1 %>">
-												<%= assetEntry.getViewCount() %> <liferay-ui:message key="views" />
-											</c:when>
-										</c:choose>
-									</div>
+							<%
+							PortletURL originalViewPageURL = renderResponse.createRenderURL();
 
-									<div class="page-categorization">
-										<div class="page-categories">
-											<liferay-asset:asset-categories-summary
-												className="<%= WikiPage.class.getName() %>"
-												classPK="<%= wikiPage.getResourcePrimKey() %>"
-												portletURL="<%= PortletURLUtil.clone(categorizedPagesURL, renderResponse) %>"
-											/>
-										</div>
+							originalViewPageURL.setParameter("mvcRenderCommandName", "/wiki/view");
+							originalViewPageURL.setParameter("nodeName", node.getName());
+							originalViewPageURL.setParameter("title", originalPage.getTitle());
+							originalViewPageURL.setParameter("followRedirect", "false");
+							%>
 
-										<div class="page-tags">
-											<liferay-asset:asset-tags-available
-												className="<%= WikiPage.class.getName() %>"
-												classPK="<%= wikiPage.getResourcePrimKey() %>"
-											>
-												<h5><liferay-ui:message key="tags" /></h5>
+							<div class="page-redirect" onClick="location.href = '<%= originalViewPageURL.toString() %>';">
+								(<liferay-ui:message arguments="<%= originalPage.getTitle() %>" key="redirected-from-x" translateArguments="<%= false %>" />)
+							</div>
+						</c:if>
 
-												<liferay-asset:asset-tags-summary
-													className="<%= WikiPage.class.getName() %>"
-													classPK="<%= wikiPage.getResourcePrimKey() %>"
-													portletURL="<%= PortletURLUtil.clone(taggedPagesURL, renderResponse) %>"
-												/>
-											</liferay-asset:asset-tags-available>
-										</div>
-									</div>
+						<c:if test="<%= !wikiPage.isHead() %>">
+							<div class="page-old-version">
+								(<liferay-ui:message key="you-are-viewing-an-archived-version-of-this-page" /> (<%= wikiPage.getVersion() %>), <aui:a href="<%= viewPageURL.toString() %>" label="go-to-the-latest-version" />)
+							</div>
+						</c:if>
 
-									<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnablePageRatings() %>">
-										<div class="page-ratings">
-											<liferay-ratings:ratings
-												className="<%= WikiPage.class.getName() %>"
-												classPK="<%= wikiPage.getResourcePrimKey() %>"
-												inTrash="<%= wikiPage.isInTrash() %>"
-											/>
-										</div>
-									</c:if>
+						<%@ include file="/wiki/view_page_content.jspf" %>
 
-									<liferay-util:include page="/wiki/view_attachments.jsp" servletContext="<%= application %>" />
+						<liferay-expando:custom-attributes-available
+							className="<%= WikiPage.class.getName() %>"
+						>
+							<liferay-expando:custom-attribute-list
+								className="<%= WikiPage.class.getName() %>"
+								classPK="<%= wikiPage.getPrimaryKey() %>"
+								editable="<%= false %>"
+								label="<%= true %>"
+							/>
+						</liferay-expando:custom-attributes-available>
 
-									<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnableRelatedAssets() %>">
-										<div class="entry-links">
-											<liferay-asset:asset-links
-												assetEntryId="<%= assetEntry.getEntryId() %>"
-											/>
-										</div>
-									</c:if>
+						<c:if test="<%= followRedirect || (redirectPage == null) %>">
+							<div class="page-actions">
+								<div class="stats">
+
+									<%
+									AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(WikiPage.class.getName(), wikiPage.getResourcePrimKey());
+									%>
+
+									<c:choose>
+										<c:when test="<%= assetEntry.getViewCount() == 1 %>">
+											<%= assetEntry.getViewCount() %> <liferay-ui:message key="view" />
+										</c:when>
+										<c:when test="<%= assetEntry.getViewCount() > 1 %>">
+											<%= assetEntry.getViewCount() %> <liferay-ui:message key="views" />
+										</c:when>
+									</c:choose>
 								</div>
 
-								<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnableComments() %>">
-									<div id="<portlet:namespace />wikiCommentsPanel">
-										<liferay-comment:discussion
+								<div class="page-categorization">
+									<div class="page-categories">
+										<liferay-asset:asset-categories-summary
 											className="<%= WikiPage.class.getName() %>"
 											classPK="<%= wikiPage.getResourcePrimKey() %>"
-											formName="fm2"
-											ratingsEnabled="<%= wikiPortletInstanceSettingsHelper.isEnableCommentRatings() %>"
-											redirect="<%= currentURL %>"
-											userId="<%= wikiPage.getUserId() %>"
+											portletURL="<%= PortletURLUtil.clone(categorizedPagesURL, renderResponse) %>"
+										/>
+									</div>
+
+									<div class="page-tags">
+										<liferay-asset:asset-tags-available
+											className="<%= WikiPage.class.getName() %>"
+											classPK="<%= wikiPage.getResourcePrimKey() %>"
+										>
+											<h5><liferay-ui:message key="tags" /></h5>
+
+											<liferay-asset:asset-tags-summary
+												className="<%= WikiPage.class.getName() %>"
+												classPK="<%= wikiPage.getResourcePrimKey() %>"
+												portletURL="<%= PortletURLUtil.clone(taggedPagesURL, renderResponse) %>"
+											/>
+										</liferay-asset:asset-tags-available>
+									</div>
+								</div>
+
+								<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnablePageRatings() %>">
+									<div class="page-ratings">
+										<liferay-ratings:ratings
+											className="<%= WikiPage.class.getName() %>"
+											classPK="<%= wikiPage.getResourcePrimKey() %>"
+											inTrash="<%= wikiPage.isInTrash() %>"
 										/>
 									</div>
 								</c:if>
+
+								<liferay-util:include page="/wiki/view_attachments.jsp" servletContext="<%= application %>" />
+
+								<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnableRelatedAssets() %>">
+									<div class="entry-links">
+										<liferay-asset:asset-links
+											assetEntryId="<%= assetEntry.getEntryId() %>"
+										/>
+									</div>
+								</c:if>
+							</div>
+
+							<c:if test="<%= wikiPortletInstanceSettingsHelper.isEnableComments() %>">
+								<div id="<portlet:namespace />wikiCommentsPanel">
+									<liferay-comment:discussion
+										className="<%= WikiPage.class.getName() %>"
+										classPK="<%= wikiPage.getResourcePrimKey() %>"
+										formName="fm2"
+										ratingsEnabled="<%= wikiPortletInstanceSettingsHelper.isEnableCommentRatings() %>"
+										redirect="<%= currentURL %>"
+										userId="<%= wikiPage.getUserId() %>"
+									/>
+								</div>
 							</c:if>
-						</div>
+						</c:if>
 					</liferay-ddm:template-renderer>
 
 					<%

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/edit_node.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/edit_node.jsp
@@ -31,7 +31,9 @@ renderResponse.setTitle((node == null) ? LanguageUtil.get(request, "new-wiki-nod
 
 <portlet:actionURL name="/wiki/edit_node" var="editNodeURL" />
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<aui:form action="<%= editNodeURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveNode();" %>'>
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -62,13 +64,13 @@ renderResponse.setTitle((node == null) ? LanguageUtil.get(request, "new-wiki-nod
 					/>
 				</aui:fieldset>
 			</c:if>
+
+			<div class="sheet-footer">
+				<aui:button type="submit" />
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button type="submit" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/import_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/import_pages.jsp
@@ -55,7 +55,9 @@ renderResponse.setTitle(LanguageUtil.get(request, "import-pages"));
 
 <portlet:actionURL name="/wiki/import_pages" var="importPagesURL" />
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
 	<aui:form action="<%= importPagesURL %>" enctype="multipart/form-data" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "importPages();" %>'>
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -74,13 +76,13 @@ renderResponse.setTitle(LanguageUtil.get(request, "import-pages"));
 			<liferay-ui:error exception="<%= NoSuchNodeException.class %>" message="the-node-could-not-be-found" />
 
 			<liferay-util:include page='<%= wikiImporterTracker.getProperty(tabs2, "page") %>' servletContext="<%= application %>" />
+
+			<div class="sheet-footer">
+				<aui:button type="submit" value="import" />
+
+				<aui:button href="<%= redirect %>" type="cancel" />
+			</div>
 		</aui:fieldset-group>
-
-		<aui:button-row>
-			<aui:button type="submit" value="import" />
-
-			<aui:button href="<%= redirect %>" type="cancel" />
-		</aui:button-row>
 	</aui:form>
 
 	<liferay-ui:upload-progress

--- a/portal-web/docroot/html/taglib/aui/fieldset/init.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/init.jsp
@@ -28,6 +28,7 @@ java.lang.String id = GetterUtil.getString((java.lang.String)request.getAttribut
 java.lang.String label = GetterUtil.getString((java.lang.String)request.getAttribute("aui:fieldset:label"));
 boolean localizeLabel = GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui:fieldset:localizeLabel")), true);
 java.lang.String markupView = GetterUtil.getString((java.lang.String)request.getAttribute("aui:fieldset:markupView"));
+java.lang.String panelHeaderLinkCssClass = GetterUtil.getString((java.lang.String)request.getAttribute("aui:fieldset:panelHeaderLinkCssClass"));
 Map<String, Object> dynamicAttributes = (Map<String, Object>)request.getAttribute("aui:fieldset:dynamicAttributes");
 %>
 

--- a/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
@@ -26,9 +26,17 @@ else if (collapsible) {
 
 	collapsed = GetterUtil.getBoolean(SessionClicks.get(request, id, null), defaultState);
 }
+
+if (Validator.isNull(cssClass)) {
+	cssClass = collapsible ? "panel panel-unstyled" : StringPool.BLANK;
+}
+
+if (Validator.isNull(panelHeaderLinkCssClass)) {
+	panelHeaderLinkCssClass = collapsible ? "sheet-subtitle" : StringPool.BLANK;
+}
 %>
 
-<fieldset aria-labelledby="<%= id %>Title" class="<%= collapsible ? "panel panel-secondary" : StringPool.BLANK %> <%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
+<fieldset aria-labelledby="<%= id %>Title" class="<%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
 	<c:if test="<%= Validator.isNotNull(label) %>">
 		<liferay-util:buffer
 			var="header"
@@ -46,20 +54,18 @@ else if (collapsible) {
 			</c:if>
 		</liferay-util:buffer>
 
-		<div class="panel-heading" id="<%= id %>Header" role="presentation">
-			<div class="panel-title" id="<%= id %>Title">
-				<c:choose>
-					<c:when test="<%= collapsible %>">
-						<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="btn btn-unstyled collapse-icon collapse-icon-middle panel-header panel-header-link <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
-							<%= header %>
-						</a>
-					</c:when>
-					<c:otherwise>
+		<c:choose>
+			<c:when test="<%= collapsible %>">
+				<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapse-icon-middle <%= panelHeaderLinkCssClass %> <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
+					<span class="c-inner" tabindex="-1">
 						<%= header %>
-					</c:otherwise>
-				</c:choose>
-			</div>
-		</div>
+					</span>
+				</a>
+			</c:when>
+			<c:otherwise>
+				<%= header %>
+			</c:otherwise>
+		</c:choose>
 	</c:if>
 
 	<div aria-labelledby="<%= id %>Header" class="<%= !collapsed ? "show" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="presentation">

--- a/portal-web/docroot/html/taglib/aui/fieldset_group/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset_group/lexicon/start.jsp
@@ -16,5 +16,5 @@
 
 <%@ include file="/html/taglib/aui/fieldset_group/init.jsp" %>
 
-<div class="card-horizontal main-content-card">
-	<div aria-multiselectable="true" class="panel-group" role="tablist">
+<div class="sheet">
+	<div aria-multiselectable="true" class="panel-group panel-group-flush" role="tablist">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
@@ -127,7 +127,7 @@ definition {
 			entrySubtitle = "${entrySubtitle}",
 			entryTitle = "${entryTitle}");
 
-		Panel.expandPanel(panel = "Categorization");
+		Panel.expandUnstyledPanel(panel = "Categorization");
 
 		AssetCategorization.addTag(tagName = "${tagName}");
 
@@ -144,7 +144,7 @@ definition {
 			entrySubtitle = "${entrySubtitle}",
 			entryTitle = "${entryTitle}");
 
-		Panel.expandPanel(panel = "Categorization");
+		Panel.expandUnstyledPanel(panel = "Categorization");
 
 		for (var tagName : list "${tagNameList}") {
 			AssetCategorization.addTag(tagName = "${tagName}");
@@ -238,7 +238,7 @@ definition {
 			entrySubtitle = "${entrySubtitle}",
 			entryTitle = "${entryTitle}");
 
-		Panel.expandPanel(panel = "Configuration");
+		Panel.expandUnstyledPanel(panel = "Configuration");
 
 		BlogsEntry.addCustomAbstract(entryAbstractDescription = "${entryAbstractDescription}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -108,7 +108,7 @@ definition {
 
 		Click.clickAt(locator1 = "TextInput#TITLE");
 
-		Panel.expandPanel(panel = "Configuration");
+		Panel.expandUnstyledPanel(panel = "Configuration");
 
 		if (isSet(kbArticleFriendlyURL)) {
 			var kbArticleTitleFormatted = StringUtil.lowerCase("${kbArticleFriendlyURL}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WikiPage.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WikiPage.macro
@@ -250,7 +250,7 @@ definition {
 				value1 = "${wikiPageContent}");
 		}
 		else if ("${htmlSource}" == "true") {
-			Panel.expandPanel(panel = "Configuration");
+			Panel.expandUnstyledPanel(panel = "Configuration");
 
 			SelectNoError(
 				locator1 = "Wiki#ADD_PAGE_FORMAT_DROPDOWN",

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/announcements/Announcements.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/announcements/Announcements.path
@@ -42,17 +42,17 @@
 <!--CARD_VIEW_ENTRY-->
 <tr>
 	<td>CARD_VIEW_ENTRY_TITLE</td>
-	<td>//div[contains(@class,'panel')]//h4[@title='${key_entryTitle}']/a</td>
+	<td>//*[@title='${key_entryTitle}']/a</td>
 	<td></td>
 </tr>
 <tr>
 	<td>CARD_VIEW_ENTRY_SCOPE</td>
-	<td>//div[contains(@class,'panel')]//h4[@title='${key_entryTitle}']/..//h5[contains(.,'${key_distributionScope}')]</td>
+	<td>//*[@title='${key_entryTitle}']/..//*[contains(.,'${key_distributionScope}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>CARD_VIEW_ENTRY_CONTENT</td>
-	<td>//div[contains(@class,'panel')]//div[contains(@class,'entry-content') and contains(.,'${key_entryContent}')]</td>
+	<td>//*[contains(@class,'entry-content') and contains(.,'${key_entryContent}')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/PGBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/PGBlogs.testcase
@@ -814,7 +814,7 @@ definition {
 			entryContent = "Blogs Entry Content",
 			entryTitle = "Blogs Entry with Small Image");
 
-		Panel.expandPanel(panel = "Configuration");
+		Panel.expandUnstyledPanel(panel = "Configuration");
 
 		BlogsEntry.addSmallImage(
 			navTab = "Documents and Media",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/PGWiki.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/PGWiki.testcase
@@ -453,7 +453,7 @@ definition {
 
 		WikiEntry.addPageTitle(wikiPageTitle = "Wiki Page Title");
 
-		Panel.expandPanel(panel = "Configuration");
+		Panel.expandUnstyledPanel(panel = "Configuration");
 
 		SelectNoError(
 			locator1 = "Wiki#ADD_PAGE_FORMAT_DROPDOWN",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/tags/TagsUseCase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/tags/TagsUseCase.testcase
@@ -466,7 +466,7 @@ definition {
 
 		BlogsNavigator.gotoEditPG(entryTitle = "Entry Title");
 
-		Panel.expandPanel(panel = "Categorization");
+		Panel.expandUnstyledPanel(panel = "Categorization");
 
 		AssetCategorization.removeTag(tagName = "tag name 1");
 

--- a/util-taglib/src/META-INF/liferay-aui.tld
+++ b/util-taglib/src/META-INF/liferay-aui.tld
@@ -474,6 +474,12 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<description><![CDATA[A CSS class for styling the panel-header-link.]]></description>
+			<name>panelHeaderLinkCssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseFieldsetTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseFieldsetTag.java
@@ -69,6 +69,10 @@ public abstract class BaseFieldsetTag extends com.liferay.taglib.util.IncludeTag
 		return _markupView;
 	}
 
+	public java.lang.String getPanelHeaderLinkCssClass() {
+		return _panelHeaderLinkCssClass;
+	}
+
 	public void setCollapsed(boolean collapsed) {
 		_collapsed = collapsed;
 	}
@@ -105,6 +109,10 @@ public abstract class BaseFieldsetTag extends com.liferay.taglib.util.IncludeTag
 		_markupView = markupView;
 	}
 
+	public void setPanelHeaderLinkCssClass(java.lang.String panelHeaderLinkCssClass) {
+		_panelHeaderLinkCssClass = panelHeaderLinkCssClass;
+	}
+
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
@@ -118,6 +126,7 @@ public abstract class BaseFieldsetTag extends com.liferay.taglib.util.IncludeTag
 		_label = null;
 		_localizeLabel = true;
 		_markupView = null;
+		_panelHeaderLinkCssClass = null;
 	}
 
 	@Override
@@ -141,6 +150,7 @@ public abstract class BaseFieldsetTag extends com.liferay.taglib.util.IncludeTag
 		setNamespacedAttribute(request, "label", _label);
 		setNamespacedAttribute(request, "localizeLabel", _localizeLabel);
 		setNamespacedAttribute(request, "markupView", _markupView);
+		setNamespacedAttribute(request, "panelHeaderLinkCssClass", _panelHeaderLinkCssClass);
 	}
 
 	protected static final String _ATTRIBUTE_NAMESPACE = "aui:fieldset:";
@@ -160,5 +170,6 @@ public abstract class BaseFieldsetTag extends com.liferay.taglib.util.IncludeTag
 	private java.lang.String _label = null;
 	private boolean _localizeLabel = true;
 	private java.lang.String _markupView = null;
+	private java.lang.String _panelHeaderLinkCssClass = null;
 
 }

--- a/util-taglib/src/com/liferay/taglib/liferay-aui.xml
+++ b/util-taglib/src/com/liferay/taglib/liferay-aui.xml
@@ -505,6 +505,12 @@
 				<inputType>java.lang.String</inputType>
 				<outputType>java.lang.String</outputType>
 			</attribute>
+			<attribute>
+				<description>A CSS class for styling the panel-header-link.</description>
+				<name>panelHeaderLinkCssClass</name>
+				<inputType>java.lang.String</inputType>
+				<outputType>java.lang.String</outputType>
+			</attribute>
 		</attributes>
 	</component>
 	<component bodyContent="true" name="FieldsetGroup">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-126737

This pr: 
- Removes `main-content-card`, adds `container-form-lg` or `container-view` for spacing between `sheet` and navigation, and replace `aui:button-row` with `sheet-footer` and move buttons inside `sheet` where applicable.
- Removes `cssClass="container-form-lg"` from `liferay-frontend:edit-form` tags since it's output by default now
- `liferay-frontend:diff-version-comparator` replace `container-fluid-1280` with `container-fluid container-fluid-max-xl container-view` and remove `main-content-card`
- `liferay-frontend:edit-form` adds `container-form-lg` by default
- `aui:fieldset` adds attribute `panelHeaderLinkCssClass` to pass css classes into the Panel Header Link. It is `sheet-subtitle` by default.
- `aui:fieldset` use `panel panel-unstyled` by default unless a `cssClass` is declared

`liferay-frontend:edit-form` with `aui:fieldset` should look like:
<img width="1479" alt="liferay-frontend-edit-form" src="https://user-images.githubusercontent.com/788266/106543551-cbc03c80-64ba-11eb-9b5e-b819db6cbb54.png">

I tried to convert all the nooks and crannies of Portal, but I'm sure I missed a lot. This took too long and hopefully I don't break any tests.
