### PR TITLE
COMMERCE-4013 accept-language headers aligned with liferay standards

### DIFF
--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/utilities/index.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/utilities/index.js
@@ -16,20 +16,9 @@ import {fetch} from 'frontend-js-web';
 
 import createOdataFilter from './odata';
 
-export function getAcceptLanguageHeaderParam() {
-	const browserLang = navigator.language || navigator.userLanguage;
-	const themeLang = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
-
-	if (browserLang === themeLang) {
-		return browserLang;
-	}
-
-	return `${browserLang}, ${themeLang};q=0.8`;
-}
-
 export const fetchHeaders = new Headers({
 	Accept: 'application/json',
-	'Accept-Language': getAcceptLanguageHeaderParam(),
+	'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
 	'Content-Type': 'application/json',
 });
 

--- a/modules/apps/commerce/commerce-frontend-js/test/dev/public/js/static-env-utils.js
+++ b/modules/apps/commerce/commerce-frontend-js/test/dev/public/js/static-env-utils.js
@@ -23,6 +23,7 @@ const Liferay = {
 		},
 	},
 	ThemeDisplay: {
+		getBCP47LanguageId: () => 'en-US',
 		getCanonicalURL: () => '/',
 		getDefaultLanguageId: () => 'en_US',
 		getLanguageId: () => 'it_IT',

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/AutocompleteFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/AutocompleteFilter.js
@@ -23,11 +23,7 @@ import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
-import {
-	getAcceptLanguageHeaderParam,
-	getValueFromItem,
-	isValuesArrayChanged,
-} from '../../../utils/index';
+import {getValueFromItem, isValuesArrayChanged} from '../../../utils/index';
 import {logError} from '../../../utils/logError';
 
 const DEFAULT_PAGE_SIZE = 10;
@@ -44,7 +40,7 @@ function fetchData(apiURL, searchParam, currentPage = 1) {
 
 	return fetch(url, {
 		headers: {
-			'Accept-Language': getAcceptLanguageHeaderParam(),
+			'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
 		},
 	}).then((response) => response.json());
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utils/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/utils/index.js
@@ -22,15 +22,6 @@ export function delay(duration) {
 	});
 }
 
-export function getAcceptLanguageHeaderParam() {
-	const browserLang = navigator.language ?? navigator.userLanguage;
-	const themeLang = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
-
-	return browserLang === themeLang
-		? browserLang
-		: `${browserLang}, ${themeLang};q=0.8`;
-}
-
 export function getData(apiURL, query) {
 	const url = new URL(apiURL);
 
@@ -162,7 +153,7 @@ export function executeAsyncAction(url, method = 'GET') {
 	return fetch(url, {
 		headers: {
 			Accept: 'application/json',
-			'Accept-Language': getAcceptLanguageHeaderParam(),
+			'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
 			'Content-Type': 'application/json',
 		},
 		method,

--- a/modules/dxp/apps/commerce/commerce-bom-admin-web/src/main/resources/META-INF/resources/js/actions/area.es.js
+++ b/modules/dxp/apps/commerce/commerce-bom-admin-web/src/main/resources/META-INF/resources/js/actions/area.es.js
@@ -37,20 +37,9 @@ export const actionDefinition = {
 	UPDATE_FORM_VALUE: 'updateFormValue',
 };
 
-export function getAcceptLanguageHeaderParam() {
-	const browserLang = navigator.language || navigator.userLanguage;
-	const themeLang = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
-
-	if (browserLang === themeLang) {
-		return browserLang;
-	}
-
-	return `${browserLang}, ${themeLang};q=0.8`;
-}
-
 export const fetchHeaders = new Headers({
 	Accept: 'application/json',
-	'Accept-Language': getAcceptLanguageHeaderParam(),
+	'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
 	'Content-Type': 'application/json',
 });
 


### PR DESCRIPTION
Purpose of this PR is replacing all the occurrences of `getAcceptLanguageHeaderParam` with `Liferay.ThemeDisplay.getBCP47LanguageId` which is widely used in portal.

The fetched data will then result correctly localised.

---
This is is a copy of [this PR](https://github.com/liferay-commerce/liferay-portal/pull/619)