### PR TITLE
[TS] LPS-127774 Accessibility fix - Add value property to input field

### DIFF
--- a/util-taglib/src/com/liferay/taglib/ui/LayoutCommonTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/LayoutCommonTag.java
@@ -107,7 +107,7 @@ public class LayoutCommonTag extends IncludeTag {
 		jspWriter.write(
 			"<form action=\"#\" aria-hidden=\"true\" class=\"hide\" " +
 				"id=\"hrefFm\" method=\"post\" name=\"hrefFm\"><span>" +
-					"</span><input hidden type=\"submit\"/></form>");
+					"</span><input hidden type=\"submit\" value=\"accessibility-fix\"/></form>");
 
 		return EVAL_PAGE;
 	}


### PR DESCRIPTION
Hi Team,

Please see the LPS for reproduction steps: https://issues.liferay.com/browse/LPS-127774

The wave tool is detecting an error as an empty button. Adding a value property to the input field will meet the accessibility requirements and the empty button (as error) detection will be no longer present. I was checking the requirements here: https://achecker.ca/checker/index.php

Please review it and let me know if you have any question.
Thank you