### PR TITLE
LPS-129456 Update inputPlaceHolder when editor is initialized

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -675,8 +675,6 @@ AUI.add(
 						return;
 					}
 
-					instance.set('editor', window[nativeEditor.name]);
-
 					instance.set(STR_INPUT_PLACEHOLDER, newPlaceholder);
 				},
 			},

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -659,6 +659,26 @@ AUI.add(
 
 					instance._updateTranslationStatus(selectedLanguageId);
 				},
+
+				updateInputPlaceholder(editor) {
+					var instance = this;
+
+					var inputPlaceholder = instance.get(STR_INPUT_PLACEHOLDER);
+
+					var nativeEditor = editor.getNativeEditor();
+
+					var newPlaceholder = A.one(
+						'#' + nativeEditor.element.getId()
+					);
+
+					if (inputPlaceholder.compareTo(newPlaceholder)) {
+						return;
+					}
+
+					instance.set('editor', window[nativeEditor.name]);
+
+					instance.set(STR_INPUT_PLACEHOLDER, newPlaceholder);
+				},
 			},
 
 			register(id, config) {

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -35,6 +35,7 @@
 					editorName="<%= editorName %>"
 					name="<%= inputEditorName %>"
 					onChangeMethod='<%= randomNamespace + "onChangeEditor" %>'
+					onInitMethod='<%= randomNamespace + "onInitEditor" %>'
 					placeholder="<%= placeholder %>"
 					toolbarSet="<%= toolbarSet %>"
 				/>
@@ -46,6 +47,14 @@
 						var editor = window['<%= namespace + HtmlUtil.escapeJS(inputEditorName) %>'];
 
 						inputLocalized.updateInputLanguage(editor.getHTML());
+					}
+
+					function <%= namespace + randomNamespace %>onInitEditor() {
+						var inputLocalized = Liferay.component('<%= namespace + HtmlUtil.escapeJS(fieldName) %>');
+
+						var editor = window['<%= namespace + HtmlUtil.escapeJS(inputEditorName) %>'];
+
+						inputLocalized.updateInputPlaceholder(editor);
 					}
 				</aui:script>
 			</c:when>

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -50,11 +50,12 @@
 					}
 
 					function <%= namespace + randomNamespace %>onInitEditor() {
-						var inputLocalized = Liferay.component('<%= namespace + HtmlUtil.escapeJS(fieldName) %>');
-
-						var editor = window['<%= namespace + HtmlUtil.escapeJS(inputEditorName) %>'];
-
-						inputLocalized.updateInputPlaceholder(editor);
+						Liferay.componentReady('<%= namespace + HtmlUtil.escapeJS(fieldName) %>')
+							.then(inputLocalized => {
+								var editor = window['<%= namespace + HtmlUtil.escapeJS(inputEditorName) %>'];
+								inputLocalized.updateInputPlaceholder(editor);
+							}
+						);
 					}
 				</aui:script>
 			</c:when>


### PR DESCRIPTION
When the browser's viewport is resized, we [destroy and recreate the
editor](https://git.io/JYLr3), to update it's toolbars.

When this editor is referenced by an `input_localized` component,
this will cause the issue mentioned in [LPS-129456](https://issues.liferay.com/browse/LPS-129456)

To fix the issue, we make use of the `InputEditorTag`'s `onInit` attribute
which will call a new `updateInputPlaceholder` function defined in
`input_localized` to update its `inputPlaceholder` property if needed.
