### PR TITLE
LPS-127012 Create balloon editor react component

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/.npmbundlerrc
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/.npmbundlerrc
@@ -1,0 +1,9 @@
+{
+	"config": {
+		"imports": {
+			"frontend-editor-ckeditor-web": {
+				"/": ">=4.0.0"
+			}
+		}
+	}
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/bnd.bnd
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Frontend Editor CKEditor Sample Web
+Bundle-SymbolicName: com.liferay.frontend.editor.ckeditor.sample.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /frontend-editor-ckeditor-sample-web

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
@@ -1,0 +1,12 @@
+dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "4.2.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-sql-dsl-api")
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
@@ -6,7 +6,6 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
-	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/package.json
@@ -1,0 +1,15 @@
+{
+	"dependencies": {
+		"frontend-editor-ckeditor-web": "*",
+		"react": "16.12.0",
+		"react-dom": "16.12.0"
+	},
+	"name": "frontend-editor-ckeditor-sample-web",
+	"private": true,
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "1.0.0"
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/constants/CKEditorSamplePortletKeys.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/constants/CKEditorSamplePortletKeys.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.editor.ckeditor.sample.web.internal.constants;
+
+/**
+ * @author Julien Castelain
+ */
+public class CKEditorSamplePortletKeys {
+
+	public static final String CKEDITOR_SAMPLE =
+		"com_liferay_editor_ckeditor_sample_web_portlet_CKEditorSamplePortlet";
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/portlet/CKEditorSamplePortlet.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/portlet/CKEditorSamplePortlet.java
@@ -59,9 +59,6 @@ public class CKEditorSamplePortlet extends MVCPortlet {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
 
-		// If we need a DisplayContext, initialize it here
-		// and use renderRequest.setAttribute to make it available in the view
-
 		super.doDispatch(renderRequest, renderResponse);
 	}
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/portlet/CKEditorSamplePortlet.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/portlet/CKEditorSamplePortlet.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.editor.ckeditor.sample.web.internal.portlet;
+
+import com.liferay.frontend.editor.ckeditor.sample.web.internal.constants.CKEditorSamplePortletKeys;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.io.IOException;
+
+import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Julien Castelain
+ */
+@Component(
+	immediate = true,
+	property = {
+		"com.liferay.portlet.css-class-wrapper=portlet-ckeditor-sample",
+		"com.liferay.portlet.display-category=category.sample",
+		"com.liferay.portlet.instanceable=true",
+		"com.liferay.portlet.layout-cacheable=true",
+		"com.liferay.portlet.private-request-attributes=false",
+		"com.liferay.portlet.private-session-attributes=false",
+		"com.liferay.portlet.render-weight=50",
+		"com.liferay.portlet.use-default-template=true",
+		"javax.portlet.display-name=CKEditor Sample",
+		"javax.portlet.expiration-cache=0",
+		"javax.portlet.init-param.template-path=/META-INF/resources/",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.name=" + CKEditorSamplePortletKeys.CKEDITOR_SAMPLE,
+		"javax.portlet.resource-bundle=content.Language",
+		"javax.portlet.security-role-ref=power-user,user"
+	},
+	service = Portlet.class
+)
+public class CKEditorSamplePortlet extends MVCPortlet {
+
+	@Override
+	public void doDispatch(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		// If we need a DisplayContext, initialize it here
+		// and use renderRequest.setAttribute to make it available in the view
+
+		super.doDispatch(renderRequest, renderResponse);
+	}
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,0 +1,3 @@
+.cke_inner .cke_top {
+	display: none;
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,3 +1,0 @@
-.cke_inner .cke_top {
-	display: none;
-}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init-ext.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init-ext.jsp
@@ -1,0 +1,15 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -14,6 +14,7 @@
  */
 --%>
 
+<%@ taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %>
 <%@ taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -14,11 +14,8 @@
  */
 --%>
 
-<%@ taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %>
-<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
+<%@ taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
-
-<%@ page import="com.liferay.portal.kernel.util.HashMapBuilder" %>
 
 <liferay-theme:defineObjects />
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,24 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+
+<%@ page import="com.liferay.portal.kernel.util.HashMapBuilder" %>
+
+<liferay-theme:defineObjects />
+
+<%@ include file="/init-ext.jsp" %>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/index.js
@@ -12,11 +12,11 @@
  * details.
  */
 
-import {InlineEditor} from 'frontend-editor-ckeditor-web';
+import {BalloonEditor} from 'frontend-editor-ckeditor-web';
 import React from 'react';
 
 import '../css/main.scss';
 
 export default function ({portletNamespace, ...otherProps}) {
-	return <InlineEditor name={`${portletNamespace}-editor`} {...otherProps} />;
+	return <BalloonEditor name={`${portletNamespace}editor`} {...otherProps} />;
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/index.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {InlineEditor} from 'frontend-editor-ckeditor-web';
+import React from 'react';
+
+import '../css/main.scss';
+
+export default function ({portletNamespace, ...otherProps}) {
+	return <InlineEditor name={`${portletNamespace}-editor`} {...otherProps} />;
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/index.js
@@ -15,8 +15,6 @@
 import {BalloonEditor} from 'frontend-editor-ckeditor-web';
 import React from 'react';
 
-import '../css/main.scss';
-
 export default function ({portletNamespace, ...otherProps}) {
 	return <BalloonEditor name={`${portletNamespace}editor`} {...otherProps} />;
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,9 +16,17 @@
 
 <%@ include file="/init.jsp" %>
 
+<%
+StringBuilder sb = new StringBuilder();
+
+sb.append("<h1>Ballon Editor</h1><p>This is a sample portlet ");
+sb.append("with a <a href=\"https://example.com\">link</a></p>");
+sb.append("<img src=\"https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=800\">");
+%>
+
 <div>
 	<liferay-editor:editor
-		contents="<h1>Ballon Editor</h1><p>More text goes here</p>"
+		contents="<%= sb.toString() %>"
 		editorName="ballooneditor"
 		name="contentEditor"
 		placeholder="content"

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -17,12 +17,10 @@
 <%@ include file="/init.jsp" %>
 
 <div>
-	<react:component
-		module="js/index"
-		props='<%=
-			HashMapBuilder.<String, Object>put(
-				"contents", "<h1>Ballon Editor</h1><p>More text goes here</p>"
-			).build()
-		%>'
+	<liferay-editor:editor
+		contents="<h1>Ballon Editor</h1><p>More text goes here</p>"
+		editorName="ballooneditor"
+		name="contentEditor"
+		placeholder="content"
 	/>
 </div>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,13 +16,12 @@
 
 <%@ include file="/init.jsp" %>
 
-<h3>CKEditor Sample</h3>
 <div>
 	<react:component
 		module="js/index"
 		props='<%=
 			HashMapBuilder.<String, Object>put(
-				"foo", "bar"
+				"contents", "<h1>Ballon Editor</h1><p>More text goes here</p>"
 			).build()
 		%>'
 	/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,29 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<h3>CKEditor Sample</h3>
+<div>
+	<react:component
+		module="js/index"
+		props='<%=
+			HashMapBuilder.<String, Object>put(
+				"foo", "bar"
+			).build()
+		%>'
+	/>
+</div>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/content/Language.properties
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/content/Language.properties
@@ -1,0 +1,1 @@
+javax.portlet.title.com_liferay_editor_ckeditor_sample_web_portlet_CKEditorSamplePortlet=CKEditor Sample

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorBalloonEditor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorBalloonEditor.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.editor.ckeditor.web.internal;
+
+import com.liferay.frontend.editor.EditorRenderer;
+import com.liferay.frontend.editor.ckeditor.web.internal.constants.CKEditorConstants;
+import com.liferay.portal.kernel.editor.Editor;
+import com.liferay.portal.kernel.servlet.PortalWebResourceConstants;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Julien Castelain
+ */
+@Component(
+	property = "name=ckeditor_balloon",
+	service = {Editor.class, EditorRenderer.class}
+)
+public class CKEditorBalloonEditor implements Editor, EditorRenderer {
+
+	@Override
+	public String getAttributeNamespace() {
+		return CKEditorConstants.ATTRIBUTE_NAMESPACE;
+	}
+
+	@Override
+	public String[] getJavaScriptModules() {
+		return new String[0];
+	}
+
+	@Override
+	public String getJspPath() {
+		return "/ckeditor_balloon.jsp";
+	}
+
+	@Override
+	public String getName() {
+		return _name;
+	}
+
+	@Override
+	public String getResourcesJspPath() {
+		return null;
+	}
+
+	@Override
+	public String getResourceType() {
+		return PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR;
+	}
+
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		_name = (String)properties.get("name");
+	}
+
+	private String _name;
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorBalloonEditor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorBalloonEditor.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Julien Castelain
  */
 @Component(
-	property = "name=ckeditor_balloon",
+	property = "name=ballooneditor",
 	service = {Editor.class, EditorRenderer.class}
 )
 public class CKEditorBalloonEditor implements Editor, EditorRenderer {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_balloon.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_balloon.jsp
@@ -1,0 +1,44 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+String contents = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":contents");
+Map<String, Object> editorData = (Map<String, Object>)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":data");
+String name = namespace + GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":name"));
+
+JSONObject editorConfigJSONObject = null;
+
+if (editorData != null) {
+	editorConfigJSONObject = (JSONObject)editorData.get("editorConfig");
+}
+%>
+
+<div>
+	<react:component
+		module="editor/BalloonEditor"
+		props='<%=
+			HashMapBuilder.<String, Object>put(
+				"config", editorConfigJSONObject
+			).put(
+				"contents", contents
+			).put(
+				"name", HtmlUtil.escapeAttribute(name)
+			).build()
+		%>'
+	/>
+</div>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_balloon.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_balloon.jsp
@@ -20,7 +20,6 @@
 String contents = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":contents");
 Map<String, Object> editorData = (Map<String, Object>)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":data");
 String name = namespace + GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":name"));
