### PR TITLE
LPS-128362 - Enable dartSass build option for themes

### DIFF
--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/package.json
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/package.json
@@ -5,6 +5,9 @@
 	"liferayTheme": {
 		"baseTheme": "styled",
 		"rubySass": false,
+		"sassOptions": {
+			"dartSass": true
+		},
 		"screenshot": "",
 		"templateLanguage": "ftl",
 		"version": "7.1"

--- a/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/package.json
+++ b/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/package.json
@@ -5,6 +5,9 @@
 	"liferayTheme": {
 		"baseTheme": "styled",
 		"rubySass": false,
+		"sassOptions": {
+			"dartSass": true
+		},
 		"screenshot": "",
 		"templateLanguage": "ftl",
 		"version": "7.1"

--- a/modules/apps/frontend-theme/frontend-theme-admin/package.json
+++ b/modules/apps/frontend-theme/frontend-theme-admin/package.json
@@ -11,6 +11,9 @@
 		"baseTheme": "styled",
 		"distName": "admin-theme",
 		"rubySass": false,
+		"sassOptions": {
+			"dartSass": true
+		},
 		"version": "7.1"
 	},
 	"main": "package.json",

--- a/modules/apps/frontend-theme/frontend-theme-classic/package.json
+++ b/modules/apps/frontend-theme/frontend-theme-classic/package.json
@@ -11,6 +11,9 @@
 		"baseTheme": "styled",
 		"distName": "classic-theme",
 		"rubySass": false,
+		"sassOptions": {
+			"dartSass": true
+		},
 		"version": "7.1"
 	},
 	"main": "package.json",


### PR DESCRIPTION
**This is not intended to be merged until @liferay/npm-scripts is merged with a greater version than v37.1.2**


This PR is intended to be used with `liferay-theme-tasksv10.3.0` which is included in the next npm-scripts release.

I am sending this now as a draft now in case I am on leave when npm-scripts is updated. Feel free to test and merge once npm-scripts is updated.