### PR TITLE
COMMERCE-5555 Columns resizable on Dataset Display

### DIFF
--- a/modules/apps/commerce/commerce-frontend-js/webpack.config.dev.js
+++ b/modules/apps/commerce/commerce-frontend-js/webpack.config.dev.js
@@ -69,7 +69,26 @@ module.exports = {
 				use: [
 					{loader: 'style-loader'},
 					{loader: 'css-loader'},
-					{loader: 'sass-loader'},
+					{
+						loader: 'sass-loader',
+						options: {
+							sassOptions: {
+								importer: (url, _, done) => {
+									if (url.includes('atlas-variables')) {
+										done({
+											file: path.resolve(
+												__dirname,
+												'../../../node_modules/@clayui/css/src/scss/atlas-variables.scss'
+											),
+										});
+									}
+									else {
+										done({file: url});
+									}
+								},
+							},
+						},
+					},
 				],
 			},
 			{

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_data_set_display.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_data_set_display.scss
@@ -1,4 +1,9 @@
 .data-set-display {
+	.table-style-default {
+		border-width: 0 0 1px;
+		border-radius: 0;
+	}
+
 	.data-set-display-management-bar-wrapper {
 		border-bottom: 1px solid $border-color;
 
@@ -11,117 +16,6 @@
 		}
 	}
 
-	.data-set-sub-item {
-		color: $secondary-text;
-
-		a {
-			color: $secondary-text;
-		}
-
-		td {
-			background-color: #f0f5ff;
-			border-bottom-width: 2px;
-			border-color: white;
-			border-top-width: 2px;
-			padding-bottom: 4px;
-			padding-top: 4px;
-
-			&:first-child {
-				border-left-width: 4px;
-			}
-
-			&:last-child {
-				border-right-width: 4px;
-			}
-		}
-
-		&.last-of-group td {
-			border-bottom-width: 4px;
-		}
-
-		.sticker {
-			transform: scale(0.8);
-			transform-origin: left;
-		}
-
-		.table-cell-data-wrapper {
-			background-color: #f0f5ff;
-		}
-	}
-
-	.table {
-		border-collapse: separate;
-		border-spacing: 0;
-
-		td:first-child,
-		th:first-child,
-		.table-cell-start {
-			padding-left: map-get($spacers, 3);
-		}
-
-		td:last-child,
-		th:last-child,
-		.table-cell-end {
-			padding-right: map-get($spacers, 3);
-		}
-
-		td {
-			border-bottom-width: 0;
-			position: relative;
-
-			&:first-child {
-				&::after {
-					background: $primary-color;
-					bottom: 0;
-					content: '';
-					left: 0;
-					position: absolute;
-					top: 0;
-					transform: scaleX(0);
-					transition: transform 0.1s ease-in;
-					width: 3px;
-				}
-			}
-		}
-
-		tr {
-			background: white;
-
-			&:first-of-type td {
-				border-top-color: white;
-			}
-
-			&.active {
-				td::after {
-					transform: scaleX(1);
-				}
-			}
-		}
-
-		.data-set-fields-selector-dropdown {
-			display: inline-block;
-			text-align: center;
-			width: 2rem;
-		}
-
-		.data-set-item-actions-wrapper {
-			padding-bottom: 15px;
-			padding-top: 15px;
-			text-align: right;
-			vertical-align: top;
-		}
-
-		.data-set-item-selector-wrapper {
-			padding-top: 22px;
-			vertical-align: top;
-		}
-	}
-
-	.table-responsive {
-		margin-bottom: 0;
-		overflow-y: hidden;
-	}
-
 	&.data-set-display-fluid {
 		.data-set-display-pagination-wrapper {
 			margin: map-get($spacers, 3) 0 0;
@@ -131,10 +25,6 @@
 	&.data-set-display-inline {
 		.data-set-display-pagination-wrapper {
 			padding-top: 0.5rem;
-		}
-
-		.table {
-			border-bottom: 1px solid $border-color;
 		}
 	}
 
@@ -179,6 +69,10 @@
 	}
 }
 
+.dnd-table .content-renderer-image {
+	width: 1%;
+}
+
 .tooltip-table {
 	color: white;
 	font-weight: 600;
@@ -218,10 +112,6 @@
 			color: $error-l1;
 		}
 	}
