### PR TITLE
LPS-128745 autoComplete attribute should be String instead of boolean o match the values of HTML autocomplete attribute

### DIFF
--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -235,7 +235,7 @@ boolean choiceField = checkboxField || radioField;
 	</c:when>
 	<c:when test="<%= (model != null) && Validator.isNull(type) %>">
 		<liferay-ui:input-field
-			autoComplete='<%= GetterUtil.getBoolean(dynamicAttributes.get("autocomplete"), true) %>'
+			autoComplete='<%= GetterUtil.getString(dynamicAttributes.get("autocomplete")) %>'
 			autoFocus="<%= autoFocus %>"
 			bean="<%= bean %>"
 			cssClass="<%= fieldCssClass %>"

--- a/portal-web/docroot/html/taglib/ui/input_field/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_field/page.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/html/taglib/init.jsp" %>
 
 <%
-boolean autoComplete = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-field:autoComplete"));
+String autoComplete = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-field:autoComplete"));
 boolean autoFocus = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-field:autoFocus"));
 boolean autoSize = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-field:autoSize"));
 Object bean = request.getAttribute("liferay-ui:input-field:bean");
@@ -492,7 +492,7 @@ if (hints != null) {
 							/>
 						</c:when>
 						<c:otherwise>
-							<input <%= !autoComplete ? "autocomplete=\"off\"" : StringPool.BLANK %> class="<%= cssClass %> lfr-input-text" <%= disabled ? "disabled=\"disabled\"" : StringPool.BLANK %> id="<%= namespace %><%= id %>" name="<%= namespace %><%= fieldParam %>" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> style="<%= upperCase ? "text-transform: uppercase;" : StringPool.BLANK %>" type="<%= secret ? "password" : "text" %>" value="<%= autoEscape ? HtmlUtil.escape(value) : value %>" />
+							<input <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> class="<%= cssClass %> lfr-input-text" <%= disabled ? "disabled=\"disabled\"" : StringPool.BLANK %> id="<%= namespace %><%= id %>" name="<%= namespace %><%= fieldParam %>" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> style="<%= upperCase ? "text-transform: uppercase;" : StringPool.BLANK %>" type="<%= secret ? "password" : "text" %>" value="<%= autoEscape ? HtmlUtil.escape(value) : value %>" />
 						</c:otherwise>
 					</c:choose>
 				</c:when>

--- a/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
@@ -26,6 +26,10 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class InputFieldTag extends IncludeTag {
 
+	public String getAutoComplete() {
+		return _autoComplete;
+	}
+
 	public Object getBean() {
 		return _bean;
 	}
@@ -78,10 +82,6 @@ public class InputFieldTag extends IncludeTag {
 		return _placeholder;
 	}
 
-	public boolean isAutoComplete() {
-		return _autoComplete;
-	}
-
 	public boolean isAutoFocus() {
 		return _autoFocus;
 	}
@@ -98,7 +98,7 @@ public class InputFieldTag extends IncludeTag {
 		return _ignoreRequestValue;
 	}
 
-	public void setAutoComplete(boolean autoComplete) {
+	public void setAutoComplete(String autoComplete) {
 		_autoComplete = autoComplete;
 	}
 
@@ -174,7 +174,7 @@ public class InputFieldTag extends IncludeTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
-		_autoComplete = true;
+		_autoComplete = null;
 		_autoFocus = false;
 		_autoSize = false;
 		_bean = null;
@@ -214,8 +214,7 @@ public class InputFieldTag extends IncludeTag {
 		}
 
 		httpServletRequest.setAttribute(
-			"liferay-ui:input-field:autoComplete",
-			String.valueOf(_autoComplete));
+			"liferay-ui:input-field:autoComplete", _autoComplete);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-field:autoFocus", String.valueOf(_autoFocus));
 		httpServletRequest.setAttribute(
@@ -255,7 +254,7 @@ public class InputFieldTag extends IncludeTag {
 
 	private static final String _PAGE = "/html/taglib/ui/input_field/page.jsp";
 
-	private boolean _autoComplete = true;
+	private String _autoComplete;
 	private boolean _autoFocus;
 	private boolean _autoSize;
 	private Object _bean;

--- a/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
@@ -14,6 +14,7 @@
 
 package com.liferay.taglib.ui;
 
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.util.IncludeTag;
 
@@ -99,7 +100,9 @@ public class InputFieldTag extends IncludeTag {
 	}
 
 	public void setAutoComplete(String autoComplete) {
-		_autoComplete = autoComplete;
+		_autoComplete =
+			ArrayUtil.contains(_VALID_AUTOCOMPLETE_VALUES, autoComplete) ?
+				autoComplete : "off";
 	}
 
 	public void setAutoFocus(boolean autoFocus) {
@@ -253,6 +256,22 @@ public class InputFieldTag extends IncludeTag {
 	}
 
 	private static final String _PAGE = "/html/taglib/ui/input_field/page.jsp";
+
+	private static final String[] _VALID_AUTOCOMPLETE_VALUES = {
+		"off", "on", "name", "honorific-prefix", "given-name",
+		"additional-name", "family-name", "honorific-suffix", "nickname",
+		"email", "username", "new-password", "current-password",
+		"one-time-code", "organization-title", "organization", "street-address",
+		"address-line1", "address-line2", "address-line3", "address-level14",
+		"address-level13", "address-level12", "address-level11", "country",
+		"country-name", "postal-code", "cc-name", "cc-given-name",
+		"cc-additional-name", "cc-family-name", "cc-number", "cc-exp",
+		"cc-exp-month", "cc-exp-year", "cc-csc", "cc-type",
+		"transaction-currency", "transaction-amount", "language", "bday",
+		"bday-day", "bday-month", "bday-year", "sex", "tel", "tel-country-code",
+		"tel-national", "tel-area-code", "tel-local", "tel-extension", "impp",
+		"url", "photo"
+	};
 
 	private String _autoComplete;
 	private boolean _autoFocus;

--- a/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
@@ -14,7 +14,9 @@
 
 package com.liferay.taglib.ui;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.util.IncludeTag;
 
@@ -100,9 +102,33 @@ public class InputFieldTag extends IncludeTag {
 	}
 
 	public void setAutoComplete(String autoComplete) {
+		autoComplete = StringUtil.toLowerCase(autoComplete.trim());
+
+		String[] autoCompleteParts = StringUtil.split(
+			autoComplete, CharPool.SPACE);
+
+		boolean validAutoComplete = false;
+
+		if (autoCompleteParts.length == 1) {
+			validAutoComplete = _validateAutoCompleteValue(
+				autoCompleteParts[0]);
+		}
+		else if (autoCompleteParts.length == 2) {
+			validAutoComplete =
+				_validateAutoCompleteValue(autoCompleteParts[1]) &&
+				(_validateAutoCompleteContactInformation(
+					autoCompleteParts[0]) ||
+				 _validateSectionAutoComplete(autoCompleteParts[0]));
+		}
+		else if (autoCompleteParts.length == 3) {
+			validAutoComplete =
+				_validateAutoCompleteValue(autoCompleteParts[2]) &&
+				_validateAutoCompleteContactInformation(autoCompleteParts[1]) &&
+				_validateSectionAutoComplete(autoCompleteParts[0]);
+		}
+
 		_autoComplete =
-			ArrayUtil.contains(_VALID_AUTOCOMPLETE_VALUES, autoComplete) ?
-				autoComplete : "off";
+			validAutoComplete ? autoComplete : _AUTOCOMPLETE_DEFAULT_VALUE;
 	}
 
 	public void setAutoFocus(boolean autoFocus) {
@@ -254,6 +280,26 @@ public class InputFieldTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-field:placeholder", _placeholder);
 	}
+
+	private boolean _validateAutoCompleteContactInformation(
+		String autoComplete) {
+
+		if (autoComplete.equals("shipping") || autoComplete.equals("billing")) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _validateAutoCompleteValue(String autoComplete) {
+		return ArrayUtil.contains(_VALID_AUTOCOMPLETE_VALUES, autoComplete);
+	}
+
+	private boolean _validateSectionAutoComplete(String autoComplete) {
+		return autoComplete.startsWith("section-");
+	}
+
+	private static final String _AUTOCOMPLETE_DEFAULT_VALUE = "off";
 
 	private static final String _PAGE = "/html/taglib/ui/input_field/page.jsp";
 


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

When we originally introduced `autocomplete` attribute for `liferay-ui:input-field` taglib in [LPS-52457](https://issues.liferay.com/browse/LPS-52457) we only thought its value could be "on" (default) or "off". In fact, we just set "off" in case `autoComplete` boolean value is `false` and we don't add it to `input` element in case is `true`. Because of that we managed it as a boolean value. However, [that HTML attribute can have many more values](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values).

**This is not affecting right now our portal itself** since every time we specified autocomplete we set it to "off" apart from [this time](https://github.com/liferay/liferay-portal/blob/master/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/password_verification.jsp#L42) when set it to "new-password", but in that case that's not an issue since it's managed as a dynamic attribute of `aui:input` taglib and [this code](https://github.com/liferay/liferay-portal/blob/master/portal-web/docroot/html/taglib/aui/input/page.jsp#L237-L256) invoking `liferay-ui:input-field` taglib is not reached.

**This is affecting external developments** since developers using `aui:input` (and meeting [this conditions](https://github.com/liferay/liferay-portal/blob/master/portal-web/docroot/html/taglib/aui/input/page.jsp#L236)) or directly `liferay-ui:input-field` can not set any other value rather than "off" or "on".

I've been testing the different key cases I could see:
1. No autoComplete attribute has been specified in taglib
2. autoComplete="name" (or any other valid value)
3. autoComplete="true"
4. autoComplete="false"
5. autoComplete="on"
6. autoComplete="off"
7. autoComplete="whatever" (or any other invalid value)
8. autoComplete=""

The cases which behavior is going to change are:
**2. autoComplete="name"** (it's a valid autocomplete value)
This is the exact case we are fixing. So far, we've been adding `autocomplete="off"`attribute to `input` element. After this change, we are going to add `autocomplete="name"` which is the expected behavior.

**3. autoComplete="true"** (it's not a valid HTML autocomplete value)
Right now, we are not adding autocomplete attribute to input element. After this change, we are going to add `autocomplete="true"` which in fact is not a valid value, so in the end the field is going to be treated the same than before, with default behavior and being autocompleted. The only change would be the HTML markup.

**4. autoComplete="false"**, **7. autoComplete="whatever"** and **8. autoComplete=""** (they are not valid HTML autocomplete values)
Right now, we are adding `autocomplete="off"` attribute to `input` element for all these cases. After this change, we are going to add `autocomplete="false|whatever|"""` which in fact they are not valid values, so in the end the field is going to be treated differently than before, because now is going to have the default behavior and would be autocompleted. For these cases I'll talk to Enterprise Release Team when backporting to add some information in "Release Notes" to make customers and developers aware of the change.
Thanks.

Regards.