### PR TITLE
LPS-125130 Remove dependencies on metal-drag-drop from layout and site-navigation

### DIFF
--- a/modules/apps/layout/layout-admin-web/package.json
+++ b/modules/apps/layout/layout-admin-web/package.json
@@ -14,7 +14,6 @@
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",
 		"metal-component": "2.16.8",
-		"metal-drag-drop": "3.3.1",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",

--- a/modules/apps/site-navigation/site-navigation-admin-web/package.json
+++ b/modules/apps/site-navigation/site-navigation-admin-web/package.json
@@ -5,7 +5,6 @@
 		"@clayui/icon": "3.1.0",
 		"@clayui/layout": "3.3.0",
 		"frontend-js-web": "*",
-		"metal-drag-drop": "3.3.1",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",
 		"react": "16.12.0"


### PR DESCRIPTION
🎩  G'day sirs and madams of the frontal infostructurious organisation. I present upon you a simple PR that obliterates pesky dependencies on `metal-drag-drop` from `layout-admin-web` and `site-navigation-admin-web` modulators. The dependencies were not being used in these modulators, so I have done them a favor and deleted them from existence in this wonderful universe. Thank you for listening to my TED talk, I bid you farewell gentlesirs and gentleladies.