### PR TITLE
LPS-127434 Add liferay-frontend:script taglib

### DIFF
--- a/util-taglib/src/META-INF/liferay-aui.tld
+++ b/util-taglib/src/META-INF/liferay-aui.tld
@@ -1345,6 +1345,11 @@
 		<tag-class>com.liferay.taglib.aui.ScriptTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
+			<name>load</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description><![CDATA[A position for the script.]]></description>
 			<name>position</name>
 			<required>false</required>

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseScriptTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseScriptTag.java
@@ -30,6 +30,10 @@ public abstract class BaseScriptTag extends com.liferay.taglib.util.PositionTagS
 		return super.doStartTag();
 	}
 
+	public java.lang.String getLoad() {
+		return _load;
+	}
+
 	public java.lang.String getRequire() {
 		return _require;
 	}
@@ -40,6 +44,10 @@ public abstract class BaseScriptTag extends com.liferay.taglib.util.PositionTagS
 
 	public java.lang.String getUse() {
 		return _use;
+	}
+
+	public void setLoad(java.lang.String load) {
+		_load = load;
 	}
 
 	public void setRequire(java.lang.String require) {
@@ -58,6 +66,7 @@ public abstract class BaseScriptTag extends com.liferay.taglib.util.PositionTagS
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_load = null;
 		_require = null;
 		_sandbox = false;
 		_use = null;
@@ -70,6 +79,7 @@ public abstract class BaseScriptTag extends com.liferay.taglib.util.PositionTagS
 	private static final String _PAGE =
 		"/html/taglib/aui/script/page.jsp";
 
+	private java.lang.String _load = null;
 	private java.lang.String _require = null;
 	private boolean _sandbox = false;
 	private java.lang.String _use = null;

--- a/util-taglib/src/com/liferay/taglib/liferay-aui.xml
+++ b/util-taglib/src/com/liferay/taglib/liferay-aui.xml
@@ -1353,6 +1353,11 @@
 		<description>Creates a script component in which to write JavaScript that facilitates using AlloyUI modules.</description>
 		<attributes>
 			<attribute>
+				<name>load</name>
+				<inputType>java.lang.String</inputType>
+				<outputType>java.lang.String</outputType>
+			</attribute>
+			<attribute>
 				<description>A position for the script.</description>
 				<name>position</name>
 				<inputType>java.lang.String</inputType>


### PR DESCRIPTION
This will replace <aui:script> taglib and, in addition, use webpack federation instead of AMD loader support to grab modules.