### PR TITLE
LPS-129169 Some management toolbars do not display the stored display style

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserManagementToolbarDisplayContext.java
@@ -223,6 +223,11 @@ public class AssetBrowserManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _assetBrowserDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesManagementToolbarDisplayContext.java
@@ -218,6 +218,11 @@ public class AssetCategoriesManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _assetCategoriesDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		if (_assetCategoriesDisplayContext.isFlattenedNavigationAllowed()) {
 			return new String[0];

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetVocabulariesManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetVocabulariesManagementToolbarDisplayContext.java
@@ -40,6 +40,8 @@ public class AssetVocabulariesManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			assetCategoriesDisplayContext.getVocabulariesSearchContainer());
+
+		_assetCategoriesDisplayContext = assetCategoriesDisplayContext;
 	}
 
 	@Override
@@ -64,6 +66,11 @@ public class AssetVocabulariesManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _assetCategoriesDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}
@@ -77,5 +84,7 @@ public class AssetVocabulariesManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"create-date"};
 	}
+
+	private final AssetCategoriesDisplayContext _assetCategoriesDisplayContext;
 
 }

--- a/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsManagementToolbarDisplayContext.java
@@ -140,6 +140,11 @@ public class AssetTagsManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _assetTagsDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminManagementToolbarDisplayContext.java
@@ -173,6 +173,11 @@ public class DepotAdminManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _depotAdminDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext.java
@@ -32,7 +32,8 @@ public class ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext
 	extends SearchContainerManagementToolbarDisplayContext {
 
 	public ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext(
-		ItemSelectorViewDescriptor<Object> itemSelectorViewDescriptor,
+		ItemSelectorViewDescriptorRendererDisplayContext
+			itemSelectorViewDescriptorRendererDisplayContext,
 		HttpServletRequest httpServletRequest,
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
@@ -42,7 +43,12 @@ public class ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			searchContainer);
 
-		_itemSelectorViewDescriptor = itemSelectorViewDescriptor;
+		_itemSelectorViewDescriptorRendererDisplayContext =
+			itemSelectorViewDescriptorRendererDisplayContext;
+
+		_itemSelectorViewDescriptor =
+			itemSelectorViewDescriptorRendererDisplayContext.
+				getItemSelectorViewDescriptor();
 	}
 
 	@Override
@@ -80,11 +86,19 @@ public class ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _itemSelectorViewDescriptorRendererDisplayContext.
+			getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"descriptive", "icon", "list"};
 	}
 
 	private final ItemSelectorViewDescriptor<Object>
 		_itemSelectorViewDescriptor;
+	private final ItemSelectorViewDescriptorRendererDisplayContext
+		_itemSelectorViewDescriptorRendererDisplayContext;
 
 }

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -26,7 +26,7 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 
 <c:if test="<%= itemSelectorViewDescriptor.isShowManagementToolbar() %>">
 	<clay:management-toolbar
-		managementToolbarDisplayContext="<%= new ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext(itemSelectorViewDescriptor, request, liferayPortletRequest, liferayPortletResponse, searchContainer) %>"
+		managementToolbarDisplayContext="<%= new ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext(itemSelectorViewDescriptorRendererDisplayContext, request, liferayPortletRequest, liferayPortletResponse, searchContainer) %>"
 	/>
 </c:if>
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewManagementToolbarDisplayContext.java
@@ -173,6 +173,11 @@ public class JournalArticleItemSelectorViewManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _journalArticleItemSelectorViewDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalFeedsManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalFeedsManagementToolbarDisplayContext.java
@@ -53,6 +53,8 @@ public class JournalFeedsManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			journalFeedsDisplayContext.getFeedsSearchContainer());
+
+		_journalFeedsDisplayContext = journalFeedsDisplayContext;
 	}
 
 	@Override
@@ -148,6 +150,11 @@ public class JournalFeedsManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _journalFeedsDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}
@@ -161,5 +168,7 @@ public class JournalFeedsManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"name", "id"};
 	}
+
+	private final JournalFeedsDisplayContext _journalFeedsDisplayContext;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryManagementToolbarDisplayContext.java
@@ -55,6 +55,7 @@ public class JournalHistoryManagementToolbarDisplayContext
 			journalHistoryDisplayContext.getArticleSearchContainer());
 
 		_article = article;
+		_journalHistoryDisplayContext = journalHistoryDisplayContext;
 	}
 
 	@Override
