### PR TITLE
LPS-129306 Add autoComplete attribute to input-date, input-time and input-checkbox taglibs

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_checkbox/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_checkbox/page.jsp
@@ -17,6 +17,7 @@
 <%@ include file="/html/taglib/init.jsp" %>
 
 <%
+String autoComplete = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-checkbox:autoComplete"));
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-checkbox:cssClass"));
 String param = (String)request.getAttribute("liferay-ui:input-checkbox:param");
 String id = (String)request.getAttribute("liferay-ui:input-checkbox:id");
@@ -31,4 +32,4 @@ if (Validator.isNull(id)) {
 }
 %>
 
-<input <%= value ? "checked" : "" %> class="<%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= HtmlUtil.escapeAttribute(id) %>" name="<%= namespace %><%= param %>" onClick="<%= onClick %>" type="checkbox" />
+<input <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> <%= value ? "checked" : "" %> class="<%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= HtmlUtil.escapeAttribute(id) %>" name="<%= namespace %><%= param %>" onClick="<%= onClick %>" type="checkbox" />

--- a/portal-web/docroot/html/taglib/ui/input_date/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_date/page.jsp
@@ -23,6 +23,7 @@ if (GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-date:di
 	namespace = StringPool.BLANK;
 }
 
+String autoComplete = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-date:autoComplete"));
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-date:cssClass"));
 String dateTogglerCheckboxLabel = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-date:dateTogglerCheckboxLabel"), "disable");
 boolean disabled = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-date:disabled"));
