### PR TITLE
LPS-129894 The management  toolbar still can be displayed after deletion

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -208,7 +208,7 @@ AUI.add(
 				_isActionUrl(url) {
 					var uri = new A.Url(url);
 
-					return uri.getParameter('p_p_lifecycle') === 1;
+					return Number(uri.getParameter('p_p_lifecycle')) === 1;
 				},
 
 				_notifyRowToggle() {


### PR DESCRIPTION
Hi @liferay-frontend,

**Test plan:** 
https://issues.liferay.com/browse/LPS-129894

With certain navigation, the parameter `p_p_lifecycle` is being returned in a string instead of in an integer.

![image](https://user-images.githubusercontent.com/67901/113128890-944fe100-921a-11eb-8855-63d3deb74f34.png)

[Failing the check](https://github.com/liferay/liferay-portal/blob/4f76fd063bae5891c9b84d8af9614d4898a38fde/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js#L211) if it is an Action URL and giving a false negative in the delete URL.

After that, the [search_container_select.js](https://github.com/liferay/liferay-portal/blob/4f76fd063bae5891c9b84d8af9614d4898a38fde/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js#L401-L408) is adding some hidden inputs to maintain the selected items and the [SelectionControls](https://github.com/liferay/liferay-portal/blob/4f76fd063bae5891c9b84d8af9614d4898a38fde/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js#L54) is recovering these deleted items as selected.

I'm only casting `p_p_lifecycle`  into a Number avoiding false negatives because of type checking.



