### PR TITLE
LPS-119068 [Page Audit] Create empty Page Audit sidebar view

### DIFF
--- a/modules/apps/layout/layout-reports-web/build.gradle
+++ b/modules/apps/layout/layout-reports-web/build.gradle
@@ -7,9 +7,9 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
-	compileOnly project(":apps:content-dashboard:content-dashboard-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/layout/layout-reports-web/package.json
+++ b/modules/apps/layout/layout-reports-web/package.json
@@ -1,0 +1,25 @@
+{
+	"dependencies": {
+		"@clayui/button": "3.6.0",
+		"@clayui/drop-down": "3.25.1",
+		"@clayui/icon": "3.1.0",
+		"@clayui/label": "3.4.1",
+		"@clayui/layout": "3.3.0",
+		"@clayui/tooltip": "3.4.5",
+		"@liferay/frontend-js-react-web": "*",
+		"classnames": "2.2.6",
+		"frontend-js-web": "*",
+		"prop-types": "15.7.2",
+		"react": "16.12.0",
+		"recharts": "1.8.5"
+	},
+	"name": "layout-reports-web",
+	"private": true,
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix",
+		"test": "liferay-npm-scripts test"
+	},
+	"version": "1.0.0"
+}

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/assets/issues-default.svg
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/assets/issues-default.svg
@@ -1,0 +1,14 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<circle cx="60" cy="60" r="60" fill="#F1F2F5"/>
+	<rect x="49" y="98" width="22" height="2" rx="1" stroke="#6B6C7E" stroke-width="2"/>
+	<rect x="21.5" y="31.5" width="77" height="57" rx="6.5" fill="white" stroke="#6B6C7E" stroke-width="3"/>
+	<line x1="62.5" y1="39.5" x2="91.5" y2="39.5" stroke="#E7E7ED" stroke-width="3" stroke-linecap="round"/>
+	<line x1="62.5" y1="47.5" x2="91.5" y2="47.5" stroke="#E7E7ED" stroke-width="3" stroke-linecap="round"/>
+	<line x1="62.5" y1="55.5" x2="91.5" y2="55.5" stroke="#E7E7ED" stroke-width="3" stroke-linecap="round"/>
+	<line x1="28.5" y1="64.5" x2="91.5" y2="64.5" stroke="#E7E7ED" stroke-width="3" stroke-linecap="round"/>
+	<line x1="28.5" y1="72.5" x2="91.5" y2="72.5" stroke="#E7E7ED" stroke-width="3" stroke-linecap="round"/>
+	<line x1="28.5" y1="80.5" x2="91.5" y2="80.5" stroke="#E7E7ED" stroke-width="3" stroke-linecap="round"/>
+	<rect x="27" y="37" width="26" height="20" rx="4" fill="#E7E7ED"/>
+	<circle cx="60" cy="60" r="12" fill="#50D2A0"/>
+	<path d="M58.0286 65.4238C57.7692 65.4238 57.5161 65.3207 57.3317 65.1363L53.3911 61.1925C52.4692 60.2269 53.9598 58.9394 54.7848 59.7988L57.9848 63.0019L65.1723 54.9113C66.0223 53.9582 67.4942 55.2707 66.6442 56.2207L58.7629 65.0925C58.5817 65.2957 58.3254 65.4144 58.0567 65.4238C58.0473 65.4238 58.0379 65.4238 58.0286 65.4238Z" fill="white"/>
+</svg>

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,4 +24,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <liferay-theme:defineObjects />
 
