### PR TITLE
LPS-128998 [Content Performance] Refactor APIService to be called in any component

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -189,10 +189,7 @@ export default function Chart({
 
 		if (validAnalyticsConnection) {
 			const promises = dataProviders.map((getter) => {
-				return getter({
-					timeSpanKey: chartState.timeSpanKey,
-					timeSpanOffset: chartState.timeSpanOffset,
-				});
+				return getter();
 			});
 
 			allSettled(promises).then((data) => {

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -63,7 +63,7 @@ export default function TrafficSources({
 	useEffect(() => {
 		if (validAnalyticsConnection) {
 			dataProvider()
-				.then((response) => setTrafficSources(response.trafficSources))
+				.then((trafficSources) => setTrafficSources(trafficSources))
 				.catch(() => {
 					setTrafficSources([]);
 					addWarning();

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/APIService.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/APIService.js
@@ -11,72 +11,58 @@
 
 import {fetch} from 'frontend-js-web';
 
-function APIService({
-	endpoints: {
+export default {
+	getHistoricalReads(
 		analyticsReportsHistoricalReadsURL,
-		analyticsReportsHistoricalViewsURL,
-		analyticsReportsTotalReadsURL,
-		analyticsReportsTotalViewsURL,
-		analyticsReportsTrafficSourcesURL,
-	},
-	namespace,
-	page: {plid},
-}) {
-	function getHistoricalReads({timeSpanKey, timeSpanOffset}) {
+		{namespace, plid, timeSpanKey, timeSpanOffset}
+	) {
 		const body = {plid, timeSpanKey, timeSpanOffset};
 
 		return _fetchWithError(analyticsReportsHistoricalReadsURL, {
 			body: _getFormDataRequest(body, namespace),
 			method: 'POST',
 		});
-	}
+	},
 
-	function getHistoricalViews({timeSpanKey, timeSpanOffset}) {
+	getHistoricalViews(
+		analyticsReportsHistoricalViewsURL,
+		{namespace, plid, timeSpanKey, timeSpanOffset}
+	) {
 		const body = {plid, timeSpanKey, timeSpanOffset};
 
 		return _fetchWithError(analyticsReportsHistoricalViewsURL, {
 			body: _getFormDataRequest(body, namespace),
 			method: 'POST',
 		});
-	}
+	},
 
-	function getTotalReads() {
+	getTotalReads(analyticsReportsTotalReadsURL, {namespace, plid}) {
 		const body = {plid};
 
 		return _fetchWithError(analyticsReportsTotalReadsURL, {
 			body: _getFormDataRequest(body, namespace),
 			method: 'POST',
 		});
-	}
+	},
 
-	function getTotalViews() {
+	getTotalViews(analyticsReportsTotalViewsURL, {namespace, plid}) {
 		const body = {plid};
 
 		return _fetchWithError(analyticsReportsTotalViewsURL, {
 			body: _getFormDataRequest(body, namespace),
 			method: 'POST',
 		});
-	}
+	},
 
-	function getTrafficSources() {
+	getTrafficSources(analyticsReportsTrafficSourcesURL, {namespace, plid}) {
 		const body = {plid};
 
 		return _fetchWithError(analyticsReportsTrafficSourcesURL, {
 			body: _getFormDataRequest(body, namespace),
 			method: 'POST',
 		});
-	}
-
-	return {
-		getHistoricalReads,
-		getHistoricalViews,
-		getTotalReads,
-		getTotalViews,
-		getTrafficSources,
-	};
-}
-
-export default APIService;
+	},
+};
 
 /**
  *

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Chart.js
@@ -171,11 +171,6 @@ describe('Chart', () => {
 			expect(mockViewsDataProvider).toHaveBeenCalledTimes(1)
 		);
 
-		expect(mockViewsDataProvider).toHaveBeenCalledWith({
-			timeSpanKey: 'last-7-days',
-			timeSpanOffset: 0,
-		});
-
 		expect(getByText('225')).toBeInTheDocument();
 
 		expect(getByText('Jan 27 - Feb 2, 2020')).toBeInTheDocument();
@@ -206,21 +201,9 @@ describe('Chart', () => {
 			</ChartStateContextProvider>
 		);
 
-		await wait(() =>
-			expect(mockViewsDataProvider).toHaveBeenCalledTimes(1)
-		);
-		await wait(() =>
-			expect(mockReadsDataProvider).toHaveBeenCalledTimes(1)
-		);
-
-		expect(mockViewsDataProvider).toHaveBeenCalledWith({
-			timeSpanKey: 'last-7-days',
-			timeSpanOffset: 0,
-		});
-
-		expect(mockReadsDataProvider).toHaveBeenCalledWith({
-			timeSpanKey: 'last-7-days',
-			timeSpanOffset: 0,
+		await wait(() => {
+			expect(mockViewsDataProvider).toHaveBeenCalledTimes(1);
+			expect(mockReadsDataProvider).toHaveBeenCalledTimes(1);
 		});
 
 		expect(getByText('225')).toBeInTheDocument();

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
@@ -22,48 +22,46 @@ describe('TrafficSources', () => {
 
 	it('displays the traffic sources with buttons to view keywords', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve({
-				trafficSources: [
-					{
-						countryKeywords: [
-							{
-								countryCode: 'us',
-								countryName: 'United States',
-								keywords: [],
-							},
-							{
-								countryCode: 'es',
-								countryName: 'Spain',
-								keywords: [],
-							},
-						],
-						helpMessage: 'Testing Help Message',
-						name: 'testing',
-						share: 30.0,
-						title: 'Testing',
-						value: 32178,
-					},
-					{
-						countryKeywords: [
-							{
-								countryCode: 'us',
-								countryName: 'United States',
-								keywords: [],
-							},
-							{
-								countryCode: 'es',
-								countryName: 'Spain',
-								keywords: [],
-							},
-						],
-						helpMessage: 'Second Testing Help Message',
-						name: 'second-testing',
-						share: 70.0,
-						title: 'Second Testing',
-						value: 278256,
-					},
-				],
-			})
+			Promise.resolve([
+				{
+					countryKeywords: [
+						{
+							countryCode: 'us',
+							countryName: 'United States',
+							keywords: [],
+						},
+						{
+							countryCode: 'es',
+							countryName: 'Spain',
+							keywords: [],
+						},
+					],
+					helpMessage: 'Testing Help Message',
+					name: 'testing',
+					share: 30.0,
+					title: 'Testing',
+					value: 32178,
+				},
+				{
+					countryKeywords: [
+						{
+							countryCode: 'us',
+							countryName: 'United States',
+							keywords: [],
+						},
+						{
+							countryCode: 'es',
+							countryName: 'Spain',
+							keywords: [],
+						},
+					],
+					helpMessage: 'Second Testing Help Message',
+					name: 'second-testing',
+					share: 70.0,
+					title: 'Second Testing',
+					value: 278256,
+				},
+			])
 		);
 
 		const {getByText} = render(
@@ -74,13 +72,9 @@ describe('TrafficSources', () => {
 			/>
 		);
 
-		await wait(() =>
-			expect(mockTrafficSourcesDataProvider).toHaveBeenCalled()
-		);
-
-		await wait(() =>
-			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1)
-		);
+		await wait(() => {
+			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1);
+		});
 
 		const button1 = getByText('Testing');
 
@@ -99,48 +93,46 @@ describe('TrafficSources', () => {
 
 	it('displays the traffic sources without buttons to view keywords when the value is 0', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve({
-				trafficSources: [
-					{
-						countryKeywords: [
-							{
-								countryCode: 'us',
-								countryName: 'United States',
-								keywords: [],
-							},
-							{
-								countryCode: 'es',
-								countryName: 'Spain',
-								keywords: [],
-							},
-						],
-						helpMessage: 'Testing Help Message',
-						name: 'testing',
-						share: 0.0,
-						title: 'Testing',
-						value: 0,
-					},
-					{
-						countryKeywords: [
-							{
-								countryCode: 'us',
-								countryName: 'United States',
-								keywords: [],
-							},
-							{
-								countryCode: 'es',
-								countryName: 'Spain',
-								keywords: [],
-							},
-						],
-						helpMessage: 'Second Testing Help Message',
-						name: 'second-testing',
-						share: 0.0,
-						title: 'Second Testing',
-						value: 0,
-					},
-				],
-			})
+			Promise.resolve([
+				{
+					countryKeywords: [
+						{
+							countryCode: 'us',
+							countryName: 'United States',
+							keywords: [],
+						},
+						{
+							countryCode: 'es',
+							countryName: 'Spain',
+							keywords: [],
+						},
+					],
+					helpMessage: 'Testing Help Message',
+					name: 'testing',
+					share: 0.0,
+					title: 'Testing',
+					value: 0,
+				},
+				{
+					countryKeywords: [
+						{
+							countryCode: 'us',
+							countryName: 'United States',
+							keywords: [],
+						},
+						{
+							countryCode: 'es',
+							countryName: 'Spain',
+							keywords: [],
+						},
+					],
+					helpMessage: 'Second Testing Help Message',
+					name: 'second-testing',
+					share: 0.0,
+					title: 'Second Testing',
+					value: 0,
+				},
+			])
 		);
 
 		const {getAllByText, getByText} = render(
@@ -149,10 +141,6 @@ describe('TrafficSources', () => {
 				languageTag="en-US"
 				onTrafficSourceClick={noop}
 			/>
-		);
-
-		await wait(() =>
-			expect(mockTrafficSourcesDataProvider).toHaveBeenCalled()
 		);
 
 		await wait(() =>
@@ -176,43 +164,41 @@ describe('TrafficSources', () => {
 
 	it('displays the traffic sources without buttons to view keywords when the value is 0 and there are country keywords', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve({
-				trafficSources: [
-					{
-						countryKeywords: [
-							{
-								countryCode: 'us',
-								countryName: 'United States',
-								keywords: [],
-							},
-							{
-								countryCode: 'es',
-								countryName: 'Spain',
-								keywords: [],
-							},
-						],
-						helpMessage: 'Testing Help Message',
-						name: 'testing',
-						share: 80.0,
-						title: 'Testing',
-						value: 345,
-					},
-					{
-						helpMessage: 'Second Testing Help Message',
-						name: 'second-testing',
-						share: 0.0,
-						title: 'Second Testing',
-						value: 0,
-					},
-					{
-						helpMessage: 'Third Testing Help Message',
-						name: 'third-testing',
-						share: 20.0,
-						title: 'Third Testing',
-						value: 77,
-					},
-				],
-			})
+			Promise.resolve([
+				{
+					countryKeywords: [
+						{
+							countryCode: 'us',
+							countryName: 'United States',
+							keywords: [],
+						},
+						{
+							countryCode: 'es',
+							countryName: 'Spain',
+							keywords: [],
+						},
+					],
+					helpMessage: 'Testing Help Message',
+					name: 'testing',
+					share: 80.0,
+					title: 'Testing',
+					value: 345,
+				},
+				{
+					helpMessage: 'Second Testing Help Message',
+					name: 'second-testing',
+					share: 0.0,
+					title: 'Second Testing',
+					value: 0,
+				},
+				{
+					helpMessage: 'Third Testing Help Message',
+					name: 'third-testing',
+					share: 20.0,
+					title: 'Third Testing',
+					value: 77,
+				},
+			])
 		);
 
 		const {getAllByText, getByText} = render(
@@ -221,10 +207,6 @@ describe('TrafficSources', () => {
 				languageTag="en-US"
 				onTrafficSourceClick={noop}
 			/>
-		);
-
-		await wait(() =>
-			expect(mockTrafficSourcesDataProvider).toHaveBeenCalled()
 		);
 
 		await wait(() =>
@@ -252,20 +234,18 @@ describe('TrafficSources', () => {
 
 	it('displays a dash instead of value when there is an endpoint error', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve({
-				trafficSources: [
-					{
-						helpMessage: 'Testing Help Message',
-						name: 'testing',
-						title: 'Testing',
-					},
-					{
-						helpMessage: 'Second Testing Help Message',
-						name: 'second-testing',
-						title: 'Second Testing',
-					},
-				],
-			})
+			Promise.resolve([
+				{
+					helpMessage: 'Testing Help Message',
+					name: 'testing',
+					title: 'Testing',
+				},
+				{
+					helpMessage: 'Second Testing Help Message',
+					name: 'second-testing',
+					title: 'Second Testing',
+				},
+			])
 		);
 
 		const {getAllByText, getByText} = render(
@@ -274,10 +254,6 @@ describe('TrafficSources', () => {
 				languageTag="en-US"
 				onTrafficSourceClick={noop}
 			/>
-		);
-
-		await wait(() =>
-			expect(mockTrafficSourcesDataProvider).toHaveBeenCalled()
 		);
 
 		await wait(() =>
@@ -296,26 +272,24 @@ describe('TrafficSources', () => {
 
 	it('displays a message informing the user that there is no incoming traffic from search engines yet', async () => {
 		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve({
-				trafficSources: [
-					{
-						countryKeywords: [],
-						helpMessage: 'Testing Help Message',
-						name: 'testing',
-						share: 0.0,
-						title: 'Testing',
-						value: 0,
-					},
-					{
-						countryKeywords: [],
-						helpMessage: 'Second Testing Help Message',
-						name: 'second-testing',
-						share: 0.0,
-						title: 'Second Testing',
-						value: 0,
-					},
-				],
-			})
+			Promise.resolve([
+				{
+					countryKeywords: [],
+					helpMessage: 'Testing Help Message',
+					name: 'testing',
+					share: 0.0,
+					title: 'Testing',
+					value: 0,
+				},
+				{
+					countryKeywords: [],
+					helpMessage: 'Second Testing Help Message',
+					name: 'second-testing',
+					share: 0.0,
+					title: 'Second Testing',
+					value: 0,
+				},
+			])
 		);
 
 		const {getAllByText, getByText} = render(
@@ -324,10 +298,6 @@ describe('TrafficSources', () => {
 				languageTag="en-US"
 				onTrafficSourceClick={noop}
 			/>
-		);
-
-		await wait(() =>
-			expect(mockTrafficSourcesDataProvider).toHaveBeenCalled()
 		);
 
 		await wait(() =>


### PR DESCRIPTION
**Description**

This is the first pull request to fix [LPS-128998 Content Performance available endpoints should load at the same time](https://issues.liferay.com/browse/LPS-128998) as I said in a previous PR (see `Notes` from description, but in summary, the idea is that every component reads data from the store instead of calling its `dataProvider` and wait until all endpoints are resolved to display the data in the UI): https://github.com/liferay-frontend/liferay-portal/pull/885#issue-588734880.

As the pull can be huge, I'm going to create sub-tasks for the issue and send the code for each of them separately.

**How to test it**

- Connect Liferay DXP with Analytics Cloud
- Create a Content Page
- Wait 24 hours to let Analytics Cloud process the data (if you don't want to wait for it, change the date of your computer and create the page in the past 😉  )
- Open the Content Performance panel

**Within this pull request**

Everything should work as before. No UI changes.
- Refactor APIService
- Create a handler for every data provider
- Fix dataProvider calls inside TrafficSources and Chart
- Fix frontend tests

**Final solution for the issue**

In the future those handlers will be converted into actions and dispatch it when necessary. Also, some information will be removed from the prop-drilling and save it in the store as-well. Components will read from the store to display the data.