### PR TITLE
LPS-127312 [Bug] Clear editingExperience state on modal close

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -95,6 +95,7 @@ const ExperienceSelector = ({
 	const {observer: modalObserver, onClose: onModalClose} = useModal({
 		onClose: () => {
 			setOpenModal(false);
+			setEditingExperience({});
 		},
 	});
 
@@ -159,7 +160,6 @@ const ExperienceSelector = ({
 			)
 				.then(() => {
 					if (isMounted()) {
-						setEditingExperience({});
 						onModalClose();
 					}
 					openToast({


### PR DESCRIPTION
**Description**

When we create an experience, we stored a state called `editingExperience` in case the data entered by the user is wrong, keep the state and display an error. But if the user clicks on `X` or `Cancel` button to dismiss the modal, the state remains there and if you want to create an experience, it will trigger an action action of the previous experience (there is an experienceId in the state).

**Solution**

When creating or updating an experience successfully, `then()` clause is going to call `onModalClose` and the modal state will be false (close) and the `editingExperience` state will be clear. Also, if the user clicks on `Cancel`, `X` or outside the modal, it will be trigger `onModalClose` too, so the state will be also clear.

**Screenshot**

https://user-images.githubusercontent.com/15845466/106878895-ca6d5a80-66da-11eb-9b31-5c1f1053ff00.mov