### PR TITLE
[TS] LPS-127302 Add event.stopPropagation() to fix onclick event on Safari…

### DIFF
--- a/util-taglib/src/com/liferay/taglib/ui/IconTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconTag.java
@@ -310,7 +310,7 @@ public class IconTag extends IncludeTag {
 		if (isForcePost()) {
 			StringBundler sb = new StringBundler(5);
 
-			sb.append("event.preventDefault();");
+			sb.append("event.preventDefault();event.stopPropagation();");
 			sb.append(onClick);
 			sb.append("submitForm(document.hrefFm, '");
 			sb.append(HtmlUtil.escapeJS(getUrl()));


### PR DESCRIPTION
Hola Team!

could you please check my fix?

The issue is only reproducable on Safari with disabled SPA (javascript.single.page.application.enabled=false)
Adding event.stopPropagation() to the onclick events fixing the issue 

Thanks, Roland