### PR TITLE
LPS-129327 Checks if editorRef is defined before use it

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -66,7 +66,7 @@ const ClassicEditor = React.forwardRef(
 		}, [contents]);
 
 		const onChangeCallback = () => {
-			if (!onChangeMethodName && !onChange && !editorRef.current) {
+			if (!onChangeMethodName && !onChange || !editorRef.current) {
 				return;
 			}
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -66,7 +66,7 @@ const ClassicEditor = React.forwardRef(
 		}, [contents]);
 
 		const onChangeCallback = () => {
-			if (!onChangeMethodName && !onChange || !editorRef.current) {
+			if (!onChangeMethodName && !onChange) {
 				return;
 			}
 
@@ -83,6 +83,16 @@ const ClassicEditor = React.forwardRef(
 				editor.resetDirty();
 			}
 		};
+
+		const editorRefsCallback = useCallback(
+			(element) => {
+				if (ref) {
+					ref.current = element;
+				}
+				editorRef.current = element;
+			},
+			[ref, editorRef]
+		);
 
 		useEffect(() => {
 			setToolbarSet(initialToolbarSet);
@@ -147,12 +157,7 @@ const ClassicEditor = React.forwardRef(
 					onInstanceReady={({editor}) => {
 						editor.setData(contents);
 					}}
-					ref={(element) => {
-						if (ref) {
-							ref.current = element;
-						}
-						editorRef.current = element;
-					}}
+					ref={editorRefsCallback}
 					{...otherProps}
 				/>
 			</div>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -66,7 +66,7 @@ const ClassicEditor = React.forwardRef(
 		}, [contents]);
 
 		const onChangeCallback = () => {
-			if (!onChangeMethodName && !onChange) {
+			if (!onChangeMethodName && !onChange && !editorRef.current) {
 				return;
 			}
 


### PR DESCRIPTION
Depending on how fast We type and change things on ClassicEditor component, onChangeCallback will be called with an invalid value for `editorRef`.

See the following images:

Error:

![image](https://user-images.githubusercontent.com/7663513/111512913-01e61280-872f-11eb-95dc-a489a2adb3da.png)

See the incorrect value: 

![image](https://user-images.githubusercontent.com/7663513/111512934-090d2080-872f-11eb-849b-3b2b48e82cab.png)



It introduce intermittent fails in some POSHI tests that uses Paragraph field on Form Builder, like: 

LocalFile.Forms#SubmitFormAfterEditingFields (See poshi summary: https://testray.liferay.com/reports/production/logs/test-1-19/1615861432082/test-portal-acceptance-pullrequest(master)/7922/functional-tomcat90-mysql57-jdk8/2/15/LocalFile.Forms_SubmitFormAfterEditingFields/summary.html.gz)
