### PR TITLE
LPS-128658 Fix misalignment of icons in the portlet-topper-toolbar

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/portlet/_portlet.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/portlet/_portlet.scss
@@ -55,6 +55,11 @@
 			width: 1.5rem;
 		}
 
+		.portlet-topper-toolbar .component-action {
+			height: 1.5rem;
+			width: 1.5rem;
+		}
+
 		.lexicon-icon {
 			height: 0.875rem;
 			width: 0.875rem;


### PR DESCRIPTION
Fixes [LPS-128658](https://issues.liferay.com/browse/LPS-128658) 

I've taken the CSS route fixing this, adding a new rule that targets `.portlet-topper-toolbar .component-action`. The rule reduces the `height` and `width` from the default `2rem` to `1rem` and changes the display to `inline-flex` allowing me to easily center the icons horizontally inside their containers.

I'm very unfamiliar with how we handle these changes, which theme to change, is a change like this the prefered way (or applying a certain class to the element).