### PR TITLE
LPS-128506 - Make sure taglibs using react and clay are using proper tooltip

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/select-objects/SelectObjects.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/select-objects/SelectObjects.es.js
@@ -15,7 +15,6 @@
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {getItem} from 'data-engine-js-components-web/js/utils/client.es';
 import {getLocalizedValue} from 'data-engine-js-components-web/js/utils/lang.es';
 import React, {useEffect, useState} from 'react';
@@ -158,17 +157,15 @@ export default function SelectObjects({
 			<DropDownWithSearch
 				{...state}
 				addButton={
-					<ClayTooltipProvider>
-						<ClayButtonWithIcon
-							className="btn btn-monospaced btn-secondary mr-2 nav-btn nav-btn-monospaced"
-							data-tooltip-align="bottom-right"
-							data-tooltip-delay="0"
-							displayType="secondary"
-							onClick={() => setModalVisible(true)}
-							symbol="plus"
-							title={Liferay.Language.get('new-custom-object')}
-						/>
-					</ClayTooltipProvider>
+					<ClayButtonWithIcon
+						className="btn btn-monospaced btn-secondary mr-2 nav-btn nav-btn-monospaced"
+						data-tooltip-align="bottom-right"
+						data-tooltip-delay="0"
+						displayType="secondary"
+						onClick={() => setModalVisible(true)}
+						symbol="plus"
+						title={Liferay.Language.get('new-custom-object')}
+					/>
 				}
 				isEmpty={items.length === 0}
 				label={label}

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/toggle-switch/ToggleSwitch.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/toggle-switch/ToggleSwitch.es.js
@@ -12,37 +12,34 @@
  * details.
  */
 
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useState} from 'react';
 
 export default ({checked = false, onChange}) => {
 	const [isChecked, setChecked] = useState(checked);
 
 	return (
-		<ClayTooltipProvider>
-			<label className="toggle-switch">
-				<input
-					checked={isChecked}
-					className="toggle-switch-check"
-					data-tooltip-align="top"
-					data-tooltip-delay="0"
-					onChange={() => {
-						const newChecked = !isChecked;
-						setChecked(newChecked);
-						onChange(newChecked);
-					}}
-					title={
-						isChecked
-							? Liferay.Language.get('turn-off')
-							: Liferay.Language.get('turn-on')
-					}
-					type="checkbox"
-				/>
+		<label className="toggle-switch">
+			<input
+				checked={isChecked}
+				className="toggle-switch-check"
+				data-tooltip-align="top"
+				data-tooltip-delay="0"
+				onChange={() => {
+					const newChecked = !isChecked;
+					setChecked(newChecked);
+					onChange(newChecked);
+				}}
+				title={
+					isChecked
+						? Liferay.Language.get('turn-off')
+						: Liferay.Language.get('turn-on')
+				}
+				type="checkbox"
+			/>
 
-				<span aria-hidden="true" className="toggle-switch-bar">
-					<span className="toggle-switch-handle"></span>
-				</span>
-			</label>
-		</ClayTooltipProvider>
+			<span aria-hidden="true" className="toggle-switch-bar">
+				<span className="toggle-switch-handle"></span>
+			</span>
+		</label>
 	);
 };

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/entry/FieldPreview.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/entry/FieldPreview.es.js
@@ -16,7 +16,6 @@ import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import {SheetSection} from '@clayui/layout';
 import ClayPanel from '@clayui/panel';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {DataDefinitionUtils} from 'data-engine-taglib';
 import React, {useContext, useEffect, useState} from 'react';
 
@@ -124,31 +123,29 @@ const DocumentRenderer = ({displayType, value = {}}) => {
 			{displayType === 'list' ? (
 				<StringRenderer value={title} />
 			) : fileEntryId ? (
-				<ClayTooltipProvider>
-					<ClayButton.Group className="data-record-document-field mb-2">
-						<ClayButton
-							data-tooltip-align="bottom"
-							data-tooltip-delay="200"
-							displayType="secondary"
-							onClick={onClickPreview}
-							title={Liferay.Language.get('file-preview')}
-						>
-							<ClayIcon
-								className="mr-2"
-								symbol={getDocumentIcon(title)}
-							/>
-							{title}
-						</ClayButton>
-						<ClayButtonWithIcon
-							data-tooltip-align="bottom"
-							data-tooltip-delay="200"
-							displayType="secondary"
-							onClick={onClickDownload}
-							symbol="download"
-							title={Liferay.Language.get('download')}
+				<ClayButton.Group className="data-record-document-field mb-2">
+					<ClayButton
+						data-tooltip-align="bottom"
+						data-tooltip-delay="200"
+						displayType="secondary"
+						onClick={onClickPreview}
+						title={Liferay.Language.get('file-preview')}
+					>
+						<ClayIcon
+							className="mr-2"
+							symbol={getDocumentIcon(title)}
 						/>
-					</ClayButton.Group>
-				</ClayTooltipProvider>
+						{title}
+					</ClayButton>
+					<ClayButtonWithIcon
+						data-tooltip-align="bottom"
+						data-tooltip-delay="200"
+						displayType="secondary"
+						onClick={onClickDownload}
+						symbol="download"
+						title={Liferay.Language.get('download')}
+					/>
+				</ClayButton.Group>
 			) : (
 				<StringRenderer />
 			)}

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/entry/ViewEntryUpperToolbar.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/entry/ViewEntryUpperToolbar.es.js
@@ -14,7 +14,6 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayButtonGroup from '@clayui/button/lib/Group';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {confirmDelete} from 'data-engine-js-components-web/js/utils/client.es';
 import {sub} from 'data-engine-js-components-web/js/utils/lang.es';
 import React, {useContext} from 'react';
@@ -100,63 +99,57 @@ function ViewEntryUpperToolbar({
 			<UpperToolbar.Item expand>{children}</UpperToolbar.Item>
 
 			<UpperToolbar.Group>
-				<ClayTooltipProvider>
-					<ClayButtonGroup>
-						<ClayButtonWithIcon
-							data-tooltip-align="bottom"
-							data-tooltip-delay="200"
-							disabled={page === 1}
-							displayType="secondary"
-							onClick={onPrev}
-							small
-							symbol="angle-left"
-							title={Liferay.Language.get('previous-entry')}
-						/>
+				<ClayButtonGroup>
+					<ClayButtonWithIcon
+						data-tooltip-align="bottom"
+						data-tooltip-delay="200"
+						disabled={page === 1}
+						displayType="secondary"
+						onClick={onPrev}
+						small
+						symbol="angle-left"
+						title={Liferay.Language.get('previous-entry')}
+					/>
 
-						<ClayButtonWithIcon
-							data-tooltip-align="bottom"
-							data-tooltip-delay="200"
-							disabled={page === totalCount}
-							displayType="secondary"
-							onClick={onNext}
-							small
-							symbol="angle-right"
-							title={Liferay.Language.get('next-entry')}
-						/>
-					</ClayButtonGroup>
-				</ClayTooltipProvider>
+					<ClayButtonWithIcon
+						data-tooltip-align="bottom"
+						data-tooltip-delay="200"
+						disabled={page === totalCount}
+						displayType="secondary"
+						onClick={onNext}
+						small
+						symbol="angle-right"
+						title={Liferay.Language.get('next-entry')}
+					/>
+				</ClayButtonGroup>
 			</UpperToolbar.Group>
 
 			{showFormView && (
 				<UpperToolbar.Group>
 					{permissions.delete && showDeleteButton && (
-						<ClayTooltipProvider>
-							<ClayButtonWithIcon
-								className="mr-2"
-								data-tooltip-align="bottom"
-								data-tooltip-delay="200"
-								displayType="secondary"
-								onClick={onDelete}
-								small
-								symbol="trash"
-								title={Liferay.Language.get('delete')}
-							/>
-						</ClayTooltipProvider>
+						<ClayButtonWithIcon
+							className="mr-2"
+							data-tooltip-align="bottom"
+							data-tooltip-delay="200"
+							displayType="secondary"
+							onClick={onDelete}
+							small
+							symbol="trash"
+							title={Liferay.Language.get('delete')}
+						/>
 					)}
 
 					{permissions.update && showUpdateButton && (
-						<ClayTooltipProvider>
-							<ClayButtonWithIcon
-								className="mr-2"
-								data-tooltip-align="bottom"
-								data-tooltip-delay="200"
-								displayType="secondary"
-								onClick={onEdit}
-								small
-								symbol="pencil"
-								title={Liferay.Language.get('edit')}
-							/>
-						</ClayTooltipProvider>
+						<ClayButtonWithIcon
+							className="mr-2"
+							data-tooltip-align="bottom"
+							data-tooltip-delay="200"
+							displayType="secondary"
+							onClick={onEdit}
+							small
+							symbol="pencil"
+							title={Liferay.Language.get('edit')}
+						/>
 					)}
 
 					{additionalButtons}

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/DropZone.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/DropZone.es.js
@@ -14,7 +14,6 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import Table from 'data-engine-js-components-web/js/components/table/Table.es';
 import {DragTypes} from 'data-engine-taglib';
@@ -116,18 +115,16 @@ const DropZone = ({fields, onAddFieldName, onRemoveFieldName}) => {
 									appliedFilters,
 									name
 								) && (
-									<ClayTooltipProvider>
-										<ClayLayout.ContentCol>
-											<ClayIcon
-												data-tooltip-align="top"
-												data-tooltip-delay="200"
-												symbol="filter"
-												title={Liferay.Language.get(
-													'this-column-has-applied-filters'
-												)}
-											/>
-										</ClayLayout.ContentCol>
-									</ClayTooltipProvider>
+									<ClayLayout.ContentCol>
+										<ClayIcon
+											data-tooltip-align="top"
+											data-tooltip-delay="200"
+											symbol="filter"
+											title={Liferay.Language.get(
+												'this-column-has-applied-filters'
+											)}
+										/>
+									</ClayLayout.ContentCol>
 								)}
 							</ClayLayout.ContentRow>
 						</ClayLayout.ContainerFluid>

--- a/modules/apps/change-tracking/change-tracking-web/package.json
+++ b/modules/apps/change-tracking/change-tracking-web/package.json
@@ -16,7 +16,6 @@
 		"@clayui/panel": "3.25.0",
 		"@clayui/progress-bar": "3.2.0",
 		"@clayui/table": "3.1.0",
-		"@clayui/tooltip": "3.4.5",
 		"frontend-js-web": "*",
 		"moment": "^2.22.2",
 		"react": "16.12.0"

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingChangesView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingChangesView.js
@@ -21,7 +21,6 @@ import ClayIcon from '@clayui/icon';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import ClayTable from '@clayui/table';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
 import ChangeTrackingRenderView from './ChangeTrackingRenderView';
@@ -1696,78 +1695,72 @@ class ChangeTrackingChangesView extends React.Component {
 		];
 
 		return (
-			<ClayTooltipProvider>
-				<ClayManagementToolbar>
-					<ClayManagementToolbar.ItemList>
-						<ClayManagementToolbar.Item>
-							<ClayDropDownWithItems
-								items={dropdownItems}
-								spritemap={this.spritemap}
-								trigger={
-									<ClayButton
-										className="nav-link"
-										displayType="unstyled"
-									>
-										<span className="navbar-breakpoint-down-d-none">
-											<span className="navbar-text-truncate">
-												{Liferay.Language.get(
-													'filter-and-order'
-												)}
-											</span>
-
-											<ClayIcon
-												className="inline-item inline-item-after"
-												spritemap={this.spritemap}
-												symbol="caret-bottom"
-											/>
+			<ClayManagementToolbar>
+				<ClayManagementToolbar.ItemList>
+					<ClayManagementToolbar.Item>
+						<ClayDropDownWithItems
+							items={dropdownItems}
+							spritemap={this.spritemap}
+							trigger={
+								<ClayButton
+									className="nav-link"
+									displayType="unstyled"
+								>
+									<span className="navbar-breakpoint-down-d-none">
+										<span className="navbar-text-truncate">
+											{Liferay.Language.get(
+												'filter-and-order'
+											)}
 										</span>
-										<span className="navbar-breakpoint-d-none">
-											<ClayIcon
-												spritemap={this.spritemap}
-												symbol="filter"
-											/>
-										</span>
-									</ClayButton>
-								}
-							/>
-						</ClayManagementToolbar.Item>
 
-						<ClayManagementToolbar.Item
-							data-tooltip-align="top"
-							title={Liferay.Language.get(
-								'reverse-sort-direction'
-							)}
+										<ClayIcon
+											className="inline-item inline-item-after"
+											spritemap={this.spritemap}
+											symbol="caret-bottom"
+										/>
+									</span>
+									<span className="navbar-breakpoint-d-none">
+										<ClayIcon
+											spritemap={this.spritemap}
+											symbol="filter"
+										/>
+									</span>
+								</ClayButton>
+							}
+						/>
+					</ClayManagementToolbar.Item>
+
+					<ClayManagementToolbar.Item
+						data-tooltip-align="top"
+						title={Liferay.Language.get('reverse-sort-direction')}
+					>
+						<ClayButton
+							className={this.state.sortDirectionClass}
+							displayType="unstyled"
+							onClick={() => this._handleSortDirectionChange()}
 						>
-							<ClayButton
-								className={this.state.sortDirectionClass}
-								displayType="unstyled"
-								onClick={() =>
-									this._handleSortDirectionChange()
-								}
-							>
-								<ClayIcon
-									spritemap={this.spritemap}
-									symbol="order-arrow"
-								/>
-							</ClayButton>
-						</ClayManagementToolbar.Item>
-
-						<ClayManagementToolbar.Item className="nav-item-expand" />
-
-						<ClayManagementToolbar.Item className="simple-toggle-switch-reverse">
-							<ClayToggle
-								label={Liferay.Language.get('show-all-items')}
-								onToggle={(showHideable) =>
-									this._handleShowHideableToggle(showHideable)
-								}
-								toggled={this.state.showHideable}
+							<ClayIcon
+								spritemap={this.spritemap}
+								symbol="order-arrow"
 							/>
-						</ClayManagementToolbar.Item>
+						</ClayButton>
+					</ClayManagementToolbar.Item>
 
-						{this._getViewTypes()}
-					</ClayManagementToolbar.ItemList>
-				</ClayManagementToolbar>
-			</ClayTooltipProvider>
+					<ClayManagementToolbar.Item className="nav-item-expand" />
+
+					<ClayManagementToolbar.Item className="simple-toggle-switch-reverse">
+						<ClayToggle
+							label={Liferay.Language.get('show-all-items')}
+							onToggle={(showHideable) =>
+								this._handleShowHideableToggle(showHideable)
+							}
+							toggled={this.state.showHideable}
+						/>
+					</ClayManagementToolbar.Item>
+
+					{this._getViewTypes()}
+				</ClayManagementToolbar.ItemList>
+			</ClayManagementToolbar>
 		);
 	}
 
@@ -1841,22 +1834,20 @@ class ChangeTrackingChangesView extends React.Component {
 
 		return (
 			<>
-				<ClayTooltipProvider>
-					<ClayTable
-						className="publications-table"
-						headingNoWrap
-						hover
-						noWrap
-					>
-						{this._getTableHead()}
+				<ClayTable
+					className="publications-table"
+					headingNoWrap
+					hover
+					noWrap
+				>
+					{this._getTableHead()}
 
-						<ClayTable.Body>
-							{this._getTableRows(
-								this._filterDisplayNodes(this.state.children)
-							)}
-						</ClayTable.Body>
-					</ClayTable>
-				</ClayTooltipProvider>
+					<ClayTable.Body>
+						{this._getTableRows(
+							this._filterDisplayNodes(this.state.children)
+						)}
+					</ClayTable.Body>
+				</ClayTable>
 
 				{this._renderPagination()}
 			</>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingConflictsView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingConflictsView.js
@@ -22,7 +22,6 @@ import ClayModal, {useModal} from '@clayui/modal';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import ClayPanel from '@clayui/panel';
 import ClayTimePicker from '@clayui/time-picker';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useState} from 'react';
 
 import ChangeTrackingBaseScheduleView from './ChangeTrackingBaseScheduleView';
@@ -512,9 +511,7 @@ const ConflictsTable = ({conflicts, spritemap}) => {
 		<>
 			{renderViewModal()}
 
-			<ClayTooltipProvider>
-				<ClayList showQuickActionsOnHover>{getListItems()}</ClayList>
-			</ClayTooltipProvider>
+			<ClayList showQuickActionsOnHover>{getListItems()}</ClayList>
 
 			{renderPagination()}
 		</>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingDiscardView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingDiscardView.js
@@ -15,7 +15,6 @@
 import ClayModal, {useModal} from '@clayui/modal';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import ClayTable from '@clayui/table';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useState} from 'react';
 
 import ChangeTrackingRenderView from './ChangeTrackingRenderView';
@@ -193,22 +192,20 @@ export default ({ctEntriesJSONArray, spritemap, typeNames, userInfo}) => {
 		<>
 			{renderViewModal()}
 
-			<ClayTooltipProvider>
-				<ClayTable className="publications-table" hover>
-					<ClayTable.Head>
-						<ClayTable.Row>
-							<ClayTable.Cell headingCell style={{width: '5%'}}>
-								{Liferay.Language.get('user')}
-							</ClayTable.Cell>
+			<ClayTable className="publications-table" hover>
+				<ClayTable.Head>
+					<ClayTable.Row>
+						<ClayTable.Cell headingCell style={{width: '5%'}}>
+							{Liferay.Language.get('user')}
+						</ClayTable.Cell>
 
-							<ClayTable.Cell headingCell style={{width: '95%'}}>
-								{Liferay.Language.get('change')}
-							</ClayTable.Cell>
-						</ClayTable.Row>
-					</ClayTable.Head>
-					<ClayTable.Body>{getTableRows()}</ClayTable.Body>
-				</ClayTable>
-			</ClayTooltipProvider>
+						<ClayTable.Cell headingCell style={{width: '95%'}}>
+							{Liferay.Language.get('change')}
+						</ClayTable.Cell>
+					</ClayTable.Row>
+				</ClayTable.Head>
+				<ClayTable.Body>{getTableRows()}</ClayTable.Body>
+			</ClayTable>
 
 			{renderPagination()}
 		</>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingIndicator.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingIndicator.js
@@ -24,7 +24,6 @@ import ClayManagementToolbar, {
 import ClayModal, {useModal} from '@clayui/modal';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import ClayTable from '@clayui/table';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {fetch} from 'frontend-js-web';
 import React, {useCallback, useEffect, useState} from 'react';
 
@@ -345,155 +344,151 @@ const PublicationsSearchContainer = ({
 		const activeViewTypeItem = viewTypeItems.find((type) => type.active);
 
 		return (
-			<ClayTooltipProvider>
-				<ClayManagementToolbar>
+			<ClayManagementToolbar>
+				<ClayManagementToolbar.ItemList>
+					<ClayManagementToolbar.Item>
+						<ClayDropDownWithItems
+							items={[
+								{
+									items,
+									label: Liferay.Language.get('order-by'),
+									type: 'group',
+								},
+							]}
+							spritemap={spritemap}
+							trigger={
+								<ClayButton
+									className="nav-link"
+									disabled={filterDisabled}
+									displayType="unstyled"
+								>
+									<span className="navbar-breakpoint-down-d-none">
+										<span className="navbar-text-truncate">
+											{Liferay.Language.get(
+												'filter-and-order'
+											)}
+										</span>
+
+										<ClayIcon
+											className="inline-item inline-item-after"
+											spritemap={spritemap}
+											symbol="caret-bottom"
+										/>
+									</span>
+									<span className="navbar-breakpoint-d-none">
+										<ClayIcon
+											spritemap={spritemap}
+											symbol="filter"
+										/>
+									</span>
+								</ClayButton>
+							}
+						/>
+					</ClayManagementToolbar.Item>
+					<ClayManagementToolbar.Item
+						data-tooltip-align="top"
+						title={Liferay.Language.get('reverse-sort-direction')}
+					>
+						<ClayButton
+							className={
+								'nav-link nav-link-monospaced ' +
+								(ascending
+									? 'order-arrow-down-active'
+									: 'order-arrow-up-active')
+							}
+							disabled={filterDisabled}
+							displayType="unstyled"
+							onClick={() => setAscending(!ascending)}
+						>
+							<ClayIcon
+								spritemap={spritemap}
+								symbol="order-arrow"
+							/>
+						</ClayButton>
+					</ClayManagementToolbar.Item>
+				</ClayManagementToolbar.ItemList>
+				<ClayManagementToolbar.Search
+					onSubmit={(event) => {
+						event.preventDefault();
+
+						onSubmit(searchTerms.trim(), state.delta, 1);
+					}}
+					showMobile={showMobile}
+				>
+					<ClayInput.Group>
+						<ClayInput.GroupItem>
+							<ClayInput
+								aria-label={Liferay.Language.get('search')}
+								className="input-group-inset input-group-inset-after"
+								disabled={searchDisabled}
+								onChange={(event) =>
+									setSearchTerms(event.target.value)
+								}
+								placeholder={`${Liferay.Language.get(
+									'search'
+								)}...`}
+								type="text"
+								value={searchTerms}
+							/>
+							<ClayInput.GroupInsetItem after tag="span">
+								<ClayButtonWithIcon
+									className="navbar-breakpoint-d-none"
+									displayType="unstyled"
+									onClick={() => setShowMobile(false)}
+									symbol="times"
+								/>
+								<ClayButtonWithIcon
+									disabled={searchDisabled}
+									displayType="unstyled"
+									symbol="search"
+									type="submit"
+								/>
+							</ClayInput.GroupInsetItem>
+						</ClayInput.GroupItem>
+					</ClayInput.Group>
+				</ClayManagementToolbar.Search>
+				<ClayManagementToolbar.ItemList>
+					<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
+						<ClayButton
+							className="nav-link nav-link-monospaced"
+							disabled={searchDisabled}
+							displayType="unstyled"
+							onClick={() => setShowMobile(true)}
+						>
+							<ClayIcon symbol="search" />
+						</ClayButton>
+					</ClayManagementToolbar.Item>
+				</ClayManagementToolbar.ItemList>
+
+				{viewTypeItems.length > 1 && (
 					<ClayManagementToolbar.ItemList>
-						<ClayManagementToolbar.Item>
+						<ClayManagementToolbar.Item
+							data-tooltip-align="top"
+							title={Liferay.Language.get('display-style')}
+						>
 							<ClayDropDownWithItems
-								items={[
-									{
-										items,
-										label: Liferay.Language.get('order-by'),
-										type: 'group',
-									},
-								]}
+								items={viewTypeItems}
 								spritemap={spritemap}
 								trigger={
 									<ClayButton
-										className="nav-link"
-										disabled={filterDisabled}
+										className="nav-link nav-link-monospaced"
 										displayType="unstyled"
 									>
-										<span className="navbar-breakpoint-down-d-none">
-											<span className="navbar-text-truncate">
-												{Liferay.Language.get(
-													'filter-and-order'
-												)}
-											</span>
-
-											<ClayIcon
-												className="inline-item inline-item-after"
-												spritemap={spritemap}
-												symbol="caret-bottom"
-											/>
-										</span>
-										<span className="navbar-breakpoint-d-none">
-											<ClayIcon
-												spritemap={spritemap}
-												symbol="filter"
-											/>
-										</span>
+										<ClayIcon
+											spritemap={spritemap}
+											symbol={
+												activeViewTypeItem
+													? activeViewTypeItem.symbolLeft
+													: ''
+											}
+										/>
 									</ClayButton>
 								}
 							/>
 						</ClayManagementToolbar.Item>
-						<ClayManagementToolbar.Item
-							data-tooltip-align="top"
-							title={Liferay.Language.get(
-								'reverse-sort-direction'
-							)}
-						>
-							<ClayButton
-								className={
-									'nav-link nav-link-monospaced ' +
-									(ascending
-										? 'order-arrow-down-active'
-										: 'order-arrow-up-active')
-								}
-								disabled={filterDisabled}
-								displayType="unstyled"
-								onClick={() => setAscending(!ascending)}
-							>
-								<ClayIcon
-									spritemap={spritemap}
-									symbol="order-arrow"
-								/>
-							</ClayButton>
-						</ClayManagementToolbar.Item>
 					</ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Search
-						onSubmit={(event) => {
-							event.preventDefault();
-
-							onSubmit(searchTerms.trim(), state.delta, 1);
-						}}
-						showMobile={showMobile}
-					>
-						<ClayInput.Group>
-							<ClayInput.GroupItem>
-								<ClayInput
-									aria-label={Liferay.Language.get('search')}
-									className="input-group-inset input-group-inset-after"
-									disabled={searchDisabled}
-									onChange={(event) =>
-										setSearchTerms(event.target.value)
-									}
-									placeholder={`${Liferay.Language.get(
-										'search'
-									)}...`}
-									type="text"
-									value={searchTerms}
-								/>
-								<ClayInput.GroupInsetItem after tag="span">
-									<ClayButtonWithIcon
-										className="navbar-breakpoint-d-none"
-										displayType="unstyled"
-										onClick={() => setShowMobile(false)}
-										symbol="times"
-									/>
-									<ClayButtonWithIcon
-										disabled={searchDisabled}
-										displayType="unstyled"
-										symbol="search"
-										type="submit"
-									/>
-								</ClayInput.GroupInsetItem>
-							</ClayInput.GroupItem>
-						</ClayInput.Group>
-					</ClayManagementToolbar.Search>
-					<ClayManagementToolbar.ItemList>
-						<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
-							<ClayButton
-								className="nav-link nav-link-monospaced"
-								disabled={searchDisabled}
-								displayType="unstyled"
-								onClick={() => setShowMobile(true)}
-							>
-								<ClayIcon symbol="search" />
-							</ClayButton>
-						</ClayManagementToolbar.Item>
-					</ClayManagementToolbar.ItemList>
-
-					{viewTypeItems.length > 1 && (
-						<ClayManagementToolbar.ItemList>
-							<ClayManagementToolbar.Item
-								data-tooltip-align="top"
-								title={Liferay.Language.get('display-style')}
-							>
-								<ClayDropDownWithItems
-									items={viewTypeItems}
-									spritemap={spritemap}
-									trigger={
-										<ClayButton
-											className="nav-link nav-link-monospaced"
-											displayType="unstyled"
-										>
-											<ClayIcon
-												spritemap={spritemap}
-												symbol={
-													activeViewTypeItem
-														? activeViewTypeItem.symbolLeft
-														: ''
-												}
-											/>
-										</ClayButton>
-									}
-								/>
-							</ClayManagementToolbar.Item>
-						</ClayManagementToolbar.ItemList>
-					)}
-				</ClayManagementToolbar>
-			</ClayTooltipProvider>
+				)}
+			</ClayManagementToolbar>
 		);
 	};
 
@@ -640,17 +635,15 @@ const PublicationsSearchContainer = ({
 					}
 				>
 					<div className={containerView ? 'container-view' : ''}>
-						<ClayTooltipProvider>
-							<ClayList
-								className={
-									loading
-										? 'publications-loading publications-table'
-										: 'publications-table'
-								}
-							>
-								{items}
-							</ClayList>
-						</ClayTooltipProvider>
+						<ClayList
+							className={
+								loading
+									? 'publications-loading publications-table'
+									: 'publications-table'
+							}
+						>
+							{items}
+						</ClayList>
 
 						{renderPagination()}
 					</div>
@@ -673,20 +666,18 @@ const PublicationsSearchContainer = ({
 					}
 				>
 					<div className={containerView ? 'container-view' : ''}>
-						<ClayTooltipProvider>
-							<ClayTable
-								className={
-									loading
-										? 'publications-loading publications-table'
-										: 'publications-table'
-								}
-								headingNoWrap
-								hover={false}
-							>
-								{getTableHead ? getTableHead() : ''}
-								<ClayTable.Body>{rows}</ClayTable.Body>
-							</ClayTable>
-						</ClayTooltipProvider>
+						<ClayTable
+							className={
+								loading
+									? 'publications-loading publications-table'
+									: 'publications-table'
+							}
+							headingNoWrap
+							hover={false}
+						>
+							{getTableHead ? getTableHead() : ''}
+							<ClayTable.Body>{rows}</ClayTable.Body>
+						</ClayTable>
 
 						{renderPagination()}
 					</div>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingRenderView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingRenderView.js
@@ -18,7 +18,6 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import ClayNavigationBar from '@clayui/navigation-bar';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {fetch} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
@@ -363,24 +362,22 @@ export default ({dataURL, getCache, spritemap, updateCache}) => {
 			elements.push(
 				<div className="autofit-col">
 					<div className="dropdown">
-						<ClayTooltipProvider>
-							<ClayButton
-								borderless
-								className="disabled"
-								data-tooltip-align="top"
-								displayType="secondary"
-								title={getContentSelectTooltip()}
-							>
-								{getContentSelectTitle(state.contentSelect)}
+						<ClayButton
+							borderless
+							className="disabled"
+							data-tooltip-align="top"
+							displayType="secondary"
+							title={getContentSelectTooltip()}
+						>
+							{getContentSelectTitle(state.contentSelect)}
 
-								<span className="inline-item inline-item-after">
-									<ClayIcon
-										spritemap={spritemap}
-										symbol="caret-bottom"
-									/>
-								</span>
-							</ClayButton>
-						</ClayTooltipProvider>
+							<span className="inline-item inline-item-after">
+								<ClayIcon
+									spritemap={spritemap}
+									symbol="caret-bottom"
+								/>
+							</span>
+						</ClayButton>
 					</div>
 				</div>
 			);
@@ -598,101 +595,84 @@ export default ({dataURL, getCache, spritemap, updateCache}) => {
 				>
 					<div className="autofit-row">
 						<div className="autofit-col">
-							<ClayTooltipProvider>
-								<ClayNavigationBar
-									spritemap={spritemap}
-									triggerLabel={Liferay.Language.get(
-										'display'
-									)}
+							<ClayNavigationBar
+								spritemap={spritemap}
+								triggerLabel={Liferay.Language.get('display')}
+							>
+								<ClayNavigationBar.Item
+									active={
+										state.contentType ===
+										CONTENT_TYPE_DISPLAY
+									}
 								>
-									<ClayNavigationBar.Item
-										active={
-											state.contentType ===
-											CONTENT_TYPE_DISPLAY
+									<ClayLink
+										className={
+											!state.renderData.content
+												? 'nav-link btn-link disabled'
+												: 'nav-link'
+										}
+										displayType="unstyled"
+										onClick={() =>
+											setContentType(CONTENT_TYPE_DISPLAY)
+										}
+										title={
+											!state.renderData.content
+												? Liferay.Language.get(
+														'item-does-not-have-a-content-display'
+												  )
+												: ''
 										}
 									>
-										<ClayLink
-											className={
-												!state.renderData.content
-													? 'nav-link btn-link disabled'
-													: 'nav-link'
-											}
-											displayType="unstyled"
-											onClick={() =>
-												setContentType(
-													CONTENT_TYPE_DISPLAY
-												)
-											}
-											title={
-												!state.renderData.content
-													? Liferay.Language.get(
-															'item-does-not-have-a-content-display'
-													  )
-													: ''
-											}
-										>
-											{Liferay.Language.get('display')}
-										</ClayLink>
-									</ClayNavigationBar.Item>
-									<ClayNavigationBar.Item
-										active={
-											state.contentType ===
-											CONTENT_TYPE_DATA
+										{Liferay.Language.get('display')}
+									</ClayLink>
+								</ClayNavigationBar.Item>
+								<ClayNavigationBar.Item
+									active={
+										state.contentType === CONTENT_TYPE_DATA
+									}
+								>
+									<ClayLink
+										className="nav-link"
+										displayType="unstyled"
+										onClick={() =>
+											setContentType(CONTENT_TYPE_DATA)
 										}
 									>
-										<ClayLink
-											className="nav-link"
-											displayType="unstyled"
-											onClick={() =>
-												setContentType(
-													CONTENT_TYPE_DATA
-												)
-											}
-										>
-											{Liferay.Language.get('data')}
-										</ClayLink>
-									</ClayNavigationBar.Item>
-								</ClayNavigationBar>
-							</ClayTooltipProvider>
+										{Liferay.Language.get('data')}
+									</ClayLink>
+								</ClayNavigationBar.Item>
+							</ClayNavigationBar>
 						</div>
 						<div className="autofit-col row-divider">
 							<div />
 						</div>
 						<div className="autofit-col">
-							<ClayTooltipProvider>
-								<ClayButton.Group>
-									<ClayButtonWithIcon
-										borderless
-										className={
-											state.viewType === VIEW_TYPE_FULL
-												? 'active'
-												: ''
-										}
-										data-tooltip-align="top"
-										displayType="secondary"
-										onClick={() =>
-											setViewType(VIEW_TYPE_FULL)
-										}
-										spritemap={spritemap}
-										symbol="rectangle"
-										title={Liferay.Language.get(
-											'full-view'
-										)}
-									/>
-									<ClayButtonWithIcon
-										borderless
-										className={splitViewClassName}
-										data-tooltip-align="top"
-										displayType="secondary"
-										onClick={() =>
-											setViewType(VIEW_TYPE_SPLIT)
-										}
-										spritemap={spritemap}
-										symbol="rectangle-split"
-										title={getSplitViewTooltip()}
-									/>
-								</ClayButton.Group>
-							</ClayTooltipProvider>
+							<ClayButton.Group>
+								<ClayButtonWithIcon
+									borderless
+									className={
+										state.viewType === VIEW_TYPE_FULL
+											? 'active'
+											: ''
+									}
+									data-tooltip-align="top"
+									displayType="secondary"
+									onClick={() => setViewType(VIEW_TYPE_FULL)}
+									spritemap={spritemap}
+									symbol="rectangle"
+									title={Liferay.Language.get('full-view')}
+								/>
+								<ClayButtonWithIcon
+									borderless
+									className={splitViewClassName}
+									data-tooltip-align="top"
+									displayType="secondary"
+									onClick={() => setViewType(VIEW_TYPE_SPLIT)}
+									spritemap={spritemap}
+									symbol="rectangle-split"
+									title={getSplitViewTooltip()}
+								/>
+							</ClayButton.Group>
 						</div>
 
 						{renderContentSelect()}

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/PublicationsHistoryView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/PublicationsHistoryView.js
@@ -30,7 +30,6 @@ import ClayLabel from '@clayui/label';
 import ClayList from '@clayui/list';
 import ClayProgressBar from '@clayui/progress-bar';
 import ClayTable from '@clayui/table';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {fetch} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
@@ -306,47 +305,45 @@ export default ({displayStyle, entries, spritemap, userInfo}) => {
 		}
 
 		return (
-			<ClayTooltipProvider>
-				<ClayTable
-					className="publications-table"
-					headingNoWrap
-					hover={false}
-				>
-					<ClayTable.Head>
-						<ClayTable.Row>
-							<ClayTable.Cell
-								className="table-cell-expand"
-								headingCell
-							>
-								{Liferay.Language.get('publication')}
-							</ClayTable.Cell>
-							<ClayTable.Cell
-								className="table-cell-expand-smaller"
-								headingCell
-							>
-								{Liferay.Language.get('published-date')}
-							</ClayTable.Cell>
-							<ClayTable.Cell
-								className="table-cell-expand-smallest text-center"
-								headingCell
-							>
-								{Liferay.Language.get('published-by')}
-							</ClayTable.Cell>
-							<ClayTable.Cell
-								className="table-cell-expand-smaller"
-								headingCell
-							>
-								{Liferay.Language.get('status')}
-							</ClayTable.Cell>
-							<ClayTable.Cell
-								className="table-cell-expand-smallest"
-								headingCell
-							/>
-						</ClayTable.Row>
-					</ClayTable.Head>
-					<ClayTable.Body>{rows}</ClayTable.Body>
-				</ClayTable>
-			</ClayTooltipProvider>
+			<ClayTable
+				className="publications-table"
+				headingNoWrap
+				hover={false}
+			>
+				<ClayTable.Head>
+					<ClayTable.Row>
+						<ClayTable.Cell
+							className="table-cell-expand"
+							headingCell
+						>
+							{Liferay.Language.get('publication')}
+						</ClayTable.Cell>
+						<ClayTable.Cell
+							className="table-cell-expand-smaller"
+							headingCell
+						>
+							{Liferay.Language.get('published-date')}
+						</ClayTable.Cell>
+						<ClayTable.Cell
+							className="table-cell-expand-smallest text-center"
+							headingCell
+						>
+							{Liferay.Language.get('published-by')}
+						</ClayTable.Cell>
+						<ClayTable.Cell
+							className="table-cell-expand-smaller"
+							headingCell
+						>
+							{Liferay.Language.get('status')}
+						</ClayTable.Cell>
+						<ClayTable.Cell
+							className="table-cell-expand-smallest"
+							headingCell
+						/>
+					</ClayTable.Row>
+				</ClayTable.Head>
+				<ClayTable.Body>{rows}</ClayTable.Body>
+			</ClayTable>
 		);
 	}
 
@@ -362,9 +359,5 @@ export default ({displayStyle, entries, spritemap, userInfo}) => {
 		);
 	}
 
-	return (
-		<ClayTooltipProvider>
-			<ClayList className="publications-table">{items}</ClayList>
-		</ClayTooltipProvider>
-	);
+	return <ClayList className="publications-table">{items}</ClayList>;
 };

--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/data_renderers/CommentRenderer.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/data_renderers/CommentRenderer.js
@@ -14,22 +14,19 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
 function CommentRenderer(props) {
 	return (
-		<ClayTooltipProvider>
-			<ClayButton
-				className="cell-comment inline-item ml-2 my-n2 px-1 text-warning"
-				data-tooltip-align="top"
-				data-tooltip-delay={0}
-				displayType="link"
-				title={props.children}
-			>
-				<ClayIcon symbol="info-circle" />
-			</ClayButton>
-		</ClayTooltipProvider>
+		<ClayButton
+			className="cell-comment inline-item ml-2 my-n2 px-1 text-warning"
+			data-tooltip-align="top"
+			data-tooltip-delay={0}
+			displayType="link"
+			title={props.children}
+		>
+			<ClayIcon symbol="info-circle" />
+		</ClayButton>
 	);
 }
 

--- a/modules/apps/content-dashboard/content-dashboard-web/package.json
+++ b/modules/apps/content-dashboard/content-dashboard-web/package.json
@@ -10,7 +10,6 @@
 		"@clayui/loading-indicator": "3.2.0",
 		"@clayui/sticker": "3.3.0",
 		"@clayui/tabs": "3.3.5",
-		"@clayui/tooltip": "3.4.5",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView.js
@@ -17,7 +17,6 @@ import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClaySticker from '@clayui/sticker';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classnames from 'classnames';
 import React, {useMemo} from 'react';
 
@@ -85,15 +84,13 @@ const SidebarPanelInfoView = ({
 			<Sidebar.Body>
 				<div className="c-mb-4">
 					<div className="component-title text-truncate-inline">
-						<ClayTooltipProvider>
-							<span
-								className="text-truncate"
-								data-tooltip-align="top"
-								title={title}
-							>
-								{title}
-							</span>
-						</ClayTooltipProvider>
+						<span
+							className="text-truncate"
+							data-tooltip-align="top"
+							title={title}
+						>
+							{title}
+						</span>
 					</div>
 
 					<p className="component-subtitle font-weight-normal">
@@ -180,21 +177,17 @@ const SidebarPanelInfoView = ({
 
 								{language.viewURL && (
 									<ClayLayout.ContentCol>
-										<ClayTooltipProvider>
-											<ClayLink
-												borderless
-												data-tooltip-align="top"
-												displayType="secondary"
-												href={language.viewURL}
-												monospaced
-												outline
-												title={Liferay.Language.get(
-													'view'
-												)}
-											>
-												<ClayIcon symbol="view" />
-											</ClayLink>
-										</ClayTooltipProvider>
+										<ClayLink
+											borderless
+											data-tooltip-align="top"
+											displayType="secondary"
+											href={language.viewURL}
+											monospaced
+											outline
+											title={Liferay.Language.get('view')}
+										>
+											<ClayIcon symbol="view" />
+										</ClayLink>
 									</ClayLayout.ContentCol>
 								)}
 							</ClayLayout.ContentRow>

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/components/table/DropDown.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/components/table/DropDown.es.js
@@ -14,7 +14,6 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown, {Align} from '@clayui/drop-down';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {cloneElement, useState} from 'react';
 
 import DropDownAction from './DropDownAction.es';
@@ -37,16 +36,12 @@ export default ({actions, item, noActionsMessage}) => {
 	);
 
 	if (actions.length === 0) {
-		return (
-			<ClayTooltipProvider>
-				{cloneElement(DropdownButton, {
-					'data-tooltip-align': 'bottom',
-					'data-tooltip-delay': '200',
-					disabled: true,
-					title: noActionsMessage,
-				})}
-			</ClayTooltipProvider>
-		);
+		return cloneElement(DropdownButton, {
+			'data-tooltip-align': 'bottom',
+			'data-tooltip-delay': '200',
+			disabled: true,
+			title: noActionsMessage,
+		});
 	}
 
 	return (

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/MultiPanelSidebar.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/MultiPanelSidebar.es.js
@@ -17,7 +17,6 @@ import './MultiPanelSidebar.scss';
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {useIsMounted, useStateSafe} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
 import React, {useRef, useState} from 'react';
@@ -159,151 +158,141 @@ export default function MultiPanelSidebar({
 	};
 
 	return (
-		<ClayTooltipProvider>
-			<div
+		<div
+			className={classNames(
+				'multi-panel-sidebar',
+				`multi-panel-sidebar-${variant}`,
+				{
+					'menu-indicator-enabled': document.querySelector(
+						CLASSNAME_INDICATORS.join(',')
+					),
+				}
+			)}
+		>
+			<nav
 				className={classNames(
-					'multi-panel-sidebar',
-					`multi-panel-sidebar-${variant}`,
-					{
-						'menu-indicator-enabled': document.querySelector(
-							CLASSNAME_INDICATORS.join(',')
-						),
-					}
+					'multi-panel-sidebar-buttons',
+					'tbar',
+					'tbar-stacked',
+					variant === 'dark'
+						? `tbar-${variant}-d1`
+						: `tbar-${variant}`
 				)}
 			>
-				<nav
-					className={classNames(
-						'multi-panel-sidebar-buttons',
-						'tbar',
-						'tbar-stacked',
-						variant === 'dark'
-							? `tbar-${variant}-d1`
-							: `tbar-${variant}`
-					)}
-				>
-					<ul className="tbar-nav">
-						{panels.reduce((elements, group, groupIndex) => {
-							const buttons = group.map((panelId) => {
-								const panel = sidebarPanels[panelId];
+				<ul className="tbar-nav">
+					{panels.reduce((elements, group, groupIndex) => {
+						const buttons = group.map((panelId) => {
+							const panel = sidebarPanels[panelId];
 
-								const active =
-									open && currentPanelId === panelId;
-								const {
-									icon,
-									isLink,
-									label,
-									pluginEntryPoint,
-									url,
-								} = panel;
+							const active = open && currentPanelId === panelId;
+							const {
+								icon,
+								isLink,
+								label,
+								pluginEntryPoint,
+								url,
+							} = panel;
 
-								const prefetch = () =>
-									load(
-										panel.sidebarPanelId,
-										pluginEntryPoint
-									).then(...swallow);
+							const prefetch = () =>
+								load(
+									panel.sidebarPanelId,
+									pluginEntryPoint
+								).then(...swallow);
 
-								const btnClasses = classNames(
-									'tbar-btn tbar-btn-monospaced',
-									{active}
-								);
+							const btnClasses = classNames(
+								'tbar-btn tbar-btn-monospaced',
+								{active}
+							);
 
-								return (
-									<li
-										className={classNames(
-											'tbar-item',
-											`tbar-item--${panel.sidebarPanelId}`
-										)}
-										key={panel.sidebarPanelId}
-									>
-										{isLink ? (
-											<a
-												className={btnClasses}
-												href={url}
-											>
-												<ClayIcon symbol={icon} />
-											</a>
-										) : (
-											<ClayButtonWithIcon
-												aria-pressed={active}
-												className={btnClasses}
-												data-tooltip-align="left"
-												displayType="unstyled"
-												id={panel.sidebarPanelId}
-												onClick={() =>
-													handleClick(panel)
-												}
-												onFocus={prefetch}
-												onMouseEnter={prefetch}
-												symbol={icon}
-												title={label}
-											/>
-										)}
-									</li>
-								);
-							});
-
-							if (groupIndex === panels.length - 1) {
-								return elements.concat(buttons);
-							}
-							else {
-								return elements.concat([
-									...buttons,
-									<hr key={`separator-${groupIndex}`} />,
-								]);
-							}
-						}, [])}
-					</ul>
-				</nav>
-				<div
-					className={classNames('multi-panel-sidebar-content', {
-						'multi-panel-sidebar-content-open': open,
-					})}
-				>
-					{hasError ? (
-						<div>
-							<ClayButton
-								block
-								displayType="secondary"
-								onClick={() => {
-									onChange({
-										sidebarOpen: false,
-										sidebarPanelId:
-											panels[0] && panels[0][0],
-									});
-									setHasError(false);
-								}}
-								small
-							>
-								{Liferay.Language.get('refresh')}
-							</ClayButton>
-						</div>
-					) : (
-						<ErrorBoundary
-							handleError={() => {
-								setHasError(true);
-							}}
-						>
-							{panelComponents.length === 0 && (
-								<ClayLoadingIndicator />
-							)}
-
-							{panelComponents.map((panel) => (
-								<div
-									className={classNames({
-										'd-none':
-											panel.sidebarPanelId !==
-											currentPanelId,
-									})}
+							return (
+								<li
+									className={classNames(
+										'tbar-item',
+										`tbar-item--${panel.sidebarPanelId}`
+									)}
 									key={panel.sidebarPanelId}
 								>
-									<panel.Component />
-								</div>
-							))}
-						</ErrorBoundary>
-					)}
-				</div>
+									{isLink ? (
+										<a className={btnClasses} href={url}>
+											<ClayIcon symbol={icon} />
+										</a>
+									) : (
+										<ClayButtonWithIcon
+											aria-pressed={active}
+											className={btnClasses}
+											data-tooltip-align="left"
+											displayType="unstyled"
+											id={panel.sidebarPanelId}
+											onClick={() => handleClick(panel)}
+											onFocus={prefetch}
+											onMouseEnter={prefetch}
+											symbol={icon}
+											title={label}
+										/>
+									)}
+								</li>
+							);
+						});
+
+						if (groupIndex === panels.length - 1) {
+							return elements.concat(buttons);
+						}
+						else {
+							return elements.concat([
+								...buttons,
+								<hr key={`separator-${groupIndex}`} />,
+							]);
+						}
+					}, [])}
+				</ul>
+			</nav>
+			<div
+				className={classNames('multi-panel-sidebar-content', {
+					'multi-panel-sidebar-content-open': open,
+				})}
+			>
+				{hasError ? (
+					<div>
+						<ClayButton
+							block
+							displayType="secondary"
+							onClick={() => {
+								onChange({
+									sidebarOpen: false,
+									sidebarPanelId: panels[0] && panels[0][0],
+								});
+								setHasError(false);
+							}}
+							small
+						>
+							{Liferay.Language.get('refresh')}
+						</ClayButton>
+					</div>
+				) : (
+					<ErrorBoundary
+						handleError={() => {
+							setHasError(true);
+						}}
+					>
+						{panelComponents.length === 0 && (
+							<ClayLoadingIndicator />
+						)}
+
+						{panelComponents.map((panel) => (
+							<div
+								className={classNames({
+									'd-none':
+										panel.sidebarPanelId !== currentPanelId,
+								})}
+								key={panel.sidebarPanelId}
+							>
+								<panel.Component />
+							</div>
+						))}
+					</ErrorBoundary>
+				)}
 			</div>
-		</ClayTooltipProvider>
+		</div>
 	);
 }
 

--- a/modules/apps/document-library/document-library-video/package.json
+++ b/modules/apps/document-library/document-library-video/package.json
@@ -4,7 +4,6 @@
 		"@clayui/form": "3.14.4",
 		"@clayui/icon": "3.1.0",
 		"@clayui/loading-indicator": "3.2.0",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",

--- a/modules/apps/document-library/document-library-video/src/main/resources/META-INF/resources/js/components/DLVideoExternalShortcutInput.js
+++ b/modules/apps/document-library/document-library-video/src/main/resources/META-INF/resources/js/components/DLVideoExternalShortcutInput.js
@@ -14,7 +14,6 @@
 
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -27,13 +26,11 @@ const DLVideoExternalShortcutPreview = ({labelTooltip, onChange, url = ''}) => {
 				{Liferay.Language.get('video-url')}
 
 				{labelTooltip && (
-					<ClayTooltipProvider>
-						<ClayIcon
-							className="ml-1 text-secondary"
-							symbol="question-circle-full"
-							title={labelTooltip}
-						/>
-					</ClayTooltipProvider>
+					<ClayIcon
+						className="ml-1 text-secondary"
+						symbol="question-circle-full"
+						title={labelTooltip}
+					/>
 				)}
 			</label>
 			<ClayInput

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -16,7 +16,6 @@ import './FieldBase.scss';
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import {
 	EVENT_TYPES,
@@ -167,145 +166,143 @@ function FieldBase({
 	}
 
 	return (
-		<ClayTooltipProvider>
-			<div
-				aria-labelledby={parentDivAriaLabelledby}
-				className={classNames('form-group', {
-					'has-error': hasError,
-					hide: !visible,
-				})}
-				data-field-name={name}
-				onClick={onClick}
-				style={style}
-				tabIndex={parentDivTabIndex}
-			>
-				{repeatable && (
-					<div className="lfr-ddm-form-field-repeatable-toolbar">
-						{repeatable && repeatedIndex > 0 && (
-							<ClayButton
-								className="ddm-form-field-repeatable-delete-button p-0"
-								disabled={readOnly}
-								onClick={() =>
-									dispatch({
-										payload: name,
-										type: EVENT_TYPES.FIELD_REMOVED,
-									})
-								}
-								small
-								title={Liferay.Language.get('remove')}
-								type="button"
-							>
-								<ClayIcon symbol="hr" />
-							</ClayButton>
-						)}
-
+		<div
+			aria-labelledby={parentDivAriaLabelledby}
+			className={classNames('form-group', {
+				'has-error': hasError,
+				hide: !visible,
+			})}
+			data-field-name={name}
+			onClick={onClick}
+			style={style}
+			tabIndex={parentDivTabIndex}
+		>
+			{repeatable && (
+				<div className="lfr-ddm-form-field-repeatable-toolbar">
+					{repeatable && repeatedIndex > 0 && (
 						<ClayButton
-							className={classNames(
-								'ddm-form-field-repeatable-add-button p-0',
-								{
-									hide: overMaximumRepetitionsLimit,
-								}
-							)}
+							className="ddm-form-field-repeatable-delete-button p-0"
 							disabled={readOnly}
 							onClick={() =>
 								dispatch({
 									payload: name,
-									type: EVENT_TYPES.FIELD_REPEATED,
+									type: EVENT_TYPES.FIELD_REMOVED,
 								})
 							}
 							small
-							title={Liferay.Language.get('duplicate')}
+							title={Liferay.Language.get('remove')}
 							type="button"
 						>
-							<ClayIcon symbol="plus" />
+							<ClayIcon symbol="hr" />
 						</ClayButton>
-					</div>
-				)}
+					)}
 
-				{renderLabel && (
-					<>
-						{showLegend ? (
-							<fieldset>
-								<legend
-									aria-labelledby={fieldDetailsId}
-									className="lfr-ddm-legend"
-									tabIndex="0"
-								>
-									{label && showLabel && label}
-
-									<FieldProperties
-										required={required}
-										tooltip={tooltip}
-									/>
-								</legend>
-								{children}
-							</fieldset>
-						) : (
-							<>
-								<label
-									aria-describedby={fieldDetailsId}
-									className={classNames({
-										'ddm-empty': !showLabel && !required,
-										'ddm-label': showLabel || required,
-									})}
-									tabIndex="0"
-								>
-									{label && showLabel && label}
-
-									<FieldProperties
-										required={required}
-										tooltip={tooltip}
-									/>
-								</label>
-								{children}
-							</>
-						)}
-					</>
-				)}
-
-				{!renderLabel && children}
-
-				{localizedValueArray.length > 0 &&
-					localizedValueArray.map((language) => (
-						<input
-							key={language.name}
-							name={language.name}
-							type="hidden"
-							value={
-								language.value
-									? convertInputValue(type, language.value)
-									: ''
+					<ClayButton
+						className={classNames(
+							'ddm-form-field-repeatable-add-button p-0',
+							{
+								hide: overMaximumRepetitionsLimit,
 							}
-						/>
-					))}
+						)}
+						disabled={readOnly}
+						onClick={() =>
+							dispatch({
+								payload: name,
+								type: EVENT_TYPES.FIELD_REPEATED,
+							})
+						}
+						small
+						title={Liferay.Language.get('duplicate')}
+						type="button"
+					>
+						<ClayIcon symbol="plus" />
+					</ClayButton>
+				</div>
+			)}
 
-				{typeof tip === 'string' && (
-					<span aria-hidden="true" className="form-text">
-						{tip}
-					</span>
-				)}
+			{renderLabel && (
+				<>
+					{showLegend ? (
+						<fieldset>
+							<legend
+								aria-labelledby={fieldDetailsId}
+								className="lfr-ddm-legend"
+								tabIndex="0"
+							>
+								{label && showLabel && label}
 
-				{hasError && (
-					<span className="form-feedback-group">
-						<div aria-hidden="true" className="form-feedback-item">
-							{errorMessage}
-						</div>
-					</span>
-				)}
+								<FieldProperties
+									required={required}
+									tooltip={tooltip}
+								/>
+							</legend>
+							{children}
+						</fieldset>
+					) : (
+						<>
+							<label
+								aria-describedby={fieldDetailsId}
+								className={classNames({
+									'ddm-empty': !showLabel && !required,
+									'ddm-label': showLabel || required,
+								})}
+								tabIndex="0"
+							>
+								{label && showLabel && label}
 
-				{fieldDetails && (
-					<span
-						className="sr-only"
-						dangerouslySetInnerHTML={{
-							__html: fieldDetails,
-						}}
-						id={fieldDetailsId}
+								<FieldProperties
+									required={required}
+									tooltip={tooltip}
+								/>
+							</label>
+							{children}
+						</>
+					)}
+				</>
+			)}
+
+			{!renderLabel && children}
+
+			{localizedValueArray.length > 0 &&
+				localizedValueArray.map((language) => (
+					<input
+						key={language.name}
+						name={language.name}
+						type="hidden"
+						value={
+							language.value
+								? convertInputValue(type, language.value)
+								: ''
+						}
 					/>
-				)}
+				))}
 
-				{nestedFields && <Layout rows={getDefaultRows(nestedFields)} />}
-			</div>
-		</ClayTooltipProvider>
+			{typeof tip === 'string' && (
+				<span aria-hidden="true" className="form-text">
+					{tip}
+				</span>
+			)}
+
+			{hasError && (
+				<span className="form-feedback-group">
+					<div aria-hidden="true" className="form-feedback-item">
+						{errorMessage}
+					</div>
+				</span>
+			)}
+
+			{fieldDetails && (
+				<span
+					className="sr-only"
+					dangerouslySetInnerHTML={{
+						__html: fieldDetails,
+					}}
+					id={fieldDetailsId}
+				/>
+			)}
+
+			{nestedFields && <Layout rows={getDefaultRows(nestedFields)} />}
+		</div>
 	);
 }
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/MultiPagesVariant.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/MultiPagesVariant.es.js
@@ -15,7 +15,6 @@
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayLayout from '@clayui/layout';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
 import {EVENT_TYPES} from '../../actions/eventTypes.es';
@@ -78,109 +77,107 @@ export const Container = ({children, empty, page, pageIndex, pages}) => {
 		<React.Fragment>
 			{pageIndex === 0 && <div className="horizontal-line" />}
 
-			<ClayTooltipProvider>
-				<div className="page">
-					<ClayLayout.Sheet
-						className="fade show tab-pane"
-						role="tabpanel"
+			<div className="page">
+				<ClayLayout.Sheet
+					className="fade show tab-pane"
+					role="tabpanel"
+				>
+					<div className="form-builder-layout">
+						<h5 className="pagination">{page.pagination}</h5>
+
+						{children}
+					</div>
+				</ClayLayout.Sheet>
+
+				<div className="ddm-paginated-builder-reorder">
+					<ClayButtonWithIcon
+						className="reorder-page-button"
+						disabled={pageIndex === 0}
+						displayType="secondary"
+						onClick={() =>
+							dispatch({
+								payload: {
+									firstIndex: pageIndex,
+									secondIndex: pageIndex - 1,
+								},
+								type: EVENT_TYPES.PAGE_SWAPPED,
+							})
+						}
+						small
+						symbol="angle-up"
+						title={Liferay.Language.get('move-page-up')}
+					/>
+
+					<ClayButtonWithIcon
+						className="reorder-page-button"
+						disabled={
+							pageIndex ===
+							pages.length -
+								(successPageSettings?.enabled ? 2 : 1)
+						}
+						displayType="secondary"
+						onClick={() =>
+							dispatch({
+								payload: {
+									firstIndex: pageIndex,
+									secondIndex: pageIndex + 1,
+								},
+								type: EVENT_TYPES.PAGE_SWAPPED,
+							})
+						}
+						small
+						symbol="angle-down"
+						title={Liferay.Language.get('move-page-down')}
+					/>
+				</div>
+
+				<div className="ddm-paginated-builder-dropdown">
+					<ClayDropDownWithItems
+						className="dropdown-action"
+						items={pageSettingsItems}
+						trigger={
+							<ClayButtonWithIcon
+								displayType="unstyled"
+								symbol="ellipsis-v"
+								title={Liferay.Language.get('page-options')}
+							/>
+						}
+					/>
+				</div>
+
+				<div className="add-page-button-container">
+					<div className="horizontal-line" />
+					<ClayButton
+						className="add-page-button"
+						displayType="secondary"
+						onClick={() =>
+							dispatch({
+								payload: {pageIndex},
+								type: EVENT_TYPES.PAGE_ADDED,
+							})
+						}
+						small
 					>
-						<div className="form-builder-layout">
-							<h5 className="pagination">{page.pagination}</h5>
+						{Liferay.Language.get('new-page')}
+					</ClayButton>
+					<div className="horizontal-line" />
+				</div>
 
-							{children}
-						</div>
-					</ClayLayout.Sheet>
-
-					<div className="ddm-paginated-builder-reorder">
-						<ClayButtonWithIcon
-							className="reorder-page-button"
-							disabled={pageIndex === 0}
-							displayType="secondary"
-							onClick={() =>
-								dispatch({
-									payload: {
-										firstIndex: pageIndex,
-										secondIndex: pageIndex - 1,
-									},
-									type: EVENT_TYPES.PAGE_SWAPPED,
-								})
-							}
-							small
-							symbol="angle-up"
-							title={Liferay.Language.get('move-page-up')}
-						/>
-
-						<ClayButtonWithIcon
-							className="reorder-page-button"
-							disabled={
-								pageIndex ===
-								pages.length -
-									(successPageSettings?.enabled ? 2 : 1)
-							}
-							displayType="secondary"
-							onClick={() =>
-								dispatch({
-									payload: {
-										firstIndex: pageIndex,
-										secondIndex: pageIndex + 1,
-									},
-									type: EVENT_TYPES.PAGE_SWAPPED,
-								})
-							}
-							small
-							symbol="angle-down"
-							title={Liferay.Language.get('move-page-down')}
-						/>
-					</div>
-
-					<div className="ddm-paginated-builder-dropdown">
-						<ClayDropDownWithItems
-							className="dropdown-action"
-							items={pageSettingsItems}
-							trigger={
-								<ClayButtonWithIcon
-									displayType="unstyled"
-									symbol="ellipsis-v"
-									title={Liferay.Language.get('page-options')}
-								/>
-							}
-						/>
-					</div>
-
+				{pages.length - 1 === pageIndex && (
 					<div className="add-page-button-container">
 						<div className="horizontal-line" />
 						<ClayButton
 							className="add-page-button"
 							displayType="secondary"
-							onClick={() =>
-								dispatch({
-									payload: {pageIndex},
-									type: EVENT_TYPES.PAGE_ADDED,
-								})
-							}
+							onClick={onAddSuccessPage}
 							small
 						>
-							{Liferay.Language.get('new-page')}
+							{Liferay.Language.get('add-success-page')}
 						</ClayButton>
 						<div className="horizontal-line" />
 					</div>
-
-					{pages.length - 1 === pageIndex && (
-						<div className="add-page-button-container">
-							<div className="horizontal-line" />
-							<ClayButton
-								className="add-page-button"
-								displayType="secondary"
-								onClick={onAddSuccessPage}
-								small
-							>
-								{Liferay.Language.get('add-success-page')}
-							</ClayButton>
-							<div className="horizontal-line" />
-						</div>
-					)}
-				</div>
-			</ClayTooltipProvider>
+				)}
+			</div>
 		</React.Fragment>
 	);
 };

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/js/components/summary/Summary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/js/components/summary/Summary.es.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
 import {formatNumber} from './../../utils/numeric.es';
@@ -26,47 +25,43 @@ export default ({summary}) => {
 	};
 
 	return (
-		<ClayTooltipProvider>
-			<div className="summary">
-				<div className="summary-item">
-					<div className="type">{Liferay.Language.get('sum')}</div>
-					<div
-						{...getAttributes(summary['sum'])}
-						data-tooltip-align="bottom"
-					>
-						{formatNumber(summary['sum'], true)}
-					</div>
-				</div>
-				<div className="summary-item">
-					<div className="type">
-						{Liferay.Language.get('average')}
-					</div>
-					<div
-						{...getAttributes(summary['average'])}
-						data-tooltip-align="bottom"
-					>
-						{formatNumber(summary['average'], true)}
-					</div>
-				</div>
-				<div className="summary-item">
-					<div className="type">{Liferay.Language.get('min')}</div>
-					<div
-						{...getAttributes(summary['min'])}
-						data-tooltip-align="bottom"
-					>
-						{formatNumber(summary['min'], true)}
-					</div>
-				</div>
-				<div className="summary-item">
-					<div className="type">{Liferay.Language.get('max')}</div>
-					<div
-						{...getAttributes(summary['max'])}
-						data-tooltip-align="bottom"
-					>
-						{formatNumber(summary['max'], true)}
-					</div>
+		<div className="summary">
+			<div className="summary-item">
+				<div className="type">{Liferay.Language.get('sum')}</div>
+				<div
+					{...getAttributes(summary['sum'])}
+					data-tooltip-align="bottom"
+				>
+					{formatNumber(summary['sum'], true)}
 				</div>
 			</div>
-		</ClayTooltipProvider>
+			<div className="summary-item">
+				<div className="type">{Liferay.Language.get('average')}</div>
+				<div
+					{...getAttributes(summary['average'])}
+					data-tooltip-align="bottom"
+				>
+					{formatNumber(summary['average'], true)}
+				</div>
+			</div>
+			<div className="summary-item">
+				<div className="type">{Liferay.Language.get('min')}</div>
+				<div
+					{...getAttributes(summary['min'])}
+					data-tooltip-align="bottom"
+				>
+					{formatNumber(summary['min'], true)}
+				</div>
+			</div>
+			<div className="summary-item">
+				<div className="type">{Liferay.Language.get('max')}</div>
+				<div
+					{...getAttributes(summary['max'])}
+					data-tooltip-align="bottom"
+				>
+					{formatNumber(summary['max'], true)}
+				</div>
+			</div>
+		</div>
 	);
 };

--- a/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/icon": "3.1.0",
+		"@clayui/tooltip": "3.4.5",
 		"classnames": "2.2.6",
 		"formik": "2.1.4",
 		"prop-types": "15.7.2",

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
@@ -13,6 +13,7 @@
  */
 
 import {ClayIconSpriteContext} from '@clayui/icon';
+import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -70,9 +71,11 @@ export default function render(renderable, renderData, container) {
 
 		// eslint-disable-next-line @liferay/portal/no-react-dom-render
 		ReactDOM.render(
-			<ClayIconSpriteContext.Provider value={spritemap}>
-				{Component ? <Component {...renderData} /> : renderable}
-			</ClayIconSpriteContext.Provider>,
+			<ClayTooltipProvider>
+				<ClayIconSpriteContext.Provider value={spritemap}>
+					{Component ? <Component {...renderData} /> : renderable}
+				</ClayIconSpriteContext.Provider>
+			</ClayTooltipProvider>,
 			container
 		);
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Multiselect.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Multiselect.js
@@ -14,6 +14,7 @@
 
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayMultiSelect from '@clayui/multi-select';
+import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useState} from 'react';
 
 export default function Multiselect({
@@ -42,36 +43,40 @@ export default function Multiselect({
 	const [selectedItems, setSelectedItems] = useState(_selectedItems);
 
 	return (
-		<ClayForm.Group className={!isValid ? 'has-error' : ''}>
-			{label && <label htmlFor={id}>{label}</label>}
+		<ClayTooltipProvider>
+			<ClayForm.Group className={!isValid ? 'has-error' : ''}>
+				{label && <label htmlFor={id}>{label}</label>}
 
-			<ClayInput.Group>
-				<ClayInput.GroupItem>
-					<ClayMultiSelect
-						className={cssClass}
-						clearAllTitle={clearAllTitle}
-						closeButtonAriaLabel={Liferay.Language.get('remove-x')}
-						disabled={disabled}
-						disabledClearAll={disabledClearAll}
-						id={id}
-						inputName={inputName}
-						inputValue={inputValue}
-						isValid={isValid}
-						items={selectedItems}
-						locator={multiselectLocator}
-						onChange={setInputValue}
-						onItemsChange={setSelectedItems}
-						sourceItems={sourceItems}
-						{...otherProps}
-					/>
+				<ClayInput.Group>
+					<ClayInput.GroupItem>
+						<ClayMultiSelect
+							className={cssClass}
+							clearAllTitle={clearAllTitle}
+							closeButtonAriaLabel={Liferay.Language.get(
+								'remove-x'
+							)}
+							disabled={disabled}
+							disabledClearAll={disabledClearAll}
+							id={id}
+							inputName={inputName}
+							inputValue={inputValue}
+							isValid={isValid}
+							items={selectedItems}
+							locator={multiselectLocator}
+							onChange={setInputValue}
+							onItemsChange={setSelectedItems}
+							sourceItems={sourceItems}
+							{...otherProps}
+						/>
 
-					{helpText && (
-						<ClayForm.FeedbackGroup>
-							<ClayForm.Text>{helpText}</ClayForm.Text>
-						</ClayForm.FeedbackGroup>
-					)}
-				</ClayInput.GroupItem>
-			</ClayInput.Group>
-		</ClayForm.Group>
+						{helpText && (
+							<ClayForm.FeedbackGroup>
+								<ClayForm.Text>{helpText}</ClayForm.Text>
+							</ClayForm.FeedbackGroup>
+						)}
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
+			</ClayForm.Group>
+		</ClayTooltipProvider>
 	);
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/CommentRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/CommentRenderer.js
@@ -14,22 +14,19 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
 function CommentRenderer({children}) {
 	return (
-		<ClayTooltipProvider>
-			<ClayButton
-				className="cell-comment inline-item ml-2 my-n2 px-1 text-warning"
-				data-tooltip-align="top"
-				data-tooltip-delay={0}
-				displayType="link"
-				title={children}
-			>
-				<ClayIcon symbol="info-circle" />
-			</ClayButton>
-		</ClayTooltipProvider>
+		<ClayButton
+			className="cell-comment inline-item ml-2 my-n2 px-1 text-warning"
+			data-tooltip-align="top"
+			data-tooltip-delay={0}
+			displayType="link"
+			title={children}
+		>
+			<ClayIcon symbol="info-circle" />
+		</ClayButton>
 	);
 }
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/CreationMenu.js
@@ -14,7 +14,6 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import PropTypes from 'prop-types';
 import React, {useContext, useState} from 'react';
 
@@ -56,20 +55,15 @@ function CreationMenu({primaryItems}) {
 							</ClayDropDown.ItemList>
 						</ClayDropDown>
 					) : (
-						<ClayTooltipProvider>
-							<ClayButtonWithIcon
-								className="nav-btn nav-btn-monospaced"
-								data-tooltip-align="top"
-								onClick={() =>
-									triggerAction(
-										primaryItems[0],
-										dataSetContext
-									)
-								}
-								symbol="plus"
-								title={primaryItems[0].label}
-							/>
-						</ClayTooltipProvider>
+						<ClayButtonWithIcon
+							className="nav-btn nav-btn-monospaced"
+							data-tooltip-align="top"
+							onClick={() =>
+								triggerAction(primaryItems[0], dataSetContext)
+							}
+							symbol="plus"
+							title={primaryItems[0].label}
+						/>
 					)}
 				</li>
 			</ul>

--- a/modules/apps/layout/layout-content-page-editor-web/package.json
+++ b/modules/apps/layout/layout-content-page-editor-web/package.json
@@ -16,7 +16,6 @@
 		"@clayui/shared": "3.5.1",
 		"@clayui/sticker": "3.3.0",
 		"@clayui/tabs": "3.3.5",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
@@ -15,7 +15,6 @@
 import {ClayButtonWithIcon, default as ClayButton} from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {useIsMounted, useStateSafe} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
 import React from 'react';
@@ -206,130 +205,127 @@ export default function Sidebar() {
 	};
 
 	return createPortal(
-		<ClayTooltipProvider>
+		<div
+			className="page-editor__sidebar page-editor__theme-adapter-forms"
+			ref={dropClearRef}
+		>
 			<div
-				className="page-editor__sidebar page-editor__theme-adapter-forms"
-				ref={dropClearRef}
+				className={classNames('page-editor__sidebar__buttons', {
+					light: true,
+				})}
+				onClick={deselectItem}
 			>
-				<div
-					className={classNames('page-editor__sidebar__buttons', {
-						light: true,
-					})}
-					onClick={deselectItem}
-				>
-					{panels.reduce((elements, group, groupIndex) => {
-						const buttons = group.map((panelId) => {
-							const panel = sidebarPanels[panelId];
+				{panels.reduce((elements, group, groupIndex) => {
+					const buttons = group.map((panelId) => {
+						const panel = sidebarPanels[panelId];
 
-							const active =
-								sidebarOpen && sidebarPanelId === panelId;
-							const {
-								icon,
-								isLink,
-								label,
-								pluginEntryPoint,
-								url,
-							} = panel;
+						const active =
+							sidebarOpen && sidebarPanelId === panelId;
+						const {
+							icon,
+							isLink,
+							label,
+							pluginEntryPoint,
+							url,
+						} = panel;
 
-							if (isLink) {
-								return (
-									<a
-										className={classNames({active})}
-										data-tooltip-align="left"
-										href={url}
-										key={panel.sidebarPanelId}
-										title={label}
-									>
-										<ClayIcon symbol={icon} />
-									</a>
-								);
-							}
-
-							const prefetch = () =>
-								load(
-									panel.sidebarPanelId,
-									pluginEntryPoint
-								).then(...swallow);
-
+						if (isLink) {
 							return (
-								<ClayButtonWithIcon
-									aria-pressed={active}
+								<a
 									className={classNames({active})}
 									data-tooltip-align="left"
-									displayType="unstyled"
-									id={`${sidebarId}${panel.sidebarPanelId}`}
+									href={url}
 									key={panel.sidebarPanelId}
-									onClick={() => handleClick(panel)}
-									onFocus={prefetch}
-									onMouseEnter={prefetch}
-									small={true}
-									symbol={icon}
 									title={label}
-								/>
+								>
+									<ClayIcon symbol={icon} />
+								</a>
 							);
-						});
-
-						// Add separator between groups.
-
-						if (groupIndex === panels.length - 1) {
-							return elements.concat(buttons);
 						}
-						else {
-							return elements.concat([
-								...buttons,
-								<hr key={`separator-${groupIndex}`} />,
-							]);
-						}
-					}, [])}
-				</div>
-				<div
-					className={classNames({
-						'page-editor__sidebar__content': true,
-						'page-editor__sidebar__content--open': sidebarOpen,
-						rtl:
-							Liferay.Language.direction[
-								themeDisplay?.getLanguageId()
-							] === 'rtl',
-					})}
-					onClick={deselectItem}
-				>
-					{hasError ? (
-						<div>
-							<ClayButton
-								block
-								displayType="secondary"
-								onClick={() => {
-									dispatch(
-										Actions.switchSidebarPanel({
-											sidebarOpen: false,
-											sidebarPanelId:
-												panels[0] && panels[0][0],
-										})
-									);
-									setHasError(false);
-								}}
-								small
-							>
-								{Liferay.Language.get('refresh')}
-							</ClayButton>
-						</div>
-					) : (
-						<ErrorBoundary
-							handleError={() => {
-								setHasError(true);
-							}}
-						>
-							<Suspense fallback={<ClayLoadingIndicator />}>
-								<SidebarPanel
-									getInstance={getInstance}
-									pluginId={sidebarPanelId}
-								/>
-							</Suspense>
-						</ErrorBoundary>
-					)}
-				</div>
+
+						const prefetch = () =>
+							load(panel.sidebarPanelId, pluginEntryPoint).then(
+								...swallow
+							);
+
+						return (
+							<ClayButtonWithIcon
+								aria-pressed={active}
+								className={classNames({active})}
+								data-tooltip-align="left"
+								displayType="unstyled"
+								id={`${sidebarId}${panel.sidebarPanelId}`}
+								key={panel.sidebarPanelId}
+								onClick={() => handleClick(panel)}
+								onFocus={prefetch}
+								onMouseEnter={prefetch}
+								small={true}
+								symbol={icon}
+								title={label}
+							/>
+						);
+					});
+
+					// Add separator between groups.
+
+					if (groupIndex === panels.length - 1) {
+						return elements.concat(buttons);
+					}
+					else {
+						return elements.concat([
+							...buttons,
+							<hr key={`separator-${groupIndex}`} />,
+						]);
+					}
+				}, [])}
 			</div>
-		</ClayTooltipProvider>,
+			<div
+				className={classNames({
+					'page-editor__sidebar__content': true,
+					'page-editor__sidebar__content--open': sidebarOpen,
+					rtl:
+						Liferay.Language.direction[
+							themeDisplay?.getLanguageId()
+						] === 'rtl',
+				})}
+				onClick={deselectItem}
+			>
+				{hasError ? (
+					<div>
+						<ClayButton
+							block
+							displayType="secondary"
+							onClick={() => {
+								dispatch(
+									Actions.switchSidebarPanel({
+										sidebarOpen: false,
+										sidebarPanelId:
+											panels[0] && panels[0][0],
+									})
+								);
+								setHasError(false);
+							}}
+							small
+						>
+							{Liferay.Language.get('refresh')}
+						</ClayButton>
+					</div>
+				) : (
+					<ErrorBoundary
+						handleError={() => {
+							setHasError(true);
+						}}
+					>
+						<Suspense fallback={<ClayLoadingIndicator />}>
+							<SidebarPanel
+								getInstance={getInstance}
+								pluginId={sidebarPanelId}
+							/>
+						</Suspense>
+					</ErrorBoundary>
+				)}
+			</div>
+		</div>,
 		document.body
 	);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceItem.js
@@ -18,7 +18,6 @@ import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayList from '@clayui/list';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -117,15 +116,13 @@ const ExperienceItem = ({
 							>
 								<ClayLayout.ContentSection>
 									<span className="text-truncate-inline">
-										<ClayTooltipProvider>
-											<span
-												className="font-weight-semi-bold text-truncate"
-												data-tooltip-align="top"
-												title={experience.name}
-											>
-												{experience.name}
-											</span>
-										</ClayTooltipProvider>
+										<span
+											className="font-weight-semi-bold text-truncate"
+											data-tooltip-align="top"
+											title={experience.name}
+										>
+											{experience.name}
+										</span>
 
 										{experience.hasLockedSegmentsExperiment && (
 											<ExperienceLockIcon />

--- a/modules/apps/questions/questions-web/package.json
+++ b/modules/apps/questions/questions-web/package.json
@@ -13,7 +13,6 @@
 		"@clayui/navigation-bar": "3.3.5",
 		"@clayui/popover": "3.5.5",
 		"@clayui/sticker": "3.3.0",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"asset-taglib": "*",
 		"bbcode-to-react": "^0.2.9",

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionRow.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionRow.es.js
@@ -15,7 +15,6 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -121,15 +120,13 @@ export default ({currentSection, items, question, showSectionLabel}) => {
 
 					{!!question.locked && (
 						<span className="c-ml-2">
-							<ClayTooltipProvider>
-								<ClayIcon
-									data-tooltip-align="top"
-									symbol="lock"
-									title={Liferay.Language.get(
-										'this-question-is-closed-new-answers-and-comments-are-disabled'
-									)}
-								/>
-							</ClayTooltipProvider>
+							<ClayIcon
+								data-tooltip-align="top"
+								symbol="lock"
+								title={Liferay.Language.get(
+									'this-question-is-closed-new-answers-and-comments-are-disabled'
+								)}
+							/>
 						</span>
 					)}
 				</h2>

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionsBadge.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionsBadge.es.js
@@ -13,25 +13,20 @@
  */
 
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
 export default ({className, symbol, tooltip, value}) => {
 	return (
-		<ClayTooltipProvider>
-			<div
-				className={`c-py-2 c-px-3 rounded stretched-link-layer ${className}`}
-			>
-				<ClayIcon
-					data-tooltip-align="top"
-					symbol={symbol}
-					title={tooltip}
-				/>
+		<div
+			className={`c-py-2 c-px-3 rounded stretched-link-layer ${className}`}
+		>
+			<ClayIcon
+				data-tooltip-align="top"
+				symbol={symbol}
+				title={tooltip}
+			/>
 
-				<span className="c-ml-2 font-weight-bold small">
-					{value || 0}
-				</span>
-			</div>
-		</ClayTooltipProvider>
+			<span className="c-ml-2 font-weight-bold small">{value || 0}</span>
+		</div>
 	);
 };

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Subscription.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Subscription.es.js
@@ -15,7 +15,6 @@
 import {useMutation} from '@apollo/client';
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useEffect, useState} from 'react';
 
 import {
@@ -80,20 +79,18 @@ export default ({
 	};
 
 	return (
-		<ClayTooltipProvider>
-			<ClayButton
-				data-tooltip-align="top"
-				displayType={subscription ? 'primary' : 'secondary'}
-				monospaced
-				onClick={changeSubscription}
-				title={
-					subscription
-						? Liferay.Language.get('unsubscribe')
-						: Liferay.Language.get('subscribe')
-				}
-			>
-				<ClayIcon symbol="bell-on" />
-			</ClayButton>
-		</ClayTooltipProvider>
+		<ClayButton
+			data-tooltip-align="top"
+			displayType={subscription ? 'primary' : 'secondary'}
+			monospaced
+			onClick={changeSubscription}
+			title={
+				subscription
+					? Liferay.Language.get('unsubscribe')
+					: Liferay.Language.get('subscribe')
+			}
+		>
+			<ClayIcon symbol="bell-on" />
+		</ClayButton>
 	);
 };

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
@@ -17,7 +17,6 @@ import ClayButton from '@clayui/button';
 import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayNavigationBar from '@clayui/navigation-bar';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import React, {useCallback, useContext, useEffect, useState} from 'react';
 import {withRouter} from 'react-router-dom';
@@ -313,22 +312,21 @@ export default withRouter(
 																setShowDeleteModalPanel
 															}
 														/>
-														<ClayTooltipProvider>
-															<ClayButton
-																data-tooltip-align="top"
-																displayType="secondary"
-																onClick={() =>
-																	setShowDeleteModalPanel(
-																		true
-																	)
-																}
-																title={Liferay.Language.get(
-																	'delete'
-																)}
-															>
-																<ClayIcon symbol="trash" />
-															</ClayButton>
-														</ClayTooltipProvider>
+
+														<ClayButton
+															data-tooltip-align="top"
+															displayType="secondary"
+															onClick={() =>
+																setShowDeleteModalPanel(
+																	true
+																)
+															}
+															title={Liferay.Language.get(
+																'delete'
+															)}
+														>
+															<ClayIcon symbol="trash" />
+														</ClayButton>
 													</>
 												)}
 

--- a/modules/apps/ratings/ratings-taglib/package.json
+++ b/modules/apps/ratings/ratings-taglib/package.json
@@ -3,7 +3,6 @@
 		"@clayui/button": "3.6.0",
 		"@clayui/icon": "3.1.0",
 		"@clayui/layout": "3.3.0",
-		"@clayui/tooltip": "3.4.5",
 		"prop-types": "15.7.2",
 		"react": "16.12.0"
 	},

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsLike.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsLike.js
@@ -14,7 +14,6 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -73,40 +72,38 @@ const RatingsLike = ({
 	};
 
 	return (
-		<ClayTooltipProvider>
-			<div className="ratings-like">
-				<ClayButton
-					aria-pressed={liked}
-					borderless
-					className={classNames({
-						'btn-animated': animatedButton,
-					})}
-					disabled={disabled}
-					displayType="secondary"
-					onClick={toggleLiked}
-					small
-					title={getTitle()}
-					value={totalLikes}
-				>
-					<span className="c-inner" tabIndex="-1">
-						<span className="inline-item inline-item-before">
-							<span className="off">
-								<ClayIcon symbol="heart" />
-							</span>
-							<span
-								className="on"
-								onAnimationEnd={HandleAnimationEnd}
-							>
-								<ClayIcon symbol="heart-full" />
-							</span>
+		<div className="ratings-like">
+			<ClayButton
+				aria-pressed={liked}
+				borderless
+				className={classNames({
+					'btn-animated': animatedButton,
+				})}
+				disabled={disabled}
+				displayType="secondary"
+				onClick={toggleLiked}
+				small
+				title={getTitle()}
+				value={totalLikes}
+			>
+				<span className="c-inner" tabIndex="-1">
+					<span className="inline-item inline-item-before">
+						<span className="off">
+							<ClayIcon symbol="heart" />
 						</span>
-						<span className="inline-item likes">
-							<AnimatedCounter counter={totalLikes} />
+						<span
+							className="on"
+							onAnimationEnd={HandleAnimationEnd}
+						>
+							<ClayIcon symbol="heart-full" />
 						</span>
 					</span>
-				</ClayButton>
-			</div>
-		</ClayTooltipProvider>
+					<span className="inline-item likes">
+						<AnimatedCounter counter={totalLikes} />
+					</span>
+				</span>
+			</ClayButton>
+		</div>
 	);
 };
 

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsSelectStars.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsSelectStars.js
@@ -16,7 +16,6 @@ import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useState} from 'react';
 
 import Lang from '../utils/lang';
@@ -40,104 +39,98 @@ export default function RatingsSelectStars({
 	};
 
 	return (
-		<ClayTooltipProvider>
-			<ClayLayout.ContentRow
-				className="ratings-stars"
-				noGutters
-				verticalAlign="center"
-			>
-				<ClayLayout.ContentCol>
-					<ClayDropDown
-						active={isDropdownOpen}
-						menuElementAttrs={{
-							className: 'ratings-stars-dropdown',
-						}}
-						onActiveChange={(isActive) =>
-							setIsDropdownOpen(isActive)
-						}
-						trigger={
-							<ClayButton
-								aria-pressed={!!score}
-								borderless
-								className="ratings-stars-dropdown-toggle"
-								disabled={disabled}
-								displayType="secondary"
-								small
-								title={getTitle()}
-								value={score}
-							>
-								<span className="inline-item inline-item-before">
-									<ClayIcon
-										symbol={score ? 'star' : 'star-o'}
-									/>
-								</span>
-								<span className="inline-item ratings-stars-button-text">
-									{score || '-'}
-								</span>
-							</ClayButton>
-						}
-					>
-						<ClayDropDown.ItemList>
-							{starScores.map(({label}, index) => {
-								const srMessage =
-									index === 0
-										? Liferay.Language.get(
-												'rate-this-x-star-out-of-x'
-										  )
-										: Liferay.Language.get(
-												'rate-this-x-stars-out-of-x'
-										  );
+		<ClayLayout.ContentRow
+			className="ratings-stars"
+			noGutters
+			verticalAlign="center"
+		>
+			<ClayLayout.ContentCol>
+				<ClayDropDown
+					active={isDropdownOpen}
+					menuElementAttrs={{
+						className: 'ratings-stars-dropdown',
+					}}
+					onActiveChange={(isActive) => setIsDropdownOpen(isActive)}
+					trigger={
+						<ClayButton
+							aria-pressed={!!score}
+							borderless
+							className="ratings-stars-dropdown-toggle"
+							disabled={disabled}
+							displayType="secondary"
+							small
+							title={getTitle()}
+							value={score}
+						>
+							<span className="inline-item inline-item-before">
+								<ClayIcon symbol={score ? 'star' : 'star-o'} />
+							</span>
+							<span className="inline-item ratings-stars-button-text">
+								{score || '-'}
+							</span>
+						</ClayButton>
+					}
+				>
+					<ClayDropDown.ItemList>
+						{starScores.map(({label}, index) => {
+							const srMessage =
+								index === 0
+									? Liferay.Language.get(
+											'rate-this-x-star-out-of-x'
+									  )
+									: Liferay.Language.get(
+											'rate-this-x-stars-out-of-x'
+									  );
 
-								return (
-									<ClayDropDown.Item
-										active={label === score}
-										key={index}
-										onClick={() => {
-											handleOnClick(index);
-										}}
-									>
-										{label}
-										<span className="sr-only">
-											{Lang.sub(srMessage, [
-												index + 1,
-												numberOfStars,
-											])}
-										</span>
-									</ClayDropDown.Item>
-								);
-							})}
+							return (
+								<ClayDropDown.Item
+									active={label === score}
+									key={index}
+									onClick={() => {
+										handleOnClick(index);
+									}}
+								>
+									{label}
+									<span className="sr-only">
+										{Lang.sub(srMessage, [
+											index + 1,
+											numberOfStars,
+										])}
+									</span>
+								</ClayDropDown.Item>
+							);
+						})}
 
-							<ClayDropDown.Item
-								disabled={score === 0}
-								onClick={handleOnClick}
-							>
-								{Liferay.Language.get('delete')}
-							</ClayDropDown.Item>
-						</ClayDropDown.ItemList>
-					</ClayDropDown>
-				</ClayLayout.ContentCol>
+						<ClayDropDown.Item
+							disabled={score === 0}
+							onClick={handleOnClick}
+						>
+							{Liferay.Language.get('delete')}
+						</ClayDropDown.Item>
+					</ClayDropDown.ItemList>
+				</ClayDropDown>
+			</ClayLayout.ContentCol>
 
-				<ClayLayout.ContentCol>
-					<span className="ratings-stars-average">
-						<span className="inline-item inline-item-before">
-							<ClayIcon
-								className="ratings-stars-average-icon"
-								symbol="star"
-							/>
-						</span>
-						<span className="inline-item ratings-stars-average-text">
-							{averageScore.toFixed(1)}
-							{!!totalEntries &&
-								` (${totalEntries} ${
-									totalEntries === 1
-										? Liferay.Language.get('vote')
-										: Liferay.Language.get('votes')
-								})`}
-						</span>
-						<span className="sr-only">{getSrAverageMessage()}</span>
+			<ClayLayout.ContentCol>
+				<span className="ratings-stars-average">
+					<span className="inline-item inline-item-before">
+						<ClayIcon
+							className="ratings-stars-average-icon"
+							symbol="star"
+						/>
 					</span>
-				</ClayLayout.ContentCol>
-			</ClayLayout.ContentRow>
-		</ClayTooltipProvider>
+					<span className="inline-item ratings-stars-average-text">
+						{averageScore.toFixed(1)}
+						{!!totalEntries &&
+							` (${totalEntries} ${
+								totalEntries === 1
+									? Liferay.Language.get('vote')
+									: Liferay.Language.get('votes')
+							})`}
+					</span>
+					<span className="sr-only">{getSrAverageMessage()}</span>
+				</span>
+			</ClayLayout.ContentCol>
+		</ClayLayout.ContentRow>
 	);
 }

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStackedStars.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStackedStars.js
@@ -14,7 +14,6 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import React, {Fragment} from 'react';
 
@@ -33,126 +32,119 @@ export default function RatingsStackedStars({
 	totalEntries,
 }) {
 	return (
-		<ClayTooltipProvider>
-			<div className="ratings-stacked-stars ratings-stars">
-				<div
-					className="ratings-stars-average"
-					title={averageScore.toFixed(1)}
-				>
-					<span className="inline-item inline-item-before">
-						{starScores.map(({label: score}, index, arr) => {
-							const previousScore =
-								arr[index - 1] && arr[index - 1].label;
-							let symbol = 'star-o';
+		<div className="ratings-stacked-stars ratings-stars">
+			<div
+				className="ratings-stars-average"
+				title={averageScore.toFixed(1)}
+			>
+				<span className="inline-item inline-item-before">
+					{starScores.map(({label: score}, index, arr) => {
+						const previousScore =
+							arr[index - 1] && arr[index - 1].label;
+						let symbol = 'star-o';
 
-							if (averageScore >= score) {
-								symbol = 'star';
-							}
-							else if (averageScore > previousScore) {
-								symbol = 'star-half';
-							}
+						if (averageScore >= score) {
+							symbol = 'star';
+						}
+						else if (averageScore > previousScore) {
+							symbol = 'star-half';
+						}
+
+						return (
+							<ClayIcon
+								className="ratings-stars-average-icon"
+								key={score}
+								symbol={symbol}
+							/>
+						);
+					})}
+				</span>
+				<span className="inline-item ratings-stars-average-text">
+					{!!totalEntries &&
+						` (${totalEntries} ${
+							totalEntries === 1
+								? Liferay.Language.get('vote')
+								: Liferay.Language.get('votes')
+						})`}
+				</span>
+				<span className="sr-only">{getSrAverageMessage()}</span>
+			</div>
+
+			<div
+				className={classNames({disabled}, 'ratings-stacked-stars-vote')}
+			>
+				<fieldset title={getTitle()}>
+					<div className="ratings-stacked-stars-vote-stars">
+						{starScores.reverse().map(({label, value}, index) => {
+							const id = `${randomNamespace}star${label}`;
+							const srMessage =
+								index === 0
+									? Liferay.Language.get(
+											'rate-this-x-star-out-of-x'
+									  )
+									: Liferay.Language.get(
+											'rate-this-x-stars-out-of-x'
+									  );
+							const full = label <= score;
 
 							return (
-								<ClayIcon
-									className="ratings-stars-average-icon"
-									key={score}
-									symbol={symbol}
-								/>
+								<Fragment key={value}>
+									<input
+										checked={label === score}
+										className="sr-only"
+										disabled={disabled}
+										id={id}
+										name={`${randomNamespace}rating`}
+										onChange={() => {
+											onVote(index);
+										}}
+										type="radio"
+										value={value}
+									/>
+									<label
+										className={
+											full
+												? 'ratings-stars-star-full'
+												: ''
+										}
+										htmlFor={id}
+									>
+										<ClayIcon
+											className="ratings-stars-icon-full"
+											symbol="star"
+										/>
+										<ClayIcon
+											className="ratings-stars-icon-empty"
+											symbol="star-o"
+										/>
+										<span className="sr-only">
+											{Lang.sub(srMessage, [
+												label,
+												numberOfStars,
+											])}
+										</span>
+									</label>
+								</Fragment>
 							);
 						})}
-					</span>
-					<span className="inline-item ratings-stars-average-text">
-						{!!totalEntries &&
-							` (${totalEntries} ${
-								totalEntries === 1
-									? Liferay.Language.get('vote')
-									: Liferay.Language.get('votes')
-							})`}
-					</span>
-					<span className="sr-only">{getSrAverageMessage()}</span>
-				</div>
+					</div>
+				</fieldset>
 
-				<div
-					className={classNames(
-						{disabled},
-						'ratings-stacked-stars-vote'
-					)}
-				>
-					<fieldset title={getTitle()}>
-						<div className="ratings-stacked-stars-vote-stars">
-							{starScores
-								.reverse()
-								.map(({label, value}, index) => {
-									const id = `${randomNamespace}star${label}`;
-									const srMessage =
-										index === 0
-											? Liferay.Language.get(
-													'rate-this-x-star-out-of-x'
-											  )
-											: Liferay.Language.get(
-													'rate-this-x-stars-out-of-x'
-											  );
-									const full = label <= score;
-
-									return (
-										<Fragment key={value}>
-											<input
-												checked={label === score}
-												className="sr-only"
-												disabled={disabled}
-												id={id}
-												name={`${randomNamespace}rating`}
-												onChange={() => {
-													onVote(index);
-												}}
-												type="radio"
-												value={value}
-											/>
-											<label
-												className={
-													full
-														? 'ratings-stars-star-full'
-														: ''
-												}
-												htmlFor={id}
-											>
-												<ClayIcon
-													className="ratings-stars-icon-full"
-													symbol="star"
-												/>
-												<ClayIcon
-													className="ratings-stars-icon-empty"
-													symbol="star-o"
-												/>
-												<span className="sr-only">
-													{Lang.sub(srMessage, [
-														label,
-														numberOfStars,
-													])}
-												</span>
-											</label>
-										</Fragment>
-									);
-								})}
-						</div>
-					</fieldset>
-
-					{score !== 0 && (
-						<ClayButton
-							className="ratings-stacked-stars-delete"
-							disabled={disabled}
-							displayType="unstyled"
-							onClick={onVote}
-							title={Liferay.Language.get('delete')}
-						>
-							<ClayIcon
-								className="lexicon-icon-vertical-align"
-								symbol="times-circle"
-							/>
-						</ClayButton>
-					)}
-				</div>
+				{score !== 0 && (
+					<ClayButton
+						className="ratings-stacked-stars-delete"
+						disabled={disabled}
+						displayType="unstyled"
+						onClick={onVote}
+						title={Liferay.Language.get('delete')}
+					>
+						<ClayIcon
+							className="lexicon-icon-vertical-align"
+							symbol="times-circle"
+						/>
+					</ClayButton>
+				)}
 			</div>
-		</ClayTooltipProvider>
+		</div>
 	);
 }

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsThumbs.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsThumbs.js
@@ -14,7 +14,6 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -166,70 +165,68 @@ const RatingsThumbs = ({
 	}, [inititalTitle, pressed]);
 
 	return (
-		<ClayTooltipProvider>
-			<div className="ratings-thumbs">
-				<ClayButton
-					aria-pressed={pressed === PRESSED_UP}
-					borderless
-					className={classNames('btn-thumbs-up', {
-						'btn-animated': animatedButtonUp,
-					})}
-					disabled={disabled}
-					displayType="secondary"
-					onClick={voteUp}
-					small
-					title={getTitleThumbsUp()}
-					value={positiveVotes}
-				>
-					<span className="c-inner" tabIndex="-1">
-						<span className="inline-item inline-item-before">
-							<span className="off">
-								<ClayIcon symbol="thumbs-up" />
-							</span>
-							<span
-								className="on"
-								onAnimationEnd={handleAnimationEndUp}
-							>
-								<ClayIcon symbol="thumbs-up-full" />
-							</span>
+		<div className="ratings-thumbs">
+			<ClayButton
+				aria-pressed={pressed === PRESSED_UP}
+				borderless
+				className={classNames('btn-thumbs-up', {
+					'btn-animated': animatedButtonUp,
+				})}
+				disabled={disabled}
+				displayType="secondary"
+				onClick={voteUp}
+				small
+				title={getTitleThumbsUp()}
+				value={positiveVotes}
+			>
+				<span className="c-inner" tabIndex="-1">
+					<span className="inline-item inline-item-before">
+						<span className="off">
+							<ClayIcon symbol="thumbs-up" />
 						</span>
-						<span className="inline-item">
-							<AnimatedCounter counter={positiveVotes} />
+						<span
+							className="on"
+							onAnimationEnd={handleAnimationEndUp}
+						>
+							<ClayIcon symbol="thumbs-up-full" />
 						</span>
 					</span>
-				</ClayButton>
-				<ClayButton
-					aria-pressed={pressed === PRESSED_DOWN}
-					borderless
-					className={classNames('btn-thumbs-down', {
-						'btn-animated': animatedButtonDown,
-					})}
-					disabled={disabled}
-					displayType="secondary"
-					onClick={voteDown}
-					small
-					title={getTitleThumbsDown()}
-					value={negativeVotes}
-				>
-					<span className="c-inner" tabIndex="-1">
-						<span className="inline-item inline-item-before">
-							<span className="off">
-								<ClayIcon symbol="thumbs-down" />
-							</span>
-							<span
-								className="on"
-								onAnimationEnd={handleAnimationEndDown}
-							>
-								<ClayIcon symbol="thumbs-down-full" />
-							</span>
+					<span className="inline-item">
+						<AnimatedCounter counter={positiveVotes} />
+					</span>
+				</span>
+			</ClayButton>
+			<ClayButton
+				aria-pressed={pressed === PRESSED_DOWN}
+				borderless
+				className={classNames('btn-thumbs-down', {
+					'btn-animated': animatedButtonDown,
+				})}
+				disabled={disabled}
+				displayType="secondary"
+				onClick={voteDown}
+				small
+				title={getTitleThumbsDown()}
+				value={negativeVotes}
+			>
+				<span className="c-inner" tabIndex="-1">
+					<span className="inline-item inline-item-before">
+						<span className="off">
+							<ClayIcon symbol="thumbs-down" />
 						</span>
-						<span className="inline-item">
-							<AnimatedCounter counter={negativeVotes} />
+						<span
+							className="on"
+							onAnimationEnd={handleAnimationEndDown}
+						>
+							<ClayIcon symbol="thumbs-down-full" />
 						</span>
 					</span>
-				</ClayButton>
-			</div>
-		</ClayTooltipProvider>
+					<span className="inline-item">
+						<AnimatedCounter counter={negativeVotes} />
+					</span>
+				</span>
+			</ClayButton>
+		</div>
 	);
 };
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/package.json
+++ b/modules/dxp/apps/analytics/analytics-reports-web/package.json
@@ -8,7 +8,6 @@
 		"@clayui/layout": "3.3.0",
 		"@clayui/loading-indicator": "3.2.0",
 		"@clayui/sticker": "3.3.0",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -12,7 +12,6 @@
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClaySticker from '@clayui/sticker';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -55,31 +54,27 @@ function BasicInformation({
 		<div className="sidebar-section">
 			<ClayLayout.ContentRow>
 				<ClayLayout.ContentCol expand>
-					<ClayTooltipProvider>
-						<span
-							className="component-title text-truncate-inline"
-							data-tooltip-align="top"
-							title={title}
-						>
-							<span className="text-truncate">{title}</span>
-						</span>
-					</ClayTooltipProvider>
+					<span
+						className="component-title text-truncate-inline"
+						data-tooltip-align="top"
+						title={title}
+					>
+						<span className="text-truncate">{title}</span>
+					</span>
 				</ClayLayout.ContentCol>
 			</ClayLayout.ContentRow>
 
 			<ClayLayout.ContentRow>
 				<ClayLayout.ContentCol expand>
-					<ClayTooltipProvider>
-						<span
-							className="text-truncate-inline"
-							data-tooltip-align="top"
-							title={canonicalURL}
-						>
-							<span className="c-mb-2 c-mt-1 text-secondary text-truncate text-truncate-reverse">
-								{canonicalURL}
-							</span>
+					<span
+						className="text-truncate-inline"
+						data-tooltip-align="top"
+						title={canonicalURL}
+					>
+						<span className="c-mb-2 c-mt-1 text-secondary text-truncate text-truncate-reverse">
+							{canonicalURL}
 						</span>
-					</ClayTooltipProvider>
+					</span>
 				</ClayLayout.ContentCol>
 			</ClayLayout.ContentRow>
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Keywords.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Keywords.js
@@ -14,7 +14,6 @@ import ClayDropDown from '@clayui/drop-down';
 import {ClaySelect} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayList from '@clayui/list';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import PropTypes from 'prop-types';
 import React, {useContext, useMemo, useState} from 'react';
 
@@ -180,17 +179,15 @@ export default function Keywords({currentPage, languageTag}) {
 								<ClayList.Item flex key={keyword}>
 									<ClayList.ItemField expand>
 										<ClayList.ItemText>
-											<ClayTooltipProvider>
-												<span
-													className="text-truncate-inline"
-													data-tooltip-align="top"
-													title={keyword}
-												>
-													<span className="text-secondary text-truncate">
-														{keyword}
-													</span>
+											<span
+												className="text-truncate-inline"
+												data-tooltip-align="top"
+												title={keyword}
+											>
+												<span className="text-secondary text-truncate">
+													{keyword}
 												</span>
-											</ClayTooltipProvider>
+											</span>
 										</ClayList.ItemText>
 									</ClayList.ItemField>
 									<ClayList.ItemField expand>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TimeSpanSelector.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TimeSpanSelector.js
@@ -11,7 +11,6 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClaySelect} from '@clayui/form';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
@@ -49,28 +48,27 @@ export default function TimeSpanSelector({
 			</ClaySelect>
 
 			<div className="d-flex ml-2">
-				<ClayTooltipProvider>
-					<ClayButtonWithIcon
-						aria-label={Liferay.Language.get('previous-period')}
-						className="mr-1"
-						data-tooltip-align="top-right"
-						disabled={
-							!validAnalyticsConnection ||
-							disabledPreviousPeriodButton
-						}
-						displayType="secondary"
-						onClick={onPreviousTimeSpanClick}
-						small
-						symbol="angle-left"
-						title={
-							disabledPreviousPeriodButton
-								? Liferay.Language.get(
-										'you-cannot-choose-a-date-prior-to-the-publication-date'
-								  )
-								: undefined
-						}
-					/>
-				</ClayTooltipProvider>
+				<ClayButtonWithIcon
+					aria-label={Liferay.Language.get('previous-period')}
+					className="mr-1"
+					data-tooltip-align="top-right"
+					disabled={
+						!validAnalyticsConnection ||
+						disabledPreviousPeriodButton
+					}
+					displayType="secondary"
+					onClick={onPreviousTimeSpanClick}
+					small
+					symbol="angle-left"
+					title={
+						disabledPreviousPeriodButton
+							? Liferay.Language.get(
+									'you-cannot-choose-a-date-prior-to-the-publication-date'
+							  )
+							: undefined
+					}
+				/>
+
 				<ClayButtonWithIcon
 					aria-label={Liferay.Language.get('next-period')}
 					disabled={!validAnalyticsConnection || disabledNextTimeSpan}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
@@ -11,7 +11,6 @@
 
 import ClayButton from '@clayui/button';
 import ClayList from '@clayui/list';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {ALIGN_POSITIONS} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useMemo, useState} from 'react';
@@ -157,21 +156,19 @@ export default function ReferralDetail({
 							<ClayList.Item flex key={url}>
 								<ClayList.ItemField expand>
 									<ClayList.ItemText>
-										<ClayTooltipProvider>
-											<span
-												className="text-truncate-inline"
-												data-tooltip-align="top"
-												title={url}
+										<span
+											className="text-truncate-inline"
+											data-tooltip-align="top"
+											title={url}
+										>
+											<a
+												className="c-mr-2 text-primary text-truncate text-truncate-reverse"
+												href={url}
+												target="_blank"
 											>
-												<a
-													className="c-mr-2 text-primary text-truncate text-truncate-reverse"
-													href={url}
-													target="_blank"
-												>
-													{url}
-												</a>
-											</span>
-										</ClayTooltipProvider>
+												{url}
+											</a>
+										</span>
 									</ClayList.ItemText>
 								</ClayList.ItemField>
 								<ClayList.ItemField expand>
@@ -237,21 +234,19 @@ export default function ReferralDetail({
 							<ClayList.Item flex key={url}>
 								<ClayList.ItemField expand>
 									<ClayList.ItemText>
-										<ClayTooltipProvider>
-											<span
-												className="text-truncate-inline"
-												data-tooltip-align="top"
-												title={url}
+										<span
+											className="text-truncate-inline"
+											data-tooltip-align="top"
+											title={url}
+										>
+											<a
+												className="c-mr-2 text-primary text-truncate"
+												href={url}
+												target="_blank"
 											>
-												<a
-													className="c-mr-2 text-primary text-truncate"
-													href={url}
-													target="_blank"
-												>
-													{url}
-												</a>
-											</span>
-										</ClayTooltipProvider>
+												{url}
+											</a>
+										</span>
 									</ClayList.ItemText>
 								</ClayList.ItemField>
 								<ClayList.ItemField expand>

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/package.json
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/package.json
@@ -8,7 +8,6 @@
 		"@clayui/link": "3.2.0",
 		"@clayui/modal": "3.8.5",
 		"@clayui/popover": "3.5.5",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/components/autocomplete/AutocompleteMultiSelect.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/components/autocomplete/AutocompleteMultiSelect.es.js
@@ -12,7 +12,6 @@
 import ClayAutocomplete from '@clayui/autocomplete';
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import isClickOutside from 'app-builder-web/js/utils/clickOutside.es';
 import React, {useEffect, useRef, useState} from 'react';
 
@@ -164,23 +163,21 @@ function AutocompleteMultiSelect({
 			</div>
 
 			{selectedItems.length > 0 && (
-				<ClayTooltipProvider>
-					<ClayButton
-						borderless
-						className="ml-2 pl-0 pr-1 py-0"
-						displayType="light"
-						onClick={() => onChange([])}
-						style={{position: 'absolute', right: '1rem'}}
-					>
-						<ClayIcon
-							className="text-secondary tooltip-icon"
-							data-tooltip-align="top"
-							data-tooltip-delay="0"
-							symbol="times-circle"
-							title={Liferay.Language.get('clear-all')}
-						/>
-					</ClayButton>
-				</ClayTooltipProvider>
+				<ClayButton
+					borderless
+					className="ml-2 pl-0 pr-1 py-0"
+					displayType="light"
+					onClick={() => onChange([])}
+					style={{position: 'absolute', right: '1rem'}}
+				>
+					<ClayIcon
+						className="text-secondary tooltip-icon"
+						data-tooltip-align="top"
+						data-tooltip-delay="0"
+						symbol="times-circle"
+						title={Liferay.Language.get('clear-all')}
+					/>
+				</ClayButton>
 			)}
 
 			<AutocompleteDropDown

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/components/workflow-info-bar/WorkflowInfoBar.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/components/workflow-info-bar/WorkflowInfoBar.es.js
@@ -10,7 +10,6 @@
  */
 
 import ClayLabel from '@clayui/label';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import {concatValues} from 'data-engine-js-components-web/js/utils/utils.es';
 import React from 'react';
@@ -88,21 +87,19 @@ export default function WorkflowInfo({
 	];
 
 	return (
-		<ClayTooltipProvider>
-			<div className={classNames('workflow-info-bar', className)}>
-				{items.map(
-					({label, show, tooltip = {}, value}, index) =>
-						show && (
-							<div className="info-item" key={index} {...tooltip}>
-								<span className="font-weight-bold text-secondary">
-									{`${label}: `}
-								</span>
+		<div className={classNames('workflow-info-bar', className)}>
+			{items.map(
+				({label, show, tooltip = {}, value}, index) =>
+					show && (
+						<div className="info-item" key={index} {...tooltip}>
+							<span className="font-weight-bold text-secondary">
+								{`${label}: `}
+							</span>
 
-								{value}
-							</div>
-						)
-				)}
-			</div>
-		</ClayTooltipProvider>
+							{value}
+						</div>
+					)
+			)}
+		</div>
 	);
 }

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/EditAppToolbar.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/EditAppToolbar.es.js
@@ -11,7 +11,6 @@
 
 import ClayBadge from '@clayui/badge';
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import UpperToolbar from 'app-builder-web/js/components/upper-toolbar/UpperToolbar.es';
 import useDeployApp from 'app-builder-web/js/hooks/useDeployApp.es';
 import EditAppContext, {
@@ -195,17 +194,15 @@ export default function EditAppToolbar({isSaving, onCancel, onSave}) {
 					</ClayButton>
 
 					{app.active && (
-						<ClayTooltipProvider>
-							<ClayButtonWithIcon
-								data-tooltip-align="bottom"
-								data-tooltip-delay="0"
-								displayType="secondary"
-								onClick={() => setDeployModalVisible(true)}
-								small
-								symbol="cog"
-								title={Liferay.Language.get('deploy-settings')}
-							/>
-						</ClayTooltipProvider>
+						<ClayButtonWithIcon
+							data-tooltip-align="bottom"
+							data-tooltip-delay="0"
+							displayType="secondary"
+							onClick={() => setDeployModalVisible(true)}
+							small
+							symbol="cog"
+							title={Liferay.Language.get('deploy-settings')}
+						/>
 					)}
 				</ClayButton.Group>
 			</UpperToolbar.Group>

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/sidebar/DataAndViewsTab.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/sidebar/DataAndViewsTab.es.js
@@ -13,7 +13,6 @@ import ClayAlert from '@clayui/alert';
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import {ClayRadio, ClayRadioGroup} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {AppContext} from 'app-builder-web/js/AppContext.es';
 import SelectObjects from 'app-builder-web/js/components/select-objects/SelectObjects.es';
 import EditAppContext, {
@@ -61,17 +60,15 @@ const NoObjectEmptyState = () => (
 );
 
 export const OpenButton = (props) => (
-	<ClayTooltipProvider>
-		<ClayButtonWithIcon
-			className="ml-2 px-2 tap-ahead-icon-wrapper"
-			data-tooltip-align="bottom-right"
-			data-tooltip-delay="0"
-			displayType="secondary"
-			symbol="tap-ahead"
-			title={Liferay.Language.get('open')}
-			{...props}
-		/>
-	</ClayTooltipProvider>
+	<ClayButtonWithIcon
+		className="ml-2 px-2 tap-ahead-icon-wrapper"
+		data-tooltip-align="bottom-right"
+		data-tooltip-delay="0"
+		displayType="secondary"
+		symbol="tap-ahead"
+		title={Liferay.Language.get('open')}
+		{...props}
+	/>
 );
 
 export default function DataAndViewsTab({
@@ -254,16 +251,14 @@ export default function DataAndViewsTab({
 	};
 
 	const AddButton = (props) => (
-		<ClayTooltipProvider>
-			<ClayButtonWithIcon
-				className="btn btn-monospaced btn-secondary mr-2 nav-btn nav-btn-monospaced"
-				data-tooltip-align="bottom-right"
-				data-tooltip-delay="0"
-				displayType="secondary"
-				symbol="plus"
-				{...props}
-			/>
-		</ClayTooltipProvider>
+		<ClayButtonWithIcon
+			className="btn btn-monospaced btn-secondary mr-2 nav-btn nav-btn-monospaced"
+			data-tooltip-align="bottom-right"
+			data-tooltip-delay="0"
+			displayType="secondary"
+			symbol="plus"
+			{...props}
+		/>
 	);
 
 	const addFormViewButton = (selectFormView) => (
@@ -315,20 +310,17 @@ export default function DataAndViewsTab({
 							])} `}
 
 							{duplicatedFields.length > 5 && (
-								<ClayTooltipProvider delay="0">
-									<a
-										className="text-primary"
-										data-tooltip-align="bottom"
-										title={fieldsLabels
-											.slice(5, fieldsLabels.length)
-											.join('\n')}
-									>
-										{'*'}
-										{Liferay.Language.get(
-											'see-other-fields'
-										)}
-									</a>
-								</ClayTooltipProvider>
+								<a
+									className="text-primary"
+									data-tooltip-align="bottom"
+									data-tooltip-delay={0}
+									title={fieldsLabels
+										.slice(5, fieldsLabels.length)
+										.join('\n')}
+								>
+									{'*'}
+									{Liferay.Language.get('see-other-fields')}
+								</a>
 							)}
 						</ClayAlert>
 					)}
@@ -403,22 +395,20 @@ export default function DataAndViewsTab({
 									</ClayRadioGroup>
 
 									{stepFormViews.length > 1 && (
-										<ClayTooltipProvider>
-											<ClayButtonWithIcon
-												borderless
-												data-tooltip-align="bottom"
-												data-tooltip-delay="0"
-												displayType="secondary"
-												onClick={() =>
-													removeStepFormView(index)
-												}
-												small
-												symbol="trash"
-												title={Liferay.Language.get(
-													'remove'
-												)}
-											/>
-										</ClayTooltipProvider>
+										<ClayButtonWithIcon
+											borderless
+											data-tooltip-align="bottom"
+											data-tooltip-delay="0"
+											displayType="secondary"
+											onClick={() =>
+												removeStepFormView(index)
+											}
+											small
+											symbol="trash"
+											title={Liferay.Language.get(
+												'remove'
+											)}
+										/>
 									)}
 								</div>
 							</div>
@@ -442,17 +432,15 @@ export default function DataAndViewsTab({
 							{Liferay.Language.get('main-data-object')}
 						</label>
 
-						<ClayTooltipProvider>
-							<ClayIcon
-								className="ml-2 text-muted tooltip-icon"
-								data-tooltip-align="top"
-								data-tooltip-delay="0"
-								symbol="question-circle-full"
-								title={Liferay.Language.get(
-									'a-data-object-stores-your-business-data-and-is-composed-by-data-fields'
-								)}
-							/>
-						</ClayTooltipProvider>
+						<ClayIcon
+							className="ml-2 text-muted tooltip-icon"
+							data-tooltip-align="top"
+							data-tooltip-delay="0"
+							symbol="question-circle-full"
+							title={Liferay.Language.get(
+								'a-data-object-stores-your-business-data-and-is-composed-by-data-fields'
+							)}
+						/>
 
 						<SelectObjects
 							label={Liferay.Language.get('select-object')}

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/sidebar/EditAppSidebar.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/sidebar/EditAppSidebar.es.js
@@ -12,7 +12,6 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import EditAppContext from 'app-builder-web/js/pages/apps/edit/EditAppContext.es';
 import classNames from 'classnames';
 import {sub} from 'data-engine-js-components-web/js/utils/lang.es';
@@ -214,17 +213,15 @@ export default function EditAppSidebar() {
 										</span>
 									</label>
 
-									<ClayTooltipProvider>
-										<ClayIcon
-											className="ml-2 text-muted tooltip-icon"
-											data-tooltip-align="top"
-											data-tooltip-delay="0"
-											symbol="question-circle-full"
-											title={Liferay.Language.get(
-												'assignees-are-the-roles-responsible-to-transition-this-workflow-step'
-											)}
-										/>
-									</ClayTooltipProvider>
+									<ClayIcon
+										className="ml-2 text-muted tooltip-icon"
+										data-tooltip-align="top"
+										data-tooltip-delay="0"
+										symbol="question-circle-full"
+										title={Liferay.Language.get(
+											'assignees-are-the-roles-responsible-to-transition-this-workflow-step'
+										)}
+									/>
 
 									<AutocompleteMultiSelect
 										emptyMessage={Liferay.Language.get(
@@ -285,20 +282,18 @@ export default function EditAppSidebar() {
 
 										<div className="d-flex">
 											{error && (
-												<ClayTooltipProvider>
-													<ClayIcon
-														className="error mr-2 mt-1 tooltip-popover-icon"
-														data-tooltip-align="left"
-														data-tooltip-delay="0"
-														fontSize="26px"
-														symbol="exclamation-full"
-														title={`${Liferay.Language.get(
-															'error'
-														)}: ${Liferay.Language.get(
-															'there-are-form-views-with-duplicated-fields'
-														)}`}
-													/>
-												</ClayTooltipProvider>
+												<ClayIcon
+													className="error mr-2 mt-1 tooltip-popover-icon"
+													data-tooltip-align="left"
+													data-tooltip-delay="0"
+													fontSize="26px"
+													symbol="exclamation-full"
+													title={`${Liferay.Language.get(
+														'error'
+													)}: ${Liferay.Language.get(
+														'there-are-form-views-with-duplicated-fields'
+													)}`}
+												/>
 											)}
 
 											{showPopoverIcon && (

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/workflow-builder/WorkflowStep.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/workflow-builder/WorkflowStep.es.js
@@ -13,7 +13,6 @@ import ClayBadge from '@clayui/badge';
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import EditAppContext from 'app-builder-web/js/pages/apps/edit/EditAppContext.es';
 import classNames from 'classnames';
 import {sub} from 'data-engine-js-components-web/js/utils/lang.es';
@@ -31,17 +30,15 @@ const Arrow = ({addStep, selected}) => {
 			/>
 
 			{selected && (
-				<ClayTooltipProvider>
-					<div
-						className={classNames('arrow-plus-button')}
-						data-tooltip-align="left"
-						data-tooltip-delay="0"
-						onClick={addStep}
-						title={Liferay.Language.get('create-new-step')}
-					>
-						<ClayIcon className="icon" symbol="plus" />
-					</div>
-				</ClayTooltipProvider>
+				<div
+					className={classNames('arrow-plus-button')}
+					data-tooltip-align="left"
+					data-tooltip-delay="0"
+					onClick={addStep}
+					title={Liferay.Language.get('create-new-step')}
+				>
+					<ClayIcon className="icon" symbol="plus" />
+				</div>
 			)}
 
 			<div className="arrow-body">
@@ -97,20 +94,18 @@ const Card = ({
 			</div>
 
 			{duplicatedFields.length > 0 && (
-				<ClayTooltipProvider>
-					<ClayIcon
-						className="error tooltip-popover-icon"
-						data-tooltip-align="bottom"
-						data-tooltip-delay="0"
-						fontSize="26px"
-						symbol="exclamation-full"
-						title={`${Liferay.Language.get(
-							'error'
-						)}: ${Liferay.Language.get(
-							'there-are-form-views-with-duplicated-fields'
-						)}`}
-					/>
-				</ClayTooltipProvider>
+				<ClayIcon
+					className="error tooltip-popover-icon"
+					data-tooltip-align="bottom"
+					data-tooltip-delay="0"
+					fontSize="26px"
+					symbol="exclamation-full"
+					title={`${Liferay.Language.get(
+						'error'
+					)}: ${Liferay.Language.get(
+						'there-are-form-views-with-duplicated-fields'
+					)}`}
+				/>
 			)}
 
 			{!app.active && appId && initial && (customField || nativeField) && (
@@ -150,35 +145,33 @@ const Card = ({
 
 			<div className="d-flex">
 				{!isInitialOrFinalSteps && (
-					<ClayTooltipProvider>
-						<ClayDropDown
-							active={active}
-							data-tooltip-align="bottom"
-							data-tooltip-delay="0"
-							onActiveChange={setActive}
-							title={Liferay.Language.get('options')}
-							trigger={
-								<ClayButtonWithIcon
-									className="border-0"
-									displayType="secondary"
-									symbol="ellipsis-v"
-								/>
-							}
-						>
-							<ClayDropDown.ItemList>
-								{actions.map(({label, onClick}, index) => (
-									<ClayDropDown.Item
-										key={index}
-										onClick={(event) =>
-											handleOnClick(event, onClick)
-										}
-									>
-										{label}
-									</ClayDropDown.Item>
-								))}
-							</ClayDropDown.ItemList>
-						</ClayDropDown>
-					</ClayTooltipProvider>
+					<ClayDropDown
+						active={active}
+						data-tooltip-align="bottom"
+						data-tooltip-delay="0"
+						onActiveChange={setActive}
+						title={Liferay.Language.get('options')}
+						trigger={
+							<ClayButtonWithIcon
+								className="border-0"
+								displayType="secondary"
+								symbol="ellipsis-v"
+							/>
+						}
+					>
+						<ClayDropDown.ItemList>
+							{actions.map(({label, onClick}, index) => (
+								<ClayDropDown.Item
+									key={index}
+									onClick={(event) =>
+										handleOnClick(event, onClick)
+									}
+								>
+									{label}
+								</ClayDropDown.Item>
+							))}
+						</ClayDropDown.ItemList>
+					</ClayDropDown>
 				)}
 			</div>
 		</div>

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/entry/EditEntry.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/entry/EditEntry.es.js
@@ -10,7 +10,6 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {useTimeout} from '@liferay/frontend-js-react-web';
 import {AppContext} from 'app-builder-web/js/AppContext.es';
 import {ControlMenuBase} from 'app-builder-web/js/components/control-menu/ControlMenu.es';
@@ -379,20 +378,16 @@ export default function EditEntry({
 							/>
 
 							{workflowInfo?.canReassign && (
-								<ClayTooltipProvider>
-									<ClayButtonWithIcon
-										className="ml-2"
-										data-tooltip-align="bottom"
-										data-tooltip-delay="200"
-										displayType="secondary"
-										onClick={() => setModalVisible(true)}
-										small
-										symbol="change"
-										title={Liferay.Language.get(
-											'assign-to'
-										)}
-									/>
-								</ClayTooltipProvider>
+								<ClayButtonWithIcon
+									className="ml-2"
+									data-tooltip-align="bottom"
+									data-tooltip-delay="200"
+									displayType="secondary"
+									onClick={() => setModalVisible(true)}
+									small
+									symbol="change"
+									title={Liferay.Language.get('assign-to')}
+								/>
 							)}
 						</div>
 					</WorkflowInfoPortal>

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/entry/ViewEntry.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/entry/ViewEntry.es.js
@@ -10,7 +10,6 @@
  */
 
 import {ClayButtonWithIcon} from '@clayui/button';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {usePrevious, useTimeout} from '@liferay/frontend-js-react-web';
 import {AppContext} from 'app-builder-web/js/AppContext.es';
 import ControlMenu from 'app-builder-web/js/components/control-menu/ControlMenu.es';
@@ -252,18 +251,16 @@ export default function ViewEntry({
 			<ViewEntryUpperToolbar
 				additionalButtons={
 					workflowInfo?.canReassign && (
-						<ClayTooltipProvider>
-							<ClayButtonWithIcon
-								className="mr-2"
-								data-tooltip-align="bottom"
-								data-tooltip-delay="200"
-								displayType="secondary"
-								onClick={() => setModalVisible(true)}
-								small
-								symbol="change"
-								title={Liferay.Language.get('assign-to')}
-							/>
-						</ClayTooltipProvider>
+						<ClayButtonWithIcon
+							className="mr-2"
+							data-tooltip-align="bottom"
+							data-tooltip-delay="200"
+							displayType="secondary"
+							onClick={() => setModalVisible(true)}
+							small
+							symbol="change"
+							title={Liferay.Language.get('assign-to')}
+						/>
 					)
 				}
 				dataRecordId={dataRecordId}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
@@ -13,7 +13,6 @@
 		"@clayui/multi-select": "3.25.1",
 		"@clayui/pagination-bar": "3.25.1",
 		"@clayui/tabs": "3.3.5",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.2.6",
 		"lodash.isfunction": "3.0.9",

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/add_result/AddResultModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/add_result/AddResultModal.es.js
@@ -17,7 +17,6 @@ import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal from '@clayui/modal';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {usePrevious} from '@liferay/frontend-js-react-web';
 import getCN from 'classnames';
 import PropTypes from 'prop-types';
@@ -437,12 +436,10 @@ function AddResultModal({
 							'modal-title-help-icon'
 						)}
 					>
-						<ClayTooltipProvider>
-							<ClayIcon
-								symbol="question-circle-full"
-								title={Liferay.Language.get('add-results-help')}
-							/>
-						</ClayTooltipProvider>
+						<ClayIcon
+							symbol="question-circle-full"
+							title={Liferay.Language.get('add-results-help')}
+						/>
 					</span>
 				</ClayModal.Header>
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
@@ -16,7 +16,6 @@
 		"@clayui/progress-bar": "3.2.0",
 		"@clayui/table": "3.1.0",
 		"@clayui/tabs": "3.3.5",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"axios": "0.21.1",
 		"classnames": "2.2.6",

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/instance-details/InstanceDetailsModalBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/instance-details/InstanceDetailsModalBody.es.js
@@ -13,7 +13,6 @@
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayModal from '@clayui/modal';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
 import ContentView from '../../../../shared/components/content-view/ContentView.es';
@@ -153,22 +152,20 @@ const Body = ({
 					/>
 				)}
 
-				<ClayTooltipProvider>
-					<a
-						className="btn btn-secondary btn-sm font-weight-medium mb-1 mt-3"
-						data-tooltip-align="bottom"
-						data-tooltip-delay="0"
-						href={`/group/control_panel/manage/-/workflow_instance/view/${id}`}
-						target="_blank"
-						title={Liferay.Language.get('open-page-in-a-new-tab')}
-					>
-						{Liferay.Language.get('go-to-submission-page')}
+				<a
+					className="btn btn-secondary btn-sm font-weight-medium mb-1 mt-3"
+					data-tooltip-align="bottom"
+					data-tooltip-delay="0"
+					href={`/group/control_panel/manage/-/workflow_instance/view/${id}`}
+					target="_blank"
+					title={Liferay.Language.get('open-page-in-a-new-tab')}
+				>
+					{Liferay.Language.get('go-to-submission-page')}
 
-						<span className="inline-item inline-item-after">
-							<ClayIcon symbol="shortcut" />
-						</span>
-					</a>
-				</ClayTooltipProvider>
+					<span className="inline-item inline-item-after">
+						<ClayIcon symbol="shortcut" />
+					</span>
+				</a>
 			</ContentView>
 		</ClayModal.Body>
 	);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/reassign/bulk/select-assignees-step/SelectAssigneesStepTable.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/reassign/bulk/select-assignees-step/SelectAssigneesStepTable.es.js
@@ -11,7 +11,6 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayTable from '@clayui/table';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useContext} from 'react';
 
 import {Autocomplete} from '../../../../../../shared/components/autocomplete/Autocomplete.es';
@@ -137,16 +136,14 @@ const Table = ({data, items}) => {
 						}}
 					>
 						{`${Liferay.Language.get('new-assignee')}`}{' '}
-						<ClayTooltipProvider>
-							<ClayIcon
-								data-tooltip-align="top"
-								style={{color: '#6B6C7E'}}
-								symbol="question-circle-full"
-								title={Liferay.Language.get(
-									'possible-assignees-must-have-permissions-to-be-assigned-to-the-corresponding-step'
-								)}
-							/>
-						</ClayTooltipProvider>
+						<ClayIcon
+							data-tooltip-align="top"
+							style={{color: '#6B6C7E'}}
+							symbol="question-circle-full"
+							title={Liferay.Language.get(
+								'possible-assignees-must-have-permissions-to-be-assigned-to-the-corresponding-step'
+							)}
+						/>
 					</ClayTable.Cell>
 				</ClayTable.Row>
 			</ClayTable.Head>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/reassign/single/SingleReassignModalTable.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/reassign/single/SingleReassignModalTable.es.js
@@ -11,7 +11,6 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayTable from '@clayui/table';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useCallback, useMemo} from 'react';
 
 import {Autocomplete} from '../../../../../shared/components/autocomplete/Autocomplete.es';
@@ -130,16 +129,14 @@ const Table = ({items, setAssigneeId}) => {
 						}}
 					>
 						{`${Liferay.Language.get('new-assignee')}`}{' '}
-						<ClayTooltipProvider>
-							<ClayIcon
-								data-tooltip-align="top"
-								style={{color: '#6B6C7E'}}
-								symbol="question-circle-full"
-								title={Liferay.Language.get(
-									'possible-assignees-must-have-permissions-to-be-assigned-to-the-corresponding-step'
-								)}
-							/>
-						</ClayTooltipProvider>
+						<ClayIcon
+							data-tooltip-align="top"
+							style={{color: '#6B6C7E'}}
+							symbol="question-circle-full"
+							title={Liferay.Language.get(
+								'possible-assignees-must-have-permissions-to-be-assigned-to-the-corresponding-step'
+							)}
+						/>
 					</ClayTable.Cell>
 				</ClayTable.Row>
 			</ClayTable.Head>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/process-items/ProcessItemsCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/process-items/ProcessItemsCard.es.js
@@ -12,7 +12,6 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useMemo} from 'react';
 
 import ContentView from '../../../shared/components/content-view/ContentView.es';
@@ -119,17 +118,15 @@ const Header = ({children, data, description, title}) => (
 			<ClayLayout.ContentCol className="flex-row" expand>
 				<span className="mr-2">{title}</span>
 
-				<ClayTooltipProvider>
-					<span>
-						<span
-							className="workflow-tooltip"
-							data-tooltip-align="right"
-							title={description}
-						>
-							<ClayIcon symbol="question-circle-full" />
-						</span>
+				<span>
+					<span
+						className="workflow-tooltip"
+						data-tooltip-align="right"
+						title={description}
+					>
+						<ClayIcon symbol="question-circle-full" />
 					</span>
-				</ClayTooltipProvider>
+				</span>
 			</ClayLayout.ContentCol>
 
 			{children && data && (

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/list-page/SLAListPageHeader.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/list-page/SLAListPageHeader.es.js
@@ -11,7 +11,6 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayManagementToolbar from '@clayui/management-toolbar';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
 import ChildLink from '../../../shared/components/router/ChildLink.es';
@@ -21,22 +20,20 @@ const Header = ({processId}) => {
 		<ClayManagementToolbar>
 			<ClayManagementToolbar.ItemList expand>
 				<ClayManagementToolbar.Item className="autofit-col-expand autofit-float-end">
-					<ClayTooltipProvider>
-						<span>
-							<span
-								className="workflow-tooltip"
-								data-tooltip-align="bottom"
-								title={Liferay.Language.get('new-sla')}
+					<span>
+						<span
+							className="workflow-tooltip"
+							data-tooltip-align="bottom"
+							title={Liferay.Language.get('new-sla')}
+						>
+							<ChildLink
+								className="btn btn-primary nav-btn nav-btn-monospaced"
+								to={`/sla/${processId}/new`}
 							>
-								<ChildLink
-									className="btn btn-primary nav-btn nav-btn-monospaced"
-									to={`/sla/${processId}/new`}
-								>
-									<ClayIcon symbol="plus" />
-								</ChildLink>
-							</span>
+								<ClayIcon symbol="plus" />
+							</ChildLink>
 						</span>
-					</ClayTooltipProvider>
+					</span>
 				</ClayManagementToolbar.Item>
 			</ClayManagementToolbar.ItemList>
 		</ClayManagementToolbar>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderReindexStatus.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderReindexStatus.es.js
@@ -9,7 +9,6 @@
  * distribution rights of the Software.
  */
 
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
 import {useReindexActions} from '../../../components/settings/indexes-page/hooks/useReindexActions.es';
@@ -28,16 +27,14 @@ const HeaderReindexStatus = ({container}) => {
 					position="after"
 				>
 					<div className="control-menu-icon px-2">
-						<ClayTooltipProvider>
-							<span
-								aria-hidden="true"
-								className="loading-animation loading-animation-sm m-0"
-								data-tooltip-align="bottom"
-								title={Liferay.Language.get(
-									'the-workflow-metrics-data-is-currently-reindexing'
-								)}
-							></span>
-						</ClayTooltipProvider>
+						<span
+							aria-hidden="true"
+							className="loading-animation loading-animation-sm m-0"
+							data-tooltip-align="bottom"
+							title={Liferay.Language.get(
+								'the-workflow-metrics-data-is-currently-reindexing'
+							)}
+						></span>
 					</div>
 				</Portal>
 			)}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/panel/Panel.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/panel/Panel.es.js
@@ -11,7 +11,6 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import getCN from 'classnames';
 import React from 'react';
 
@@ -65,17 +64,15 @@ const HeaderWithOptions = ({
 				<ClayLayout.ContentRow className="flex-row" expand="true">
 					<span className="mr-2">{title}</span>
 
-					<ClayTooltipProvider>
-						<span>
-							<span
-								className="workflow-tooltip"
-								data-tooltip-align={tooltipPosition}
-								title={description}
-							>
-								<ClayIcon symbol="question-circle-full" />
-							</span>
+					<span>
+						<span
+							className="workflow-tooltip"
+							data-tooltip-align={tooltipPosition}
+							title={description}
+						>
+							<ClayIcon symbol="question-circle-full" />
 						</span>
-					</ClayTooltipProvider>
+					</span>
 				</ClayLayout.ContentRow>
 
 				{children}

--- a/modules/dxp/apps/segments/segments-experiment-web/package.json
+++ b/modules/dxp/apps/segments/segments-experiment-web/package.json
@@ -9,7 +9,6 @@
 		"@clayui/link": "3.2.0",
 		"@clayui/modal": "3.8.5",
 		"@clayui/tabs": "3.3.5",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -12,7 +12,6 @@
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import {useEventListener} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
 import {throttle} from 'frontend-js-web';
@@ -224,15 +223,14 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 				<ClayForm.Group>
 					<label htmlFor="clickableElement">
 						{Liferay.Language.get('element-id')}
-						<ClayTooltipProvider>
-							<ClayIcon
-								className="c-ml-1 text-secondary"
-								data-tooltip-align="top"
-								small="true"
-								symbol="question-circle"
-								title={Liferay.Language.get('element-id-help')}
-							/>
-						</ClayTooltipProvider>
+
+						<ClayIcon
+							className="c-ml-1 text-secondary"
+							data-tooltip-align="top"
+							small="true"
+							symbol="question-circle"
+							title={Liferay.Language.get('element-id-help')}
+						/>
 					</label>
 					<ClayInput.Group
 						className={classNames({
@@ -243,52 +241,45 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 							<ClayInput.GroupText>#</ClayInput.GroupText>
 						</ClayInput.GroupItem>
 						<ClayInput.GroupItem append>
-							<ClayTooltipProvider>
-								<ClayInput
-									className={classNames({
-										'input-group-inset input-group-inset-after':
-											allowEdit && selectedTarget,
-									})}
-									data-tooltip-align="top"
-									id="clickableElement"
-									onBlur={handleBlur}
-									onChange={handleInputChange}
-									onKeyDown={handleKeyDown}
-									readOnly={!allowEdit || selectedTarget}
-									title={selectorInputValue}
-									type="text"
-									value={selectorInputValue}
-								/>
-							</ClayTooltipProvider>
+							<ClayInput
+								className={classNames({
+									'input-group-inset input-group-inset-after':
+										allowEdit && selectedTarget,
+								})}
+								data-tooltip-align="top"
+								id="clickableElement"
+								onBlur={handleBlur}
+								onChange={handleInputChange}
+								onKeyDown={handleKeyDown}
+								readOnly={!allowEdit || selectedTarget}
+								title={selectorInputValue}
+								type="text"
+								value={selectorInputValue}
+							/>
+
 							{allowEdit && selectedTarget && (
 								<ClayInput.GroupInsetItem after>
-									<ClayTooltipProvider>
-										<ClayButtonWithIcon
-											data-tooltip-align="bottom-right"
-											disabled={!selectedTarget}
-											displayType="unstyled"
-											monospaced={false}
-											onClick={handleDelete}
-											symbol="times-circle"
-											title={Liferay.Language.get(
-												'clear'
-											)}
-										/>
-									</ClayTooltipProvider>
+									<ClayButtonWithIcon
+										data-tooltip-align="bottom-right"
+										disabled={!selectedTarget}
+										displayType="unstyled"
+										monospaced={false}
+										onClick={handleDelete}
+										symbol="times-circle"
+										title={Liferay.Language.get('clear')}
+									/>
 								</ClayInput.GroupInsetItem>
 							)}
 						</ClayInput.GroupItem>
 						<ClayInput.GroupItem shrink>
-							<ClayTooltipProvider>
-								<ClayButtonWithIcon
-									data-tooltip-align="bottom-right"
-									disabled={!selectedTarget}
-									displayType="secondary"
-									onClick={scrollIntoView}
-									symbol="view"
-									title={Liferay.Language.get('show-element')}
-								/>
-							</ClayTooltipProvider>
+							<ClayButtonWithIcon
+								data-tooltip-align="bottom-right"
+								disabled={!selectedTarget}
+								displayType="secondary"
+								onClick={scrollIntoView}
+								symbol="view"
+								title={Liferay.Language.get('show-element')}
+							/>
 						</ClayInput.GroupItem>
 						{!isValidTarget && (
 							<ClayForm.FeedbackGroup>
@@ -561,31 +552,30 @@ function Target({allowEdit, element, geometry, mode, selector}) {
 				top: spaceOnTop,
 			}}
 		>
-			<ClayTooltipProvider>
-				<div
-					className={classNames({
-						'lfr-segments-experiment-click-goal-target-overlay':
-							!selectedTarget ||
-							mode === 'editing' ||
-							mode === 'selected',
-						'lfr-segments-experiment-click-goal-target-overlay-editing':
-							mode === 'editing',
-						'lfr-segments-experiment-click-goal-target-overlay-selected':
-							mode === 'selected',
-					})}
-					data-target-selector={selector}
-					data-tooltip-align="bottom-left"
-					onClick={handleClick}
-					style={{height, width}}
-					title={
-						mode === 'inactive'
-							? Liferay.Language.get(
-									'click-element-to-set-as-click-target-for-your-goal'
-							  )
-							: ''
-					}
-				></div>
-			</ClayTooltipProvider>
+			<div
+				className={classNames({
+					'lfr-segments-experiment-click-goal-target-overlay':
+						!selectedTarget ||
+						mode === 'editing' ||
+						mode === 'selected',
+					'lfr-segments-experiment-click-goal-target-overlay-editing':
+						mode === 'editing',
+					'lfr-segments-experiment-click-goal-target-overlay-selected':
+						mode === 'selected',
+				})}
+				data-target-selector={selector}
+				data-tooltip-align="bottom-left"
+				onClick={handleClick}
+				style={{height, width}}
+				title={
+					mode === 'inactive'
+						? Liferay.Language.get(
+								'click-element-to-set-as-click-target-for-your-goal'
+						  )
+						: ''
+				}
+			></div>
+
 			{mode !== 'inactive' && (
 				<ClickGoalPicker.TargetTopper
 					allowEdit={allowEdit}


### PR DESCRIPTION
This addresses https://issues.liferay.com/browse/LPS-128506

The main change here is that we wrap out **`render`** with a **`ClayTooltipProvider`** similar to how we provide a `ClayIconContext` so that devs don't have to provide it themselves(unless they want to override the styles).

This means that everything render through `react:component`, `ReactRenderer` or `import {render} from 'frontend-js-react-web`'  automatically provides default tooltip support simplifying the setup for applications down the line.

Because removing the provider in the modules changes basically all the indentation of the files, it can easily cause conflicts.

/cc @liferay-echo, @liferay-tango, @liferay-lima, @liferay-commerce, @liferay-headless, @liferay-app-builder, @liferay-data-engine, @liferay-forms, @liferay-workflow, @liferay-search... and maybe others 🙈 