### PR TITLE
LRQA-62432 Add portlet to test Alert Toast Message

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Frontend Taglib Clay Test Alert Toast
+Bundle-SymbolicName: com.liferay.frontend.taglib.clay.test.alert.toast
+Bundle-Version: 1.0.0
+Web-ContextPath: /frontend-taglib-clay-test-alert-toast

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/build.gradle
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/package.json
@@ -1,0 +1,17 @@
+{
+	"dependencies": {
+		"@clayui/alert": "3.5.1",
+		"@clayui/button": "3.6.0",
+		"frontend-js-web": "*",
+		"react": "16.12.0",
+		"react-dom": "16.12.0"
+	},
+	"main": "js/App.es",
+	"name": "frontend-taglib-clay-test-alert-toast",
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "1.0.0"
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/java/com/liferay/frontend/taglib/clay/test/alert/toast/FrontendTaglibClayTestAlertToast.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/java/com/liferay/frontend/taglib/clay/test/alert/toast/FrontendTaglibClayTestAlertToast.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.test.alert.toast;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+
+import javax.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Summer Zhang
+ */
+@Component(
+	immediate = true,
+	property = {
+		"com.liferay.portlet.display-category=category.sample",
+		"javax.portlet.display-name=Taglib Clay Test Alert Toast",
+		"javax.portlet.init-param.template-path=/META-INF/resources/",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.resource-bundle=content.Language",
+		"javax.portlet.security-role-ref=power-user,user"
+	},
+	service = Portlet.class
+)
+public class FrontendTaglibClayTestAlertToast extends MVCPortlet {
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/resources/META-INF/resources/css/main.scss
@@ -1,0 +1,3 @@
+.clay-test-class {
+	font-style: italic;
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,24 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/resources/META-INF/resources/js/App.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/resources/META-INF/resources/js/App.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayAlert from '@clayui/alert';
+import ClayButton from '@clayui/button';
+import {openToast} from 'frontend-js-web';
+import React from 'react';
+
+import '../css/main.scss';
+
+export default () => {
+	const onClickSuccess = () => {
+		openToast({
+			message: Liferay.Language.get(
+				'your-request-completed-successfully'
+			),
+			title: Liferay.Language.get('success'),
+			type: 'success',
+		});
+	};
+
+	const onClickFail = () => {
+		openToast({
+			message: Liferay.Language.get('an-unexpected-error-occurred'),
+			title: Liferay.Language.get('error'),
+			type: 'danger',
+		});
+	};
+
+	return (
+		<div>
+			<ClayAlert title="Info">
+				This widget is used to test out Clay Toast Alert.
+			</ClayAlert>
+
+			<div className="sheet-footer">
+				<ClayButton.Group spaced>
+					<ClayButton onClick={onClickSuccess} type="submit">
+						{Liferay.Language.get('success-submit')}
+					</ClayButton>
+
+					<ClayButton
+						displayType="secondary"
+						onClick={onClickFail}
+						type="submit"
+					>
+						{Liferay.Language.get('fail-submit')}
+					</ClayButton>
+				</ClayButton.Group>
+			</div>
+		</div>
+	);
+};

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,23 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<div>
+	<react:component
+		module="js/App"
+	/>
+</div>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/resources/content/Language.properties
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-test/frontend-taglib-clay-test-alert-toast/src/main/resources/content/Language.properties
@@ -1,0 +1,2 @@
+fail-submit=Fail Submit
+success-submit=Success Submit


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-62432

The portlet is to be used for testing Clay Toast Alert in Poshi tests.

This is how it looks like after deploying to a page:
![test portlet](https://user-images.githubusercontent.com/25576873/112480219-c2fc3080-8db0-11eb-82cf-15a9c6f8c5d3.gif)

Please take a look if this is ok for testing. Thanks!