### PR TITLE
LPS-121890 Migrate v2 usages in Message Boards

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -92,6 +92,12 @@ function ManagementToolbar({
 							selectAllURL={selectAllURL}
 							setActionDropdownItems={setActionDropdownItems}
 							setActive={setActive}
+							showCheckBoxLabel={
+								!active &&
+								!filterDropdownItems &&
+								!sortingURL &&
+								!showSearch
+							}
 							supportsBulkActions={supportsBulkActions}
 						/>
 					)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -34,6 +34,7 @@ const SelectionControls = ({
 	selectAllURL,
 	setActionDropdownItems,
 	setActive,
+	showCheckBoxLabel,
 	supportsBulkActions,
 }) => {
 	const [selectedItems, setSelectedItems] = useState(initialSelectedItems);
@@ -133,6 +134,11 @@ const SelectionControls = ({
 					checked={checkboxStatus !== 'unchecked'}
 					disabled={disabled}
 					indeterminate={checkboxStatus === 'indeterminate'}
+					label={
+						showCheckBoxLabel
+							? Liferay.Language.get('select-items')
+							: ''
+					}
 					onChange={(event) => {
 						onCheckboxChange(event);
 

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBBannedUsersManagementToolbarDisplayContext.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBBannedUsersManagementToolbarDisplayContext.java
@@ -27,12 +27,17 @@ import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.PortletURL;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -66,6 +71,21 @@ public class MBBannedUsersManagementToolbarDisplayContext {
 					LanguageUtil.get(_httpServletRequest, "unban-user"));
 
 				dropdownItem.setQuickAction(true);
+			}
+		).build();
+	}
+
+	public Map<String, Object> getAdditionalProps() {
+		return HashMapBuilder.<String, Object>put(
+			"banUsersURL",
+			() -> {
+				PortletURL banUsersURL =
+					_liferayPortletResponse.createActionURL();
+
+				banUsersURL.setParameter(
+					ActionRequest.ACTION_NAME, "/message_boards/ban_user");
+
+				return banUsersURL.toString();
 			}
 		).build();
 	}

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBEntriesManagementToolbarDisplayContext.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBEntriesManagementToolbarDisplayContext.java
@@ -43,6 +43,8 @@ import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -51,8 +53,10 @@ import com.liferay.trash.TrashHelper;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
+import javax.portlet.ActionRequest;
 import javax.portlet.PortletException;
 import javax.portlet.PortletURL;
 
@@ -123,6 +127,39 @@ public class MBEntriesManagementToolbarDisplayContext {
 					LanguageUtil.get(_httpServletRequest, "unlock"));
 				dropdownItem.setQuickAction(true);
 			}
+		).build();
+	}
+
+	public Map<String, Object> getAdditionalProps() {
+		return HashMapBuilder.<String, Object>put(
+			"deleteEntriesCmd",
+			() -> {
+				if (_trashHelper.isTrashEnabled(
+						_themeDisplay.getScopeGroupId())) {
+
+					return Constants.MOVE_TO_TRASH;
+				}
+
+				return Constants.DELETE;
+			}
+		).put(
+			"editEntryURL",
+			() -> {
+				PortletURL editEntryURL =
+					_liferayPortletResponse.createActionURL();
+
+				editEntryURL.setParameter(
+					ActionRequest.ACTION_NAME, "/message_boards/edit_entry");
+
+				return editEntryURL.toString();
+			}
+		).put(
+			"lockCmd", Constants.LOCK
+		).put(
+			"trashEnabled",
+			() -> _trashHelper.isTrashEnabled(_themeDisplay.getScopeGroupId())
+		).put(
+			"unlockCmd", Constants.UNLOCK
 		).build();
 	}
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
@@ -133,7 +133,6 @@ page import="com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker" %><%@
 page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
 page import="com.liferay.portal.kernel.editor.Editor" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
