### PR TITLE
COMMERCE-5695 dataset event definitions path updated

### DIFF
--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/definition_pricing_class/definition_pricing_classes.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/definition_pricing_class/definition_pricing_classes.jsp
@@ -28,7 +28,7 @@ CProduct cProduct = cpDefinition.getCProduct();
 	<div class="pt-4" id="<portlet:namespace />productPricingClassRelsContainer">
 		<div id="item-finder-root"></div>
 
-		<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/utilities/index as utilities">
+		<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/utilities/index as utilities">
 			var headers = utilities.fetchParams.headers;
 			var productId = <%= cpDefinition.getCProductId() %>;
 			var productExternalReferenceCode = '<%= cProduct.getExternalReferenceCode() %>';

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/account_groups.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/account_groups.jspf
@@ -19,7 +19,7 @@
 		<div class="col-12">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommerceDiscountAccountGroupsResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/accounts.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/accounts.jspf
@@ -19,7 +19,7 @@
 		<div class="col-12">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommerceDiscountAccountsResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/channels.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/channels.jspf
@@ -19,7 +19,7 @@
 		<div class="col-12">
 			<div id="item-finder-root-channel"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommerceDiscountChannelsResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/edit_commerce_discount_rule.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/edit_commerce_discount_rule.jsp
@@ -86,7 +86,7 @@ String type = BeanParamUtil.getString(commerceDiscountRule, request, "type");
 	</aui:form>
 </commerce-ui:side-panel-content>
 
-<aui:script require="commerce-frontend-js/utilities/notifications as NotificationUtils, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+<aui:script require="commerce-frontend-js/utilities/notifications as NotificationUtils, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 	var CommerceDiscountRuleResource = ServiceProvider.default.AdminPricingAPI(
 		'v2'
 	);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/type/products.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/type/products.jspf
