### PR TITLE
LRQA-64994 | Replace wait for metal component card macro usage with alternatives

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/functions/WaitForElementPresent.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/WaitForElementPresent.function
@@ -5,4 +5,8 @@ definition {
 		selenium.waitForElementPresent();
 	}
 
+	function waitForLastScript {
+		selenium.waitForElementPresent("xpath=(//script)[last()]");
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/masterspagetemplate/MastersPageTemplates.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/masterspagetemplate/MastersPageTemplates.macro
@@ -49,9 +49,7 @@ definition {
 	macro selectMasterViaPageDesignOptions {
 		Navigator.gotoNavTab(navTab = "Master");
 
-		MetalComponent.waitForCard(card = "${masterLayoutName}");
-
-		Click(
+		Click.waitForMenuToggleJSClick(
 			key_card = "${masterLayoutName}",
 			locator1 = "Card#CARD_TYPE_ASSET");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/stylebooks/StyleBooks.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/stylebooks/StyleBooks.macro
@@ -50,9 +50,7 @@ definition {
 	macro selectStyleBookViaPageDesignOptions {
 		Navigator.gotoNavTab(navTab = "Style Book");
 
-		MetalComponent.waitForCard(card = "${styleBookName}");
-
-		Click(
+		Click.waitForMenuToggleJSClick(
 			key_card = "${styleBookName}",
 			locator1 = "Card#CARD_TYPE_ASSET");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/site/Site.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/site/Site.macro
@@ -54,8 +54,6 @@ definition {
 				var siteTemplateName = "${siteType} Site";
 			}
 
-			MetalComponent.waitForCard(card = "${siteTemplateName}");
-
 			LexiconCard.clickCard(card = "${siteTemplateName}");
 
 			PortletEntry.inputName(name = "${siteName}");
@@ -124,8 +122,6 @@ definition {
 
 	macro addCustomCP {
 		LexiconEntry.gotoAdd();
-
-		MetalComponent.waitForCard(card = "${siteTemplateName}");
 
 		LexiconCard.clickCard(card = "${siteTemplateName}");
 
@@ -1134,7 +1130,7 @@ definition {
 	macro viewCannotAdd {
 		LexiconEntry.gotoAdd();
 
-		MetalComponent.waitForCard(card = "Blank Site");
+		WaitForElementPresent.waitForLastScript();
 
 		LexiconEntry.gotoEntry(rowEntry = "Blank Site");
 


### PR DESCRIPTION
**Description**
This replaces the MetalComponent.waitForCard macro to fix tests that are pausing for 30 seconds. 

This macro isn’t functioning correctly any more. The metal component macro is supposed to get the id of an element and pass that along to be identified in the Liferay.component() function in the DOM. The card for Sites doesn’t have an id so it waits 30 seconds by default to finish through the while loop. This is a workaround until we can identify if it's still possible to still use Lifray.component() for this usecase or better solution.

**Test Plan**
- :heavy_check_mark: Validate ci tests pass and tests don't hang when selecting site card. Passes in https://github.com/john-co/liferay-portal/pull/381#issuecomment-781678364
- :heavy_check_mark: Validate ci tests pass where MetalComponent.waitForCard is replaced. Passes in https://github.com/john-co/liferay-portal/pull/381#issuecomment-781678364

**Ticket**
https://issues.liferay.com/browse/LRQA-64994