### PR TITLE
LPS-127719 Clay:data-set-display tag returns sort == null

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/jaxrs/context/provider/SortContextProvider.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/jaxrs/context/provider/SortContextProvider.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.taglib.clay.internal.jaxrs.context.provider;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -43,15 +44,23 @@ public class SortContextProvider implements ContextProvider<Sort> {
 
 		String sortString = ParamUtil.getString(
 			httpServletRequest, "sort.field");
-
-		if (Validator.isNull(sortString)) {
-			return null;
-		}
-
 		String sortDir = ParamUtil.getString(httpServletRequest, "sort.dir");
 
-		return SortFactoryUtil.create(
-			StringUtil.trim(sortString), sortDir.equals("desc"));
+		if (Validator.isNotNull(sortString) && Validator.isNotNull(sortDir)) {
+			return SortFactoryUtil.create(
+				StringUtil.trim(sortString), sortDir.equals("desc"));
+		}
+
+		String sort = ParamUtil.getString(httpServletRequest, "sort");
+
+		if (Validator.isNotNull(sort)) {
+			String[] sortArray = StringUtil.split(sort, StringPool.COLON);
+
+			return SortFactoryUtil.create(
+				StringUtil.trim(sortArray[0]), sortArray[1].equals("desc"));
+		}
+
+		return null;
 	}
 
 }


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-127719

This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/784. That PR was merged, but reverted because of a regression bug https://issues.liferay.com/browse/COMMERCE-5972

In this PR, we are still doing the same solution as concluded in https://github.com/liferay-frontend/liferay-portal/pull/784#issuecomment-790699767, implementing support for both param formats. The bug in [previous solution](https://github.com/liferay-frontend/liferay-portal/pull/784/commits/45f8dc633b77b641b789c17604f0f209a1d16647) was that we didn't handle the case when there are no sorting parameters. Code split an empty string into an array and broke on array[1].

For test case, see the the original LPP: https://issues.liferay.com/browse/LPP-39921. I tested on the provided sample module, and on a page that used to contain a regression bug.

![after](https://user-images.githubusercontent.com/5435511/111643551-58228680-87ff-11eb-8440-302dfda7cfab.gif)
