### PR TITLE
LPS-128835 active filters are now highlighted on dataset display filters dropdown

### DIFF
--- a/modules/apps/commerce/commerce-frontend-js/test/dev/components/DatasetDisplay.js
+++ b/modules/apps/commerce/commerce-frontend-js/test/dev/components/DatasetDisplay.js
@@ -409,10 +409,10 @@ const ordersDataSetDisplayProps = {
 			items: [
 				{
 					label: 'Completed',
-					value: 1,
+					value: 0,
 				},
 				{
-					label: 'Not-completed',
+					label: 'Not completed',
 					value: 999,
 				},
 			],

--- a/modules/apps/commerce/commerce-frontend-js/test/dev/public/dataset-display.html
+++ b/modules/apps/commerce/commerce-frontend-js/test/dev/public/dataset-display.html
@@ -13,7 +13,6 @@
 
 	<title>Dataset Display Component</title>
 
-	<link href="/o/admin-theme/css/clay.css?browserId=other&themeId=admin_WAR_admintheme&languageId=en_US&b=7110&t=1591614610749" rel="stylesheet" />
 	<link href="https://cdn.jsdelivr.net/npm/clay/lib/css/atlas.css" rel="stylesheet" />
 </head>
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -352,7 +352,7 @@ function DataSetDisplay({
 					readOnly
 					value={selectedItemsValue.join(',')}
 				/>
-				{items.length ||
+				{items?.length ||
 				overrideEmptyResultView ||
 				inlineAddingSettings ? (
 					<CurrentViewComponent

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/ManagementBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/ManagementBar.js
@@ -45,19 +45,14 @@ function ManagementBar({
 			updateFilters((filters) => {
 				return filters.map((element) => ({
 					...element,
-					additionalData: null,
-					odataFilterString: null,
-					resumeCustomLabel: null,
-					value: null,
+					additionalData: undefined,
+					odataFilterString: undefined,
+					resumeCustomLabel: undefined,
+					value: undefined,
 				}));
 			});
 		},
-		updateFilterState: (
-			id,
-			value = null,
-			formattedValue = null,
-			odataFilterString = null
-		) => {
+		updateFilterState: (id, value, formattedValue, odataFilterString) => {
 			updateFilters((filters) => {
 				return filters.map((filter) => ({
 					...filter,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/ActiveFiltersBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/ActiveFiltersBar.js
@@ -24,7 +24,9 @@ function ActiveFiltersBar({disabled}) {
 
 	const activeFilters = filtersState.filters.reduce(
 		(acc, filter) =>
-			filter.value && !filter.invisible ? acc.concat(filter.id) : acc,
+			filter.value !== undefined && !filter.invisible
+				? acc.concat(filter.id)
+				: acc,
 		[]
 	);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FiltersDropdown.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FiltersDropdown.js
@@ -25,17 +25,20 @@ function FiltersDropdown() {
 	const [active, setActive] = useState(false);
 	const [query, setQuery] = useState('');
 
-	const [visibleFilters] = useState(
-		filtersState.filters.filter((filter) => !filter.invisible)
+	const visibleFilters = useMemo(
+		() => filtersState.filters.filter((filter) => !filter.invisible),
+		[filtersState]
 	);
 
 	const [activeFilterId, setActiveFilterId] = useState(null);
 
 	const activeFilter = useMemo(() => {
-		return (
-			activeFilterId &&
-			visibleFilters.find((filter) => filter.id === activeFilterId)
-		);
+		return visibleFilters.length && activeFilterId
+			? activeFilterId &&
+					visibleFilters.find(
+						(filter) => filter.id === activeFilterId
+					)
+			: null;
 	}, [visibleFilters, activeFilterId]);
 
 	return filtersState.filters.length ? (
@@ -91,7 +94,9 @@ function FiltersDropdown() {
 										item.value !== null
 									}
 									key={item.id}
-									onClick={() => setActiveFilterId(item.id)}
+									onClick={() => {
+										setActiveFilterId(item.id);
+									}}
 								>
 									{item.label}
 								</ClayDropDown.Item>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FiltersDropdown.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/FiltersDropdown.js
@@ -89,10 +89,7 @@ function FiltersDropdown() {
 						<ClayDropDown.ItemList>
 							{visibleFilters.map((item) => (
 								<ClayDropDown.Item
-									active={
-										item.value !== undefined &&
-										item.value !== null
-									}
+									active={item.value !== undefined}
 									key={item.id}
 									onClick={() => {
 										setActiveFilterId(item.id);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/NumberFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/NumberFilter.js
@@ -48,7 +48,7 @@ function NumberFilter({
 								min={min}
 								onChange={(e) => setValue(e.target.value)}
 								type="number"
-								value={value || ''}
+								value={value !== undefined ? value : ''}
 							/>
 						</div>
 						{inputText && (
@@ -64,7 +64,9 @@ function NumberFilter({
 			<ClayDropDown.Divider />
 			<ClayDropDown.Caption>
 				<ClayButton
-					disabled={Number(value) === valueProp}
+					disabled={
+						value === undefined || Number(value) === valueProp
+					}
 					onClick={() =>
 						updateFilterState(
 							id,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/RadioFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/RadioFilter.js
@@ -41,9 +41,9 @@ function RadioFilter({id, items, updateFilterState, value: valueProp}) {
 	let submitDisabled = true;
 
 	if (
-		(!valueProp && itemValue) ||
+		(!valueProp && itemValue !== undefined) ||
 		(valueProp && valueProp.itemValue !== itemValue) ||
-		(valueProp && itemValue && valueProp.exclude !== exclude)
+		(valueProp && itemValue !== undefined && valueProp.exclude !== exclude)
 	) {
 		submitDisabled = false;
 	}


### PR DESCRIPTION
From https://github.com/liferay-frontend/liferay-portal/pull/872 because for some reason my ssh setup doesn't allow me to push to PRs even if they've allowed edits by maintainers and I've run out of time today to try to figure out why again.

I have:
- Moved the IFI to LPS-128835
- Renamed the commits
- Rebased
- Executed `formatSource` without seeing any changes, so going to take a chance at CI.
---

> Just a trivial fix. Filters didn't update in the dataset display management bar; now they do.
>
> I've also enforced some type checking: radio filters and numbers didn't work well when an item value was === 0.