### PR TITLE
LPS-119068 [Page Audit] Close dropdown after selecting an item

### DIFF
--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/LanguagesDropdown.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/LanguagesDropdown.js
@@ -56,6 +56,7 @@ export default function LanguagesDropdown({
 						key={index}
 						onClick={() => {
 							onSelectedLanguageId(languageId);
+							setActive(false);
 						}}
 						symbolLeft={languageId.toLowerCase()}
 					>


### PR DESCRIPTION
**Description**

In the Page Audit sidebar panel, we have a dropdown with the different languages available for that page. The user can select click on them to see the metrics of that selected language.

**Solution**

When clicking, the sidebar does not call any endpoint for now, it's just rendering the title and canonicalURL from the props so we have to close the dropdown after selecting a language item.