### PR TITLE
LPS-127308 [TS] [Bug: 7.3.x, master] LPS-127308 Category Filters are removed when doing a text search in Content Dashboard

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -375,16 +375,16 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 		List<Long> assetCategoryIds =
 			_contentDashboardAdminDisplayContext.getAssetCategoryIds();
 
-		if (!assetCategoryIds.isEmpty()) {
-			String[] assetCategoryIdsStrings =
-				new String[assetCategoryIds.size()];
+		if (!ListUtil.isEmpty(assetCategoryIds)) {
+			Stream<Long> stream = assetCategoryIds.stream();
 
-			for (int i = 0; i < assetCategoryIds.size(); i++) {
-				assetCategoryIdsStrings[i] = String.valueOf(
-					assetCategoryIds.get(i));
-			}
-
-			portletURL.setParameter("assetCategoryId", assetCategoryIdsStrings);
+			portletURL.setParameter(
+				"assetCategoryId",
+				stream.map(
+					String::valueOf
+				).toArray(
+					String[]::new
+				));
 		}
 
 		List<? extends ContentDashboardItemType> contentDashboardItemTypes =

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -380,6 +381,31 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 
 			portletURL.setParameter(
 				"assetCategoryId",
+				stream.map(
+					String::valueOf
+				).toArray(
+					String[]::new
+				));
+		}
+
+		Set<String> assetTagIds =
+			_contentDashboardAdminDisplayContext.getAssetTagIds();
+
+		if (!SetUtil.isEmpty(assetTagIds)) {
+			Stream<String> stream = assetTagIds.stream();
+
+			portletURL.setParameter(
+				"assetTagId", stream.toArray(String[]::new));
+		}
+
+		List<Long> authorIds =
+			_contentDashboardAdminDisplayContext.getAuthorIds();
+
+		if (!ListUtil.isEmpty(authorIds)) {
+			Stream<Long> stream = authorIds.stream();
+
+			portletURL.setParameter(
+				"authorIds",
 				stream.map(
 					String::valueOf
 				).toArray(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -372,6 +372,21 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 	public String getSearchActionURL() {
 		PortletURL portletURL = liferayPortletResponse.createRenderURL();
 
+		List<Long> assetCategoryIds =
+			_contentDashboardAdminDisplayContext.getAssetCategoryIds();
+
+		if (!assetCategoryIds.isEmpty()) {
+			String[] assetCategoryIdsStrings =
+				new String[assetCategoryIds.size()];
+
+			for (int i = 0; i < assetCategoryIds.size(); i++) {
+				assetCategoryIdsStrings[i] = String.valueOf(
+					assetCategoryIds.get(i));
+			}
+
+			portletURL.setParameter("assetCategoryId", assetCategoryIdsStrings);
+		}
+
 		List<? extends ContentDashboardItemType> contentDashboardItemTypes =
 			_contentDashboardAdminDisplayContext.getContentDashboardItemTypes();
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
@@ -20,6 +20,30 @@ import {
 } from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
+	const selectAuthor = (itemData) => {
+		openSelectionModal({
+			buttonAddLabel: Liferay.Language.get('select'),
+			multiple: true,
+			onSelect(selectedItem) {
+				if (selectedItem) {
+					let redirectURL = itemData.redirectURL;
+
+					selectedItem.forEach((item) => {
+						redirectURL = addParams(
+							`${portletNamespace}authorIds=${item.id}`,
+							redirectURL
+						);
+					});
+
+					navigate(redirectURL);
+				}
+			},
+			selectEventName: `${portletNamespace}selectedAuthorItem`,
+			title: itemData.dialogTitle,
+			url: itemData.selectAuthorURL,
+		});
+	};
+
 	const selectAssetCategory = (itemData) => {
 		const itemSelectorDialog = new ItemSelectorDialog({
 			buttonAddLabel: Liferay.Language.get('select'),
@@ -131,6 +155,9 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 			}
 			else if (action === 'selectAssetTag') {
 				selectAssetTag(item.data);
+			}
+			else if (action === 'selectAuthor') {
+				selectAuthor(item.data);
 			}
 			else if (action === 'selectContentDashboardItemType') {
 				selectContentDashboardItemType(item.data);

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {
+	ItemSelectorDialog,
+	addParams,
+	navigate,
+	openSelectionModal,
+} from 'frontend-js-web';
+
+export default function propsTransformer({portletNamespace, ...otherProps}) {
+	const selectAssetCategory = (itemData) => {
+		const itemSelectorDialog = new ItemSelectorDialog({
+			buttonAddLabel: Liferay.Language.get('select'),
+			eventName: `${portletNamespace}selectedAssetCategory`,
+			title: itemData.dialogTitle,
+			url: itemData.selectAssetCategoryURL,
+		});
+
+		itemSelectorDialog.on('selectedItemChange', (event) => {
+			const selectedItem = event.selectedItem;
+
+			if (selectedItem) {
+				const assetCategories = Object.keys(selectedItem).filter(
+					(key) => !selectedItem[key].unchecked
+				);
+
+				let redirectURL = itemData.redirectURL;
+
+				assetCategories.forEach((assetCategory) => {
+					redirectURL = addParams(
+						`${portletNamespace}assetCategoryId=${selectedItem[assetCategory].categoryId}`,
+						redirectURL
+					);
+				});
+
+				navigate(redirectURL);
+			}
+		});
+
+		itemSelectorDialog.open();
+	};
+
+	const selectAssetTag = (itemData) => {
+		openSelectionModal({
+			buttonAddLabel: Liferay.Language.get('select'),
+			multiple: true,
+			onSelect(selectedItem) {
+				if (selectedItem) {
+					const assetTags = selectedItem['items'].split(',');
+
+					let redirectURL = itemData.redirectURL;
+
+					assetTags.forEach((assetTag) => {
+						redirectURL = addParams(
+							`${portletNamespace}assetTagId=${assetTag}`,
+							redirectURL
+						);
+					});
+
+					navigate(redirectURL);
+				}
+			},
+			selectEventName: `${portletNamespace}selectedAssetTag`,
+			title: itemData.dialogTitle,
+			url: itemData.selectTagURL,
+		});
+	};
+
+	const selectContentDashboardItemType = (itemData) => {
+		openSelectionModal({
+			buttonAddLabel: Liferay.Language.get('select'),
+			multiple: true,
+			onSelect(selectedItem) {
+				if (selectedItem) {
+					let redirectURL = itemData.redirectURL;
+
+					selectedItem.forEach((item) => {
+						redirectURL = addParams(
+							`${portletNamespace}contentDashboardItemTypePayload=${JSON.stringify(
+								item
+							)}`,
+							redirectURL
+						);
+					});
+
+					navigate(redirectURL);
+				}
+			},
+			selectEventName: `${portletNamespace}selectedContentDashboardItemTypeItem`,
+			title: itemData.dialogTitle,
+			url: itemData.selectContentDashboardItemTypeURL,
+		});
+	};
+
+	const selectScope = (itemData) => {
+		openSelectionModal({
+			id: `${portletNamespace}selectedScopeIdItem`,
+			onSelect(selectedItem) {
+				navigate(
+					addParams(
+						`${portletNamespace}scopeId=${selectedItem.groupid}`,
+						itemData.redirectURL
+					)
+				);
+			},
+			selectEventName: `${portletNamespace}selectedScopeIdItem`,
+			title: itemData.dialogTitle,
+			url: itemData.selectScopeURL,
+		});
+	};
+
+	return {
+		...otherProps,
+		onFilterDropdownItemClick(event, {item}) {
+			const action = item.data?.action;
+
+			if (action === 'selectAssetCategory') {
+				selectAssetCategory(item.data);
+			}
+			else if (action === 'selectAssetTag') {
+				selectAssetTag(item.data);
+			}
+			else if (action === 'selectContentDashboardItemType') {
+				selectContentDashboardItemType(item.data);
+			}
+			else if (action === 'selectScope') {
+				selectScope(item.data);
+			}
+		},
+	};
+}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,8 +18,6 @@
 
 <%
 ContentDashboardAdminDisplayContext contentDashboardAdminDisplayContext = (ContentDashboardAdminDisplayContext)request.getAttribute(ContentDashboardWebKeys.CONTENT_DASHBOARD_ADMIN_DISPLAY_CONTEXT);
-
-ContentDashboardAdminManagementToolbarDisplayContext contentDashboardAdminManagementToolbarDisplayContext = (ContentDashboardAdminManagementToolbarDisplayContext)request.getAttribute(ContentDashboardWebKeys.CONTENT_DASHBOARD_ADMIN_MANAGEMENT_TOOLBAR_DISPLAY_CONTEXT);
 %>
 
 <div class="sidebar-wrapper">
@@ -98,7 +96,7 @@ ContentDashboardAdminManagementToolbarDisplayContext contentDashboardAdminManage
 
 			<clay:management-toolbar
 				cssClass="content-dashboard-management-toolbar"
-				managementToolbarDisplayContext="<%= contentDashboardAdminManagementToolbarDisplayContext %>"
+				managementToolbarDisplayContext="<%= (ContentDashboardAdminManagementToolbarDisplayContext)request.getAttribute(ContentDashboardWebKeys.CONTENT_DASHBOARD_ADMIN_MANAGEMENT_TOOLBAR_DISPLAY_CONTEXT) %>"
 				propsTransformer="js/ContentDashboardManagementToolbarPropsTransformer"
 			/>
 
@@ -270,8 +268,3 @@ ContentDashboardAdminManagementToolbarDisplayContext contentDashboardAdminManage
 		</clay:sheet>
 	</clay:container-fluid>
 </div>
-
-<liferay-frontend:component
-	componentId="<%= contentDashboardAdminManagementToolbarDisplayContext.getDefaultEventHandler() %>"
-	module="js/ContentDashboardManagementToolbarDefaultEventHandler"
-/>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -96,9 +96,10 @@ ContentDashboardAdminManagementToolbarDisplayContext contentDashboardAdminManage
 				</span>
 			</h2>
 
-			<clay:management-toolbar-v2
-				displayContext="<%= contentDashboardAdminManagementToolbarDisplayContext %>"
-				elementClasses="content-dashboard-management-toolbar"
+			<clay:management-toolbar
+				cssClass="content-dashboard-management-toolbar"
+				managementToolbarDisplayContext="<%= contentDashboardAdminManagementToolbarDisplayContext %>"
+				propsTransformer="js/ContentDashboardManagementToolbarPropsTransformer"
 			/>
 
 			<liferay-ui:search-container

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view_content_dashboard_item_types.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view_content_dashboard_item_types.jsp
@@ -22,8 +22,8 @@ ContentDashboardItemTypeItemSelectorViewManagementToolbarDisplayContext contentD
 ContentDashboardItemTypeItemSelectorViewDisplayContext contentDashboardItemTypeItemSelectorViewDisplayContext = (ContentDashboardItemTypeItemSelectorViewDisplayContext)request.getAttribute(ContentDashboardItemTypeItemSelectorViewDisplayContext.class.getName());
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= contentDashboardItemTypeItemSelectorViewManagementToolbarDisplayContext %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= contentDashboardItemTypeItemSelectorViewManagementToolbarDisplayContext %>"
 />
 
 <clay:container-fluid>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.taglib.util.TagResourceBundleUtil;
 
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -1067,8 +1068,8 @@ public class ManagementToolbarTag extends BaseContainerTag {
 		return SKIP_BODY;
 	}
 
-	private Map<String, String> _getParamsMap(String url) {
-		Map<String, String> searchData = new HashMap<>();
+	private Map<String, List<String>> _getParamsMap(String url) {
+		Map<String, List<String>> searchData = new HashMap<>();
 
 		String[] parameters = StringUtil.split(
 			HttpUtil.getQueryString(url), CharPool.AMPERSAND);
@@ -1095,7 +1096,15 @@ public class ManagementToolbarTag extends BaseContainerTag {
 
 			parameterValue = HttpUtil.decodeURL(parameterValue);
 
-			searchData.put(parameterName, parameterValue);
+			List<String> parameterValues = searchData.get(parameterName);
+
+			if (parameterValues == null) {
+				parameterValues = new LinkedList<>();
+
+				searchData.put(parameterName, parameterValues);
+			}
+
+			parameterValues.add(parameterValue);
 		}
 
 		return searchData;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -463,8 +464,8 @@ public class ManagementToolbarTag extends BaseClayTag {
 		return sb.toString();
 	}
 
-	private Map<String, Object> _getSearchData(String searchActionURL) {
-		Map<String, Object> searchData = new HashMap<>();
+	private Map<String, List<Object>> _getSearchData(String searchActionURL) {
+		Map<String, List<Object>> searchData = new HashMap<>();
 
 		String[] parameters = StringUtil.split(
 			HttpUtil.getQueryString(searchActionURL), CharPool.AMPERSAND);
@@ -491,7 +492,15 @@ public class ManagementToolbarTag extends BaseClayTag {
 
 			parameterValue = HttpUtil.decodeURL(parameterValue);
 
-			searchData.put(parameterName, parameterValue);
+			List<Object> parameterValues = searchData.get(parameterName);
+
+			if (parameterValues == null) {
+				parameterValues = new LinkedList<>();
+
+				searchData.put(parameterName, parameterValues);
+			}
+
+			parameterValues.add(parameterValue);
 		}
 
 		return searchData;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
@@ -20,13 +20,32 @@ import React from 'react';
 
 import LinkOrButton from './LinkOrButton';
 
-const FilterOrderControls = ({disabled, filterDropdownItems, sortingURL}) => {
+const FilterOrderControls = ({
+	disabled,
+	filterDropdownItems,
+	onFilterDropdownItemClick,
+	sortingURL,
+}) => {
 	return (
 		<>
 			{filterDropdownItems && (
 				<ClayManagementToolbar.Item>
 					<ClayDropDownWithItems
-						items={filterDropdownItems}
+						items={filterDropdownItems.map((item) => {
+							return {
+								...item,
+								items: item.items.map((childItem) => {
+									return {
+										...childItem,
+										onClick(event) {
+											onFilterDropdownItemClick(event, {
+												item: childItem,
+											});
+										},
+									};
+								}),
+							};
+						})}
 						trigger={
 							<ClayButton
 								className="nav-link"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -45,6 +45,7 @@ function ManagementToolbar({
 	onCreateButtonClick = () => {},
 	onCreationMenuItemClick = () => {},
 	onInfoButtonClick = () => {},
+	onFilterDropdownItemClick = () => {},
 	onSelectAllButtonClick = () => {},
 	onShowMoreButtonClick,
 	searchActionURL,
@@ -101,6 +102,9 @@ function ManagementToolbar({
 						<FilterOrderControls
 							disabled={disabled}
 							filterDropdownItems={filterDropdownItems}
+							onFilterDropdownItemClick={
+								onFilterDropdownItemClick
+							}
 							sortingURL={sortingURL}
 						/>
 					)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.soy
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.soy
@@ -207,7 +207,9 @@
 			{let $searchData: $customData.searchData /}
 
 			{foreach $key in keys($searchData)}
-				<input name="{$key}" type="hidden" value="{$searchData[$key]}" />
+				{foreach $value in $searchData[$key]}
+					<input name="{$key}" type="hidden" value="{$value}" />
+				{/foreach}
 			{/foreach}
 		</form>
 	{/let}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
@@ -67,14 +67,16 @@ const SearchControls = ({
 				</ClayInput.Group>
 
 				{searchData &&
-					Object.keys(searchData).map((key) => (
-						<ClayInput
-							key={key}
-							name={key}
-							type="hidden"
-							value={searchData[key]}
-						/>
-					))}
+					Object.keys(searchData).map((key) =>
+						searchData[key].map((value) => (
+							<ClayInput
+								key={key}
+								name={key}
+								type="hidden"
+								value={value}
+							/>
+						))
+					)}
 			</ClayManagementToolbar.Search>
 		</>
 	);


### PR DESCRIPTION
**Motivation**

TS has found the next bug:

*Steps to Reproduce*

1. Create a Vocabulary and a category in it
2. Create 2 web contents: one with the category titled "test 1", one without a category titled "test 2"
3. Go to the App Menu > Content Dashboard
4. Select the category in the category filter
5. Search for the keyword "test"
6. Search result is shown without category filter

The original cause was that the Content Dashboard was not filling the assetCategoryId to the Search URL (done in this [commit](https://github.com/liferay-frontend/liferay-portal/pull/773/commits/9ca6f604674878ff2409cfabd49404c4d94545d60) ), but even with this change, @balazssk has found that only one value per assetCategoryId was set.

![Screenshot 2021-02-09 at 10 44 06](https://user-images.githubusercontent.com/5776822/107345620-0bdb7c80-6ac4-11eb-878b-898933637f83.png)

![Screenshot 2021-02-09 at 10 44 19](https://user-images.githubusercontent.com/5776822/107345626-0e3dd680-6ac4-11eb-9a4f-69c9a264c47d.png)

That is the reason he has needed to make this commit in the [ManagementToolbarTag]( https://github.com/liferay-frontend/liferay-portal/pull/773/commits/9ce4bd3d36a5b9e42a5ef52deed303769ef98df7), so we can handle multiple values for the same parameter name.

If you have any doubt, please, let me know.

Thanks!!

/cc @balazssk
