### PR TITLE
LPS-127657 Update ClassicEditor usage

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -13,7 +13,7 @@
  */
 
 import {ClassicEditor} from 'frontend-editor-ckeditor-web';
-import React, {useState} from 'react';
+import React, {useRef, useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
 import {useSyncValue} from '../hooks/useSyncValue.es';
@@ -34,6 +34,8 @@ const RichText = ({
 	);
 
 	const [dirty, setDirty] = useState(false);
+
+	const editorRef = useRef();
 
 	return (
 		<FieldBase
@@ -75,6 +77,7 @@ const RichText = ({
 					}
 				}}
 				readOnly={readOnly}
+				ref={editorRef}
 			/>
 
 			<input

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -13,12 +13,13 @@
  */
 
 import {ClassicEditor} from 'frontend-editor-ckeditor-web';
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
 import {useSyncValue} from '../hooks/useSyncValue.es';
 
 const RichText = ({
+	editingLanguageId,
 	editorConfig,
 	id,
 	name,
@@ -36,6 +37,19 @@ const RichText = ({
 	const [dirty, setDirty] = useState(false);
 
 	const editorRef = useRef();
+
+	useEffect(() => {
+		const editor = editorRef.current?.editor;
+
+		if (editor) {
+			editor.config.contentsLangDirection =
+				Liferay.Language.direction[editingLanguageId];
+
+			editor.config.contentsLanguage = editingLanguageId;
+
+			editor.setData(editor.getData());
+		}
+	}, [editingLanguageId, editorRef]);
 
 	return (
 		<FieldBase

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -15,135 +15,143 @@
 import {useEventListener} from '@liferay/frontend-js-react-web';
 import {debounce} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
 import {Editor} from './Editor';
 
-const ClassicEditor = ({
-	contents = '',
-	editorConfig,
-	initialToolbarSet = 'simple',
-	name,
-	onChange,
-	onChangeMethodName,
-	title,
-	...otherProps
-}) => {
-	const editorRef = useRef();
+const ClassicEditor = React.forwardRef(
+	(
+		{
+			contents = '',
+			editorConfig,
+			initialToolbarSet = 'simple',
+			name,
+			onChange,
+			onChangeMethodName,
+			title,
+			...otherProps
+		},
+		ref
+	) => {
+		const [toolbarSet, setToolbarSet] = useState(initialToolbarSet);
 
-	const [toolbarSet, setToolbarSet] = useState(initialToolbarSet);
-
-	const getConfig = () => {
-		return {
-			toolbar: toolbarSet,
-			...editorConfig,
+		const getConfig = () => {
+			return {
+				toolbar: toolbarSet,
+				...editorConfig,
+			};
 		};
-	};
 
-	const getHTML = useCallback(() => {
-		let data = contents;
+		const getHTML = useCallback(() => {
+			let data = contents;
 
-		const editor = editorRef.current.editor;
+			const editor = ref.current.editor;
 
-		if (editor && editor.instanceReady) {
-			data = editor.getData();
+			if (editor && editor.instanceReady) {
+				data = editor.getData();
 
-			if (CKEDITOR.env.gecko && CKEDITOR.tools.trim(data) === '<br />') {
-				data = '';
+				if (
+					CKEDITOR.env.gecko &&
+					CKEDITOR.tools.trim(data) === '<br />'
+				) {
+					data = '';
+				}
+
+				data = data.replace(/(\u200B){7}/, '');
 			}
 
-			data = data.replace(/(\u200B){7}/, '');
-		}
+			return data;
+		}, [contents, ref]);
 
-		return data;
-	}, [contents]);
-
-	const onChangeCallback = () => {
-		if (!onChangeMethodName && !onChange) {
-			return;
-		}
-
-		const editor = editorRef.current.editor;
-
-		if (editor.checkDirty()) {
-			if (onChangeMethodName) {
-				window[onChangeMethodName](getHTML());
-			}
-			else {
-				onChange(getHTML());
+		const onChangeCallback = () => {
+			if (!onChangeMethodName && !onChange) {
+				return;
 			}
 
-			editor.resetDirty();
-		}
-	};
+			const editor = ref.current.editor;
 
-	useEffect(() => {
-		setToolbarSet(initialToolbarSet);
-	}, [initialToolbarSet]);
+			if (editor.checkDirty()) {
+				if (onChangeMethodName) {
+					window[onChangeMethodName](getHTML());
+				}
+				else {
+					onChange(getHTML());
+				}
 
-	useEffect(() => {
-		window[name] = {
-			getHTML,
-			getText() {
-				return contents;
-			},
+				editor.resetDirty();
+			}
 		};
-	}, [contents, getHTML, name]);
 
-	const onResize = debounce(() => {
-		setToolbarSet(initialToolbarSet);
-	}, 200);
+		useEffect(() => {
+			setToolbarSet(initialToolbarSet);
+		}, [initialToolbarSet]);
 
-	useEventListener('resize', onResize, true, window);
+		useEffect(() => {
+			window[name] = {
+				getHTML,
+				getText() {
+					return contents;
+				},
+			};
+		}, [contents, getHTML, name]);
 
-	return (
-		<div id={`${name}Container`}>
-			{title && (
-				<label className="control-label" htmlFor={name}>
-					{title}
-				</label>
-			)}
-			<Editor
-				className="lfr-editable"
-				config={getConfig()}
-				name={name}
-				onBeforeLoad={(CKEDITOR) => {
-					CKEDITOR.disableAutoInline = true;
-					CKEDITOR.dtd.$removeEmpty.i = 0;
-					CKEDITOR.dtd.$removeEmpty.span = 0;
+		const onResize = debounce(() => {
+			setToolbarSet(initialToolbarSet);
+		}, 200);
 
-					CKEDITOR.getNextZIndex = function () {
-						return CKEDITOR.dialog._.currentZIndex
-							? CKEDITOR.dialog._.currentZIndex + 10
-							: Liferay.zIndex.WINDOW + 10;
-					};
-				}}
-				onChange={onChangeCallback}
-				onDrop={(event) => {
-					const data = event.data.dataTransfer.getData('text/html');
-					const editor = event.editor;
+		useEventListener('resize', onResize, true, window);
 
-					if (data) {
-						const fragment = CKEDITOR.htmlParser.fragment.fromHtml(
-							data
+		return (
+			<div id={`${name}Container`}>
+				{title && (
+					<label className="control-label" htmlFor={name}>
+						{title}
+					</label>
+				)}
+				<Editor
+					className="lfr-editable"
+					config={getConfig()}
+					name={name}
+					onBeforeLoad={(CKEDITOR) => {
+						CKEDITOR.disableAutoInline = true;
+						CKEDITOR.dtd.$removeEmpty.i = 0;
+						CKEDITOR.dtd.$removeEmpty.span = 0;
+
+						CKEDITOR.getNextZIndex = function () {
+							return CKEDITOR.dialog._.currentZIndex
+								? CKEDITOR.dialog._.currentZIndex + 10
+								: Liferay.zIndex.WINDOW + 10;
+						};
+					}}
+					onChange={onChangeCallback}
+					onDrop={(event) => {
+						const data = event.data.dataTransfer.getData(
+							'text/html'
 						);
+						const editor = event.editor;
 
-						const name = fragment.children[0].name;
+						if (data) {
+							const fragment = CKEDITOR.htmlParser.fragment.fromHtml(
+								data
+							);
 
-						if (name) {
-							return editor.pasteFilter.check(name);
+							const name = fragment.children[0].name;
+
+							if (name) {
+								return editor.pasteFilter.check(name);
+							}
 						}
-					}
-				}}
-				onInstanceReady={({editor}) => {
-					editor.setData(contents);
-				}}
-				ref={editorRef}
-				{...otherProps}
-			/>
-		</div>
-	);
-};
+					}}
+					onInstanceReady={({editor}) => {
+						editor.setData(contents);
+					}}
+					ref={ref}
+					{...otherProps}
+				/>
+			</div>
+		);
+	}
+);
 
 ClassicEditor.propTypes = {
 	contents: PropTypes.string,


### PR DESCRIPTION
This is intended to fix https://issues.liferay.com/browse/LPS-127657 (CKEditor is not listening to config changes, so it does not apply rtl direction when setting a rtl language). It's the first part of the fix, the second one will be sent to liferay-data-engine.

The idea consists in wrapping `ClassicEditor` component in `React.forwardRef`, so we can use the editor instance outside this component. 

This way, we'll be able to update the editor config when a web content's language is switched.

cc @julien 🙂