### PR TITLE
LPS-122094 Flip JSPArrowFunctionCheck default to disabled

### DIFF
--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -911,6 +911,7 @@
 		<check name="JSPArrowFunctionCheck">
 			<category name="Bug Prevention" />
 			<description name="Checks that there are no array functions." />
+			<property name="enabled" value="false" />
 		</check>
 		<check name="JSPDefineObjectsCheck">
 			<category name="Performance" />

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -110,7 +110,6 @@
 		<suppress checks="JavaXMLSecurityCheck" files="portal-impl/src/com/liferay/portal/xml/SAXReaderFactory\.java" />
 		<suppress checks="JavaXMLSecurityCheck" files="util-java/src/com/liferay/util/ant/Java2WsddTask\.java" />
 		<suppress checks="JavaXMLSecurityCheck" files="util-java/src/com/liferay/util/xml/XMLMergerRunner\.java" />
-		<suppress checks="JSPArrowFunctionCheck" />
 		<suppress checks="JSPIllegalSyntaxCheck" files="portal-web/docroot/html/portal/api/jsonws/action\.jsp" />
 		<suppress checks="JSPLineBreakCheck" files="portal-web/docroot/html/portal/progress_poller\.jsp" />
 		<suppress checks="LocaleUtilCheck" files="portal-kernel/src/com/liferay/portal/kernel/util/LocaleUtil\.java" />


### PR DESCRIPTION
Instead of a suppression that will live on in `master` (and then `7.4.x`, `7.5.x` etc) for the foreseeable future, get rid of the suppression, flip the default for the check to `enabled=false`. We'll then turn the check back on on the older branches (will send separate PRs for those soon).

This is follow-up as discussed on [#98778](https://github.com/brianchandotcom/liferay-portal/pull/98778#issuecomment-779787201) and [in Slack](https://liferay.slack.com/archives/C1SJ64S9X/p1613407506004600).