### PR TITLE
 LPS-121877 Migrate v2 usages in export-import-web

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/view_export_configurations.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/view_export_configurations.jsp
@@ -59,8 +59,8 @@ if (liveGroup == null) {
 ExportTemplatesToolbarDisplayContext exportTemplatesToolbarDisplayContext = new ExportTemplatesToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, liveGroupId, company, portletURL);
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= exportTemplatesToolbarDisplayContext %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= exportTemplatesToolbarDisplayContext %>"
 	searchFormName="searchFm"
 	selectable="<%= false %>"
 	showCreationMenu="<%= true %>"

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_templates/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_templates/view.jsp
@@ -66,7 +66,7 @@ clearResultsURL.setParameter("keywords", StringPool.BLANK);
 			<portlet:param name="publishConfigurationButtons" value="saved" />
 		</liferay-portlet:renderURL>
 
-		<clay:management-toolbar-v2
+		<clay:management-toolbar
 			clearResultsURL="<%= clearResultsURL.toString() %>"
 			itemsTotal="<%= exportImportConfigurationsCount %>"
 			searchActionURL="<%= searchURL.toString() %>"

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/toolbar.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/toolbar.jsp
@@ -20,7 +20,7 @@
 ExportImportToolbarDisplayContext exportImportToolbarDisplayContext = new ExportImportToolbarDisplayContext(request, liferayPortletResponse);
 %>
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	actionDropdownItems="<%= exportImportToolbarDisplayContext.getActionDropdownItems() %>"
 	creationMenu="<%= exportImportToolbarDisplayContext.getCreationMenu() %>"
 	filterDropdownItems="<%= exportImportToolbarDisplayContext.getFilterDropdownItems() %>"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -42,6 +42,15 @@ const CreationMenu = ({
 		primaryItems.length + secondaryItemsCountRef.current
 	);
 
+	const getPlusIconLabel = () => {
+		const item =
+			primaryItems?.[0] ??
+			secondaryItems?.[0].items?.[0] ??
+			secondaryItems?.[0];
+
+		return item?.label || Liferay.Language.get('new');
+	};
+
 	const getVisibleItemsCount = () => {
 		const primaryItemsCount = primaryItems.length;
 		const secondaryItemsCount = secondaryItemsCountRef.current;
@@ -152,8 +161,10 @@ const CreationMenu = ({
 					onActiveChange={setActive}
 					trigger={
 						<ClayButtonWithIcon
+							aria-label={getPlusIconLabel()}
 							className="nav-btn nav-btn-monospaced"
 							symbol="plus"
+							title={getPlusIconLabel()}
 						/>
 					}
 				>
@@ -209,6 +220,7 @@ const CreationMenu = ({
 				</ClayDropDown>
 			) : (
 				<LinkOrButton
+					aria-label={getPlusIconLabel()}
 					button={true}
 					className="nav-btn nav-btn-monospaced"
 					displayType="primary"
@@ -217,6 +229,7 @@ const CreationMenu = ({
 						onCreateButtonClick(event, {item: primaryItems[0]});
 					}}
 					symbol="plus"
+					title={getPlusIconLabel()}
 				/>
 			)}
 		</>


### PR DESCRIPTION
Original pull https://github.com/moltam89/liferay-portal/pull/582

The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

**Test plan:** 
1. Navigate to Publishing > Export
2. Create a process and save. Here you see the management toolbar present in `toolbar.jsp`. 
3. On the top kebab menu, click on Export templates. Here is the management `toolbar from view_export_configurations.jsp`

I did not found how to render the changes done in `publish_templates/view.jsp`, so please test it, although, behaviour shouldn't have changed. 

Notice that there was a previous bug and it is still present in the PR: 

<img width="1043" alt="MT in export import" src="https://user-images.githubusercontent.com/8373764/109013731-c5854080-76b3-11eb-9b44-24314049bafd.png">

The total items are not being calculated. I guess that you are missing the `itemsTotal` parameter in the taglib. 

/cc @jonmak08 @julien @markocikos