### PR TITLE
LPS-130112 Pass contents as a prop and avoid unwanted onChange

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -155,7 +155,7 @@ const ClassicEditor = React.forwardRef(
 						}
 					}}
 					onInstanceReady={({editor}) => {
-						editor.setData(contents);
+						editor.setData(contents, {internal: true});
 					}}
 					ref={editorRefsCallback}
 					{...otherProps}


### PR DESCRIPTION
Currently, when using `ClassicEditor`, the `onChange` callback is called
when the editor is "ready", because we're calling `setData` in
the `onInstanceReady` callback.  Ideally, the `onChange` callback
should be called when the editor's contents have changed,
so to fix that, we're passing the content as the `data` prop.

**Before**

![](https://user-images.githubusercontent.com/5572/113835243-134d9800-978c-11eb-949c-8cc3d7a88f5c.gif)

**After**

![](https://user-images.githubusercontent.com/5572/113835261-1a74a600-978c-11eb-8e5d-d08d9ae217d0.gif)

**Test plan**:
- Navigate to **Content & Data** > **Web Content**
- Create a new **Basic Web Content** and publish it
- Put a breakpoint (or a logpoint) [here](https://git.io/JYbSQ)
- Edit the web content you created previously
- Assert that the breakpoint is not "hit" when the Web Content's editor
  is initalized and ready