### PR TITLE
LPS-128998 [Content Performance] Separate dispatch from state and unified warnings

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -16,7 +16,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
-import {StoreContext} from '../context/StoreContext';
+import {StoreStateContext} from '../context/StoreContext';
 
 function Author({author: {authorId, name, url}}) {
 	return (
@@ -40,7 +40,7 @@ function Author({author: {authorId, name, url}}) {
 }
 
 function BasicInformation({author, canonicalURL, publishDate, title}) {
-	const [{languageTag}] = useContext(StoreContext);
+	const {languageTag} = useContext(StoreStateContext);
 
 	const formattedPublishDate = Intl.DateTimeFormat(languageTag, {
 		day: 'numeric',

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -36,7 +36,7 @@ import {
 	useSetLoading,
 } from '../context/ChartStateContext';
 import ConnectionContext from '../context/ConnectionContext';
-import {StoreStateContext, useHistoricalWarning} from '../context/StoreContext';
+import {StoreDispatchContext, StoreStateContext} from '../context/StoreContext';
 import {generateDateFormatters as dateFormat} from '../utils/dateFormat';
 import {numberFormat} from '../utils/numberFormat';
 import {ActiveDot as CustomActiveDot, Dot as CustomDot} from './CustomDots';
@@ -142,6 +142,8 @@ export default function Chart({
 }) {
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
+	const dispatch = useContext(StoreDispatchContext);
+
 	const {languageTag, publishedToday} = useContext(StoreStateContext);
 
 	const chartState = useChartState();
@@ -149,8 +151,6 @@ export default function Chart({
 	const {firstDate, lastDate} = useDateTitle();
 
 	const isPreviousPeriodButtonDisabled = useIsPreviousPeriodButtonDisabled();
-
-	const [, addHistoricalWarning] = useHistoricalWarning();
 
 	const addDataSetItems = useAddDataSetItems();
 
@@ -206,7 +206,7 @@ export default function Chart({
 						};
 					}
 					else {
-						addHistoricalWarning();
+						dispatch({type: 'ADD_WARNING'});
 					}
 				}
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -36,7 +36,7 @@ import {
 	useSetLoading,
 } from '../context/ChartStateContext';
 import ConnectionContext from '../context/ConnectionContext';
-import {StoreContext, useHistoricalWarning} from '../context/StoreContext';
+import {StoreStateContext, useHistoricalWarning} from '../context/StoreContext';
 import {generateDateFormatters as dateFormat} from '../utils/dateFormat';
 import {numberFormat} from '../utils/numberFormat';
 import {ActiveDot as CustomActiveDot, Dot as CustomDot} from './CustomDots';
@@ -142,7 +142,7 @@ export default function Chart({
 }) {
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
-	const [{languageTag, publishedToday}] = useContext(StoreContext);
+	const {languageTag, publishedToday} = useContext(StoreStateContext);
 
 	const chartState = useChartState();
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Keywords.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Keywords.js
@@ -17,7 +17,7 @@ import ClayList from '@clayui/list';
 import PropTypes from 'prop-types';
 import React, {useContext, useMemo, useState} from 'react';
 
-import {StoreContext} from '../context/StoreContext';
+import {StoreStateContext} from '../context/StoreContext';
 import {numberFormat} from '../utils/numberFormat';
 import Hint from './Hint';
 
@@ -34,7 +34,7 @@ export default function Keywords({currentPage}) {
 		KEYWORD_VALUE_TYPE[0]
 	);
 
-	const [{languageTag, publishedToday}] = useContext(StoreContext);
+	const {languageTag, publishedToday} = useContext(StoreStateContext);
 
 	const countries = useMemo(() => {
 		const dataKeys = new Set();

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -31,14 +31,9 @@ export default function Navigation({
 	timeSpanOptions,
 	viewURLs,
 }) {
-	const {
-		endpoints,
-		historicalWarning,
-		namespace,
-		page,
-		publishedToday,
-		warning,
-	} = useContext(StoreStateContext);
+	const {endpoints, namespace, page, publishedToday, warning} = useContext(
+		StoreStateContext
+	);
 
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
@@ -144,7 +139,7 @@ export default function Navigation({
 				</ClayAlert>
 			)}
 
-			{validAnalyticsConnection && (historicalWarning || warning) && (
+			{validAnalyticsConnection && warning && (
 				<ClayAlert displayType="warning" variant="stripe">
 					{Liferay.Language.get(
 						'some-data-is-temporarily-unavailable'
@@ -152,20 +147,15 @@ export default function Navigation({
 				</ClayAlert>
 			)}
 
-			{validAnalyticsConnection &&
-				publishedToday &&
-				!historicalWarning &&
-				!warning && (
-					<ClayAlert
-						displayType="info"
-						title={Liferay.Language.get('no-data-is-available-yet')}
-						variant="stripe"
-					>
-						{Liferay.Language.get(
-							'content-has-just-been-published'
-						)}
-					</ClayAlert>
-				)}
+			{validAnalyticsConnection && publishedToday && !warning && (
+				<ClayAlert
+					displayType="info"
+					title={Liferay.Language.get('no-data-is-available-yet')}
+					variant="stripe"
+				>
+					{Liferay.Language.get('content-has-just-been-published')}
+				</ClayAlert>
+			)}
 
 			{currentPage.view === 'main' && (
 				<div>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -15,7 +15,7 @@ import React, {useCallback, useContext, useState} from 'react';
 
 import {useChartState} from '../context/ChartStateContext';
 import ConnectionContext from '../context/ConnectionContext';
-import {StoreContext} from '../context/StoreContext';
+import {StoreStateContext} from '../context/StoreContext';
 import APIService from '../utils/APIService';
 import Detail from './Detail';
 import Main from './Main';
@@ -31,16 +31,14 @@ export default function Navigation({
 	timeSpanOptions,
 	viewURLs,
 }) {
-	const [
-		{
-			endpoints,
-			historicalWarning,
-			namespace,
-			page,
-			publishedToday,
-			warning,
-		},
-	] = useContext(StoreContext);
+	const {
+		endpoints,
+		historicalWarning,
+		namespace,
+		page,
+		publishedToday,
+		warning,
+	} = useContext(StoreStateContext);
 
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import React, {useContext, useEffect} from 'react';
 
 import ConnectionContext from '../context/ConnectionContext';
-import {StoreStateContext, useWarning} from '../context/StoreContext';
+import {StoreDispatchContext, StoreStateContext} from '../context/StoreContext';
 import {numberFormat} from '../utils/numberFormat';
 import Hint from './Hint';
 
@@ -32,7 +32,7 @@ function TotalCount({
 
 	const [value, setValue] = useStateSafe('-');
 
-	const [, addWarning] = useWarning();
+	const dispatch = useContext(StoreDispatchContext);
 
 	const {languageTag, publishedToday} = useContext(StoreStateContext);
 
@@ -42,10 +42,10 @@ function TotalCount({
 				.then(setValue)
 				.catch(() => {
 					setValue('-');
-					addWarning();
+					dispatch({type: 'ADD_WARNING'});
 				});
 		}
-	}, [addWarning, dataProvider, setValue, validAnalyticsConnection]);
+	}, [dispatch, dataProvider, setValue, validAnalyticsConnection]);
 
 	let displayValue = '-';
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import React, {useContext, useEffect} from 'react';
 
 import ConnectionContext from '../context/ConnectionContext';
-import {StoreContext, useWarning} from '../context/StoreContext';
+import {StoreStateContext, useWarning} from '../context/StoreContext';
 import {numberFormat} from '../utils/numberFormat';
 import Hint from './Hint';
 
@@ -34,7 +34,7 @@ function TotalCount({
 
 	const [, addWarning] = useWarning();
 
-	const [{languageTag, publishedToday}] = useContext(StoreContext);
+	const {languageTag, publishedToday} = useContext(StoreStateContext);
 
 	useEffect(() => {
 		if (validAnalyticsConnection) {

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -17,7 +17,7 @@ import React, {useContext, useEffect, useMemo, useState} from 'react';
 import {Cell, Pie, PieChart, Tooltip} from 'recharts';
 
 import ConnectionContext from '../context/ConnectionContext';
-import {StoreStateContext, useWarning} from '../context/StoreContext';
+import {StoreDispatchContext, StoreStateContext} from '../context/StoreContext';
 import {numberFormat} from '../utils/numberFormat';
 import EmptyPieChart from './EmptyPieChart';
 import Hint from './Hint';
@@ -48,9 +48,9 @@ const getColorByName = (name) => COLORS_MAP[name] || FALLBACK_COLOR;
 export default function TrafficSources({dataProvider, onTrafficSourceClick}) {
 	const [highlighted, setHighlighted] = useState(null);
 
-	const [, addWarning] = useWarning();
-
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
+
+	const dispatch = useContext(StoreDispatchContext);
 
 	const {languageTag, publishedToday} = useContext(StoreStateContext);
 
@@ -62,10 +62,10 @@ export default function TrafficSources({dataProvider, onTrafficSourceClick}) {
 				.then((trafficSources) => setTrafficSources(trafficSources))
 				.catch(() => {
 					setTrafficSources([]);
-					addWarning();
+					dispatch({type: 'ADD_WARNING'});
 				});
 		}
-	}, [addWarning, dataProvider, setTrafficSources, validAnalyticsConnection]);
+	}, [dispatch, dataProvider, setTrafficSources, validAnalyticsConnection]);
 
 	const fullPieChart = useMemo(
 		() =>
@@ -82,9 +82,9 @@ export default function TrafficSources({dataProvider, onTrafficSourceClick}) {
 
 	useEffect(() => {
 		if (missingTrafficSourceValue) {
-			addWarning();
+			dispatch({type: 'ADD_WARNING'});
 		}
-	}, [addWarning, missingTrafficSourceValue]);
+	}, [dispatch, missingTrafficSourceValue]);
 
 	function handleLegendMouseEnter(name) {
 		setHighlighted(name);

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -17,7 +17,7 @@ import React, {useContext, useEffect, useMemo, useState} from 'react';
 import {Cell, Pie, PieChart, Tooltip} from 'recharts';
 
 import ConnectionContext from '../context/ConnectionContext';
-import {StoreContext, useWarning} from '../context/StoreContext';
+import {StoreStateContext, useWarning} from '../context/StoreContext';
 import {numberFormat} from '../utils/numberFormat';
 import EmptyPieChart from './EmptyPieChart';
 import Hint from './Hint';
@@ -52,7 +52,7 @@ export default function TrafficSources({dataProvider, onTrafficSourceClick}) {
 
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
-	const [{languageTag, publishedToday}] = useContext(StoreContext);
+	const {languageTag, publishedToday} = useContext(StoreStateContext);
 
 	const [trafficSources, setTrafficSources] = useStateSafe([]);
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Translation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Translation.js
@@ -18,10 +18,10 @@ import PropTypes from 'prop-types';
 import React, {useContext, useMemo, useState} from 'react';
 
 import {useChartState} from '../context/ChartStateContext';
-import {StoreContext} from '../context/StoreContext';
+import {StoreStateContext} from '../context/StoreContext';
 
 export default function Translation({onSelectedLanguageClick, viewURLs}) {
-	const [{languageTag: defaultLanguage}] = useContext(StoreContext);
+	const {languageTag: defaultLanguage} = useContext(StoreStateContext);
 
 	const [active, setActive] = useState(false);
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
@@ -23,7 +23,7 @@ import {
 	useNextTimeSpan,
 	usePreviousTimeSpan,
 } from '../../context/ChartStateContext';
-import {StoreContext} from '../../context/StoreContext';
+import {StoreStateContext} from '../../context/StoreContext';
 import {generateDateFormatters as dateFormat} from '../../utils/dateFormat';
 import {numberFormat} from '../../utils/numberFormat';
 import Hint from '../Hint';
@@ -39,7 +39,7 @@ export default function ReferralDetail({
 	trafficShareDataProvider,
 	trafficVolumeDataProvider,
 }) {
-	const [{languageTag}] = useContext(StoreContext);
+	const {languageTag} = useContext(StoreStateContext);
 
 	const [isReferringPagesExpanded, setIsReferringPagesExpanded] = useState(
 		false

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
@@ -23,7 +23,7 @@ import {
 	useNextTimeSpan,
 	usePreviousTimeSpan,
 } from '../../context/ChartStateContext';
-import {StoreContext} from '../../context/StoreContext';
+import {StoreStateContext} from '../../context/StoreContext';
 import {generateDateFormatters as dateFormat} from '../../utils/dateFormat';
 import {numberFormat} from '../../utils/numberFormat';
 import TimeSpanSelector from '../TimeSpanSelector';
@@ -48,7 +48,7 @@ export default function SocialDetail({
 	trafficShareDataProvider,
 	trafficVolumeDataProvider,
 }) {
-	const [{languageTag}] = useContext(StoreContext);
+	const {languageTag} = useContext(StoreStateContext);
 
 	const {referringSocialMedia} = currentPage.data;
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/StoreContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/StoreContext.js
@@ -21,7 +21,8 @@ const ADD_WARNING = 'add-warning';
 
 const noop = () => {};
 
-export const StoreContext = createContext([INITIAL_STATE, noop]);
+export const StoreDispatchContext = React.createContext(() => {});
+export const StoreStateContext = createContext([INITIAL_STATE, noop]);
 
 function reducer(state = INITIAL_STATE, action) {
 	if (action.type === ADD_HISTORICAL_WARNING) {
@@ -37,17 +38,19 @@ function reducer(state = INITIAL_STATE, action) {
 }
 
 export function StoreContextProvider({children, value}) {
-	const stateAndDispatch = useReducer(reducer, {...INITIAL_STATE, ...value});
+	const [state, dispatch] = useReducer(reducer, {...INITIAL_STATE, ...value});
 
 	return (
-		<StoreContext.Provider value={stateAndDispatch}>
-			{children}
-		</StoreContext.Provider>
+		<StoreDispatchContext.Provider value={dispatch}>
+			<StoreStateContext.Provider value={state}>
+				{children}
+			</StoreStateContext.Provider>
+		</StoreDispatchContext.Provider>
 	);
 }
 
 export function useHistoricalWarning() {
-	const [state, dispatch] = useContext(StoreContext);
+	const [state, dispatch] = useContext(StoreStateContext);
 
 	const addHistoricalWarning = useCallback(() => {
 		dispatch({
@@ -61,7 +64,7 @@ export function useHistoricalWarning() {
 }
 
 export function useWarning() {
-	const [state, dispatch] = useContext(StoreContext);
+	const [state, dispatch] = useContext(StoreStateContext);
 
 	const addWarning = useCallback(() => {
 		dispatch({

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/StoreContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/StoreContext.js
@@ -9,15 +9,14 @@
  * distribution rights of the Software.
  */
 
-import React, {createContext, useCallback, useContext, useReducer} from 'react';
+import React, {createContext, useReducer} from 'react';
+
+const ADD_WARNING = 'ADD_WARNING';
 
 const INITIAL_STATE = {
-	historicalWarning: false,
 	publishedToday: false,
 	warning: false,
 };
-const ADD_HISTORICAL_WARNING = 'add-historical-warning';
-const ADD_WARNING = 'add-warning';
 
 const noop = () => {};
 
@@ -25,16 +24,17 @@ export const StoreDispatchContext = React.createContext(() => {});
 export const StoreStateContext = createContext([INITIAL_STATE, noop]);
 
 function reducer(state = INITIAL_STATE, action) {
-	if (action.type === ADD_HISTORICAL_WARNING) {
-		return state.historicalWarning
-			? state
-			: {...state, historicalWarning: true};
-	}
-	else if (action.type === ADD_WARNING) {
-		return state.warning ? state : {...state, warning: true};
+	let nextState = state;
+
+	switch (action.type) {
+		case ADD_WARNING:
+			nextState = state.warning ? state : {...state, warning: true};
+			break;
+		default:
+			return state;
 	}
 
-	return state;
+	return nextState;
 }
 
 export function StoreContextProvider({children, value}) {
@@ -47,32 +47,4 @@ export function StoreContextProvider({children, value}) {
 			</StoreStateContext.Provider>
 		</StoreDispatchContext.Provider>
 	);
-}
-
-export function useHistoricalWarning() {
-	const [state, dispatch] = useContext(StoreStateContext);
-
-	const addHistoricalWarning = useCallback(() => {
-		dispatch({
-			type: ADD_HISTORICAL_WARNING,
-		});
-	}, [dispatch]);
-
-	const hasHistoricalWarning = state.historicalWarning;
-
-	return [hasHistoricalWarning, addHistoricalWarning];
-}
-
-export function useWarning() {
-	const [state, dispatch] = useContext(StoreStateContext);
-
-	const addWarning = useCallback(() => {
-		dispatch({
-			type: ADD_WARNING,
-		});
-	}, [dispatch]);
-
-	const hasWarning = state.warning;
-
-	return [hasWarning, addWarning];
 }


### PR DESCRIPTION
**Description**

This is the third pull request to fix [LPS-128998 Content Performance available endpoints should load at the same time](https://issues.liferay.com/browse/LPS-128998) as I said in a previous PR (see `Notes` from description, but in summary, the idea is that every component reads data from the store instead of calling its `dataProvider` and wait until all endpoints are resolved to display the data in the UI): https://github.com/liferay-frontend/liferay-portal/pull/885#issue-588734880.

As the pull can be huge, I'm going to create sub-tasks for the issue and send the code for each of them separately.

**How to test it**

- Connect Liferay DXP with Analytics Cloud
- Create a Content Page
- Wait 24 hours to let Analytics Cloud process the data (if you don't want to wait for it, change the date of your computer and create the page in the past 😉  )
- Open the Content Performance panel

**Within this pull request**

Everything should work as before. No UI changes.
- Separate dispatch from state in StoreContext
- Unified historical warning and warning (we are not displaying different messages, so a simple warning is enough)
- Use dispatch to call `addWarning` action

**Final solution for the issue**

In the future the handlers from `Navigation` component will be converted into actions and dispatch it when necessary. Also, some information will be removed from the prop-drilling and save it in the store as-well. Components will read from the store to display the data.

**History pull requests**

- LPS-128998 [Content Performance] Refactor APIService to be called in any component: https://github.com/brianchandotcom/liferay-portal/pull/99816
- LPS-128998 [Content Performance] Save attributes in store instead of prop-drilling them: https://github.com/brianchandotcom/liferay-portal/pull/99883