### PR TITLE
LPS-129734 Bump @liferay/npm-scripts to v40.0.1

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
@@ -14,7 +14,6 @@
 
 import '../../../css/main.scss';
 
-import dom from 'metal-dom';
 import React, {
 	useCallback,
 	useEffect,
@@ -98,15 +97,11 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 	}, []);
 
 	useEffect(() => {
-		let onHandle;
-
-		let submitHandle;
-
 		if (containerRef.current) {
 			const form = getFormNode(containerRef.current);
 
 			if (form) {
-				onHandle = Liferay.on(
+				const onHandle = Liferay.on(
 					'submitForm',
 					(event) => {
 						if (event.form && event.form.getDOM() === form) {
@@ -116,19 +111,15 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 					this
 				);
 
-				submitHandle = dom.on(form, 'submit', handleFormSubmitted);
+				form.addEventListener('submit', handleFormSubmitted);
+
+				return () => {
+					onHandle.detach();
+
+					form.removeEventListener('submit', handleFormSubmitted);
+				};
 			}
 		}
-
-		return () => {
-			if (onHandle) {
-				onHandle.detach();
-			}
-
-			if (submitHandle) {
-				submitHandle.removeListener();
-			}
-		};
 	}, [containerRef, handleFormSubmitted]);
 };
 

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@liferay/npm-scripts": "39.1.0",
+		"@liferay/npm-scripts": "40.0.1",
 		"acorn": "7.1.0",
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1550,10 +1550,10 @@
   resolved "https://registry.yarnpkg.com/@liferay/amd-loader/-/amd-loader-4.3.1.tgz#35cde6128f6e2795b7e45378e8f115f596b6cdda"
   integrity sha512-95i+LRK3gPTiBc75lJsr9OwRNFdzaamSe3B5x+kHLHYr78qS/4WD5mkDJ+WYv3CY0jFFnROTNLl3x6zCRuDMxw==
 
-"@liferay/eslint-config@22.0.0":
-  version "22.0.0"
-  resolved "https://registry.yarnpkg.com/@liferay/eslint-config/-/eslint-config-22.0.0.tgz#f52f343316d6eb1aa8b99d5a9c393d25872827e2"
-  integrity sha512-aLOyJdORT2y0MoUcdakf8XFTu7gbHtxz1ygKmw5mZkmd/9Ihdgurly28tI3fBRbxjpZ2YMZCHGV/dLfK6vYFiQ==
+"@liferay/eslint-config@23.0.0":
+  version "23.0.0"
+  resolved "https://registry.yarnpkg.com/@liferay/eslint-config/-/eslint-config-23.0.0.tgz#c2bafdab3a884629cfd4851c6aa3cc1be7256083"
+  integrity sha512-N6dyL6ZG+fPpQxdgFGmzhwC9UrrJHCjVwnD49rxXRsGozkLv/eDwt0oNyZyP0XzJG0JcuZlw/aIsSvQ9qoJFAg==
   dependencies:
     "@typescript-eslint/eslint-plugin" "4.3.0"
     "@typescript-eslint/parser" "4.3.0"
@@ -1620,10 +1620,10 @@
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-"@liferay/npm-scripts@39.1.0":
-  version "39.1.0"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-39.1.0.tgz#9ba8bd7bc77e737f5b2fbacc44f6321bec32da8b"
-  integrity sha512-JJIWTG32o+DFNqe8K1nIolCfwTVoVyRqBvHsDe+rbCRB260h8BoUc2aBmpl+bzTjbT6+VL21XhHW3jARf/w57Q==
+"@liferay/npm-scripts@40.0.1":
+  version "40.0.1"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-40.0.1.tgz#a63be774a4399a12630aabecbb6f748984c05152"
+  integrity sha512-UBMNHAB0AQiSexXppg79ZOso4PAuOF4LluUDFWfowy5tnN7ZZnSBaGvlzWUGtCS6Kn48v1yVKf9dG9fCNpN+Jw==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"
@@ -1635,7 +1635,7 @@
     "@babel/preset-env" "^7.4.2"
     "@babel/preset-react" "^7.8.3"
     "@babel/preset-typescript" "^7.10.4"
-    "@liferay/eslint-config" "22.0.0"
+    "@liferay/eslint-config" "23.0.0"
     "@liferay/jest-junit-reporter" "1.2.0"
     "@liferay/js-toolkit-core" "3.0.1"
     "@testing-library/dom" "^5.6.1"
@@ -1649,7 +1649,7 @@
     babel-jest "^25.1.0"
     babel-loader "^8.1.0"
     babel-plugin-transform-react-remove-prop-types "0.4.24"
-    babel-preset-liferay-standard "2.24.1"
+    babel-preset-liferay-standard "2.24.2"
     bourbon "4.2.3"
     cosmiconfig "^7.0.0"
     cross-env "^7.0.0"
@@ -1667,15 +1667,15 @@
     jest-fetch-mock "^3.0.3"
     liferay-frontend-common-css "^1.0.4"
     liferay-lang-key-dev-loader "^1.0.3"
-    liferay-npm-bridge-generator "2.24.1"
-    liferay-npm-bundler "2.24.1"
-    liferay-npm-bundler-loader-css-loader "2.24.1"
-    liferay-npm-bundler-plugin-exclude-imports "2.24.1"
-    liferay-npm-bundler-plugin-inject-imports-dependencies "2.24.1"
-    liferay-npm-bundler-plugin-inject-peer-dependencies "2.24.1"
-    liferay-npm-bundler-plugin-namespace-packages "2.24.1"
-    liferay-npm-bundler-plugin-replace-browser-modules "2.24.1"
-    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.24.1"
+    liferay-npm-bridge-generator "2.24.2"
+    liferay-npm-bundler "2.24.2"
+    liferay-npm-bundler-loader-css-loader "2.24.2"
+    liferay-npm-bundler-plugin-exclude-imports "2.24.2"
+    liferay-npm-bundler-plugin-inject-imports-dependencies "2.24.2"
+    liferay-npm-bundler-plugin-inject-peer-dependencies "2.24.2"
+    liferay-npm-bundler-plugin-namespace-packages "2.24.2"
+    liferay-npm-bundler-plugin-replace-browser-modules "2.24.2"
+    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.24.2"
     liferay-theme-tasks "10.3.0"
     metal-tools-soy "4.3.2"
     mini-css-extract-plugin "0.11.2"
@@ -2987,35 +2987,20 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-add-module-metadata@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.23.0.tgz#ecea45dee74730b8a03baf0e3dc282bcc3d2679e"
-  integrity sha512-pjTxQ6HZSfZHpX4D3p9s+MqQichjC7CsuBfalboxJR4ZUIj6pU5bFDV8CpwGYzCG6wNAxIx6q1KCZPSw+MY3MQ==
+babel-plugin-add-module-metadata@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.24.2.tgz#b8bfea8f0104a4dd5b19792c1ae37782a55b6e8b"
+  integrity sha512-CscZnR/LumeI4LGGsSbgectZShOPX0ztQJBjdk/Sf9/h2/PbC/O7GX5zf+t3JUmH4vcv7XeDgFCdZinEoScK0g==
   dependencies:
-    liferay-npm-build-tools-common "2.23.0"
+    liferay-npm-build-tools-common "2.24.2"
     read-json-sync "^2.0.1"
 
-babel-plugin-add-module-metadata@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.24.1.tgz#33edbc5d80b0267f81fca6c8c1a3b417a1f9e9b8"
-  integrity sha512-6iAREPP4p+oDFs+sHwH/d4Hv821MaI1uYqPOZJUo6O6HMQ5YRlSTJOW7ht2Sn1XKa1P+bq9aC+VBXQVCRnDlvg==
+babel-plugin-alias-modules@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.24.2.tgz#745ecab09170061b4f087ca832cd95ee50f26dd3"
+  integrity sha512-lthJ0ZnN0Va1KolpIVvZdG0MOxDjgIQhdyGvOBYPKunOQzVKo6kacqvvSSyjPXEI4qjF5U5G/3sgrd4Qt6GGlQ==
   dependencies:
-    liferay-npm-build-tools-common "2.24.1"
-    read-json-sync "^2.0.1"
-
-babel-plugin-alias-modules@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.23.0.tgz#f04c39c1da080b77f580baafb32d99bad784dd03"
-  integrity sha512-H+aFZWsgxuNChIlo/oeeRO3W0Bg6k1z3G5qWzjQoYtr3GsS8fFpFWMsur9r3YXbPJerVGqR2BouH44WKM60W5A==
-  dependencies:
-    liferay-npm-build-tools-common "2.23.0"
-
-babel-plugin-alias-modules@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.24.1.tgz#d6da3063bec4c93884b0484478e1179a58b30eb5"
-  integrity sha512-XxcI34E7Ftt4EfdTrEs9jphfFf58AKzJwkQbcWzk1i9wjCyd521ZpvW8sBQ0qmdBYtHaX6E8dPaohpLONe52/g==
-  dependencies:
-    liferay-npm-build-tools-common "2.24.1"
+    liferay-npm-build-tools-common "2.24.2"
 
 babel-plugin-dynamic-import-node@^2.3.0:
   version "2.3.0"
@@ -3060,61 +3045,33 @@ babel-plugin-minify-dead-code-elimination@0.5.1:
     babel-helper-remove-or-void "^0.4.3"
     lodash "^4.17.11"
 
-babel-plugin-name-amd-modules@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.23.0.tgz#c8a7260c584984bee6a7f09ed45f61ec79cc86fc"
-  integrity sha512-Kth2WC4a8xcXNHT6Duy4LJXm7MKVcgzn+P3Ch/a9rfEI1ZTGmPqGGLn/43SSAJT3kby5j9NIbdT+X5sJKiy7TA==
+babel-plugin-name-amd-modules@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.24.2.tgz#eefd60ddd478e8b83311b91f809385472be7b9e3"
+  integrity sha512-s68+92OJUmkqrCAWS+s7nC8tp2WjujJkfAXmpngyEOdyUYjqmUbUM2gQf7XK83PWpfrp3yp6zhp1cqVlY6XerA==
   dependencies:
-    liferay-npm-build-tools-common "2.23.0"
+    liferay-npm-build-tools-common "2.24.2"
 
-babel-plugin-name-amd-modules@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.24.1.tgz#7de49bed8571bc8832eddbf8b59e5332ca16eeff"
-  integrity sha512-N640u2TNnPfA+4zLc07v0YJwU+NMbDQmC7Ko1hYu8Ov+h6c/MZlQ4iQqhZvihNIY+0RzxU5WGCLyoPTRG19SJg==
+babel-plugin-namespace-amd-define@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.24.2.tgz#056ad80794888c05169576af18418e0495532458"
+  integrity sha512-+ACN242u+6l5KvbvgPo2XWRd94lZVjCEc4GvZr1ittPdOa58MZFFWOwWUzgXncjM3wv2Ojs7jh/rujrBj5TgiQ==
   dependencies:
-    liferay-npm-build-tools-common "2.24.1"
+    liferay-npm-build-tools-common "2.24.2"
 
-babel-plugin-namespace-amd-define@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.23.0.tgz#834fc3790a97f2530e023c4d680ce4fdd1fc22ab"
-  integrity sha512-YpQZ8LYfEyEdphhgRFkF1N8L3gPWdL5UJzQlAJUKKOOZWs6sTW1ZrqMS8FX08ItuKRlWzoC9w9i36Yx9eDAQYg==
+babel-plugin-namespace-modules@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.24.2.tgz#237ff908c6bec445b8ef83fb08bac8a9e6be0f2d"
+  integrity sha512-t+x6pRCWXZbZoO/gguZR+9k9rQ5SgOL+EMARDzBmifSdwpQotpzReMvKFUkO+S3MKxrweSHY5wJqTASQxw0JJg==
   dependencies:
-    liferay-npm-build-tools-common "2.23.0"
+    liferay-npm-build-tools-common "2.24.2"
 
-babel-plugin-namespace-amd-define@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.24.1.tgz#35f04370cc168ae63ca0c07be9f16fb6c0284c6a"
-  integrity sha512-m2rHb1Bd+NrEL/iZ9/yVhzudGyaCX6axg1qRhdjNl423NW7X0DxQR21pwQ/zCWTGzPLGCVhSXWhAsbWZmkkIhw==
+babel-plugin-normalize-requires@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.24.2.tgz#44b0ac42ff2e788e7f0156ec12487b6ae1905438"
+  integrity sha512-+/xveg1Fred6+nhRYxGDecDLGekOmrCPXmRgft/iSESvs1JmMlXQe5A9QtkWvLpm3wkFzFUcVdcrwizF73+yJA==
   dependencies:
-    liferay-npm-build-tools-common "2.24.1"
-
-babel-plugin-namespace-modules@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.23.0.tgz#fd1b13dbc9d9edf2c78ae89d7ad5468ea687fd25"
-  integrity sha512-VLk+PXLPAc2KwrsQIO8TOAplPi0ugOIxbvhiptmsXQ6zCe+Ab79dnpCw1cAsNRmGgLduq0A3TvGw6ebu5cenFA==
-  dependencies:
-    liferay-npm-build-tools-common "2.23.0"
-
-babel-plugin-namespace-modules@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.24.1.tgz#7a450d7b327471d070470e38d1bf2e63268be992"
-  integrity sha512-EHzODP5h2wF6aFFp2Rh8owryIwUNT5inj8iwp5kLpaFJKD2BLNJ7mYOoMFadENGdhyhIYdA3Q5BL89zCEdeePA==
-  dependencies:
-    liferay-npm-build-tools-common "2.24.1"
-
-babel-plugin-normalize-requires@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.23.0.tgz#a36d7f954c28806df5ea76b2bc7e0415d1ba1a7f"
-  integrity sha512-MQLDKZzvH/5/xgX0URliJ6Ly6FWcad2WU58D9S9hRgDD5Daz/zxEyM1kmG6ui1GHG9TVo2AGaCNTFFk6bPQcaQ==
-  dependencies:
-    liferay-npm-build-tools-common "2.23.0"
-
-babel-plugin-normalize-requires@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.24.1.tgz#5166d753ef276f4793fe22bd85c20f1f92e80b4f"
-  integrity sha512-T3tQjZVtTxf4PnwvPMeOMdITYXcqx4pbtTrD8DX0XJAGuQlBefhk0BnO3WEyOKuHmEf7END3uKbD5S52zWaB5A==
-  dependencies:
-    liferay-npm-build-tools-common "2.24.1"
+    liferay-npm-build-tools-common "2.24.2"
 
 babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
@@ -3131,22 +3088,13 @@ babel-plugin-transform-react-remove-prop-types@0.4.24:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
 
-babel-plugin-wrap-modules-amd@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.23.0.tgz#a16e37fa3e3e26f8946066de811af874945cf213"
-  integrity sha512-iEnb8XuTvSgBjpyohzLTrlafvA+rlWIYUCu111QV9BLMlZ911pzjVjxQt/ASgINmyHNaTmsL2WBUiITCWLpvww==
+babel-plugin-wrap-modules-amd@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.24.2.tgz#3a6276bf796b937aecd648e74c9aea48e348b5c4"
+  integrity sha512-G4WjQNsu+QDJqpnqukEUZADN5X2Xwuof7O5gqDtgEx/Wu4SSY7vYp6zh+Loo30uKJPfndYtqJmoPH/H51AD5Kg==
   dependencies:
     babel-template "^6.26.0"
-    liferay-npm-build-tools-common "2.23.0"
-    read-json-sync "^2.0.1"
-
-babel-plugin-wrap-modules-amd@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.24.1.tgz#466958537644f6e81db2b8f8372d4480aa75afe5"
-  integrity sha512-QOMP8/q+wFvl1RwKPcRae4iBXhvEDI64mM06dokWAjuVEgOQIyYU95fOfvF4uO9RVu/TiDZrqICzSXkItorlfA==
-  dependencies:
-    babel-template "^6.26.0"
-    liferay-npm-build-tools-common "2.24.1"
+    liferay-npm-build-tools-common "2.24.2"
     read-json-sync "^2.0.1"
 
 babel-preset-jest@^25.1.0:
@@ -3158,35 +3106,20 @@ babel-preset-jest@^25.1.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^25.1.0"
 
-babel-preset-liferay-standard@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.23.0.tgz#5457667a8ece0e6002a32787559ca3ff0d3542e0"
-  integrity sha512-dYdSJlc1dnEzwtWqvB1O2Uu/CBINWABHYsqpQUabnk/adcgwdAk93Gc3Cb2gA0Fi528SL4e54NIzodw2Bitabw==
+babel-preset-liferay-standard@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.24.2.tgz#1b52de37aaa05d7294f37205f5efa91c8e902ae7"
+  integrity sha512-81Cu2nPL2/msPICS6/tiHmi0Oz2gpIYS/TJrPwl/okA4e1byaQXexJljlqalZqrNd8GTi2qRmOkimgJTez7nfA==
   dependencies:
-    babel-plugin-add-module-metadata "2.23.0"
-    babel-plugin-alias-modules "2.23.0"
+    babel-plugin-add-module-metadata "2.24.2"
+    babel-plugin-alias-modules "2.24.2"
     babel-plugin-minify-dead-code-elimination "0.5.1"
-    babel-plugin-name-amd-modules "2.23.0"
-    babel-plugin-namespace-amd-define "2.23.0"
-    babel-plugin-namespace-modules "2.23.0"
-    babel-plugin-normalize-requires "2.23.0"
+    babel-plugin-name-amd-modules "2.24.2"
+    babel-plugin-namespace-amd-define "2.24.2"
+    babel-plugin-namespace-modules "2.24.2"
+    babel-plugin-normalize-requires "2.24.2"
     babel-plugin-transform-node-env-inline "0.4.3"
-    babel-plugin-wrap-modules-amd "2.23.0"
-
-babel-preset-liferay-standard@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.24.1.tgz#a0bb653bdf8103fbe8feafa89ad340650fa10482"
-  integrity sha512-ApSE9oSr3fnOCc6iQ4X+pmN2IhKw8htI2d/02rGmL3c3kfsVwTx8nGFR0aVLHLGNEj812ESwB12UuqUgBw4MAA==
-  dependencies:
-    babel-plugin-add-module-metadata "2.24.1"
-    babel-plugin-alias-modules "2.24.1"
-    babel-plugin-minify-dead-code-elimination "0.5.1"
-    babel-plugin-name-amd-modules "2.24.1"
-    babel-plugin-namespace-amd-define "2.24.1"
-    babel-plugin-namespace-modules "2.24.1"
-    babel-plugin-normalize-requires "2.24.1"
-    babel-plugin-transform-node-env-inline "0.4.3"
-    babel-plugin-wrap-modules-amd "2.24.1"
+    babel-plugin-wrap-modules-amd "2.24.2"
 
 babel-register@^6.26.0:
   version "6.26.0"
@@ -9590,180 +9523,104 @@ liferay-lang-key-dev-loader@^1.0.3:
     loader-utils "^1.1.0"
     properties "^1.2.1"
 
-liferay-npm-bridge-generator@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.24.1.tgz#b11bc4eef7bfcb9bcb7785d2e3fba1b52caa8c1b"
-  integrity sha512-s3sPZSIQKYObMKeBOaUNALCzmo5jTg+mVLeqdJ8LLnm6DIf4/4JRkUeO4p6ktYyNL+Ff9W5oDZKxoWYN7qGd2w==
+liferay-npm-bridge-generator@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.24.2.tgz#bbf26ec264122463852c7a8f8afe25ce67477efa"
+  integrity sha512-R8JOdQ7JUIa7OQ6+w8UtjQ1Hu3irk8BgW9VsBWI/+7jgjkD+vr1leP7AswBZ3q8bm8Gm+ypbrVER5kiYwcpjqA==
   dependencies:
     fs-extra "^8.1.0"
     globby "^10.0.1"
     read-json-sync "^2.0.1"
     yargs "^14.0.0"
 
-liferay-npm-build-tools-common@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.23.0.tgz#c5b8ee849de1da23a5eeb5850dcbb74f9678e4f6"
-  integrity sha512-aqWDPaKKL+YuSfKQdFWSP2J+Dk6nqyZZhWtp2bLEqyVUE5kQIP6mQkJrk5ZG2PnURgYp7GhL0h7B3R2aWpAVIw==
+liferay-npm-build-tools-common@2.24.2, liferay-npm-build-tools-common@^2.17.1:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.24.2.tgz#1bc54bfe08de9d14d7b54a0b5b2c4bd5fc17febb"
+  integrity sha512-2Gbv6yulnJ02WdQQTSmB+pS99zGMTO6lBAwWe+2XjlURQtSY7bj/EiTWr1IbB7+wMk1rOoXLWP6RA/2ItSrhqg==
   dependencies:
     chalk "^2.4.2"
     dot-prop "^5.0.1"
     escape-string-regexp "^2.0.0"
-    liferay-npm-bundler-preset-standard "2.23.0"
+    liferay-npm-bundler-preset-standard "2.24.2"
     merge "^1.2.1"
     properties "^1.2.1"
     read-json-sync "^2.0.1"
     resolve "^1.8.1"
 
-liferay-npm-build-tools-common@2.24.1, liferay-npm-build-tools-common@^2.17.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.24.1.tgz#70e78f04d45eea34e57ec79f686ad1c33058a621"
-  integrity sha512-Dp0uisf1ycNeAz+buswjGBi1l/cVmE1/DDH92YZYuWllkZ96O3U8P6fH5ev/hkHMLRVKWMzKTIpttb/Xsyymrw==
+liferay-npm-bundler-loader-css-loader@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.24.2.tgz#280dbaca269293424a4f943f51e48e27bb9a03ec"
+  integrity sha512-wd1Oi4/CpaNFNkMi3bN9LJMrvc8Io37Z7QvPausLaEIdgq4DgkVyxc/RPzQ20OOtugKqg2oFY1wPrF67uNnw9g==
   dependencies:
-    chalk "^2.4.2"
-    dot-prop "^5.0.1"
-    escape-string-regexp "^2.0.0"
-    liferay-npm-bundler-preset-standard "2.24.1"
-    merge "^1.2.1"
-    properties "^1.2.1"
-    read-json-sync "^2.0.1"
-    resolve "^1.8.1"
-
-liferay-npm-bundler-loader-css-loader@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.24.1.tgz#32c98a56376fdc116a3a582b9e207cbb7c260a13"
-  integrity sha512-lL7V5RoC/gSfh+tmT5zrjwXx7RLpXVpLJcFT5a/fTLcFJA+Xo4eBVeaVkiSzyYt7KZDjLCHlvgk64Ts8FFmZZw==
-  dependencies:
-    liferay-npm-build-tools-common "2.24.1"
+    liferay-npm-build-tools-common "2.24.2"
     read-json-sync "^2.0.1"
 
-liferay-npm-bundler-plugin-exclude-imports@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.23.0.tgz#6b1824fe6288398eef6a6d603b92d05d826db452"
-  integrity sha512-S223XpJKw49yqbkLQCFD25VhTtQQ9JOdxOipRuOE2FaHSE6+lRs4n0QO3bpzaTozk+i68fLrkJNRaJPhWUtyoQ==
+liferay-npm-bundler-plugin-exclude-imports@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.24.2.tgz#cc965321a068af7554fb8e0ec88fbb8258d19094"
+  integrity sha512-ejvgUYgdo4CQsUtTetpvampk/J2xzQ0mvuNiuu7Mz53Gj9JUxqoDQyZeK/dhylAEZLjX8Kwfkyx5f5v+nnS8Jw==
   dependencies:
-    liferay-npm-build-tools-common "2.23.0"
+    liferay-npm-build-tools-common "2.24.2"
 
-liferay-npm-bundler-plugin-exclude-imports@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.24.1.tgz#f9507181eb799f5f8ffc2dc1affdd06963faf8ed"
-  integrity sha512-hXnhej7WWo1Ym1ToJ8nX102clldruFCDcfKUoUml2ELwSHTZpBDzYmGr8gzYbSOUUzYN5T8QoLJsziU8TIL0uw==
+liferay-npm-bundler-plugin-inject-imports-dependencies@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.24.2.tgz#591b10edd1a234912b8d4a2699000091ad16a0b9"
+  integrity sha512-S8vEK5y+3dmD2IDk5aNxF5cAxQLQRrkC3Jr0WVMXWyp/c7+JmB+nS+0R+J4SWokdIXviHVgwdcrbqJz1iaUBfw==
   dependencies:
-    liferay-npm-build-tools-common "2.24.1"
+    liferay-npm-build-tools-common "2.24.2"
 
-liferay-npm-bundler-plugin-inject-imports-dependencies@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.23.0.tgz#c480113626dfb2557fa0d2b438d5c598a0d37b1c"
-  integrity sha512-B5NtTWu2bEXtvzGtJM0sDcafTE9Gnp6cJBM8o39++PuMF0TOOcZx/B6xrGB2OofigmOPsBm+dyi+0fpS/Is9rg==
-  dependencies:
-    liferay-npm-build-tools-common "2.23.0"
-
-liferay-npm-bundler-plugin-inject-imports-dependencies@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.24.1.tgz#e1dd60b7a59c05c95a9b918d900a96b8f295e6bb"
-  integrity sha512-45hlSoXu4OaebSG8ATsOZwZuJpxzpcDnTKZd1m7iBD6oRPpsW3hsZhzJSCXyFiwpU/8SH4JoggBbHXTGAqKswQ==
-  dependencies:
-    liferay-npm-build-tools-common "2.24.1"
-
-liferay-npm-bundler-plugin-inject-peer-dependencies@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.23.0.tgz#3af93aa00fd07b1a5a60300d66e14b2397288f80"
-  integrity sha512-dp0KbZntVzDtjLwZfgPaZPLNYTYCXr8v6MhG5Fhgwdc957g0DERGi+3ZDVrlL7ENrBJ9RtDi14w2ris1PO7diw==
+liferay-npm-bundler-plugin-inject-peer-dependencies@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.24.2.tgz#f2915d1d5a828b5b91ea7fd6a3929299711dfe5d"
+  integrity sha512-Hyb7P/WzBXOUo7OeW2pWBAMHxRznEBkj8z2TSCXDyv4VIIJMurWQhFq/8IcI9IaeaLCxkCIl6ldDA5m3SiRhcA==
   dependencies:
     globby "^10.0.1"
-    liferay-npm-build-tools-common "2.23.0"
+    liferay-npm-build-tools-common "2.24.2"
     read-json-sync "^2.0.1"
     resolve "^1.8.1"
 
-liferay-npm-bundler-plugin-inject-peer-dependencies@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.24.1.tgz#bbf3e0ea28ce94748cfb9c58c6ca599af7d849e6"
-  integrity sha512-SzVXBFE/Iym41ubgNU2+Tx6ejitwrxKMcwgUWADIv7cpBgkomjZxJKqJELHynttJr/34eBw2yw9oPCr6zzenHw==
+liferay-npm-bundler-plugin-namespace-packages@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.24.2.tgz#7acd4394859aaf827c8f68785d3e423678c9caed"
+  integrity sha512-9BAiX/i/9ER6S23y1Oe4rJ7NQzrm+mN2Bq1zpVVasCQK0j74H+u0zoRAdI93chRpkG7vqqdMt25wSD5boM2jTg==
   dependencies:
-    globby "^10.0.1"
-    liferay-npm-build-tools-common "2.24.1"
-    read-json-sync "^2.0.1"
-    resolve "^1.8.1"
+    liferay-npm-build-tools-common "2.24.2"
 
-liferay-npm-bundler-plugin-namespace-packages@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.23.0.tgz#49fee4fdfe5ba391913048628aadeb259904a55d"
-  integrity sha512-k9Ze4FwHeyEZ0rQWKIm+Raay5j5ySNElKN9JZXBH4EAs+tYHRtwWxtscPpTVdRevc2lKmi1LbClhprRVHmIRSQ==
-  dependencies:
-    liferay-npm-build-tools-common "2.23.0"
-
-liferay-npm-bundler-plugin-namespace-packages@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.24.1.tgz#17d6fb84b2f55d14d8d18aca70f7e4050ca613da"
-  integrity sha512-+rHJ6q6qbTWyS43+ESuu1XVMbMzqomG1ITlTxncnwhrmFTV9+ZX7eROqNCACXatq5KNnERyGOt+OH+4Dw6xmmA==
-  dependencies:
-    liferay-npm-build-tools-common "2.24.1"
-
-liferay-npm-bundler-plugin-replace-browser-modules@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.23.0.tgz#329742a7ba56e0c52517af7164f368afd84d6a5b"
-  integrity sha512-ivhzbCJ/TvJ9l1j7yVSiv4k/zy7ruG9mWHNqnLnkea1xhkZho+sFV/kTIL0v7kq83b8+zjSSahaB4vMhSpJ25Q==
+liferay-npm-bundler-plugin-replace-browser-modules@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.24.2.tgz#e22466287c3c8e9e6e5f7650c57469e0b697ee41"
+  integrity sha512-u01dHgvk2h7ohe0oQ+jNt9QZAVu9qrtaPJs8KhavX8uEujS+mYSMkOBsqV0mD901HiykFZq66fhRiPTdvmblgQ==
   dependencies:
     dot-prop "^5.0.1"
     fs-extra "^8.1.0"
-    liferay-npm-build-tools-common "2.23.0"
+    liferay-npm-build-tools-common "2.24.2"
 
-liferay-npm-bundler-plugin-replace-browser-modules@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.24.1.tgz#e2572e95bd8b879ab0b7f752f71836950a0b7f5b"
-  integrity sha512-xFN0pVb9V3iRSRN5KILjDMM3Hj9fIbi5dVwfOTk9BjBCOzQKkl/AS1vWKCDqqkvaVXnfamrlWstGPKMwyOL7tQ==
+liferay-npm-bundler-plugin-resolve-linked-dependencies@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.24.2.tgz#8674ff34be7151b6509222d92b3ec48f3f3bd5d5"
+  integrity sha512-stKCDAHdwODkjnQoLBIFfy8+XYEMQd+zYKqZ9ub0GZI3CDX+3ifubfdjoSn6dN4yhrpE6uDaBYAOUFSxkxPzkw==
   dependencies:
-    dot-prop "^5.0.1"
-    fs-extra "^8.1.0"
-    liferay-npm-build-tools-common "2.24.1"
-
-liferay-npm-bundler-plugin-resolve-linked-dependencies@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.23.0.tgz#f84ac9339b012c5461a80eed484581c19bfe6bd2"
-  integrity sha512-5n9qY2qLjz4NT7xfbkgWDKXgGHgNK8dDPIZYYU3KLNRDqj/M2R5Yq5kgv/oTCX8qDucz0CreqQnGmZw3lPEeWw==
-  dependencies:
-    liferay-npm-build-tools-common "2.23.0"
+    liferay-npm-build-tools-common "2.24.2"
     read-json-sync "^2.0.1"
     semver "^6.3.0"
 
-liferay-npm-bundler-plugin-resolve-linked-dependencies@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.24.1.tgz#d5a704748aa0e17cee8fa0ff205db2beecd69ec2"
-  integrity sha512-2dU4QQaBYz/R4rwjMhQbm8eG3+BmL6P+tmI6vYVfzmNHy1wxZfamzx0UgC1rswHM9l8nbMj0oCSHT8waYcTDwA==
+liferay-npm-bundler-preset-standard@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.24.2.tgz#bda63e29d5ea62bf03401c31f1bdc2c8ee39b618"
+  integrity sha512-OohnMiPtLa7aclkXZmV97Lx3wIgwY/usjgKQE06kARAtFF4mBlMndNuK+HEosgNrihimmd61Sh7BkSs+JYIR/g==
   dependencies:
-    liferay-npm-build-tools-common "2.24.1"
-    read-json-sync "^2.0.1"
-    semver "^6.3.0"
+    babel-preset-liferay-standard "2.24.2"
+    liferay-npm-bundler-plugin-exclude-imports "2.24.2"
+    liferay-npm-bundler-plugin-inject-imports-dependencies "2.24.2"
+    liferay-npm-bundler-plugin-inject-peer-dependencies "2.24.2"
+    liferay-npm-bundler-plugin-namespace-packages "2.24.2"
+    liferay-npm-bundler-plugin-replace-browser-modules "2.24.2"
+    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.24.2"
 
-liferay-npm-bundler-preset-standard@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.23.0.tgz#b279429ec003d8c32fbd201d4dad1ea92d96d7c4"
-  integrity sha512-jTI+YwI8KHMznzgatR82HoN1BjFJXpOYGKJ4BqtMBC3j0vfbg9WViWrKlwaeDS8S7j4yvwyNHvCitVr32gC/Ww==
-  dependencies:
-    babel-preset-liferay-standard "2.23.0"
-    liferay-npm-bundler-plugin-exclude-imports "2.23.0"
-    liferay-npm-bundler-plugin-inject-imports-dependencies "2.23.0"
-    liferay-npm-bundler-plugin-inject-peer-dependencies "2.23.0"
-    liferay-npm-bundler-plugin-namespace-packages "2.23.0"
-    liferay-npm-bundler-plugin-replace-browser-modules "2.23.0"
-    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.23.0"
-
-liferay-npm-bundler-preset-standard@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.24.1.tgz#4b95d5521a5da5403dc1da16935b62942330f8ef"
-  integrity sha512-8HOM3l4lyo5wqOP+9UlODn7hectpM2gMR7LnixPl3GV0WmHXwpzFnqdu9DwlrtrJMVpgluu7uzqXqzmXr+SpZQ==
-  dependencies:
-    babel-preset-liferay-standard "2.24.1"
-    liferay-npm-bundler-plugin-exclude-imports "2.24.1"
-    liferay-npm-bundler-plugin-inject-imports-dependencies "2.24.1"
-    liferay-npm-bundler-plugin-inject-peer-dependencies "2.24.1"
-    liferay-npm-bundler-plugin-namespace-packages "2.24.1"
-    liferay-npm-bundler-plugin-replace-browser-modules "2.24.1"
-    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.24.1"
-
-liferay-npm-bundler@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler/-/liferay-npm-bundler-2.24.1.tgz#a736d66058ef7721dff0e04377f32902be9ef192"
-  integrity sha512-Fhf04uwodbKTjUSz4pltWu1vMOO/GfAUUVtPACyrfr8O38JG+VWPkl/oG3pOQ/gvoxpcI7tR8jGVFIV7kxhbcg==
+liferay-npm-bundler@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler/-/liferay-npm-bundler-2.24.2.tgz#d95016bc88b4e845af184b3df94dd92dcd339533"
+  integrity sha512-YN6Y8QDY4SJPksfplMscxUPGd29GxlX4kETaZxT1DVpCAKMyd8C6Ms4HxBeE/KFHZfvKsOmgOsC3yKDycE0QWQ==
   dependencies:
     babel-core "^6.26.3"
     clone "^2.1.2"
@@ -9773,8 +9630,8 @@ liferay-npm-bundler@2.24.1:
     globby "^10.0.1"
     insight "0.10.3"
     jszip "^3.1.5"
-    liferay-npm-build-tools-common "2.24.1"
-    liferay-npm-bundler-preset-standard "2.24.1"
+    liferay-npm-build-tools-common "2.24.2"
+    liferay-npm-bundler-preset-standard "2.24.2"
     merge "^1.2.1"
     pretty-time "^1.1.0"
     read-json-sync "^2.0.1"


### PR DESCRIPTION
Fixes [LPS-129734](https://issues.liferay.com/browse/LPS-129734).

## Overview
- Removes last usage of `metal-dom` that was added after we already removed all usages 👿 
- Updates the `@liferay/npm-scripts` version to 40.0.1:
  - [Release notes for v40.0.0](https://github.com/liferay/liferay-frontend-projects/releases/tag/npm-scripts%2Fv40.0.0)
  - [Release notes for v40.0.1](https://github.com/liferay/liferay-frontend-projects/releases/tag/npm-scripts%2Fv40.0.1) 
- Updates the `yarn.lock` after building it with the new `@liferay/npm-scripts` version

## Testing the `metal-dom` removal
I've tested this to make sure it behaves as it did before. You can test it yourself by going to `Content & Data > Forms > Add Form > add a form element`, the element should be added successfully and you will be able to save the form without any console errors. I couldn't figure out how to test if the event is properly removed, but I didn't notice any unexpected behaviour during my testing.