-}
-
-.table .content-renderer-image {
-	width: 1%;
 }
 
 .filter-resume {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_data_set_display.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_data_set_display.scss
@@ -1,7 +1,7 @@
 .data-set-display {
 	.table-style-default {
-		border-width: 0 0 1px;
 		border-radius: 0;
+		border-width: 0 0 1px;
 	}
 
 	.data-set-display-management-bar-wrapper {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_dnd_table.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_dnd_table.scss
@@ -1,0 +1,180 @@
+.dnd-th {
+	font-weight: 600;
+	position: relative;
+}
+
+.dnd-thead {
+	display: table-header-group;
+
+	.fixed & {
+		display: block;
+	}
+}
+
+.dnd-tbody {
+	display: table-row-group;
+
+	.fixed & {
+		display: block;
+	}
+}
+
+.dnd-th,
+.dnd-td {
+	border-right: 1px solid $border-color;
+	display: table-cell;
+	padding: $spacer * 0.75;
+	white-space: normal;
+	overflow: hidden;
+	opacity: 0;
+	transition: opacity 0.1s ease-in;
+
+	.fixed & {
+		opacity: 1;
+	}
+
+	&:last-child {
+		border-right: none;
+	}
+
+	&.item-actions,
+	&.item-selector {
+		width: 1%;
+	}
+
+	&.expand {
+		min-width: 150px;
+		width: 20%;
+	}
+
+	.fixed & {
+		display: flex;
+		min-width: auto;
+		align-items: center;
+	}
+}
+
+.dnd-tr {
+	border-bottom: 1px solid $border-color;
+	position: relative;
+	display: table-row;
+	min-width: 100%;
+
+	.dnd-tbody &:last-child {
+		border-bottom: none;
+	}
+
+	&.with-bg {
+		background-color: $gray-100;
+	}
+
+	&::before {
+		background: var(--primary);
+		bottom: 0;
+		content: '';
+		left: 0;
+		position: absolute;
+		top: 0;
+		transform: scaleX(0);
+		transition: transform 0.1s ease-in;
+		width: 3px;
+	}
+
+	&.active::before {
+		transform: scaleX(1);
+	}
+
+	.fixed & {
+		display: flex;
+		width: fit-content;
+	}
+
+	&.nested + &.dnd-tr:not(.nested) {
+		border-top: 1px solid $border-color;
+	}
+
+	&.nested {
+		border-width: 0;
+		margin: 0;
+		overflow: hidden;
+		position: relative;
+		border-bottom: 1px solid var(--white);
+
+		&.last {
+			border-radius: 0 0 10px 10px;
+			border-bottom: none;
+			margin-bottom: 8px;
+
+			.dnd-td:first-child {
+				border-bottom-left-radius: 10px;
+			}
+
+			.dnd-td:last-child {
+				border-bottom-right-radius: 10px;
+			}
+		}
+
+		.dnd-td {
+			border-color: var(--white);
+			background-color: #f0f5ff;
+			padding-bottom: $spacer * 0.5;
+			padding-top: $spacer * 0.5;
+			overflow: hidden;
+		}
+
+		.sticker {
+			transform: scale(0.8);
+			transform-origin: left;
+		}
+	}
+}
+
+.dnd-table {
+	background-color: var(--white);
+	overflow-x: scroll;
+	border: 1px solid $border-color;
+	white-space: nowrap;
+	width: 100%;
+	display: table;
+	transition: opacity 0.1s ease-in;
+	color: $table-text;
+	font-size: 0.875rem;
+	border-radius: 2px;
+
+	&.fixed {
+		display: block;
+	}
+
+	&.is-dragging {
+		cursor: col-resize;
+		touch-action: none;
+		user-select: none;
+	}
+}
+
+.dnd-th-resizer {
+	cursor: col-resize;
+	display: block;
+	position: absolute;
+	width: 4px;
+	height: 100%;
+	background: var(--info);
+	opacity: 0;
+	right: 0;
+	top: 0;
+	z-index: 1;
+	transition: background-color 0.1s ease-in;
+
+	&:hover {
+		opacity: 1;
+	}
+
+	&.is-active {
+		background: var(--danger);
+		opacity: 1;
+
+		&.is-allowed {
+			background: var(--primary);
+		}
+	}
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_dnd_table.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_dnd_table.scss
@@ -1,8 +1,3 @@
-.dnd-th {
-	font-weight: 600;
-	position: relative;
-}
-
 .dnd-thead {
 	display: table-header-group;
 
@@ -19,15 +14,15 @@
 	}
 }
 
-.dnd-th,
-.dnd-td {
-	border-right: 1px solid $border-color;
+.dnd-td,
+.dnd-th {
+	border-right: 1px solid $table-list-border-color;
 	display: table-cell;
-	padding: $spacer * 0.75;
-	white-space: normal;
-	overflow: hidden;
 	opacity: 0;
+	overflow: hidden;
+	padding: $table-cell-padding;
 	transition: opacity 0.1s ease-in;
+	white-space: normal;
 
 	.fixed & {
 		opacity: 1;
@@ -48,28 +43,33 @@
 	}
 
 	.fixed & {
+		align-items: center;
 		display: flex;
 		min-width: auto;
-		align-items: center;
 	}
 }
 
-.dnd-tr {
-	border-bottom: 1px solid $border-color;
+.dnd-th {
+	font-weight: 600;
 	position: relative;
+}
+
+.dnd-tr {
+	border-bottom: 1px solid $table-list-border-color;
 	display: table-row;
 	min-width: 100%;
+	position: relative;
 
 	.dnd-tbody &:last-child {
 		border-bottom: none;
 	}
 
 	&.with-bg {
-		background-color: $gray-100;
+		background-color: $table-accent-bg;
 	}
 
 	&::before {
-		background: var(--primary);
+		background: $primary;
 		bottom: 0;
 		content: '';
 		left: 0;
@@ -90,19 +90,19 @@
 	}
 
 	&.nested + &.dnd-tr:not(.nested) {
-		border-top: 1px solid $border-color;
+		border-top: 1px solid $table-list-border-color;
 	}
 
 	&.nested {
+		border-bottom: 1px solid $table-bg;
 		border-width: 0;
 		margin: 0;
 		overflow: hidden;
 		position: relative;
-		border-bottom: 1px solid var(--white);
 
 		&.last {
-			border-radius: 0 0 10px 10px;
 			border-bottom: none;
+			border-radius: 0 0 10px 10px;
 			margin-bottom: 8px;
 
 			.dnd-td:first-child {
@@ -115,11 +115,11 @@
 		}
 
 		.dnd-td {
-			border-color: var(--white);
-			background-color: #f0f5ff;
+			background-color: $table-list-active-bg;
+			border-color: $table-bg;
+			overflow: hidden;
 			padding-bottom: $spacer * 0.5;
 			padding-top: $spacer * 0.5;
-			overflow: hidden;
 		}
 
 		.sticker {
@@ -130,16 +130,16 @@
 }
 
 .dnd-table {
-	background-color: var(--white);
+	background-color: $table-bg;
+	border: 1px solid $table-list-border-color;
+	border-radius: 2px;
+	color: $table-list-color;
+	display: table;
+	font-size: 0.875rem;
 	overflow-x: scroll;
-	border: 1px solid $border-color;
+	transition: opacity 0.1s ease-in;
 	white-space: nowrap;
 	width: 100%;
-	display: table;
-	transition: opacity 0.1s ease-in;
-	color: $table-text;
-	font-size: 0.875rem;
-	border-radius: 2px;
 
 	&.fixed {
 		display: block;
@@ -153,28 +153,28 @@
 }
 
 .dnd-th-resizer {
+	background: $info;
 	cursor: col-resize;
 	display: block;
-	position: absolute;
-	width: 4px;
 	height: 100%;
-	background: var(--info);
 	opacity: 0;
+	position: absolute;
 	right: 0;
 	top: 0;
-	z-index: 1;
 	transition: background-color 0.1s ease-in;
+	width: 4px;
+	z-index: 1;
 
 	&:hover {
 		opacity: 1;
 	}
 
 	&.is-active {
-		background: var(--danger);
+		background: $danger;
 		opacity: 1;
 
 		&.is-allowed {
-			background: var(--primary);
+			background: $primary;
 		}
 	}
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/ActionsDropdownRenderer.js
@@ -352,7 +352,7 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 		});
 
 	return (
-		<div className="d-flex justify-content-end">
+		<div className="d-flex justify-content-end ml-auto">
 			{inlineEditingAlwaysOn && inlineEditingActions}
 			<ClayDropDown
 				active={menuActive}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/styles/_variables.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/styles/_variables.scss
@@ -12,6 +12,8 @@ $info-primary: #2e5aac;
 
 $error-l1: lighten($danger-primary, 28%);
 $gray-600: #6b6c7e;
+$gray-100: #f7f8f9;
+$table-text: #272833;
 $secondary-text: $gray-600;
 $spacer: 1rem;
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/styles/_variables.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/styles/_variables.scss
@@ -1,3 +1,5 @@
+@import 'atlas-variables';
+
 $warning-secondary: #ff8f39;
 $warning-primary: #863a00;
 
@@ -12,8 +14,6 @@ $info-primary: #2e5aac;
 
 $error-l1: lighten($danger-primary, 28%);
 $gray-600: #6b6c7e;
-$gray-100: #f7f8f9;
-$table-text: #272833;
 $secondary-text: $gray-600;
 $spacer: 1rem;
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/styles/main.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/styles/main.scss
@@ -2,6 +2,7 @@
 
 @import '../data_renderers/data_renderers';
 @import '../data_set_display';
+@import '../dnd_table';
 @import '../modal/modal';
 @import '../quantity_selector/quantity_selector';
 @import '../side_panel/side_panel';

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/cards/Cards.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/cards/Cards.js
@@ -13,16 +13,18 @@
  */
 
 import {ClayCardWithInfo} from '@clayui/card';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
+import EmptyResultMessage from '../../EmptyResultMessage';
 import {
 	handleAction,
 	isLink,
 } from '../../data_renderers/ActionsDropdownRenderer';
 
-function Cards({dataSetDisplayContext, items, schema}) {
+function Cards({dataLoading, dataSetDisplayContext, items, schema}) {
 	const {
 		executeAsyncItemAction,
 		highlightItems,
@@ -34,6 +36,14 @@ function Cards({dataSetDisplayContext, items, schema}) {
 		selectedItemsValue,
 		style,
 	} = useContext(dataSetDisplayContext);
+
+	if (dataLoading) {
+		return <ClayLoadingIndicator className="mt-7" />;
+	}
+
+	if (!items?.length) {
+		return <EmptyResultMessage />;
+	}
 
 	return (
 		<div

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/emails_list/EmailsList.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/emails_list/EmailsList.js
@@ -14,11 +14,13 @@
 
 import ClayLabel from '@clayui/label';
 import ClayList from '@clayui/list';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClaySticker from '@clayui/sticker';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
+import EmptyResultMessage from '../../EmptyResultMessage';
 import ActionsDropdownRenderer from '../../data_renderers/ActionsDropdownRenderer';
 
 function Email({
@@ -136,8 +138,16 @@ Email.defaultProps = {
 	actionItems: [],
 };
 
-function EmailsList({dataSetDisplayContext, items}) {
+function EmailsList({dataLoading, dataSetDisplayContext, items}) {
 	const {style} = useContext(dataSetDisplayContext);
+
+	if (dataLoading) {
+		return <ClayLoadingIndicator className="mt-7" />;
+	}
+
+	if (!items?.length) {
+		return <EmptyResultMessage />;
+	}
 
 	return (
 		<ClayList

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/list/List.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/list/List.js
@@ -15,15 +15,18 @@
 import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayList from '@clayui/list';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClaySticker from '@clayui/sticker';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
+import EmptyResultMessage from '../../EmptyResultMessage';
 import ActionsDropdownRenderer from '../../data_renderers/ActionsDropdownRenderer';
 import ImageRenderer from '../../data_renderers/ImageRenderer';
 
 function List({
+	dataLoading,
 	dataSetDisplayContext,
 	items,
 	schema: {description, image, sticker, symbol, title},
@@ -35,6 +38,14 @@ function List({
 		selectedItemsValue,
 		selectionType,
 	} = useContext(dataSetDisplayContext);
+
+	if (dataLoading) {
+		return <ClayLoadingIndicator className="mt-7" />;
+	}
+
+	if (!items?.length) {
+		return <EmptyResultMessage />;
+	}
 
 	return (
 		<ClayList>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/selectable_table/SelectableTable.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/selectable_table/SelectableTable.js
@@ -13,17 +13,22 @@
  */
 
 import {ClayCheckbox} from '@clayui/form';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayTable from '@clayui/table';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useState} from 'react';
 
 import DataSetDisplayContext from '../../DataSetDisplayContext';
+import EmptyResultMessage from '../../EmptyResultMessage';
 
-function SelectableTable({items: itemsProp, schema, style}) {
+function SelectableTable({dataLoading, items: itemsProp, schema, style}) {
 	const {namespace} = useContext(DataSetDisplayContext);
 	const {selectedItemsKey} = useContext(DataSetDisplayContext);
+	const [items, updateItems] = useState(null);
 
-	const [items, updateItems] = useState(itemsProp);
+	useEffect(() => {
+		updateItems(itemsProp);
+	}, [itemsProp]);
 
 	useEffect(() => {
 		updateItems(items);
@@ -55,6 +60,14 @@ function SelectableTable({items: itemsProp, schema, style}) {
 		});
 
 		updateItems(updatedItems);
+	}
+
+	if (dataLoading) {
+		return <ClayLoadingIndicator className="mt-7" />;
+	}
+
+	if (!items?.length) {
+		return <EmptyResultMessage />;
 	}
 
 	return (

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/FieldsSelectorDropdown.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/FieldsSelectorDropdown.js
@@ -53,14 +53,12 @@ const FieldsSelectorDropdown = ({fields}) => {
 	return (
 		<ClayDropDown
 			active={active}
-			className="data-set-fields-selector-dropdown"
+			className="ml-auto"
 			onActiveChange={setActive}
 			trigger={
 				<ClayButtonWithIcon
 					borderless
-					className="p-0"
 					displayType="secondary"
-					monospaced={false}
 					symbol={active ? 'caret-top' : 'caret-bottom'}
 				/>
 			}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/Table.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/Table.js
@@ -259,19 +259,19 @@ function Table({dataLoading, items, itemsActions, schema, style}) {
 		);
 	}
 
-	const columnsNames = [];
+	const columnNames = [];
 
 	if (selectable) {
-		columnsNames.push('item-selector');
+		columnNames.push('item-selector');
 	}
 
-	columnsNames.push(
+	columnNames.push(
 		...visibleFields.map((field) => String(field.fieldName)),
 		'item-actions'
 	);
 
 	return (
-		<DndTable.ContextProvider columnsNames={columnsNames}>
+		<DndTable.ContextProvider columnNames={columnNames}>
 			{viewContent}
 		</DndTable.ContextProvider>
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableCell.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableCell.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import ClayTable from '@clayui/table';
 import React, {useContext, useEffect, useState} from 'react';
 
 import DataSetDisplayContext from '../../DataSetDisplayContext';
@@ -22,6 +21,7 @@ import {
 	getDataRendererByURL,
 	getInputRendererById,
 } from '../../utils/dataRenderers';
+import DndTableCell from './dnd_table/Cell';
 
 function InlineEditInputRenderer({
 	itemId,
@@ -114,7 +114,7 @@ function TableCell({
 		(itemInlineChanges || inlineEditingSettings?.alwaysOn)
 	) {
 		return (
-			<ClayTable.Cell>
+			<DndTableCell columnName={String(options.fieldName)}>
 				<InlineEditInputRenderer
 					actions={actions}
 					itemData={itemData}
@@ -125,12 +125,12 @@ function TableCell({
 					value={value}
 					valuePath={valuePath}
 				/>
-			</ClayTable.Cell>
+			</DndTableCell>
 		);
 	}
 
 	return (
-		<ClayTable.Cell>
+		<DndTableCell columnName={String(options.fieldName)}>
 			{currentView.Component && !loading ? (
 				<currentView.Component
 					actions={actions}
@@ -147,7 +147,7 @@ function TableCell({
 					className="loading-animation loading-animation-sm"
 				/>
 			)}
-		</ClayTable.Cell>
+		</DndTableCell>
 	);
 }
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableHead.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableHead.js
@@ -13,14 +13,15 @@
  */
 
 import {ClayCheckbox} from '@clayui/form';
-import ClayTable from '@clayui/table';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import FieldsSelectorDropdown from './FieldsSelectorDropdown';
 import TableHeadCell from './TableHeadCell';
+import DndTable from './dnd_table/index';
 
-function TableHeadRow({
+function TableHead({
+	fields,
 	items,
 	schema,
 	selectItems,
@@ -30,9 +31,8 @@ function TableHeadRow({
 	selectionType,
 	sorting,
 	updateSorting,
-	visibleFields,
 }) {
-	const expandableColumns = visibleFields.some((field) => field.expand);
+	const expandableColumns = fields.some((field) => field.expand);
 
 	function handleCheckboxClick() {
 		if (selectedItemsValue.length === items.length) {
@@ -43,10 +43,14 @@ function TableHeadRow({
 	}
 
 	return (
-		<ClayTable.Head>
-			<ClayTable.Row>
+		<DndTable.Head>
+			<DndTable.Row>
 				{selectable && (
-					<ClayTable.Cell headingCell>
+					<DndTable.Cell
+						className="item-selector"
+						columnName="item-selector"
+						heading
+					>
 						{items.length && selectionType === 'multiple' ? (
 							<ClayCheckbox
 								checked={!!selectedItemsValue.length}
@@ -58,9 +62,9 @@ function TableHeadRow({
 								onChange={handleCheckboxClick}
 							/>
 						) : null}
-					</ClayTable.Cell>
+					</DndTable.Cell>
 				)}
-				{visibleFields.map((field) => (
+				{fields.map((field) => (
 					<TableHeadCell
 						{...field}
 						expandableColumns={expandableColumns}
@@ -69,15 +73,24 @@ function TableHeadRow({
 						updateSorting={updateSorting}
 					/>
 				))}
-				<ClayTable.Cell className="text-right" headingCell>
+				<DndTable.Cell
+					className="item-actions"
+					columnName="item-actions"
+					heading
+				>
 					<FieldsSelectorDropdown fields={schema.fields} />
-				</ClayTable.Cell>
-			</ClayTable.Row>
-		</ClayTable.Head>
+				</DndTable.Cell>
+			</DndTable.Row>
+		</DndTable.Head>
 	);
 }
 
-TableHeadRow.propTypes = {
+TableHead.propTypes = {
+	fields: PropTypes.arrayOf(
+		PropTypes.shape({
+			expand: PropTypes.bool,
+		})
+	),
 	items: PropTypes.array,
 	schema: PropTypes.shape({
 		fields: PropTypes.any,
@@ -91,11 +104,6 @@ TableHeadRow.propTypes = {
 	selectionType: PropTypes.oneOf(['single', 'multiple']),
 	sorting: PropTypes.any,
 	updateSorting: PropTypes.func.isRequired,
-	visibleFields: PropTypes.arrayOf(
-		PropTypes.shape({
-			expand: PropTypes.bool,
-		})
-	),
 };
 
-export default TableHeadRow;
+export default TableHead;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableHeadCell.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableHeadCell.js
@@ -12,16 +12,17 @@
  * details.
  */
 
+import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import ClayTable from '@clayui/table';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
+import Cell from './dnd_table/Cell';
+
 function TableHeadCell({
 	contentRenderer,
 	expand,
-	expandableColumns,
 	fieldName,
 	hideColumnLabel,
 	label,
@@ -71,21 +72,21 @@ function TableHeadCell({
 	}
 
 	return (
-		<ClayTable.Cell
+		<Cell
 			className={classNames({
-				'table-cell-expand-small': expandableColumns && expand,
-				'table-cell-expand-smaller': !expandableColumns,
 				[`content-renderer-${contentRenderer}`]: contentRenderer,
 			})}
-			headingCell
-			headingTitle
+			columnName={String(fieldName)}
+			expand={expand}
+			heading
+			resizable
 		>
 			{sortable ? (
-				<a
-					className="inline-item text-nowrap text-truncate-inline"
-					data-senna-off
-					href="#"
+				<ClayButton
+					className="btn-sorting inline-item text-nowrap text-truncate-inline"
+					displayType="unstyled"
 					onClick={handleSortingCellClick}
+					small
 				>
 					{!hideColumnLabel && label}
 					<span className="inline-item inline-item-after sorting-icons-wrapper">
@@ -106,11 +107,11 @@ function TableHeadCell({
 							symbol="order-arrow-down"
 						/>
 					</span>
-				</a>
+				</ClayButton>
 			) : (
 				!hideColumnLabel && label
 			)}
-		</ClayTable.Cell>
+		</Cell>
 	);
 }
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableInlineAddingRow.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableInlineAddingRow.js
@@ -14,12 +14,12 @@
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import ClayTable from '@clayui/table';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import React, {useContext, useState} from 'react';
 
 import DataSetDisplayContext from '../../DataSetDisplayContext';
 import {getInputRendererById} from '../../utils/dataRenderers';
+import DndTable from './dnd_table/index';
 
 function TableInlineAddingRow({fields, selectable}) {
 	const {
@@ -34,9 +34,12 @@ function TableInlineAddingRow({fields, selectable}) {
 		itemsChanges[0] && !!Object.keys(itemsChanges[0]).length;
 
 	return (
-		<ClayTable.Row>
+		<DndTable.Row>
 			{selectable && (
-				<ClayTable.Cell className="data-set-item-selector-wrapper" />
+				<DndTable.Cell
+					className="item-selector"
+					columnName="item-selector"
+				/>
 			)}
 			{fields.map((field) => {
 				let InputRenderer = null;
@@ -60,7 +63,10 @@ function TableInlineAddingRow({fields, selectable}) {
 				const newItem = itemsChanges[0] || {};
 
 				return (
-					<ClayTable.Cell key={field.fieldName}>
+					<DndTable.Cell
+						columnName={String(field.fieldName)}
+						key={field.fieldName}
+					>
 						{InputRenderer ? (
 							<InputRenderer
 								updateItem={(value) => {
@@ -78,11 +84,11 @@ function TableInlineAddingRow({fields, selectable}) {
 								valuePath={rootPropertyName}
 							/>
 						) : null}
-					</ClayTable.Cell>
+					</DndTable.Cell>
 				);
 			})}
-			<ClayTable.Cell className="data-set-item-actions-wrapper">
-				<div className="d-flex justify-content-end">
+			<DndTable.Cell className="item-actions" columnName="item-actions">
+				<div className="d-flex ml-auto">
 					<ClayButtonWithIcon
 						className="mr-1"
 						disabled={!itemHasChanged}
@@ -113,8 +119,8 @@ function TableInlineAddingRow({fields, selectable}) {
 						/>
 					)}
 				</div>
-			</ClayTable.Cell>
-		</ClayTable.Row>
+			</DndTable.Cell>
+		</DndTable.Row>
 	);
 }
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Cell.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Cell.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import classNames from 'classnames';
+import {throttle} from 'frontend-js-web';
+import PropTypes from 'prop-types';
+import React, {useContext, useEffect, useMemo, useRef} from 'react';
+
+import Context from './TableContext';
+
+function Cell({children, className, columnName, expand, heading, resizable}) {
+	const cellRef = useRef();
+	const clientX = useRef({current: null});
+
+	const {
+		columnsDefinitions,
+		draggingAllowed,
+		draggingColumnName,
+		isFixed,
+		registerColumn,
+		resizeColumn,
+		updateDraggingAllowed,
+		updateDraggingColumnName,
+	} = useContext(Context);
+
+	useEffect(() => {
+		if (columnName && heading && !isFixed) {
+			const {width} = cellRef.current.getClientRects()[0];
+
+			registerColumn(columnName, width, resizable);
+		}
+	}, [columnName, isFixed, registerColumn, heading, resizable]);
+
+	const resizeCol = useMemo(() => {
+		return throttle((event) => {
+			if (event.clientX === clientX.current || !cellRef.current) {
+				return;
+			}
+
+			updateDraggingColumnName(columnName);
+
+			clientX.current = event.clientX;
+
+			const {x: headerCellX} = cellRef.current.getClientRects()[0];
+			const newWidth = event.clientX - headerCellX;
+
+			resizeColumn(columnName, newWidth, resizable);
+		}, 20);
+	}, [columnName, resizable, resizeColumn, updateDraggingColumnName]);
+
+	function initializeDrag() {
+		window.addEventListener('mousemove', resizeCol);
+		window.addEventListener(
+			'mouseup',
+			() => {
+				updateDraggingAllowed(true);
+				updateDraggingColumnName(null);
+				window.removeEventListener('mousemove', resizeCol);
+			},
+			{once: true}
+		);
+	}
+
+	const width = useMemo(() => {
+		const columnDetails = columnsDefinitions.get(columnName);
+
+		return columnDetails && isFixed && columnDetails.width;
+	}, [isFixed, columnsDefinitions, columnName]);
+
+	return (
+		<div
+			className={classNames(
+				heading ? 'dnd-th' : 'dnd-td',
+				expand && 'expand',
+				className
+			)}
+			ref={cellRef}
+			style={{
+				width,
+			}}
+		>
+			{children}
+
+			{resizable && (
+				<span
+					className={classNames('dnd-th-resizer', {
+						'is-active': columnName === draggingColumnName,
+						'is-allowed': draggingAllowed,
+					})}
+					onMouseDown={initializeDrag}
+				/>
+			)}
+		</div>
+	);
+}
+
+Cell.defaultProps = {
+	expand: false,
+	heading: false,
+	resizable: false,
+};
+
+Cell.propTypes = {
+	className: PropTypes.string,
+	columnName: PropTypes.string,
+	expand: PropTypes.bool,
+	heading: PropTypes.bool,
+	resizable: PropTypes.bool,
+};
+
+export default Cell;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Cell.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Cell.js
@@ -15,7 +15,7 @@
 import classNames from 'classnames';
 import {throttle} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useContext, useEffect, useMemo, useRef} from 'react';
+import React, {useContext, useLayoutEffect, useMemo, useRef} from 'react';
 
 import Context from './TableContext';
 
@@ -24,7 +24,7 @@ function Cell({children, className, columnName, expand, heading, resizable}) {
 	const clientX = useRef({current: null});
 
 	const {
-		columnsDefinitions,
+		columnDefinitions,
 		draggingAllowed,
 		draggingColumnName,
 		isFixed,
@@ -34,7 +34,7 @@ function Cell({children, className, columnName, expand, heading, resizable}) {
 		updateDraggingColumnName,
 	} = useContext(Context);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (columnName && heading && !isFixed) {
 			const {width} = cellRef.current.getClientRects()[0];
 
@@ -42,7 +42,7 @@ function Cell({children, className, columnName, expand, heading, resizable}) {
 		}
 	}, [columnName, isFixed, registerColumn, heading, resizable]);
 
-	const resizeCol = useMemo(() => {
+	const handleDrag = useMemo(() => {
 		return throttle((event) => {
 			if (event.clientX === clientX.current || !cellRef.current) {
 				return;
@@ -60,23 +60,23 @@ function Cell({children, className, columnName, expand, heading, resizable}) {
 	}, [columnName, resizable, resizeColumn, updateDraggingColumnName]);
 
 	function initializeDrag() {
-		window.addEventListener('mousemove', resizeCol);
+		window.addEventListener('mousemove', handleDrag);
 		window.addEventListener(
 			'mouseup',
 			() => {
 				updateDraggingAllowed(true);
 				updateDraggingColumnName(null);
-				window.removeEventListener('mousemove', resizeCol);
+				window.removeEventListener('mousemove', handleDrag);
 			},
 			{once: true}
 		);
 	}
 
 	const width = useMemo(() => {
-		const columnDetails = columnsDefinitions.get(columnName);
+		const columnDetails = columnDefinitions.get(columnName);
 
 		return columnDetails && isFixed && columnDetails.width;
-	}, [isFixed, columnsDefinitions, columnName]);
+	}, [isFixed, columnDefinitions, columnName]);
 
 	return (
 		<div

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/ContextProvider.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/ContextProvider.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React, {useCallback, useMemo, useState} from 'react';
+
+import Context from './TableContext';
+
+function ContextProvider({children, columnsNames}) {
+	const [tableWidth, updateTableWidth] = useState(null);
+	const [columnsDefinitions, updateColumnsDefinitions] = useState(new Map());
+	const [draggingColumnName, updateDraggingColumnName] = useState(null);
+	const [draggingAllowed, updateDraggingAllowed] = useState(true);
+
+	const registerColumn = (name, width, resizable) => {
+		updateColumnsDefinitions((definitions) => {
+			const updatedDefinitions = new Map(definitions);
+
+			updatedDefinitions.set(name, {
+				resizable,
+				width,
+			});
+
+			return updatedDefinitions;
+		});
+	};
+
+	const isFixed = useMemo(() => {
+		const columnsAreAllRegistered = columnsNames.reduce(
+			(registered, name) => {
+				return registered && !!columnsDefinitions.get(name);
+			},
+			true
+		);
+
+		return columnsAreAllRegistered;
+	}, [columnsDefinitions, columnsNames]);
+
+	const resizeColumn = useCallback(
+		(name, width) => {
+			if (isFixed) {
+				updateColumnsDefinitions((definitions) => {
+					const resizedColumn = definitions.get(name);
+
+					const isColumnReducing = resizedColumn.width > width;
+
+					let totalColsWidth = 0;
+
+					definitions.forEach((definition) => {
+						totalColsWidth += definition.width;
+					});
+
+					const nextColumnName =
+						columnsNames[columnsNames.indexOf(name) + 1];
+					const nextColumn = definitions.get(nextColumnName);
+					const columnsAreShorterThanContainer =
+						totalColsWidth < tableWidth;
+
+					if (
+						(isColumnReducing &&
+							columnsAreShorterThanContainer &&
+							!nextColumn?.resizable) ||
+						width < 40
+					) {
+						updateDraggingAllowed(false);
+
+						return definitions;
+					}
+
+					updateDraggingAllowed(true);
+
+					const newDefinitions = new Map(definitions);
+
+					if (isColumnReducing && columnsAreShorterThanContainer) {
+						newDefinitions.set(nextColumnName, {
+							...nextColumn,
+							width:
+								nextColumn.width + resizedColumn.width - width,
+						});
+					}
+
+					newDefinitions.set(name, {
+						...resizedColumn,
+						width,
+					});
+
+					return newDefinitions;
+				});
+			}
+		},
+		[columnsNames, tableWidth, isFixed]
+	);
+
+	return (
+		<Context.Provider
+			value={{
+				columnsDefinitions,
+				columnsNames,
+				draggingAllowed,
+				draggingColumnName,
+				isFixed,
+				registerColumn,
+				resizeColumn,
+				tableWidth,
+				updateDraggingAllowed,
+				updateDraggingColumnName,
+				updateTableWidth,
+			}}
+		>
+			{children}
+		</Context.Provider>
+	);
+}
+
+export default ContextProvider;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/ContextProvider.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/ContextProvider.js
@@ -12,18 +12,19 @@
  * details.
  */
 
+import PropTypes from 'prop-types';
 import React, {useCallback, useMemo, useState} from 'react';
 
 import Context from './TableContext';
 
-function ContextProvider({children, columnsNames}) {
+function ContextProvider({children, columnNames}) {
 	const [tableWidth, updateTableWidth] = useState(null);
-	const [columnsDefinitions, updateColumnsDefinitions] = useState(new Map());
+	const [columnDefinitions, updateColumnDefinitions] = useState(new Map());
 	const [draggingColumnName, updateDraggingColumnName] = useState(null);
 	const [draggingAllowed, updateDraggingAllowed] = useState(true);
 
 	const registerColumn = (name, width, resizable) => {
-		updateColumnsDefinitions((definitions) => {
+		updateColumnDefinitions((definitions) => {
 			const updatedDefinitions = new Map(definitions);
 
 			updatedDefinitions.set(name, {
@@ -36,35 +37,32 @@ function ContextProvider({children, columnsNames}) {
 	};
 
 	const isFixed = useMemo(() => {
-		const columnsAreAllRegistered = columnsNames.reduce(
-			(registered, name) => {
-				return registered && !!columnsDefinitions.get(name);
-			},
-			true
+		const allRegistered = columnNames.every((name) =>
+			columnDefinitions.has(name)
 		);
 
-		return columnsAreAllRegistered;
-	}, [columnsDefinitions, columnsNames]);
+		return allRegistered;
+	}, [columnDefinitions, columnNames]);
 
 	const resizeColumn = useCallback(
 		(name, width) => {
 			if (isFixed) {
-				updateColumnsDefinitions((definitions) => {
+				updateColumnDefinitions((definitions) => {
 					const resizedColumn = definitions.get(name);
 
 					const isColumnReducing = resizedColumn.width > width;
 
-					let totalColsWidth = 0;
+					let totalWidth = 0;
 
 					definitions.forEach((definition) => {
-						totalColsWidth += definition.width;
+						totalWidth += definition.width;
 					});
 
 					const nextColumnName =
-						columnsNames[columnsNames.indexOf(name) + 1];
+						columnNames[columnNames.indexOf(name) + 1];
 					const nextColumn = definitions.get(nextColumnName);
 					const columnsAreShorterThanContainer =
-						totalColsWidth < tableWidth;
+						totalWidth < tableWidth;
 
 					if (
 						(isColumnReducing &&
@@ -98,14 +96,14 @@ function ContextProvider({children, columnsNames}) {
 				});
 			}
 		},
-		[columnsNames, tableWidth, isFixed]
+		[columnNames, tableWidth, isFixed]
 	);
 
 	return (
 		<Context.Provider
 			value={{
-				columnsDefinitions,
-				columnsNames,
+				columnDefinitions,
+				columnNames,
 				draggingAllowed,
 				draggingColumnName,
 				isFixed,
@@ -121,5 +119,13 @@ function ContextProvider({children, columnsNames}) {
 		</Context.Provider>
 	);
 }
+
+ContextProvider.defaultProps = {
+	columnNames: [],
+};
+
+ContextProvider.propTypes = {
+	columnNames: PropTypes.arrayOf(PropTypes.string),
+};
 
 export default ContextProvider;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Row.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Row.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React, {useContext, useMemo} from 'react';
+
+import Cell from './Cell';
+import TableContext from './TableContext';
+
+function Row({children, className, paddingLeftCells}) {
+	const {columnsDefinitions, columnsNames, isFixed} = useContext(
+		TableContext
+	);
+
+	const marginLeft = useMemo(() => {
+		let margin = 0;
+
+		if (isFixed) {
+			for (let i = 0; i < paddingLeftCells; i++) {
+				margin += columnsDefinitions.get(columnsNames[i]).width;
+			}
+		}
+
+		return margin;
+	}, [columnsDefinitions, columnsNames, isFixed, paddingLeftCells]);
+
+	const style = marginLeft
+		? {
+				marginLeft,
+				minWidth: `calc(100% - ${marginLeft}px)`,
+		  }
+		: {};
+
+	let counter = 0;
+	const placeholderPaddingCells = !isFixed
+		? new Array(paddingLeftCells).fill(<Cell key={counter++} />)
+		: null;
+
+	return (
+		<div className={classNames('dnd-tr', className)} style={style}>
+			{placeholderPaddingCells}
+			{children}
+		</div>
+	);
+}
+
+Row.defaultProps = {
+	paddingLeftCells: 0,
+};
+
+Row.propTypes = {
+	paddingLeftCells: PropTypes.number,
+};
+
+export default Row;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Row.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Row.js
@@ -20,21 +20,19 @@ import Cell from './Cell';
 import TableContext from './TableContext';
 
 function Row({children, className, paddingLeftCells}) {
-	const {columnsDefinitions, columnsNames, isFixed} = useContext(
-		TableContext
-	);
+	const {columnDefinitions, columnNames, isFixed} = useContext(TableContext);
 
 	const marginLeft = useMemo(() => {
 		let margin = 0;
 
 		if (isFixed) {
 			for (let i = 0; i < paddingLeftCells; i++) {
-				margin += columnsDefinitions.get(columnsNames[i]).width;
+				margin += columnDefinitions.get(columnNames[i]).width;
 			}
 		}
 
 		return margin;
-	}, [columnsDefinitions, columnsNames, isFixed, paddingLeftCells]);
+	}, [columnDefinitions, columnNames, isFixed, paddingLeftCells]);
 
 	const style = marginLeft
 		? {
@@ -43,10 +41,13 @@ function Row({children, className, paddingLeftCells}) {
 		  }
 		: {};
 
-	let counter = 0;
-	const placeholderPaddingCells = !isFixed
-		? new Array(paddingLeftCells).fill(<Cell key={counter++} />)
-		: null;
+	const placeholderPaddingCells = [];
+
+	if (!isFixed) {
+		for (let i = 0; i < paddingLeftCells; i++) {
+			placeholderPaddingCells.push(<Cell key={i} />);
+		}
+	}
 
 	return (
 		<div className={classNames('dnd-tr', className)} style={style}>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Table.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Table.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import classNames from 'classnames';
+import React, {useContext, useEffect, useRef} from 'react';
+
+import TableContext from './TableContext';
+
+function Table({children, className}) {
+	const {draggingColumnName, isFixed, updateTableWidth} = useContext(
+		TableContext
+	);
+	const dndTableRef = useRef(null);
+
+	useEffect(() => {
+		const tableWidth = dndTableRef.current.getBoundingClientRect().width;
+		updateTableWidth(tableWidth);
+	}, [updateTableWidth]);
+
+	return (
+		<div
+			className={classNames(
+				'dnd-table',
+				{
+					fixed: isFixed,
+					'is-dragging': draggingColumnName !== null,
+				},
+				className
+			)}
+			ref={dndTableRef}
+		>
+			{children}
+		</div>
+	);
+}
+
+export default Table;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Table.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/Table.js
@@ -13,7 +13,7 @@
  */
 
 import classNames from 'classnames';
-import React, {useContext, useEffect, useRef} from 'react';
+import React, {useContext, useLayoutEffect, useRef} from 'react';
 
 import TableContext from './TableContext';
 
@@ -23,7 +23,7 @@ function Table({children, className}) {
 	);
 	const dndTableRef = useRef(null);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		const tableWidth = dndTableRef.current.getBoundingClientRect().width;
 		updateTableWidth(tableWidth);
 	}, [updateTableWidth]);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/TableContext.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/TableContext.js
@@ -12,26 +12,8 @@
  * details.
  */
 
-import ClayList from '@clayui/list';
-import PropTypes from 'prop-types';
-import React from 'react';
+import {createContext} from 'react';
 
-function Example({items}) {
-	return (
-		<ClayList className="bg-white mb-0 p-3">
-			<pre className="mb-0 text-wrap">{JSON.stringify(items)}</pre>
-		</ClayList>
-	);
-}
+const Context = createContext(null);
 
-Example.propTypes = {
-	dataRenderers: PropTypes.object,
-	dataSetDisplayContext: PropTypes.any,
-	items: PropTypes.array,
-};
-
-Example.defaultProps = {
-	items: [],
-};
-
-export default Example;
+export default Context;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/dnd_table/index.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import classNames from 'classnames';
+import React from 'react';
+
+import Cell from './Cell';
+import ContextProvider from './ContextProvider';
+import Row from './Row';
+import Table from './Table';
+
+function Body({children, className}) {
+	return <div className={classNames('dnd-tbody', className)}>{children}</div>;
+}
+
+function Head({children, className}) {
+	return <div className={classNames('dnd-thead', className)}>{children}</div>;
+}
+
+export default Object.assign(Table, {
+	Body,
+	Cell,
+	ContextProvider,
+	Head,
+	Row,
+	Table,
+});


### PR DESCRIPTION
Columns on dataset display are now resizable. 
Only exceptions are the first one with checkboxes and the last one with the items actions.

It's possible increasing the size of the table by expanding the columns out of the table borders; in this case the hidden content will be visible via horizontal scrolling.

I created some dnd utilities in the table view folder and used div elements rather than table related ones in order to have more flexibility. 

What happens is:
1) The dataset display is rendered using divs with tables / table rows / table cells display attributes so the columns width will be dynamically calculated based on the content and consistent across all the items.
2) Once the columns are rendered a snapshot is taken and the widths are saved.
3) A `fixed` css class is applied to the dataset. The class changes the display behaviour of the elements involved within the table and the saved widths are given to the columns

![Kapture 2021-02-12 at 21 29 39](https://user-images.githubusercontent.com/44569796/107819618-c21bbc00-6d79-11eb-91a5-82dd1437c429.gif)
