### PR TITLE
LPS 128635 | Workaround for failing remote app test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -28,14 +28,14 @@ definition {
 	macro viewTableEntryName {
 		AssertTextEquals(
 			key_tableEntryName = "${entryName}",
-			locator1 = "RemoteApps#TABLE_ENTRY_NAME",
+			locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE",
 			value1 = "${entryName}");
 	}
 
 	macro viewTableEntryURL {
 		AssertTextEquals(
 			key_tableEntryURL = "${entryURL}",
-			locator1 = "RemoteApps#TABLE_ENTRY_URL",
+			locator1 = "RemoteApps#TABLE_ENTRY_URL_REMOTE_TABLE",
 			value1 = "${entryURL}");
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -14,8 +14,18 @@
 	<td></td>
 </tr>
 <tr>
+	<td>TABLE_ENTRY_NAME_REMOTE_TABLE</td>
+	<td>//div[contains(@class,'dnd-td')]//div[contains(@class,'table-list-title')]//*[contains(text(),'${key_tableEntryName}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>TABLE_ENTRY_URL</td>
 	<td>//table//tbody//td[contains(text(),'${key_tableEntryURL}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>TABLE_ENTRY_URL_REMOTE_TABLE</td>
+	<td>//div[contains(@class,'dnd-td') and contains(text(),'${key_tableEntryURL}')]</td>
 	<td></td>
 </tr>
 </tbody>


### PR DESCRIPTION
Workaround for failing remote app test due to remote app table changes
**Test Plan:**

1. Go to Control Panel > Custom Apps > Remote Apps
2. Add a new Remote App by clicking on + icon
3. Name remote app "Test Remote App"
4. Observe the Remote Apps table

https://issues.liferay.com/browse/LPS-128635