### PR TITLE
LPS-129438

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
@@ -15,17 +15,13 @@
 import ClayColorPicker from '@clayui/color-picker';
 import React, {useState} from 'react';
 
-function normalizeColor(color) {
-	return color.startsWith('#') ? color.substring(1) : color;
-}
-
 const ColorPicker = ({color, label, name}) => {
-	const [colorValue, setColorValue] = useState(normalizeColor(color));
+	const [colorValue, setColorValue] = useState(color);
 	const [customColors, setCustomColors] = useState([]);
 
 	return (
 		<div className="form-group">
-			<input name={name} type="hidden" value={`#${colorValue}`} />
+			<input name={name} type="hidden" value={`${colorValue}`} />
 
 			<ClayColorPicker
 				colors={customColors}

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
@@ -21,7 +21,7 @@ const ColorPicker = ({color, label, name}) => {
 
 	return (
 		<div className="form-group">
-			<input name={name} type="hidden" value={`${colorValue}`} />
+			<input name={name} type="hidden" value={colorValue} />
 
 			<ClayColorPicker
 				colors={customColors}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-129438

### Steps to reproduce

1. Add widget page
2. Add Hello World portlet to the widget page
3. Select Look and Feel Configuration from the options menu in the web contents widget
4. Navigate to Border Styles
5. Select "Same for All" under Border Width and set to 15 px
6. Select "Same for All" under Border Color and type in "crimson"
7. Save and refresh the page

Expected behavior is that we are able to use named colors due to using clay color-picker version 3.4.0+ (https://github.com/liferay/clay/commit/f52dabab66f99f95db941e5c3ae1af3995d043eb) and that we see a crimson border around the Hello World portlet.

Actual behavior is that Liferay adds a # sign and thus the named color does not work, and we instead have a blue border (the default border color) around the Hello World portlet.

### Solution overview

This is due to an attempt to always add a `#` to the input value that's submitted to the server, so we remove it. Additionally, value normalization is already handled by clay color-picker with the v3.4.0 changes, so we can remove the unnecessary code trying to remove the leading `#`.