+<%@ page import="com.liferay.layout.reports.web.internal.constants.LayoutReportsWebKeys" %><%@
+page import="com.liferay.layout.reports.web.internal.display.context.LayoutReportsDisplayContext" %>
+
 <%@ include file="/init-ext.jsp" %>

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/init.jsp
@@ -18,6 +18,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/LayoutReportsApp.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/LayoutReportsApp.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React from 'react';
+
+import BasicInformation from './components/BasicInformation';
+import EmptyLayoutReports from './components/EmptyLayoutReports';
+
+export default function ({context}) {
+	const {
+		assetsPath,
+		canonicalURLs,
+		defaultLanguageId,
+		showButton,
+		validConnection,
+	} = context;
+
+	return (
+		<>
+			<BasicInformation
+				canonicalURLs={canonicalURLs}
+				defaultLanguageId={defaultLanguageId}
+			/>
+
+			{validConnection || (
+				<EmptyLayoutReports
+					assetsPath={assetsPath}
+					showButton={showButton}
+				/>
+			)}
+		</>
+	);
+}

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayLayout from '@clayui/layout';
+import {ClayTooltipProvider} from '@clayui/tooltip';
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+
+import LanguagesDropdown from './LanguagesDropdown';
+
+export default function BasicInformation({canonicalURLs, defaultLanguageId}) {
+	const [selectedCanonicalURL, setSeletedCanonicalURL] = useState(
+		canonicalURLs.find(({languageId}) => languageId === defaultLanguageId)
+	);
+
+	const handleSelectLanguageId = (selectedLanguageId) => {
+		if (selectedCanonicalURL.languageId !== selectedLanguageId) {
+			setSeletedCanonicalURL(
+				canonicalURLs.find(
+					({languageId}) => languageId === selectedLanguageId
+				)
+			);
+		}
+	};
+
+	return (
+		<ClayLayout.ContentRow>
+			<ClayLayout.ContentCol>
+				<div className="inline-item-before">
+					<ClayLayout.ContentRow>
+						<ClayLayout.ContentCol>
+							<LanguagesDropdown
+								canonicalURLs={canonicalURLs}
+								defaultLanguageId={defaultLanguageId}
+								onSelectedLanguageId={handleSelectLanguageId}
+								selectedLanguageId={
+									selectedCanonicalURL.languageId
+								}
+							/>
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
+				</div>
+			</ClayLayout.ContentCol>
+			<ClayLayout.ContentCol expand>
+				<ClayLayout.ContentRow>
+					<ClayTooltipProvider>
+						<span className="font-weight-semi-bold text-truncate-inline">
+							<span
+								className="text-truncate"
+								data-tooltip-align="bottom"
+								title={selectedCanonicalURL.title}
+							>
+								{selectedCanonicalURL.title}
+							</span>
+						</span>
+					</ClayTooltipProvider>
+				</ClayLayout.ContentRow>
+				<ClayLayout.ContentRow>
+					<ClayTooltipProvider>
+						<span className="text-secondary text-truncate-inline text-truncate-reverse">
+							<span
+								className="text-truncate"
+								data-tooltip-align="bottom"
+								title={selectedCanonicalURL.canonicalURL}
+							>
+								{selectedCanonicalURL.canonicalURL}
+							</span>
+						</span>
+					</ClayTooltipProvider>
+				</ClayLayout.ContentRow>
+			</ClayLayout.ContentCol>
+		</ClayLayout.ContentRow>
+	);
+}
+
+BasicInformation.propTypes = {
+	canonicalURLs: PropTypes.arrayOf(
+		PropTypes.shape({
+			canonicalURL: PropTypes.string.isRequired,
+			languageId: PropTypes.string.isRequired,
+			title: PropTypes.string.isRequired,
+		})
+	),
+	defaultLanguageId: PropTypes.string.isRequired,
+};

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/EmptyLayoutReports.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/EmptyLayoutReports.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton from '@clayui/button';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default function EmptyLayoutReports({assetsPath, showButton}) {
+	const defaultIllustration = `${assetsPath}/issues-default.svg`;
+
+	return (
+		<div className="text-center">
+			<img
+				alt={Liferay.Language.get(
+					'default-page-audit-image-alt-description'
+				)}
+				className="c-mb-4 c-mt-5"
+				src={defaultIllustration}
+				width="120px"
+			/>
+
+			<div className="c-mb-2 font-weight-semi-bold">
+				<span>
+					{Liferay.Language.get(
+						"check-issues-that-impact-on-your-page's-accessibility-and-seo"
+					)}
+				</span>
+			</div>
+
+			{showButton ? (
+				<>
+					<div className="c-mb-3 text-secondary">
+						{Liferay.Language.get(
+							'connect-to-pagespeed-to-run-a-page-audit'
+						)}
+					</div>
+
+					<ClayButton displayType="secondary">
+						{Liferay.Language.get('connect-to-pagespeed')}
+					</ClayButton>
+				</>
+			) : (
+				<div className="text-secondary">
+					<span>
+						{Liferay.Language.get(
+							'to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed'
+						)}
+					</span>
+				</div>
+			)}
+		</div>
+	);
+}
+
+EmptyLayoutReports.propTypes = {
+	assetsPath: PropTypes.string.isRequired,
+	showButton: PropTypes.bool.isRequired,
+};

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/LanguagesDropdown.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/LanguagesDropdown.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton from '@clayui/button';
+import ClayDropDown from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
+import ClayLabel from '@clayui/label';
+import ClayLayout from '@clayui/layout';
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+
+export default function LanguagesDropdown({
+	canonicalURLs,
+	defaultLanguageId,
+	onSelectedLanguageId,
+	selectedLanguageId,
+}) {
+	const [active, setActive] = useState(false);
+
+	return (
+		<ClayDropDown
+			active={active}
+			hasLeftSymbols
+			onActiveChange={setActive}
+			trigger={
+				<ClayButton
+					className="btn-monospaced"
+					displayType="secondary"
+					small
+				>
+					<ClayIcon symbol={selectedLanguageId.toLowerCase()} />
+					<span
+						className="d-block font-weight-normal"
+						style={{fontSize: '9px'}}
+					>
+						{selectedLanguageId}
+					</span>
+				</ClayButton>
+			}
+		>
+			<ClayDropDown.ItemList>
+				{Object.values(canonicalURLs).map(({languageId}, index) => (
+					<ClayDropDown.Item
+						active={selectedLanguageId === languageId}
+						key={index}
+						onClick={() => {
+							onSelectedLanguageId(languageId);
+						}}
+						symbolLeft={languageId.toLowerCase()}
+					>
+						<ClayLayout.ContentRow>
+							<ClayLayout.ContentCol expand>
+								<span>{languageId}</span>
+							</ClayLayout.ContentCol>
+							{defaultLanguageId === languageId && (
+								<ClayLayout.ContentCol>
+									<ClayLabel displayType="primary">
+										{Liferay.Language.get('default')}
+									</ClayLabel>
+								</ClayLayout.ContentCol>
+							)}
+						</ClayLayout.ContentRow>
+					</ClayDropDown.Item>
+				))}
+			</ClayDropDown.ItemList>
+		</ClayDropDown>
+	);
+}
+
+LanguagesDropdown.propTypes = {
+	canonicalURLs: PropTypes.arrayOf(
+		PropTypes.shape({
+			canonicalURL: PropTypes.string.isRequired,
+			languageId: PropTypes.string.isRequired,
+			title: PropTypes.string.isRequired,
+		})
+	),
+	defaultLanguageId: PropTypes.string.isRequired,
+	onSelectedLanguageId: PropTypes.func.isRequired,
+	selectedLanguageId: PropTypes.string.isRequired,
+};

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/layout_reports_panel.jsp
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/layout_reports_panel.jsp
@@ -16,5 +16,17 @@
 
 <%@ include file="/init.jsp" %>
 
