### PR TITLE
[TS] LPS-128028 Preventing curParam from being removed in the URL, so it can ensure independent pagination between Search Container 

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -327,7 +327,7 @@ private String _getHREF(String formName, String curParam, int cur, String jsCall
 	String href = null;
 
 	if (Validator.isNotNull(url)) {
-		href = HtmlUtil.escape(url + curParam + "=" + cur + urlAnchor);
+		href = HtmlUtil.escapeHREF(HttpUtil.addParameter(HttpUtil.removeParameter(url, curParam) + urlAnchor, curParam, cur));
 	}
 	else {
 		href = "javascript:document." + formName + "." + curParam + ".value = '" + cur + "'; " + jsCall;

--- a/portal-web/docroot/html/taglib/ui/search_paginator/lexicon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_paginator/lexicon/page.jsp
@@ -33,7 +33,6 @@ String type = (String)request.getAttribute("liferay-ui:search:type");
 PortletURL iteratorURL = searchContainer.getIteratorURL();
 
 if (iteratorURL != null) {
-	iteratorURL.setParameter(searchContainer.getCurParam(), (String)null);
 	iteratorURL.setParameter("resetCur", Boolean.FALSE.toString());
 }
 %>

--- a/portal-web/docroot/html/taglib/ui/search_paginator/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_paginator/page.jsp
@@ -32,7 +32,6 @@ String type = (String)request.getAttribute("liferay-ui:search:type");
 PortletURL iteratorURL = searchContainer.getIteratorURL();
 
 if (iteratorURL != null) {
-	iteratorURL.setParameter(searchContainer.getCurParam(), (String)null);
 	iteratorURL.setParameter("resetCur", Boolean.FALSE.toString());
 }
 %>


### PR DESCRIPTION
Hello,

This PR is a continuation of PR: https://github.com/liferay-frontend/liferay-portal/pull/812

<hr>

Search containers do not ensure independent pagination currently, however different curParam variables are included in the search containers liferay-ui:search-container taglib for example here .

Root cause analysis: curParam, that ensures independent pagination, is not included in the iteratorURL when multiple search container pagination is being used on a site. Therefore, the cur value will be reset and set to the default value.
The curParam is set to null here that prevents the parameter being included in the URL.

Fix: curParam will be included in the URL by removing the code from search_paginator.

Please see more information on PTR: https://issues.liferay.com/browse/PTR-2221

LPS: https://issues.liferay.com/browse/LPS-128028

Cc. @antonio-ortega