### PR TITLE
LPS-125185 Remove mentions of metal in .npmbundlerrc file within document-library 

### DIFF
--- a/modules/apps/document-library/document-library-web/.npmbundlerrc
+++ b/modules/apps/document-library/document-library-web/.npmbundlerrc
@@ -7,23 +7,6 @@
 			"data-engine-taglib": {
 				"/": ">=2.0.0"
 			},
-			"frontend-taglib-clay": {
-				"clay-autocomplete": ">=2.9.0",
-				"clay-button": ">=2.9.0",
-				"clay-data-provider": ">=2.9.0",
-				"clay-icon": ">=2.9.0",
-				"clay-label": ">=2.9.0",
-				"clay-link": ">=2.9.0",
-				"clay-multi-select": ">=2.9.0",
-				"clay-portal": ">=2.9.0",
-				"clay-radio": ">=2.9.0"
-			},
-			"frontend-js-metal-web": {
-				"metal": ">=2.16.5",
-				"metal-component": ">=2.16.5",
-				"metal-soy": ">=2.16.5",
-				"metal-state": ">=2.16.5"
-			},
 			"frontend-js-web": {
 				"/": ">=3.0.0"
 			}


### PR DESCRIPTION
Fixes [LPS-125185](https://issues.liferay.com/browse/LPS-125185).

I played around with doing the same with the remaining 2 modules that have `metal` mentions (`frontend-taglib-clay` & `frontend-taglib-chart`). I deduced that removing mentions from `frontend-taglib-clay` didn't cause any errors in my quick tests (clicking around a few modules), but removing mentions from `frontend-taglib-chart` and dropping a `Chart` portlet into the landing page triggers the following error:
```bash
2021-03-22 11:31:20.238 INFO  [fileinstall-directory-watcher][BundleStartStopLogger:49] STOPPED com.liferay.frontend.taglib.chart_4.0.0 [271]
2021-03-22 11:31:20.364 INFO  [Refresh Thread: Equinox Container: da509087-e1cd-4c59-adc9-ef15535fc560][BundleStartStopLogger:49] STOPPED com.liferay.frontend.taglib.chart.sample.web_1.0.0 [1035]
2021-03-22 11:31:20.449 ERROR [fileinstall-directory-watcher][DirectoryWatcher:1156] Unable to start bundle: file:/Users/kresimircoko/Documents/Work/Projects/dxp/bundles/osgi/modules/com.liferay.frontend.taglib.chart.sample.web.jar
org.osgi.framework.BundleException: Could not resolve module: com.liferay.frontend.taglib.chart.sample.web [1035]_  Unresolved requirement: Import-Package: com.liferay.frontend.taglib.chart.model; version="[1.0.0,2.0.0)"_ [Sanitized]
        at org.eclipse.osgi.container.Module.start(Module.java:444)
        at org.eclipse.osgi.internal.framework.EquinoxBundle.start(EquinoxBundle.java:428)
        at com.liferay.portal.file.install.internal.DirectoryWatcher._startBundle(DirectoryWatcher.java:1139)
        at com.liferay.portal.file.install.internal.DirectoryWatcher._startBundles(DirectoryWatcher.java:1172)
        at com.liferay.portal.file.install.internal.DirectoryWatcher._startAllBundles(DirectoryWatcher.java:1117)
        at com.liferay.portal.file.install.internal.DirectoryWatcher._process(DirectoryWatcher.java:1029)
        at com.liferay.portal.file.install.internal.DirectoryWatcher.run(DirectoryWatcher.java:272)
2021-03-22 11:31:41.283 INFO  [Refresh Thread: Equinox Container: da509087-e1cd-4c59-adc9-ef15535fc560][BundleStartStopLogger:46] STARTED com.liferay.frontend.taglib.chart.sample.web_1.0.0 [1035]
2021-03-22 11:31:41.427 INFO  [fileinstall-directory-watcher][BundleStartStopLogger:46] STARTED com.liferay.frontend.taglib.chart_4.0.0 [1156]
```

So I decided to just push a commit that removes `metal` mentions from `document-library-web/.npmbundlerrc`.
If you think I should add a commit that removes `metal` from `frontend-taglib-clay` to test out yourself, let me know!

/cc @liferay-lima