### PR TITLE
[don't forward] LPS-121875 Migrate management toolbar v2 usages in dynamic-data-mapping-web

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/.npmbundlerrc
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/.npmbundlerrc
@@ -1,5 +1,8 @@
 {
     "ignore": [
-        "**/*"
+        "**/config.js",
+        "**/custom_fields.js",
+        "**/ddm_form.js",
+        "**/main.js"
     ]
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/package.json
@@ -1,5 +1,9 @@
 {
+	"dependencies": {
+		"frontend-js-web": "*"
+	},
 	"name": "dynamic-data-mapping-web",
+	"private": true,
 	"scripts": {
 		"build": "liferay-npm-scripts build",
 		"checkFormat": "liferay-npm-scripts check",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/init.jsp
@@ -105,6 +105,7 @@ page import="com.liferay.portal.kernel.template.TemplateHandler" %><%@
 page import="com.liferay.portal.kernel.template.TemplateHandlerRegistryUtil" %><%@
 page import="com.liferay.portal.kernel.template.TemplateVariableDefinition" %><%@
 page import="com.liferay.portal.kernel.template.TemplateVariableGroup" %><%@
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.LocaleUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMSelectStructureManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMSelectStructureManagementToolbarPropsTransformer.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {focusFormField} from 'frontend-js-web';
+
+export default function propsTransformer({portletNamespace, ...otherProps}) {
+	return {
+		...otherProps,
+		onComponentMount: () => {
+			focusFormField(
+				document[`${portletNamespace}searchForm`][
+					`${portletNamespace}keywords`
+				]
+			);
+		},
+	};
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMSelectTemplateManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMSelectTemplateManagementToolbarPropsTransformer.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {focusFormField} from 'frontend-js-web';
+
+export default function propsTransformer({portletNamespace, ...otherProps}) {
+	return {
+		...otherProps,
+		onComponentMount: () => {
+			focusFormField(
+				document[`${portletNamespace}searchForm`][
+					`${portletNamespace}keywords`
+				]
+			);
+		},
+	};
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMStructureManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMStructureManagementToolbarPropsTransformer.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {postForm} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {deleteStructuresURL},
+	portletNamespace,
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		onActionButtonClick(event, {item}) {
+			if (item.data?.action === 'deleteStructures') {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-this'
+						)
+					)
+				) {
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					const searchContainer = document.getElementById(
+						`${portletNamespace}entriesContainer`
+					);
+
+					if (form && searchContainer) {
+						postForm(form, {
+							data: {
+								deleteStructureIds: Liferay.Util.listCheckedExcept(
+									searchContainer,
+									`${portletNamespace}allRowIds`
+								),
+							},
+							url: deleteStructuresURL,
+						});
+					}
+				}
+			}
+		},
+	};
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMTemplateManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMTemplateManagementToolbarPropsTransformer.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {postForm} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {deleteTemplatesURL},
+	portletNamespace,
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		onActionButtonClick(event, {item}) {
+			if (item.data?.action === 'deleteTemplates') {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-this'
+						)
+					)
+				) {
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					const searchContainer = document.getElementById(
+						`${portletNamespace}entriesContainer`
+					);
+
+					if (form && searchContainer) {
+						postForm(form, {
+							data: {
+								deleteTemplateIds: Liferay.Util.listCheckedExcept(
+									searchContainer,
+									`${portletNamespace}allRowIds`
+								),
+							},
+							url: deleteTemplatesURL,
+						});
+					}
+				}
+			}
+		},
+	};
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/management_bar.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/management_bar.jsp
@@ -16,15 +16,23 @@
 
 <%@ include file="/init.jsp" %>
 
-<clay:management-toolbar-v2
+<portlet:actionURL name="/dynamic_data_mapping/delete_structure" var="deleteStructuresURL">
+	<portlet:param name="mvcPath" value="/view.jsp" />
+</portlet:actionURL>
+
+<clay:management-toolbar
 	actionDropdownItems='<%= ddmDisplayContext.getActionItemsDropdownItems("deleteStructures") %>'
