### PR TITLE
LPS-128890 Update Clay dependencies

### DIFF
--- a/modules/apps/document-library/document-library-web/package.json
+++ b/modules/apps/document-library/document-library-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"@clayui/alert": "3.5.1",
 		"@clayui/button": "3.6.0",
-		"@clayui/css": "3.25.1",
+		"@clayui/css": "3.25.2",
 		"@clayui/form": "3.14.4",
 		"@clayui/icon": "3.1.0",
 		"@clayui/loading-indicator": "3.2.0",

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -8,7 +8,7 @@
 		"@clayui/card": "3.25.1",
 		"@clayui/charts": "3.25.1",
 		"@clayui/color-picker": "3.25.1",
-		"@clayui/css": "3.25.1",
+		"@clayui/css": "3.25.2",
 		"@clayui/data-provider": "3.3.10",
 		"@clayui/date-picker": "3.25.1",
 		"@clayui/drop-down": "3.25.1",

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/package.json
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/css": "3.25.1"
+		"@clayui/css": "3.25.2"
 	},
 	"name": "liferay-frontend-theme-unstyled",
 	"scripts": {

--- a/modules/dxp/apps/commerce/commerce-dashboard-web/package.json
+++ b/modules/dxp/apps/commerce/commerce-dashboard-web/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/charts": "3.25.1",
-		"@clayui/css": "3.25.1",
+		"@clayui/css": "3.25.2",
 		"@liferay/frontend-js-react-web": "*",
 		"frontend-js-web": "*",
 		"react": "16.12.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -966,10 +966,10 @@
     classnames "^2.2.6"
     tinycolor2 "^1.4.1"
 
-"@clayui/css@3.25.1":
-  version "3.25.1"
-  resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.25.1.tgz#6c66e2a3043e36079f7035a4750c25dbbe328c96"
-  integrity sha512-SAXzqQpKzzTv4jYloaHvel43AFxp2XWhzB2NS6D14+4pJZ0/m4sDikXUYsEixQZKE90chw9qgiBv7vHQZlFRmA==
+"@clayui/css@3.25.2":
+  version "3.25.2"
+  resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.25.2.tgz#2a27a218b2f888d07cbfbafb7a77cb17170c994a"
+  integrity sha512-ZGQUDM1FrqDs6ityBXcqKIdSSh9dtKZ02trxOnTHLkKSQOKXgD9Ru6nNeqDIoK9Hw17ZDY9zrWOrgdEd5IQUrw==
 
 "@clayui/data-provider@3.3.10":
   version "3.3.10"


### PR DESCRIPTION
## [3.25.2](https://github.com/liferay/clay/compare/v3.25.1...v3.25.2) (2021-03-10)
### Bug Fixes

-   **@clayui/css:** Dual List Box `form-control-inset` is too narrow caused by [#3972](https://github.com/liferay/clay/issues/3972) ([637e65b](https://github.com/liferay/clay/commit/637e65b)), closes [#3976](https://github.com/liferay/clay/issues/3976)
-   **@clayui/css:** Forms `.col-form-label-*` should use `$input-border-bottom-width` or `$input-border-top-width` to avoid invalid property value ([ade3649](https://github.com/liferay/clay/commit/ade3649)), closes [#3946](https://github.com/liferay/clay/issues/3946)