@@ -115,10 +116,10 @@ else {
 <span class="lfr-input-date" id="<%= randomNamespace %>displayDate">
 	<c:choose>
 		<c:when test="<%= BrowserSnifferUtil.isMobile(request) %>">
-			<input class="form-control <%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= namespace + HtmlUtil.escapeAttribute(name) %>" type="date" value="<%= dateString %>" />
+			<input <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> class="form-control <%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= namespace + HtmlUtil.escapeAttribute(name) %>" type="date" value="<%= dateString %>" />
 		</c:when>
 		<c:otherwise>
-			<aui:input cssClass="<%= cssClass %>" disabled="<%= disabled %>" id="<%= HtmlUtil.getAUICompatibleId(name) %>" label="" name="<%= name %>" placeholder="<%= StringUtil.toLowerCase(placeholderValue) %>" required="<%= required %>" title="" type="text" value="<%= dateString %>" wrappedField="<%= true %>">
+			<aui:input <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> cssClass="<%= cssClass %>" disabled="<%= disabled %>" id="<%= HtmlUtil.getAUICompatibleId(name) %>" label="" name="<%= name %>" placeholder="<%= StringUtil.toLowerCase(placeholderValue) %>" required="<%= required %>" title="" type="text" value="<%= dateString %>" wrappedField="<%= true %>">
 				<aui:validator errorMessage="please-enter-a-valid-date" name="custom">
 					function(val) {
 						return AUI().use('aui-datatype-date-parse').Parsers.date('<%= mask %>', val);

--- a/portal-web/docroot/html/taglib/ui/input_date/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_date/page.jsp
@@ -119,13 +119,26 @@ else {
 			<input <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> class="form-control <%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= namespace + HtmlUtil.escapeAttribute(name) %>" type="date" value="<%= dateString %>" />
 		</c:when>
 		<c:otherwise>
-			<aui:input <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> cssClass="<%= cssClass %>" disabled="<%= disabled %>" id="<%= HtmlUtil.getAUICompatibleId(name) %>" label="" name="<%= name %>" placeholder="<%= StringUtil.toLowerCase(placeholderValue) %>" required="<%= required %>" title="" type="text" value="<%= dateString %>" wrappedField="<%= true %>">
-				<aui:validator errorMessage="please-enter-a-valid-date" name="custom">
-					function(val) {
-						return AUI().use('aui-datatype-date-parse').Parsers.date('<%= mask %>', val);
-					}
-				</aui:validator>
-			</aui:input>
+			<c:choose>
+				<c:when test="<%= Validator.isNotNull(autoComplete) %>">
+					<aui:input autocomplete="<%= autoComplete %>" cssClass="<%= cssClass %>" disabled="<%= disabled %>" id="<%= HtmlUtil.getAUICompatibleId(name) %>" label="" name="<%= name %>" placeholder="<%= StringUtil.toLowerCase(placeholderValue) %>" required="<%= required %>" title="" type="text" value="<%= dateString %>" wrappedField="<%= true %>">
+						<aui:validator errorMessage="please-enter-a-valid-date" name="custom">
+							function(val) {
+								return AUI().use('aui-datatype-date-parse').Parsers.date('<%= mask %>', val);
+							}
+						</aui:validator>
+					</aui:input>
+				</c:when>
+				<c:otherwise>
+					<aui:input cssClass="<%= cssClass %>" disabled="<%= disabled %>" id="<%= HtmlUtil.getAUICompatibleId(name) %>" label="" name="<%= name %>" placeholder="<%= StringUtil.toLowerCase(placeholderValue) %>" required="<%= required %>" title="" type="text" value="<%= dateString %>" wrappedField="<%= true %>">
+						<aui:validator errorMessage="please-enter-a-valid-date" name="custom">
+							function(val) {
+								return AUI().use('aui-datatype-date-parse').Parsers.date('<%= mask %>', val);
+							}
+						</aui:validator>
+					</aui:input>
+				</c:otherwise>
+			</c:choose>
 		</c:otherwise>
 	</c:choose>
 

--- a/portal-web/docroot/html/taglib/ui/input_field/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_field/page.jsp
@@ -72,6 +72,7 @@ if (hints != null) {
 			%>
 
 			<liferay-ui:input-checkbox
+				autoComplete="<%= autoComplete %>"
 				cssClass="<%= cssClass %>"
 				defaultValue="<%= value %>"
 				disabled="<%= disabled %>"
@@ -220,6 +221,7 @@ if (hints != null) {
 			<div class="form-group-autofit">
 				<div class="form-group-item">
 					<liferay-ui:input-date
+						autoComplete="<%= autoComplete %>"
 						autoFocus="<%= autoFocus %>"
 						cssClass="<%= cssClass %>"
 						dayParam='<%= fieldParam + "Day" %>'
@@ -240,6 +242,7 @@ if (hints != null) {
 						<liferay-ui:input-time
 							amPmParam='<%= fieldParam + "AmPm" %>'
 							amPmValue="<%= amPm %>"
+							autoComplete="<%= autoComplete %>"
 							cssClass="<%= cssClass %>"
 							disabled="<%= disabled %>"
 							hourParam='<%= fieldParam + "Hour" %>'

--- a/portal-web/docroot/html/taglib/ui/input_time/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_time/page.jsp
@@ -21,6 +21,7 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_input_
 
 String amPmParam = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-time:amPmParam"));
 int amPmValue = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-time:amPmValue"));
+String autoComplete = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-time:autoComplete"));
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-time:cssClass"));
 String dateParam = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-time:dateParam"), "date");
 Date dateValue = (Date)GetterUtil.getObject(request.getAttribute("liferay-ui:input-time:dateValue"));
@@ -81,10 +82,10 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPa
 <span class="lfr-input-time" id="<%= randomNamespace %>displayTime">
 	<c:choose>
 		<c:when test="<%= BrowserSnifferUtil.isMobile(request) %>">
-			<input class="form-control <%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= namespace + HtmlUtil.escapeAttribute(name) %>" type="time" value="<%= format.format(calendar.getTime()) %>" />
+			<input <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> class="form-control <%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= namespace + HtmlUtil.escapeAttribute(name) %>" type="time" value="<%= format.format(calendar.getTime()) %>" />
 		</c:when>
 		<c:otherwise>
-			<input class="form-control <%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= namespace + HtmlUtil.escapeAttribute(name) %>" placeholder="<%= placeholder %>" type="text" value="<%= format.format(calendar.getTime()) %>" />
+			<input <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> class="form-control <%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= namespace + HtmlUtil.escapeAttribute(name) %>" placeholder="<%= placeholder %>" type="text" value="<%= format.format(calendar.getTime()) %>" />
 		</c:otherwise>
 	</c:choose>
 

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -766,6 +766,11 @@
 		<tag-class>com.liferay.taglib.ui.InputCheckBoxTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
+			<name>autoComplete</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>A CSS class for styling the component.</description>
 			<name>cssClass</name>
 			<required>false</required>
@@ -815,6 +820,11 @@
 		<name>input-date</name>
 		<tag-class>com.liferay.taglib.ui.InputDateTag</tag-class>
 		<body-content>JSP</body-content>
+		<attribute>
+			<name>autoComplete</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 		<attribute>
 			<description>Whether the date field gets focus by default. The default value is <![CDATA[<code>false</code>]]>.</description>
 			<name>autoFocus</name>
@@ -1573,6 +1583,11 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>int</type>
+		</attribute>
+		<attribute>
+			<name>autoComplete</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description>A CSS class for styling the component.</description>

--- a/util-taglib/src/com/liferay/taglib/ui/InputCheckBoxTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputCheckBoxTag.java
@@ -33,6 +33,10 @@ public class InputCheckBoxTag extends IncludeTag {
 		return super.doEndTag();
 	}
 
+	public String getAutoComplete() {
+		return _autoComplete;
+	}
+
 	public String getCssClass() {
 		return _cssClass;
 	}
@@ -59,6 +63,10 @@ public class InputCheckBoxTag extends IncludeTag {
 
 	public boolean isDisabled() {
 		return _disabled;
+	}
+
+	public void setAutoComplete(String autoComplete) {
+		_autoComplete = autoComplete;
 	}
 
 	public void setCssClass(String cssClass) {
@@ -93,6 +101,7 @@ public class InputCheckBoxTag extends IncludeTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_autoComplete = null;
 		_cssClass = null;
 		_defaultValue = false;
 		_disabled = false;
@@ -109,6 +118,8 @@ public class InputCheckBoxTag extends IncludeTag {
 
 	@Override
 	protected void setAttributes(HttpServletRequest httpServletRequest) {
+		httpServletRequest.setAttribute(
+			"liferay-ui:input-checkbox:autoComplete", _autoComplete);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-checkbox:cssClass", _cssClass);
 		httpServletRequest.setAttribute(
@@ -139,6 +150,7 @@ public class InputCheckBoxTag extends IncludeTag {
 	private static final String _PAGE =
 		"/html/taglib/ui/input_checkbox/page.jsp";
 
+	private String _autoComplete;
 	private String _cssClass;
 	private boolean _defaultValue;
 	private boolean _disabled;

--- a/util-taglib/src/com/liferay/taglib/ui/InputDateTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputDateTag.java
@@ -27,6 +27,10 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class InputDateTag extends BaseValidatorTagSupport {
 
+	public String getAutoComplete() {
+		return _autoComplete;
+	}
+
 	public String getCssClass() {
 		return _cssClass;
 	}
@@ -110,6 +114,10 @@ public class InputDateTag extends BaseValidatorTagSupport {
 
 	public boolean isShowDisableCheckbox() {
 		return _showDisableCheckbox;
+	}
+
+	public void setAutoComplete(String autoComplete) {
+		_autoComplete = autoComplete;
 	}
 
 	public void setAutoFocus(boolean autoFocus) {
@@ -196,6 +204,7 @@ public class InputDateTag extends BaseValidatorTagSupport {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_autoComplete = null;
 		_autoFocus = false;
 		_cssClass = null;
 		_dateTogglerCheckboxLabel = null;
@@ -225,6 +234,8 @@ public class InputDateTag extends BaseValidatorTagSupport {
 
 	@Override
 	protected void setAttributes(HttpServletRequest httpServletRequest) {
+		httpServletRequest.setAttribute(
+			"liferay-ui:input-date:autoComplete", _autoComplete);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-date:autoFocus", String.valueOf(_autoFocus));
 		httpServletRequest.setAttribute(
@@ -272,6 +283,7 @@ public class InputDateTag extends BaseValidatorTagSupport {
 
 	private static final String _PAGE = "/html/taglib/ui/input_date/page.jsp";
 
+	private String _autoComplete;
 	private boolean _autoFocus;
 	private String _cssClass;
 	private String _dateTogglerCheckboxLabel;

--- a/util-taglib/src/com/liferay/taglib/ui/InputTimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputTimeTag.java
@@ -33,6 +33,10 @@ public class InputTimeTag extends IncludeTag {
 		return _amPmValue;
 	}
 
+	public String getAutoComplete() {
+		return _autoComplete;
+	}
+
 	public String getCssClass() {
 		return _cssClass;
 	}
@@ -85,6 +89,10 @@ public class InputTimeTag extends IncludeTag {
 		_amPmValue = amPmValue;
 	}
 
+	public void setAutoComplete(String autoComplete) {
+		_autoComplete = autoComplete;
+	}
+
 	public void setCssClass(String cssClass) {
 		_cssClass = cssClass;
 	}
@@ -135,6 +143,7 @@ public class InputTimeTag extends IncludeTag {
 
 		_amPmParam = null;
 		_amPmValue = 0;
+		_autoComplete = null;
 		_cssClass = null;
 		_dateParam = null;
 		_dateValue = null;
@@ -159,6 +168,8 @@ public class InputTimeTag extends IncludeTag {
 			"liferay-ui:input-time:amPmParam", _amPmParam);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-time:amPmValue", String.valueOf(_amPmValue));
+		httpServletRequest.setAttribute(
+			"liferay-ui:input-time:autoComplete", _autoComplete);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-time:cssClass", _cssClass);
 		httpServletRequest.setAttribute(
@@ -187,6 +198,7 @@ public class InputTimeTag extends IncludeTag {
 
 	private String _amPmParam;
 	private int _amPmValue;
+	private String _autoComplete;
 	private String _cssClass;
 	private String _dateParam;
 	private Date _dateValue;


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

As you can guess this is coming from the same customer than [LPS-128745](https://issues.liferay.com/browse/LPS-128745).

Once they've got that solution, they realised it was not working with date fields. Just by having a look at the code I saw it could happen as well with time and checkbox fields.

Because of that I'm adding this attribute to those three taglibs: input-date, input-time and input-checkbox.

Additionally, I'm updating the use we make of them within input-field to propagate autoComplete value.

Let me know if you have further questions.

Thanks.

Regards.