### PR TITLE
LPS-127081 Adjust remote-app-client-js for forwards-compatibility

### DIFF
--- a/modules/apps/remote-app/remote-app-client-js/tsconfig.json
+++ b/modules/apps/remote-app/remote-app-client-js/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "es6",
+		"moduleResolution": "node",
 		"outDir": "./build/node/packageRunBuild/dist/",
 		"sourceMap": true,
 		"strict": true,
@@ -10,5 +11,9 @@
 			"./node_modules/@types",
 			"./src/main/resources/META-INF/resources/js/types"
 		]
-	}
+	},
+	"include": [
+		"src/**/*",
+		"tests/**/*"
+	]
 }


### PR DESCRIPTION
A forthcoming `@liferay/npm-scripts` release will include [this PR](https://github.com/liferay/liferay-frontend-projects/pull/425) which adds some basic support for building TypeScript in liferay-portal (beyond the webpack-based build that we're already using in remote-app-client-js).

I don't know exactly when the next release will be, because we have other changes ongoing in `@liferay/npm-scripts` and I don't want to clash with those, but I do want to make sure that _if_ we were to merge, and cut a release, liferay-portal would be ready for it.

This configuration tweak allows the existing `HEAD` of the `master` branch to continue building correctly (verified with `yarn build`), while preparing it for the subsequent `@liferay/npm-scripts` release, whenever that ends up happening.