### PR TITLE
LPS-124280 The help message on the video miss the language key

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -66,6 +66,10 @@ if (editorOptions != null) {
 </c:if>
 
 <script data-senna-track="temporary" type="text/javascript">
+	CKEDITOR.ADDITIONAL_RESOURCE_PARAMS = {
+		languageId: themeDisplay.getLanguageId(),
+	};
+
 	CKEDITOR.disableAutoInline = true;
 
 	CKEDITOR.dtd.$removeEmpty.i = 0;


### PR DESCRIPTION
This PR fixes [LPS-124280](https://issues.liferay.com/browse/LPS-124280). By adding the `languageId` property to the `CKEditor.ADDITIONAL_RESOURCE_PARAMS` object, the provided language key `video-playback-is-disabled-during-edit-mode` is properly translated to `Video playback is disabled during edit mode`.

## Before
![image](https://user-images.githubusercontent.com/24564752/110116426-c60a8f00-7db7-11eb-9707-97ef32215143.png)

## After
![image](https://user-images.githubusercontent.com/24564752/110116880-71b3df00-7db8-11eb-88a9-329c3b6bc029.png)
