### PR TITLE
LPS-128908 Deprecates CSSRTLConverter utility

### DIFF
--- a/modules/apps/frontend-css/frontend-css-rtl-servlet/src/main/java/com/liferay/frontend/css/rtl/servlet/internal/converter/CSSRTLConverter.java
+++ b/modules/apps/frontend-css/frontend-css-rtl-servlet/src/main/java/com/liferay/frontend/css/rtl/servlet/internal/converter/CSSRTLConverter.java
@@ -42,7 +42,9 @@ import java.util.regex.Pattern;
 
 /**
  * @author David Truong
+ * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
+@Deprecated
 public class CSSRTLConverter {
 
 	public CSSRTLConverter() {


### PR DESCRIPTION
What it says... deprecates `CSSRTLConverter` utility even though the utility is internal. The main reason to flag it as deprecated to prevent future usage or attempts at generalizing it.

This is part of our [Consolidate and improve SCSS compilation process](https://issues.liferay.com/browse/LPS-122900)

- Note 1:  We don't fully own [CSSBuilder](https://github.com/liferay-frontend/liferay-portal/tree/master/modules/util/css-builder) so I decided not to deprecate it and leave it for @david-truong and @dsanz consideration.
- Note 2: `CSSBuilder` [uses some version](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/util/css-builder/build.gradle#L44) `CSSRTLConverter` which I'm not sure where it's coming from