### PR TITLE
LPS-127704 - Add css scope for management-bar-v2 tag to avoid breaking changes from new CSS in clay v3

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_management_bar.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_management_bar.scss
@@ -7,6 +7,12 @@
 	}
 }
 
+.management-bar-v2 .subnav-tbar {
+	.label-item .lexicon-icon-times {
+		padding: 2px;
+	}
+}
+
 .management-bar-container {
 	position: relative;
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.soy
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.soy
@@ -113,6 +113,13 @@
 		label: string
 	]>}
 
+	{let $cssClasses kind="text"}
+		management-bar-v2
+		{if $elementClasses}
+			{sp}{$elementClasses}
+		{/if}
+	{/let}
+
 	{call ClayManagementToolbar.render}
 		{param defaultEventHandler: $defaultEventHandler /}
 		{param actionItems: $actionItems /}
@@ -126,7 +133,7 @@
 			'searchData': $searchData
 		] /}
 		{param disabled: $disabled /}
-		{param elementClasses: $elementClasses /}
+		{param elementClasses: $cssClasses /}
 		{param events: [
 			'clearSelectionButtonClicked': $_handleClearSelectionButtonClicked,
 			'creationMenuMoreButtonClicked': $_handleCreationMenuMoreButtonClicked,


### PR DESCRIPTION
Jira: https://issues.liferay.com/browse/LPS-127704

This adds a css scope to v2 management toolbar taglib. This allows us to scope specific styling to this older version of management toolbar without having to add two different types of styles to @clayui/css