### PR TITLE
LPS-128744 Fix broken DOM structure caused by LPS-120600

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
@@ -80,11 +80,11 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 							</span>
 						</c:otherwise>
 					</c:choose>
-
-					<span class="d-inline-flex">
-						<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
-					</span>
 				</p>
+
+				<div class="d-inline-flex">
+					<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
+				</div>
 			</div>
 
 			<span class="asset-anchor lfr-asset-anchor" id="<%= assetEntry.getEntryId() %>"></span>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -96,9 +96,9 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 			request.setAttribute("view.jsp-fullContentRedirect", fullContentRedirect);
 			%>
 
-			<span class="d-inline-flex">
+			<div class="d-inline-flex">
 				<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
-			</span>
+			</div>
 		</c:if>
 	</div>
 


### PR DESCRIPTION
LPS-128744 Fix broken DOM structure caused by LPS-120600, DOM contains an empty element p and asset-actions.jsp content places outside his parent element span. Change asset_actions.jsp parent element span with div for markup validity as actions contain a div and span can't be parent of a div.