-page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
 page import="com.liferay.portal.kernel.log.Log" %><%@
 page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.model.ModelHintsConstants" %><%@

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/js/BanUsersManagementToolbarPropsTransformer.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/js/BanUsersManagementToolbarPropsTransformer.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {postForm} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {banUsersURL},
+	portletNamespace,
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		onActionButtonClick: (event, {item}) => {
+			if (item?.data?.action === 'unbanUser') {
+				const form = document.getElementById(`${portletNamespace}fm`);
+
+				if (!form) {
+					return;
+				}
+
+				postForm(form, {
+					data: {
+						cmd: 'unban',
+					},
+					url: banUsersURL,
+				});
+			}
+		},
+	};
+}

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/js/MBEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/js/MBEntriesManagementToolbarPropsTransformer.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {postForm} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {
+		deleteEntriesCmd,
+		editEntryURL,
+		lockCmd,
+		trashEnabled,
+		unlockCmd,
+	},
+	portletNamespace,
+	...otherProps
+}) {
+	const form = document.getElementById(`${portletNamespace}fm`);
+
+	const deleteEntries = () => {
+		const message = trashEnabled
+			? Liferay.Language.get(
+					'are-you-sure-you-want-to-move-the-selected-entries-to-the-recycle-bin'
+			  )
+			: Liferay.Language.get(
+					'are-you-sure-you-want-to-delete-the-selected-entries'
+			  );
+
+		if (trashEnabled || confirm(Liferay.Language.get(message))) {
+			postForm(form, {
+				data: {
+					cmd: deleteEntriesCmd,
+				},
+				url: editEntryURL,
+			});
+		}
+	};
+
+	const lockEntries = () => {
+		postForm(form, {
+			data: {
+				cmd: lockCmd,
+			},
+			url: editEntryURL,
+		});
+	};
+
+	const unlockEntries = () => {
+		postForm(form, {
+			data: {
+				cmd: unlockCmd,
+			},
+			url: editEntryURL,
+		});
+	};
+
+	return {
+		...otherProps,
+		onActionButtonClick: (event, {item}) => {
+			if (!form) {
+				return;
+			}
+
+			const action = item?.data?.action;
+			if (action === 'deleteEntries') {
+				deleteEntries();
+			}
+			else if (action === 'lockEntries') {
+				lockEntries();
+			}
+			else if (action === 'unlockEntries') {
+				unlockEntries();
+			}
+		},
+	};
+}

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view.jsp
@@ -69,8 +69,9 @@ mbAdminListDisplayContext.populateResultsAndTotal(entriesSearchContainer);
 String entriesNavigation = ParamUtil.getString(request, "entriesNavigation", "all");
 %>
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	actionDropdownItems="<%= mbEntriesManagementToolbarDisplayContext.getActionDropdownItems() %>"
+	additionalProps="<%= mbEntriesManagementToolbarDisplayContext.getAdditionalProps() %>"
 	clearResultsURL="<%= mbEntriesManagementToolbarDisplayContext.getSearchActionURL() %>"
 	componentId="mbEntriesManagementToolbar"
 	creationMenu="<%= mbEntriesManagementToolbarDisplayContext.getCreationMenu() %>"