+<%
+LayoutReportsDisplayContext layoutReportsDisplayContext = (LayoutReportsDisplayContext)request.getAttribute(LayoutReportsWebKeys.LAYOUT_REPORTS_DISPLAY_CONTEXT);
+%>
+
 <div class="c-p-3" id="<portlet:namespace />-layout-reports-root">
+	<div class="inline-item my-5 p-5 w-100">
+		<span aria-hidden="true" class="loading-animation"></span>
+	</div>
+
+	<react:component
+		module="js/LayoutReportsApp"
+		props="<%= layoutReportsDisplayContext.getData() %>"
+	/>
 </div>

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO.
+connect-to-pagespeed=Connect To PageSpeed
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit.
+default-page-audit-image-alt-description=Default Page Audit image.
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports
 page-audit=Page Audit
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed.

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ar.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_bg.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ca.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_cs.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_da.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_de.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_el.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_en.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO.
+connect-to-pagespeed=Connect To PageSpeed
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit.
+default-page-audit-image-alt-description=Default Page Audit image.
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports
 page-audit=Page Audit
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed.

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_en_AU.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_en_GB.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_es.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_et.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_eu.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_fa.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_fi.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Asetteluraportit
 page-audit=Sivun Valvonta
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_fr.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_fr_CA.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_gl.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_hr.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_hu.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_in.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_it.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_iw.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ja.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=レイアウトレポート
 page-audit=ページ監査
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_kk.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ko.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_lo.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_lt.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ms.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_nb.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_nl.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_pl.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ro.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ru.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_sk.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_sl.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_sv.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_ta_IN.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_th.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_tr.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_uk.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_vi.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,2 +1,7 @@
+check-issues-that-impact-on-your-page's-accessibility-and-seo=Check issues that impact on your page's accessibility and SEO. (Automatic Copy)
+connect-to-pagespeed=Connect To PageSpeed (Automatic Copy)
+connect-to-pagespeed-to-run-a-page-audit=Connect to PageSpeed to run a Page Audit. (Automatic Copy)
+default-page-audit-image-alt-description=Default Page Audit image. (Automatic Copy)
 javax.portlet.title.com_liferay_layout_reports_web_internal_portlet_LayoutReportsPortlet=Layout Reports (Automatic Copy)
 page-audit=Page Audit (Automatic Copy)
