### PR TITLE
LPS-127202 [Content Performance] Hide TimeSpanSelector in Referral traffic channel detail

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
@@ -35,6 +35,7 @@ const ITEMS_TO_SHOW = 5;
 export default function ReferralDetail({
 	currentPage,
 	languageTag,
+	showTimeSpanSelector = false,
 	timeSpanOptions,
 	trafficShareDataProvider,
 	trafficVolumeDataProvider,
@@ -78,21 +79,27 @@ export default function ReferralDetail({
 
 	return (
 		<div className="c-p-3 traffic-source-detail">
-			<div className="c-mb-3 c-mt-2">
-				<TimeSpanSelector
-					disabledNextTimeSpan={chartState.timeSpanOffset === 0}
-					disabledPreviousPeriodButton={
-						isPreviousPeriodButtonDisabled
-					}
-					onNextTimeSpanClick={nextTimeSpan}
-					onPreviousTimeSpanClick={previousTimeSpan}
-					onTimeSpanChange={handleTimeSpanChange}
-					timeSpanKey={chartState.timeSpanKey}
-					timeSpanOptions={timeSpanOptions}
-				/>
-			</div>
+			{showTimeSpanSelector && (
+				<>
+					<div className="c-mb-3 c-mt-2">
+						<TimeSpanSelector
+							disabledNextTimeSpan={
+								chartState.timeSpanOffset === 0
+							}
+							disabledPreviousPeriodButton={
+								isPreviousPeriodButtonDisabled
+							}
+							onNextTimeSpanClick={nextTimeSpan}
+							onPreviousTimeSpanClick={previousTimeSpan}
+							onTimeSpanChange={handleTimeSpanChange}
+							timeSpanKey={chartState.timeSpanKey}
+							timeSpanOptions={timeSpanOptions}
+						/>
+					</div>
 
-			{title && <h5 className="c-mb-4">{title}</h5>}
+					{title && <h5 className="c-mb-4">{title}</h5>}
+				</>
+			)}
 
 			<TotalCount
 				className="c-mb-2"
@@ -286,6 +293,7 @@ export default function ReferralDetail({
 ReferralDetail.propTypes = {
 	currentPage: PropTypes.object.isRequired,
 	languageTag: PropTypes.string.isRequired,
+	showTimeSpanSelector: PropTypes.bool,
 	timeSpanOptions: PropTypes.arrayOf(
 		PropTypes.shape({
 			key: PropTypes.string,


### PR DESCRIPTION
**Description**

The information needed for the `TimeSpanSelector` component to work in Referral traffic detail view is not provided by the Analytics Cloud endpoint yet, so we decided to hide that component until it's ready.

**Screenshot**

_Note: This image was created using mock data because we need 24h to process AC data._

![Screenshot 2021-02-10 at 16 29 56](https://user-images.githubusercontent.com/15845466/107533093-debfc480-6bbe-11eb-8acd-f2190d3a6517.png)