### PR TITLE
LPS-128596 Align back button web content title and action button in Asset Publisher

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -67,7 +67,7 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 
 <div class="asset-full-content clearfix mb-5 <%= assetPublisherDisplayContext.isDefaultAssetPublisher() ? "default-asset-publisher" : StringPool.BLANK %> <%= assetPublisherDisplayContext.isShowAssetTitle() ? "show-asset-title" : "no-title" %> <%= ((previewClassNameId == assetEntry.getClassNameId()) && (previewClassPK == assetEntry.getClassPK())) ? "p-1 preview-asset-entry" : StringPool.BLANK %>" <%= AUIUtil.buildData(fragmentsEditorData) %>>
 	<div class="align-items-center d-flex mb-2">
-		<p class="component-title h4">
+		<p class="component-title d-inline-flex h4">
 			<c:if test="<%= showBackURL && Validator.isNotNull(redirect) %>">
 				<liferay-ui:icon
 					cssClass="header-back-to"


### PR DESCRIPTION
LPS-128596 Align back button web content title and action button in Asset Publisher when selecting a content

Not sure why isn't happening in 7.3.x as is having same changes, this affects only master.
