### PR TITLE
LPS-127998 Localize label when setting status

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/LabelItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/LabelItem.java
@@ -14,6 +14,8 @@
 
 package com.liferay.frontend.taglib.clay.servlet.taglib.util;
 
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.HashMap;
@@ -73,7 +75,10 @@ public class LabelItem extends HashMap<String, Object> {
 	}
 
 	public void setStatus(int status) {
-		setLabel(WorkflowConstants.getStatusLabel(status));
+		setLabel(
+			LanguageUtil.get(
+				LocaleUtil.getMostRelevantLocale(),
+				WorkflowConstants.getStatusLabel(status)));
 
 		setStyle(WorkflowConstants.getStatusStyle(status));
 	}


### PR DESCRIPTION
This pull fixes [LPS-127998](https://issues.liferay.com/browse/LPS-127998)

Reproduction steps:

1. In a clean bundle create a basic web content
2. Change the display style to "Cards" from the management toolbar
3. Change the user display language to spanish

Expected behavior:

- Content's status is showed in spanish ("Aprobado")

Actual behavior:

- When the page is loading the content's status is showed in spanish but when page load ends it is changed showing the English translation