### PR TITLE
LPS-129626 overriding dialog onShow event handler to make sure the dialog is centered when it is shown

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -146,6 +146,32 @@ const ClassicEditor = React.forwardRef(
 					}}
 					onInstanceReady={({editor}) => {
 						editor.setData(contents);
+
+						CKEDITOR.on(
+							'dialogDefinition',
+							({data: {definition}}) => {
+								definition.onShow = CKEDITOR.tools.override(
+									definition.onShow,
+									(onShow) => {
+										return () => {
+											onShow.call(definition.dialog);
+
+											const {dialog} = definition;
+											const dialogSize = dialog.getSize();
+
+											const x =
+												window.innerWidth / 2 -
+												dialogSize.width / 2;
+											const y =
+												window.innerHeight / 2 -
+												dialogSize.height / 2;
+
+											dialog.move(x, y);
+										};
+									}
+								);
+							}
+						);
 					}}
 					ref={(element) => {
 						if (ref) {


### PR DESCRIPTION
Hi @liferay-frontend,

This pull intends to fix the issue that keeps the CKEditor plugin dialogs decentralized.

Basically, I needed to override the `onShow` function from the dialog definition, then I used `CKEDITOR.tools.override` so 
I can call the previous `onShow` implementation, which has different logic for each plugin, and add the code related to centralizing the dialog.

Please let me know if you have any points about this

Thanks in advance 😃

Related issue: https://issues.liferay.com/browse/LPS-129626