### PR TITLE
LPS 129469 Fixing viewRestorePortlet macro to assert restored theme

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Theme.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Theme.macro
@@ -128,6 +128,10 @@ definition {
 			locator1 = "MenuItem#ANY_MENU_ITEM",
 			value1 = "Restore");
 
+		AssertTextPresent(
+			locator1 = "HelloWorld#PORTLET_CONTENT",
+			value1 = "Welcome to Liferay");
+
 		// Refresh step is a workaround for LPS-91762
 
 		Refresh();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/ClassicTheme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/ClassicTheme.testcase
@@ -89,8 +89,6 @@ definition {
 		Portlet.gotoPortletOptions(portletName = "Hello World");
 
 		Theme.viewRestorePortlet();
-
-		Smoke.viewWelcomeContentPage();
 	}
 
 }


### PR DESCRIPTION
**Jira Ticket:**
https://issues.liferay.com/browse/LPS-129469

**Test Plan:**

1. Add assertion to check for restored theme 
2. Remove Smoke.viewWelcomeContentPage() macro from ClassicTheme.testcase due to failure upstream fix by Echo team https://github.com/liferay-echo/liferay-portal/pull/4050/commits/ea9458b33f893a80ea93c5ee65770d264bb35e8f
3. Ticket for the failure is here: https://issues.liferay.com/browse/LPS-129064

This PR will fix the failure upstream for ClassicTheme#ConfigureLookAndFeelSettingsSinglePage https://issues.liferay.com/browse/LRQA-65990
cc/ @jbalsas Do you think we should transfer this test to echo team? Since the viewWelcomeContentPage macro is under Echo team.