### PR TITLE
LPS-129738 Replace usage of metal-dom inside dynamic-data-mapping-form-renderer

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
@@ -14,7 +14,6 @@
 
 import '../../../css/main.scss';
 
-import dom from 'metal-dom';
 import React, {
 	useCallback,
 	useEffect,
@@ -99,11 +98,10 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 
 	useEffect(() => {
 		let onHandle;
-
-		let submitHandle;
+		let form;
 
 		if (containerRef.current) {
-			const form = getFormNode(containerRef.current);
+			form = getFormNode(containerRef.current);
 
 			if (form) {
 				onHandle = Liferay.on(
@@ -116,7 +114,7 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 					this
 				);
 
-				submitHandle = dom.on(form, 'submit', handleFormSubmitted);
+				form.addEventListener('submit', handleFormSubmitted);
 			}
 		}
 
@@ -125,8 +123,8 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 				onHandle.detach();
 			}
 
-			if (submitHandle) {
-				submitHandle.removeListener();
+			if (form) {
+				form.removeEventListener('submit', handleFormSubmitted);
 			}
 		};
 	}, [containerRef, handleFormSubmitted]);


### PR DESCRIPTION
Fixes [LPS-129738](https://issues.liferay.com/browse/LPS-129738).

This is the last leftover usage of `metal-dom` that was added after we already removed all usages. I've tested this to make sure it behaves as it did before. You can test it yourself by going to `Content & Data > Forms > Add Form > add a form element`, the element should be added successfully and you will be able to save the form without any console errors.