### PR TITLE
LPS-129309 ClayTooltip not properly displayed in Page Editor Sidebar

### DIFF
--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
@@ -83,11 +83,13 @@ export default function render(
 
 		// eslint-disable-next-line @liferay/portal/no-react-dom-render
 		ReactDOM.render(
-			<ClayTooltipProvider>
-				<ClayIconSpriteContext.Provider value={spritemap}>
-					{Component ? <Component {...renderData} /> : renderable}
-				</ClayIconSpriteContext.Provider>
-			</ClayTooltipProvider>,
+			<ClayIconSpriteContext.Provider value={spritemap}>
+				<ClayTooltipProvider>
+					<span>
+						{Component ? <Component {...renderData} /> : renderable}
+					</span>
+				</ClayTooltipProvider>
+			</ClayIconSpriteContext.Provider>,
 			container
 		);
 	}


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-129309

Previous discussion on this: https://github.com/liferay-frontend/liferay-portal/pull/940#discussion_r602190513

Test cases:
- The first commit fixes Page Editor Sidebar. See test case in ticket description.
- The second commit fixes App Builder Workflow App. See test case in ticket [comment](https://issues.liferay.com/browse/LPS-129309?focusedCommentId=2403636&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2403636)
- There is one more case in ticket comments, bit it is the same as the first one, with bug in Page Editor Sidebar.

The best I could figure out, the problem in these two modules is that we are using low-level React renders. There is [`createPortal` for sidebar](https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js#L207) and [`<Route>` render for app builder](https://github.com/liferay/liferay-portal/blob/master/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/object/ViewObject.es.js#L75-L84). These don't seem to inherit [`<ClayTooltipProvider>` from the base component](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js#L74-L78), instead setting their own context. I do recall @wincent saying that we should never use `react-dom` directly, looks like this is one of the reasons why.

In this PR, we are adding `<ClayTooltipProvider>` after those renders. A better solution would be to make `ClayTooltipProvider` somehow be always applied, but I don't know how we could do that.

/cc @jbalsas @dgarciasarai
ping also to Clay wizards @matuzalemsteles @bryceosterhaus 

After fix:
![after](https://user-images.githubusercontent.com/5435511/113007065-2d78ec00-9176-11eb-8ca7-147128189d5a.gif)
