### PR TITLE
LRQA-62049 part 2 | Reduce FI tests pause to less then 3 seconds for WYSIWYGUsecase#AddBlogsEntryWithImageViaBlogsImages

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/BlogsNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BlogsNavigator.macro
@@ -166,7 +166,9 @@ definition {
 	}
 
 	macro gotoSelectFile {
-		Pause(locator1 = "5000");
+		WaitForElementPresent(
+			locator1 = "BlogsEntry#ENTRY_COVER_IMAGE_SELECT_FILE",
+			value1 = "Select File");
 
 		AssertClick(
 			locator1 = "BlogsEntry#ENTRY_COVER_IMAGE_SELECT_FILE",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
@@ -524,7 +524,7 @@ definition {
 			Click.clickNoMouseOver(locator1 = "Modal#CLOSE_BUTTON");
 		}
 		else {
-			Pause(locator1 = "5000");
+			Pause(locator1 = "3000");
 
 			AssertElementPresent.pauseAssertVisible(
 				locator1 = "ItemSelector#ADD_BUTTON",


### PR DESCRIPTION
Reduce FI tests pause to less then 3 seconds for WYSIWYGUsecase#AddBlogsEntryWithImageViaBlogsImages
Test Plan:
1. Change 5s Pause to 3s Pause on ItemSelector.uploadFile
2. Change 5s Pause to WaitForElementPresent() on gotoSelectFile() macro

https://issues.liferay.com/browse/LRQA-62049