### PR TITLE
LPS-127923 Standardize link-or-button controls markup in management toolbar

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
@@ -14,12 +14,11 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
-import ClayIcon from '@clayui/icon';
-import ClayLink from '@clayui/link';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import React from 'react';
 
 import getDataAttributes from '../get_data_attributes';
+import LinkOrButton from './LinkOrButton';
 
 const ActionControls = ({
 	actionDropdownItems,
@@ -37,34 +36,19 @@ const ActionControls = ({
 								className="navbar-breakpoint-down-d-none"
 								key={index}
 							>
-								{item.href ? (
-									<ClayLink
-										className="nav-link nav-link-monospaced"
-										displayType="unstyled"
-										href={item.href}
-										onClick={(event) => {
-											onActionButtonClick(event, {
-												item,
-											});
-										}}
-										title={item.label}
-									>
-										<ClayIcon symbol={item.icon} />
-									</ClayLink>
-								) : (
-									<ClayButtonWithIcon
-										className="nav-link nav-link-monospaced"
-										disabled={disabled || item.disabled}
-										displayType="unstyled"
-										onClick={(event) => {
-											onActionButtonClick(event, {
-												item,
-											});
-										}}
-										symbol={item.icon}
-										title={item.label}
-									/>
-								)}
+								<LinkOrButton
+									className="nav-link nav-link-monospaced"
+									disabled={disabled || item.disabled}
+									displayType="unstyled"
+									href={item.href}
+									onClick={(event) => {
+										onActionButtonClick(event, {
+											item,
+										});
+									}}
+									symbol={item.icon}
+									title={item.label}
+								/>
 							</ClayManagementToolbar.Item>
 						))}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -12,11 +12,11 @@
  * details.
  */
 
-import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
-import ClayIcon from '@clayui/icon';
-import ClayLink from '@clayui/link';
 import React, {useRef, useState} from 'react';
+
+import LinkOrButton from './LinkOrButton';
 
 const CreationMenu = ({
 	maxPrimaryItems,
@@ -117,33 +117,24 @@ const CreationMenu = ({
 							</div>
 
 							<div className="dropdown-section">
-								{viewMoreURL ? (
-									<ClayLink
-										button={{block: true}}
-										displayType="secondary"
-										href={viewMoreURL}
-									>
-										{Liferay.Language.get('more')}
-									</ClayLink>
-								) : (
-									<ClayButton
-										block={true}
-										displayType="secondary"
-										onClick={() => {
-											if (onShowMoreButtonClick) {
-												onShowMoreButtonClick();
+								<LinkOrButton
+									button={{block: true}}
+									displayType="secondary"
+									href={viewMoreURL}
+									onClick={() => {
+										if (onShowMoreButtonClick) {
+											onShowMoreButtonClick();
 
-												return;
-											}
+											return;
+										}
 
-											setVisibleItemsCount(
-												totalItemsCountRef.current
-											);
-										}}
-									>
-										{Liferay.Language.get('more')}
-									</ClayButton>
-								)}
+										setVisibleItemsCount(
+											totalItemsCountRef.current
+										);
+									}}
+								>
+									{Liferay.Language.get('more')}
+								</LinkOrButton>
 							</div>
 						</>
 					) : (
@@ -154,19 +145,12 @@ const CreationMenu = ({
 						/>
 					)}
 				</ClayDropDown>
-			) : primaryItems[0].href ? (
-				<ClayLink
+			) : (
+				<LinkOrButton
 					button={true}
 					className="nav-btn nav-btn-monospaced"
 					displayType="primary"
 					href={primaryItems[0].href}
-				>
-					<ClayIcon symbol="plus" />
-				</ClayLink>
-			) : (
-				<ClayButtonWithIcon
-					className="nav-btn nav-btn-monospaced"
-					displayType="primary"
 					onClick={(event) => {
 						onCreateButtonClick(event, {item: primaryItems[0]});
 					}}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
@@ -15,9 +15,10 @@
 import ClayButton from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import ClayLink from '@clayui/link';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import React from 'react';
+
+import LinkOrButton from './LinkOrButton';
 
 const FilterOrderControls = ({disabled, filterDropdownItems, sortingURL}) => {
 	return (
@@ -56,14 +57,14 @@ const FilterOrderControls = ({disabled, filterDropdownItems, sortingURL}) => {
 
 			{sortingURL && (
 				<ClayManagementToolbar.Item>
-					<ClayLink
+					<LinkOrButton
 						className="nav-link nav-link-monospaced"
+						disabled={disabled}
 						displayType="unstyled"
 						href={sortingURL}
+						symbol="order-arrow"
 						title={Liferay.Language.get('reverse-sort-direction')}
-					>
-						<ClayIcon symbol={'order-arrow'} />
-					</ClayLink>
+					/>
 				</ClayManagementToolbar.Item>
 			)}
 		</>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import ClayLink from '@clayui/link';
+import React from 'react';
+
+const LinkOrButton = ({
+	button,
+	children,
+	disabled,
+	href,
+	symbol,
+	...otherProps
+}) => {
+	return (
+		<>
+			{href && !disabled ? (
+				<ClayLink {...otherProps} button={button} href={href}>
+					{symbol ? <ClayIcon symbol={symbol} /> : children}
+				</ClayLink>
+			) : (
+				<ClayButton
+					{...otherProps}
+					block={button?.block}
+					disabled={disabled}
+				>
+					{symbol ? <ClayIcon symbol={symbol} /> : children}
+				</ClayButton>
+			)}
+		</>
+	);
+};
+
+export default LinkOrButton;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -12,11 +12,11 @@
  * details.
  */
 
-import ClayButton from '@clayui/button';
 import {ClayCheckbox} from '@clayui/form';
-import ClayLink from '@clayui/link';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import React, {useEffect, useRef, useState} from 'react';
+
+import LinkOrButton from './LinkOrButton';
 
 const SelectionControls = ({
 	actionDropdownItems,
@@ -167,85 +167,57 @@ const SelectionControls = ({
 					{supportsBulkActions && (
 						<>
 							<ClayManagementToolbar.Item className="nav-item-shrink">
-								{clearSelectionURL ? (
-									<ClayLink
-										className="nav-link"
-										href={clearSelectionURL}
-									>
-										<span className="text-truncate-inline">
-											<span className="text-truncate">
-												{Liferay.Language.get('clear')}
-											</span>
+								<LinkOrButton
+									className="nav-link"
+									displayType="unstyled"
+									href={clearSelectionURL}
+									onClick={(event) => {
+										searchContainerRef.current?.select?.toggleAllRows(
+											false
+										);
+
+										setActive(false);
+
+										setCheckboxStatus('unchecked');
+
+										onClearButtonClick(event);
+									}}
+								>
+									<span className="text-truncate-inline">
+										<span className="text-truncate">
+											{Liferay.Language.get('clear')}
 										</span>
-									</ClayLink>
-								) : (
-									<ClayButton
-										className="nav-link"
-										displayType="unstyled"
-										onClick={(event) => {
-											searchContainerRef.current?.select?.toggleAllRows(
-												false
-											);
-
-											setActive(false);
-
-											setCheckboxStatus('unchecked');
-
-											onClearButtonClick(event);
-										}}
-									>
-										<span className="text-truncate-inline">
-											<span className="text-truncate">
-												{Liferay.Language.get('clear')}
-											</span>
-										</span>
-									</ClayButton>
-								)}
+									</span>
+								</LinkOrButton>
 							</ClayManagementToolbar.Item>
 
 							{selectAllButtonVisible && (
 								<ClayManagementToolbar.Item className="nav-item-shrink">
-									{selectAllURL ? (
-										<ClayLink
-											className="nav-link"
-											href={selectAllURL}
-										>
-											<span className="text-truncate-inline">
-												<span className="text-truncate">
-													{Liferay.Language.get(
-														'select-all'
-													)}
-												</span>
+									<LinkOrButton
+										className="nav-link"
+										displayType="unstyled"
+										href={selectAllURL}
+										onClick={(event) => {
+											searchContainerRef.current?.select?.toggleAllRows(
+												true,
+												true
+											);
+
+											setSelectAllButtonVisible(false);
+
+											setSelectedItems(itemsTotal);
+
+											onSelectAllButtonClick(event);
+										}}
+									>
+										<span className="text-truncate-inline">
+											<span className="text-truncate">
+												{Liferay.Language.get(
+													'select-all'
+												)}
 											</span>
-										</ClayLink>
-									) : (
-										<ClayButton
-											className="nav-link"
-											displayType="unstyled"
-											onClick={(event) => {
-												searchContainerRef.current?.select?.toggleAllRows(
-													true,
-													true
-												);
-
-												setSelectAllButtonVisible(
-													false
-												);
-
-												setSelectedItems(itemsTotal);
-
-												onSelectAllButtonClick(event);
-											}}
-										>
-											<span className="text-truncate-inline">
-												<span className="text-truncate">
-													{Liferay.Language.get(
-														'select-all'
-													)}
-												</span>
-											</span>
-										</ClayButton>
-									)}
+										</span>
+									</LinkOrButton>
 								</ClayManagementToolbar.Item>
 							)}
 						</>


### PR DESCRIPTION
@ambrinchaudhary  @julien @jonmak08 

The main purpose of this PR is to squash a lot of code duplication in management toolbar tag. In quite a few places we are doing
```js
if (href) ? <ClayLink ... /> : <ClayButton ... />
```
... with a lot of same props. Instead, in this PR we are introducing
```js
<LinkOrButton />
```
There is the [LinkOrButton](https://github.com/liferay/clay/blob/master/packages/clay-shared/src/LinkOrButton.tsx) in Clay, but I opted not to use it. There as significant differences in API and implementation:
- we want `disabled` prop to render a disabled button, to match cases in [management toolbar v2](https://github.com/liferay/clay/blob/2.x/packages/clay-management-toolbar/src/ClayManagementToolbar.soy#L733).
- we want to support `symbol` prop, with `children` as fallback
- we want to support `button` prop
- we don't need two `*DisplayTypes`

Clay's LinkOrButton is in @clayui/shared, probably not intended to be used externally. It is used internally in several places, so there would need to be some refactoring, quickly complicating solution. Maybe this would make sense to do if there are other DXP modules that could use this component. I don't know of any.

Along with this refactoring, we are fixing a bug, where sort button is never disabled:
![screen](https://user-images.githubusercontent.com/5435511/107976314-a3a40380-6fb9-11eb-9be4-312d8cbe6b0b.png)

Before it was a `ClayLink` that cannot be disabled, now it is a `LinkOrButton` that can be disabled.

Finally, I should note that I flipped a coin to call it `<LinkOrButton />` or `<Control />`. Control sounds better, but is not quite accurate, as it can be an element that is not a link or a button.