### PR TITLE
LPS-127201 [Content Performance] Hide TimeSpanSelector in Social traffic channel detail

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
@@ -43,6 +43,7 @@ const SOCIAL_MEDIA_COLORS = {
 export default function SocialDetail({
 	currentPage,
 	languageTag,
+	showTimeSpanSelector = false,
 	timeSpanOptions,
 	trafficShareDataProvider,
 	trafficVolumeDataProvider,
@@ -100,21 +101,27 @@ export default function SocialDetail({
 
 	return (
 		<div className="c-p-3 traffic-source-detail">
-			<div className="c-mb-3 c-mt-2">
-				<TimeSpanSelector
-					disabledNextTimeSpan={chartState.timeSpanOffset === 0}
-					disabledPreviousPeriodButton={
-						isPreviousPeriodButtonDisabled
-					}
-					onNextTimeSpanClick={nextTimeSpan}
-					onPreviousTimeSpanClick={previousTimeSpan}
-					onTimeSpanChange={handleTimeSpanChange}
-					timeSpanKey={chartState.timeSpanKey}
-					timeSpanOptions={timeSpanOptions}
-				/>
-			</div>
+			{showTimeSpanSelector && (
+				<>
+					<div className="c-mb-3 c-mt-2">
+						<TimeSpanSelector
+							disabledNextTimeSpan={
+								chartState.timeSpanOffset === 0
+							}
+							disabledPreviousPeriodButton={
+								isPreviousPeriodButtonDisabled
+							}
+							onNextTimeSpanClick={nextTimeSpan}
+							onPreviousTimeSpanClick={previousTimeSpan}
+							onTimeSpanChange={handleTimeSpanChange}
+							timeSpanKey={chartState.timeSpanKey}
+							timeSpanOptions={timeSpanOptions}
+						/>
+					</div>
 
-			{title && <h5 className="c-mb-4">{title}</h5>}
+					{title && <h5 className="c-mb-4">{title}</h5>}
+				</>
+			)}
 
 			<TotalCount
 				className="c-mb-2"
@@ -212,6 +219,7 @@ export default function SocialDetail({
 SocialDetail.propTypes = {
 	currentPage: PropTypes.object.isRequired,
 	languageTag: PropTypes.string.isRequired,
+	showTimeSpanSelector: PropTypes.bool,
 	timeSpanOptions: PropTypes.arrayOf(
 		PropTypes.shape({
 			key: PropTypes.string,


### PR DESCRIPTION
**Description**

The information needed for the `TimeSpanSelector` component to work in Social traffic detail view is not provided by the Analytics Cloud endpoint yet, so we decided to hide that component until it's ready.

**Screenshot**

_Note: This image was created using mock data because we need 24h to process AC data._

![Screenshot 2021-02-10 at 16 13 57](https://user-images.githubusercontent.com/15845466/107529281-feed8480-6bba-11eb-805d-db2af3157886.png)
