### PR TITLE
LPS-127831 Search Iterator display style icon should only use active …

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -75,8 +75,20 @@ AUI.add(
 				},
 
 				rowClassNameActive: {
-					validator: Lang.isString,
-					value: 'active table-active',
+					setter(rowClassNameActive) {
+						if (Lang.isString(rowClassNameActive)) {
+							var active = rowClassNameActive.split(',');
+							var rowSelector = [
+								'li[data-selectable="true"]',
+								'tr[data-selectable="true"]',
+							];
+
+							return active[
+								rowSelector.indexOf(this.get(STR_ROW_SELECTOR))
+							];
+						}
+					},
+					value: 'active,table-active',
 				},
 
 				rowSelector: {


### PR DESCRIPTION
…class when highlighted instead of active table-active

https://issues.liferay.com/browse/LPS-127831

I was trying to figure out how to access the `rowSelector` string in `rowClassNameActive`, but couldn't figure it out.

Card View image card doesn't show active border because it is a special case where we can't style the card with the `input:checked ~ .card` selector or with the `active` class on the `li` element. This needs the `active` class on the card. There was a pr that was merged on the Clay repo that addresses this. See https://github.com/liferay/clay/pull/3937.

![active-on-img-card](https://user-images.githubusercontent.com/788266/108571212-82e2f300-72c4-11eb-9690-e807355b1c34.jpg)
