### PR TITLE
LPS-129731 Users cannot deselect asset library by first click in cards view after select all from management bar

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/HorizontalCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/HorizontalCard.js
@@ -13,8 +13,9 @@
  */
 
 import {ClayCardWithHorizontal} from '@clayui/card';
-import React, {useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
+import {EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS} from '../constants';
 import getDataAttributes from '../get_data_attributes';
 
 export default function HorizontalCard({
@@ -36,6 +37,27 @@ export default function HorizontalCard({
 	...otherProps
 }) {
 	const [selected, setSelected] = useState(initialSelected);
+
+	const handleToggleAllItems = useCallback(
+		({checked}) => {
+			setSelected(checked);
+		},
+		[setSelected]
+	);
+
+	useEffect(() => {
+		Liferay.on(
+			EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS,
+			handleToggleAllItems
+		);
+
+		return () => {
+			Liferay.detach(
+				EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS,
+				handleToggleAllItems
+			);
+		};
+	}, [handleToggleAllItems]);
 
 	return (
 		<ClayCardWithHorizontal

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/UserCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/UserCard.js
@@ -13,8 +13,9 @@
  */
 
 import {ClayCardWithUser} from '@clayui/card';
-import React, {useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
+import {EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS} from '../constants';
 import getDataAttributes from '../get_data_attributes';
 
 export default function UserCard({
@@ -33,6 +34,27 @@ export default function UserCard({
 	...otherProps
 }) {
 	const [selected, setSelected] = useState(initialSelected);
+
+	const handleToggleAllItems = useCallback(
+		({checked}) => {
+			setSelected(checked);
+		},
+		[setSelected]
+	);
+
+	useEffect(() => {
+		Liferay.on(
+			EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS,
+			handleToggleAllItems
+		);
+
+		return () => {
+			Liferay.detach(
+				EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS,
+				handleToggleAllItems
+			);
+		};
+	}, [handleToggleAllItems]);
 
 	return (
 		<ClayCardWithUser

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
@@ -15,8 +15,9 @@
 import {ClayCardWithInfo} from '@clayui/card';
 import ClayIcon from '@clayui/icon';
 import ClaySticker from '@clayui/sticker';
-import React, {useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
+import {EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS} from '../constants';
 import getDataAttributes from '../get_data_attributes';
 
 export default function VerticalCard({
@@ -84,6 +85,27 @@ export default function VerticalCard({
 		stickerShape,
 		stickerStyle,
 	]);
+
+	const handleToggleAllItems = useCallback(
+		({checked}) => {
+			setSelected(checked);
+		},
+		[setSelected]
+	);
+
+	useEffect(() => {
+		Liferay.on(
+			EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS,
+			handleToggleAllItems
+		);
+
+		return () => {
+			Liferay.detach(
+				EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS,
+				handleToggleAllItems
+			);
+		};
+	}, [handleToggleAllItems]);
 
 	return (
 		<ClayCardWithInfo

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/constants.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/constants.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export const EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS =
+	'eventManagementToolbarToggleAllItems';

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -16,6 +16,7 @@ import {ClayCheckbox} from '@clayui/form';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import React, {useEffect, useRef, useState} from 'react';
 
+import {EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS} from '../constants';
 import LinkOrButton from './LinkOrButton';
 
 const SelectionControls = ({
@@ -150,6 +151,13 @@ const SelectionControls = ({
 
 						searchContainerRef.current?.select?.toggleAllRows(
 							checked
+						);
+
+						Liferay.fire(
+							EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS,
+							{
+								checked,
+							}
 						);
 					}}
 				/>


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-129731

The bug is caused by the fact that selection from management toolbar does not update state in cards.
1. In management toolbar selection controls, we are invoking `searchContainerRef.current.select.toggleAllRows`, [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js#L151-L153). This updates DOM and toggles all chackboxes, but does not update states of card components.
2. In a card component, [select state](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js#L151-L153) determines if the card is checked or not. This is updated [on select change](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js#L151-L153) . This is why selection works with all clicks after the first one, after the state syncs back.

In this PR, we are updating card states over global event bus. 

Some alternative solutions I considered:
- Instead of changing state, we could check DOM for `checked` attribute in each card, on `onSelectChange`. I don't think this is currently possible in a React-friendly way: we cannot access checkbox `ref` as it is hidden in Clay, and we don't even have access to `event` object in [onSelectChange](https://github.com/liferay/clay/blob/master/packages/clay-card/src/CardWithInfo.tsx#L211). I think this is good, as we are abstracting `selected` component state from implementation. Tinkering with DOM is likely to lead to more headache in the future.
- I don't think this is a case for the [upcoming](https://github.com/liferay-frontend/liferay-portal/pull/942) `useLiferayState`. We don't really want to update a simple global state in management toolbar, card components have little use for something like `allSelected` flag. On the flip side, cards keeping their own state globally gets us back to what is basically an event bus. @wincent

After fix:
![after](https://user-images.githubusercontent.com/5435511/112838975-efa89480-909d-11eb-86c6-181326129260.gif)


/cc @carloslancha @julien 