### PR TITLE
LPS-127936 Check if searchControl's select exists

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -73,27 +73,28 @@ function ManagementToolbar({
 		<>
 			<ClayManagementToolbar active={active}>
 				<ClayManagementToolbar.ItemList>
-					<SelectionControls
-						actionDropdownItems={actionDropdownItems}
-						active={active}
-						clearSelectionURL={clearSelectionURL}
-						disabled={disabled}
-						initialCheckboxStatus={initialCheckboxStatus}
-						initialSelectAllButtonVisible={
-							initialSelectAllButtonVisible
-						}
-						initialSelectedItems={initialSelectedItems}
-						itemsTotal={itemsTotal}
-						onCheckboxChange={onCheckboxChange}
-						onClearButtonClick={onClearSelectionButtonClick}
-						onSelectAllButtonClick={onSelectAllButtonClick}
-						searchContainerId={searchContainerId}
-						selectAllURL={selectAllURL}
-						selectable={selectable}
-						setActionDropdownItems={setActionDropdownItems}
-						setActive={setActive}
-						supportsBulkActions={supportsBulkActions}
-					/>
+					{selectable && (
+						<SelectionControls
+							actionDropdownItems={actionDropdownItems}
+							active={active}
+							clearSelectionURL={clearSelectionURL}
+							disabled={disabled}
+							initialCheckboxStatus={initialCheckboxStatus}
+							initialSelectAllButtonVisible={
+								initialSelectAllButtonVisible
+							}
+							initialSelectedItems={initialSelectedItems}
+							itemsTotal={itemsTotal}
+							onCheckboxChange={onCheckboxChange}
+							onClearButtonClick={onClearSelectionButtonClick}
+							onSelectAllButtonClick={onSelectAllButtonClick}
+							searchContainerId={searchContainerId}
+							selectAllURL={selectAllURL}
+							setActionDropdownItems={setActionDropdownItems}
+							setActive={setActive}
+							supportsBulkActions={supportsBulkActions}
+						/>
+					)}
 
 					{!active && (
 						<FilterOrderControls

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -32,7 +32,6 @@ const SelectionControls = ({
 	onSelectAllButtonClick,
 	searchContainerId,
 	selectAllURL,
-	selectable,
 	setActionDropdownItems,
 	setActive,
 	supportsBulkActions,
@@ -85,6 +84,10 @@ const SelectionControls = ({
 
 			const select = searchContainer.select;
 
+			if (!select) {
+				return;
+			}
+
 			const bulkSelection =
 				supportsBulkActions && select.get('bulkSelection');
 
@@ -125,30 +128,26 @@ const SelectionControls = ({
 
 	return (
 		<>
-			{selectable && (
-				<ClayManagementToolbar.Item>
-					<ClayCheckbox
-						checked={checkboxStatus !== 'unchecked'}
-						disabled={disabled}
-						indeterminate={checkboxStatus === 'indeterminate'}
-						onChange={(event) => {
-							onCheckboxChange(event);
+			<ClayManagementToolbar.Item>
+				<ClayCheckbox
+					checked={checkboxStatus !== 'unchecked'}
+					disabled={disabled}
+					indeterminate={checkboxStatus === 'indeterminate'}
+					onChange={(event) => {
+						onCheckboxChange(event);
 
-							const checked = event.target.checked;
+						const checked = event.target.checked;
 
-							setActive(checked);
+						setActive(checked);
 
-							setCheckboxStatus(
-								checked ? 'checked' : 'unchecked'
-							);
+						setCheckboxStatus(checked ? 'checked' : 'unchecked');
 
-							searchContainerRef.current?.select?.toggleAllRows(
-								checked
-							);
-						}}
-					/>
-				</ClayManagementToolbar.Item>
-			)}
+						searchContainerRef.current?.select?.toggleAllRows(
+							checked
+						);
+					}}
+				/>
+			</ClayManagementToolbar.Item>
 
 			{active && (
 				<>


### PR DESCRIPTION
In the metal+soy version of the ManagamentToolbar, [we used to check if
the searchContainer's select (plugin) was present](https://github.com/liferay/liferay-portal/blob/eb44efa36ce0ed22e8d59a1a2acce659a6f411e2/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.es.js#L55-L60) before trying to use it.

In our current React version, we [don't have this check](https://github.com/liferay/liferay-portal/blob/eb44efa36ce0ed22e8d59a1a2acce659a6f411e2/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js#L112-L114), and if the
`liferay-search-container-select` AUI plugin/module is not present, (because it
[doesn't always get loaded](https://github.com/liferay/liferay-portal/blob/eb44efa36ce0ed22e8d59a1a2acce659a6f411e2/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/bottom.jspf#L42
)) the component will throw an error making the
management toolbar unusable.

So in this change, we're simply adding that check.