### PR TITLE
LPS-124170 Avoid crash if the experience ID is not in the list of available experiences

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getLanguages.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getLanguages.js
@@ -22,6 +22,7 @@ export default function getLanguages(
 	if (
 		!availableSegmentsExperiences ||
 		!segmentsExperienceId ||
+		!availableSegmentsExperiences[segmentsExperienceId] ||
 		segmentsExperienceId === config.defaultSegmentsExperienceId
 	) {
 		return availableLanguages;


### PR DESCRIPTION
**Description**

When trying to edit a variant from an A/B Test, the UI crashes because it's not able to get the `languageIds`.

**Solution**

To avoid that we check if the `segmentsExperienceId` exists in the `availableSegmentsExperiences` array in `getLanguages` method from `~/modules/layout/layout-content-page-editor-web`.

**How to test it**

- Connect Liferay DXP with Analytics Cloud
- Create a page
- Create an A/B Test
- Create a variant
- Click on the pencil icon to edit the variant