### PR TITLE
LRQA-62049 part 3 | Remove the hard pause in add portlet macro and instead waits for portletReady event

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/LiferayEvent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LiferayEvent.macro
@@ -1,0 +1,10 @@
+definition {
+
+	macro waitForPortletReady {
+		WaitForLiferayEvent(
+			attributeName = "type",
+			attributeValue = "portletReady",
+			eventName = "portletReady");
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
@@ -49,8 +49,6 @@ definition {
 		while (!((IsElementPresent(locator1 = "Home#PORTLET")) || ("${i}" == "3"))) {
 			var i = ${i} + 1;
 
-			Pause(locator1 = "30000");
-
 			echo("The PORTLET could not be found. Refreshing the page. Attempt number ${i}...");
 
 			Refresh();
@@ -83,7 +81,7 @@ definition {
 
 		Navigator.gotoNavTab(navTab = "Widgets");
 
-		Pause(locator1 = "5000");
+		Pause(locator1 = "3000");
 
 		Type(
 			locator1 = "NavBar#APPLICATION_SEARCH_FIELD",
@@ -92,6 +90,8 @@ definition {
 		Portlet._clickAddPortlet(portletName = "${portletName}");
 
 		var key_portletName = "${portletName}";
+
+		LiferayEvent.waitForPortletReady();
 
 		AssertElementPresent(locator1 = "Portlet#LOADED");
 	}


### PR DESCRIPTION
Remove the hard pause in add portlet macro and instead waits for portletReady event. This depends on commit from LRQA-65670 from https://github.com/liferay-frontend/liferay-portal/pull/884

**Test Plan**
- pass ci:test:acceptance
- pass ci:test:frontend

**JIRA Ticket**
https://issues.liferay.com/browse/LRQA-62049