### PR TITLE
LPS-127488 Add missing propsTransformer for <clay:button />

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
@@ -63,14 +63,6 @@ String taglibOnChange = "Liferay.Util.toggleDisabled('#" + liferayPortletRespons
 	</aui:input>
 </div>
 
-<clay:button
-	cssClass="mb-4"
-	displayType="secondary"
-	id='<%= liferayPortletResponse.getNamespace() + "chooseLayout" %>'
-	label='<%= LanguageUtil.get(resourceBundle, "choose") %>'
-	small="<%= true %>"
-/>
-
 <%
 String eventName = liferayPortletResponse.getNamespace() + "selectLayout";
 
@@ -87,15 +79,24 @@ if (selLayout != null) {
 }
 %>
 
-<liferay-frontend:component
-	componentId='<%= liferayPortletResponse.getNamespace() + "editLayout" %>'
-	context='<%=
+<clay:button
+	additionalProps='<%=
 		HashMapBuilder.<String, Object>put(
 			"eventName", eventName
 		).put(
 			"itemSelectorURL", itemSelectorURL.toString()
 		).build()
 	%>'
+	cssClass="mb-4"
+	displayType="secondary"
+	id='<%= liferayPortletResponse.getNamespace() + "chooseLayout" %>'
+	label='<%= LanguageUtil.get(resourceBundle, "choose") %>'
+	propsTransformer="js/ChooseLayoutButtonPropsTransformer"
+	small="<%= true %>"
+/>
+
+<liferay-frontend:component
+	componentId='<%= liferayPortletResponse.getNamespace() + "editLayout" %>'
 	module="js/EditLayout"
 	servletContext="<%= application %>"
 />

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/js/ChooseLayoutButtonPropsTransformer.js
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/js/ChooseLayoutButtonPropsTransformer.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {openSelectionModal} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {eventName, itemSelectorURL},
+	portletNamespace,
+	...props
+}) {
+	const url = new URL(itemSelectorURL);
+
+	return {
+		...props,
+		onClick() {
+			const groupIdInput = document.getElementById(
+				`${portletNamespace}groupId`
+			);
+
+			const layoutItemRemoveButton = document.getElementById(
+				`${portletNamespace}layoutItemRemove`
+			);
+
+			const layoutNameInput = document.getElementById(
+				`${portletNamespace}layoutNameInput`
+			);
+
+			const layoutUuidInput = document.getElementById(
+				`${portletNamespace}layoutUuid`
+			);
+
+			const privateLayoutInput = document.getElementById(
+				`${portletNamespace}privateLayout`
+			);
+
+			openSelectionModal({
+				multiple: true,
+				onSelect: (selectedItem) => {
+					if (selectedItem) {
+						groupIdInput.value = selectedItem.groupId;
+						layoutUuidInput.value = selectedItem.id;
+						layoutNameInput.textContent = selectedItem.name;
+						privateLayoutInput.value = selectedItem.privateLayout;
+
+						url.searchParams.set(
+							`${Liferay.Util.getPortletNamespace(
+								Liferay.PortletKeys.ITEM_SELECTOR
+							)}layoutUuid`,
+							selectedItem.id
+						);
+
+						layoutItemRemoveButton.classList.remove('hide');
+					}
+				},
+				selectEventName: eventName,
+				title: Liferay.Language.get('select-layout'),
+				url: url.href,
+			});
+		},
+	};
+}

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/js/EditLayout.js
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/js/EditLayout.js
@@ -12,61 +12,15 @@
  * details.
  */
 
-export default function ({
-	eventName,
-	itemSelectorURL: initialItemSelectorURL,
-	namespace,
-}) {
-	const namespaceId = (id) => `${namespace}${id}`;
-
-	const groupIdInput = document.getElementById(namespaceId('groupId'));
-
+export default function ({namespace}) {
 	const layoutItemRemoveButton = document.getElementById(
-		namespaceId('layoutItemRemove')
+		`${namespace}layoutItemRemove`
 	);
 	const layoutNameInput = document.getElementById(
-		namespaceId('layoutNameInput')
+		`${namespace}layoutNameInput`
 	);
 
-	const layoutUuidInput = document.getElementById(namespaceId('layoutUuid'));
-
-	const privateLayoutInput = document.getElementById(
-		namespaceId('privateLayout')
-	);
-
-	const chooseLayoutButton = document.getElementById(
-		namespaceId('chooseLayout')
-	);
-
-	const itemSelectorURL = new URL(initialItemSelectorURL);
-
-	const onChooseLayoutButtonClick = () => {
-		Liferay.Util.openSelectionModal({
-			multiple: true,
-			onSelect: (selectedItem) => {
-				if (selectedItem) {
-					groupIdInput.value = selectedItem.groupId;
-					layoutUuidInput.value = selectedItem.id;
-					layoutNameInput.textContent = selectedItem.name;
-					privateLayoutInput.value = selectedItem.privateLayout;
-
-					itemSelectorURL.searchParams.set(
-						`${Liferay.Util.getPortletNamespace(
-							Liferay.PortletKeys.ITEM_SELECTOR
-						)}layoutUuid`,
-						selectedItem.id
-					);
-
-					layoutItemRemoveButton.classList.remove('hide');
-				}
-			},
-			selectEventName: eventName,
-			title: Liferay.Language.get('select-layout'),
-			url: itemSelectorURL.href,
-		});
-	};
-
-	chooseLayoutButton.addEventListener('click', onChooseLayoutButtonClick);
+	const layoutUuidInput = document.getElementById(`${namespace}layoutUuid`);
 
 	const onLayoutItemRemoveButtonClick = () => {
 		layoutNameInput.textContent = Liferay.Language.get('none');
@@ -82,10 +36,6 @@ export default function ({
 
 	return {
 		dispose() {
-			chooseLayoutButton.removeEventListener(
-				'click',
-				onChooseLayoutButtonClick
-			);
 			layoutItemRemoveButton.removeEventListener(
 				'click',
 				onLayoutItemRemoveButtonClick


### PR DESCRIPTION
In [LPS-125256](https://issues.liferay.com/browse/LPS-125256), we forgot to add a `propsTransformer` 
for a `<clay:button />` which caused a loss of functionality.

With this change, it's now possible to choose the layout for navigation menus, as expected.

![recording (1)](https://user-images.githubusercontent.com/5572/107216267-d32c9c00-6a0c-11eb-9c68-8ce450cc53d4.gif)


**Test plan**:
- Navigate to **Site Builder**>**Pages**
- Create a new public page based on the Blank template 
   (found in **Basic Tempates**)
- Publish the page
- Navigate to **Site Builder**>**Navigation Menus**
- Create a new **Navigation menu**
- From the **New** button select **Page**
- In the item selector, select the page you just published
- Select the page by clicking on it
- Change the layout by clicking on the **Choose** button