### PR TITLE
LPS-128194 Show only views/reads and traffic channels for general Layouts Content Performance Panel

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-api/src/main/java/com/liferay/analytics/reports/info/item/AnalyticsReportsInfoItem.java
+++ b/modules/dxp/apps/analytics/analytics-reports-api/src/main/java/com/liferay/analytics/reports/info/item/AnalyticsReportsInfoItem.java
@@ -17,6 +17,7 @@ package com.liferay.analytics.reports.info.item;
 import com.liferay.info.type.WebImage;
 import com.liferay.portal.kernel.util.LocaleUtil;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -26,6 +27,12 @@ import java.util.Locale;
  * @author David Arques
  */
 public interface AnalyticsReportsInfoItem<T> {
+
+	public default List<Action> getActions() {
+		return Arrays.asList(
+			Action.HISTORICAL_VIEWS, Action.TOTAL_VIEWS,
+			Action.TRAFFIC_CHANNELS);
+	}
 
 	public String getAuthorName(T model);
 
@@ -55,6 +62,13 @@ public interface AnalyticsReportsInfoItem<T> {
 
 	public default boolean isShow(T model) {
 		return false;
+	}
+
+	public enum Action {
+
+		HISTORICAL_READS, HISTORICAL_VIEWS, TOTAL_READS, TOTAL_VIEWS,
+		TRAFFIC_CHANNELS,
+
 	}
 
 }

--- a/modules/dxp/apps/analytics/analytics-reports-journal-impl/src/main/java/com/liferay/analytics/reports/journal/internal/info/item/JournalArticleAnalyticsReportsInfoItem.java
+++ b/modules/dxp/apps/analytics/analytics-reports-journal-impl/src/main/java/com/liferay/analytics/reports/journal/internal/info/item/JournalArticleAnalyticsReportsInfoItem.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -55,6 +56,12 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = AnalyticsReportsInfoItem.class)
 public class JournalArticleAnalyticsReportsInfoItem
 	implements AnalyticsReportsInfoItem<JournalArticle> {
+
+	public List<Action> getActions() {
+		return Arrays.asList(
+			Action.HISTORICAL_READS, Action.HISTORICAL_VIEWS,
+			Action.TOTAL_READS, Action.TOTAL_VIEWS, Action.TRAFFIC_CHANNELS);
+	}
 
 	@Override
 	public String getAuthorName(JournalArticle journalArticle) {

--- a/modules/dxp/apps/analytics/analytics-reports-test/src/testIntegration/java/com/liferay/analytics/reports/web/internal/portlet/action/test/GetDataMVCResourceCommandTest.java
+++ b/modules/dxp/apps/analytics/analytics-reports-test/src/testIntegration/java/com/liferay/analytics/reports/web/internal/portlet/action/test/GetDataMVCResourceCommandTest.java
@@ -333,6 +333,52 @@ public class GetDataMVCResourceCommandTest {
 	}
 
 	@Test
+	public void testGetEndpoints() throws Exception {
+		MockContextUtil.testWithMockContext(
+			MockContextUtil.MockContext.builder(
+			).mockObjectAnalyticsReportsInfoItem(
+				MockObjectAnalyticsReportsInfoItem.builder(
+				).build()
+			).build(),
+			() -> {
+				MockLiferayResourceResponse mockLiferayResourceResponse =
+					new MockLiferayResourceResponse();
+
+				_mvcResourceCommand.serveResource(
+					_getMockLiferayResourceRequest(
+						new InfoItemReference(MockObject.class.getName(), 0L)),
+					mockLiferayResourceResponse);
+
+				ByteArrayOutputStream byteArrayOutputStream =
+					(ByteArrayOutputStream)
+						mockLiferayResourceResponse.getPortletOutputStream();
+
+				JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+					new String(byteArrayOutputStream.toByteArray()));
+
+				JSONObject contextJSONObject = jsonObject.getJSONObject(
+					"context");
+
+				JSONObject endpointsJSONObject =
+					contextJSONObject.getJSONObject("endpoints");
+
+				Assert.assertNull(
+					endpointsJSONObject.get(
+						"analyticsReportsHistoricalReadsURL"));
+				Assert.assertNotNull(
+					endpointsJSONObject.get(
+						"analyticsReportsHistoricalViewsURL"));
+				Assert.assertNull(
+					endpointsJSONObject.get("analyticsReportsTotalReadsURL"));
+				Assert.assertNotNull(
+					endpointsJSONObject.get("analyticsReportsTotalViewsURL"));
+				Assert.assertNotNull(
+					endpointsJSONObject.get(
+						"analyticsReportsTrafficSourcesURL"));
+			});
+	}
+
+	@Test
 	public void testGetViewURLs() throws Exception {
 		MockContextUtil.testWithMockContext(
 			MockContextUtil.MockContext.builder(

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -110,7 +110,7 @@ Author.propTypes = {
 };
 
 BasicInformation.propTypes = {
-	author: PropTypes.object.isRequired,
+	author: PropTypes.object,
 	canonicalURL: PropTypes.string.isRequired,
 	languageTag: PropTypes.string.isRequired,
 	publishDate: PropTypes.string.isRequired,

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -19,7 +19,7 @@ import React from 'react';
 
 function Author({author: {authorId, name, url}}) {
 	return (
-		<div className="text-secondary">
+		<div className="c-mt-3 text-secondary">
 			<ClaySticker
 				className={classnames('c-mr-2 sticker-user-icon', {
 					[`user-icon-color-${parseInt(authorId, 10) % 10}`]: !url,
@@ -85,12 +85,12 @@ function BasicInformation({
 
 			<ClayLayout.ContentRow>
 				<ClayLayout.ContentCol expand>
-					<p className="text-secondary">
+					<span className="text-secondary">
 						{Liferay.Util.sub(
 							Liferay.Language.get('published-on-x'),
 							formattedPublishDate
 						)}
-					</p>
+					</span>
 				</ClayLayout.ContentCol>
 			</ClayLayout.ContentRow>
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -181,10 +181,11 @@ export default function Chart({
 				? HOUR_IN_MILLISECONDS
 				: DAY_IN_MILLISECONDS;
 
-		const keys = [
-			'analyticsReportsHistoricalViews',
-			'analyticsReportsHistoricalReads',
-		];
+		const keys = new Set(['analyticsReportsHistoricalViews']);
+
+		if (dataProviders.length === 2) {
+			keys.add('analyticsReportsHistoricalReads');
+		}
 
 		if (validAnalyticsConnection) {
 			const promises = dataProviders.map((getter) => {

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
@@ -66,15 +66,19 @@ export default function Main({
 				)}
 			/>
 
-			<TotalCount
-				dataProvider={totalReadsDataProvider}
-				label={Liferay.Util.sub(Liferay.Language.get('total-reads'))}
-				languageTag={languageTag}
-				popoverHeader={Liferay.Language.get('total-reads')}
-				popoverMessage={Liferay.Language.get(
-					'this-number-refers-to-the-total-number-of-reads-since-the-content-was-published'
-				)}
-			/>
+			{totalReadsDataProvider && (
+				<TotalCount
+					dataProvider={totalReadsDataProvider}
+					label={Liferay.Util.sub(
+						Liferay.Language.get('total-reads')
+					)}
+					languageTag={languageTag}
+					popoverHeader={Liferay.Language.get('total-reads')}
+					popoverMessage={Liferay.Language.get(
+						'this-number-refers-to-the-total-number-of-reads-since-the-content-was-published'
+					)}
+				/>
+			)}
 
 			<Chart
 				dataProviders={chartDataProviders}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -139,17 +139,21 @@ export default function Navigation({
 					<Main
 						author={author}
 						canonicalURL={canonicalURL}
-						chartDataProviders={[
-							getHistoricalViews,
-							getHistoricalReads,
-						]}
+						chartDataProviders={
+							endpoints.analyticsReportsHistoricalReadsURL
+								? [getHistoricalViews, getHistoricalReads]
+								: [getHistoricalViews]
+						}
 						languageTag={languageTag}
 						onSelectedLanguageClick={onSelectedLanguageClick}
 						onTrafficSourceClick={handleTrafficSourceClick}
 						pagePublishDate={pagePublishDate}
 						pageTitle={pageTitle}
 						timeSpanOptions={timeSpanOptions}
-						totalReadsDataProvider={handleTotalReads}
+						totalReadsDataProvider={
+							endpoints.analyticsReportsTotalReadsURL &&
+							handleTotalReads
+						}
 						totalViewsDataProvider={handleTotalViews}
 						trafficSourcesDataProvider={getTrafficSources}
 						viewURLs={viewURLs}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
@@ -169,7 +169,7 @@ function reducer(state, action) {
 
 	switch (action.type) {
 		case ADD_DATA_SET_ITEMS:
-			nextState = action.payload.keys.reduce((state, key) => {
+			nextState = [...action.payload.keys].reduce((state, key) => {
 				const dataSetItem =
 					action.payload.dataSetItems?.[key] ??
 					FALLBACK_DATA_SET_ITEM;


### PR DESCRIPTION
**Motivation**

The Content Performance panel for widget and content pages will be the same that the web content's DPT, except for the reads (total and historical), that will be removed.

**Proposed solution**

1. Add a small API to AnalyticsReportsInfoAPI that returns the available metrics of a given AnalyticsReportsInfoItem
2. Change JS, so the endpoint is not injected to frontend

<img width="551" alt="Screenshot 2021-03-09 at 23 48 53" src="https://user-images.githubusercontent.com/15845466/110549215-065c6b00-8132-11eb-8f39-63309072c717.png">

**Notes**

* Backend reviewed here: https://github.com/liferay-tango/liferay-portal/pull/971
* The idea for the future is to refactor JS to be more dynamic and wait until are endpoints are settled to load the Content Performance panel content. This is a huge change and I'm currently working on it but it's taking time (refactor + fix test). The idea is to improve the `APIService` and the `StoreContext` and every component that has a `dataProvider` will read from the store instead of calling the data provider to retrieve the data. Also, I will move some props to the store to reduce the prop-drilling

Thanks!