@@ -175,6 +176,11 @@ public class JournalHistoryManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _journalHistoryDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -193,5 +199,6 @@ public class JournalHistoryManagementToolbarDisplayContext
 		JournalHistoryManagementToolbarDisplayContext.class);
 
 	private final JournalArticle _article;
+	private final JournalHistoryDisplayContext _journalHistoryDisplayContext;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalSelectDDMTemplateManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalSelectDDMTemplateManagementToolbarDisplayContext.java
@@ -81,6 +81,11 @@ public class JournalSelectDDMTemplateManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _journalSelectDDMTemplateDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "icon"};
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/OrphanPortletsManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/OrphanPortletsManagementToolbarDisplayContext.java
@@ -40,6 +40,8 @@ public class OrphanPortletsManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			orphanPortletsDisplayContext.getOrphanPortletsSearchContainer());
+
+		_orphanPortletsDisplayContext = orphanPortletsDisplayContext;
 	}
 
 	@Override
@@ -61,6 +63,11 @@ public class OrphanPortletsManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _orphanPortletsDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}
@@ -74,5 +81,7 @@ public class OrphanPortletsManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"name"};
 	}
+
+	private final OrphanPortletsDisplayContext _orphanPortletsDisplayContext;
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectThemeManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectThemeManagementToolbarDisplayContext.java
@@ -35,6 +35,8 @@ public class SelectThemeManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			selectThemeDisplayContext.getThemesSearchContainer());
+
+		_selectThemeDisplayContext = selectThemeDisplayContext;
 	}
 
 	@Override
@@ -45,6 +47,11 @@ public class SelectThemeManagementToolbarDisplayContext
 	@Override
 	public Boolean isSelectable() {
 		return false;
+	}
+
+	@Override
+	protected String getDisplayStyle() {
+		return _selectThemeDisplayContext.getDisplayStyle();
 	}
 
 	@Override
@@ -61,5 +68,7 @@ public class SelectThemeManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"name"};
 	}
+
+	private final SelectThemeDisplayContext _selectThemeDisplayContext;
 
 }

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationTemplatesManagementToolbarDisplayContext.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationTemplatesManagementToolbarDisplayContext.java
@@ -42,6 +42,9 @@ public class PortletConfigurationTemplatesManagementToolbarDisplayContext
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			portletConfigurationTemplatesDisplayContext.
 				getArchivedSettingsSearchContainer());
+
+		_portletConfigurationTemplatesDisplayContext =
+			portletConfigurationTemplatesDisplayContext;
 	}
 
 	@Override
@@ -74,6 +77,11 @@ public class PortletConfigurationTemplatesManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _portletConfigurationTemplatesDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -87,5 +95,8 @@ public class PortletConfigurationTemplatesManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"name", "modified-date"};
 	}
+
+	private final PortletConfigurationTemplatesDisplayContext
+		_portletConfigurationTemplatesDisplayContext;
 
 }

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminManagementToolbarDisplayContext.java
@@ -161,6 +161,11 @@ public class SiteNavigationAdminManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _siteNavigationAdminDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/java/com/liferay/site/navigation/item/selector/web/internal/display/context/SiteNavigationMenuItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/java/com/liferay/site/navigation/item/selector/web/internal/display/context/SiteNavigationMenuItemSelectorViewManagementToolbarDisplayContext.java
@@ -40,6 +40,9 @@ public class SiteNavigationMenuItemSelectorViewManagementToolbarDisplayContext
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			siteNavigationMenuItemSelectorViewDisplayContext.
 				getSearchContainer());
+
+		_siteNavigationMenuItemSelectorViewDisplayContext =
+			siteNavigationMenuItemSelectorViewDisplayContext;
 	}
 
 	@Override
@@ -69,6 +72,12 @@ public class SiteNavigationMenuItemSelectorViewManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _siteNavigationMenuItemSelectorViewDisplayContext.
+			getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}
@@ -82,5 +91,8 @@ public class SiteNavigationMenuItemSelectorViewManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"create-date", "name"};
 	}
+
+	private final SiteNavigationMenuItemSelectorViewDisplayContext
+		_siteNavigationMenuItemSelectorViewDisplayContext;
 
 }

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminManagementToolbarDisplayContext.java
@@ -185,6 +185,11 @@ public class SiteAdminManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _siteAdminDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}

