### PR TITLE
LPS-128895 Update liferay-ckeditor to v4.14.1-liferay.20

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"ckeditor4-react": "1.3.0",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.14.1-liferay.18",
+		"liferay-ckeditor": "4.14.1-liferay.20",
 		"prop-types": "15.7.2"
 	},
 	"main": "index.js",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -4091,7 +4091,7 @@ clay-loading-indicator@2.22.2, clay-loading-indicator@^2.22.2:
     metal-dom "^2.16.0"
     metal-state "^2.16.0"
 
-clay-management-toolbar@2.22.3, clay-management-toolbar@^2.22.3:
+clay-management-toolbar@^2.22.3:
   version "2.22.3"
   resolved "https://registry.yarnpkg.com/clay-management-toolbar/-/clay-management-toolbar-2.22.3.tgz#07e8fcc69fd8d0d797afebf30601538e6ef66510"
   integrity sha512-WqSGJgngtBeYOntCpveN5AY2Yn+q+dTP9klUvYl+be3jScExRdE1wpy6QX+uwYrk99016MrKyA1MpVojcp5PwA==
@@ -9565,10 +9565,10 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
-liferay-ckeditor@4.14.1-liferay.18:
-  version "4.14.1-liferay.18"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.14.1-liferay.18.tgz#991e84184c272b49a323a64e2ed81902dd454ae9"
-  integrity sha512-YPHV9vQcxC7EJVaMkT96/TKKRAiuxy1aeGPT+8+Gq4CBPtQgSE4jj+1t2Ybbjc5/Ec9+g9R+BNiUlEELEC3dMA==
+liferay-ckeditor@4.14.1-liferay.20:
+  version "4.14.1-liferay.20"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.14.1-liferay.20.tgz#a6a2ef4f46184806f15cb66b2b5cd55156873d56"
+  integrity sha512-Z7RjtjbweLA3+CB3L7Ij87UVkYP+O5XfppOJyTuOjDjpdDjapOt0tgcxuQaxnCevN87Z/CGq8nCgmUtWbC/zCw==
 
 liferay-font-awesome@3.4.0:
   version "3.4.0"


### PR DESCRIPTION
Which contains [this fix](https://github.com/liferay/liferay-ckeditor/pull/159) for the [issue described here](https://issues.liferay.com/browse/LPS-128895)

[Full changelog](https://github.com/liferay/liferay-ckeditor/releases/tag/v4.14.1-liferay.20)

**Test plan**
- Navigate to **Content & Data** > **Web Content**
- Create a new **Basic Web Content**
- Add a title, some content and (optionally) publish it
- Edit the Web Content you created
- Switch to source mode
- Click on the "preview" button
- Make sure that the content of your article is visible in the preview dialog

**Before**

![](https://user-images.githubusercontent.com/5572/112025407-6a6d2f00-8b35-11eb-93bc-76d566c17997.gif)

**After**

![](https://user-images.githubusercontent.com/5572/112025297-51fd1480-8b35-11eb-8e46-6c0a152316f9.gif)

**Additional notes**

Why the switch from `4.14.1-liferay.18` to `4.14.1-liferay.20`?
It seems [`4.14.1-liferay.20`](https://github.com/liferay/liferay-ckeditor/releases/tag/v4.14.1-liferay.19) was released,
but we didn't update in DXP.