### PR TITLE
LPS-129321 [Bug] Wrong canonicalURL when truncate in Content Performance and Page Audit sidebar panels

### DIFF
--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -68,14 +68,14 @@ export default function BasicInformation({canonicalURLs, defaultLanguageId}) {
 				</ClayLayout.ContentRow>
 				<ClayLayout.ContentRow>
 					<ClayTooltipProvider>
-						<span className="text-secondary text-truncate-inline text-truncate-reverse">
-							<span
-								className="text-truncate"
-								data-tooltip-align="bottom"
-								title={selectedCanonicalURL.canonicalURL}
-							>
+						<span
+							className="text-truncate text-truncate-reverse"
+							data-tooltip-align="bottom"
+							title={selectedCanonicalURL.canonicalURL}
+						>
+							<bdi className="text-secondary">
 								{selectedCanonicalURL.canonicalURL}
-							</span>
+							</bdi>
 						</span>
 					</ClayTooltipProvider>
 				</ClayLayout.ContentRow>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -51,29 +51,23 @@ function BasicInformation({author, canonicalURL, publishDate, title}) {
 	return (
 		<div className="sidebar-section">
 			<ClayLayout.ContentRow>
-				<ClayLayout.ContentCol expand>
-					<span
-						className="component-title text-truncate-inline"
-						data-tooltip-align="top"
-						title={title}
-					>
-						<span className="text-truncate">{title}</span>
-					</span>
-				</ClayLayout.ContentCol>
+				<span
+					className="component-title text-truncate-inline"
+					data-tooltip-align="bottom"
+					title={title}
+				>
+					<span className="text-truncate">{title}</span>
+				</span>
 			</ClayLayout.ContentRow>
 
 			<ClayLayout.ContentRow>
-				<ClayLayout.ContentCol expand>
-					<span
-						className="text-truncate-inline"
-						data-tooltip-align="top"
-						title={canonicalURL}
-					>
-						<span className="c-mb-2 c-mt-1 text-secondary text-truncate text-truncate-reverse">
-							{canonicalURL}
-						</span>
-					</span>
-				</ClayLayout.ContentCol>
+				<span
+					className="c-mb-2 c-mt-1 text-truncate text-truncate-reverse"
+					data-tooltip-align="bottom"
+					title={canonicalURL}
+				>
+					<bdi className="text-secondary">{canonicalURL}</bdi>
+				</span>
 			</ClayLayout.ContentRow>
 
 			<ClayLayout.ContentRow>


### PR DESCRIPTION
**Description**

For Content Performance and Page Audit panels, we used the canonicalURL of the page. We decided that we want to truncate the URL from the beginning.

**Bug description**

The canonicalURL ends with a slash (/) and for truncating the text we are changing via CSS the direction of the text: `direction: rtl;`. This method isn't friendly with special characters so we have to look for a workaround.

**Solution**

Use HTML tag `<bdi>` with `direction: rtl;`.

**Screenshot**

![Screenshot 2021-03-26 at 11 06 29](https://user-images.githubusercontent.com/15845466/112615946-7140be00-8e23-11eb-98be-d94e5f319b67.png) ![Screenshot 2021-03-26 at 11 07 01](https://user-images.githubusercontent.com/15845466/112615947-7140be00-8e23-11eb-8730-aed5cc11fc3b.png)

![Screenshot 2021-03-26 at 11 05 52](https://user-images.githubusercontent.com/15845466/112615941-70a82780-8e23-11eb-9ac6-6d517214c7e6.png) ![Screenshot 2021-03-26 at 11 06 07](https://user-images.githubusercontent.com/15845466/112615943-70a82780-8e23-11eb-84ab-ae4ea98ef7ea.png)