### PR TITLE
LPS-129364 Update Clay dependencies

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/package.json
+++ b/modules/apps/change-tracking/change-tracking-web/package.json
@@ -3,7 +3,7 @@
 		"@clayui/alert": "3.5.1",
 		"@clayui/breadcrumb": "3.25.1",
 		"@clayui/button": "3.6.0",
-		"@clayui/date-picker": "3.25.1",
+		"@clayui/date-picker": "3.25.4",
 		"@clayui/drop-down": "3.25.1",
 		"@clayui/form": "3.14.4",
 		"@clayui/icon": "3.1.0",

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -10,7 +10,7 @@
 		"@clayui/color-picker": "3.25.1",
 		"@clayui/css": "3.25.3",
 		"@clayui/data-provider": "3.3.10",
-		"@clayui/date-picker": "3.25.1",
+		"@clayui/date-picker": "3.25.4",
 		"@clayui/drop-down": "3.25.1",
 		"@clayui/empty-state": "3.2.0",
 		"@clayui/form": "3.14.4",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -980,10 +980,10 @@
     fast-json-stable-stringify "^2.0.0"
     warning "^4.0.3"
 
-"@clayui/date-picker@3.25.1":
-  version "3.25.1"
-  resolved "https://registry.yarnpkg.com/@clayui/date-picker/-/date-picker-3.25.1.tgz#539644af297551133874acb46d976d837db25f49"
-  integrity sha512-BzulbC8GoVUcy+AOFOVDJ1nMwqTr2JKBgdIDP9ZfWfikyy7EuWAVKjhJSn04m8AXxbtg9v2nsHJbT4utzABbcg==
+"@clayui/date-picker@3.25.4":
+  version "3.25.4"
+  resolved "https://registry.yarnpkg.com/@clayui/date-picker/-/date-picker-3.25.4.tgz#f59ddbba0b46c94ed99bb9d061346cd558ffc3ff"
+  integrity sha512-u71vq5fb0uRFUXkHvrx9TVNBZfncVmXh5kC/iUaFUpqWvM02htKkiKIpSwGC0nhsLghavjkGwG3Q+iFodUrmFQ==
   dependencies:
     "@clayui/button" "^3.6.0"
     "@clayui/drop-down" "^3.25.1"


### PR DESCRIPTION
## [3.25.4](https://github.com/liferay/clay/compare/v3.25.3...v3.25.4) (2021-04-07)

### Bug Fixes

-   **@clayui/date-picker:** Date Navigation Controls are wrong color. This adds clay css classes but also leaves btn-monospaced and btn-sm just incase. ([850286e](https://github.com/liferay/clay/commit/850286e))
-   **@clayui/date-picker:** disable focus control using the arrow keys ([d21dd7d](https://github.com/liferay/clay/commit/d21dd7d))
-   **@clayui/date-picker:** Removes `btn-sm` and `btn-monospaced` from Date Navigation controls. They're not needed. ([e70ad3c](https://github.com/liferay/clay/commit/e70ad3c))