### PR TITLE
LPS-129051 Remove unneeded propsTransformer attribute

### DIFF
--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
@@ -69,7 +69,6 @@ else {
 <clay:management-toolbar
 	clearResultsURL="<%= selectRoleManagementToolbarDisplayContext.getClearResultsURL() %>"
 	itemsTotal="<%= (step == 1) ? organizations.size() : roleSearchContainer.getTotal() %>"
-	propsTransformer="js/ViewRolesManagementToolbarPropsTransformer"
 	searchActionURL="<%= selectRoleManagementToolbarDisplayContext.getSearchActionURL() %>"
 	searchFormName="searchFm"
 	selectable="<%= false %>"

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
@@ -72,7 +72,6 @@ SearchContainer<Role> roleSearchContainer = selectRoleManagementToolbarDisplayCo
 <clay:management-toolbar
 	clearResultsURL="<%= selectRoleManagementToolbarDisplayContext.getClearResultsURL() %>"
 	itemsTotal="<%= (step == 1) ? groups.size() : roleSearchContainer.getTotal() %>"
-	propsTransformer="js/ViewRolesManagementToolbarPropsTransformer"
 	searchActionURL="<%= selectRoleManagementToolbarDisplayContext.getSearchActionURL() %>"
 	searchFormName="searchFm"
 	selectable="<%= false %>"


### PR DESCRIPTION
In [`22b0aff`](https://github.com/liferay/liferay-portal/commit/22b0aff696eff783ec4016c7942a3da853d9de16),we migrated `<clay:management-toolbar-v2 />` to
`<clay:management-toolbar />`, and introduced a bug:

The instances of the `<clay:management-toolbar />` tag in
[select_organization_role.jspf](https://github.com/liferay/liferay-portal/blob/aa7b7141b63ef4781020c31783b3cdd13fc883f0/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf) and [select_site_role.jspf](https://github.com/liferay/liferay-portal/blob/aa7b7141b63ef4781020c31783b3cdd13fc883f0/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf)
don't need a `propsTransformer` attribute **and adding one will cause the
following JavaScript error** in the brower's console, when these JSPs are loaded:

```javascript
TypeError: Cannot read property 'deleteRolesURL' of undefined
    at Object.propsTransformer [as default] (ViewRolesManagementToolbarPropsTransformer.js:18)
```

This change fixes the JavaScript error.

**Before this change** (i.e. in `master` with [`aa7b714`](https://github.com/liferay/liferay-portal/commit/aa7b714))

*Pay attention to the browser's console in the .gif*

![error-in-master](https://user-images.githubusercontent.com/5572/110917642-6c0b4b80-831a-11eb-8df1-c0b2e74ac615.gif)

**With this change**:

![](https://user-images.githubusercontent.com/5572/110917691-7af1fe00-831a-11eb-8806-3c5188203e7c.gif)

However, even when reverting [these changes](https://github.com/liferay/liferay-portal/commit/22b0aff696eff783ec4016c7942a3da853d9de16), the search results
are still not shown correctly.