### PR TITLE
LRQA-65670 | Do not fail test on waitForLiferayEvent function

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/functions/WaitForLiferayEvent.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/WaitForLiferayEvent.function
@@ -94,7 +94,9 @@ definition {
 
 		var message = '''Event "${eventName}" with attribute "${attributeName}" and value "${attributeValue}" not fired.''';
 
-		selenium.waitForJavaScript("${javascript}", "${message}", "");
+		selenium.waitForJavaScriptNoError("${javascript}", "${message}", "");
+
+		selenium.verifyJavaScript("${javascript}", "${message}", "");
 	}
 
 }


### PR DESCRIPTION
**Description**
The aim of the waitForLiferayEvent function is to resolve some timing issues with tests waiting for iframe to load. But if it fails to detect the js event then it should not fail the test and should allow the test to try to continue. This PR hopes to reduce some test flakiness involved with the function by only throwing a warning message and not failing the test.

**Test plan**
- pass ci:test:frontend
- pass ci:test:relevant

**JIRA Ticket**
https://issues.liferay.com/browse/LRQA-65670