### PR TITLE
LPS-127248 Use getAttribute to avoid problems with forms that contain an input field with action as name.

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
@@ -102,7 +102,7 @@
 			}
 
 			if (!hasErrors) {
-				var action = event.action || form.attr('action');
+				var action = event.action || form.getAttribute('action');
 
 				var singleSubmit = event.singleSubmit;
 


### PR DESCRIPTION
Currently it isn't reproducible in master because the way of dealing with structures has changed after data engine.

**Steps to Reproduce in branches**
1. Create a web content structure.
2. Add a text field, using "action" as name.
3. Save the structure.

**Expected Results** 
Structure should be save correctly.

**Actual Results**
A JS error is obtained while saving: _Uncaught TypeError: action.indexOf is not a function_

The reason is that we're using _form.attr_ to retrieve the action, but that can return an input field if the field is named **action**. Normally across the code this won't happen because we prepend the portlet namespace, but still is risky as it can originate situations as the one described in previous branches, so we shouldn't assume a "correct" naming of the fields.

/cc @antonio-ortega