### PR TITLE
LPS-130102 Wiki insert link is showing the wrong link dialog

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorCreoleConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorCreoleConfigContributor.java
@@ -85,7 +85,7 @@ public class CKEditorCreoleConfigContributor
 		StringBundler sb = new StringBundler(4);
 
 		sb.append("bidi,codemirror,colorbutton,colordialog,div,");
-		sb.append("elementspath,font,forms,indentblock,justify,keystrokes");
+		sb.append("elementspath,font,forms,indentblock,justify,keystrokes,");
 		sb.append("link,maximize,newpage,pagebreak,preview,print,save,");
 		sb.append("showblocks,smiley,stylescombo,templates,video");
 


### PR DESCRIPTION
Hi @liferay-frontend,

**Description:**

When trying to add a new link in a wiki (creole) the generic link dialog is shown instead of the [wikilinks](https://github.com/liferay/liferay-portal/blob/c63c92cc3904d262e385dbdff50b35b21c18272a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/wikilink/dialogs/link.js).

**How to test it**

1. Go to: Product Menu > Content & Data > Wiki > Main > [+] (New Wiki Page)
2. Click on the link icon
 

**Before the fix**
Show the generic link dialog, throw browser error.

![image](https://user-images.githubusercontent.com/67901/113706778-5dc50b00-96df-11eb-9650-bf6d291c991f.png)


**After the fix**
Show the specific wiki link dialog.

![image](https://user-images.githubusercontent.com/67901/113707334-0d01e200-96e0-11eb-96c9-45ffed11dfb5.png)
