### PR TITLE
LPS-128998 [On hold - Content Performance] ChartStateContext refactor

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -199,12 +199,12 @@ export default function Chart({publishDate, timeSpanOptions}) {
 				validAnalyticsConnection,
 			});
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		dispatch,
 		endpoints.analyticsReportsHistoricalReadsURL,
 		historicalReads,
 		historicalViews,
-		timeSpanKey,
 		validAnalyticsConnection,
 	]);
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -10,7 +10,6 @@
  */
 
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import {useIsMounted} from '@liferay/frontend-js-react-web';
 import className from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useMemo} from 'react';
@@ -28,7 +27,6 @@ import {
 import {
 	ChartDispatchContext,
 	ChartStateContext,
-	useAddDataSetItems,
 	useDateTitle,
 	useIsPreviousPeriodButtonDisabled,
 	useSetLoading,
@@ -146,13 +144,17 @@ export default function Chart({publishDate, timeSpanOptions}) {
 
 	const dispatch = useContext(ChartDispatchContext);
 
-	const {dataSet, loading, timeRange, timeSpanKey, timeSpanOffset} = useContext(ChartStateContext);
+	const {
+		dataSet,
+		loading,
+		timeRange,
+		timeSpanKey,
+		timeSpanOffset,
+	} = useContext(ChartStateContext);
 
 	const {firstDate, lastDate} = useDateTitle();
 
 	const isPreviousPeriodButtonDisabled = useIsPreviousPeriodButtonDisabled();
-
-	const addDataSetItems = useAddDataSetItems();
 
 	const setLoading = useSetLoading();
 
@@ -161,8 +163,6 @@ export default function Chart({publishDate, timeSpanOptions}) {
 	]);
 
 	const title = dateFormatters.formatChartTitle([firstDate, lastDate]);
-
-	const isMounted = useIsMounted();
 
 	useEffect(() => {
 		setLoading();
@@ -182,23 +182,29 @@ export default function Chart({publishDate, timeSpanOptions}) {
 		}
 
 		if (validAnalyticsConnection) {
-			addDataSetItems({
-				dataSetItems,
-				keys,
-				timeSpanComparator,
+			dispatch({
+				payload: {
+					dataSetItems,
+					keys,
+					timeSpanComparator,
+				},
+				type: 'ADD_DATA_SET_ITEMS',
+				validAnalyticsConnection,
 			});
 		}
 		else {
-			addDataSetItems({
-				keys,
-				timeSpanComparator,
+			dispatch({
+				payload: {
+					keys,
+					timeSpanComparator,
+				},
+				type: 'ADD_DATA_SET_ITEMS',
+				validAnalyticsConnection,
 			});
 		}
 	}, [
-		addDataSetItems,
+		dispatch,
 		endpoints.analyticsReportsHistoricalReadsURL,
-		endpoints.analyticsReportsHistoricalViewsURL,
-		isMounted,
 		historicalReads,
 		historicalViews,
 		setLoading,
@@ -304,8 +310,12 @@ export default function Chart({publishDate, timeSpanOptions}) {
 									!validAnalyticsConnection ||
 									histogram.length === 0
 										? [
-											new Date(timeRange.startDate).getDate(),
-											new Date(timeRange.endDate).getDate(),
+												new Date(
+													timeRange.startDate
+												).getDate(),
+												new Date(
+													timeRange.endDate
+												).getDate(),
 										  ]
 										: []
 								}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -29,7 +29,6 @@ import {
 	ChartDispatchContext,
 	ChartStateContext,
 	useAddDataSetItems,
-	useChangeTimeSpanKey,
 	useDateTitle,
 	useIsPreviousPeriodButtonDisabled,
 	useSetLoading,
@@ -155,8 +154,6 @@ export default function Chart({publishDate, timeSpanOptions}) {
 
 	const addDataSetItems = useAddDataSetItems();
 
-	const changeTimeSpanKey = useChangeTimeSpanKey();
-
 	const setLoading = useSetLoading();
 
 	const dateFormatters = useMemo(() => dateFormat(languageTag), [
@@ -222,7 +219,7 @@ export default function Chart({publishDate, timeSpanOptions}) {
 	const handleTimeSpanChange = (event) => {
 		const {value} = event.target;
 
-		changeTimeSpanKey({key: value});
+		dispatch({payload: {key: value}, type: 'CHANGE_TIME_SPAN_KEY'});
 	};
 
 	const legendFormatter =

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -162,8 +162,6 @@ export default function Chart({publishDate, timeSpanOptions}) {
 	const title = dateFormatters.formatChartTitle([firstDate, lastDate]);
 
 	useEffect(() => {
-		dispatch({type: 'SET_LOADING'});
-
 		const timeSpanComparator =
 			timeSpanKey === LAST_24_HOURS
 				? HOUR_IN_MILLISECONDS

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -218,12 +218,6 @@ export default function Chart({publishDate, timeSpanOptions}) {
 			: publishDateISOString.split('T')[0].concat('T00:00:00');
 	}, [timeSpanKey, publishDate]);
 
-	const handleTimeSpanChange = (event) => {
-		const {value} = event.target;
-
-		dispatch({payload: {key: value}, type: 'CHANGE_TIME_SPAN_KEY'});
-	};
-
 	const legendFormatter =
 		dataSet &&
 		legendFormatterGenerator(
@@ -251,9 +245,6 @@ export default function Chart({publishDate, timeSpanOptions}) {
 						disabledPreviousPeriodButton={
 							isPreviousPeriodButtonDisabled
 						}
-						onNextTimeSpanClick={() => dispatch({type: 'NEXT_TIME_SPAN'})}
-						onPreviousTimeSpanClick={() => dispatch({type: 'PREV_TIME_SPAN'})}
-						onTimeSpanChange={handleTimeSpanChange}
 						timeSpanKey={timeSpanKey}
 						timeSpanOptions={timeSpanOptions}
 					/>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -26,13 +26,12 @@ import {
 } from 'recharts';
 
 import {
+	ChartDispatchContext,
 	ChartStateContext,
 	useAddDataSetItems,
 	useChangeTimeSpanKey,
 	useDateTitle,
 	useIsPreviousPeriodButtonDisabled,
-	useNextTimeSpan,
-	usePreviousTimeSpan,
 	useSetLoading,
 } from '../context/ChartStateContext';
 import ConnectionContext from '../context/ConnectionContext';
@@ -146,6 +145,8 @@ export default function Chart({publishDate, timeSpanOptions}) {
 		publishedToday,
 	} = useContext(StoreStateContext);
 
+	const dispatch = useContext(ChartDispatchContext);
+
 	const {dataSet, loading, timeRange, timeSpanKey, timeSpanOffset} = useContext(ChartStateContext);
 
 	const {firstDate, lastDate} = useDateTitle();
@@ -155,10 +156,6 @@ export default function Chart({publishDate, timeSpanOptions}) {
 	const addDataSetItems = useAddDataSetItems();
 
 	const changeTimeSpanKey = useChangeTimeSpanKey();
-
-	const nextTimeSpan = useNextTimeSpan();
-
-	const previousTimeSpan = usePreviousTimeSpan();
 
 	const setLoading = useSetLoading();
 
@@ -255,8 +252,8 @@ export default function Chart({publishDate, timeSpanOptions}) {
 						disabledPreviousPeriodButton={
 							isPreviousPeriodButtonDisabled
 						}
-						onNextTimeSpanClick={nextTimeSpan}
-						onPreviousTimeSpanClick={previousTimeSpan}
+						onNextTimeSpanClick={() => dispatch({type: 'NEXT_TIME_SPAN'})}
+						onPreviousTimeSpanClick={() => dispatch({type: 'PREV_TIME_SPAN'})}
 						onTimeSpanChange={handleTimeSpanChange}
 						timeSpanKey={timeSpanKey}
 						timeSpanOptions={timeSpanOptions}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -26,9 +26,9 @@ import {
 } from 'recharts';
 
 import {
+	ChartStateContext,
 	useAddDataSetItems,
 	useChangeTimeSpanKey,
-	useChartState,
 	useDateTitle,
 	useIsPreviousPeriodButtonDisabled,
 	useNextTimeSpan,
@@ -146,7 +146,7 @@ export default function Chart({publishDate, timeSpanOptions}) {
 		publishedToday,
 	} = useContext(StoreStateContext);
 
-	const chartState = useChartState();
+	const {dataSet, loading, timeRange, timeSpanKey, timeSpanOffset} = useContext(ChartStateContext);
 
 	const {firstDate, lastDate} = useDateTitle();
 
@@ -174,7 +174,7 @@ export default function Chart({publishDate, timeSpanOptions}) {
 		setLoading();
 
 		const timeSpanComparator =
-			chartState.timeSpanKey === LAST_24_HOURS
+			timeSpanKey === LAST_24_HOURS
 				? HOUR_IN_MILLISECONDS
 				: DAY_IN_MILLISECONDS;
 
@@ -202,26 +202,25 @@ export default function Chart({publishDate, timeSpanOptions}) {
 		}
 	}, [
 		addDataSetItems,
-		chartState.timeSpanKey,
 		endpoints.analyticsReportsHistoricalReadsURL,
 		endpoints.analyticsReportsHistoricalViewsURL,
 		isMounted,
 		historicalReads,
 		historicalViews,
 		setLoading,
+		timeSpanKey,
 		validAnalyticsConnection,
 	]);
 
-	const {dataSet} = chartState;
 	const {histogram, keyList} = dataSet;
 
 	const referenceDotPosition = useMemo(() => {
 		const publishDateISOString = new Date(publishDate).toISOString();
 
-		return chartState.timeSpanKey === LAST_24_HOURS
+		return timeSpanKey === LAST_24_HOURS
 			? publishDateISOString.split(':')[0].concat(':00:00')
 			: publishDateISOString.split('T')[0].concat('T00:00:00');
-	}, [chartState.timeSpanKey, publishDate]);
+	}, [timeSpanKey, publishDate]);
 
 	const handleTimeSpanChange = (event) => {
 		const {value} = event.target;
@@ -239,12 +238,12 @@ export default function Chart({publishDate, timeSpanOptions}) {
 		);
 
 	const xAxisFormatter =
-		chartState.timeSpanKey === LAST_24_HOURS
+		timeSpanKey === LAST_24_HOURS
 			? dateFormatters.formatNumericHour
 			: dateFormatters.formatNumericDay;
 
 	const lineChartWrapperClasses = className('line-chart-wrapper', {
-		'line-chart-wrapper--loading': chartState.loading,
+		'line-chart-wrapper--loading': loading,
 	});
 
 	return (
@@ -252,14 +251,14 @@ export default function Chart({publishDate, timeSpanOptions}) {
 			{timeSpanOptions.length && (
 				<div className="c-mb-3 c-mt-4">
 					<TimeSpanSelector
-						disabledNextTimeSpan={chartState.timeSpanOffset === 0}
+						disabledNextTimeSpan={timeSpanOffset === 0}
 						disabledPreviousPeriodButton={
 							isPreviousPeriodButtonDisabled
 						}
 						onNextTimeSpanClick={nextTimeSpan}
 						onPreviousTimeSpanClick={previousTimeSpan}
 						onTimeSpanChange={handleTimeSpanChange}
-						timeSpanKey={chartState.timeSpanKey}
+						timeSpanKey={timeSpanKey}
 						timeSpanOptions={timeSpanOptions}
 					/>
 				</div>
@@ -267,7 +266,7 @@ export default function Chart({publishDate, timeSpanOptions}) {
 
 			{dataSet ? (
 				<div className={lineChartWrapperClasses}>
-					{chartState.loading && (
+					{loading && (
 						<ClayLoadingIndicator
 							className="chart-loading-indicator"
 							small
@@ -311,12 +310,8 @@ export default function Chart({publishDate, timeSpanOptions}) {
 									!validAnalyticsConnection ||
 									histogram.length === 0
 										? [
-												new Date(
-													chartState.timeRange.startDate
-												).getDate(),
-												new Date(
-													chartState.timeRange.endDate
-												).getDate(),
+											new Date(timeRange.startDate).getDate(),
+											new Date(timeRange.endDate).getDate(),
 										  ]
 										: []
 								}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -29,7 +29,6 @@ import {
 	ChartStateContext,
 	useDateTitle,
 	useIsPreviousPeriodButtonDisabled,
-	useSetLoading,
 } from '../context/ChartStateContext';
 import ConnectionContext from '../context/ConnectionContext';
 import {StoreStateContext} from '../context/StoreContext';
@@ -156,8 +155,6 @@ export default function Chart({publishDate, timeSpanOptions}) {
 
 	const isPreviousPeriodButtonDisabled = useIsPreviousPeriodButtonDisabled();
 
-	const setLoading = useSetLoading();
-
 	const dateFormatters = useMemo(() => dateFormat(languageTag), [
 		languageTag,
 	]);
@@ -165,7 +162,7 @@ export default function Chart({publishDate, timeSpanOptions}) {
 	const title = dateFormatters.formatChartTitle([firstDate, lastDate]);
 
 	useEffect(() => {
-		setLoading();
+		dispatch({type: 'SET_LOADING'});
 
 		const timeSpanComparator =
 			timeSpanKey === LAST_24_HOURS
@@ -207,7 +204,6 @@ export default function Chart({publishDate, timeSpanOptions}) {
 		endpoints.analyticsReportsHistoricalReadsURL,
 		historicalReads,
 		historicalViews,
-		setLoading,
 		timeSpanKey,
 		validAnalyticsConnection,
 	]);

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Detail.js
@@ -14,6 +14,7 @@ import ClayIcon from '@clayui/icon';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
+import {ChartDispatchContext} from '../context/ChartStateContext';
 import {StoreDispatchContext} from '../context/StoreContext';
 import KeywordsDetail from './detail/KeywordsDetail';
 import ReferralDetail from './detail/ReferralDetail';
@@ -32,6 +33,8 @@ export default function Detail({
 	onCurrentPageChange,
 	timeSpanOptions,
 }) {
+	const chartDispatch = useContext(ChartDispatchContext);
+
 	const dispatch = useContext(StoreDispatchContext);
 
 	return (
@@ -41,6 +44,7 @@ export default function Detail({
 					displayType="unstyled"
 					onClick={() => {
 						onCurrentPageChange({view: 'main'});
+						chartDispatch({type: 'SET_LOADING'});
 						dispatch({
 							selectedTrafficSourceName: '',
 							type: 'SET_SELECTED_TRAFFIC_SOURCE_NAME',

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -14,7 +14,7 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import PropTypes from 'prop-types';
 import React, {useCallback, useContext, useEffect, useState} from 'react';
 
-import {useChartState} from '../context/ChartStateContext';
+import {ChartStateContext} from '../context/ChartStateContext';
 import ConnectionContext from '../context/ConnectionContext';
 import {StoreDispatchContext, StoreStateContext} from '../context/StoreContext';
 import APIService from '../utils/APIService';
@@ -50,9 +50,7 @@ export default function Navigation({
 
 	const [currentPage, setCurrentPage] = useState({view: 'main'});
 
-	const chartState = useChartState();
-
-	const {timeSpanKey, timeSpanOffset} = chartState;
+	const {timeSpanKey, timeSpanOffset} = useContext(ChartStateContext);
 
 	useEffect(() => {
 		const requests = Object.keys(endpoints).map((request) => {

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TimeSpanSelector.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TimeSpanSelector.js
@@ -14,18 +14,18 @@ import {ClaySelect} from '@clayui/form';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
+import {ChartDispatchContext} from '../context/ChartStateContext';
 import ConnectionContext from '../context/ConnectionContext';
 
 export default function TimeSpanSelector({
 	disabledNextTimeSpan,
 	disabledPreviousPeriodButton,
-	onNextTimeSpanClick,
-	onPreviousTimeSpanClick,
-	onTimeSpanChange,
 	timeSpanKey,
 	timeSpanOptions,
 }) {
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
+
+	const dispatch = useContext(ChartDispatchContext);
 
 	return (
 		<div className="d-flex">
@@ -33,7 +33,14 @@ export default function TimeSpanSelector({
 				aria-label={Liferay.Language.get('select-date-range')}
 				className="bg-white"
 				disabled={!validAnalyticsConnection}
-				onChange={onTimeSpanChange}
+				onChange={(event) => {
+					const {value} = event.target;
+
+					dispatch({
+						payload: {key: value},
+						type: 'CHANGE_TIME_SPAN_KEY',
+					});
+				}}
 				value={timeSpanKey}
 			>
 				{timeSpanOptions.map((option) => {
@@ -57,7 +64,7 @@ export default function TimeSpanSelector({
 						disabledPreviousPeriodButton
 					}
 					displayType="secondary"
-					onClick={onPreviousTimeSpanClick}
+					onClick={() => dispatch({type: 'PREV_TIME_SPAN'})}
 					small
 					symbol="angle-left"
 					title={
@@ -73,7 +80,7 @@ export default function TimeSpanSelector({
 					aria-label={Liferay.Language.get('next-period')}
 					disabled={!validAnalyticsConnection || disabledNextTimeSpan}
 					displayType="secondary"
-					onClick={onNextTimeSpanClick}
+					onClick={() => dispatch({type: 'NEXT_TIME_SPAN'})}
 					small
 					symbol="angle-right"
 				/>
@@ -85,9 +92,6 @@ export default function TimeSpanSelector({
 TimeSpanSelector.proptypes = {
 	disabledNextTimeSpan: PropTypes.bool.isRequired,
 	disabledPreviousPeriodButton: PropTypes.bool.isRequired,
-	onNextTimeSpanClick: PropTypes.func.isRequired,
-	onPreviousTimeSpanClick: PropTypes.func.isRequired,
-	onTimeSpanChange: PropTypes.func.isRequired,
 	timeSpanKey: PropTypes.string.isRequired,
 	timeSpanOptions: PropTypes.arrayOf(
 		PropTypes.shape({

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Translation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Translation.js
@@ -18,7 +18,7 @@ import {ClayTooltipProvider} from '@clayui/tooltip';
 import PropTypes from 'prop-types';
 import React, {useContext, useMemo, useState} from 'react';
 
-import {useChartState} from '../context/ChartStateContext';
+import {ChartStateContext} from '../context/ChartStateContext';
 import {StoreStateContext} from '../context/StoreContext';
 
 export default function Translation({onSelectedLanguageClick, viewURLs}) {
@@ -33,7 +33,7 @@ export default function Translation({onSelectedLanguageClick, viewURLs}) {
 		);
 	}, [defaultLanguage, viewURLs]);
 
-	const chartState = useChartState();
+	const {timeSpanKey, timeSpanOffset} = useContext(ChartStateContext);
 
 	return (
 		<ClayLayout.ContentRow>
@@ -76,8 +76,8 @@ export default function Translation({onSelectedLanguageClick, viewURLs}) {
 								onClick={() => {
 									onSelectedLanguageClick(
 										language.viewURL,
-										chartState.timeSpanKey,
-										chartState.timeSpanOffset
+										timeSpanKey,
+										timeSpanOffset
 									);
 								}}
 								symbolLeft={language.languageId.toLowerCase()}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
@@ -16,12 +16,11 @@ import PropTypes from 'prop-types';
 import React, {useContext, useMemo, useState} from 'react';
 
 import {
+	ChartDispatchContext,
 	ChartStateContext,
 	useChangeTimeSpanKey,
 	useDateTitle,
 	useIsPreviousPeriodButtonDisabled,
-	useNextTimeSpan,
-	usePreviousTimeSpan,
 } from '../../context/ChartStateContext';
 import {StoreStateContext} from '../../context/StoreContext';
 import {generateDateFormatters as dateFormat} from '../../utils/dateFormat';
@@ -62,15 +61,13 @@ export default function ReferralDetail({
 		return dateFormatters.formatChartTitle([firstDate, lastDate]);
 	}, [dateFormatters, firstDate, lastDate]);
 
+	const dispatch = useContext(ChartDispatchContext);
+
 	const {timeSpanKey, timeSpanOffset} = useContext(ChartStateContext);
 
 	const isPreviousPeriodButtonDisabled = useIsPreviousPeriodButtonDisabled();
 
 	const changeTimeSpanKey = useChangeTimeSpanKey();
-
-	const nextTimeSpan = useNextTimeSpan();
-
-	const previousTimeSpan = usePreviousTimeSpan();
 
 	const handleTimeSpanChange = (event) => {
 		const {value} = event.target;
@@ -88,8 +85,12 @@ export default function ReferralDetail({
 							disabledPreviousPeriodButton={
 								isPreviousPeriodButtonDisabled
 							}
-							onNextTimeSpanClick={nextTimeSpan}
-							onPreviousTimeSpanClick={previousTimeSpan}
+							onNextTimeSpanClick={() =>
+								dispatch({type: 'NEXT_TIME_SPAN'})
+							}
+							onPreviousTimeSpanClick={() =>
+								dispatch({type: 'PREV_TIME_SPAN'})
+							}
 							onTimeSpanChange={handleTimeSpanChange}
 							timeSpanKey={timeSpanKey}
 							timeSpanOptions={timeSpanOptions}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
@@ -18,7 +18,6 @@ import React, {useContext, useMemo, useState} from 'react';
 import {
 	ChartDispatchContext,
 	ChartStateContext,
-	useChangeTimeSpanKey,
 	useDateTitle,
 	useIsPreviousPeriodButtonDisabled,
 } from '../../context/ChartStateContext';
@@ -67,12 +66,10 @@ export default function ReferralDetail({
 
 	const isPreviousPeriodButtonDisabled = useIsPreviousPeriodButtonDisabled();
 
-	const changeTimeSpanKey = useChangeTimeSpanKey();
-
 	const handleTimeSpanChange = (event) => {
 		const {value} = event.target;
 
-		changeTimeSpanKey({key: value});
+		dispatch({payload: {key: value}, type: 'CHANGE_TIME_SPAN_KEY'});
 	};
 
 	return (

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
@@ -16,8 +16,8 @@ import PropTypes from 'prop-types';
 import React, {useContext, useMemo, useState} from 'react';
 
 import {
+	ChartStateContext,
 	useChangeTimeSpanKey,
-	useChartState,
 	useDateTitle,
 	useIsPreviousPeriodButtonDisabled,
 	useNextTimeSpan,
@@ -62,7 +62,7 @@ export default function ReferralDetail({
 		return dateFormatters.formatChartTitle([firstDate, lastDate]);
 	}, [dateFormatters, firstDate, lastDate]);
 
-	const chartState = useChartState();
+	const {timeSpanKey, timeSpanOffset} = useContext(ChartStateContext);
 
 	const isPreviousPeriodButtonDisabled = useIsPreviousPeriodButtonDisabled();
 
@@ -84,16 +84,14 @@ export default function ReferralDetail({
 				<>
 					<div className="c-mb-3 c-mt-2">
 						<TimeSpanSelector
-							disabledNextTimeSpan={
-								chartState.timeSpanOffset === 0
-							}
+							disabledNextTimeSpan={timeSpanOffset === 0}
 							disabledPreviousPeriodButton={
 								isPreviousPeriodButtonDisabled
 							}
 							onNextTimeSpanClick={nextTimeSpan}
 							onPreviousTimeSpanClick={previousTimeSpan}
 							onTimeSpanChange={handleTimeSpanChange}
-							timeSpanKey={chartState.timeSpanKey}
+							timeSpanKey={timeSpanKey}
 							timeSpanOptions={timeSpanOptions}
 						/>
 					</div>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
@@ -16,12 +16,11 @@ import PropTypes from 'prop-types';
 import React, {useContext, useMemo, useState} from 'react';
 
 import {
+	ChartDispatchContext,
 	ChartStateContext,
 	useChangeTimeSpanKey,
 	useDateTitle,
 	useIsPreviousPeriodButtonDisabled,
-	useNextTimeSpan,
-	usePreviousTimeSpan,
 } from '../../context/ChartStateContext';
 import {StoreStateContext} from '../../context/StoreContext';
 import {generateDateFormatters as dateFormat} from '../../utils/dateFormat';
@@ -60,15 +59,13 @@ export default function SocialDetail({
 
 	const title = dateFormatters.formatChartTitle([firstDate, lastDate]);
 
+	const dispatch = useContext(ChartDispatchContext);
+
 	const {timeSpanKey, timeSpanOffset} = useContext(ChartStateContext);
 
 	const isPreviousPeriodButtonDisabled = useIsPreviousPeriodButtonDisabled();
 
 	const changeTimeSpanKey = useChangeTimeSpanKey();
-
-	const previousTimeSpan = usePreviousTimeSpan();
-
-	const nextTimeSpan = useNextTimeSpan();
 
 	const handleTimeSpanChange = (event) => {
 		const {value} = event.target;
@@ -111,8 +108,12 @@ export default function SocialDetail({
 							disabledPreviousPeriodButton={
 								isPreviousPeriodButtonDisabled
 							}
-							onNextTimeSpanClick={nextTimeSpan}
-							onPreviousTimeSpanClick={previousTimeSpan}
+							onNextTimeSpanClick={() =>
+								dispatch({type: 'NEXT_TIME_SPAN'})
+							}
+							onPreviousTimeSpanClick={() =>
+								dispatch({type: 'PREV_TIME_SPAN'})
+							}
 							onTimeSpanChange={handleTimeSpanChange}
 							timeSpanKey={timeSpanKey}
 							timeSpanOptions={timeSpanOptions}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
@@ -16,8 +16,8 @@ import PropTypes from 'prop-types';
 import React, {useContext, useMemo, useState} from 'react';
 
 import {
+	ChartStateContext,
 	useChangeTimeSpanKey,
-	useChartState,
 	useDateTitle,
 	useIsPreviousPeriodButtonDisabled,
 	useNextTimeSpan,
@@ -60,7 +60,7 @@ export default function SocialDetail({
 
 	const title = dateFormatters.formatChartTitle([firstDate, lastDate]);
 
-	const chartState = useChartState();
+	const {timeSpanKey, timeSpanOffset} = useContext(ChartStateContext);
 
 	const isPreviousPeriodButtonDisabled = useIsPreviousPeriodButtonDisabled();
 
@@ -107,16 +107,14 @@ export default function SocialDetail({
 				<>
 					<div className="c-mb-3 c-mt-2">
 						<TimeSpanSelector
-							disabledNextTimeSpan={
-								chartState.timeSpanOffset === 0
-							}
+							disabledNextTimeSpan={timeSpanOffset === 0}
 							disabledPreviousPeriodButton={
 								isPreviousPeriodButtonDisabled
 							}
 							onNextTimeSpanClick={nextTimeSpan}
 							onPreviousTimeSpanClick={previousTimeSpan}
 							onTimeSpanChange={handleTimeSpanChange}
-							timeSpanKey={chartState.timeSpanKey}
+							timeSpanKey={timeSpanKey}
 							timeSpanOptions={timeSpanOptions}
 						/>
 					</div>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
@@ -18,7 +18,6 @@ import React, {useContext, useMemo, useState} from 'react';
 import {
 	ChartDispatchContext,
 	ChartStateContext,
-	useChangeTimeSpanKey,
 	useDateTitle,
 	useIsPreviousPeriodButtonDisabled,
 } from '../../context/ChartStateContext';
@@ -65,12 +64,10 @@ export default function SocialDetail({
 
 	const isPreviousPeriodButtonDisabled = useIsPreviousPeriodButtonDisabled();
 
-	const changeTimeSpanKey = useChangeTimeSpanKey();
-
 	const handleTimeSpanChange = (event) => {
 		const {value} = event.target;
 
-		changeTimeSpanKey({key: value});
+		dispatch({payload: {key: value}, type: 'CHANGE_TIME_SPAN_KEY'});
 	};
 
 	const keyToHexColor = (name) => {

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
@@ -54,10 +54,9 @@ export const ChartStateContextProvider = ({
 };
 
 export function useDateTitle() {
-	const [state] = useContext(ChartStateContext);
+	const {dataSet, timeRange} = useContext(ChartStateContext);
 
-	const {histogram} = state.dataSet;
-	const {timeRange} = state;
+	const {histogram} = dataSet;
 
 	if (histogram.length) {
 		const firstDateLabel = histogram[0].label;
@@ -77,10 +76,9 @@ export function useDateTitle() {
 }
 
 export function useIsPreviousPeriodButtonDisabled() {
-	const [state] = useContext(ChartStateContext);
+	const {dataSet, publishDate} = useContext(ChartStateContext);
 
-	const {histogram} = state.dataSet;
-	const {publishDate} = state;
+	const {histogram} = dataSet;
 
 	if (histogram.length) {
 		const firstDateLabel = histogram[0].label;

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
@@ -70,12 +70,6 @@ export const useAddDataSetItems = () => {
 	);
 };
 
-export const useChangeTimeSpanKey = () => {
-	const [, dispatch] = useContext(ChartStateContext);
-
-	return (payload) => dispatch({payload, type: CHANGE_TIME_SPAN_KEY});
-};
-
 export function useDateTitle() {
 	const [state] = useContext(ChartStateContext);
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
@@ -76,12 +76,6 @@ export const useChangeTimeSpanKey = () => {
 	return (payload) => dispatch({payload, type: CHANGE_TIME_SPAN_KEY});
 };
 
-export const useChartState = () => {
-	const [state] = useContext(ChartStateContext);
-
-	return state;
-};
-
 export function useDateTitle() {
 	const [state] = useContext(ChartStateContext);
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
@@ -123,6 +123,7 @@ function reducer(state, action) {
 
 	switch (action.type) {
 		case ADD_DATA_SET_ITEMS:
+			nextState = setLoadingState(state);
 			nextState = [...action.payload.keys].reduce((state, key) => {
 				const dataSetItem =
 					action.payload.dataSetItems?.[key] ??

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
@@ -142,6 +142,7 @@ function reducer(state, action) {
 		case CHANGE_TIME_SPAN_KEY:
 			nextState = {
 				...state,
+				loading: true,
 				timeSpanKey: action.payload.key,
 				timeSpanOffset: 0,
 			};
@@ -149,12 +150,14 @@ function reducer(state, action) {
 		case NEXT_TIME_SPAN:
 			nextState = {
 				...state,
+				loading: true,
 				timeSpanOffset: state.timeSpanOffset - 1,
 			};
 			break;
 		case PREV_TIME_SPAN:
 			nextState = {
 				...state,
+				loading: true,
 				timeSpanOffset: state.timeSpanOffset + 1,
 			};
 			break;

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
@@ -11,8 +11,6 @@
 
 import React, {createContext, useCallback, useContext, useReducer} from 'react';
 
-import ConnectionContext from './ConnectionContext';
-
 const ADD_DATA_SET_ITEMS = 'ADD_DATA_SET_ITEMS';
 const CHANGE_TIME_SPAN_KEY = 'CHANGE_TIME_SPAN_KEY';
 const NEXT_TIME_SPAN = 'NEXT_TIME_SPAN';
@@ -52,21 +50,6 @@ export const ChartStateContextProvider = ({
 				{children}
 			</ChartStateContext.Provider>
 		</ChartDispatchContext.Provider>
-	);
-};
-
-export const useAddDataSetItems = () => {
-	const [, dispatch] = useContext(ChartStateContext);
-	const {validAnalyticsConnection} = useContext(ConnectionContext);
-
-	return useCallback(
-		(payload) =>
-			dispatch({
-				payload,
-				type: ADD_DATA_SET_ITEMS,
-				validAnalyticsConnection,
-			}),
-		[dispatch, validAnalyticsConnection]
 	);
 };
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
@@ -30,7 +30,8 @@ const INITIAL_STATE = {
 
 const FALLBACK_DATA_SET_ITEM = {histogram: [], value: null};
 
-const ChartStateContext = createContext(INITIAL_STATE);
+export const ChartDispatchContext = createContext(() => {});
+export const ChartStateContext = createContext(INITIAL_STATE);
 
 export const ChartStateContextProvider = ({
 	children,
@@ -38,7 +39,7 @@ export const ChartStateContextProvider = ({
 	timeRange,
 	timeSpanKey,
 }) => {
-	const stateAndDispatch = useReducer(reducer, {
+	const [state, dispatch] = useReducer(reducer, {
 		...INITIAL_STATE,
 		publishDate,
 		timeRange,
@@ -46,9 +47,11 @@ export const ChartStateContextProvider = ({
 	});
 
 	return (
-		<ChartStateContext.Provider value={stateAndDispatch}>
-			{children}
-		</ChartStateContext.Provider>
+		<ChartDispatchContext.Provider value={dispatch}>
+			<ChartStateContext.Provider value={state}>
+				{children}
+			</ChartStateContext.Provider>
+		</ChartDispatchContext.Provider>
 	);
 };
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
@@ -9,7 +9,7 @@
  * distribution rights of the Software.
  */
 
-import React, {createContext, useCallback, useContext, useReducer} from 'react';
+import React, {createContext, useContext, useReducer} from 'react';
 
 const ADD_DATA_SET_ITEMS = 'ADD_DATA_SET_ITEMS';
 const CHANGE_TIME_SPAN_KEY = 'CHANGE_TIME_SPAN_KEY';
@@ -93,12 +93,6 @@ export function useIsPreviousPeriodButtonDisabled() {
 
 	return true;
 }
-
-export const useSetLoading = () => {
-	const [, dispatch] = useContext(ChartStateContext);
-
-	return useCallback(() => dispatch({type: SET_LOADING}), [dispatch]);
-};
 
 /**
  * {

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
@@ -165,7 +165,7 @@ function reducer(state, action) {
 			nextState = setLoadingState(state);
 			break;
 		default:
-			state = nextState;
+			nextState = state;
 			break;
 	}
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/ChartStateContext.js
@@ -13,11 +13,11 @@ import React, {createContext, useCallback, useContext, useReducer} from 'react';
 
 import ConnectionContext from './ConnectionContext';
 
-const ADD_DATA_SET_ITEMS = 'add-data-keys';
-const CHANGE_TIME_SPAN_KEY = 'change-time-span-key';
-const NEXT_TIME_SPAN = 'next-time-span';
-const PREV_TIME_SPAN = 'previous-time-span';
-const SET_LOADING = 'set-loading';
+const ADD_DATA_SET_ITEMS = 'ADD_DATA_SET_ITEMS';
+const CHANGE_TIME_SPAN_KEY = 'CHANGE_TIME_SPAN_KEY';
+const NEXT_TIME_SPAN = 'NEXT_TIME_SPAN';
+const PREV_TIME_SPAN = 'PREV_TIME_SPAN';
+const SET_LOADING = 'SET_LOADING';
 
 const INITIAL_STATE = {
 	dataSet: {histogram: [], keyList: [], totals: []},
@@ -117,22 +117,10 @@ export function useIsPreviousPeriodButtonDisabled() {
 	return true;
 }
 
-export const useNextTimeSpan = () => {
-	const [, dispatch] = useContext(ChartStateContext);
-
-	return () => dispatch({type: NEXT_TIME_SPAN});
-};
-
 export const useSetLoading = () => {
 	const [, dispatch] = useContext(ChartStateContext);
 
 	return useCallback(() => dispatch({type: SET_LOADING}), [dispatch]);
-};
-
-export const usePreviousTimeSpan = () => {
-	const [, dispatch] = useContext(ChartStateContext);
-
-	return () => dispatch({type: PREV_TIME_SPAN});
 };
 
 /**


### PR DESCRIPTION
**Description**

This is the fifth (and last) pull request to fix [LPS-128998 Content Performance available endpoints should load at the same time](https://issues.liferay.com/browse/LPS-128998) as I said in a previous PR (see `Notes` from description, but in summary, the idea is that every component reads data from the store instead of calling its `dataProvider` and wait until all endpoints are resolved to display the data in the UI): https://github.com/liferay-frontend/liferay-portal/pull/885#issue-588734880.

As the pull can be huge, I'm going to create sub-tasks for the issue and send the code for each of them separately.

**How to test it**

- Connect Liferay DXP with Analytics Cloud
- Create a Content Page
- Wait 24 hours to let Analytics Cloud process the data (if you don't want to wait for it, change the date of your computer and create the page in the past 😉  )
- Open the Content Performance panel

**Within this pull request**

Everything should work as before. No UI changes.

- Separate state from dispatch in `ChartStateContext`
- Remove simple custom hooks and dispatch actions
- Dispatch actions in TimeSpanSelector instead of prop-drilling the props
- Add loading when changing the time range or offset

**History pull requests**

- LPS-128998 [Content Performance] Refactor APIService to be called in any component: https://github.com/brianchandotcom/liferay-portal/pull/99816
- LPS-128998 [Content Performance] Save attributes in store instead of prop-drilling them: https://github.com/brianchandotcom/liferay-portal/pull/99883
- LPS-128998 [Content Performance] Separate dispatch from state and unified warnings: https://github.com/brianchandotcom/liferay-portal/pull/99913
- LPS-128998 [Content Performance] Remove data providers from components and wait until all finished to display the data: https://github.com/brianchandotcom/liferay-portal/pull/100040

**Notes**

Only one pull left to clean up and refactor the Content Performance panel, remove data providers and get the data from the store.