### PR TITLE
LPS-125138 Add new, simplified, validators API as a first step of removing `import {Config} from 'metal-state'`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -101,3 +101,14 @@ export {default as navigate} from './liferay/util/navigate.es';
 export {default as normalizeFriendlyURL} from './liferay/util/normalize_friendly_url';
 export {default as runScriptsInElement} from './liferay/util/run_scripts_in_element.es';
 export {default as toggleDisabled} from './liferay/util/toggle_disabled';
+
+// Validators API
+
+export {
+	validateArray,
+	validateBoolean,
+	validateFunction,
+	validateNumber,
+	validateObject,
+	validateString,
+} from './liferay/validators';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/validators.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/validators.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export function validateAny() {
+	return true;
+}
+
+export function validateArray(value, name, context) {
+	return validateType('array', value, name, context);
+}
+
+export function validateString(value, name, context) {
+	return validateType('string', value, name, context);
+}
+
+export function validateObject(value, name, context) {
+	return validateType('object', value, name, context);
+}
+
+export function validateBoolean(value, name, context) {
+	return validateType('boolean', value, name, context);
+}
+
+export function validateFunction(value, name, context) {
+	return validateType('function', value, name, context);
+}
+
+export function validateNumber(value, name, context) {
+	return validateType('number', value, name, context);
+}
+
+/**
+ * Checks if the given value matches the expected type.
+ * @param {string} expectedType String representing the expected type.
+ * @param {*} value The value to match the type of.
+ * @param {string} name The name of the property being checked.
+ * @param {!Object} context Owner of the property being checked.
+ * @return {!Error|boolean} `true` if the type matches, or an error otherwise.
+ */
+function validateType(expectedType, value, name, context) {
+	const type = typeof value;
+
+	if (type !== expectedType) {
+		const errorMessage = `Expected type '${expectedType}', but received type '${type}'.`;
+
+		return composeError(errorMessage, name, context);
+	}
+
+	return true;
+}
+
+/**
+ * Composes a warning a warning message.
+ * @param {string} error Error message to display to console.
+ * @param {?string} name Name of state property that is giving the error.
+ * @param {Object} context The property's owner.
+ * @return {!Error}
+ */
+function composeError(error, name, context) {
+	const componentName = context ? getFunctionName(context.constructor) : null;
+	const renderer = context?.getRenderer && context.getRenderer();
+
+	const parent = renderer?.getParent && renderer.getParent();
+
+	const parentName = parent ? getFunctionName(parent.constructor) : null;
+
+	const location = parentName
+		? `Check render method of '${parentName}'.`
+		: '';
+
+	return new Error(
+		`Invalid state passed to '${name}'.` +
+			` ${error} Passed to '${componentName}'. ${location}`
+	);
+}
+
+/**
+ * Gets the name of the given function. If the current browser doesn't
+ * support the `name` property, like IE11, this will calculate it from the function's
+ * content string.
+ * @param {!function()} fn
+ * @return {string}
+ */
+function getFunctionName(fn) {
+	if (!fn.name) {
+		const stringifiedName = fn.toString();
+
+		fn.name = stringifiedName.substring(9, stringifiedName.indexOf('('));
+	}
+
+	return fn.name;
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/validators.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/validators.js
@@ -25,6 +25,12 @@ export function validateString(value, name, context) {
 }
 
 export function validateObject(value, name, context) {
+	if (value === null || value === undefined) {
+		const errorMessage = `${name} cannot be null or undefined.`;
+
+		return composeError(errorMessage, name, context);
+	}
+
 	return validateType('object', value, name, context);
 }
 
@@ -86,17 +92,15 @@ function composeError(error, name, context) {
 }
 
 /**
- * Gets the name of the given function. If the current browser doesn't
- * support the `name` property, like IE11, this will calculate it from the function's
- * content string.
- * @param {!function()} fn
+ * Gets the name of the given function.
+ * @param {Function} fn The function to get the name of.
  * @return {string}
  */
 function getFunctionName(fn) {
 	if (!fn.name) {
 		const stringifiedName = fn.toString();
 
-		fn.name = stringifiedName.substring(9, stringifiedName.indexOf('('));
+		return stringifiedName.substring(9, stringifiedName.indexOf('('));
 	}
 
 	return fn.name;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/MoveEntries.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/MoveEntries.es.js
@@ -103,10 +103,8 @@ MoveEntries.STATE = {
 	 * @type {string}
 	 */
 	selectFolderURL: {
-		config: {
-			required: true,
-			validator: validateString,
-		},
+		required: true,
+		validator: validateString,
 	},
 };
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/MoveEntries.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/MoveEntries.es.js
@@ -12,8 +12,7 @@
  * details.
  */
 
-import {PortletBase, openSelectionModal} from 'frontend-js-web';
-import {Config} from 'metal-state';
+import {PortletBase, openSelectionModal, validateString} from 'frontend-js-web';
 
 /**
  * @class MoveEntries
@@ -103,7 +102,12 @@ MoveEntries.STATE = {
 	 * @review
 	 * @type {string}
 	 */
-	selectFolderURL: Config.string().required(),
+	selectFolderURL: {
+		config: {
+			required: true,
+			validator: validateString,
+		},
+	},
 };
 
 export default MoveEntries;


### PR DESCRIPTION
Here's a resurrected attempt at [LPS-125138](https://issues.liferay.com/browse/LPS-125138). The initial, closed, PR has a lot of discussion that lead to this iteration and can be found at https://github.com/liferay-frontend/liferay-portal/pull/746. 

I've essentially copied the implementation of `metal-state/validators.js` into `frontend-js-web/validators.js` while focusing on understanding how it works together with `metal-state/State` so that we can still rely on `metal-state/State` but remove the validators bit-by-bit.

I have tested this by passing a wrong type to see if the proper error is thrown. I've also tested the `required` property and confirmed it will work properly. In the initial PR we had a problem that `required` properties were undefined - this variant of the API doesn't have that problem.