+to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed=To run a Page Audit connect with PageSpeed from Instance Settings > Pages > PageSpeed. (Automatic Copy)

--- a/modules/apps/layout/layout-reports-web/test/js/components/BasicInformation.js
+++ b/modules/apps/layout/layout-reports-web/test/js/components/BasicInformation.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import BasicInformation from '../../../src/main/resources/META-INF/resources/js/components/BasicInformation';
+
+import '@testing-library/jest-dom/extend-expect';
+
+const testProps = {
+	canonicalURLs: [
+		{
+			canonicalURL: 'http://foo.com:8080/en/web/guest/home',
+			languageId: 'en-US',
+			title: 'Home',
+		},
+		{
+			canonicalURL: 'http://foo.com:8080/es/en/web/guest/inicio',
+			languageId: 'es-ES',
+			title: 'Inicio',
+		},
+	],
+	defaultLanguageId: 'en-US',
+};
+
+describe('BasicInformation', () => {
+	afterEach(cleanup);
+
+	it('renders page title, canonicalURL and languages', () => {
+		const {getByText} = render(
+			<BasicInformation
+				canonicalURLs={testProps.canonicalURLs}
+				defaultLanguageId={testProps.defaultLanguageId}
+			/>
+		);
+
+		expect(getByText('Home')).toBeInTheDocument();
+		expect(
+			getByText('http://foo.com:8080/en/web/guest/home')
+		).toBeInTheDocument();
+	});
+
+	it('renders page title and canonicalURL changed when selecting another language in the dropdown', () => {
+		const {getByText} = render(
+			<BasicInformation
+				canonicalURLs={testProps.canonicalURLs}
+				defaultLanguageId={testProps.defaultLanguageId}
+			/>
+		);
+
+		const dropdownItem = getByText('es-ES');
+
+		userEvent.click(dropdownItem);
+
+		expect(getByText('Inicio')).toBeInTheDocument();
+		expect(
+			getByText('http://foo.com:8080/es/en/web/guest/inicio')
+		).toBeInTheDocument();
+	});
+});

