### PR TITLE
LPS-128891 [Bug - Content Performance] Traffic sources with link and full pie chart when the content was published today and there is some data for that content in AC side

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -72,8 +72,11 @@ export default function TrafficSources({
 	}, [addWarning, dataProvider, setTrafficSources, validAnalyticsConnection]);
 
 	const fullPieChart = useMemo(
-		() => trafficSources.some(({value}) => value),
-		[trafficSources]
+		() =>
+			validAnalyticsConnection &&
+			!publishedToday &&
+			trafficSources.some(({value}) => value),
+		[publishedToday, trafficSources, validAnalyticsConnection]
 	);
 
 	const missingTrafficSourceValue = useMemo(
@@ -153,7 +156,10 @@ export default function TrafficSources({
 												)
 											}
 										>
-											{entry.value > 0 && hasDetails ? (
+											{validAnalyticsConnection &&
+											!publishedToday &&
+											entry.value > 0 &&
+											hasDetails ? (
 												<ClayButton
 													className="px-0 py-1 text-primary"
 													displayType="link"


### PR DESCRIPTION
**Description**

In the Content Performance panel, when the content was published today, we don't have data from Analytics Cloud yet to display in the panel. We should wait ~24h to show proper data in the panel. When the content and/or the page was published today, the traffic sources should not have a link to navigate to the detail view and the pie chart should be empty (default one, grey one). In this case, AC side has some data for that content and it's displaying the link and the full pie chart (the one with colors) even though the content was published today.

**Steps to reproduce**

- Connect Liferay DXP with Analytics Cloud (UAT)
- Create a DPT
- Create a Web Content (Web Content 2)
- Create a Content Page and add an Asset Publisher widget
- Navigate to Web Content 2 through the Asset Publisher

**Actual behavior**

Some traffic sources appear with link and full pie chart when the content was published today and there is some data for that content in AC side

**Expected behavior**

When the content was published today, the traffic sources don't have link to navigate to the detail view and the pie chart is empty (default one, grey)

**Screenshots**

1. Bug
2. Fixed

<img width="330" alt="LPS-128891 bug" src="https://user-images.githubusercontent.com/15845466/110609158-3ab14500-818d-11eb-955c-846458dd63e3.png"> <img width="327" alt="LPS-128891 fixed" src="https://user-images.githubusercontent.com/15845466/110609165-3c7b0880-818d-11eb-87a5-c593aa6dcd61.png">