-
 JSONObject editorConfigJSONObject = null;
 
 if (editorData != null) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,0 +1,3 @@
+.cke_inner .cke_top {
+	display: none;
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -102,5 +102,4 @@ BalloonEditor.propTypes = {
 	name: PropTypes.string,
 };
 
-export {BalloonEditor};
 export default BalloonEditor;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -17,6 +17,8 @@ import React from 'react';
 
 import {Editor} from './Editor';
 
+import '../css/main.scss';
+
 const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 	const defaultExtraPlugins = 'balloontoolbar,floatingspace';
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {Editor} from './Editor';
+
+const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
+	const defaultExtraPlugins = 'balloontoolbar,floatingspace';
+
+	const getConfig = () => {
+		const extraPlugins = config.extraPlugins
+			? `${config.extraPlugins}`
+			: '';
+
+		return {
+			...config,
+			extraAllowedContent: '*',
+			extraPlugins: `${extraPlugins}${defaultExtraPlugins}`,
+		};
+	};
+
+	return (
+		<Editor
+			config={getConfig()}
+			name={name}
+			onBeforeLoad={(CKEDITOR) => {
+				CKEDITOR.disableAutoInline = true;
+			}}
+			onInstanceReady={(event) => {
+				const editor = event.editor;
+
+				const balloonToolbars = editor.balloonToolbars;
+
+				balloonToolbars.create({
+					buttons:
+						'Bold,Italic,Underline,RemoveFormat,Link,NumberedList,BulletedList,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,Anchor',
+					refresh(editor, path) {
+						const tags = new Set([
+							'h1',
+							'h2',
+							'h3',
+							'p',
+							'span',
+							'strong',
+							'li',
+						]);
+
+						let result = false;
+
+						tags.forEach((tag) => {
+							if (path.contains(tag)) {
+								result = true;
+							}
+						});
+
+						return result;
+					},
+				});
+
+				balloonToolbars.create({
+					buttons: 'Link,Unlink',
+					priority:
+						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
+					refresh(editor, path) {
+						return path.contains('a');
+					},
+				});
+
+				balloonToolbars.create({
+					buttons:
+						'JustifyLeft,JustifyCenter,JustifyRight,Link,Unlink',
+					priority:
+						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
+					widgets: 'image,image2',
+				});
+
+				if (contents) {
+					editor.setData(contents);
+				}
+			}}
+			type="inline"
+			{...otherProps}
+		/>
+	);
+};
+
+BalloonEditor.propTypes = {
+	config: PropTypes.object,
+	name: PropTypes.string,
+};
+
+export {BalloonEditor};

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -103,3 +103,4 @@ BalloonEditor.propTypes = {
 };
 
 export {BalloonEditor};
+export default BalloonEditor;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+export {BalloonEditor} from './editor/BalloonEditor';
 export {ClassicEditor} from './editor/ClassicEditor';
 export {Editor} from './editor/Editor';
 export {InlineEditor} from './editor/InlineEditor';


### PR DESCRIPTION
This add the `BalloonEditor` component in `frontend-editor-ckeditor-web` 
and a new `frontend-editor-ckeditor-sample-web` portlet.

As we are not replacing our current AlloyEditors (present in Blogs and Page Editor) for now (until work is completely finished), this example allows us to test the `BalloonEditor` easily in DXP. 
The idea is to evolve this portlet and render any other editors available, with a switch or any selector. 

To add this portlet, edit the main page (or either create another widget page) 
and look for **CKEditor Sample** in the widgets section. 

For now, this is what it renders (note that we still have to work in the toolbars and other stuff). 

**Preview**

![](https://user-images.githubusercontent.com/5572/113869318-dba51700-97b0-11eb-8f38-7caa8aaa428f.png)

 