### PR TITLE
[Don't forward] LPS-121865 Migrate v2 usages in bookmarks/bookmarks-web

### DIFF
--- a/modules/apps/bookmarks/bookmarks-web/.npmbundlerrc
+++ b/modules/apps/bookmarks/bookmarks-web/.npmbundlerrc
@@ -1,5 +1,6 @@
 {
     "ignore": [
-        "**/*"
+        "**/config.js",
+        "**/main.js"
     ]
 }

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/js/BookmarksManagementToolbarPropsTransformer.js
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/js/BookmarksManagementToolbarPropsTransformer.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function propsTransformer({
+	additionalProps: {deleteEntriesURL, inputId, inputValue, trashEnabled},
+	portletNamespace,
+	...props
+}) {
+	const deleteEntries = () => {
+		if (
+			trashEnabled ||
+			confirm(
+				Liferay.Language.get(
+					'are-you-sure-you-want-to-delete-the-selected-entries'
+				)
+			)
+		) {
+			const form = document.getElementById(`${portletNamespace}fm`);
+
+			if (!form) {
+				return;
+			}
+
+			form.setAttribute('method', 'post');
+
+			const inputElement = document.getElementById(
+				`${portletNamespace}${inputId}`
+			);
+
+			if (inputElement) {
+				inputElement.setAttribute('value', inputValue);
+
+				submitForm(form, deleteEntriesURL);
+			}
+		}
+	};
+
+	return {
+		...props,
+		onActionButtonClick(event, {item}) {
+			if (item.data?.action === 'deleteEntries') {
+				deleteEntries();
+			}
+		},
+	};
+}

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/toolbar.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/toolbar.jsp
@@ -20,8 +20,21 @@
 BookmarksManagementToolbarDisplayContext bookmarksManagementToolbarDisplayContext = new BookmarksManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, bookmarksGroupServiceOverriddenConfiguration, portalPreferences, trashHelper);
 %>
 
-<clay:management-toolbar-v2
+<portlet:actionURL name="/bookmarks/edit_entry" var="deleteEntriesURL" />
+
+<clay:management-toolbar
 	actionDropdownItems="<%= bookmarksManagementToolbarDisplayContext.getActionDropdownItems() %>"
+	additionalProps='<%=
+		HashMapBuilder.<String, Object>put(
+			"deleteEntriesURL", deleteEntriesURL.toString()
+		).put(
+			"inputId", Constants.CMD
+		).put(
+			"inputValue", trashHelper.isTrashEnabled(scopeGroupId) ? Constants.MOVE_TO_TRASH : Constants.DELETE
+		).put(
+			"trashEnabled", trashHelper.isTrashEnabled(scopeGroupId)
+		).build()
+	%>'
 	clearResultsURL="<%= bookmarksManagementToolbarDisplayContext.getClearResultsURL() %>"
 	componentId="bookmarksManagementToolbar"
 	creationMenu="<%= bookmarksManagementToolbarDisplayContext.getCreationMenu() %>"
@@ -30,6 +43,7 @@ BookmarksManagementToolbarDisplayContext bookmarksManagementToolbarDisplayContex
 	filterLabelItems="<%= bookmarksManagementToolbarDisplayContext.getFilterLabelItems() %>"
 	infoPanelId="infoPanelId"
 	itemsTotal="<%= bookmarksManagementToolbarDisplayContext.getTotalItems() %>"
+	propsTransformer="bookmarks/js/BookmarksManagementToolbarPropsTransformer"
 	searchActionURL="<%= String.valueOf(bookmarksManagementToolbarDisplayContext.getSearchActionURL()) %>"
 	searchContainerId="<%= bookmarksManagementToolbarDisplayContext.getSearchContainerId() %>"
 	selectable="<%= bookmarksManagementToolbarDisplayContext.isSelectable() %>"
@@ -37,52 +51,3 @@ BookmarksManagementToolbarDisplayContext bookmarksManagementToolbarDisplayContex
 	showSearch="<%= bookmarksManagementToolbarDisplayContext.isShowSearch() %>"
 	viewTypeItems="<%= bookmarksManagementToolbarDisplayContext.getViewTypes() %>"
 />
-
-<aui:script>
-	var deleteEntries = function () {
-		if (
-			<%= trashHelper.isTrashEnabled(scopeGroupId) %> ||
-			confirm(
-				'<liferay-ui:message key="are-you-sure-you-want-to-delete-the-selected-entries" />'
-			)
-		) {
-			var form = document.getElementById('<portlet:namespace />fm');
-
-			if (form) {
-				form.setAttribute('method', 'post');
-
-				var cmd = form.querySelector(
-					'#<portlet:namespace /><%= Constants.CMD %>'
-				);
-
-				if (cmd) {
-					cmd.setAttribute(
-						'value',
-						'<%= trashHelper.isTrashEnabled(scopeGroupId) ? Constants.MOVE_TO_TRASH : Constants.DELETE %>'
-					);
-
-					submitForm(
-						form,
-						'<portlet:actionURL name="/bookmarks/edit_entry" />'
-					);
-				}
-			}
-		}
-	};
-
-	var ACTIONS = {
-		deleteEntries: deleteEntries,
-	};
-
-	Liferay.componentReady('bookmarksManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
-
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
-</aui:script>


### PR DESCRIPTION
In this change we've updated the `<clay:management-toolbar-v2 />`
to `<clay:management-toolbar />` (which uses clay v3), adding new
bookmarks and bookmarks folders or deleting them works as expected.

![](https://user-images.githubusercontent.com/5572/107036621-35419300-67ba-11eb-845c-19e3923a4182.gif)

**Test plan**:
- Navigate to **Content & Data > Bookmarks**
- From the management toolbar you should be able to 
    - Create a bookmark
    - Create a bookmark folder
    - Delete a bookmark
    - Delete a bookmark folder 

cc @markocikos @jonmak08 @ambrinchaudhary 

Please note that this is for internal review and will be forwarded manually to @liferay-lima once reviewed.