### PR TITLE
LPS-127831 Sets proper active class depending on search container displayStyle

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -76,7 +76,7 @@ AUI.add(
 
 				rowClassNameActive: {
 					validator: Lang.isString,
-					value: 'active table-active',
+					value: 'active',
 				},
 
 				rowSelector: {

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/bottom.jspf
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/bottom.jspf
@@ -65,6 +65,7 @@
 				{
 					cfg: {
 						keepSelection: rememberCheckBoxState,
+						rowClassNameActive: '<%= displayStyle.equals(SearchIteratorTag.DEFAULT_DISPLAY_STYLE) ? "table-active" : "active" %>',
 						rowSelector: rowSelector
 					},
 					fn: A.Plugin.SearchContainerSelect


### PR DESCRIPTION
After dropping the BS3-BS4 compat layer, the `active` class no longer works for table displays which need the `table-active` class instead.

This commit makes it so the `table-active` class is used for tables (default displayStyle) and `active` for any other visualization.

This is a continuation of https://github.com/liferay-frontend/liferay-portal/pull/821 because I couldn't push to @pat270's origin...