### PR TITLE
[Don't forward] LPS-121924 Migrate v2 usages in users-admin/users-admin-web

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -23,6 +23,7 @@ const CreationMenu = ({
 	maxSecondaryItems,
 	maxTotalItems = 15,
 	onCreateButtonClick,
+	onCreationMenuItemClick,
 	onShowMoreButtonClick,
 	primaryItems,
 	secondaryItems,
@@ -82,6 +83,59 @@ const CreationMenu = ({
 	const [visibleItemsCount, setVisibleItemsCount] = useState(
 		getVisibleItemsCount()
 	);
+
+	const Item = ({item}) => {
+		return (
+			<ClayDropDown.Item
+				href={item.href}
+				onClick={(event) => {
+					onCreationMenuItemClick(event, {item});
+				}}
+				symbolLeft={item.icon}
+			>
+				{item.label}
+			</ClayDropDown.Item>
+		);
+	};
+
+	const ItemList = () => {
+		let currentItemCount = 0;
+
+		return (
+			<ClayDropDown.ItemList>
+				{primaryItems?.map((item, index) => {
+					currentItemCount++;
+
+					if (currentItemCount > visibleItemsCount) {
+						return false;
+					}
+
+					return <Item item={item} key={index} />;
+				})}
+
+				{secondaryItems?.map((secondaryItemsGroup, index) => (
+					<ClayDropDown.Group
+						header={secondaryItemsGroup.label}
+						key={index}
+					>
+						{secondaryItemsGroup.items.map((item, index) => {
+							currentItemCount++;
+
+							if (currentItemCount > visibleItemsCount) {
+								return false;
+							}
+
+							return <Item item={item} key={index} />;
+						})}
+
+						{secondaryItemsGroup.separator && (
+							<ClayDropDown.Item className="dropdown-divider" />
+						)}
+					</ClayDropDown.Group>
+				))}
+			</ClayDropDown.ItemList>
+		);
+	};
 
 	return (
 		<>
@@ -148,6 +202,7 @@ const CreationMenu = ({
 						</>
 					) : (
 						<ItemList
+							onCreationMenuItemClick={onCreationMenuItemClick}
 							primaryItems={primaryItems}
 							secondaryItems={secondaryItems}
 							visibleItemsCount={totalItemsCountRef.current}
@@ -174,53 +229,6 @@ const CreationMenu = ({
 				/>
 			)}
 		</>
-	);
-};
-
-const ItemList = ({primaryItems, secondaryItems, visibleItemsCount}) => {
-	let currentItemCount = 0;
-
-	return (
-		<ClayDropDown.ItemList>
-			{primaryItems?.map((item, index) => {
-				currentItemCount++;
-
-				if (currentItemCount > visibleItemsCount) {
-					return false;
-				}
-
-				return (
-					<ClayDropDown.Item href={item.href} key={index}>
-						{item.label}
-					</ClayDropDown.Item>
-				);
-			})}
-
-			{secondaryItems?.map((secondaryItemsGroup, index) => (
-				<ClayDropDown.Group
-					header={secondaryItemsGroup.label}
-					key={index}
-				>
-					{secondaryItemsGroup.items.map((item, index) => {
-						currentItemCount++;
-
-						if (currentItemCount > visibleItemsCount) {
-							return false;
-						}
-
-						return (
-							<ClayDropDown.Item href={item.href} key={index}>
-								{item.label}
-							</ClayDropDown.Item>
-						);
-					})}
-
-					{secondaryItemsGroup.separator && (
-						<ClayDropDown.Item className="dropdown-divider" />
-					)}
-				</ClayDropDown.Group>
-			))}
-		</ClayDropDown.ItemList>
 	);
 };
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -43,6 +43,7 @@ function ManagementToolbar({
 	onCheckboxChange = () => {},
 	onClearSelectionButtonClick = () => {},
 	onCreateButtonClick = () => {},
+	onCreationMenuItemClick = () => {},
 	onInfoButtonClick = () => {},
 	onSelectAllButtonClick = () => {},
 	onShowMoreButtonClick,
@@ -166,6 +167,9 @@ function ManagementToolbar({
 										{...creationMenu}
 										onCreateButtonClick={
 											onCreateButtonClick
+										}
+										onCreationMenuItemClick={
+											onCreationMenuItemClick
 										}
 										onShowMoreButtonClick={
 											onShowMoreButtonClick

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/ViewTreeManagementToolbarPropsTransformer.js
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/ViewTreeManagementToolbarPropsTransformer.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {createPortletURL, openSelectionModal} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {
+		assignmentsURL,
+		editOrganizationAssignmentURL,
+		selectUsersURL,
+	},
+	portletNamespace,
+	...otherProps
+}) {
+	const selectUsers = (organizationId) => {
+		if (!organizationId) {
+			return;
+		}
+
+		const url = createPortletURL(selectUsersURL, {
+			organizationId,
+		});
+
+		openSelectionModal({
+			buttonAddLabel: Liferay.Language.get('done'),
+			multiple: true,
+			onSelect: (data) => {
+				if (data) {
+					const assignmentsRedirectURL = createPortletURL(
+						assignmentsURL,
+						{
+							organizationId,
+						}
+					);
+
+					const editAssignmentParameters = {
+						addUserIds: data.value,
+						assignmentsRedirect: assignmentsRedirectURL.toString(),
+						organizationId,
+					};
+
+					const editAssignmentURL = createPortletURL(
+						editOrganizationAssignmentURL,
+						editAssignmentParameters
+					);
+
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					if (!form) {
+						return;
+					}
+
+					submitForm(form, editAssignmentURL.toString());
+				}
+			},
+			selectEventName: `${portletNamespace}selectUsers`,
+			title: Liferay.Language.get('assign-users'),
+			url: url.toString(),
+		});
+	};
+
+	return {
+		...otherProps,
+		onCreationMenuItemClick(event, {item}) {
+			if (item.data?.action === 'selectUsers') {
+				selectUsers(item.data?.organizationId);
+			}
+		},
+	};
+}

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/select_organization.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/select_organization.jsp
@@ -38,7 +38,7 @@ SearchContainer<Organization> searchContainer = selectOrganizationManagementTool
 renderResponse.setTitle(LanguageUtil.get(request, "organizations"));
 %>
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	clearResultsURL="<%= selectOrganizationManagementToolbarDisplayContext.getClearResultsURL() %>"
 	filterDropdownItems="<%= selectOrganizationManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	itemsTotal="<%= searchContainer.getTotal() %>"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/select_organization_users.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/select_organization_users.jsp
@@ -43,7 +43,7 @@ SearchContainer<User> userSearchContainer = selectOrganizationUsersManagementToo
 
 <liferay-ui:membership-policy-error />
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	clearResultsURL="<%= selectOrganizationUsersManagementToolbarDisplayContext.getClearResultsURL() %>"
 	filterDropdownItems="<%= selectOrganizationUsersManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	itemsTotal="<%= userSearchContainer.getTotal() %>"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_organizations.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_organizations.jsp
@@ -63,7 +63,7 @@ if (filterManageableOrganizations) {
 		SearchContainer<Organization> searchContainer = viewOrganizationsManagementToolbarDisplayContext.getSearchContainer(organizationParams, filterManageableOrganizations);
 		%>
 
-		<clay:management-toolbar-v2
+		<clay:management-toolbar
 			actionDropdownItems="<%= viewOrganizationsManagementToolbarDisplayContext.getActionDropdownItems() %>"
 			clearResultsURL="<%= viewOrganizationsManagementToolbarDisplayContext.getClearResultsURL() %>"
 			creationMenu="<%= viewOrganizationsManagementToolbarDisplayContext.getCreationMenu() %>"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_users.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_users.jsp
@@ -28,8 +28,8 @@ request.setAttribute(UsersAdminWebKeys.STATUS, viewFlatUsersDisplayContext.getSt
 String displayStyle = viewFlatUsersDisplayContext.getDisplayStyle();
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= viewFlatUsersDisplayContext.getManagementToolbarDisplayContext() %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= viewFlatUsersDisplayContext.getManagementToolbarDisplayContext() %>"
 />
 
 <aui:form action="<%= currentURLObj.toString() %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "search();" %>'>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_tree.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_tree.jsp
@@ -74,14 +74,36 @@ if (organization != null) {
 		SearchContainer<Object> searchContainer = viewTreeManagementToolbarDisplayContext.getSearchContainer();
 		%>
 
-		<clay:management-toolbar-v2
+		<portlet:renderURL var="assignmentsURL">
+			<portlet:param name="mvcRenderCommandName" value="/users_admin/view" />
+			<portlet:param name="toolbarItem" value="view-all-organizations" />
+			<portlet:param name="usersListView" value="<%= UserConstants.LIST_VIEW_TREE %>" />
+		</portlet:renderURL>
+
+		<portlet:actionURL name="/users_admin/edit_organization_assignments" var="editOrganizationAssignmentURL" />
+
+		<portlet:renderURL var="selectUsersURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+			<portlet:param name="mvcPath" value="/select_organization_users.jsp" />
+		</portlet:renderURL>
+
+		<clay:management-toolbar
 			actionDropdownItems="<%= viewTreeManagementToolbarDisplayContext.getActionDropdownItems() %>"
+			additionalProps='<%=
+				HashMapBuilder.<String, Object>put(
+					"assignmentsURL", assignmentsURL.toString()
+				).put(
+					"editOrganizationAssignmentURL", editOrganizationAssignmentURL.toString()
+				).put(
+					"selectUsersURL", selectUsersURL.toString()
+				).build()
+			%>'
 			clearResultsURL="<%= viewTreeManagementToolbarDisplayContext.getClearResultsURL() %>"
 			componentId="viewTreeManagementToolbar"
 			creationMenu="<%= viewTreeManagementToolbarDisplayContext.getCreationMenu() %>"
 			filterDropdownItems="<%= viewTreeManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 			filterLabelItems="<%= viewTreeManagementToolbarDisplayContext.getFilterLabelItems() %>"
 			itemsTotal="<%= searchContainer.getTotal() %>"
+			propsTransformer="js/ViewTreeManagementToolbarPropsTransformer"
 			searchActionURL="<%= viewTreeManagementToolbarDisplayContext.getSearchActionURL() %>"
 			searchContainerId="organizationUsers"
 			searchFormName="searchFm"


### PR DESCRIPTION
The `<clay:management-toolbar-v2 />` tag has been replaced with the
`<clay:management-toolbar />` tag (which uses clay v3).

Creating users and organizations as well a deleting them
and adding users to organizations works as expected.

![](https://user-images.githubusercontent.com/5572/107396766-5bd73500-6afe-11eb-92e3-b47e228a046e.gif)

**Test plan**:
- From the global application menu select the **Control Panel** tab
- Under **Users**, select **Users and Organizations**
- Check that creating a new user by clicking on the "+" button works
- From the management toolbar check that deactivating the user works
  both from the action button or the dropdown menu
- Select the "Organizations" tab
- From the management toolbar check that removing an organization works
  both from the action button or the dropdown menu
- Select an existing organization by clicking on it's name
- From the management toolbar check that adding a nested user works
- From the management toolbar check that adding a nested organization works
- From the management toolbar check that deactivating, removing or restoring nested
  users or organizations works both from the action button or the dropdown menu

**Additionally**
A new callback has been added to the management toolbar's creation menu
to handle creation menu items that are not links

cc @markocikos @ambrinchaudhary @jonmak08 

Please note that since I made changes to the management toolbar's creation menu, I'd like this to be reviewed internally before forwarding.