### PR TITLE
LPS-129013 Adding color back to google drive icons

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -17,6 +17,7 @@ import ClayDropDown from '@clayui/drop-down';
 import classNames from 'classnames';
 import React, {useRef, useState} from 'react';
 
+import getDataAttributes from '../get_data_attributes';
 import LinkOrButton from './LinkOrButton';
 
 const CreationMenu = ({
@@ -95,11 +96,6 @@ const CreationMenu = ({
 	);
 
 	const Item = ({item}) => {
-		const mapKeys = (obj, fn) =>
-			Object.fromEntries(
-				Object.entries(obj).map(([key, value]) => [fn(key), value])
-			);
-
 		return (
 			<ClayDropDown.Item
 				href={item.href}
@@ -107,7 +103,7 @@ const CreationMenu = ({
 					onCreationMenuItemClick(event, {item});
 				}}
 				symbolLeft={item.icon}
-				{...mapKeys(item.data, (key) => `data-${key}`)}
+				{...getDataAttributes(item.data)}
 			>
 				{item.label}
 			</ClayDropDown.Item>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -95,6 +95,11 @@ const CreationMenu = ({
 	);
 
 	const Item = ({item}) => {
+		const mapKeys = (obj, fn) =>
+			Object.fromEntries(
+				Object.entries(obj).map(([key, value]) => [fn(key), value])
+			);
+
 		return (
 			<ClayDropDown.Item
 				href={item.href}
@@ -102,6 +107,7 @@ const CreationMenu = ({
 					onCreationMenuItemClick(event, {item});
 				}}
 				symbolLeft={item.icon}
+				{...mapKeys(item.data, (key) => `data-${key}`)}
 			>
 				{item.label}
 			</ClayDropDown.Item>


### PR DESCRIPTION
Hi team,

We need to add data attributes in the management toolbar dropdowns items again because we lose the Google icon's colors.

**Test plan**

1. Go to System Settings -> Documents and Media -> Google Drive.
2. Set some random values for the key and secret fields and save.
3. Go to Documents And Media.
4. Click on the plus button.

**Before the fix**
![image](https://user-images.githubusercontent.com/67901/110909380-509b4300-8310-11eb-86af-f00d86a61c32.png)


**After the fix**
![image](https://user-images.githubusercontent.com/67901/110910142-3c0b7a80-8311-11eb-80de-cb31239c5f2d.png)

