### PR TITLE
LPS-127052 [Impedibug] AB tests can be run with an invalid ID

### DIFF
--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -62,11 +62,11 @@ const OVERLAY_TARGET_CLASS = 'lfr-segments-experiment-click-goal-target';
 function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 	const [state, dispatch] = useReducer(reducer, target, getInitialState);
 
-	const [selectorInputValue, setSelectorInputValue] = useState(
-		state.selectedTarget
-	);
+	const {isValidTarget, mode, selectedTarget} = state;
 
-	const {isValidTarget, selectedTarget} = state;
+	const [selectorInputValue, setSelectorInputValue] = useState(
+		selectedTarget
+	);
 
 	const {errors} = useContext(GlobalStateContext);
 
@@ -108,7 +108,7 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 	}
 
 	const scrollIntoView = (event) => {
-		const target = document.getElementById(state.selectedTarget);
+		const target = document.getElementById(selectedTarget);
 
 		if (target) {
 			target.scrollIntoView();
@@ -204,7 +204,7 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 						onClick={() => dispatch({type: 'activate'})}
 						small
 					>
-						{state.selectedTarget
+						{selectedTarget
 							? Liferay.Language.get('change-clickable-element')
 							: Liferay.Language.get('select-clickable-element')}
 					</ClayButton>
@@ -250,7 +250,7 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 							<ClayTooltipProvider>
 								<ClayButtonWithIcon
 									data-tooltip-align="bottom-right"
-									disabled={!state.selectedTarget}
+									disabled={!selectedTarget}
 									displayType="secondary"
 									onClick={scrollIntoView}
 									symbol="view"
@@ -269,7 +269,7 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 					</ClayInput.Group>
 				</ClayForm.Group>
 
-				{state.mode === 'active' ? (
+				{mode === 'active' ? (
 					<ClickGoalPicker.OverlayContainer
 						allowEdit={allowEdit}
 						root={root}

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -146,10 +146,12 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 	};
 
 	const handleBlur = (event) => {
-		const value = event.target.value;
+		if (!selectedTarget) {
+			const value = event.target.value;
 
-		if (isValidNewClickTargetElement(value)) {
-			selectNewClickTargetElement(event);
+			if (isValidNewClickTargetElement(value)) {
+				selectNewClickTargetElement(event);
+			}
 		}
 	};
 

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -167,6 +167,15 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 		setSelectorInputValue(event.target.value);
 	};
 
+	const handleDelete = (event) => {
+		stopImmediatePropagation(event);
+
+		dispatch({
+			selector: '',
+			type: 'selectTarget',
+		});
+	};
+
 	return (
 		<DispatchContext.Provider value={dispatch}>
 			<StateContext.Provider value={state}>
@@ -234,17 +243,37 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 						<ClayInput.GroupItem append>
 							<ClayTooltipProvider>
 								<ClayInput
+									className={classNames({
+										'input-group-inset input-group-inset-after': selectedTarget,
+									})}
 									data-tooltip-align="top"
 									id="clickableElement"
 									onBlur={handleBlur}
 									onChange={handleInputChange}
 									onKeyDown={handleKeyDown}
-									readOnly={!allowEdit}
+									readOnly={!allowEdit || selectedTarget}
 									title={selectorInputValue}
 									type="text"
 									value={selectorInputValue}
 								/>
 							</ClayTooltipProvider>
+							{selectedTarget && (
+								<ClayInput.GroupInsetItem after>
+									<ClayTooltipProvider>
+										<ClayButtonWithIcon
+											data-tooltip-align="bottom-right"
+											disabled={!selectedTarget}
+											displayType="unstyled"
+											monospaced={false}
+											onClick={handleDelete}
+											symbol="times-circle"
+											title={Liferay.Language.get(
+												'clear'
+											)}
+										/>
+									</ClayTooltipProvider>
+								</ClayInput.GroupInsetItem>
+							)}
 						</ClayInput.GroupItem>
 						<ClayInput.GroupItem shrink>
 							<ClayTooltipProvider>

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -517,6 +517,8 @@ Overlay.propTypes = {
 function Target({allowEdit, element, geometry, mode, selector}) {
 	const dispatch = useContext(DispatchContext);
 
+	const {selectedTarget} = useContext(StateContext);
+
 	const {bottom, height, left, right, top, width} = getElementGeometry(
 		element
 	);
@@ -558,15 +560,16 @@ function Target({allowEdit, element, geometry, mode, selector}) {
 		>
 			<ClayTooltipProvider>
 				<div
-					className={classNames(
-						'lfr-segments-experiment-click-goal-target-overlay',
-						{
-							'lfr-segments-experiment-click-goal-target-overlay-editing':
-								mode === 'editing',
-							'lfr-segments-experiment-click-goal-target-overlay-selected':
-								mode === 'selected',
-						}
-					)}
+					className={classNames({
+						'lfr-segments-experiment-click-goal-target-overlay':
+							!selectedTarget ||
+							mode === 'editing' ||
+							mode === 'selected',
+						'lfr-segments-experiment-click-goal-target-overlay-editing':
+							mode === 'editing',
+						'lfr-segments-experiment-click-goal-target-overlay-selected':
+							mode === 'selected',
+					})}
 					data-target-selector={selector}
 					data-tooltip-align="bottom-left"
 					onClick={handleClick}


### PR DESCRIPTION
**Description**

With A/B Testing functionality, the user can create tests with goal Click. In those tests, is required to select a clickable element as click goal target.

**Solution**

A couple of pull requests ago, we decided to implement a new `input` to enter manually the click goal target (clickable element ID), see https://github.com/liferay-frontend/liferay-portal/pull/650. Testing this feature, we found that a user, can let the input empty, the `ID was not found.` message appear, but the target is already in DB so the user can review and run the AB Test. This is a weird behavior and we decided to change a few things:

1. If the user selects a target, the input becomes readonly
2. If the user wants to select a target:
    * If there is a selected target, he/she has to remove it first and then select the new one
    * if there isn't a selected target, he/she can select it with the highlighted ones, or enter manually the ID in the input box
3. If the user wants to remove the target:
    * Click in the `x` in the topper of the element in the page
    * Click in the `x` in the input of the AB Testing sidebar
4. If there is a selected target, this is the only element highlighted in the page, if not, every OOTB clickable element (a, button and input[submit]) is highlighted

**How to test it**

* Connect Liferay DXP with Analytics Cloud
* Create a page
* Click in the AB Test icon in the Control Menu
* Create new test with Click goal

**Screenshots**

![Screenshot 2021-02-03 at 13 43 54](https://user-images.githubusercontent.com/15845466/106751044-f7f9cb80-6628-11eb-869e-b65cf5bc27eb.png)
![Screenshot 2021-02-03 at 13 43 43](https://user-images.githubusercontent.com/15845466/106751048-f9c38f00-6628-11eb-941b-593c0e1d26c8.png)