+	additionalProps='<%=
+		HashMapBuilder.<String, Object>put(
+			"deleteStructuresURL", deleteStructuresURL.toString()
+		).build()
+	%>'
 	clearResultsURL="<%= ddmDisplayContext.getClearResultsURL() %>"
-	componentId="ddmStructureManagementToolbar"
 	creationMenu="<%= ddmDisplayContext.getStructureCreationMenu() %>"
 	disabled="<%= ddmDisplayContext.isDisabledManagementBar(DDMWebKeys.DYNAMIC_DATA_MAPPING_STRUCTURE) %>"
 	filterDropdownItems="<%= ddmDisplayContext.getFilterItemsDropdownItems() %>"
 	itemsTotal="<%= ddmDisplayContext.getTotalItems(DDMWebKeys.DYNAMIC_DATA_MAPPING_STRUCTURE) %>"
-	namespace="<%= liferayPortletResponse.getNamespace() %>"
+	propsTransformer="js/DDMStructureManagementToolbarPropsTransformer"
 	searchActionURL="<%= ddmDisplayContext.getStructureSearchActionURL() %>"
 	searchContainerId="<%= ddmDisplayContext.getStructureSearchContainerId() %>"
 	searchFormName="fm1"
@@ -32,49 +40,3 @@
 	sortingOrder="<%= ddmDisplayContext.getOrderByType() %>"
 	sortingURL="<%= ddmDisplayContext.getSortingURL() %>"
 />
-
-<aui:script sandbox="<%= true %>">
-	var deleteStructures = function () {
-		if (
-			confirm(
-				'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
-			)
-		) {
-			var searchContainer = document.getElementById(
-				'<portlet:namespace />entriesContainer'
-			);
-
-			if (searchContainer) {
-				<portlet:actionURL name="/dynamic_data_mapping/delete_structure" var="deleteStructuresURL">
-					<portlet:param name="mvcPath" value="/view.jsp" />
-				</portlet:actionURL>
-
-				Liferay.Util.postForm(document.<portlet:namespace />fm, {
-					data: {
-						deleteStructureIds: Liferay.Util.listCheckedExcept(
-							searchContainer,
-							'<portlet:namespace />allRowIds'
-						),
-					},
-					url: '<%= deleteStructuresURL %>',
-				});
-			}
-		}
-	};
-
-	var ACTIONS = {
-		deleteStructures: deleteStructures,
-	};
-
-	Liferay.componentReady('ddmStructureManagementToolbar').then(
-		(managementToolbar) => {
-			managementToolbar.on('actionItemClicked', (event) => {
-				var itemData = event.data.item.data;
-
-				if (itemData && itemData.action && ACTIONS[itemData.action]) {
-					ACTIONS[itemData.action]();
-				}
-			});
-		}
-	);
-</aui:script>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_structure.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_structure.jsp
@@ -26,14 +26,13 @@ SearchContainer<DDMStructure> structureSearch = ddmDisplayContext.getStructureSe
 
 <liferay-util:include page="/structure_navigation_bar.jsp" servletContext="<%= application %>" />
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	clearResultsURL="<%= ddmDisplayContext.getClearResultsURL() %>"
-	componentId="ddmStructureManagementToolbar"
 	creationMenu="<%= ddmDisplayContext.getSelectStructureCreationMenu() %>"
 	disabled="<%= ddmDisplayContext.isDisabledManagementBar(DDMWebKeys.DYNAMIC_DATA_MAPPING_STRUCTURE) %>"
 	filterDropdownItems="<%= ddmDisplayContext.getFilterItemsDropdownItems() %>"
 	itemsTotal="<%= ddmDisplayContext.getTotalItems(DDMWebKeys.DYNAMIC_DATA_MAPPING_STRUCTURE) %>"
-	namespace="<%= liferayPortletResponse.getNamespace() %>"
+	propsTransformer="js/DDMSelectStructureManagementToolbarPropsTransformer"
 	searchActionURL="<%= ddmDisplayContext.getSelectStructureSearchActionURL() %>"
 	searchContainerId="<%= ddmDisplayContext.getStructureSearchContainerId() %>"
 	searchFormName="searchForm"
