### PR TITLE
LPS-129697 Remove usage of Liferay.Util.selectEntityHandler in knowledge-base

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/select_parent.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/select_parent.jsp
@@ -287,10 +287,3 @@ kbObjectSearchContainer.setResults(results);
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />fm',
-		'<%= HtmlUtil.escape(eventName) %>'
-	);
-</script>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/select_version.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/select_version.jsp
@@ -23,7 +23,6 @@ int status = (Integer)request.getAttribute(KBWebKeys.KNOWLEDGE_BASE_STATUS);
 int selStatus = KBArticlePermission.contains(permissionChecker, kbArticle, KBActionKeys.UPDATE) ? WorkflowConstants.STATUS_ANY : status;
 
 int sourceVersion = ParamUtil.getInteger(request, "sourceVersion");
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectVersionFm");
 
 PortletURL portletURL = PortletURLBuilder.createRenderURL(
 	renderResponse
@@ -103,10 +102,3 @@ PortletURL portletURL = PortletURLBuilder.createRenderURL(
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectVersionFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</script>


### PR DESCRIPTION
Fixes [LPS-129697](https://issues.liferay.com/browse/LPS-129697).

Sending this here to get some eyes on it before sending it to the proper team.

I've manually tested if this works, and indeed it does!
The reason just removing the existing functionality works is because we handle that functionality in our modern implementation of Modal here: [Modal.js](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js#L410-L420)
If you wanna test it here are the steps:

## `select_version.jsp`

1. Content & Data > Knowledge Base
2. Add an Article
3. Edit it a couple times to create different versions
4. Go to versions
5. Choose a version
6. Modal opens

https://user-images.githubusercontent.com/24564752/112951969-3a78e980-913c-11eb-897a-d1fa20d7c6c5.mp4

## `select_parent.jsp`

1. Content & Data > Knowledge Base
2. Add an Article
3. Add a Folder
4. Move the Article by choosing the `Move` option in the ellipsis menu
5. Click the Select button
6. Select the Folder you want to move the Article to
7. Success

https://user-images.githubusercontent.com/24564752/112952920-4d3fee00-913d-11eb-88b6-ca372b7aa385.mp4

/cc @markocikos @jonmak08 