### PR TITLE
LPS-128419 MT: Can not distinguish the sort order from UI when sorting assets

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
@@ -24,8 +24,14 @@ const FilterOrderControls = ({
 	disabled,
 	filterDropdownItems,
 	onFilterDropdownItemClick,
+	sortingOrder,
 	sortingURL,
 }) => {
+	const sortingClasses =
+		sortingOrder === 'desc'
+			? 'order-arrow-down-active'
+			: 'order-arrow-up-active';
+
 	return (
 		<>
 			{filterDropdownItems && (
@@ -77,7 +83,7 @@ const FilterOrderControls = ({
 			{sortingURL && (
 				<ClayManagementToolbar.Item>
 					<LinkOrButton
-						className="nav-link nav-link-monospaced"
+						className={`nav-link nav-link-monospaced ${sortingClasses}`}
 						disabled={disabled}
 						displayType="unstyled"
 						href={sortingURL}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -62,6 +62,7 @@ function ManagementToolbar({
 	showInfoButton,
 	showResultsBar,
 	showSearch,
+	sortingOrder,
 	sortingURL,
 	supportsBulkActions,
 	viewTypeItems,
@@ -112,6 +113,7 @@ function ManagementToolbar({
 							onFilterDropdownItemClick={
 								onFilterDropdownItemClick
 							}
+							sortingOrder={sortingOrder}
 							sortingURL={sortingURL}
 						/>
 					)}


### PR DESCRIPTION

**Steps to reproduce:**
1. Go to DM
2. Upload some documents
3. Check the order arrow icon button on the management-bar

**Expected results:** The user can distinguish the sort order from UI.
![71](https://user-images.githubusercontent.com/8373764/112131210-99cd7b80-8bc9-11eb-8781-078aff4e33f6.png)


**Actual results:** The user can not distinguish the sort order from UI when sorting assets.
