### PR TITLE
LPS-128886 The display style of the assign user will be affected when editing the display style of users

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
@@ -61,7 +61,7 @@ public class SelectUsersDisplayContext {
 		_displayStyle = SearchDisplayStyleUtil.getDisplayStyle(
 			_httpServletRequest,
 			SiteMembershipsPortletKeys.SITE_MEMBERSHIPS_ADMIN,
-			"display-style-users", "icon");
+			"display-style-select-users", "icon");
 
 		return _displayStyle;
 	}


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-128886

See description and test case in the linked JIRA ticket.

The bug was that two search containers stored the display styles under the same key. In this PR, we are making them unique.

After fix, the display style in user selection remains saved:
![after](https://user-images.githubusercontent.com/5435511/110964558-962d2f80-8353-11eb-9a86-1644da30f8fa.gif)


/cc @ealonso @jbalsas 