--- a/modules/apps/layout/layout-reports-web/test/js/components/EmptyLayoutReports.js
+++ b/modules/apps/layout/layout-reports-web/test/js/components/EmptyLayoutReports.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import EmptyLayoutReports from '../../../src/main/resources/META-INF/resources/js/components/EmptyLayoutReports';
+
+import '@testing-library/jest-dom/extend-expect';
+
+const testProps = {
+	assetsPath: 'assetsPath',
+	showButton: false,
+};
+
+describe('EmptyLayoutReports', () => {
+	afterEach(cleanup);
+
+	it('renders empty view with information', () => {
+		const {getByText} = render(
+			<EmptyLayoutReports
+				assetsPath={testProps.assetsPath}
+				showButton={testProps.showButton}
+			/>
+		);
+
+		expect(
+			getByText(
+				"check-issues-that-impact-on-your-page's-accessibility-and-seo"
+			)
+		).toBeInTheDocument();
+		expect(
+			getByText(
+				'to-run-a-page-audit-connect-with-pagespeed-from-instance-settings-pages-pagespeed'
+			)
+		).toBeInTheDocument();
+	});
+
+	it('renders empty view with information and button', () => {
+		const {getByText} = render(
+			<EmptyLayoutReports
+				assetsPath={testProps.assetsPath}
+				showButton={true}
+			/>
+		);
+
+		expect(
+			getByText(
+				"check-issues-that-impact-on-your-page's-accessibility-and-seo"
+			)
+		).toBeInTheDocument();
+		expect(
+			getByText('connect-to-pagespeed-to-run-a-page-audit')
+		).toBeInTheDocument();
+		expect(getByText('connect-to-pagespeed')).toBeInTheDocument();
+	});
+});

--- a/modules/apps/layout/layout-reports-web/test/js/components/LanguagesDropdown.js
+++ b/modules/apps/layout/layout-reports-web/test/js/components/LanguagesDropdown.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import LanguagesDropdown from '../../../src/main/resources/META-INF/resources/js/components/LanguagesDropdown';
+
+import '@testing-library/jest-dom/extend-expect';
+
+const noop = () => {};
+
+describe('LanguageDropdown', () => {
+	afterEach(cleanup);
+
+	it('renders all available languages', () => {
+		const testProps = {
+			canonicalURLs: [
+				{
+					canonicalURL: 'http://foo.com:8080/en/web/guest/home',
+					languageId: 'en-US',
+					title: 'Home',
+				},
+				{
+					canonicalURL: 'http://foo.com:8080/es/en/web/guest/inicio',
+					languageId: 'es-ES',
+					title: 'Inicio',
+				},
+			],
+			defaultLanguageId: 'en-US',
+			selectedLanguageId: 'en-US',
+		};
+
+		const {getAllByText, getByText} = render(
+			<LanguagesDropdown
+				canonicalURLs={testProps.canonicalURLs}
+				defaultLanguageId={testProps.defaultLanguageId}
+				onSelectedLanguageId={noop}
+				selectedLanguageId={testProps.selectedLanguageId}
+			/>
+		);
+
+		const defaultLanguageId = getAllByText('en-US');
+		expect(defaultLanguageId.length === 2);
+		expect(defaultLanguageId[0]).toBeInTheDocument();
+
+		expect(getByText('es-ES')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
**Description**

Show empty/default Page Audit view in the sidebar when the user is not connected yet with PageSpeed functionality.

**How to test it**

- Add config file in `~/bundles/osgi/configs` to display the Page Audit icon in the Control Menu (you can find it in the ticket: https://issues.liferay.com/browse/LPS-119068)
- Create a Page
- Open the Page Audit sidebar panel

![Screenshot 2021-03-15 at 11 04 46](https://user-images.githubusercontent.com/15845466/111136682-48e0d600-857e-11eb-8e44-0405d7f64abc.png)

**Within this pull request**

- Inject react data to frontend via React props
- Create the empty view
- Frontend unit tests

**Commits**

- LPS-119068 Inject data to frontend 10b18c24
- LPS-119068 Create react app and empty page audit view cd376f6
- LPS-119068 BuildLang b4c1f87
- LPS-119068 Add frontend tests 9d0ce24

**Screenshots**

![Screenshot 2021-03-15 at 11 03 23](https://user-images.githubusercontent.com/15845466/111136480-1505b080-857e-11eb-9725-00c2a7f0dd10.png) ![Screenshot 2021-03-15 at 10 58 15](https://user-images.githubusercontent.com/15845466/111136577-3070bb80-857e-11eb-819e-30044329d581.png)