### PR TITLE
LPS-128998 [Content Performace] Save attributes in store instead of prop-drilling them

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/AnalyticsReportsApp.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/AnalyticsReportsApp.js
@@ -130,6 +130,10 @@ export default function ({context}) {
 			>
 				<StoreContextProvider
 					value={{
+						endpoints: {...state.data.endpoints},
+						languageTag: state.data.languageTag,
+						namespace: state.data.namespace,
+						page: state.data.page,
 						publishedToday: state.data.publishedToday,
 					}}
 				>
@@ -142,13 +146,9 @@ export default function ({context}) {
 							<Navigation
 								author={state.data.author}
 								canonicalURL={state.data.canonicalURL}
-								endpoints={state.data.endpoints}
-								languageTag={state.data.languageTag}
-								namespace={state.data.namespace}
 								onSelectedLanguageClick={
 									handleSelectedLanguageClick
 								}
-								page={state.data.page}
 								pagePublishDate={state.data.publishDate}
 								pageTitle={state.data.title}
 								timeSpanOptions={state.data.timeSpans}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -15,7 +15,9 @@ import ClaySticker from '@clayui/sticker';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useContext} from 'react';
+
+import {StoreContext} from '../context/StoreContext';
 
 function Author({author: {authorId, name, url}}) {
 	return (
@@ -38,13 +40,9 @@ function Author({author: {authorId, name, url}}) {
 	);
 }
 
-function BasicInformation({
-	author,
-	canonicalURL,
-	languageTag,
-	publishDate,
-	title,
-}) {
+function BasicInformation({author, canonicalURL, publishDate, title}) {
+	const [{languageTag}] = useContext(StoreContext);
+
 	const formattedPublishDate = Intl.DateTimeFormat(languageTag, {
 		day: 'numeric',
 		month: 'long',
@@ -112,7 +110,6 @@ Author.propTypes = {
 BasicInformation.propTypes = {
 	author: PropTypes.object,
 	canonicalURL: PropTypes.string.isRequired,
-	languageTag: PropTypes.string.isRequired,
 	publishDate: PropTypes.string.isRequired,
 	title: PropTypes.string.isRequired,
 };

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -137,13 +137,12 @@ function legendFormatterGenerator(
 
 export default function Chart({
 	dataProviders = [],
-	languageTag,
 	publishDate,
 	timeSpanOptions,
 }) {
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
-	const [{publishedToday}] = useContext(StoreContext);
+	const [{languageTag, publishedToday}] = useContext(StoreContext);
 
 	const chartState = useChartState();
 
@@ -467,7 +466,6 @@ function allSettled(promises) {
 
 Chart.propTypes = {
 	dataProviders: PropTypes.arrayOf(PropTypes.func).isRequired,
-	languageTag: PropTypes.string.isRequired,
 	publishDate: PropTypes.string.isRequired,
 	timeSpanOptions: PropTypes.arrayOf(
 		PropTypes.shape({

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
@@ -28,7 +28,6 @@ const TRAFFIC_CHANNELS = {
 
 export default function Detail({
 	currentPage,
-	languageTag,
 	onCurrentPageChange,
 	onTrafficSourceNameChange,
 	timeSpanOptions,
@@ -59,7 +58,6 @@ export default function Detail({
 				currentPage.data.countryKeywords.length > 0 && (
 					<KeywordsDetail
 						currentPage={currentPage}
-						languageTag={languageTag}
 						trafficShareDataProvider={trafficShareDataProvider}
 						trafficVolumeDataProvider={trafficVolumeDataProvider}
 					/>
@@ -68,7 +66,6 @@ export default function Detail({
 			{currentPage.view === TRAFFIC_CHANNELS.REFERRAL && (
 				<ReferralDetail
 					currentPage={currentPage}
-					languageTag={languageTag}
 					timeSpanOptions={timeSpanOptions}
 					trafficShareDataProvider={trafficShareDataProvider}
 					trafficVolumeDataProvider={trafficVolumeDataProvider}
@@ -78,7 +75,6 @@ export default function Detail({
 			{currentPage.view === TRAFFIC_CHANNELS.SOCIAL && (
 				<SocialDetail
 					currentPage={currentPage}
-					languageTag={languageTag}
 					timeSpanOptions={timeSpanOptions}
 					trafficShareDataProvider={trafficShareDataProvider}
 					trafficVolumeDataProvider={trafficVolumeDataProvider}
@@ -90,7 +86,6 @@ export default function Detail({
 
 Detail.proptypes = {
 	currentPage: PropTypes.object.isRequired,
-	languageTag: PropTypes.string.isRequired,
 	onCurrentPageChange: PropTypes.func.isRequired,
 	onTrafficSourceNameChange: PropTypes.func.isRequired,
 	timeSpanOptions: PropTypes.arrayOf(

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Keywords.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Keywords.js
@@ -28,14 +28,14 @@ const KEYWORD_VALUE_TYPE = [
 	{label: Liferay.Language.get('position'), name: 'position'},
 ];
 
-export default function Keywords({currentPage, languageTag}) {
+export default function Keywords({currentPage}) {
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
 	const [keywordValueType, setKeywordValueType] = useState(
 		KEYWORD_VALUE_TYPE[0]
 	);
 
-	const [{publishedToday}] = useContext(StoreContext);
+	const [{languageTag, publishedToday}] = useContext(StoreContext);
 
 	const countries = useMemo(() => {
 		const dataKeys = new Set();
@@ -231,5 +231,4 @@ export default function Keywords({currentPage, languageTag}) {
 
 Keywords.proptypes = {
 	currentPage: PropTypes.object.isRequired,
-	languageTag: PropTypes.string.isRequired,
 };

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
@@ -22,7 +22,6 @@ export default function Main({
 	author,
 	canonicalURL,
 	chartDataProviders,
-	languageTag,
 	onSelectedLanguageClick,
 	onTrafficSourceClick,
 	pagePublishDate,
@@ -38,14 +37,12 @@ export default function Main({
 			<BasicInformation
 				author={author}
 				canonicalURL={canonicalURL}
-				languageTag={languageTag}
 				publishDate={pagePublishDate}
 				title={pageTitle}
 			/>
 
 			<div className="mt-4">
 				<Translation
-					defaultLanguage={languageTag}
 					onSelectedLanguageClick={onSelectedLanguageClick}
 					viewURLs={viewURLs}
 				/>
@@ -59,7 +56,6 @@ export default function Main({
 				className="mb-2"
 				dataProvider={totalViewsDataProvider}
 				label={Liferay.Util.sub(Liferay.Language.get('total-views'))}
-				languageTag={languageTag}
 				popoverHeader={Liferay.Language.get('total-views')}
 				popoverMessage={Liferay.Language.get(
 					'this-number-refers-to-the-total-number-of-views-since-the-content-was-published'
@@ -72,7 +68,6 @@ export default function Main({
 					label={Liferay.Util.sub(
 						Liferay.Language.get('total-reads')
 					)}
-					languageTag={languageTag}
 					popoverHeader={Liferay.Language.get('total-reads')}
 					popoverMessage={Liferay.Language.get(
 						'this-number-refers-to-the-total-number-of-reads-since-the-content-was-published'
@@ -82,14 +77,12 @@ export default function Main({
 
 			<Chart
 				dataProviders={chartDataProviders}
-				languageTag={languageTag}
 				publishDate={pagePublishDate}
 				timeSpanOptions={timeSpanOptions}
 			/>
 
 			<TrafficSources
 				dataProvider={trafficSourcesDataProvider}
-				languageTag={languageTag}
 				onTrafficSourceClick={onTrafficSourceClick}
 			/>
 		</div>
@@ -100,7 +93,6 @@ Main.proptypes = {
 	author: PropTypes.object.isRequired,
 	canonicalURL: PropTypes.string.isRequired,
 	chartDataProviders: PropTypes.arrayOf(PropTypes.func.isRequired).isRequired,
-	languageTag: PropTypes.string.isRequired,
 	onSelectedLanguageClick: PropTypes.func.isRequired,
 	onTrafficSourceClick: PropTypes.func.isRequired,
 	pagePublishDate: PropTypes.string.isRequired,

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -25,19 +25,22 @@ const noop = () => {};
 export default function Navigation({
 	author,
 	canonicalURL,
-	endpoints,
-	languageTag,
-	namespace,
 	onSelectedLanguageClick = noop,
-	page,
 	pagePublishDate,
 	pageTitle,
 	timeSpanOptions,
 	viewURLs,
 }) {
-	const [{historicalWarning, publishedToday, warning}] = useContext(
-		StoreContext
-	);
+	const [
+		{
+			endpoints,
+			historicalWarning,
+			namespace,
+			page,
+			publishedToday,
+			warning,
+		},
+	] = useContext(StoreContext);
 
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
@@ -176,7 +179,6 @@ export default function Navigation({
 								? [handleHistoricalViews, handleHistoricalReads]
 								: [handleHistoricalViews]
 						}
-						languageTag={languageTag}
 						onSelectedLanguageClick={onSelectedLanguageClick}
 						onTrafficSourceClick={handleTrafficSourceClick}
 						pagePublishDate={pagePublishDate}
@@ -196,7 +198,6 @@ export default function Navigation({
 			{currentPage.view !== 'main' && (
 				<Detail
 					currentPage={currentPage}
-					languageTag={languageTag}
 					onCurrentPageChange={handleCurrentPage}
 					onTrafficSourceNameChange={handleTrafficSourceName}
 					timeSpanOptions={timeSpanOptions}
@@ -211,15 +212,7 @@ export default function Navigation({
 Navigation.proptypes = {
 	author: PropTypes.object.isRequired,
 	canonicalURL: PropTypes.string.isRequired,
-	endpoints: PropTypes.object.isRequired,
-	languageTag: PropTypes.string.isRequired,
-	namespace: PropTypes.string.isRequired,
 	onSelectedLanguageClick: PropTypes.func.isRequired,
-	page: PropTypes.objectOf(
-		PropTypes.shape({
-			plid: PropTypes.number.isRequired,
-		})
-	).isRequired,
 	pagePublishDate: PropTypes.string.isRequired,
 	pageTitle: PropTypes.string.isRequired,
 	timeSpanOptions: PropTypes.arrayOf(

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
@@ -22,7 +22,6 @@ function TotalCount({
 	className,
 	dataProvider,
 	label,
-	languageTag,
 	percentage = false,
 	popoverAlign,
 	popoverHeader,
@@ -35,7 +34,7 @@ function TotalCount({
 
 	const [, addWarning] = useWarning();
 
-	const [{publishedToday}] = useContext(StoreContext);
+	const [{languageTag, publishedToday}] = useContext(StoreContext);
 
 	useEffect(() => {
 		if (validAnalyticsConnection) {
@@ -82,7 +81,6 @@ function TotalCount({
 TotalCount.propTypes = {
 	dataProvider: PropTypes.func.isRequired,
 	label: PropTypes.string.isRequired,
-	languageTag: PropTypes.string,
 	percentage: PropTypes.bool,
 	popoverHeader: PropTypes.string.isRequired,
 	popoverMessage: PropTypes.string.isRequired,

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -45,18 +45,14 @@ const FALLBACK_COLOR = '#e92563';
 
 const getColorByName = (name) => COLORS_MAP[name] || FALLBACK_COLOR;
 
-export default function TrafficSources({
-	dataProvider,
-	languageTag,
-	onTrafficSourceClick,
-}) {
+export default function TrafficSources({dataProvider, onTrafficSourceClick}) {
 	const [highlighted, setHighlighted] = useState(null);
 
 	const [, addWarning] = useWarning();
 
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
-	const [{publishedToday}] = useContext(StoreContext);
+	const [{languageTag, publishedToday}] = useContext(StoreContext);
 
 	const [trafficSources, setTrafficSources] = useStateSafe([]);
 
@@ -314,6 +310,5 @@ function TrafficSourcesCustomTooltip(props) {
 
 TrafficSources.propTypes = {
 	dataProvider: PropTypes.func.isRequired,
-	languageTag: PropTypes.string.isRequired,
 	onTrafficSourceClick: PropTypes.func.isRequired,
 };

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Translation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Translation.js
@@ -15,15 +15,14 @@ import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import PropTypes from 'prop-types';
-import React, {useMemo, useState} from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 
 import {useChartState} from '../context/ChartStateContext';
+import {StoreContext} from '../context/StoreContext';
 
-export default function Translation({
-	defaultLanguage,
-	onSelectedLanguageClick,
-	viewURLs,
-}) {
+export default function Translation({onSelectedLanguageClick, viewURLs}) {
+	const [{languageTag: defaultLanguage}] = useContext(StoreContext);
+
 	const [active, setActive] = useState(false);
 
 	const selectedLanguage = useMemo(() => {
@@ -102,7 +101,6 @@ export default function Translation({
 }
 
 Translation.propTypes = {
-	defaultLanguage: PropTypes.string.isRequired,
 	onSelectedLanguageClick: PropTypes.func.isRequired,
 	viewURLs: PropTypes.arrayOf(
 		PropTypes.shape({

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/KeywordsDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/KeywordsDetail.js
@@ -18,7 +18,6 @@ import TotalCount from '../TotalCount';
 
 export default function KeywordsDetail({
 	currentPage,
-	languageTag,
 	trafficShareDataProvider,
 	trafficVolumeDataProvider,
 }) {
@@ -28,7 +27,6 @@ export default function KeywordsDetail({
 				className="mb-2"
 				dataProvider={trafficVolumeDataProvider}
 				label={Liferay.Util.sub(Liferay.Language.get('traffic-volume'))}
-				languageTag={languageTag}
 				popoverAlign={ALIGN_POSITIONS.Bottom}
 				popoverHeader={Liferay.Language.get('traffic-volume')}
 				popoverMessage={Liferay.Language.get(
@@ -48,14 +46,13 @@ export default function KeywordsDetail({
 				)}
 			/>
 
-			<Keywords currentPage={currentPage} languageTag={languageTag} />
+			<Keywords currentPage={currentPage} />
 		</div>
 	);
 }
 
 KeywordsDetail.proptypes = {
 	currentPage: PropTypes.object.isRequired,
-	languageTag: PropTypes.string.isRequired,
 	trafficShareDataProvider: PropTypes.func.isRequired,
 	trafficVolumeDataProvider: PropTypes.func.isRequired,
 };

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
@@ -14,7 +14,7 @@ import ClayList from '@clayui/list';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import {ALIGN_POSITIONS} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useMemo, useState} from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 
 import {
 	useChangeTimeSpanKey,
@@ -24,6 +24,7 @@ import {
 	useNextTimeSpan,
 	usePreviousTimeSpan,
 } from '../../context/ChartStateContext';
+import {StoreContext} from '../../context/StoreContext';
 import {generateDateFormatters as dateFormat} from '../../utils/dateFormat';
 import {numberFormat} from '../../utils/numberFormat';
 import Hint from '../Hint';
@@ -34,12 +35,13 @@ const ITEMS_TO_SHOW = 5;
 
 export default function ReferralDetail({
 	currentPage,
-	languageTag,
 	showTimeSpanSelector = false,
 	timeSpanOptions,
 	trafficShareDataProvider,
 	trafficVolumeDataProvider,
 }) {
+	const [{languageTag}] = useContext(StoreContext);
+
 	const [isReferringPagesExpanded, setIsReferringPagesExpanded] = useState(
 		false
 	);
@@ -105,7 +107,6 @@ export default function ReferralDetail({
 				className="c-mb-2"
 				dataProvider={trafficVolumeDataProvider}
 				label={Liferay.Util.sub(Liferay.Language.get('traffic-volume'))}
-				languageTag={languageTag}
 				popoverAlign={ALIGN_POSITIONS.Bottom}
 				popoverHeader={Liferay.Language.get('traffic-volume')}
 				popoverMessage={Liferay.Language.get(
@@ -292,7 +293,6 @@ export default function ReferralDetail({
 
 ReferralDetail.propTypes = {
 	currentPage: PropTypes.object.isRequired,
-	languageTag: PropTypes.string.isRequired,
 	showTimeSpanSelector: PropTypes.bool,
 	timeSpanOptions: PropTypes.arrayOf(
 		PropTypes.shape({

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
@@ -13,7 +13,7 @@ import ClayList from '@clayui/list';
 import className from 'classnames';
 import {ALIGN_POSITIONS} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useMemo, useState} from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 
 import {
 	useChangeTimeSpanKey,
@@ -23,6 +23,7 @@ import {
 	useNextTimeSpan,
 	usePreviousTimeSpan,
 } from '../../context/ChartStateContext';
+import {StoreContext} from '../../context/StoreContext';
 import {generateDateFormatters as dateFormat} from '../../utils/dateFormat';
 import {numberFormat} from '../../utils/numberFormat';
 import TimeSpanSelector from '../TimeSpanSelector';
@@ -42,12 +43,13 @@ const SOCIAL_MEDIA_COLORS = {
 
 export default function SocialDetail({
 	currentPage,
-	languageTag,
 	showTimeSpanSelector = false,
 	timeSpanOptions,
 	trafficShareDataProvider,
 	trafficVolumeDataProvider,
 }) {
+	const [{languageTag}] = useContext(StoreContext);
+
 	const {referringSocialMedia} = currentPage.data;
 
 	const dateFormatters = useMemo(() => dateFormat(languageTag), [
@@ -127,7 +129,6 @@ export default function SocialDetail({
 				className="c-mb-2"
 				dataProvider={trafficVolumeDataProvider}
 				label={Liferay.Util.sub(Liferay.Language.get('traffic-volume'))}
-				languageTag={languageTag}
 				popoverAlign={ALIGN_POSITIONS.Bottom}
 				popoverHeader={Liferay.Language.get('traffic-volume')}
 				popoverMessage={Liferay.Language.get(
@@ -218,7 +219,6 @@ export default function SocialDetail({
 
 SocialDetail.propTypes = {
 	currentPage: PropTypes.object.isRequired,
-	languageTag: PropTypes.string.isRequired,
 	showTimeSpanSelector: PropTypes.bool,
 	timeSpanOptions: PropTypes.arrayOf(
 		PropTypes.shape({

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/BasicInformation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/BasicInformation.js
@@ -28,7 +28,6 @@ describe('BasicInformation', () => {
 			},
 			canonicalURL:
 				'http://localhost:8080/en/web/guest/-/basic-web-content',
-			languageTag: 'en-US',
 			publishDate: 'Thu Feb 17 08:17:57 GMT 2020',
 			title: 'A testing page',
 		};
@@ -37,7 +36,6 @@ describe('BasicInformation', () => {
 			<BasicInformation
 				author={testProps.author}
 				canonicalURL={testProps.canonicalURL}
-				languageTag={testProps.languageTag}
 				publishDate={testProps.publishDate}
 				title={testProps.title}
 			/>

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Chart.js
@@ -15,6 +15,7 @@ import React from 'react';
 
 import Chart from '../../../src/main/resources/META-INF/resources/js/components/Chart';
 import {ChartStateContextProvider} from '../../../src/main/resources/META-INF/resources/js/context/ChartStateContext';
+import {StoreContextProvider} from '../../../src/main/resources/META-INF/resources/js/context/StoreContext';
 
 const mockReadsDataProvider = jest.fn(() =>
 	Promise.resolve({
@@ -122,6 +123,8 @@ const mockViewsDataProvider = jest.fn(() =>
 	})
 );
 
+const mockLanguageTag = 'en-US';
+
 const mockPublishDate = 'Thu Aug 10 08:17:57 GMT 2020';
 
 const mockTimeSpanOptions = [
@@ -153,18 +156,19 @@ describe('Chart', () => {
 		};
 
 		const {getByText} = render(
-			<ChartStateContextProvider
-				publishDate={testProps.pagePublishDate}
-				timeRange={testProps.timeRange}
-				timeSpanKey={testProps.timeSpanKey}
-			>
-				<Chart
-					dataProviders={[mockViewsDataProvider]}
-					languageTag="en-US"
-					publishDate={mockPublishDate}
-					timeSpanOptions={mockTimeSpanOptions}
-				/>
-			</ChartStateContextProvider>
+			<StoreContextProvider value={{languageTag: mockLanguageTag}}>
+				<ChartStateContextProvider
+					publishDate={testProps.pagePublishDate}
+					timeRange={testProps.timeRange}
+					timeSpanKey={testProps.timeSpanKey}
+				>
+					<Chart
+						dataProviders={[mockViewsDataProvider]}
+						publishDate={mockPublishDate}
+						timeSpanOptions={mockTimeSpanOptions}
+					/>
+				</ChartStateContextProvider>
+			</StoreContextProvider>
 		);
 
 		await wait(() =>
@@ -184,21 +188,22 @@ describe('Chart', () => {
 		};
 
 		const {getByText} = render(
-			<ChartStateContextProvider
-				publishDate={testProps.pagePublishDate}
-				timeRange={testProps.timeRange}
-				timeSpanKey={testProps.timeSpanKey}
-			>
-				<Chart
-					dataProviders={[
-						mockViewsDataProvider,
-						mockReadsDataProvider,
-					]}
-					languageTag="en-US"
-					publishDate={mockPublishDate}
-					timeSpanOptions={mockTimeSpanOptions}
-				/>
-			</ChartStateContextProvider>
+			<StoreContextProvider value={{languageTag: mockLanguageTag}}>
+				<ChartStateContextProvider
+					publishDate={testProps.pagePublishDate}
+					timeRange={testProps.timeRange}
+					timeSpanKey={testProps.timeSpanKey}
+				>
+					<Chart
+						dataProviders={[
+							mockViewsDataProvider,
+							mockReadsDataProvider,
+						]}
+						publishDate={mockPublishDate}
+						timeSpanOptions={mockTimeSpanOptions}
+					/>
+				</ChartStateContextProvider>
+			</StoreContextProvider>
 		);
 
 		await wait(() => {

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Detail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Detail.js
@@ -16,6 +16,7 @@ import React from 'react';
 
 import Detail from '../../../src/main/resources/META-INF/resources/js/components/Detail';
 import {ChartStateContextProvider} from '../../../src/main/resources/META-INF/resources/js/context/ChartStateContext';
+import {StoreContextProvider} from '../../../src/main/resources/META-INF/resources/js/context/StoreContext';
 
 const mockOnCurrentPageChange = jest.fn(() => Promise.resolve({view: 'main'}));
 
@@ -223,6 +224,8 @@ const mockCurrentPageSocial = {
 	view: 'social',
 };
 
+const mockLanguageTag = 'en-US';
+
 const mockTimeSpanOptions = [
 	{
 		key: 'last-30-days',
@@ -252,29 +255,32 @@ describe('Detail', () => {
 		};
 
 		const {getByText} = render(
-			<ChartStateContextProvider
-				publishDate={testProps.publishDate}
-				timeRange={testProps.timeRange}
-				timeSpanKey={testProps.timeSpanKey}
-			>
-				<Detail
-					currentPage={mockCurrentPageReferral}
-					languageTag="en-US"
-					onCurrentPageChange={mockOnCurrentPageChange}
-					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
-					timeSpanOptions={mockTimeSpanOptions}
-					trafficShareDataProvider={mockTrafficShareDataProvider}
-					trafficVolumeDataProvider={mockTrafficVolumeDataProvider}
-				/>
-			</ChartStateContextProvider>
+			<StoreContextProvider value={{languageTag: mockLanguageTag}}>
+				<ChartStateContextProvider
+					publishDate={testProps.publishDate}
+					timeRange={testProps.timeRange}
+					timeSpanKey={testProps.timeSpanKey}
+				>
+					<Detail
+						currentPage={mockCurrentPageReferral}
+						onCurrentPageChange={mockOnCurrentPageChange}
+						onTrafficSourceNameChange={
+							mockOnTrafficSourceNameChange
+						}
+						timeSpanOptions={mockTimeSpanOptions}
+						trafficShareDataProvider={mockTrafficShareDataProvider}
+						trafficVolumeDataProvider={
+							mockTrafficVolumeDataProvider
+						}
+					/>
+				</ChartStateContextProvider>
+			</StoreContextProvider>
 		);
 
-		await wait(() =>
-			expect(mockTrafficShareDataProvider).toHaveBeenCalled()
-		);
-		await wait(() =>
-			expect(mockTrafficVolumeDataProvider).toHaveBeenCalled()
-		);
+		await wait(() => {
+			expect(mockTrafficShareDataProvider).toHaveBeenCalled();
+			expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
+		});
 
 		const viewMoreButton = getByText('view-more');
 		userEvent.click(viewMoreButton);
@@ -293,7 +299,6 @@ describe('Detail', () => {
 			const {getByText} = render(
 				<Detail
 					currentPage={mockCurrentPageOrganic}
-					languageTag="en-US"
 					onCurrentPageChange={mockOnCurrentPageChange}
 					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
 					timeSpanOptions={mockTimeSpanOptions}
@@ -302,12 +307,10 @@ describe('Detail', () => {
 				/>
 			);
 
-			await wait(() =>
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled()
-			);
-			await wait(() =>
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled()
-			);
+			await wait(() => {
+				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
+				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
+			});
 
 			expect(getByText('Organic')).toBeInTheDocument();
 			expect(getByText('90%')).toBeInTheDocument();
@@ -321,7 +324,6 @@ describe('Detail', () => {
 			const {getByText} = render(
 				<Detail
 					currentPage={mockCurrentPageOrganic}
-					languageTag="en-US"
 					onCurrentPageChange={mockOnCurrentPageChange}
 					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
 					timeSpanOptions={mockTimeSpanOptions}
@@ -330,12 +332,10 @@ describe('Detail', () => {
 				/>
 			);
 
-			await wait(() =>
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled()
-			);
-			await wait(() =>
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled()
-			);
+			await wait(() => {
+				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
+				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
+			});
 
 			expect(getByText('United States')).toBeInTheDocument();
 			expect(getByText('Spain')).toBeInTheDocument();
@@ -362,7 +362,6 @@ describe('Detail', () => {
 			const {getByText} = render(
 				<Detail
 					currentPage={mockCurrentPageOrganic}
-					languageTag="en-US"
 					onCurrentPageChange={mockOnCurrentPageChange}
 					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
 					timeSpanOptions={mockTimeSpanOptions}
@@ -371,12 +370,10 @@ describe('Detail', () => {
 				/>
 			);
 
-			await wait(() =>
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled()
-			);
-			await wait(() =>
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled()
-			);
+			await wait(() => {
+				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
+				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
+			});
 
 			const bestKeywordLabel = getByText('best-keyword');
 			const questionCircleIcon = within(bestKeywordLabel).getByRole(
@@ -390,7 +387,6 @@ describe('Detail', () => {
 			const {getAllByText, getByText} = render(
 				<Detail
 					currentPage={mockCurrentPageOrganic}
-					languageTag="en-US"
 					onCurrentPageChange={mockOnCurrentPageChange}
 					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
 					timeSpanOptions={mockTimeSpanOptions}
@@ -399,12 +395,10 @@ describe('Detail', () => {
 				/>
 			);
 
-			await wait(() =>
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled()
-			);
-			await wait(() =>
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled()
-			);
+			await wait(() => {
+				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
+				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
+			});
 
 			const trafficDropdown = getAllByText('traffic')[0];
 			userEvent.click(trafficDropdown);
@@ -416,7 +410,6 @@ describe('Detail', () => {
 			const {getAllByText, getByText} = render(
 				<Detail
 					currentPage={mockCurrentPageOrganic}
-					languageTag="en-US"
 					onCurrentPageChange={mockOnCurrentPageChange}
 					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
 					timeSpanOptions={mockTimeSpanOptions}
@@ -425,12 +418,10 @@ describe('Detail', () => {
 				/>
 			);
 
-			await wait(() =>
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled()
-			);
-			await wait(() =>
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled()
-			);
+			await wait(() => {
+				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
+				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
+			});
 
 			const trafficDropdown = getAllByText('traffic')[0];
 			userEvent.click(trafficDropdown);
@@ -459,7 +450,6 @@ describe('Detail', () => {
 			const {getAllByText, getByText} = render(
 				<Detail
 					currentPage={mockCurrentPageOrganic}
-					languageTag="en-US"
 					onCurrentPageChange={mockOnCurrentPageChange}
 					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
 					timeSpanOptions={mockTimeSpanOptions}
@@ -468,12 +458,10 @@ describe('Detail', () => {
 				/>
 			);
 
-			await wait(() =>
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled()
-			);
-			await wait(() =>
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled()
-			);
+			await wait(() => {
+				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
+				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
+			});
 
 			const trafficDropdown = getAllByText('traffic')[0];
 			userEvent.click(trafficDropdown);
@@ -508,33 +496,34 @@ describe('Detail', () => {
 			};
 
 			const {getByText} = render(
-				<ChartStateContextProvider
-					publishDate={testProps.publishDate}
-					timeRange={testProps.timeRange}
-					timeSpanKey={testProps.timeSpanKey}
-				>
-					<Detail
-						currentPage={mockCurrentPageReferral}
-						languageTag="en-US"
-						onCurrentPageChange={mockOnCurrentPageChange}
-						onTrafficSourceNameChange={
-							mockOnTrafficSourceNameChange
-						}
-						timeSpanOptions={mockTimeSpanOptions}
-						trafficShareDataProvider={mockTrafficShareDataProvider}
-						trafficVolumeDataProvider={
-							mockTrafficVolumeDataProvider
-						}
-					/>
-				</ChartStateContextProvider>
+				<StoreContextProvider value={{languageTag: mockLanguageTag}}>
+					<ChartStateContextProvider
+						publishDate={testProps.publishDate}
+						timeRange={testProps.timeRange}
+						timeSpanKey={testProps.timeSpanKey}
+					>
+						<Detail
+							currentPage={mockCurrentPageReferral}
+							onCurrentPageChange={mockOnCurrentPageChange}
+							onTrafficSourceNameChange={
+								mockOnTrafficSourceNameChange
+							}
+							timeSpanOptions={mockTimeSpanOptions}
+							trafficShareDataProvider={
+								mockTrafficShareDataProvider
+							}
+							trafficVolumeDataProvider={
+								mockTrafficVolumeDataProvider
+							}
+						/>
+					</ChartStateContextProvider>
+				</StoreContextProvider>
 			);
 
-			await wait(() =>
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled()
-			);
-			await wait(() =>
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled()
-			);
+			await wait(() => {
+				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
+				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
+			});
 
 			expect(getByText('Referral')).toBeInTheDocument();
 			expect(getByText('90%')).toBeInTheDocument();
@@ -580,33 +569,34 @@ describe('Detail', () => {
 			};
 
 			const {getByText} = render(
-				<ChartStateContextProvider
-					publishDate={testProps.publishDate}
-					timeRange={testProps.timeRange}
-					timeSpanKey={testProps.timeSpanKey}
-				>
-					<Detail
-						currentPage={mockCurrentPageSocial}
-						languageTag="en-US"
-						onCurrentPageChange={mockOnCurrentPageChange}
-						onTrafficSourceNameChange={
-							mockOnTrafficSourceNameChange
-						}
-						timeSpanOptions={mockTimeSpanOptions}
-						trafficShareDataProvider={mockTrafficShareDataProvider}
-						trafficVolumeDataProvider={
-							mockTrafficVolumeDataProvider
-						}
-					/>
-				</ChartStateContextProvider>
+				<StoreContextProvider value={{languageTag: mockLanguageTag}}>
+					<ChartStateContextProvider
+						publishDate={testProps.publishDate}
+						timeRange={testProps.timeRange}
+						timeSpanKey={testProps.timeSpanKey}
+					>
+						<Detail
+							currentPage={mockCurrentPageSocial}
+							onCurrentPageChange={mockOnCurrentPageChange}
+							onTrafficSourceNameChange={
+								mockOnTrafficSourceNameChange
+							}
+							timeSpanOptions={mockTimeSpanOptions}
+							trafficShareDataProvider={
+								mockTrafficShareDataProvider
+							}
+							trafficVolumeDataProvider={
+								mockTrafficVolumeDataProvider
+							}
+						/>
+					</ChartStateContextProvider>
+				</StoreContextProvider>
 			);
 
-			await wait(() =>
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled()
-			);
-			await wait(() =>
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled()
-			);
+			await wait(() => {
+				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
+				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
+			});
 
 			expect(getByText('Social')).toBeInTheDocument();
 			expect(getByText('90%')).toBeInTheDocument();

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Keywords.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Keywords.js
@@ -39,9 +39,7 @@ describe('Keywords', () => {
 			view: 'organic',
 		};
 
-		const {getByText} = render(
-			<Keywords currentPage={mockCurrentPage} languageTag="en-US" />
-		);
+		const {getByText} = render(<Keywords currentPage={mockCurrentPage} />);
 
 		expect(getByText('there-are-no-best-keywords-yet')).toBeInTheDocument();
 	});

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Navigation.js
@@ -27,6 +27,12 @@ const mockEndpoints = {
 	analyticsReportsTrafficSourcesURL: 'analyticsReportsTrafficSourcesURL',
 };
 
+const mockLanguageTag = 'en-US';
+
+const mockNamespace = 'namespace';
+
+const mockPage = {plid: 20};
+
 const mockTimeSpanOptions = [
 	{
 		key: 'last-30-days',
@@ -74,8 +80,6 @@ describe('Navigation', () => {
 			},
 			canonicalURL:
 				'http://localhost:8080/en/web/guest/-/basic-web-content',
-			languageTag: 'en-US',
-			page: {plid: 20},
 			pagePublishDate: 'Thu Aug 10 08:17:57 GMT 2020',
 			pageTitle: 'A testing page',
 			timeRange: {endDate: '2020-01-27', startDate: '2020-02-02'},
@@ -88,24 +92,32 @@ describe('Navigation', () => {
 					validAnalyticsConnection: false,
 				}}
 			>
-				<ChartStateContextProvider
-					publishDate={testProps.pagePublishDate}
-					timeRange={testProps.timeRange}
-					timeSpanKey={testProps.timeSpanKey}
+				<StoreContextProvider
+					value={{
+						endpoints: mockEndpoints,
+						languageTag: mockLanguageTag,
+						namespace: mockNamespace,
+						page: mockPage,
+					}}
 				>
-					<Navigation
-						author={testProps.author}
-						canonicalURL={testProps.canonicalURL}
-						endpoints={mockEndpoints}
-						languageTag={testProps.languageTag}
-						onSelectedLanguageClick={noop}
-						page={testProps.page}
-						pagePublishDate={testProps.pagePublishDate}
-						pageTitle={testProps.pageTitle}
-						timeSpanOptions={mockTimeSpanOptions}
-						viewURLs={mockViewURLs}
-					/>
-				</ChartStateContextProvider>
+					<ChartStateContextProvider
+						publishDate={testProps.pagePublishDate}
+						timeRange={testProps.timeRange}
+						timeSpanKey={testProps.timeSpanKey}
+					>
+						<Navigation
+							author={testProps.author}
+							canonicalURL={testProps.canonicalURL}
+							endpoints={mockEndpoints}
+							onSelectedLanguageClick={noop}
+							page={testProps.page}
+							pagePublishDate={testProps.pagePublishDate}
+							pageTitle={testProps.pageTitle}
+							timeSpanOptions={mockTimeSpanOptions}
+							viewURLs={mockViewURLs}
+						/>
+					</ChartStateContextProvider>
+				</StoreContextProvider>
 			</ConnectionContext.Provider>
 		);
 
@@ -121,8 +133,6 @@ describe('Navigation', () => {
 			},
 			canonicalURL:
 				'http://localhost:8080/en/web/guest/-/basic-web-content',
-			languageTag: 'en-US',
-			page: {plid: 20},
 			pagePublishDate: 'Thu Aug 10 08:17:57 GMT 2020',
 			pageTitle: 'A testing page',
 			timeRange: {endDate: '2020-01-27', startDate: '2020-02-02'},
@@ -130,7 +140,15 @@ describe('Navigation', () => {
 		};
 
 		const {getByText} = render(
-			<StoreContextProvider value={{warning: true}}>
+			<StoreContextProvider
+				value={{
+					endpoints: mockEndpoints,
+					languageTag: mockLanguageTag,
+					namespace: mockNamespace,
+					page: mockPage,
+					warning: true,
+				}}
+			>
 				<ChartStateContextProvider
 					publishDate={testProps.publishDate}
 					timeRange={testProps.timeRange}
@@ -140,7 +158,6 @@ describe('Navigation', () => {
 						author={testProps.author}
 						canonicalURL={testProps.canonicalURL}
 						endpoints={mockEndpoints}
-						languageTag={testProps.languageTag}
 						onSelectedLanguageClick={noop}
 						page={testProps.page}
 						pagePublishDate={testProps.pagePublishDate}
@@ -166,8 +183,6 @@ describe('Navigation', () => {
 			},
 			canonicalURL:
 				'http://localhost:8080/en/web/guest/-/basic-web-content',
-			languageTag: 'en-US',
-			page: {plid: 20},
 			pagePublishDate: 'Thu Feb 02 08:17:57 GMT 2020',
 			pageTitle: 'A testing page',
 			timeRange: {endDate: '2020-01-27', startDate: '2020-02-02'},
@@ -175,7 +190,15 @@ describe('Navigation', () => {
 		};
 
 		const {getByText} = render(
-			<StoreContextProvider value={{publishedToday: true}}>
+			<StoreContextProvider
+				value={{
+					endpoints: mockEndpoints,
+					languageTag: mockLanguageTag,
+					namespace: mockNamespace,
+					page: mockPage,
+					publishedToday: true,
+				}}
+			>
 				<ChartStateContextProvider
 					publishDate={testProps.pagePublishDate}
 					timeRange={testProps.timeRange}
@@ -185,7 +208,6 @@ describe('Navigation', () => {
 						author={testProps.author}
 						canonicalURL={testProps.canonicalURL}
 						endpoints={mockEndpoints}
-						languageTag={testProps.languageTag}
 						onSelectedLanguageClick={noop}
 						page={testProps.page}
 						pagePublishDate={testProps.pagePublishDate}


### PR DESCRIPTION
**Description**

This is the second pull request to fix [LPS-128998 Content Performance available endpoints should load at the same time](https://issues.liferay.com/browse/LPS-128998) as I said in a previous PR (see `Notes` from description, but in summary, the idea is that every component reads data from the store instead of calling its `dataProvider` and wait until all endpoints are resolved to display the data in the UI): https://github.com/liferay-frontend/liferay-portal/pull/885#issue-588734880.

As the pull can be huge, I'm going to create sub-tasks for the issue and send the code for each of them separately.

**How to test it**

- Connect Liferay DXP with Analytics Cloud
- Create a Content Page
- Wait 24 hours to let Analytics Cloud process the data (if you don't want to wait for it, change the date of your computer and create the page in the past 😉  )
- Open the Content Performance panel

**Within this pull request**

Everything should work as before. No UI changes.
- Save endpoints, languageTag, namespace and page attributes in store
- Apply in all components and remove prop-drilling those attributes
- Fix frontend tests

**Final solution for the issue**

In the future those handlers will be converted into actions and dispatch it when necessary. Also, some information will be removed from the prop-drilling and save it in the store as-well. Components will read from the store to display the data.

**History pull requests**

- LPS-128998 [Content Performance] Refactor APIService to be called in any component: https://github.com/brianchandotcom/liferay-portal/pull/99816