### PR TITLE
LPS-128463 - Fix social icons misalignment

### DIFF
--- a/modules/apps/social/social-bookmark-facebook/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-facebook/src/main/resources/META-INF/resources/page.jsp
@@ -24,11 +24,10 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 
 <clay:link
 	borderless="<%= true %>"
-	cssClass="lfr-portal-tooltip"
+	cssClass="c-px-2 lfr-portal-tooltip"
 	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="social-facebook"
-	monospaced="<%= true %>"
 	outline="<%= true %>"
 	small="<%= true %>"
 	title="<%= socialBookmark.getName(request.getLocale()) %>"

--- a/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/page.jsp
@@ -24,11 +24,10 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 
 <clay:link
 	borderless="<%= true %>"
-	cssClass="lfr-portal-tooltip"
+	cssClass="c-px-2 lfr-portal-tooltip"
 	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="social-linkedin"
-	monospaced="<%= true %>"
 	outline="<%= true %>"
 	small="<%= true %>"
 	title="<%= socialBookmark.getName(request.getLocale()) %>"

--- a/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/page.jsp
@@ -24,11 +24,10 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 
 <clay:link
 	borderless="<%= true %>"
-	cssClass="lfr-portal-tooltip"
+	cssClass="c-px-2 lfr-portal-tooltip"
 	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="twitter"
-	monospaced="<%= true %>"
 	outline="<%= true %>"
 	small="<%= true %>"
 	title="<%= socialBookmark.getName(request.getLocale()) %>"

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmark/deprecated_bookmark.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmark/deprecated_bookmark.jsp
@@ -23,7 +23,7 @@ String icon = PropsUtil.get(PropsKeys.SOCIAL_BOOKMARK_ICON, new Filter(type));
 <liferay-ui:icon
 	image="<%= icon %>"
 	label="<%= false %>"
-	linkCssClass="btn btn-borderless btn-monospaced btn-outline-borderless btn-outline-secondary btn-sm"
+	linkCssClass="btn btn-borderless btn-outline-borderless btn-outline-secondary btn-sm c-px-2"
 	message="<%= socialBookmark.getName(locale) %>"
 	method="get"
 	src="<%= icon %>"


### PR DESCRIPTION
This PR fixes a misalignment that was previously fixed in an incorrect way in the compact layer.

![image](https://user-images.githubusercontent.com/7963804/109799990-f538c900-7c1c-11eb-9d2f-d98f2849a7d0.png)

Clay does not have vertically centered links with class `btn-monospaced`, since they were defined to be localized-input in two lines, flag, and text:
https://clayui.com/docs/components/localized-input.html

So, in general, to fix this with `btn-sm` we will use `c-px-2`.

---

How to test this PR:

- Add the blog portlet to the page.
- Create a blog entry.

Result:

![image](https://user-images.githubusercontent.com/7963804/109800100-113c6a80-7c1d-11eb-9cb2-b8937e9d587c.png)