@@ -78,6 +79,7 @@ String entriesNavigation = ParamUtil.getString(request, "entriesNavigation", "al
 	filterDropdownItems="<%= mbEntriesManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	filterLabelItems="<%= mbEntriesManagementToolbarDisplayContext.getFilterLabelItems() %>"
 	itemsTotal="<%= entriesSearchContainer.getTotal() %>"
+	propsTransformer="message_boards_admin/js/MBEntriesManagementToolbarPropsTransformer"
 	searchActionURL="<%= mbEntriesManagementToolbarDisplayContext.getSearchActionURL() %>"
 	searchContainerId="mbEntries"
 	searchFormName="searchFm"
@@ -94,62 +96,3 @@ if (category != null) {
 	PortalUtil.setPageDescription(category.getDescription(), request);
 }
 %>
-
-<aui:script>
-	var form = document.<portlet:namespace />fm;
-
-	<portlet:actionURL name="/message_boards/edit_entry" var="editEntryURL" />
-
-	var deleteEntries = function () {
-		if (
-			<%= trashHelper.isTrashEnabled(scopeGroupId) %> ||
-			confirm(
-				'<%= UnicodeLanguageUtil.get(request, trashHelper.isTrashEnabled(scopeGroupId) ? "are-you-sure-you-want-to-move-the-selected-entries-to-the-recycle-bin" : "are-you-sure-you-want-to-delete-the-selected-entries") %>'
-			)
-		) {
-			Liferay.Util.postForm(form, {
-				data: {
-					<%= Constants.CMD %>:
-						'<%= trashHelper.isTrashEnabled(scopeGroupId) ? Constants.MOVE_TO_TRASH : Constants.DELETE %>',
-				},
-				url: '<%= editEntryURL %>',
-			});
-		}
-	};
-
-	var lockEntries = function () {
-		Liferay.Util.postForm(form, {
-			data: {
-				<%= Constants.CMD %>: '<%= Constants.LOCK %>',
-			},
-			url: '<%= editEntryURL %>',
-		});
-	};
-
-	var unlockEntries = function () {
-		Liferay.Util.postForm(form, {
-			data: {
-				<%= Constants.CMD %>: '<%= Constants.UNLOCK %>',
-			},
-			url: '<%= editEntryURL %>',
-		});
-	};
-
-	var ACTIONS = {
-		deleteEntries: deleteEntries,
-		lockEntries: lockEntries,
-		unlockEntries: unlockEntries,
-	};
-
-	Liferay.componentReady('mbEntriesManagementToolbar').then(
-		(managementToolbar) => {
-			managementToolbar.on('actionItemClicked', (event) => {
-				var itemData = event.data.item.data;
-
-				if (itemData && itemData.action && ACTIONS[itemData.action]) {
-					ACTIONS[itemData.action]();
-				}
-			});
-		}
-	);
-</aui:script>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_banned_users.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_banned_users.jsp
@@ -32,11 +32,13 @@ MBBannedUsersManagementToolbarDisplayContext mbBannedUsersManagementToolbarDispl
 int totalBannedUsers = MBBanLocalServiceUtil.getBansCount(scopeGroupId);
 %>
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	actionDropdownItems="<%= mbBannedUsersManagementToolbarDisplayContext.getActionDropdownItems() %>"
+	additionalProps="<%= mbBannedUsersManagementToolbarDisplayContext.getAdditionalProps() %>"
 	componentId="mbBannedUsersManagementToolbar"
 	disabled="<%= totalBannedUsers == 0 %>"
 	itemsTotal="<%= totalBannedUsers %>"
+	propsTransformer="message_boards_admin/js/BanUsersManagementToolbarPropsTransformer"
 	searchContainerId="mbBanUsers"
 	showCreationMenu="<%= false %>"
 	showInfoButton="<%= false %>"
@@ -136,30 +138,3 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, TextForm
 
 PortalUtil.setPageSubtitle(LanguageUtil.get(request, "banned-users"), request);
 %>
-
-<aui:script>
-	var unbanUser = function () {
-		Liferay.Util.postForm(document.<portlet:namespace />fm, {
-			data: {
-				<%= Constants.CMD %>: 'unban',
-			},
-			url: '<portlet:actionURL name="/message_boards/ban_user" />',
-		});
-	};
-
-	var ACTIONS = {
-		unbanUser: unbanUser,
-	};
-
-	Liferay.componentReady('mbBannedUsersManagementToolbar').then(
-		(managementToolbar) => {
-			managementToolbar.on('actionItemClicked', (event) => {
-				var itemData = event.data.item.data;
-
-				if (itemData && itemData.action && ACTIONS[itemData.action]) {
-					ACTIONS[itemData.action]();
-				}
-			});
-		}
-	);
-</aui:script>


### PR DESCRIPTION
@markocikos @julien @jonmak08 

Hey guys, I'm sending you this PR before to the Lima team because of this [change](https://github.com/liferay-frontend/liferay-portal/pull/801/commits/9585dc904499f3971b0612acc4a94b1f0ab29d33) in the Management toolbar. 

See in the screenshot the comparison with the V2, there was a label for the checkbox if other elements on the right where not present (see https://github.com/liferay/clay/blob/2.x/packages/clay-management-toolbar/src/ClayManagementToolbar.soy\#L670)

<img width="1287" alt="MT message boards" src="https://user-images.githubusercontent.com/8373764/108123495-3b7f1b80-70a6-11eb-9133-c855d457a863.png">


Test plan for adding Banned User: 

1. With "Test" user, create a thread. 
2. Create a new user (must not have admin role)
3. Login with the new user
4. Reply to the previous thread opened by Test
5. Login again with "Test"
6. On the new message created with the other user, click on the kebab menu and select "Ban this user"

<img width="995" alt="Screenshot 2021-02-16 at 22 32 21" src="https://user-images.githubusercontent.com/8373764/108123976-f0b1d380-70a6-11eb-9593-5d81de30436e.png">

 