@@ -25,7 +25,7 @@ String typeSettings = unicodeProperties.getProperty(commerceDiscountRule.getType
 
 	<aui:input id="typeSettings" name="typeSettings" type="hidden" value="<%= (typeSettings == null) ? StringPool.BLANK : typeSettings %>" />
 
-	<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+	<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 		var CommerceDiscountRuleResource = ServiceProvider.default.AdminPricingAPI(
 			'v2'
 		);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/categories.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/categories.jspf
@@ -19,7 +19,7 @@
 		<div class="col-12">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommerceDiscountCategoriesResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/pricing_classes.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/pricing_classes.jspf
@@ -19,7 +19,7 @@
 		<div class="col-12">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommerceDiscountProductGroupsResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/products.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/products.jspf
@@ -19,7 +19,7 @@
 		<div class="col-12">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommerceDiscountProductsResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_entries.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_entries.jsp
@@ -34,7 +34,7 @@ if (CommercePriceListConstants.TYPE_PROMOTION.equals(commercePriceEntryDisplayCo
 		<div class="col-12">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommercePriceEntriesResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/categories.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/categories.jsp
@@ -28,7 +28,7 @@ long commercePriceModifierId = commercePriceListDisplayContext.getCommercePriceM
 		<div class="col-12">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommercePriceModifierCategoriesResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/pricing_classes.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/pricing_classes.jsp
@@ -28,7 +28,7 @@ long commercePriceModifierId = commercePriceListDisplayContext.getCommercePriceM
 		<div class="col-12">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommercePriceModifierProductGroupsResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/products.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/products.jsp
@@ -28,7 +28,7 @@ long commercePriceModifierId = commercePriceListDisplayContext.getCommercePriceM
 		<div class="col-12">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommercePriceModifierProductsResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/account_groups.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/account_groups.jspf
@@ -19,7 +19,7 @@
 		<div class="col-12">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommercePriceListAccountGroupsResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/accounts.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/accounts.jspf
@@ -19,7 +19,7 @@
 		<div class="col-12">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommercePriceListAccountsResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/channels.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/channels.jspf
@@ -19,7 +19,7 @@
 		<div class="col-12">
 			<div id="item-finder-root-channel"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommercePriceListChannelsResource = ServiceProvider.default.AdminPricingAPI(
 					'v2'
 				);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/pricing_class/products.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/pricing_class/products.jsp
@@ -31,7 +31,7 @@ boolean hasPermission = commercePricingClassCPDefinitionDisplayContext.hasPermis
 		<div class="col-12 pt-4">
 			<div id="item-finder-root"></div>
 
-			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
+			<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/ServiceProvider/index as ServiceProvider">
 				var CommerceProductGroupsResource = ServiceProvider.default.AdminCatalogAPI(
 					'v1'
 				);

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
@@ -196,7 +196,7 @@ if ((cpDefinition != null) && (cpDefinition.getExpirationDate() != null)) {
 			<div class="col-12">
 				<div id="item-finder-root"></div>
 
-				<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/utilities/index as utilities">
+				<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/utilities/index as utilities">
 					var headers = utilities.fetchParams.headers;
 					var id = <%= cpDefinitionsDisplayContext.getCPDefinitionId() %>;
 					var productId = <%= cpDefinition.getCProductId() %>;

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition_option_rels.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition_option_rels.jsp
@@ -26,7 +26,7 @@ CPDefinition cpDefinition = cpDefinitionOptionRelDisplayContext.getCPDefinition(
 	<div class="pt-4" id="<portlet:namespace />productOptionRelsContainer">
 		<div id="item-finder-root"></div>
 
-		<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, commerce-frontend-js/utilities/eventsDefinitions as events, commerce-frontend-js/utilities/index as utilities">
+		<aui:script require="commerce-frontend-js/components/item_finder/entry as itemFinder, commerce-frontend-js/utilities/slugify as slugify, frontend-taglib-clay/data_set_display/utils/eventsDefinitions as events, commerce-frontend-js/utilities/index as utilities">
 			var headers = utilities.fetchParams.headers;
 			var productId = <%= cpDefinition.getCProductId() %>;
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/.npmbridgerc
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/.npmbridgerc
@@ -1,4 +1,17 @@
 {
+	"frontend-taglib-clay": {
+		"dest-mod-name-mapper": {
+			"from": "(.*)\\.js$",
+			"to": "bridge/frontend-taglib-clay/$1"
+		},
+		"file-globs": "**/*.js,**/*.soy.js",
+		"input": "build/node/packageRunBuild/resources",
+		"output": "build/node/packageRunBuild/resources/bridge/frontend-taglib-clay",
+		"src-mod-name-mapper": {
+			"from": "(.*)\\.js$",
+			"to": "frontend-taglib-clay/$1"
+		}
+	},
 	"metal": {
 		"dest-file-mapper": {
 			"from": "(.*)\\$(.*)@.*/lib/(.*)",

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -47,7 +47,8 @@ Liferay-JS-Submodules-Bridge:\
 	clay-select,\
 	clay-sticker,\
 	clay-table,\
-	clay-tooltip
+	clay-tooltip,\
+	frontend-taglib-clay
 Provide-Capability:\
 	osgi.extender;\
 		osgi.extender="jsp.taglib";\


### PR DESCRIPTION
The dataset got moved from `commerce-frontend-js` to `frontend-taglib-clay` but the events definitions path had not been updated in the jsp files.

What happens now is that, when we want a dataset display to be updated, we fire an event named after the content of the const `UPDATE_DATASET_DISPLAY`. 

The `UPDATE_DATASET_DISPLAY` we export from `commerce-frontend-js` contains `update-dataset-display`, the one from `frontend-taglib-clay` had been changed and now it contains `update-data-set-display`. They diverge so, at the moment, the Dataset is listening to an event that it will never be fired. 
The quickest solution was removing the `-` in `update-data-set-display` but it was not the safest on the long term.



Purpose of this PR was updating the paths. I'm not sure it's the best way to fix the problem and it will surely clash with [this](https://github.com/liferay-frontend/liferay-portal/pull/792) 

cc @jbalsas 