### PR TITLE
COMMERCE-5644 dataset display - default string props fixed when empty ones are passed

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/init.jsp
@@ -14,6 +14,8 @@
  */
 --%>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
@@ -25,7 +27,8 @@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONSerializer" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.PortalUtil" %>
+page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
+page import="com.liferay.portal.kernel.util.Validator" %>
 
 <%@ page import="java.util.List" %>
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/page.jsp
@@ -36,27 +36,40 @@
 			creationMenu: <%= jsonSerializer.serializeDeep(creationMenu) %>,
 			currentURL: '<%= PortalUtil.getCurrentURL(request) %>',
 			dataProviderKey: '<%= dataProviderKey %>',
-			formId: '<%= GetterUtil.getString(formId) %>',
+			<c:if test="<%= Validator.isNotNull(formId) %>">
+				formId: '<%= formId %>',
+			</c:if>
 			id: '<%= id %>',
-			nestedItemsKey: '<%= GetterUtil.getString(nestedItemsKey) %>',
-			nestedItemsReferenceKey:
-				'<%= GetterUtil.getString(nestedItemsReferenceKey) %>',
+			namespace: '<%= namespace %>',
+			<c:if test="<%= Validator.isNotNull(nestedItemsKey) %>">
+				nestedItemsKey: '<%= nestedItemsKey %>',
+			</c:if>
+
+			<c:if test="<%= Validator.isNotNull(nestedItemsReferenceKey) %>">
+				nestedItemsReferenceKey: '<%= nestedItemsReferenceKey %>',
+			</c:if>
 			pagination: {
 				deltas: <%= jsonSerializer.serializeDeep(clayPaginationEntries) %>,
 				initialDelta: <%= itemsPerPage %>,
 				initialPageNumber: <%= pageNumber %>,
 			},
-			showManagementBar: <%= showManagementBar %>,
-			showPagination: <%= showPagination %>,
-			showSearch: <%= showSearch %>,
-			namespace: '<%= namespace %>',
 			portletId: '<%= portletDisplay.getRootPortletId() %>',
 			portletURL: '<%= portletURL %>',
 			selectedItems: <%= jsonSerializer.serializeDeep(selectedItems) %>,
-			selectedItemsKey: '<%= GetterUtil.getString(selectedItemsKey) %>',
-			selectionType: '<%= GetterUtil.getString(selectionType) %>',
+			<c:if test="<%= Validator.isNotNull(selectedItemsKey) %>">
+				selectedItemsKey: '<%= selectedItemsKey %>',
+			</c:if>
+
+			<c:if test="<%= Validator.isNotNull(selectionType) %>">
+				selectionType: '<%= selectionType %>',
+			</c:if>
+			showManagementBar: <%= showManagementBar %>,
+			showPagination: <%= showPagination %>,
+			showSearch: <%= showSearch %>,
 			sorting: <%= jsonSerializer.serializeDeep(sortItemList) %>,
-			style: '<%= style %>',
+			<c:if test="<%= Validator.isNotNull(style) %>">
+				style: '<%= style %>',
+			</c:if>
 			views: <%= jsonSerializer.serializeDeep(clayDataSetDisplayViewsContext) %>,
 		},
 		container

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/init.jsp
@@ -14,6 +14,8 @@
  */
 --%>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
@@ -26,7 +28,8 @@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONSerializer" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.PortalUtil" %>
+page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
+page import="com.liferay.portal.kernel.util.Validator" %>
 
 <%@ page import="java.util.List" %>
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/headless_data_set_display/page.jsp
@@ -41,13 +41,19 @@ JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
 			creationMenu: <%= jsonSerializer.serializeDeep(creationMenu) %>,
 			currentURL: '<%= PortalUtil.getCurrentURL(request) %>',
 			filters: <%= jsonSerializer.serializeDeep(clayDataSetFiltersContext) %>,
-			formId: '<%= GetterUtil.getString(formId) %>',
+			<c:if test="<%= Validator.isNotNull(formId) %>">
+				formId: '<%= formId %>',
+			</c:if>
 			id: '<%= id %>',
 			itemsActions: <%= jsonSerializer.serializeDeep(clayDataSetActionDropdownItems) %>,
 			namespace: '<%= namespace %>',
-			nestedItemsKey: '<%= GetterUtil.getString(nestedItemsKey) %>',
-			nestedItemsReferenceKey:
-				'<%= GetterUtil.getString(nestedItemsReferenceKey) %>',
+			<c:if test="<%= Validator.isNotNull(nestedItemsKey) %>">
+				nestedItemsKey: '<%= nestedItemsKey %>',
+			</c:if>
+
+			<c:if test="<%= Validator.isNotNull(nestedItemsReferenceKey) %>">
+				nestedItemsReferenceKey: '<%= nestedItemsReferenceKey %>',
+			</c:if>
 			pagination: {
 				deltas: <%= jsonSerializer.serializeDeep(clayPaginationEntries) %>,
 				initialDelta: <%= itemsPerPage %>,
@@ -56,13 +62,20 @@ JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
 			portletId: '<%= portletDisplay.getRootPortletId() %>',
 			portletURL: '<%= portletURL %>',
 			selectedItems: <%= jsonSerializer.serializeDeep(selectedItems) %>,
-			selectedItemsKey: '<%= GetterUtil.getString(selectedItemsKey) %>',
+			<c:if test="<%= Validator.isNotNull(selectedItemsKey) %>">
+				selectedItemsKey: '<%= selectedItemsKey %>',
+			</c:if>
+
+			<c:if test="<%= Validator.isNotNull(selectionType) %>">
+				selectionType: '<%= selectionType %>',
+			</c:if>
 			showManagementBar: <%= showManagementBar %>,
-			showSearch: <%= showSearch %>,
-			style: '<%= style %>',
-			selectionType: '<%= GetterUtil.getString(selectionType) %>',
 			showPagination: <%= showPagination %>,
+			showSearch: <%= showSearch %>,
 			sorting: <%= jsonSerializer.serializeDeep(sortItemList) %>,
+			<c:if test="<%= Validator.isNotNull(style) %>">
+				style: '<%= style %>',
+			</c:if>
 			views: <%= jsonSerializer.serializeDeep(clayDataSetDisplayViewsContext) %>,
 		},
 		document.getElementById('<%= containerId %>')


### PR DESCRIPTION
At the moment when a dataset is invoked, if a string prop is not initialised, it is passed anyway as an empty string.

This invalidates `defaultProps` within the dataset display because in order to be used they need the prop to be `undefined`, not just `falsy`.

I've also sorted the props names