### PR TITLE
[WIP] Simple move clay load to main.scss

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/clay.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/clay.scss
@@ -1,1 +1,0 @@
-@import 'clay/atlas';

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/main.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/main.scss
@@ -1,0 +1,23 @@
+@import 'clay/atlas';
+
+@import 'imports';
+
+@import 'base';
+
+@import 'portal';
+
+@import 'taglib';
+
+@import 'application';
+
+@import 'layout';
+
+@import 'navigation';
+
+@import 'portlet';
+
+@import 'widget';
+
+@import 'extras';
+
+@import 'custom';


### PR DESCRIPTION
Moving `clay.scss` file in `main.scss`

It looks like:

![image](https://user-images.githubusercontent.com/7963804/106608060-3f6a5400-6564-11eb-8e33-4527d1d2b1cf.png)

Exactly the same.

We go from:

- clay.css -  628 KB (not compressed)
- main.css -  233 KB (not compressed)

to: 

- main.css -  862 KB (not compressed)
