### PR TITLE
LPS-120676 [Content Dashboard] Fix wrong copy message when a bar is selected

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/AuditGraphApp.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/AuditGraphApp.js
@@ -33,7 +33,7 @@ export default function ({context, props}) {
 					<ClayAlert displayType="info">
 						<span>
 							{Liferay.Language.get(
-								'press-escape-to-remove-the-bar\'s-category-filters'
+								"press-escape-to-remove-the-bar's-category-filters"
 							)}
 						</span>
 					</ClayAlert>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into
 metrics=Metrics
 no-x-specified=No {0} Specified
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters.
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters.
 select-author=Select Author
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above.
 select-subtype=Select Subtype

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ar.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=اللغات التي تمت الترجمة إليها
 metrics=المقاييس
 no-x-specified=لا يوجد {0} مُحدّد
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=تحديد مؤلف
 select-categories-from-the-checkboxes-in-the-legend-above=حدد الفئات من خانات الاختيار في وسيلة الإيضاح أعلاه.
 select-subtype=تصفية حسب النوع الفرعي

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_bg.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Езици, преведени на (Automatic Translation)
 metrics=Показатели (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Избор на автор (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Изберете категории от квадратчетата за отметка в легендата по-горе. (Automatic Translation)
 select-subtype=Изберете подвид (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ca.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Idiomes traduïts a
 metrics=Analítica web
 no-x-specified=No s'ha especificat cap {0}
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Seleccioneu un autor
 select-categories-from-the-checkboxes-in-the-legend-above=Seleccioneu categories a les caselles de selecció de la llegenda de dalt.
 select-subtype=Seleccioneu el subtipus

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_cs.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Jazyky přeložené do (Automatic Translation)
 metrics=Metriky (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Vybrat autora (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Vyberte kategorie ze zaškrtávacích políček ve výše uvedené legendě. (Automatic Translation)
 select-subtype=Vybrat podtyp (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_da.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_de.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Sprachen übersetzt zu
 metrics=Metriken
 no-x-specified=Keine {0} angegeben
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Autor auswählen
 select-categories-from-the-checkboxes-in-the-legend-above=Wählen Sie Kategorien aus den Kontrollkästchen oben in der Legende.
 select-subtype=Untertyp auswählen

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_el.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Γλώσσες μεταφρασμένες σε (Automatic Translation)
 metrics=Μετρήσεις (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Επιλογή συντάκτη (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Επιλέξτε κατηγορίες από τα πλαίσια ελέγχου στο παραπάνω υπόμνημα. (Automatic Translation)
 select-subtype=Επιλογή δευτερεύοντος τύπου (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into
 metrics=Metrics
 no-x-specified=No {0} Specified
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters.
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters.
 select-author=Select Author
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above.
 select-subtype=Select Subtype

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_AU.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_GB.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_es.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Idiomas traducidos a
 metrics=Métricas
 no-x-specified=No se ha especificado ningún elemento de {0}
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Seleccionar autor
 select-categories-from-the-checkboxes-in-the-legend-above=Seleccione las categorías mediante las casillas de la leyenda anterior.
 select-subtype=Seleccionar subtipo

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_et.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Keeled tõlgitud (Automatic Translation)
 metrics=Meetrika (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Vali autor (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Valige ülaltoodud legendi ruudud. (Automatic Translation)
 select-subtype=Alamtüübi valimine (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_eu.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fa.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=زبان های ترجمه شده به (Automatic Translation)
 metrics=متریک (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=انتخاب نویسنده
 select-categories-from-the-checkboxes-in-the-legend-above=دسته ها را انتخاب کنید از چک باکس در افسانه بالا. (Automatic Translation)
 select-subtype=انتخاب زیرگروه (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fi.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Kielet, Joille Käännetään
 metrics=Metriikat
 no-x-specified={0} Ei Määritetty
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Valitse Tekijä
 select-categories-from-the-checkboxes-in-the-legend-above=Valitse luokat yllä olevan selitteen valintaruuduista.
 select-subtype=Valitse Alatyyppi

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Langues traduites en
 metrics=Données métriques
 no-x-specified=Aucun {0} spécifié
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Sélectionner l'auteur
 select-categories-from-the-checkboxes-in-the-legend-above=Sélectionner les catégories à partir des cases à cocher dans la légende ci-dessus.
 select-subtype=Sélectionner un sous-type

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr_CA.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_gl.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Métricas
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Seleccionar autor
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hi_IN.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=भाषाओं में अनुवादित (Automatic Translation)
 metrics=मैट्रिक्स (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=लेखक का चयन करें (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=ऊपर दिए गए किंवदंती में चेकबॉक्स से श्रेणियों का चयन करें। (Automatic Translation)
 select-subtype=सबटाइप का चयन करें (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hr.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hu.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Fordítási célnyelvek
 metrics=Mérőszámok
 no-x-specified=Nincs megadva {0}
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Szerző kiválasztása
 select-categories-from-the-checkboxes-in-the-legend-above=Válasszon kategóriákat a fenti jelmagyarázat jelölőnégyzeteiből.
 select-subtype=Altípus kiválasztása

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_in.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Bahasa yang diterjemahkan ke dalam (Automatic Translation)
 metrics=Metrik (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Pilih Pengarang (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Pilih kategori dari kotak centang di legenda di atas. (Automatic Translation)
 select-subtype=Pilih subtipe (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_it.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Lingue tradotte in (Automatic Translation)
 metrics=Metriche (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Seleziona autore (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Selezionare le categorie dalle caselle di controllo nella legenda precedente. (Automatic Translation)
 select-subtype=Seleziona sottotipo (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_iw.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=שפות שתורגמו ל (Automatic Translation)
 metrics=מדדים (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=בחר מחבר (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=בחר קטגוריות מתיבות הסימון במקרא שלעיל. (Automatic Translation)
 select-subtype=בחר תת-סוג (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ja.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=翻訳先言語
 metrics=統計情報
 no-x-specified={0}が指定されていません
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=作成者の選択
 select-categories-from-the-checkboxes-in-the-legend-above=上記の凡例のチェックボックスからカテゴリを選択してください。
 select-subtype=サブタイプを選択

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_kk.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ko.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=번역된 언어 (Automatic Translation)
 metrics=메트릭 (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=작성자 선택 (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=위의 범례에서 확인란에서 범주를 선택합니다. (Automatic Translation)
 select-subtype=하위 유형 선택 (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lo.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lt.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Kalbos išverstos į (Automatic Translation)
 metrics=Metrika (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Pasirinkti autorių (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Pasirinkite kategorijas iš aukščiau pateiktos legendos žymės langelių. (Automatic Translation)
 select-subtype=Pasirinkti potipį (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ms.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nb.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Språk oversatt til (Automatic Translation)
 metrics=Beregninger (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Velg Forfatter (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Velg kategorier fra avmerkingsboksene i forklaringen ovenfor. (Automatic Translation)
 select-subtype=Velg Undertype (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Doeltalen
 metrics=Meetwaarden
 no-x-specified=Geen {0} opgegeven
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Auteur selecteren
 select-categories-from-the-checkboxes-in-the-legend-above=Selecteer categorieën via de selectievakjes hierboven.
 select-subtype=Subtype selecteren

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl_BE.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pl.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Języki przetłumaczone na (Automatic Translation)
 metrics=Metryki (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Wybierz autora (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Wybierz kategorie z pól wyboru w powyższej legendzie. (Automatic Translation)
 select-subtype=Wybierz podtyp (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_BR.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Idiomas para o qual traduzir
 metrics=Métricas
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Selecionar Autor
 select-categories-from-the-checkboxes-in-the-legend-above=Selecione as categorias nas caixas de verificação na legenda acima.
 select-subtype=Selecionar subtipo

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_PT.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Idiomas traduzidos para (Automatic Translation)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Selecione Autor (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ro.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Limbi traduse în (Automatic Translation)
 metrics=Măsurători (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Selectare autor (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Selectați categorii din casetele de selectare din legenda de mai sus. (Automatic Translation)
 select-subtype=Selectare subtip (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ru.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Языки, переведенные в (Automatic Translation)
 metrics=Метрики (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Выберите автора (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Выберите категории из флажка в легенде выше. (Automatic Translation)
 select-subtype=Выберите подтип (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sk.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Jazyky preložené do (Automatic Translation)
 metrics=Metriky (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Vybrať autora (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Vyberte kategórie zo začiarkavacích políčok v legende vyššie. (Automatic Translation)
 select-subtype=Vybrať podtyp (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sl.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Jeziki, prevedeni v (Automatic Translation)
 metrics=Metrika (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Izberite avtor (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Izberite kategorije iz potrditvenih polj v zgornji legendi. (Automatic Translation)
 select-subtype=Izberi podvrsto (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sv.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Språk översatta till
 metrics=Mätvärden
 no-x-specified=Ingen {0} har angetts
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Välj författare
 select-categories-from-the-checkboxes-in-the-legend-above=Välj kategorier från kryssrutorna i förklaringen ovanför.
 select-subtype=Välj undertyp

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ta_IN.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Languages Translated Into (Automatic Copy)
 metrics=Metrics (Automatic Copy)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Select Author (Automatic Copy)
 select-categories-from-the-checkboxes-in-the-legend-above=Select categories from the checkboxes in the legend above. (Automatic Copy)
 select-subtype=Select Subtype (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_th.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=ภาษาที่แปลเป็นภาษา (Automatic Translation)
 metrics=วัด (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=เลือกผู้เขียน (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=เลือกหมวดหมู่จากช่องทําเครื่องหมายในคําอธิบายแผนภูมิด้านบน (Automatic Translation)
 select-subtype=เลือกชนิดย่อย (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_tr.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Dillere Çevrildi (Automatic Translation)
 metrics=Ölçüm (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Yazar Seç (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Yukarıdaki göstergedeki onay kutularından kategoriler seçin. (Automatic Translation)
 select-subtype=Alt Türü seçin (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_uk.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Мови переведені в (Automatic Translation)
 metrics=Метрик (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Виберіть автор (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Виберіть категорії з прапорців у легенді вище. (Automatic Translation)
 select-subtype=Вибрати підтип (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_vi.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=Ngôn ngữ dịch into (Automatic Translation)
 metrics=Metrics (Automatic Translation)
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=Chọn tác giả (Automatic Translation)
 select-categories-from-the-checkboxes-in-the-legend-above=Chọn danh mục từ các hộp kiểm trong truyền thuyết ở trên. (Automatic Translation)
 select-subtype=Chọn loại phụ (Automatic Translation)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_CN.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=翻译的目标语言
 metrics=指标
 no-x-specified=未指定{0}
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=选择作者
 select-categories-from-the-checkboxes-in-the-legend-above=从上面图例中的复选框内选择类别。
 select-subtype=选择子类型

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_TW.properties
@@ -18,7 +18,7 @@ javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAd
 languages-translated-into=翻譯的目標語言
 metrics=指標
 no-x-specified=No {0} Specified (Automatic Copy)
-press-escape-to-remove-the-bar's-category-filters=Press escape to the remove bar's category filters. (Automatic Copy)
+press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters. (Automatic Copy)
 select-author=選擇創建者
 select-categories-from-the-checkboxes-in-the-legend-above=從上面圖例中的複選框中選擇類別。 (Automatic Translation)
 select-subtype=選擇子類型


### PR DESCRIPTION
**Description**

We've confirmed that a way to zoom into one category's assets in the graph is needed in the Content Dashboard. By clicking on the bars in the chart, users will be able to filter the content's list below. The filter will consist in applying an "AND" operator with the selected category over the already existing filters.

**History**

* https://github.com/brianchandotcom/liferay-portal/commit/bdd1d74c78be557d1d358550319d3eae4c9c975a -> Compiling was broken
* https://github.com/liferay-tango/liferay-portal/commit/64ccaf095d72dc2a56133197f5abe26ebc620e2d -> This change fix the compilation problem and I tried with that key and apparently it was working fine, but false alarm, the portal seems not getting the language key 😢 

**Solution**

Language key:

```
press-escape-to-remove-the-bar's-category-filters=Press escape to remove the bar's category filters.
```

And in the JS:

```js
Liferay.Language.get("press-escape-to-remove-the-bar's-category-filters")
```

Also, I fix the typo in the language message.

**How to test it**

* Create at least one category for one vocabulary (for example: Fantasy inside Topic vocabulary)
* Create a Web Content and categorize it with Fantasy category
* Go to Content Dashboard and configure the graph with Topic vocabulary
* Click in one of the bars of the graph to see the alert info message

**Screenshot**

<img width="1239" alt="Screenshot 2021-02-22 at 16 45 17" src="https://user-images.githubusercontent.com/15845466/108731930-5c73c080-752d-11eb-92d1-5cc83b5e428f.png">
