### PR TITLE
LPS-129586  Migrate selection modals in account modules

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/select_default_address.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/select_default_address.jsp
@@ -104,10 +104,3 @@ accountEntryAddressDisplaySearchContainer.setRowChecker(null);
 		/>
 	</liferay-ui:search-container>
 </clay:container-fluid>
-
-<script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectDefaultAddress',
-		'<%= HtmlUtil.escapeJS(liferayPortletResponse.getNamespace() + "selectDefaultAddress") %>'
-	);
-</script>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
@@ -76,6 +76,7 @@ export default function propsTransformer({
 						}
 					}
 				},
+				searchContainerId: otherProps.searchContainerId,
 				selectEventName: `${portletNamespace}assignAccountUsers`,
 				title: Liferay.Util.sub(
 					Liferay.Language.get('assign-users-to-x'),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/select_account_users.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/select_account_users.jsp
@@ -141,9 +141,4 @@ String eventName = ParamUtil.getString(request, "eventName", liferayPortletRespo
 			result
 		);
 	});
-
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectAccountUser',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
 </aui:script>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/select_account_users.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/select_account_users.jsp
@@ -26,8 +26,6 @@ SelectAccountUsersManagementToolbarDisplayContext selectAccountUsersManagementTo
 if (selectAccountUsersManagementToolbarDisplayContext.isSingleSelect()) {
 	userSearchContainer.setRowChecker(null);
 }
-
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "assignAccountUsers");
 %>
 
 <liferay-portlet:renderURL portletName="<%= AccountPortletKeys.ACCOUNT_USERS_ADMIN %>" var="addAccountEntryUserURL">
@@ -117,28 +115,3 @@ String eventName = ParamUtil.getString(request, "eventName", liferayPortletRespo
 		/>
 	</liferay-ui:search-container>
 </clay:container-fluid>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get(
-		'<portlet:namespace />accountUsers'
-	);
-
-	searchContainer.on('rowToggled', (event) => {
-		var selectedItems = event.elements.allSelectedElements;
-
-		var result = {};
-
-		if (!selectedItems.isEmpty()) {
-			result = {
-				data: {
-					value: selectedItems.get('value').join(','),
-				},
-			};
-		}
-
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(eventName) %>',
-			result
-		);
-	});
-</aui:script>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupAccountEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupAccountEntriesManagementToolbarPropsTransformer.js
@@ -75,6 +75,7 @@ export default function propsTransformer({
 						}
 					}
 				},
