### PR TITLE
LRQA-64887 | Refactor panel macro to just use one set

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/AnnouncementsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/AnnouncementsEntry.macro
@@ -169,7 +169,7 @@ definition {
 
 		SelectFrame(value1 = "relative=top");
 
-		Panel.expandUnstyledPanel(panel = "Configuration");
+		Panel.expandPanel(panel = "Configuration");
 
 		Type(
 			locator1 = "TextInput#URL",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
@@ -127,7 +127,7 @@ definition {
 			entrySubtitle = "${entrySubtitle}",
 			entryTitle = "${entryTitle}");
 
-		Panel.expandUnstyledPanel(panel = "Categorization");
+		Panel.expandPanel(panel = "Categorization");
 
 		AssetCategorization.addTag(tagName = "${tagName}");
 
@@ -144,7 +144,7 @@ definition {
 			entrySubtitle = "${entrySubtitle}",
 			entryTitle = "${entryTitle}");
 
-		Panel.expandUnstyledPanel(panel = "Categorization");
+		Panel.expandPanel(panel = "Categorization");
 
 		for (var tagName : list "${tagNameList}") {
 			AssetCategorization.addTag(tagName = "${tagName}");
@@ -238,7 +238,7 @@ definition {
 			entrySubtitle = "${entrySubtitle}",
 			entryTitle = "${entryTitle}");
 
-		Panel.expandUnstyledPanel(panel = "Configuration");
+		Panel.expandPanel(panel = "Configuration");
 
 		BlogsEntry.addCustomAbstract(entryAbstractDescription = "${entryAbstractDescription}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -2069,7 +2069,7 @@ definition {
 
 		AssertElementPresent(locator1 = "DocumentsAndMediaDocument#DOCUMENT_INFO_GET_URL_OR_WEBDAV_URL");
 
-		Panel.expandUnstyledPanel(panel = "Automatically Extracted Metadata");
+		Panel.expandPanel(panel = "Automatically Extracted Metadata");
 	}
 
 	macro viewDocumentMetadataCP {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -108,7 +108,7 @@ definition {
 
 		Click.clickAt(locator1 = "TextInput#TITLE");
 
-		Panel.expandUnstyledPanel(panel = "Configuration");
+		Panel.expandPanel(panel = "Configuration");
 
 		if (isSet(kbArticleFriendlyURL)) {
 			var kbArticleTitleFormatted = StringUtil.lowerCase("${kbArticleFriendlyURL}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Panel.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Panel.macro
@@ -18,22 +18,4 @@ definition {
 		AssertElementPresent(locator1 = "Panel#PANEL_EXPANDED");
 	}
 
-	macro expandUnstyledPanel {
-		Portlet.waitForForm();
-
-		var key_panel = "${panel}";
-
-		AssertVisible(
-			key_panel = "${panel}",
-			locator1 = "Panel#UNSTYLED_PANEL");
-
-		if ((IsElementPresent(locator1 = "Panel#UNSTYLED_PANEL_COLLAPSED")) && (IsVisible(locator1 = "Panel#UNSTYLED_PANEL_COLLAPSED"))) {
-			AssertClick(
-				locator1 = "Panel#UNSTYLED_PANEL_COLLAPSED",
-				value1 = "${panel}");
-		}
-
-		AssertElementPresent(locator1 = "Panel#UNSTYLED_PANEL_EXPANDED");
-	}
-
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/PasswordPolicies.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/PasswordPolicies.macro
@@ -38,8 +38,8 @@ definition {
 		if ("${enableLockout}" == "true") {
 			var key_panel = "Lockout";
 
-			if (IsElementPresent(locator1 = "Panel#UNSTYLED_PANEL_COLLAPSED")) {
-				Panel.expandUnstyledPanel(panel = "Lockout");
+			if (IsElementPresent(locator1 = "Panel#PANEL_COLLAPSED")) {
+				Panel.expandPanel(panel = "Lockout");
 			}
 
 			Check.checkToggleSwitch(locator1 = "Checkbox#ENABLE_LOCKOUT");
@@ -61,7 +61,7 @@ definition {
 	macro editSyntaxChecking {
 		PasswordPoliciesNavigator.gotoPolicy(passwordPolicyName = "${passwordPolicyName}");
 
-		Panel.expandUnstyledPanel(panel = "Password Syntax Checking");
+		Panel.expandPanel(panel = "Password Syntax Checking");
 
 		if (isSet(minimumAlphaNumeric)) {
 			Type(
@@ -109,7 +109,7 @@ definition {
 	}
 
 	macro enableDefaultPasswordPolicyLockout {
-		Panel.expandUnstyledPanel(panel = "Lockout");
+		Panel.expandPanel(panel = "Lockout");
 
 		Check.checkToggleSwitch(locator1 = "Checkbox#ENABLE_LOCKOUT");
 
@@ -123,7 +123,7 @@ definition {
 	macro enableSyntaxChecking {
 		PasswordPoliciesNavigator.gotoPolicy(passwordPolicyName = "${passwordPolicyName}");
 
-		Panel.expandUnstyledPanel(panel = "Password Syntax Checking");
+		Panel.expandPanel(panel = "Password Syntax Checking");
 
 		Check.checkToggleSwitch(locator1 = "Checkbox#ENABLE_SYNTAX_CHECKING");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/PasswordPoliciesNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/PasswordPoliciesNavigator.macro
@@ -9,7 +9,7 @@ definition {
 	macro gotoPolicyPanel {
 		PasswordPoliciesNavigator.gotoPolicy(passwordPolicyName = "${passwordPolicyName}");
 
-		Panel.expandUnstyledPanel(panel = "${passwordPolicyPanel}");
+		Panel.expandPanel(panel = "${passwordPolicyPanel}");
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ServerAdministration.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ServerAdministration.macro
@@ -27,13 +27,13 @@ definition {
 		}
 
 		if ((isSet(installXuggler)) && (IsElementNotPresent(locator1 = "ServerAdministrationExternalServices#XUGGLER_ENABLED_CHECKBOX"))) {
-			Panel.expandUnstyledPanel(panel = "Enabling Xuggler provides video conversion functionality.");
+			Panel.expandPanel(panel = "Enabling Xuggler provides video conversion functionality.");
 
 			AssertClick(
 				locator1 = "ServerAdministrationExternalServices#XUGGLER_INSTALL_BUTTON",
 				value1 = "Install");
 
-			Panel.expandUnstyledPanel(panel = "Enabling Xuggler provides video conversion functionality.");
+			Panel.expandPanel(panel = "Enabling Xuggler provides video conversion functionality.");
 
 			AssertTextNotEquals(
 				locator1 = "Message#INFO",
@@ -161,7 +161,7 @@ definition {
 	macro executeServerResourcesActions {
 		Navigator.gotoNavItem(navItem = "Resources");
 
-		Panel.expandUnstyledPanel(panel = "Clean Up Actions");
+		Panel.expandPanel(panel = "Clean Up Actions");
 
 		var key_actionsDescription = "${actionsDescription}";
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WikiPage.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WikiPage.macro
@@ -250,7 +250,7 @@ definition {
 				value1 = "${wikiPageContent}");
 		}
 		else if ("${htmlSource}" == "true") {
-			Panel.expandUnstyledPanel(panel = "Configuration");
+			Panel.expandPanel(panel = "Configuration");
 
 			SelectNoError(
 				locator1 = "Wiki#ADD_PAGE_FORMAT_DROPDOWN",

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/Panel.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/Panel.path
@@ -30,12 +30,12 @@
 </tr>
 <tr>
 	<td>PANEL_COLLAPSED</td>
-	<td>//div[contains(@class,'panel')]//*[@aria-expanded='false' and contains(@class,'collapsed')]//parent::*[normalize-space(text())='${key_panel}'][not(contains(@data-qa-id,'app'))]</td>
+	<td>//div[contains(@class,'panel')]//*[@aria-expanded='false']//parent::*[normalize-space(text())='${key_panel}'][not(contains(@data-qa-id,'app'))]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>PANEL_EXPANDED</td>
-	<td>//div[contains(@class,'panel')]//*[@aria-expanded='true' and not(contains(@class,'collapsed'))]//parent::*[normalize-space(text())='${key_panel}'][not(contains(@data-qa-id,'app'))]</td>
+	<td>//div[contains(@class,'panel')]//*[@aria-expanded='true']//parent::*[normalize-space(text())='${key_panel}'][not(contains(@data-qa-id,'app'))]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/Panel.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/Panel.path
@@ -25,17 +25,17 @@
 </tr>
 <tr>
 	<td>PANEL</td>
-	<td>//div[@class='panel-heading']//a[normalize-space(text())='${key_panel}']</td>
+	<td>//div[contains(@class,'panel')]//*[normalize-space(text())='${key_panel}'][not(contains(@data-qa-id,'app'))]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>PANEL_COLLAPSED</td>
-	<td>//div[@class='panel-heading']//a[normalize-space(text())='${key_panel}'][@aria-expanded='false' or contains(@class,'collapsed')]</td>
+	<td>//div[contains(@class,'panel')]//*[@aria-expanded='false' and contains(@class,'collapsed')]//parent::*[normalize-space(text())='${key_panel}'][not(contains(@data-qa-id,'app'))]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>PANEL_EXPANDED</td>
-	<td>//div[@class='panel-heading']//a[normalize-space(text())='${key_panel}'][@aria-expanded='true' and not(contains(@class,'collapsed'))]</td>
+	<td>//div[contains(@class,'panel')]//*[@aria-expanded='true' and not(contains(@class,'collapsed'))]//parent::*[normalize-space(text())='${key_panel}'][not(contains(@data-qa-id,'app'))]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/Panel.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/Panel.path
@@ -39,21 +39,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>UNSTYLED_PANEL</td>
-	<td>//div[contains(@class,'panel-group')]//span[normalize-space(text())='${key_panel}']</td>
-	<td></td>
-</tr>
-<tr>
-	<td>UNSTYLED_PANEL_COLLAPSED</td>
-	<td>//div[contains(@class,'panel-group')]//a[@aria-expanded='false']//span[normalize-space(text())='${key_panel}']</td>
-	<td></td>
-</tr>
-<tr>
-	<td>UNSTYLED_PANEL_EXPANDED</td>
-	<td>//div[contains(@class,'panel-group')]//a[@aria-expanded='true']//span[normalize-space(text())='${key_panel}']</td>
-	<td></td>
-</tr>
-<tr>
 	<td></td>
 	<td></td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/PGBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/PGBlogs.testcase
@@ -814,7 +814,7 @@ definition {
 			entryContent = "Blogs Entry Content",
 			entryTitle = "Blogs Entry with Small Image");
 
-		Panel.expandUnstyledPanel(panel = "Configuration");
+		Panel.expandPanel(panel = "Configuration");
 
 		BlogsEntry.addSmallImage(
 			navTab = "Documents and Media",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/PGWiki.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/PGWiki.testcase
@@ -453,7 +453,7 @@ definition {
 
 		WikiEntry.addPageTitle(wikiPageTitle = "Wiki Page Title");
 
-		Panel.expandUnstyledPanel(panel = "Configuration");
+		Panel.expandPanel(panel = "Configuration");
 
 		SelectNoError(
 			locator1 = "Wiki#ADD_PAGE_FORMAT_DROPDOWN",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/tags/TagsUseCase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/tags/TagsUseCase.testcase
@@ -466,7 +466,7 @@ definition {
 
 		BlogsNavigator.gotoEditPG(entryTitle = "Entry Title");
 
-		Panel.expandUnstyledPanel(panel = "Categorization");
+		Panel.expandPanel(panel = "Categorization");
 
 		AssetCategorization.removeTag(tagName = "tag name 1");
 


### PR DESCRIPTION
**Description**
The test fixes in https://github.com/liferay-frontend/liferay-portal/pull/737 introduced unnecessary redundancy in paths and macros to collapse and expand a panel. It also looks like we tried to continue with this strategy with follow up fixes for the clay panel update in https://github.com/brianchandotcom/liferay-portal/pull/98512. The following commits aim to make the paths more robust and remove the redundancy to make maintenance easier and also fix the remaining tests from the clay panel update listed in this [testray run](https://testray.liferay.com/home/-/testray/case_results/index?delta=200&p_p_state=normal&orderByCol=status_sortable&orderByType=asc&testrayBuildId=1472019420&testrayCaseTypeId=101949&statuses=3&errors=heading
)
 
**Test Plan**
- :heavy_check_mark: Run acceptance poshi tests and make sure they do not have related failures on panel. https://testray.liferay.com/home/-/testray/runs/compare?compare=true&view=details&statusA=3&testrayRunIdB=1475023970&testrayRunIdA=1474991493&statusB=2
- :heavy_check_mark:  panel locators are compatible for portal panels prior to and after clay panel update 
- :heavy_check_mark:  panel locators are compatible for bootstrap pattern: https://www.w3schools.com/bootstrap/bootstrap_collapse.asp 
- :heavy_check_mark: panel locators are compatible for current clayui doc panel pattern: https://clayui.com/docs/components/panel.html 
- :heavy_check_mark: panel locators are compatible for panels within iframes
- :heavy_check_mark: panel locators exclude Product Menu panels and categories

**JIRA Ticket**
https://issues.liferay.com/browse/LRQA-64887