### PR TITLE
LPS-122094 [7.4-only] Suppress IE-specific arrow function check

### DIFF
--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -110,6 +110,7 @@
 		<suppress checks="JavaXMLSecurityCheck" files="portal-impl/src/com/liferay/portal/xml/SAXReaderFactory\.java" />
 		<suppress checks="JavaXMLSecurityCheck" files="util-java/src/com/liferay/util/ant/Java2WsddTask\.java" />
 		<suppress checks="JavaXMLSecurityCheck" files="util-java/src/com/liferay/util/xml/XMLMergerRunner\.java" />
+		<suppress checks="JSPArrowFunctionCheck" />
 		<suppress checks="JSPIllegalSyntaxCheck" files="portal-web/docroot/html/portal/api/jsonws/action\.jsp" />
 		<suppress checks="JSPLineBreakCheck" files="portal-web/docroot/html/portal/progress_poller\.jsp" />
 		<suppress checks="LocaleUtilCheck" files="portal-kernel/src/com/liferay/portal/kernel/util/LocaleUtil\.java" />


### PR DESCRIPTION
We no longer need to keep arrow functions out of our JSP on `master`, because we no longer need to support IE there.

Note that it might be nice to do the inverse version of this change (turn off that check _by default_ and then opt-in to it on the older branches, so that `master` is clean and doesn't carry around a suppression until the end of time), but I don't think there is a way to turn SF checks _on_, only to turn them _off_, so we're kind of forced to do it this way. I'll ask in the `#source-formatter` channel on Slack for confirmation of that.

**Test plan:** Add an arrow function to a module without this change and see `gradlew formatSource` spit out an error:

```
Do not use arrow function, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/checks/jsp_arrow_function_check.markdown: ./src/main/resources/META-INF/resources/adaptive_media/view.jsp 220 (SourceCheck:JSPArrowFunctionCheck)
java.lang.Exception: Found 1 formatting issues:
1: Do not use arrow function, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/checks/jsp_arrow_function_check.markdown: ./src/main/resources/META-INF/resources/adaptive_media/view.jsp 220 (SourceCheck:JSPArrowFunctionCheck)
```

Then apply the suppression and see `gradlew formatSource` all happy.