+				searchContainerId: otherProps.searchContainerId,
 				selectEventName: `${portletNamespace}selectAccountEntries`,
 				title: Liferay.Util.sub(
 					Liferay.Language.get('assign-accounts-to-x'),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entry.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entry.jsp
@@ -98,30 +98,3 @@ if (selectAccountEntryManagementToolbarDisplayContext.isSingleSelect()) {
 		/>
 	</liferay-ui:search-container>
 </clay:container-fluid>
-
-<c:if test="<%= !selectAccountEntryManagementToolbarDisplayContext.isSingleSelect() %>">
-	<aui:script use="liferay-search-container">
-		var searchContainer = Liferay.SearchContainer.get(
-			'<portlet:namespace />accountEntries'
-		);
-
-		searchContainer.on('rowToggled', (event) => {
-			var selectedItems = event.elements.allSelectedElements;
-
-			var result = {};
-
-			if (!selectedItems.isEmpty()) {
-				result = {
-					data: {
-						value: selectedItems.get('value').join(','),
-					},
-				};
-			}
-
-			Liferay.Util.getOpener().Liferay.fire(
-				'<%= HtmlUtil.escapeJS(liferayPortletResponse.getNamespace() + "selectAccountEntries") %>',
-				result
-			);
-		});
-	</aui:script>
-</c:if>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entry.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entry.jsp
@@ -99,39 +99,29 @@ if (selectAccountEntryManagementToolbarDisplayContext.isSingleSelect()) {
 	</liferay-ui:search-container>
 </clay:container-fluid>
 
-<c:choose>
-	<c:when test="<%= selectAccountEntryManagementToolbarDisplayContext.isSingleSelect() %>">
-		<aui:script>
-			Liferay.Util.selectEntityHandler(
-				'#<portlet:namespace />selectAccountEntry',
-				'<%= HtmlUtil.escapeJS(liferayPortletResponse.getNamespace() + "selectAccountEntry") %>'
+<c:if test="<%= !selectAccountEntryManagementToolbarDisplayContext.isSingleSelect() %>">
+	<aui:script use="liferay-search-container">
+		var searchContainer = Liferay.SearchContainer.get(
+			'<portlet:namespace />accountEntries'
+		);
+
+		searchContainer.on('rowToggled', (event) => {
+			var selectedItems = event.elements.allSelectedElements;
+
+			var result = {};
+
+			if (!selectedItems.isEmpty()) {
+				result = {
+					data: {
+						value: selectedItems.get('value').join(','),
+					},
+				};
+			}
+
+			Liferay.Util.getOpener().Liferay.fire(
+				'<%= HtmlUtil.escapeJS(liferayPortletResponse.getNamespace() + "selectAccountEntries") %>',
+				result
 			);
-		</aui:script>
-	</c:when>
-	<c:otherwise>
-		<aui:script use="liferay-search-container">
-			var searchContainer = Liferay.SearchContainer.get(
-				'<portlet:namespace />accountEntries'
-			);
-
-			searchContainer.on('rowToggled', (event) => {
-				var selectedItems = event.elements.allSelectedElements;
-
-				var result = {};
-
-				if (!selectedItems.isEmpty()) {
-					result = {
-						data: {
-							value: selectedItems.get('value').join(','),
-						},
-					};
-				}
-
-				Liferay.Util.getOpener().Liferay.fire(
-					'<%= HtmlUtil.escapeJS(liferayPortletResponse.getNamespace() + "selectAccountEntries") %>',
-					result
-				);
-			});
-		</aui:script>
-	</c:otherwise>
-</c:choose>
+		});
+	</aui:script>
+</c:if>

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -334,6 +334,7 @@ const openSelectionModal = ({
 	multiple = false,
 	onClose,
 	onSelect,
+	searchContainerId,
 	selectEventName,
 	selectedData,
 	size,
@@ -377,7 +378,9 @@ const openSelectionModal = ({
 				onClose();
 			}
 		},
-		onOpen: ({container, processClose}) => {
+		onOpen: ({iframeWindow, processClose}) => {
+			const container = iframeWindow.document.body;
+
 			const selectEventHandler = Liferay.on(selectEventName, (event) => {
 				selectedItem = event.data || event;
 
@@ -414,6 +417,25 @@ const openSelectionModal = ({
 						Liferay.fire(selectEventName, delegateTarget.dataset);
 					}
 				});
+			}
+
+			if (searchContainerId && multiple) {
+				iframeWindow.Liferay.componentReady(searchContainerId).then(
+					(searchContainer) => {
+						searchContainer.on('rowToggled', (event) => {
+							const allSelectedElements =
+								event.elements.allSelectedElements;
+
+							if (!allSelectedElements.isEmpty()) {
+								selectedItem = {
+									value: allSelectedElements
+										.get('value')
+										.join(','),
+								};
+							}
+						});
+					}
+				);
 			}
 		},
 		size,
@@ -489,7 +511,7 @@ class Iframe extends React.Component {
 
 		if (this.props.onOpen) {
 			this.props.onOpen({
-				container: iframeWindow.document.body,
+				iframeWindow,
 				processClose: this.props.processClose,
 			});
 		}


### PR DESCRIPTION
aka a check about removing `Liferay.Util.selectEntityHandler` utility.

Before forwarding this to the `User and System Management` team (a proud no-code team), I wanted to open this for a quick review, as a first migration task of it's kind.

The three modals of this PR have already been migrated to `openSelectionModal`. However, there still are trailing `Liferay.Util.selectEntityHandler`s, that I think we can remove.

I though of mass-removing all of them in DXP, but there are few issues with that:
- It is not safe, as these are still required by legacy utils, such as `selectEntity`. Just looking at them, you cannot tell from what util they are invoked.
- The most important code in [selectEntityHandler](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js#L1300-L1369) was migrated to [openSelectionModal](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js#L408-L416), but not all. Some usages still might rely on non-migrated code, like the `disabled` handling.
- There might be some other purpose to `selectEntityHandler` that I'm missing, so don't want to go too deep before a review.

@jbalsas 

Test cases:
- GM > Accounts > An account > Assign a user to account
- GM > Accounts > An account > Details > Set default address
- GM > Account Users > A user > General > Accounts > Select.