--- a/modules/apps/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserManagementToolbarDisplayContext.java
@@ -83,6 +83,11 @@ public class SiteBrowserManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _siteBrowserDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}

--- a/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/SitesItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/SitesItemSelectorViewManagementToolbarDisplayContext.java
@@ -96,6 +96,11 @@ public class SitesItemSelectorViewManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _sitesItemSelectorViewDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/OrganizationsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/OrganizationsManagementToolbarDisplayContext.java
@@ -193,6 +193,11 @@ public class OrganizationsManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _organizationsDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/RolesManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/RolesManagementToolbarDisplayContext.java
@@ -40,6 +40,8 @@ public class RolesManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			rolesDisplayContext.getRoleSearchSearchContainer());
+
+		_rolesDisplayContext = rolesDisplayContext;
 	}
 
 	@Override
@@ -74,6 +76,11 @@ public class RolesManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _rolesDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -87,5 +94,7 @@ public class RolesManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"title"};
 	}
+
+	private final RolesDisplayContext _rolesDisplayContext;
 
 }

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectOrganizationsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectOrganizationsManagementToolbarDisplayContext.java
@@ -39,6 +39,8 @@ public class SelectOrganizationsManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			selectOrganizationsDisplayContext.getOrganizationSearchContainer());
+
+		_selectOrganizationsDisplayContext = selectOrganizationsDisplayContext;
 	}
 
 	@Override
@@ -68,6 +70,11 @@ public class SelectOrganizationsManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _selectOrganizationsDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -81,5 +88,8 @@ public class SelectOrganizationsManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"name", "type"};
 	}
+
+	private final SelectOrganizationsDisplayContext
+		_selectOrganizationsDisplayContext;
 
 }

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectRolesManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectRolesManagementToolbarDisplayContext.java
@@ -39,6 +39,8 @@ public class SelectRolesManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			selectRolesDisplayContext.getRoleSearchSearchContainer());
+
+		_selectRolesDisplayContext = selectRolesDisplayContext;
 	}
 
 	@Override
@@ -78,6 +80,11 @@ public class SelectRolesManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _selectRolesDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -91,5 +98,7 @@ public class SelectRolesManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"title"};
 	}
+
+	private final SelectRolesDisplayContext _selectRolesDisplayContext;
 
 }

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUserGroupsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUserGroupsManagementToolbarDisplayContext.java
@@ -38,6 +38,8 @@ public class SelectUserGroupsManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			selectUserGroupsDisplayContext.getUserGroupSearchContainer());
+
+		_selectUserGroupsDisplayContext = selectUserGroupsDisplayContext;
 	}
 
 	@Override
@@ -67,6 +69,11 @@ public class SelectUserGroupsManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _selectUserGroupsDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}
@@ -80,5 +87,8 @@ public class SelectUserGroupsManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"name", "description"};
 	}
+
+	private final SelectUserGroupsDisplayContext
+		_selectUserGroupsDisplayContext;
 
 }

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersManagementToolbarDisplayContext.java
@@ -38,6 +38,8 @@ public class SelectUsersManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			selectUsersDisplayContext.getUserSearchContainer());
+
+		_selectUsersDisplayContext = selectUsersDisplayContext;
 	}
 
 	@Override
@@ -72,6 +74,11 @@ public class SelectUsersManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _selectUsersDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -85,5 +92,7 @@ public class SelectUsersManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"first-name", "screen-name"};
 	}
+
+	private final SelectUsersDisplayContext _selectUsersDisplayContext;
 
 }

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserGroupRolesManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserGroupRolesManagementToolbarDisplayContext.java
@@ -40,6 +40,8 @@ public class UserGroupRolesManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			userGroupRolesDisplayContext.getRoleSearchSearchContainer());
+
+		_userGroupRolesDisplayContext = userGroupRolesDisplayContext;
 	}
 
 	@Override
@@ -74,6 +76,11 @@ public class UserGroupRolesManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _userGroupRolesDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -87,5 +94,7 @@ public class UserGroupRolesManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"title"};
 	}
+
+	private final UserGroupRolesDisplayContext _userGroupRolesDisplayContext;
 
 }

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserGroupsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserGroupsManagementToolbarDisplayContext.java
@@ -298,6 +298,11 @@ public class UserGroupsManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _userGroupsDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserRolesManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserRolesManagementToolbarDisplayContext.java
@@ -40,6 +40,8 @@ public class UserRolesManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			userRolesDisplayContext.getRoleSearchSearchContainer());
+
+		_userRolesDisplayContext = userRolesDisplayContext;
 	}
 
 	@Override
