### PR TITLE
LPS-128998 [Content Performance] Remove data providers from components and wait until all finished to display the data

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
@@ -12,8 +12,9 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useContext} from 'react';
 
+import {StoreDispatchContext} from '../context/StoreContext';
 import KeywordsDetail from './detail/KeywordsDetail';
 import ReferralDetail from './detail/ReferralDetail';
 import SocialDetail from './detail/SocialDetail';
@@ -29,11 +30,10 @@ const TRAFFIC_CHANNELS = {
 export default function Detail({
 	currentPage,
 	onCurrentPageChange,
-	onTrafficSourceNameChange,
 	timeSpanOptions,
-	trafficShareDataProvider,
-	trafficVolumeDataProvider,
 }) {
+	const dispatch = useContext(StoreDispatchContext);
+
 	return (
 		<>
 			<div className="c-pt-3 c-px-3 d-flex">
@@ -41,7 +41,10 @@ export default function Detail({
 					displayType="unstyled"
 					onClick={() => {
 						onCurrentPageChange({view: 'main'});
-						onTrafficSourceNameChange('');
+						dispatch({
+							selectedTrafficSourceName: '',
+							type: 'SET_SELECTED_TRAFFIC_SOURCE_NAME',
+						});
 					}}
 					small={true}
 				>
@@ -56,19 +59,13 @@ export default function Detail({
 			{(currentPage.view === TRAFFIC_CHANNELS.ORGANIC ||
 				currentPage.view === TRAFFIC_CHANNELS.PAID) &&
 				currentPage.data.countryKeywords.length > 0 && (
-					<KeywordsDetail
-						currentPage={currentPage}
-						trafficShareDataProvider={trafficShareDataProvider}
-						trafficVolumeDataProvider={trafficVolumeDataProvider}
-					/>
+					<KeywordsDetail currentPage={currentPage} />
 				)}
 
 			{currentPage.view === TRAFFIC_CHANNELS.REFERRAL && (
 				<ReferralDetail
 					currentPage={currentPage}
 					timeSpanOptions={timeSpanOptions}
-					trafficShareDataProvider={trafficShareDataProvider}
-					trafficVolumeDataProvider={trafficVolumeDataProvider}
 				/>
 			)}
 
@@ -76,8 +73,6 @@ export default function Detail({
 				<SocialDetail
 					currentPage={currentPage}
 					timeSpanOptions={timeSpanOptions}
-					trafficShareDataProvider={trafficShareDataProvider}
-					trafficVolumeDataProvider={trafficVolumeDataProvider}
 				/>
 			)}
 		</>
@@ -87,13 +82,10 @@ export default function Detail({
 Detail.proptypes = {
 	currentPage: PropTypes.object.isRequired,
 	onCurrentPageChange: PropTypes.func.isRequired,
-	onTrafficSourceNameChange: PropTypes.func.isRequired,
 	timeSpanOptions: PropTypes.arrayOf(
 		PropTypes.shape({
 			key: PropTypes.string,
 			label: PropTypes.string,
 		})
 	).isRequired,
-	trafficShareDataProvider: PropTypes.func.isRequired,
-	trafficVolumeDataProvider: PropTypes.func.isRequired,
 };

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
@@ -9,11 +9,14 @@
  * distribution rights of the Software.
  */
 
+import ClayLoadingIndicator from '@clayui/loading-indicator';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useContext} from 'react';
 
+import {StoreStateContext} from '../context/StoreContext';
 import BasicInformation from './BasicInformation';
 import Chart from './Chart';
+import Hint from './Hint';
 import TotalCount from './TotalCount';
 import TrafficSources from './TrafficSources';
 import Translation from './Translation';
@@ -21,18 +24,20 @@ import Translation from './Translation';
 export default function Main({
 	author,
 	canonicalURL,
-	chartDataProviders,
 	onSelectedLanguageClick,
 	onTrafficSourceClick,
 	pagePublishDate,
 	pageTitle,
 	timeSpanOptions,
-	totalReadsDataProvider,
-	totalViewsDataProvider,
-	trafficSourcesDataProvider,
 	viewURLs,
 }) {
-	return (
+	const {endpoints, loading, totalReads, totalViews} = useContext(
+		StoreStateContext
+	);
+
+	return loading ? (
+		<ClayLoadingIndicator small />
+	) : (
 		<div className="c-p-3">
 			<BasicInformation
 				author={author}
@@ -54,17 +59,16 @@ export default function Main({
 
 			<TotalCount
 				className="mb-2"
-				dataProvider={totalViewsDataProvider}
 				label={Liferay.Util.sub(Liferay.Language.get('total-views'))}
 				popoverHeader={Liferay.Language.get('total-views')}
 				popoverMessage={Liferay.Language.get(
 					'this-number-refers-to-the-total-number-of-views-since-the-content-was-published'
 				)}
+				value={totalViews}
 			/>
 
-			{totalReadsDataProvider && (
+			{endpoints.analyticsReportsTotalReadsURL && (
 				<TotalCount
-					dataProvider={totalReadsDataProvider}
 					label={Liferay.Util.sub(
 						Liferay.Language.get('total-reads')
 					)}
@@ -72,19 +76,25 @@ export default function Main({
 					popoverMessage={Liferay.Language.get(
 						'this-number-refers-to-the-total-number-of-reads-since-the-content-was-published'
 					)}
+					value={totalReads}
 				/>
 			)}
 
 			<Chart
-				dataProviders={chartDataProviders}
 				publishDate={pagePublishDate}
 				timeSpanOptions={timeSpanOptions}
 			/>
 
-			<TrafficSources
-				dataProvider={trafficSourcesDataProvider}
-				onTrafficSourceClick={onTrafficSourceClick}
-			/>
+			<h5 className="mt-3 sheet-subtitle">
+				{Liferay.Language.get('traffic-channels')}
+				<Hint
+					message={Liferay.Language.get('traffic-channels-help')}
+					secondary={true}
+					title={Liferay.Language.get('traffic-channels')}
+				/>
+			</h5>
+
+			<TrafficSources onTrafficSourceClick={onTrafficSourceClick} />
 		</div>
 	);
 }
@@ -92,7 +102,6 @@ export default function Main({
 Main.proptypes = {
 	author: PropTypes.object.isRequired,
 	canonicalURL: PropTypes.string.isRequired,
-	chartDataProviders: PropTypes.arrayOf(PropTypes.func.isRequired).isRequired,
 	onSelectedLanguageClick: PropTypes.func.isRequired,
 	onTrafficSourceClick: PropTypes.func.isRequired,
 	pagePublishDate: PropTypes.string.isRequired,
@@ -103,9 +112,6 @@ Main.proptypes = {
 			label: PropTypes.string,
 		})
 	).isRequired,
-	totalReadsDataProvider: PropTypes.func.isRequired,
-	totalViewsDataProvider: PropTypes.func.isRequired,
-	trafficSourcesDataProvider: PropTypes.func.isRequired,
 	viewURLs: PropTypes.arrayOf(
 		PropTypes.shape({
 			default: PropTypes.bool.isRequired,

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
@@ -9,7 +9,6 @@
  * distribution rights of the Software.
  */
 
-import ClayLoadingIndicator from '@clayui/loading-indicator';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
@@ -31,13 +30,9 @@ export default function Main({
 	timeSpanOptions,
 	viewURLs,
 }) {
-	const {endpoints, loading, totalReads, totalViews} = useContext(
-		StoreStateContext
-	);
+	const {endpoints, totalReads, totalViews} = useContext(StoreStateContext);
 
-	return loading ? (
-		<ClayLoadingIndicator small />
-	) : (
+	return (
 		<div className="c-p-3">
 			<BasicInformation
 				author={author}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -50,8 +50,6 @@ export default function Navigation({
 
 	const [currentPage, setCurrentPage] = useState({view: 'main'});
 
-	const [trafficSourceName, setTrafficSourceName] = useState('');
-
 	const chartState = useChartState();
 
 	const {timeSpanKey, timeSpanOffset} = chartState;
@@ -126,7 +124,10 @@ export default function Navigation({
 	}, []);
 
 	const handleTrafficSourceClick = (trafficSourceName) => {
-		setTrafficSourceName(trafficSourceName);
+		dispatch({
+			selectedTrafficSourceName: trafficSourceName,
+			type: 'SET_SELECTED_TRAFFIC_SOURCE_NAME',
+		});
 
 		const trafficSource = trafficSources.find((trafficSource) => {
 			return trafficSource.name === trafficSourceName;
@@ -137,25 +138,6 @@ export default function Navigation({
 			view: trafficSource.name,
 		});
 	};
-
-	const handleTrafficSourceName = (trafficSourceName) =>
-		setTrafficSourceName(trafficSourceName);
-
-	const handleTrafficShare = useCallback(() => {
-		const trafficSource = trafficSources.find((trafficSource) => {
-			return trafficSource.name === trafficSourceName;
-		});
-
-		return Promise.resolve(trafficSource?.share ?? '-');
-	}, [trafficSourceName, trafficSources]);
-
-	const handleTrafficVolume = useCallback(() => {
-		const trafficSource = trafficSources.find((trafficSource) => {
-			return trafficSource.name === trafficSourceName;
-		});
-
-		return Promise.resolve(trafficSource?.value ?? '-');
-	}, [trafficSourceName, trafficSources]);
 
 	return loading ? (
 		<ClayLoadingIndicator small />
@@ -204,10 +186,7 @@ export default function Navigation({
 				<Detail
 					currentPage={currentPage}
 					onCurrentPageChange={handleCurrentPage}
-					onTrafficSourceNameChange={handleTrafficSourceName}
 					timeSpanOptions={timeSpanOptions}
-					trafficShareDataProvider={handleTrafficShare}
-					trafficVolumeDataProvider={handleTrafficVolume}
 				/>
 			)}
 		</>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -10,6 +10,7 @@
  */
 
 import ClayAlert from '@clayui/alert';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
 import PropTypes from 'prop-types';
 import React, {useCallback, useContext, useEffect, useState} from 'react';
 
@@ -35,6 +36,7 @@ export default function Navigation({
 
 	const {
 		endpoints,
+		loading,
 		namespace,
 		page,
 		publishedToday,
@@ -155,7 +157,9 @@ export default function Navigation({
 		return Promise.resolve(trafficSource?.value ?? '-');
 	}, [trafficSourceName, trafficSources]);
 
-	return (
+	return loading ? (
+		<ClayLoadingIndicator small />
+	) : (
 		<>
 			{!validAnalyticsConnection && (
 				<ClayAlert displayType="danger" variant="stripe">

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
@@ -9,57 +9,36 @@
  * distribution rights of the Software.
  */
 
-import {useStateSafe} from '@liferay/frontend-js-react-web';
 import PropTypes from 'prop-types';
-import React, {useContext, useEffect} from 'react';
+import React, {useContext} from 'react';
 
 import ConnectionContext from '../context/ConnectionContext';
-import {StoreDispatchContext, StoreStateContext} from '../context/StoreContext';
+import {StoreStateContext} from '../context/StoreContext';
 import {numberFormat} from '../utils/numberFormat';
 import Hint from './Hint';
 
-function TotalCount({
+export default function TotalCount({
 	className,
-	dataProvider,
 	label,
 	percentage = false,
 	popoverAlign,
 	popoverHeader,
 	popoverMessage,
 	popoverPosition,
+	value,
 }) {
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
-	const [value, setValue] = useStateSafe('-');
-
-	const dispatch = useContext(StoreDispatchContext);
-
 	const {languageTag, publishedToday} = useContext(StoreStateContext);
-
-	useEffect(() => {
-		if (validAnalyticsConnection) {
-			dataProvider()
-				.then(setValue)
-				.catch(() => {
-					setValue('-');
-					dispatch({type: 'ADD_WARNING'});
-				});
-		}
-	}, [dispatch, dataProvider, setValue, validAnalyticsConnection]);
 
 	let displayValue = '-';
 
-	if (validAnalyticsConnection && !publishedToday) {
-		displayValue =
-			value !== '-' ? (
-				percentage ? (
-					<span>{`${value}%`}</span>
-				) : (
-					numberFormat(languageTag, value)
-				)
-			) : (
-				value
-			);
+	if (validAnalyticsConnection && !publishedToday && value >= 0) {
+		displayValue = percentage ? (
+			<span>{`${value}%`}</span>
+		) : (
+			numberFormat(languageTag, value)
+		);
 	}
 
 	return (
@@ -79,11 +58,9 @@ function TotalCount({
 }
 
 TotalCount.propTypes = {
-	dataProvider: PropTypes.func.isRequired,
 	label: PropTypes.string.isRequired,
 	percentage: PropTypes.bool,
 	popoverHeader: PropTypes.string.isRequired,
 	popoverMessage: PropTypes.string.isRequired,
+	value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
-
-export default TotalCount;

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -59,15 +59,12 @@ export default function TrafficSources({onTrafficSourceClick}) {
 		() =>
 			validAnalyticsConnection &&
 			!publishedToday &&
-			trafficSources &&
-			trafficSources.some(({value}) => value),
+			trafficSources?.some(({value}) => value),
 		[publishedToday, trafficSources, validAnalyticsConnection]
 	);
 
 	const missingTrafficSourceValue = useMemo(
-		() =>
-			trafficSources &&
-			trafficSources.some(({value}) => value === undefined),
+		() => trafficSources?.some(({value}) => value === undefined),
 		[trafficSources]
 	);
 
@@ -99,86 +96,81 @@ export default function TrafficSources({onTrafficSourceClick}) {
 				<div className="pie-chart-wrapper--legend">
 					<table>
 						<tbody>
-							{trafficSources &&
-								trafficSources.map((entry) => {
-									const hasDetails =
-										entry?.countryKeywords ||
-										(entry?.referringPages &&
-											entry?.referringDomains) ||
-										entry?.referringSocialMedia;
+							{trafficSources?.map((entry) => {
+								const hasDetails =
+									entry?.countryKeywords ||
+									(entry?.referringPages &&
+										entry?.referringDomains) ||
+									entry?.referringSocialMedia;
 
-									return (
-										<tr key={entry.name}>
-											<td
-												className="px-0"
-												onMouseOut={
-													handleLegendMouseLeave
-												}
-												onMouseOver={() =>
-													handleLegendMouseEnter(
+								return (
+									<tr key={entry.name}>
+										<td
+											className="px-0"
+											onMouseOut={handleLegendMouseLeave}
+											onMouseOver={() =>
+												handleLegendMouseEnter(
+													entry.name
+												)
+											}
+										>
+											<span
+												className="pie-chart-wrapper--legend--dot"
+												style={{
+													backgroundColor: getColorByName(
 														entry.name
-													)
-												}
-											>
-												<span
-													className="pie-chart-wrapper--legend--dot"
-													style={{
-														backgroundColor: getColorByName(
+													),
+												}}
+											></span>
+										</td>
+										<td
+											className="c-py-1 text-secondary"
+											onMouseOut={handleLegendMouseLeave}
+											onMouseOver={() =>
+												handleLegendMouseEnter(
+													entry.name
+												)
+											}
+										>
+											{validAnalyticsConnection &&
+											!publishedToday &&
+											entry.value > 0 &&
+											hasDetails ? (
+												<ClayButton
+													className="px-0 py-1 text-primary"
+													displayType="link"
+													onClick={() =>
+														onTrafficSourceClick(
 															entry.name
-														),
-													}}
-												></span>
-											</td>
-											<td
-												className="c-py-1 text-secondary"
-												onMouseOut={
-													handleLegendMouseLeave
-												}
-												onMouseOver={() =>
-													handleLegendMouseEnter(
-														entry.name
-													)
-												}
-											>
-												{validAnalyticsConnection &&
-												!publishedToday &&
-												entry.value > 0 &&
-												hasDetails ? (
-													<ClayButton
-														className="px-0 py-1 text-primary"
-														displayType="link"
-														onClick={() =>
-															onTrafficSourceClick(
-																entry.name
-															)
-														}
-														small
-													>
-														{entry.title}
-													</ClayButton>
-												) : (
-													<span>{entry.title}</span>
-												)}
-											</td>
-											<td className="text-secondary">
-												<Hint
-													message={entry.helpMessage}
-													title={entry.title}
-												/>
-											</td>
-											<td className="font-weight-semi-bold">
-												{validAnalyticsConnection &&
-												!publishedToday &&
-												entry.value !== undefined
-													? numberFormat(
-															languageTag,
-															entry.value
-													  )
-													: '-'}
-											</td>
-										</tr>
-									);
-								})}
+														)
+													}
+													small
+												>
+													{entry.title}
+												</ClayButton>
+											) : (
+												<span>{entry.title}</span>
+											)}
+										</td>
+										<td className="text-secondary">
+											<Hint
+												message={entry.helpMessage}
+												title={entry.title}
+											/>
+										</td>
+										<td className="font-weight-semi-bold">
+											{validAnalyticsConnection &&
+											!publishedToday &&
+											entry.value !== undefined
+												? numberFormat(
+														languageTag,
+														entry.value
+												  )
+												: '-'}
+										</td>
+									</tr>
+								);
+							})}
 						</tbody>
 					</table>
 				</div>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/KeywordsDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/KeywordsDetail.js
@@ -11,21 +11,19 @@
 
 import {ALIGN_POSITIONS} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useContext} from 'react';
 
+import {StoreStateContext} from '../../context/StoreContext';
 import Keywords from '../Keywords';
 import TotalCount from '../TotalCount';
 
-export default function KeywordsDetail({
-	currentPage,
-	trafficShareDataProvider,
-	trafficVolumeDataProvider,
-}) {
+export default function KeywordsDetail({currentPage}) {
+	const {trafficShare, trafficVolume} = useContext(StoreStateContext);
+
 	return (
 		<div className="c-p-3 traffic-source-detail">
 			<TotalCount
 				className="mb-2"
-				dataProvider={trafficVolumeDataProvider}
 				label={Liferay.Util.sub(Liferay.Language.get('traffic-volume'))}
 				popoverAlign={ALIGN_POSITIONS.Bottom}
 				popoverHeader={Liferay.Language.get('traffic-volume')}
@@ -33,17 +31,18 @@ export default function KeywordsDetail({
 					'traffic-volume-is-the-number-of-page-views-coming-from-one-channel'
 				)}
 				popoverPosition="bottom"
+				value={trafficVolume}
 			/>
 
 			<TotalCount
 				className="mb-4"
-				dataProvider={trafficShareDataProvider}
 				label={Liferay.Util.sub(Liferay.Language.get('traffic-share'))}
 				percentage={true}
 				popoverHeader={Liferay.Language.get('traffic-share')}
 				popoverMessage={Liferay.Language.get(
 					'traffic-share-is-the-percentage-of-traffic-sent-to-your-page-by-one-channel'
 				)}
+				value={trafficShare}
 			/>
 
 			<Keywords currentPage={currentPage} />
@@ -53,6 +52,4 @@ export default function KeywordsDetail({
 
 KeywordsDetail.proptypes = {
 	currentPage: PropTypes.object.isRequired,
-	trafficShareDataProvider: PropTypes.func.isRequired,
-	trafficVolumeDataProvider: PropTypes.func.isRequired,
 };

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
@@ -36,10 +36,10 @@ export default function ReferralDetail({
 	currentPage,
 	showTimeSpanSelector = false,
 	timeSpanOptions,
-	trafficShareDataProvider,
-	trafficVolumeDataProvider,
 }) {
-	const {languageTag} = useContext(StoreStateContext);
+	const {languageTag, trafficShare, trafficVolume} = useContext(
+		StoreStateContext
+	);
 
 	const [isReferringPagesExpanded, setIsReferringPagesExpanded] = useState(
 		false
@@ -104,7 +104,6 @@ export default function ReferralDetail({
 
 			<TotalCount
 				className="c-mb-2"
-				dataProvider={trafficVolumeDataProvider}
 				label={Liferay.Util.sub(Liferay.Language.get('traffic-volume'))}
 				popoverAlign={ALIGN_POSITIONS.Bottom}
 				popoverHeader={Liferay.Language.get('traffic-volume')}
@@ -112,17 +111,18 @@ export default function ReferralDetail({
 					'traffic-volume-is-the-number-of-page-views-coming-from-one-channel'
 				)}
 				popoverPosition="bottom"
+				value={trafficVolume}
 			/>
 
 			<TotalCount
 				className="c-mb-3"
-				dataProvider={trafficShareDataProvider}
 				label={Liferay.Util.sub(Liferay.Language.get('traffic-share'))}
 				percentage={true}
 				popoverHeader={Liferay.Language.get('traffic-share')}
 				popoverMessage={Liferay.Language.get(
 					'traffic-share-is-the-percentage-of-traffic-sent-to-your-page-by-one-channel'
 				)}
+				value={trafficShare}
 			/>
 
 			<ClayList className="list-group-pages-list">
@@ -295,6 +295,4 @@ ReferralDetail.propTypes = {
 			label: PropTypes.string,
 		})
 	).isRequired,
-	trafficShareDataProvider: PropTypes.func.isRequired,
-	trafficVolumeDataProvider: PropTypes.func.isRequired,
 };

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
@@ -45,10 +45,10 @@ export default function SocialDetail({
 	currentPage,
 	showTimeSpanSelector = false,
 	timeSpanOptions,
-	trafficShareDataProvider,
-	trafficVolumeDataProvider,
 }) {
-	const {languageTag} = useContext(StoreStateContext);
+	const {languageTag, trafficShare, trafficVolume} = useContext(
+		StoreStateContext
+	);
 
 	const {referringSocialMedia} = currentPage.data;
 
@@ -127,7 +127,6 @@ export default function SocialDetail({
 
 			<TotalCount
 				className="c-mb-2"
-				dataProvider={trafficVolumeDataProvider}
 				label={Liferay.Util.sub(Liferay.Language.get('traffic-volume'))}
 				popoverAlign={ALIGN_POSITIONS.Bottom}
 				popoverHeader={Liferay.Language.get('traffic-volume')}
@@ -135,17 +134,18 @@ export default function SocialDetail({
 					'traffic-volume-is-the-number-of-page-views-coming-from-one-channel'
 				)}
 				popoverPosition="bottom"
+				value={trafficVolume}
 			/>
 
 			<TotalCount
 				className="c-mb-3"
-				dataProvider={trafficShareDataProvider}
 				label={Liferay.Util.sub(Liferay.Language.get('traffic-share'))}
 				percentage={true}
 				popoverHeader={Liferay.Language.get('traffic-share')}
 				popoverMessage={Liferay.Language.get(
 					'traffic-share-is-the-percentage-of-traffic-sent-to-your-page-by-one-channel'
 				)}
+				value={trafficShare}
 			/>
 
 			<ClayList className="list-group-pages-list">
@@ -226,6 +226,4 @@ SocialDetail.propTypes = {
 			label: PropTypes.string,
 		})
 	).isRequired,
-	trafficShareDataProvider: PropTypes.func.isRequired,
-	trafficVolumeDataProvider: PropTypes.func.isRequired,
 };

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/StoreContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/StoreContext.js
@@ -13,10 +13,12 @@ import React, {createContext, useReducer} from 'react';
 
 const ADD_WARNING = 'ADD_WARNING';
 const SET_METRICS = 'SET_METRICS';
+const SET_SELECTED_TRAFFIC_SOURCE_NAME = 'SET_SELECTED_TRAFFIC_SOURCE_NAME';
 
 const INITIAL_STATE = {
 	loading: true,
 	publishedToday: false,
+	selectedTrafficSourceName: '',
 	warning: false,
 };
 
@@ -49,6 +51,32 @@ function reducer(state = INITIAL_STATE, action) {
 				trafficSources: action.payload.trafficSources,
 			};
 			break;
+		case SET_SELECTED_TRAFFIC_SOURCE_NAME: {
+			const selectedTrafficSourceName = action.selectedTrafficSourceName;
+
+			if (selectedTrafficSourceName === '') {
+				nextState = {
+					...state,
+					selectedTrafficSourceName,
+					trafficShare: undefined,
+					trafficVolume: undefined,
+				};
+			}
+			else {
+				const trafficSource = state.trafficSources.find(
+					(trafficSource) =>
+						trafficSource.name === selectedTrafficSourceName
+				);
+
+				nextState = {
+					...state,
+					selectedTrafficSourceName,
+					trafficShare: trafficSource?.share ?? '-',
+					trafficVolume: trafficSource?.value ?? '-',
+				};
+			}
+			break;
+		}
 		default:
 			return state;
 	}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/StoreContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/StoreContext.js
@@ -12,15 +12,17 @@
 import React, {createContext, useReducer} from 'react';
 
 const ADD_WARNING = 'ADD_WARNING';
+const SET_METRICS = 'SET_METRICS';
 
 const INITIAL_STATE = {
+	loading: true,
 	publishedToday: false,
 	warning: false,
 };
 
 const noop = () => {};
 
-export const StoreDispatchContext = React.createContext(() => {});
+export const StoreDispatchContext = createContext(() => {});
 export const StoreStateContext = createContext([INITIAL_STATE, noop]);
 
 function reducer(state = INITIAL_STATE, action) {
@@ -29,6 +31,23 @@ function reducer(state = INITIAL_STATE, action) {
 	switch (action.type) {
 		case ADD_WARNING:
 			nextState = state.warning ? state : {...state, warning: true};
+			break;
+		case SET_METRICS:
+			nextState = {
+				...state,
+				historicalReads: {
+					analyticsReportsHistoricalReads:
+						action.payload?.analyticsReportsHistoricalReads,
+				},
+				historicalViews: {
+					analyticsReportsHistoricalViews:
+						action.payload?.analyticsReportsHistoricalViews,
+				},
+				loading: false,
+				totalReads: action.payload?.analyticsReportsTotalReads,
+				totalViews: action.payload.analyticsReportsTotalViews,
+				trafficSources: action.payload.trafficSources,
+			};
 			break;
 		default:
 			return state;

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/StoreContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/StoreContext.js
@@ -39,16 +39,16 @@ function reducer(state = INITIAL_STATE, action) {
 				...state,
 				historicalReads: {
 					analyticsReportsHistoricalReads:
-						action.payload?.analyticsReportsHistoricalReads,
+						action.analyticsReportsHistoricalReads,
 				},
 				historicalViews: {
 					analyticsReportsHistoricalViews:
-						action.payload?.analyticsReportsHistoricalViews,
+						action.analyticsReportsHistoricalViews,
 				},
 				loading: false,
-				totalReads: action.payload?.analyticsReportsTotalReads,
-				totalViews: action.payload.analyticsReportsTotalViews,
-				trafficSources: action.payload.trafficSources,
+				totalReads: action.analyticsReportsTotalReads,
+				totalViews: action.analyticsReportsTotalViews,
+				trafficSources: action.trafficSources,
 			};
 			break;
 		case SET_SELECTED_TRAFFIC_SOURCE_NAME: {

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Chart.js
@@ -10,118 +10,122 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
-import {cleanup, render, wait} from '@testing-library/react';
+import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 
 import Chart from '../../../src/main/resources/META-INF/resources/js/components/Chart';
 import {ChartStateContextProvider} from '../../../src/main/resources/META-INF/resources/js/context/ChartStateContext';
 import {StoreContextProvider} from '../../../src/main/resources/META-INF/resources/js/context/StoreContext';
 
-const mockReadsDataProvider = jest.fn(() =>
-	Promise.resolve({
-		analyticsReportsHistoricalReads: {
-			histogram: [
-				{
-					key: '2020-01-27T00:00',
-					previousKey: '2020-01-20T00:00',
-					previousValue: 22.0,
-					value: 33.0,
-				},
-				{
-					key: '2020-01-28T00:00',
-					previousKey: '2020-01-21T00:00',
-					previousValue: 23.0,
-					value: 33.0,
-				},
-				{
-					key: '2020-01-29T00:00',
-					previousKey: '2020-01-22T00:00',
-					previousValue: 24.0,
-					value: 34.0,
-				},
-				{
-					key: '2020-01-30T00:00',
-					previousKey: '2020-01-23T00:00',
-					previousValue: 25.0,
-					value: 33.0,
-				},
-				{
-					key: '2020-01-31T00:00',
-					previousKey: '2020-01-24T00:00',
-					previousValue: 26.0,
-					value: 32.0,
-				},
-				{
-					key: '2020-02-01T00:00',
-					previousKey: '2020-01-25T00:00',
-					previousValue: 27.0,
-					value: 31.0,
-				},
-				{
-					key: '2020-02-02T00:00',
-					previousKey: '2020-01-26T00:00',
-					previousValue: 28.0,
-					value: 30.0,
-				},
-			],
-			previousValue: 175.0,
-			value: 226.0,
-		},
-	})
-);
+const mockEndpoints = {
+	analyticsReportsHistoricalReadsURL: 'analyticsReportsHistoricalReadsURL',
+	analyticsReportsHistoricalViewsURL: 'analyticsReportsHistoricalViewsURL',
+	analyticsReportsTotalReadsURL: 'analyticsReportsTotalReadsURL',
+	analyticsReportsTotalViewsURL: 'analyticsReportsTotalViewsURL',
+	analyticsReportsTrafficSourcesURL: 'analyticsReportsTrafficSourcesURL',
+};
 
-const mockViewsDataProvider = jest.fn(() =>
-	Promise.resolve({
-		analyticsReportsHistoricalViews: {
-			histogram: [
-				{
-					key: '2020-01-27T00:00',
-					previousKey: '2020-01-20T00:00',
-					previousValue: 22.0,
-					value: 32.0,
-				},
-				{
-					key: '2020-01-28T00:00',
-					previousKey: '2020-01-21T00:00',
-					previousValue: 23.0,
-					value: 33.0,
-				},
-				{
-					key: '2020-01-29T00:00',
-					previousKey: '2020-01-22T00:00',
-					previousValue: 24.0,
-					value: 34.0,
-				},
-				{
-					key: '2020-01-30T00:00',
-					previousKey: '2020-01-23T00:00',
-					previousValue: 25.0,
-					value: 33.0,
-				},
-				{
-					key: '2020-01-31T00:00',
-					previousKey: '2020-01-24T00:00',
-					previousValue: 26.0,
-					value: 32.0,
-				},
-				{
-					key: '2020-02-01T00:00',
-					previousKey: '2020-01-25T00:00',
-					previousValue: 27.0,
-					value: 31.0,
-				},
-				{
-					key: '2020-02-02T00:00',
-					previousKey: '2020-01-26T00:00',
-					previousValue: 28.0,
-					value: 30.0,
-				},
-			],
-			previousValue: 175.0,
-			value: 225.0,
-		},
-	})
-);
+const mockHistoricalReads = {
+	analyticsReportsHistoricalReads: {
+		histogram: [
+			{
+				key: '2020-01-27T00:00',
+				previousKey: '2020-01-20T00:00',
+				previousValue: 22.0,
+				value: 33.0,
+			},
+			{
+				key: '2020-01-28T00:00',
+				previousKey: '2020-01-21T00:00',
+				previousValue: 23.0,
+				value: 33.0,
+			},
+			{
+				key: '2020-01-29T00:00',
+				previousKey: '2020-01-22T00:00',
+				previousValue: 24.0,
+				value: 34.0,
+			},
+			{
+				key: '2020-01-30T00:00',
+				previousKey: '2020-01-23T00:00',
+				previousValue: 25.0,
+				value: 33.0,
+			},
+			{
+				key: '2020-01-31T00:00',
+				previousKey: '2020-01-24T00:00',
+				previousValue: 26.0,
+				value: 32.0,
+			},
+			{
+				key: '2020-02-01T00:00',
+				previousKey: '2020-01-25T00:00',
+				previousValue: 27.0,
+				value: 31.0,
+			},
+			{
+				key: '2020-02-02T00:00',
+				previousKey: '2020-01-26T00:00',
+				previousValue: 28.0,
+				value: 30.0,
+			},
+		],
+		previousValue: 175.0,
+		value: 226.0,
+	},
+};
+
+const mockHistoricalViews = {
+	analyticsReportsHistoricalViews: {
+		histogram: [
+			{
+				key: '2020-01-27T00:00',
+				previousKey: '2020-01-20T00:00',
+				previousValue: 22.0,
+				value: 32.0,
+			},
+			{
+				key: '2020-01-28T00:00',
+				previousKey: '2020-01-21T00:00',
+				previousValue: 23.0,
+				value: 33.0,
+			},
+			{
+				key: '2020-01-29T00:00',
+				previousKey: '2020-01-22T00:00',
+				previousValue: 24.0,
+				value: 34.0,
+			},
+			{
+				key: '2020-01-30T00:00',
+				previousKey: '2020-01-23T00:00',
+				previousValue: 25.0,
+				value: 33.0,
+			},
+			{
+				key: '2020-01-31T00:00',
+				previousKey: '2020-01-24T00:00',
+				previousValue: 26.0,
+				value: 32.0,
+			},
+			{
+				key: '2020-02-01T00:00',
+				previousKey: '2020-01-25T00:00',
+				previousValue: 27.0,
+				value: 31.0,
+			},
+			{
+				key: '2020-02-02T00:00',
+				previousKey: '2020-01-26T00:00',
+				previousValue: 28.0,
+				value: 30.0,
+			},
+		],
+		previousValue: 175.0,
+		value: 225.0,
+	},
+};
 
 const mockLanguageTag = 'en-US';
 
@@ -148,7 +152,7 @@ describe('Chart', () => {
 		cleanup();
 	});
 
-	it('displays total views and date range title for default time span', async () => {
+	it('displays total views and date range title for default time span', () => {
 		const testProps = {
 			pagePublishDate: 'Thu Aug 10 08:17:57 GMT 2020',
 			timeRange: {endDate: '2020-01-27', startDate: '2020-02-02'},
@@ -156,23 +160,24 @@ describe('Chart', () => {
 		};
 
 		const {getByText} = render(
-			<StoreContextProvider value={{languageTag: mockLanguageTag}}>
+			<StoreContextProvider
+				value={{
+					endpoints: mockEndpoints,
+					historicalViews: mockHistoricalViews,
+					languageTag: mockLanguageTag,
+				}}
+			>
 				<ChartStateContextProvider
 					publishDate={testProps.pagePublishDate}
 					timeRange={testProps.timeRange}
 					timeSpanKey={testProps.timeSpanKey}
 				>
 					<Chart
-						dataProviders={[mockViewsDataProvider]}
 						publishDate={mockPublishDate}
 						timeSpanOptions={mockTimeSpanOptions}
 					/>
 				</ChartStateContextProvider>
 			</StoreContextProvider>
-		);
-
-		await wait(() =>
-			expect(mockViewsDataProvider).toHaveBeenCalledTimes(1)
 		);
 
 		expect(getByText('225')).toBeInTheDocument();
@@ -180,7 +185,7 @@ describe('Chart', () => {
 		expect(getByText('Jan 27 - Feb 2, 2020')).toBeInTheDocument();
 	});
 
-	it('displays total views and reads and date range title for default time span', async () => {
+	it('displays total views and reads and date range title for default time span', () => {
 		const testProps = {
 			pagePublishDate: 'Thu Aug 10 08:17:57 GMT 2020',
 			timeRange: {endDate: '2020-01-27', startDate: '2020-02-02'},
@@ -188,28 +193,26 @@ describe('Chart', () => {
 		};
 
 		const {getByText} = render(
-			<StoreContextProvider value={{languageTag: mockLanguageTag}}>
+			<StoreContextProvider
+				value={{
+					endpoints: mockEndpoints,
+					historicalReads: mockHistoricalReads,
+					historicalViews: mockHistoricalViews,
+					languageTag: mockLanguageTag,
+				}}
+			>
 				<ChartStateContextProvider
 					publishDate={testProps.pagePublishDate}
 					timeRange={testProps.timeRange}
 					timeSpanKey={testProps.timeSpanKey}
 				>
 					<Chart
-						dataProviders={[
-							mockViewsDataProvider,
-							mockReadsDataProvider,
-						]}
 						publishDate={mockPublishDate}
 						timeSpanOptions={mockTimeSpanOptions}
 					/>
 				</ChartStateContextProvider>
 			</StoreContextProvider>
 		);
-
-		await wait(() => {
-			expect(mockViewsDataProvider).toHaveBeenCalledTimes(1);
-			expect(mockReadsDataProvider).toHaveBeenCalledTimes(1);
-		});
 
 		expect(getByText('225')).toBeInTheDocument();
 		expect(getByText('226')).toBeInTheDocument();

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Detail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Detail.js
@@ -10,7 +10,7 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
-import {cleanup, render, wait, within} from '@testing-library/react';
+import {cleanup, render, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -19,12 +19,6 @@ import {ChartStateContextProvider} from '../../../src/main/resources/META-INF/re
 import {StoreContextProvider} from '../../../src/main/resources/META-INF/resources/js/context/StoreContext';
 
 const mockOnCurrentPageChange = jest.fn(() => Promise.resolve({view: 'main'}));
-
-const mockOnTrafficSourceNameChange = jest.fn(() => Promise.resolve(''));
-
-const mockTrafficShareDataProvider = jest.fn(() => Promise.resolve(90));
-
-const mockTrafficVolumeDataProvider = jest.fn(() => Promise.resolve(278256));
 
 const mockCurrentPageOrganic = {
 	data: {
@@ -107,7 +101,7 @@ const mockCurrentPageOrganic = {
 		helpMessage:
 			'This number refers to the volume of people that find your page through a search engine.',
 		name: 'organic',
-		share: 90,
+		share: '90',
 		title: 'Organic',
 		value: 278256,
 	},
@@ -183,7 +177,7 @@ const mockCurrentPageReferral = {
 				url: 'http://ten.example.com',
 			},
 		],
-		share: 90,
+		share: '90',
 		title: 'Referral',
 		value: 278256,
 	},
@@ -217,7 +211,7 @@ const mockCurrentPageSocial = {
 				trafficAmount: 30,
 			},
 		],
-		share: 90,
+		share: '90',
 		title: 'Social',
 		value: 278256,
 	},
@@ -241,13 +235,17 @@ const mockTimeSpanOptions = [
 	},
 ];
 
+const mockTrafficShare = '90';
+
+const mockTrafficVolume = 278256;
+
 describe('Detail', () => {
 	afterEach(() => {
 		jest.clearAllMocks();
 		cleanup();
 	});
 
-	it('displays 10 urls when clicking on the view more button', async () => {
+	it('displays 10 urls when clicking on the view more button', () => {
 		const testProps = {
 			pagePublishDate: 'Thu Aug 10 08:17:57 GMT 2020',
 			timeRange: {endDate: '2020-01-27', startDate: '2020-02-02'},
@@ -264,23 +262,11 @@ describe('Detail', () => {
 					<Detail
 						currentPage={mockCurrentPageReferral}
 						onCurrentPageChange={mockOnCurrentPageChange}
-						onTrafficSourceNameChange={
-							mockOnTrafficSourceNameChange
-						}
 						timeSpanOptions={mockTimeSpanOptions}
-						trafficShareDataProvider={mockTrafficShareDataProvider}
-						trafficVolumeDataProvider={
-							mockTrafficVolumeDataProvider
-						}
 					/>
 				</ChartStateContextProvider>
 			</StoreContextProvider>
 		);
-
-		await wait(() => {
-			expect(mockTrafficShareDataProvider).toHaveBeenCalled();
-			expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
-		});
 
 		const viewMoreButton = getByText('view-more');
 		userEvent.click(viewMoreButton);
@@ -295,47 +281,48 @@ describe('Detail', () => {
 	});
 
 	describe('Organic Detail', () => {
-		it('displays the organic detail according to API', async () => {
-			const {getByText} = render(
-				<Detail
-					currentPage={mockCurrentPageOrganic}
-					onCurrentPageChange={mockOnCurrentPageChange}
-					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
-					timeSpanOptions={mockTimeSpanOptions}
-					trafficShareDataProvider={mockTrafficShareDataProvider}
-					trafficVolumeDataProvider={mockTrafficVolumeDataProvider}
-				/>
-			);
+		it('displays the organic detail according to API', () => {
+			const testProps = {
+				pagePublishDate: 'Thu Aug 10 08:17:57 GMT 2020',
+				timeRange: {endDate: '2020-01-27', startDate: '2020-02-02'},
+				timeSpanKey: 'last-7-days',
+			};
 
-			await wait(() => {
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
-			});
+			const {getByText} = render(
+				<StoreContextProvider
+					value={{
+						languageTag: mockLanguageTag,
+						trafficShare: mockTrafficShare,
+						trafficVolume: mockTrafficVolume,
+					}}
+				>
+					<ChartStateContextProvider
+						publishDate={testProps.publishDate}
+						timeRange={testProps.timeRange}
+						timeSpanKey={testProps.timeSpanKey}
+					>
+						<Detail
+							currentPage={mockCurrentPageOrganic}
+							onCurrentPageChange={mockOnCurrentPageChange}
+							timeSpanOptions={mockTimeSpanOptions}
+						/>
+					</ChartStateContextProvider>
+				</StoreContextProvider>
+			);
 
 			expect(getByText('Organic')).toBeInTheDocument();
 			expect(getByText('90%')).toBeInTheDocument();
 			expect(getByText('278,256')).toBeInTheDocument();
-
-			expect(mockTrafficShareDataProvider).toHaveBeenCalledTimes(1);
-			expect(mockTrafficVolumeDataProvider).toHaveBeenCalledTimes(1);
 		});
 
-		it('displays the top five relevant keywords by country sorted by traffic', async () => {
+		it('displays the top five relevant keywords by country sorted by traffic', () => {
 			const {getByText} = render(
 				<Detail
 					currentPage={mockCurrentPageOrganic}
 					onCurrentPageChange={mockOnCurrentPageChange}
-					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
 					timeSpanOptions={mockTimeSpanOptions}
-					trafficShareDataProvider={mockTrafficShareDataProvider}
-					trafficVolumeDataProvider={mockTrafficVolumeDataProvider}
 				/>
 			);
-
-			await wait(() => {
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
-			});
 
 			expect(getByText('United States')).toBeInTheDocument();
 			expect(getByText('Spain')).toBeInTheDocument();
@@ -358,22 +345,14 @@ describe('Detail', () => {
 			expect(getByText('10,100')).toBeInTheDocument();
 		});
 
-		it('displays a tooltip with info on hover tooltip signs', async () => {
+		it('displays a tooltip with info on hover tooltip signs', () => {
 			const {getByText} = render(
 				<Detail
 					currentPage={mockCurrentPageOrganic}
 					onCurrentPageChange={mockOnCurrentPageChange}
-					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
 					timeSpanOptions={mockTimeSpanOptions}
-					trafficShareDataProvider={mockTrafficShareDataProvider}
-					trafficVolumeDataProvider={mockTrafficVolumeDataProvider}
 				/>
 			);
-
-			await wait(() => {
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
-			});
 
 			const bestKeywordLabel = getByText('best-keyword');
 			const questionCircleIcon = within(bestKeywordLabel).getByRole(
@@ -383,22 +362,14 @@ describe('Detail', () => {
 			expect(getByText('best-keyword-help')).toBeInTheDocument();
 		});
 
-		it('displays a dropdown with options to display in the keywords table', async () => {
+		it('displays a dropdown with options to display in the keywords table', () => {
 			const {getAllByText, getByText} = render(
 				<Detail
 					currentPage={mockCurrentPageOrganic}
 					onCurrentPageChange={mockOnCurrentPageChange}
-					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
 					timeSpanOptions={mockTimeSpanOptions}
-					trafficShareDataProvider={mockTrafficShareDataProvider}
-					trafficVolumeDataProvider={mockTrafficVolumeDataProvider}
 				/>
 			);
-
-			await wait(() => {
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
-			});
 
 			const trafficDropdown = getAllByText('traffic')[0];
 			userEvent.click(trafficDropdown);
@@ -406,22 +377,14 @@ describe('Detail', () => {
 			expect(getByText('position')).toBeInTheDocument();
 		});
 
-		it('displays the top five relevant keywords sorted by search volume when user clicks on the dropdown option search volume', async () => {
+		it('displays the top five relevant keywords sorted by search volume when user clicks on the dropdown option search volume', () => {
 			const {getAllByText, getByText} = render(
 				<Detail
 					currentPage={mockCurrentPageOrganic}
 					onCurrentPageChange={mockOnCurrentPageChange}
-					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
 					timeSpanOptions={mockTimeSpanOptions}
-					trafficShareDataProvider={mockTrafficShareDataProvider}
-					trafficVolumeDataProvider={mockTrafficVolumeDataProvider}
 				/>
 			);
-
-			await wait(() => {
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
-			});
 
 			const trafficDropdown = getAllByText('traffic')[0];
 			userEvent.click(trafficDropdown);
@@ -446,22 +409,14 @@ describe('Detail', () => {
 			expect(getByText('7,100')).toBeInTheDocument();
 		});
 
-		it('displays the top five relevant keywords sorted by position when user clicks on the dropdown option position', async () => {
+		it('displays the top five relevant keywords sorted by position when user clicks on the dropdown option position', () => {
 			const {getAllByText, getByText} = render(
 				<Detail
 					currentPage={mockCurrentPageOrganic}
 					onCurrentPageChange={mockOnCurrentPageChange}
-					onTrafficSourceNameChange={mockOnTrafficSourceNameChange}
 					timeSpanOptions={mockTimeSpanOptions}
-					trafficShareDataProvider={mockTrafficShareDataProvider}
-					trafficVolumeDataProvider={mockTrafficVolumeDataProvider}
 				/>
 			);
-
-			await wait(() => {
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
-			});
 
 			const trafficDropdown = getAllByText('traffic')[0];
 			userEvent.click(trafficDropdown);
@@ -488,7 +443,7 @@ describe('Detail', () => {
 	});
 
 	describe('Referral Detail', () => {
-		it('displays the referral detail according to API', async () => {
+		it('displays the referral detail according to API', () => {
 			const testProps = {
 				pagePublishDate: 'Thu Aug 10 08:17:57 GMT 2020',
 				timeRange: {endDate: '2020-01-27', startDate: '2020-02-02'},
@@ -496,7 +451,13 @@ describe('Detail', () => {
 			};
 
 			const {getByText} = render(
-				<StoreContextProvider value={{languageTag: mockLanguageTag}}>
+				<StoreContextProvider
+					value={{
+						languageTag: mockLanguageTag,
+						trafficShare: mockTrafficShare,
+						trafficVolume: mockTrafficVolume,
+					}}
+				>
 					<ChartStateContextProvider
 						publishDate={testProps.publishDate}
 						timeRange={testProps.timeRange}
@@ -505,25 +466,11 @@ describe('Detail', () => {
 						<Detail
 							currentPage={mockCurrentPageReferral}
 							onCurrentPageChange={mockOnCurrentPageChange}
-							onTrafficSourceNameChange={
-								mockOnTrafficSourceNameChange
-							}
 							timeSpanOptions={mockTimeSpanOptions}
-							trafficShareDataProvider={
-								mockTrafficShareDataProvider
-							}
-							trafficVolumeDataProvider={
-								mockTrafficVolumeDataProvider
-							}
 						/>
 					</ChartStateContextProvider>
 				</StoreContextProvider>
 			);
-
-			await wait(() => {
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
-			});
 
 			expect(getByText('Referral')).toBeInTheDocument();
 			expect(getByText('90%')).toBeInTheDocument();
@@ -554,14 +501,11 @@ describe('Detail', () => {
 			expect(getByText('4,601,453')).toBeInTheDocument();
 			expect(getByText('http://fred.example.com')).toBeInTheDocument();
 			expect(getByText('253,399')).toBeInTheDocument();
-
-			expect(mockTrafficShareDataProvider).toHaveBeenCalledTimes(1);
-			expect(mockTrafficVolumeDataProvider).toHaveBeenCalledTimes(1);
 		});
 	});
 
 	describe('Social Detail', () => {
-		it('displays the social detail according to API', async () => {
+		it('displays the social detail according to API', () => {
 			const testProps = {
 				pagePublishDate: 'Thu Aug 10 08:17:57 GMT 2020',
 				timeRange: {endDate: '2020-01-27', startDate: '2020-02-02'},
@@ -569,7 +513,13 @@ describe('Detail', () => {
 			};
 
 			const {getByText} = render(
-				<StoreContextProvider value={{languageTag: mockLanguageTag}}>
+				<StoreContextProvider
+					value={{
+						languageTag: mockLanguageTag,
+						trafficShare: mockTrafficShare,
+						trafficVolume: mockTrafficVolume,
+					}}
+				>
 					<ChartStateContextProvider
 						publishDate={testProps.publishDate}
 						timeRange={testProps.timeRange}
@@ -578,25 +528,11 @@ describe('Detail', () => {
 						<Detail
 							currentPage={mockCurrentPageSocial}
 							onCurrentPageChange={mockOnCurrentPageChange}
-							onTrafficSourceNameChange={
-								mockOnTrafficSourceNameChange
-							}
 							timeSpanOptions={mockTimeSpanOptions}
-							trafficShareDataProvider={
-								mockTrafficShareDataProvider
-							}
-							trafficVolumeDataProvider={
-								mockTrafficVolumeDataProvider
-							}
 						/>
 					</ChartStateContextProvider>
 				</StoreContextProvider>
 			);
-
-			await wait(() => {
-				expect(mockTrafficShareDataProvider).toHaveBeenCalled();
-				expect(mockTrafficVolumeDataProvider).toHaveBeenCalled();
-			});
 
 			expect(getByText('Social')).toBeInTheDocument();
 			expect(getByText('90%')).toBeInTheDocument();
@@ -612,9 +548,6 @@ describe('Detail', () => {
 			expect(getByText('771')).toBeInTheDocument();
 			expect(getByText('Others')).toBeInTheDocument();
 			expect(getByText('30')).toBeInTheDocument();
-
-			expect(mockTrafficShareDataProvider).toHaveBeenCalledTimes(1);
-			expect(mockTrafficVolumeDataProvider).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Keywords.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Keywords.js
@@ -32,7 +32,7 @@ describe('Keywords', () => {
 				helpMessage:
 					'This number refers to the volume of people that find your page through a search engine.',
 				name: 'organic',
-				share: 0,
+				share: '0',
 				title: 'Organic',
 				value: 0,
 			},

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Navigation.js
@@ -9,7 +9,7 @@
  * distribution rights of the Software.
  */
 
-import {cleanup, render} from '@testing-library/react';
+import {cleanup, render, wait} from '@testing-library/react';
 import React from 'react';
 
 import Navigation from '../../../src/main/resources/META-INF/resources/js/components/Navigation';
@@ -73,7 +73,7 @@ describe('Navigation', () => {
 		cleanup();
 	});
 
-	it('displays an alert error message if there is no valid connection', () => {
+	it('displays an alert error message if there is no valid connection', async () => {
 		const testProps = {
 			author: {
 				authorId: '',
@@ -110,9 +110,7 @@ describe('Navigation', () => {
 						<Navigation
 							author={testProps.author}
 							canonicalURL={testProps.canonicalURL}
-							endpoints={mockEndpoints}
 							onSelectedLanguageClick={noop}
-							page={testProps.page}
 							pagePublishDate={testProps.pagePublishDate}
 							pageTitle={testProps.pageTitle}
 							timeSpanOptions={mockTimeSpanOptions}
@@ -123,10 +121,14 @@ describe('Navigation', () => {
 			</ConnectionContext.Provider>
 		);
 
-		expect(getByText('an-unexpected-error-occurred')).toBeInTheDocument();
+		await wait(() =>
+			expect(
+				getByText('an-unexpected-error-occurred')
+			).toBeInTheDocument()
+		);
 	});
 
-	it('displays an alert warning message if some data is temporarily unavailable', () => {
+	it('displays an alert warning message if some data is temporarily unavailable', async () => {
 		const testProps = {
 			author: {
 				authorId: '',
@@ -159,9 +161,7 @@ describe('Navigation', () => {
 					<Navigation
 						author={testProps.author}
 						canonicalURL={testProps.canonicalURL}
-						endpoints={mockEndpoints}
 						onSelectedLanguageClick={noop}
-						page={testProps.page}
 						pagePublishDate={testProps.pagePublishDate}
 						pageTitle={testProps.pageTitle}
 						timeSpanOptions={mockTimeSpanOptions}
@@ -171,12 +171,14 @@ describe('Navigation', () => {
 			</StoreContextProvider>
 		);
 
-		expect(
-			getByText('some-data-is-temporarily-unavailable')
-		).toBeInTheDocument();
+		await wait(() =>
+			expect(
+				getByText('some-data-is-temporarily-unavailable')
+			).toBeInTheDocument()
+		);
 	});
 
-	it('displays an alert info message if the content was published today', () => {
+	it('displays an alert info message if the content was published today', async () => {
 		const testProps = {
 			author: {
 				authorId: '',
@@ -209,9 +211,7 @@ describe('Navigation', () => {
 					<Navigation
 						author={testProps.author}
 						canonicalURL={testProps.canonicalURL}
-						endpoints={mockEndpoints}
 						onSelectedLanguageClick={noop}
-						page={testProps.page}
 						pagePublishDate={testProps.pagePublishDate}
 						pageTitle={testProps.pageTitle}
 						timeSpanOptions={mockTimeSpanOptions}
@@ -221,9 +221,11 @@ describe('Navigation', () => {
 			</StoreContextProvider>
 		);
 
-		expect(getByText('no-data-is-available-yet')).toBeInTheDocument();
-		expect(
-			getByText('content-has-just-been-published')
-		).toBeInTheDocument();
+		await wait(() => {
+			expect(getByText('no-data-is-available-yet')).toBeInTheDocument();
+			expect(
+				getByText('content-has-just-been-published')
+			).toBeInTheDocument();
+		});
 	});
 });

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TotalCount.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TotalCount.js
@@ -9,7 +9,7 @@
  * distribution rights of the Software.
  */
 
-import {cleanup, render, wait} from '@testing-library/react';
+import {cleanup, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -20,17 +20,13 @@ import '@testing-library/jest-dom/extend-expect';
 describe('TotalCount', () => {
 	afterEach(cleanup);
 
-	it('renders text, help text and total count number', async () => {
-		const mockDataProvider = jest.fn(() => {
-			return Promise.resolve(9999);
-		});
-
+	it('renders text, help text and total count number', () => {
 		const testProps = {
-			dataProvider: mockDataProvider,
 			label: 'Total Views',
 			popoverHeader: 'Total Views',
 			popoverMessage:
 				'This number refers to the total number of views since the content was published.',
+			value: 9999,
 		};
 
 		const {getByRole, getByText} = render(
@@ -39,10 +35,9 @@ describe('TotalCount', () => {
 				label={testProps.label}
 				popoverHeader={testProps.popoverHeader}
 				popoverMessage={testProps.popoverMessage}
+				value={testProps.value}
 			/>
 		);
-
-		await wait(() => expect(mockDataProvider).toHaveBeenCalled());
 
 		expect(getByText('9,999')).toBeInTheDocument();
 
@@ -56,21 +51,15 @@ describe('TotalCount', () => {
 		getByText(
 			'This number refers to the total number of views since the content was published.'
 		);
-
-		expect(mockDataProvider).toHaveBeenCalledTimes(1);
 	});
 
-	it('renders a dash instead of total count number when there is an error', async () => {
-		const mockDataProvider = jest.fn(() => {
-			return Promise.reject('-');
-		});
-
+	it('renders a dash instead of total count number when there is an error', () => {
 		const testProps = {
-			dataProvider: mockDataProvider,
 			label: 'Total Views',
 			popoverHeader: 'Total Views',
 			popoverMessage:
 				'This number refers to the total number of views since the content was published.',
+			value: {undefined},
 		};
 
 		const {getByText} = render(
@@ -82,10 +71,6 @@ describe('TotalCount', () => {
 			/>
 		);
 
-		await wait(() => expect(mockDataProvider).toHaveBeenCalled());
-
 		expect(getByText('-')).toBeInTheDocument();
-
-		expect(mockDataProvider).toHaveBeenCalledTimes(1);
 	});
 });

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
@@ -10,71 +10,71 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
-import {cleanup, render, wait} from '@testing-library/react';
+import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 
 import TrafficSources from '../../../src/main/resources/META-INF/resources/js/components/TrafficSources';
+import {StoreContextProvider} from '../../../src/main/resources/META-INF/resources/js/context/StoreContext';
 
 const noop = () => {};
+
+const mockLanguageTag = 'en-US';
 
 describe('TrafficSources', () => {
 	afterEach(cleanup);
 
-	it('displays the traffic sources with buttons to view keywords', async () => {
-		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve([
-				{
-					countryKeywords: [
-						{
-							countryCode: 'us',
-							countryName: 'United States',
-							keywords: [],
-						},
-						{
-							countryCode: 'es',
-							countryName: 'Spain',
-							keywords: [],
-						},
-					],
-					helpMessage: 'Testing Help Message',
-					name: 'testing',
-					share: 30.0,
-					title: 'Testing',
-					value: 32178,
-				},
-				{
-					countryKeywords: [
-						{
-							countryCode: 'us',
-							countryName: 'United States',
-							keywords: [],
-						},
-						{
-							countryCode: 'es',
-							countryName: 'Spain',
-							keywords: [],
-						},
-					],
-					helpMessage: 'Second Testing Help Message',
-					name: 'second-testing',
-					share: 70.0,
-					title: 'Second Testing',
-					value: 278256,
-				},
-			])
-		);
+	it('displays the traffic sources with buttons to view keywords', () => {
+		const mockTrafficSources = [
+			{
+				countryKeywords: [
+					{
+						countryCode: 'us',
+						countryName: 'United States',
+						keywords: [],
+					},
+					{
+						countryCode: 'es',
+						countryName: 'Spain',
+						keywords: [],
+					},
+				],
+				helpMessage: 'Testing Help Message',
+				name: 'testing',
+				share: '30.0',
+				title: 'Testing',
+				value: 32178,
+			},
+			{
+				countryKeywords: [
+					{
+						countryCode: 'us',
+						countryName: 'United States',
+						keywords: [],
+					},
+					{
+						countryCode: 'es',
+						countryName: 'Spain',
+						keywords: [],
+					},
+				],
+				helpMessage: 'Second Testing Help Message',
+				name: 'second-testing',
+				share: '70.0',
+				title: 'Second Testing',
+				value: 278256,
+			},
+		];
 
 		const {getByText} = render(
-			<TrafficSources
-				dataProvider={mockTrafficSourcesDataProvider}
-				languageTag="en-US"
-				onTrafficSourceClick={noop}
-			/>
+			<StoreContextProvider
+				value={{
+					languageTag: mockLanguageTag,
+					trafficSources: mockTrafficSources,
+				}}
+			>
+				<TrafficSources onTrafficSourceClick={noop} />
+			</StoreContextProvider>
 		);
-
-		await wait(() => {
-			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1);
-		});
 
 		const button1 = getByText('Testing');
 
@@ -91,60 +91,57 @@ describe('TrafficSources', () => {
 		expect(getByText('278,256')).toBeInTheDocument();
 	});
 
-	it('displays the traffic sources without buttons to view keywords when the value is 0', async () => {
-		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve([
-				{
-					countryKeywords: [
-						{
-							countryCode: 'us',
-							countryName: 'United States',
-							keywords: [],
-						},
-						{
-							countryCode: 'es',
-							countryName: 'Spain',
-							keywords: [],
-						},
-					],
-					helpMessage: 'Testing Help Message',
-					name: 'testing',
-					share: 0.0,
-					title: 'Testing',
-					value: 0,
-				},
-				{
-					countryKeywords: [
-						{
-							countryCode: 'us',
-							countryName: 'United States',
-							keywords: [],
-						},
-						{
-							countryCode: 'es',
-							countryName: 'Spain',
-							keywords: [],
-						},
-					],
-					helpMessage: 'Second Testing Help Message',
-					name: 'second-testing',
-					share: 0.0,
-					title: 'Second Testing',
-					value: 0,
-				},
-			])
-		);
+	it('displays the traffic sources without buttons to view keywords when the value is 0', () => {
+		const mockTrafficSources = [
+			{
+				countryKeywords: [
+					{
+						countryCode: 'us',
+						countryName: 'United States',
+						keywords: [],
+					},
+					{
+						countryCode: 'es',
+						countryName: 'Spain',
+						keywords: [],
+					},
+				],
+				helpMessage: 'Testing Help Message',
+				name: 'testing',
+				share: '0.0',
+				title: 'Testing',
+				value: 0,
+			},
+			{
+				countryKeywords: [
+					{
+						countryCode: 'us',
+						countryName: 'United States',
+						keywords: [],
+					},
+					{
+						countryCode: 'es',
+						countryName: 'Spain',
+						keywords: [],
+					},
+				],
+				helpMessage: 'Second Testing Help Message',
+				name: 'second-testing',
+				share: '0.0',
+				title: 'Second Testing',
+				value: 0,
+			},
+		];
 
 		const {getAllByText, getByText} = render(
-			<TrafficSources
-				dataProvider={mockTrafficSourcesDataProvider}
-				languageTag="en-US"
-				onTrafficSourceClick={noop}
-			/>
-		);
-
-		await wait(() =>
-			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1)
+			<StoreContextProvider
+				value={{
+					languageTag: mockLanguageTag,
+					trafficSources: mockTrafficSources,
+				}}
+			>
+				<TrafficSources onTrafficSourceClick={noop} />
+			</StoreContextProvider>
 		);
 
 		const text1 = getByText('Testing');
@@ -162,55 +159,52 @@ describe('TrafficSources', () => {
 		expect(zeroValues.length).toBe(2);
 	});
 
-	it('displays the traffic sources without buttons to view keywords when the value is 0 and there are country keywords', async () => {
-		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve([
-				{
-					countryKeywords: [
-						{
-							countryCode: 'us',
-							countryName: 'United States',
-							keywords: [],
-						},
-						{
-							countryCode: 'es',
-							countryName: 'Spain',
-							keywords: [],
-						},
-					],
-					helpMessage: 'Testing Help Message',
-					name: 'testing',
-					share: 80.0,
-					title: 'Testing',
-					value: 345,
-				},
-				{
-					helpMessage: 'Second Testing Help Message',
-					name: 'second-testing',
-					share: 0.0,
-					title: 'Second Testing',
-					value: 0,
-				},
-				{
-					helpMessage: 'Third Testing Help Message',
-					name: 'third-testing',
-					share: 20.0,
-					title: 'Third Testing',
-					value: 77,
-				},
-			])
-		);
+	it('displays the traffic sources without buttons to view keywords when the value is 0 and there are country keywords', () => {
+		const mockTrafficSources = [
+			{
+				countryKeywords: [
+					{
+						countryCode: 'us',
+						countryName: 'United States',
+						keywords: [],
+					},
+					{
+						countryCode: 'es',
+						countryName: 'Spain',
+						keywords: [],
+					},
+				],
+				helpMessage: 'Testing Help Message',
+				name: 'testing',
+				share: '80.0',
+				title: 'Testing',
+				value: 345,
+			},
+			{
+				helpMessage: 'Second Testing Help Message',
+				name: 'second-testing',
+				share: '0.0',
+				title: 'Second Testing',
+				value: 0,
+			},
+			{
+				helpMessage: 'Third Testing Help Message',
+				name: 'third-testing',
+				share: '20.0',
+				title: 'Third Testing',
+				value: 77,
+			},
+		];
 
 		const {getAllByText, getByText} = render(
-			<TrafficSources
-				dataProvider={mockTrafficSourcesDataProvider}
-				languageTag="en-US"
-				onTrafficSourceClick={noop}
-			/>
-		);
-
-		await wait(() =>
-			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1)
+			<StoreContextProvider
+				value={{
+					languageTag: mockLanguageTag,
+					trafficSources: mockTrafficSources,
+				}}
+			>
+				<TrafficSources onTrafficSourceClick={noop} />
+			</StoreContextProvider>
 		);
 
 		const text1 = getByText('Testing');
@@ -232,32 +226,29 @@ describe('TrafficSources', () => {
 		expect(text3).not.toHaveAttribute('type', 'button');
 	});
 
-	it('displays a dash instead of value when there is an endpoint error', async () => {
-		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve([
-				{
-					helpMessage: 'Testing Help Message',
-					name: 'testing',
-					title: 'Testing',
-				},
-				{
-					helpMessage: 'Second Testing Help Message',
-					name: 'second-testing',
-					title: 'Second Testing',
-				},
-			])
-		);
+	it('displays a dash instead of value when there is an endpoint error', () => {
+		const mockTrafficSources = [
+			{
+				helpMessage: 'Testing Help Message',
+				name: 'testing',
+				title: 'Testing',
+			},
+			{
+				helpMessage: 'Second Testing Help Message',
+				name: 'second-testing',
+				title: 'Second Testing',
+			},
+		];
 
 		const {getAllByText, getByText} = render(
-			<TrafficSources
-				dataProvider={mockTrafficSourcesDataProvider}
-				languageTag="en-US"
-				onTrafficSourceClick={noop}
-			/>
-		);
-
-		await wait(() =>
-			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1)
+			<StoreContextProvider
+				value={{
+					languageTag: mockLanguageTag,
+					trafficSources: mockTrafficSources,
+				}}
+			>
+				<TrafficSources onTrafficSourceClick={noop} />
+			</StoreContextProvider>
 		);
 
 		const text1 = getByText('Testing');
@@ -270,38 +261,35 @@ describe('TrafficSources', () => {
 		expect(text2).not.toHaveAttribute('type', 'button');
 	});
 
-	it('displays a message informing the user that there is no incoming traffic from search engines yet', async () => {
-		const mockTrafficSourcesDataProvider = jest.fn(() =>
-			Promise.resolve([
-				{
-					countryKeywords: [],
-					helpMessage: 'Testing Help Message',
-					name: 'testing',
-					share: 0.0,
-					title: 'Testing',
-					value: 0,
-				},
-				{
-					countryKeywords: [],
-					helpMessage: 'Second Testing Help Message',
-					name: 'second-testing',
-					share: 0.0,
-					title: 'Second Testing',
-					value: 0,
-				},
-			])
-		);
+	it('displays a message informing the user that there is no incoming traffic from search engines yet', () => {
+		const mockTrafficSources = [
+			{
+				countryKeywords: [],
+				helpMessage: 'Testing Help Message',
+				name: 'testing',
+				share: '0.0',
+				title: 'Testing',
+				value: 0,
+			},
+			{
+				countryKeywords: [],
+				helpMessage: 'Second Testing Help Message',
+				name: 'second-testing',
+				share: '0.0',
+				title: 'Second Testing',
+				value: 0,
+			},
+		];
 
 		const {getAllByText, getByText} = render(
-			<TrafficSources
-				dataProvider={mockTrafficSourcesDataProvider}
-				languageTag="en-US"
-				onTrafficSourceClick={noop}
-			/>
-		);
-
-		await wait(() =>
-			expect(mockTrafficSourcesDataProvider).toHaveBeenCalledTimes(1)
+			<StoreContextProvider
+				value={{
+					languageTag: mockLanguageTag,
+					trafficSources: mockTrafficSources,
+				}}
+			>
+				<TrafficSources onTrafficSourceClick={noop} />
+			</StoreContextProvider>
 		);
 
 		expect(getByText('Testing')).toBeInTheDocument();


### PR DESCRIPTION
**Description**

This is the fourth pull request to fix [LPS-128998 Content Performance available endpoints should load at the same time](https://issues.liferay.com/browse/LPS-128998) as I said in a previous PR (see `Notes` from description, but in summary, the idea is that every component reads data from the store instead of calling its `dataProvider` and wait until all endpoints are resolved to display the data in the UI): https://github.com/liferay-frontend/liferay-portal/pull/885#issue-588734880.

As the pull can be huge, I'm going to create sub-tasks for the issue and send the code for each of them separately.

**How to test it**

- Connect Liferay DXP with Analytics Cloud
- Create a Content Page
- Wait 24 hours to let Analytics Cloud process the data (if you don't want to wait for it, change the date of your computer and create the page in the past 😉  )
- Open the Content Performance panel

**Within this pull request**

Everything should work as before. No major UI changes. Now there is one loading indicator more in `Navigation` component until all endpoints finish.

- Add new action type to set metrics when all endpoints are settled
- Remove data providers from components
- Use data from store: historical, totals, share and volume
- Fix frontend tests

**History pull requests**

- LPS-128998 [Content Performance] Refactor APIService to be called in any component: https://github.com/brianchandotcom/liferay-portal/pull/99816
- LPS-128998 [Content Performance] Save attributes in store instead of prop-drilling them: https://github.com/brianchandotcom/liferay-portal/pull/99883
- LPS-128998 [Content Performance] Separate dispatch from state and unified warnings: https://github.com/brianchandotcom/liferay-portal/pull/99913

**Notes**

Only one pull left to clean up and refactor the Content Performance panel, remove data providers and get the data from the store.