@@ -107,15 +106,6 @@ SearchContainer<DDMStructure> structureSearch = ddmDisplayContext.getStructureSe
 </aui:form>
 
 <aui:script>
-	Liferay.componentReady('ddmStructureManagementToolbar').then(
-		(managementToolbar) => {
-			Liferay.Util.focusFormField(
-				document.<portlet:namespace />searchForm
-					.<portlet:namespace />keywords
-			);
-		}
-	);
-
 	Liferay.Util.selectEntityHandler(
 		'#<portlet:namespace />selectStructureFm',
 		'<%= HtmlUtil.escapeJS(eventName) %>'

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_template.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_template.jsp
@@ -34,14 +34,13 @@ if ((classPK > 0) && (structureClassNameId == classNameId)) {
 
 <liferay-util:include page="/navigation_bar.jsp" servletContext="<%= application %>" />
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	clearResultsURL="<%= ddmDisplayContext.getClearResultsURL() %>"
-	componentId="ddmTemplateManagementToolbar"
 	creationMenu="<%= ddmDisplayContext.getTemplateCreationMenu() %>"
 	disabled="<%= ddmDisplayContext.isDisabledManagementBar(DDMWebKeys.DYNAMIC_DATA_MAPPING_TEMPLATE) %>"
 	filterDropdownItems="<%= ddmDisplayContext.getFilterItemsDropdownItems() %>"
 	itemsTotal="<%= ddmDisplayContext.getTotalItems(DDMWebKeys.DYNAMIC_DATA_MAPPING_TEMPLATE) %>"
-	namespace="<%= liferayPortletResponse.getNamespace() %>"
+	propsTransformer="js/DDMSelectTemplateManagementToolbarPropsTransformer"
 	searchActionURL="<%= ddmDisplayContext.getSelectTemplateSearchActionURL() %>"
 	searchFormName="searchForm"
 	selectable="<%= false %>"
@@ -114,14 +113,6 @@ if ((classPK > 0) && (structureClassNameId == classNameId)) {
 		</liferay-ui:search-container>
 	</clay:container-fluid>
 </aui:form>
-
-<aui:script>
-	Liferay.componentReady('ddmTemplateManagementToolbar').then(() => {
-		Liferay.Util.focusFormField(
-			document.<portlet:namespace />searchForm.<portlet:namespace />keywords
-		);
-	});
-</aui:script>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/template_management_bar.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/template_management_bar.jsp
@@ -20,15 +20,23 @@
 boolean includeCheckBox = ParamUtil.getBoolean(request, "includeCheckBox", true);
 %>
 
-<clay:management-toolbar-v2
+<portlet:actionURL name="/dynamic_data_mapping/delete_template" var="deleteTemplatesURL">
+	<portlet:param name="mvcPath" value="/view_template.jsp" />
+</portlet:actionURL>
+
+<clay:management-toolbar
 	actionDropdownItems='<%= ddmDisplayContext.getActionItemsDropdownItems("deleteTemplates") %>'
+	additionalProps='<%=
+		HashMapBuilder.<String, Object>put(
+			"deleteTemplatesURL", deleteTemplatesURL.toString()
+		).build()
+	%>'
 	clearResultsURL="<%= ddmDisplayContext.getClearResultsURL() %>"
-	componentId="ddmTemplateManagementToolbar"
 	creationMenu="<%= ddmDisplayContext.getTemplateCreationMenu() %>"
 	disabled="<%= ddmDisplayContext.isDisabledManagementBar(DDMWebKeys.DYNAMIC_DATA_MAPPING_TEMPLATE) %>"
 	filterDropdownItems="<%= ddmDisplayContext.getFilterItemsDropdownItems() %>"
 	itemsTotal="<%= ddmDisplayContext.getTotalItems(DDMWebKeys.DYNAMIC_DATA_MAPPING_TEMPLATE) %>"
-	namespace="<%= liferayPortletResponse.getNamespace() %>"
+	propsTransformer="js/DDMTemplateManagementToolbarPropsTransformer"
 	searchActionURL="<%= ddmDisplayContext.getTemplateSearchActionURL() %>"
 	searchContainerId="<%= ddmDisplayContext.getTemplateSearchContainerId() %>"
 	searchFormName="fm1"
@@ -36,49 +44,3 @@ boolean includeCheckBox = ParamUtil.getBoolean(request, "includeCheckBox", true)
 	sortingOrder="<%= ddmDisplayContext.getOrderByType() %>"
 	sortingURL="<%= ddmDisplayContext.getSortingURL() %>"
 />
-
-<aui:script sandbox="<%= true %>">
-	var deleteTemplates = function () {
-		if (
-			confirm(
-				'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
-			)
-		) {
-			var searchContainer = document.getElementById(
-				'<portlet:namespace />entriesContainer'
-			);
-
-			<portlet:actionURL name="/dynamic_data_mapping/delete_template" var="deleteTemplatesURL">
-				<portlet:param name="mvcPath" value="/view_template.jsp" />
-			</portlet:actionURL>
-
-			if (searchContainer) {
-				Liferay.Util.postForm(document.<portlet:namespace />fm, {
-					data: {
-						deleteTemplateIds: Liferay.Util.listCheckedExcept(
-							searchContainer,
-							'<portlet:namespace />allRowIds'
-						),
-					},
-					url: '<%= deleteTemplatesURL %>',
-				});
-			}
-		}
-	};
-
-	var ACTIONS = {
-		deleteTemplates: deleteTemplates,
-	};
-
-	Liferay.componentReady('ddmTemplateManagementToolbar').then(
-		(managementToolbar) => {
-			managementToolbar.on('actionItemClicked', (event) => {
-				var itemData = event.data.item.data;
-
-				if (itemData && itemData.action && ACTIONS[itemData.action]) {
-					ACTIONS[itemData.action]();
-				}
-			});
-		}
-	);
-</aui:script>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -16,7 +16,7 @@ import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import ActionControls from './ActionControls';
 import CreationMenu from './CreationMenu';
@@ -44,6 +44,7 @@ function ManagementToolbar({
 	onClearSelectionButtonClick = () => {},
 	onCreateButtonClick = () => {},
 	onCreationMenuItemClick = () => {},
+	onComponentMount,
 	onInfoButtonClick = () => {},
 	onSelectAllButtonClick = () => {},
 	onShowMoreButtonClick,
@@ -69,6 +70,14 @@ function ManagementToolbar({
 	);
 	const [active, setActive] = useState(initialCheckboxStatus !== 'unchecked');
 	const [searchMobile, setSearchMobile] = useState(false);
+
+	useEffect(() => {
+		if (onComponentMount) {
+			onComponentMount();
+		}
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	return (
 		<>


### PR DESCRIPTION
@jonmak08 @julien @ambrinchaudhary 

See task details in https://issues.liferay.com/browse/LPS-121875

I'm opening this PR here, before forwarding to product team, because we are extending tag API. We are adding a callback on component mount. Also pinging @wincent for this part:
- Is there a more elegant solution? We cannot leave this in JSP, as there is no toolbar component instance. `PropsTransformer` is not a component, so we cannot have `useEffect` in it.
- Is there a better name than `onComponentMount`? I went with something similar to React's `componentDidMount`, but not quite the same, so it does not imply some kind of override. Is there a best practice how to refer to lifecycle moments in functional components? 

Test plan:
1. C&D > Dynamic Data Lists > Ellipsis icon > Manage Data Definitions
1. C&D > Dynamic Data Lists > Create New List > Data Definition > Select <-- **here you can see the new callback**
1. Design > Widget Templates
1. ??? Somewhere we can select a DDM template. I couldn't not find such a place. The code is identical to (2) so I have high confidence it'll work.

Search field focuses on mount:
![after](https://user-images.githubusercontent.com/5435511/108740071-91841100-7535-11eb-87a9-1f835d196bf6.gif)