@@ -74,6 +76,11 @@ public class UserRolesManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _userRolesDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -87,5 +94,7 @@ public class UserRolesManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"title"};
 	}
+
+	private final UserRolesDisplayContext _userRolesDisplayContext;
 
 }

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UsersManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UsersManagementToolbarDisplayContext.java
@@ -331,6 +331,11 @@ public class UsersManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _usersDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/ViewMembershipRequestsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/ViewMembershipRequestsManagementToolbarDisplayContext.java
@@ -37,6 +37,9 @@ public class ViewMembershipRequestsManagementToolbarDisplayContext
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			viewMembershipRequestsDisplayContext.
 				getSiteMembershipSearchContainer());
+
+		_viewMembershipRequestsDisplayContext =
+			viewMembershipRequestsDisplayContext;
 	}
 
 	@Override
@@ -55,6 +58,11 @@ public class ViewMembershipRequestsManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _viewMembershipRequestsDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -68,5 +76,8 @@ public class ViewMembershipRequestsManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"date"};
 	}
+
+	private final ViewMembershipRequestsDisplayContext
+		_viewMembershipRequestsDisplayContext;
 
 }

--- a/modules/apps/site/site-my-sites-web/src/main/java/com/liferay/site/my/sites/web/internal/display/context/SiteMySitesManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-my-sites-web/src/main/java/com/liferay/site/my/sites/web/internal/display/context/SiteMySitesManagementToolbarDisplayContext.java
@@ -38,6 +38,8 @@ public class SiteMySitesManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			siteMySitesDisplayContext.getGroupSearchContainer());
+
+		_siteMySitesDisplayContext = siteMySitesDisplayContext;
 	}
 
 	@Override
@@ -72,6 +74,11 @@ public class SiteMySitesManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _siteMySitesDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -85,5 +92,7 @@ public class SiteMySitesManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"name"};
 	}
+
+	private final SiteMySitesDisplayContext _siteMySitesDisplayContext;
 
 }

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUserGroupsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUserGroupsManagementToolbarDisplayContext.java
@@ -152,6 +152,12 @@ public class EditSiteTeamAssignmentsUserGroupsManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _editSiteTeamAssignmentsUserGroupsDisplayContext.
+			getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUsersManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUsersManagementToolbarDisplayContext.java
@@ -155,6 +155,11 @@ public class EditSiteTeamAssignmentsUsersManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _editSiteTeamAssignmentsUsersDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectTeamManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectTeamManagementToolbarDisplayContext.java
@@ -38,6 +38,8 @@ public class SelectTeamManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			selectTeamDisplayContext.getTeamSearchContainer());
+
+		_selectTeamDisplayContext = selectTeamDisplayContext;
 	}
 
 	@Override
@@ -67,6 +69,11 @@ public class SelectTeamManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _selectTeamDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}
@@ -80,5 +87,7 @@ public class SelectTeamManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"name"};
 	}
+
+	private final SelectTeamDisplayContext _selectTeamDisplayContext;
 
 }

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectUserGroupsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectUserGroupsManagementToolbarDisplayContext.java
@@ -38,6 +38,8 @@ public class SelectUserGroupsManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			selectUserGroupsDisplayContext.getUserGroupSearchContainer());
+
+		_selectUserGroupsDisplayContext = selectUserGroupsDisplayContext;
 	}
 
 	@Override
@@ -67,6 +69,11 @@ public class SelectUserGroupsManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _selectUserGroupsDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}
@@ -80,5 +87,8 @@ public class SelectUserGroupsManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"name", "description"};
 	}
+
+	private final SelectUserGroupsDisplayContext
+		_selectUserGroupsDisplayContext;
 
 }

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectUsersManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectUsersManagementToolbarDisplayContext.java
@@ -38,6 +38,8 @@ public class SelectUsersManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			selectUsersDisplayContext.getUserSearchContainer());
+
+		_selectUsersDisplayContext = selectUsersDisplayContext;
 	}
 
 	@Override
@@ -72,6 +74,11 @@ public class SelectUsersManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _selectUsersDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -85,5 +92,7 @@ public class SelectUsersManagementToolbarDisplayContext
 	protected String[] getOrderByKeys() {
 		return new String[] {"first-name", "screen-name"};
 	}
