### PR TITLE
[TECHNICAL SUPPORT] LPS-127302 Site scope setting of Asset Publisher portlet does not work properly using Safari with disabled SPA

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -352,6 +352,12 @@
 			if (currentElement) {
 				const url = currentElement.getAttribute('href');
 
+				// LPS-127302
+
+				if (url === 'javascript:;') {
+					return;
+				}
+
 				const newWindow =
 					currentElement.getAttribute('target') == '_blank';
 


### PR DESCRIPTION
Hello,
[LPS-127302](https://issues.liferay.com/browse/LPS-127302)

I modified the solution according to the discussion on https://github.com/liferay-frontend/liferay-portal/pull/849
please review it,

Thanks