### PR TITLE
LPS 122219 | Add new automation test deleting a newly added remote app and assert remote app is not on a table on admin page

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -10,6 +10,12 @@ definition {
 		PortletEntry.save();
 	}
 
+	macro deleteRemoteApp {
+		Click(locator1 = "RemoteApps#REMOTE_TABLE_ELLIPSI");
+
+		Click(locator1 = "RemoteApps#REMOTE_TABLE_DELETE");
+	}
+
 	macro tearDown {
 		ApplicationsMenu.gotoPortlet(
 			category = "Custom Apps",
@@ -23,6 +29,10 @@ definition {
 
 			MenuItem.clickNoError(menuItem = "Delete");
 		}
+	}
+
+	macro viewEmptyRemoteTable {
+		AssertElementPresent(locator1 = "RemoteApps#EMPTY_REMOTE_TABLE_MESSAGE");
 	}
 
 	macro viewTableEntryName {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -11,7 +11,7 @@ definition {
 	}
 
 	macro deleteRemoteApp {
-		Click(locator1 = "RemoteApps#REMOTE_TABLE_ELLIPSI");
+		Click(locator1 = "RemoteApps#REMOTE_TABLE_ELLIPSIS");
 
 		Click(locator1 = "RemoteApps#REMOTE_TABLE_DELETE");
 	}
@@ -37,6 +37,13 @@ definition {
 
 	macro viewTableEntryName {
 		AssertTextEquals(
+			key_tableEntryName = "${entryName}",
+			locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE",
+			value1 = "${entryName}");
+	}
+
+	macro viewTableEntryNameNotPresent {
+		AssertElementNotPresent(
 			key_tableEntryName = "${entryName}",
 			locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE",
 			value1 = "${entryName}");

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -19,7 +19,7 @@
 	<td></td>
 </tr>
 <tr>
-	<td>REMOTE_TABLE_ELLIPSI</td>
+	<td>REMOTE_TABLE_ELLIPSIS</td>
 	<td>//button[contains(@class,'component-action')]</td>
 	<td></td>
 </tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -9,6 +9,21 @@
 </thead>
 <tbody>
 <tr>
+	<td>EMPTY_REMOTE_TABLE_MESSAGE</td>
+	<td>//div[contains(@class,'sheet-text') and contains(.,'No items were found.')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>REMOTE_TABLE_DELETE</td>
+	<td>//a[contains(@class,'dropdown-item') and contains(.,'Delete')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>REMOTE_TABLE_ELLIPSI</td>
+	<td>//button[contains(@class,'component-action')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>TABLE_ENTRY_NAME</td>
 	<td>//table//tbody//td//*[contains(@class,'table-list-title')]//*[contains(text(),'${key_tableEntryName}')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -43,4 +43,24 @@ definition {
 		RemoteApps.viewTableEntryURL(entryURL = "http://www.liferay.com");
 	}
 
+	@priority = "5"
+	test DeleteRemoteApp {
+		property portal.acceptance = "true";
+
+		ApplicationsMenu.gotoPortlet(
+			category = "Custom Apps",
+			panel = "Applications",
+			portlet = "Remote Apps");
+
+		RemoteApps.addApp(
+			entryName = "Test Remote App",
+			entryURL = "http://www.liferay.com");
+
+		RemoteApps.deleteRemoteApp(tableEntry = "Test Remote App");
+
+		RemoteApps.viewTableEntryNameNotPresent(entryName = "Test Remote App");
+
+		RemoteApps.viewEmptyRemoteTable();
+	}
+
 }


### PR DESCRIPTION
### JIRA Ticket:
https://issues.liferay.com/browse/LPS-122219

### Description:
This adds an automated functional test to validate a Remote App can be delete and not listed in a table on admin page

#### TestCase: Delete a Remote App
1. Navigate to App Menu > Remote App
2. Click plus button
3. Enter text in Name field: Test Remote App
4. Enter text in URL field: http://www.liferay.com
5. Click Save button
6. Click on the ellipsis on 'Test Remote App'
7. Delete 'Test Remote App' 
8. Assert Test Remote App is not present
9. Assert the table is empty
