### PR TITLE
LPS-127708 liferay-ui:icon-menu dropdown menu items have no hover styles

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
@@ -7,23 +7,6 @@
 	border: 1px solid $dropdown-border-color;
 }
 
-// Moved .dropdown-menu > li > a to .dropdown-item in BS4
-
-.dropdown-menu > li > a,
-.dropdown-menu .link-list > li > a {
-	color: #6b6c7e;
-	display: block;
-	overflow: hidden;
-	padding: 0.5rem 1.25rem;
-}
-
-.dropdown-menu > li.disabled > a,
-.dropdown-menu .link-list > .disabled > a {
-	box-shadow: none;
-	color: #a7a9bc;
-	cursor: not-allowed;
-}
-
 .dropdown-toggle:after {
 	border-width: 0;
 	content: normal;

--- a/portal-web/docroot/html/taglib/ui/icon/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/init.jsp
@@ -91,6 +91,10 @@ if (toolTip) {
 	cssClass += " lfr-portal-tooltip";
 }
 
+if (Validator.isNull(linkCssClass)) {
+	linkCssClass = "dropdown-item";
+}
+
 linkCssClass += " lfr-icon-item taglib-icon";
 %>
 

--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -26,7 +26,9 @@ boolean urlIsNotNull = Validator.isNotNull(url);
 			<c:choose>
 				<c:when test="<%= urlIsNotNull %>">
 					<aui:a ariaRole="menuitem" cssClass="<%= linkCssClass %>" data="<%= data %>" href="<%= url %>" id="<%= id %>" lang="<%= lang %>" onClick="<%= onClick %>" target="<%= target %>">
-						<%@ include file="/html/taglib/ui/icon/link_content.jspf" %>
+						<span class="c-inner" tabindex="-1">
+							<%@ include file="/html/taglib/ui/icon/link_content.jspf" %>
+						</span>
 					</aui:a>
 				</c:when>
 				<c:otherwise>
@@ -40,7 +42,9 @@ boolean urlIsNotNull = Validator.isNotNull(url);
 			<c:choose>
 				<c:when test="<%= urlIsNotNull %>">
 					<aui:a ariaRole="menuitem" cssClass="<%= linkCssClass %>" data="<%= data %>" href="<%= url %>" id="<%= id %>" lang="<%= lang %>" onClick="<%= onClick %>" target="<%= target %>">
-						<%@ include file="/html/taglib/ui/icon/link_content.jspf" %>
+						<span class="c-inner" tabindex="-1">
+							<%@ include file="/html/taglib/ui/icon/link_content.jspf" %>
+						</span>
 					</aui:a>
 				</c:when>
 				<c:otherwise>

--- a/util-taglib/src/com/liferay/taglib/ui/IconDeleteTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconDeleteTag.java
@@ -90,6 +90,8 @@ public class IconDeleteTag extends IconTag {
 					icon = "times-circle";
 				}
 			}
+
+			setLinkCssClass("component-action");
 		}
 
 		setIcon(icon);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-127708

- liferay-ui:icon output css class `dropdown-item` if no `linkCssClass` is declared
- adds `c-inner` around link content to only show focus border on keyboard interaction
- liferay-ui:icon-delete output css class `component-action` if an icon is declared
- styled-theme removes BS3 compatibility CSS all dropdown-menu > li > a should have `dropdown-item` now

How to test:

Hover styles should appear on dropdown items
- Application Menu > Control Panel > Roles > click ellipsis icon
- Documents and Media > Add Folder > click ellipsis icon

liferay-ui:icon-delete
Application Menu > Applications > Account Groups > Add Group > Add Account

![documents-media-dd-item](https://user-images.githubusercontent.com/788266/108437695-ae9da480-7202-11eb-9c8d-b3dbfa4000b3.jpg)
![accounts-dd-item](https://user-images.githubusercontent.com/788266/108437558-726a4400-7202-11eb-9147-7961581d923f.jpg)
![account-groups-account-delete-icon](https://user-images.githubusercontent.com/788266/108437630-94fc5d00-7202-11eb-8ec8-2a545585d1dd.jpg)