+
+	private final SelectUsersDisplayContext _selectUsersDisplayContext;
 
 }

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SiteTeamsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SiteTeamsManagementToolbarDisplayContext.java
@@ -54,6 +54,8 @@ public class SiteTeamsManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			siteTeamsDisplayContext.getSearchContainer());
+
+		_siteTeamsDisplayContext = siteTeamsDisplayContext;
 	}
 
 	@Override
@@ -146,6 +148,11 @@ public class SiteTeamsManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _siteTeamsDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive"};
 	}
@@ -162,5 +169,7 @@ public class SiteTeamsManagementToolbarDisplayContext
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SiteTeamsManagementToolbarDisplayContext.class);
+
+	private final SiteTeamsDisplayContext _siteTeamsDisplayContext;
 
 }

--- a/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashContainerManagementToolbarDisplayContext.java
+++ b/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashContainerManagementToolbarDisplayContext.java
@@ -40,6 +40,8 @@ public class TrashContainerManagementToolbarDisplayContext
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			trashDisplayContext.getTrashContainerSearchContainer());
+
+		_trashDisplayContext = trashDisplayContext;
 	}
 
 	@Override
@@ -74,6 +76,11 @@ public class TrashContainerManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _trashDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -82,5 +89,7 @@ public class TrashContainerManagementToolbarDisplayContext
 	protected String[] getNavigationKeys() {
 		return new String[] {"all"};
 	}
+
+	private final TrashDisplayContext _trashDisplayContext;
 
 }

--- a/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashManagementToolbarDisplayContext.java
+++ b/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashManagementToolbarDisplayContext.java
@@ -62,6 +62,8 @@ public class TrashManagementToolbarDisplayContext
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			trashDisplayContext.getEntrySearch());
 
+		_trashDisplayContext = trashDisplayContext;
+
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 	}
@@ -167,6 +169,11 @@ public class TrashManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _trashDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list", "descriptive", "icon"};
 	}
@@ -220,5 +227,6 @@ public class TrashManagementToolbarDisplayContext
 	}
 
 	private final ThemeDisplay _themeDisplay;
+	private final TrashDisplayContext _trashDisplayContext;
 
 }

--- a/modules/apps/users-admin/users-admin-item-selector-web/src/main/java/com/liferay/users/admin/item/selector/web/internal/display/context/UserItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/users-admin/users-admin-item-selector-web/src/main/java/com/liferay/users/admin/item/selector/web/internal/display/context/UserItemSelectorViewManagementToolbarDisplayContext.java
@@ -68,6 +68,11 @@ public class UserItemSelectorViewManagementToolbarDisplayContext
 	}
 
 	@Override
+	protected String getDisplayStyle() {
+		return _userItemSelectorViewDisplayContext.getDisplayStyle();
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"descriptive", "icon", "list"};
 	}


### PR DESCRIPTION
Fixes https://issues.liferay.com/browse/LPS-129169
- this issue is a splitoff from https://github.com/liferay-frontend/liferay-portal/pull/899. The bug was noticed in that ticket, but it was unrelated. See https://github.com/liferay-frontend/liferay-portal/pull/899#issuecomment-799295104
- this is somewhat the part 2 of [Make Display Style persist in multiple menus](https://github.com/brianchandotcom/liferay-portal/pull/98787), applying it to management toolbars.

@izaera @jbalsas @ealonso

The key change is that management toolbar needs to get the active display style from the same source as the rest of the page. Both need to use display contexts, that leverage the new utility. We added this in https://github.com/brianchandotcom/liferay-portal/pull/98787.

We have total of 146 management toolbars. 40 of them are updated in this PR. It was not possible to have a common solution in a base class, as the storage key is set in a display context, where both key and display context class are unique for each usage. Unfortunately our `*DisplayContext`s don't extend a base class, that would maybe make this PR easier.

These are the types of management toolbars that did **not** need to be updated:
- MTs with no display types
- MTs that implement `getViewTypeItems`. This attribute overrides the simpler `getDisplayViews` attribute and requires display style, so these are already using the value from context. These were the MTs that worked as expected from the ticket description, such as blogs.
- MTs with only one display type

Sample after the fix, there are too many to gif them all 
![after](https://user-images.githubusercontent.com/5435511/111187707-895b4680-85b4-11eb-9e2b-80a27c8a7758.gif)
