### PR TITLE
LPS-127832 Manage boolean dynamic attributes

### DIFF
--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -481,3 +481,34 @@ The `frontend-taglib-clay` module is now using components from
 previous attributes.
 
 ---------------------------------------
+### Handling HTML boolean attributes in tags
+- **Date:** 2021-Feb-18
+- **JIRA Ticket:** [LPS-127832](https://issues.liferay.com/browse/LPS-127832)
+
+#### What changed?
+
+Boolean HTML attributes will only be rendered if passed a value of `true`.
+For example, previously, a value such as `false` for a `disabled` attribute
+would be rendered into the DOM as `disabled="false"`; now, it is simply
+omitted.
+
+#### Who is affected?
+
+Anyone passing the following boolean attributes to tag libraries:
+
+"allowfullscreen", "allowpaymentrequest", "async", "autofocus", "autoplay",
+"checked", "controls", "default", "disabled", "formnovalidate", "hidden",
+"ismap", "itemscope", "loop", "multiple", "muted", "nomodule", "novalidate",
+"open", "playsinline", "readonly", "required", "reversed", "selected",
+and "truespeed".
+
+#### How should I update my code?
+
+Ensure that you pass `true` when you want a boolean attribute to
+be present in the DOM.
+
+#### Why was this change made?
+
+This change is being made for better compliance with [the HTML Standard](https://html.spec.whatwg.org/#boolean-attribute),
+which says that "The presence of a boolean attribute on an element represents
+the true value, and the absence of the attribute represents the false value."

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -488,9 +488,13 @@ previous attributes.
 #### What changed?
 
 Boolean HTML attributes will only be rendered if passed a value of `true`.
-For example, previously, a value such as `false` for a `disabled` attribute
+The value for such attributes will be their canonical name.
+
+Previously, a value such as `false` for a `disabled` attribute
 would be rendered into the DOM as `disabled="false"`; now, it is simply
-omitted.
+omitted. Likewise, a `true` value for a `disabled` attribute was
+formerly rendered into the DOM as `disabled="true"`; now it is rendered
+as `disabled="disabled"`.
 
 #### Who is affected?
 
@@ -504,11 +508,16 @@ and "truespeed".
 
 #### How should I update my code?
 
-Ensure that you pass `true` when you want a boolean attribute to
-be present in the DOM.
+Ensure that you pass `true` when you want a boolean attribute to be
+present in the DOM. If you have any CSS selectors targeting a `true`
+value (e.g., `[disabled="true"]`) update them to instead target presence
+of the attribute (e.g., `[disabled]`) or its canonical name (e.g.,
+`[disabled="disabled"]`).
 
 #### Why was this change made?
 
 This change is being made for better compliance with [the HTML Standard](https://html.spec.whatwg.org/#boolean-attribute),
 which says that "The presence of a boolean attribute on an element represents
-the true value, and the absence of the attribute represents the false value."
+the true value, and the absence of the attribute represents the false value. If
+the attribute is present, its value must either be the empty string or a value
+that is an ASCII case-insensitive match for the attribute's canonical name."

--- a/util-taglib/src/com/liferay/taglib/util/InlineUtil.java
+++ b/util-taglib/src/com/liferay/taglib/util/InlineUtil.java
@@ -17,7 +17,10 @@ package com.liferay.taglib.util;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Shuyang Zhou
@@ -37,14 +40,37 @@ public class InlineUtil {
 			String key = entry.getKey();
 
 			if (!key.equals("class")) {
+				String value = String.valueOf(entry.getValue());
+
+				if (_attributesSet.contains(key)) {
+					Boolean attributeValue = Boolean.valueOf(value);
+
+					if (!attributeValue) {
+						continue;
+					}
+
+					value = key;
+				}
+
 				sb.append(key);
 				sb.append("=\"");
-				sb.append(String.valueOf(entry.getValue()));
+				sb.append(value);
 				sb.append("\" ");
 			}
 		}
 
 		return sb.toString();
 	}
+
+	private static final String[] _HTML_BOOLEAN_ATTRIBUTES = {
+		"allowfullscreen", "allowpaymentrequest", "async", "autofocus",
+		"autoplay", "checked", "controls", "default", "disabled",
+		"formnovalidate", "hidden", "ismap", "itemscope", "loop", "multiple",
+		"muted", "nomodule", "novalidate", "open", "playsinline", "readonly",
+		"required", "reversed", "selected", "truespeed"
+	};
+
+	private static final Set<String> _attributesSet = new HashSet<>(
+		Arrays.asList(_HTML_BOOLEAN_ATTRIBUTES));
 
 }


### PR DESCRIPTION
In this change, we're changing the `buildDynamicAttributes` method of
the [InlineUtil](https://github.com/liferay/liferay-portal/blob/7985dd55f78d0b4e4960d1b8b07158787e32d29f/util-taglib/src/com/liferay/taglib/util/InlineUtil.java) class to handle boolean attributes.

According to the [spec](https://html.spec.whatwg.org/#boolean-attribute), the presence of
a boolean attribute on an element represents the "true" value, and the
absence of the attribute represents the "false" value, but the values
"true" and "false" are not allowed on boolean attributes. To represent a
false value, the attribute has to be omitted altogether.

If a dynamic attribute is one of the 25 available boolean attributes (see [here](https://meiert.com/en/blog/boolean-attributes-of-html/))
and it's value is "false", we omit writting it and if it's value is
"true" we replace it with the name of the attribute.

**Test plan**
- Fetch this branch
- Deploy the `util-taglib` module
- Add this code to a jsp, for example [buttons.jsp](https://github.com/liferay/liferay-portal/blob/85f66220f377144c4cf025be77a04c763a9f04b2/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/buttons.jsp)

```jsp
<clay:button disabled="<%= true %>" label="Disabled" />
<clay:button disabled="<%= false %>" label="Enabled" />
```

- Assert that it renders
    - A button with the `disabled` attribute (and no value)
    - A button without a `disabled` attribute