### PR TITLE
LPS-127988 liferay-ui:icon-menu ellipsis-v icon is too small

### DIFF
--- a/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
@@ -45,7 +45,7 @@ if (Validator.isNull(icon)) {
 			</button>
 		</c:when>
 		<c:otherwise>
-			<a class="direction-<%= direction %> dropdown-toggle icon-monospaced <%= triggerCssClass %>" href="javascript:;" id="<%= id %>" title="<%= message %>">
+			<a class="component-action direction-<%= direction %> dropdown-toggle <%= triggerCssClass %>" href="javascript:;" id="<%= id %>" title="<%= message %>">
 				<aui:icon image="<%= icon %>" markupView="lexicon" />
 			</a>
 		</c:otherwise>

--- a/util-taglib/src/com/liferay/taglib/aui/IconTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/IconTag.java
@@ -72,10 +72,15 @@ public class IconTag extends BaseIconTag {
 
 			String cssClass = GetterUtil.getString(getCssClass());
 
+			jspWriter.write("class=\"");
+
 			if (Validator.isNotNull(cssClass)) {
-				jspWriter.write("class=\"");
 				jspWriter.write(cssClass);
 				jspWriter.write("\" ");
+			}
+			else {
+				jspWriter.write("c-inner");
+				jspWriter.write("\" tabindex=\"-1\" ");
 			}
 
 			jspWriter.write(AUIUtil.buildData(getData()));

--- a/util-taglib/src/com/liferay/taglib/portletext/IconOptionsTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/IconOptionsTag.java
@@ -126,7 +126,7 @@ public class IconOptionsTag extends IconTag {
 		iconMenuTag.setMessage("options");
 		iconMenuTag.setShowArrow(false);
 		iconMenuTag.setShowWhenSingleIcon(true);
-		iconMenuTag.setTriggerCssClass("icon-monospaced");
+		iconMenuTag.setTriggerCssClass("component-action");
 
 		iconMenuTag.doBodyTag(
 			pageContext, this::_processPortletConfigurationIcons);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-127988

- replaces icon-monospaced with component-action
- aui:icon output `c-inner` and `tabindex="-1"` on span element if no `cssClass` is declared

![icon-menu](https://user-images.githubusercontent.com/788266/108420240-640f2e80-71e8-11eb-8792-021fbaa174ac.jpg)
