### PR TITLE
LRQA 62049 part 1 | Reduce FI tests pause to less then 3 seconds for WYSIWYGUsecase#AddWebContentArticleCopyPasteContent

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
@@ -54,6 +54,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>BODY_TEXT</td>
+	<td>//body[contains(@class,'cke_editable') and contains(.,'${key_text}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>OK_BUTTON</td>
 	<td>//a[contains(@role,'button')][normalize-space()='OK']</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -224,7 +224,9 @@ definition {
 			RobotType.robotTypeShortcut(locator1 = "Ctrl + v");
 		}
 
-		Pause(locator1 = "5000");
+		WaitForElementPresent(
+			key_text = "Sample document for editor area test",
+			locator1 = "CKEditor#BODY_TEXT");
 
 		takeScreenshot();
 


### PR DESCRIPTION
Reduce FI tests pause to less then 3 seconds for WYSIWYGUsecase#AddWebContentArticleCopyPasteContent
**Test Plan:**
1. Remove 5s Pause
2. Use WaitForElementToPresent() macro to check if the paste function correctly paste on the editor
https://issues.liferay.com/browse/LRQA-62049