### PR TITLE
LPS-127922 [Impedibug - A/B Testing] Remove click goal target is only allowed if the experiment is in draft status

### DIFF
--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -246,7 +246,8 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 							<ClayTooltipProvider>
 								<ClayInput
 									className={classNames({
-										'input-group-inset input-group-inset-after': selectedTarget,
+										'input-group-inset input-group-inset-after':
+											allowEdit && selectedTarget,
 									})}
 									data-tooltip-align="top"
 									id="clickableElement"
@@ -259,7 +260,7 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 									value={selectorInputValue}
 								/>
 							</ClayTooltipProvider>
-							{selectedTarget && (
+							{allowEdit && selectedTarget && (
 								<ClayInput.GroupInsetItem after>
 									<ClayTooltipProvider>
 										<ClayButtonWithIcon


### PR DESCRIPTION
**Description**

Previous changes: https://github.com/liferay-frontend/liferay-portal/pull/751.

We can remove the selected target from the input box only when the experiment is in draft status.

**Screenshot**

<img width="318" alt="Screenshot 2021-02-15 at 17 48 23" src="https://user-images.githubusercontent.com/15845466/107974413-d5679b00-6fb6-11eb-94fd-bdb407f38c50.png">