### PR TITLE
LPS-128386 [Bug: Segments Editor] Assign site roles should be disabled if the option "Enable Assign Roles by Segment" is unchecked (disabled) in System Settings

### DIFF
--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_entry_action.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_entry_action.jsp
@@ -75,10 +75,15 @@ SegmentsEntry segmentsEntry = (SegmentsEntry)row.getObject();
 		roleItemSelectorCriterion.setExcludedRoleNames(excludedRoleNames);
 
 		PortletURL itemSelectorURL = itemSelector.getItemSelectorURL(RequestBackedPortletURLFactoryUtil.create(renderRequest), eventName, roleItemSelectorCriterion);
+
+		String linkCssClass = "assign-site-roles-link dropdown-item";
+
+		if (!segmentsDisplayContext.isRoleSegmentationEnabled()) {
+			linkCssClass += " action disabled";
+		}
 		%>
 
 		<liferay-ui:icon
-			cssClass='<%= segmentsDisplayContext.isRoleSegmentationEnabled() ? "" : "action disabled" %>'
 			data='<%=
 				HashMapBuilder.<String, Object>put(
 					"itemSelectorURL", itemSelectorURL.toString()
@@ -86,7 +91,7 @@ SegmentsEntry segmentsEntry = (SegmentsEntry)row.getObject();
 					"segmentsEntryId", segmentsEntry.getSegmentsEntryId()
 				).build()
 			%>'
-			linkCssClass="assign-site-roles-link"
+			linkCssClass="<%= linkCssClass %>"
 			message="assign-site-roles"
 			url="javascript:;"
 		/>


### PR DESCRIPTION
**Description**

Assign site roles option in Segments Editor should be disabled if the option "Enable Assign Roles by Segment" is unchecked (disabled) in System Settings > Segments.

**Steps to reproduce**

- Verify that in System Settings the option "Enable Assign Roles by Segment" is unchecked (disabled)
- Go to People > Segments
- Create a Segment (doesn't matter the conditions)
- Click on the kebab menu to see the actions

**Actual behavior**

Assign Site Roles option appears as a link and not disabled

**Expected behavior**

Assign Sites Roles option appears with the same style as others and disabled because the option "Enable Assign Roles by Segment" is unchecked (disabled) in System Settings

**Solution**

Proposed by @edalgrin in this Slack thread: https://liferay.slack.com/archives/CNBG06JS3/p1614248675027800. Add `dropdown-item` to `linkCssClass`.

**Screenshots: before and after**

<img width="335" alt="LPS-128386 bug" src="https://user-images.githubusercontent.com/15845466/109143621-87922600-7760-11eb-8a3f-29cf4e747051.png"> <img width="266" alt="Screenshot 2021-02-25 at 11 56 52" src="https://user-images.githubusercontent.com/15845466/109143672-94167e80-7760-11eb-8d60-d322b87d21eb.png">
