### PR TITLE
LPS-127084 [POC] Model `destroyPortlet` events in terms of global state

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -198,16 +198,21 @@
 				});
 			};
 
-			var onDestroyPortlet = function (event) {
-				if (event.portletId === '<%= portletDisplay.getId() %>') {
-					liferayDDMForm.destroy();
+			// Again, note the somewhat icky use of the `__unsafe__` namespace
+			// here.
 
-					Liferay.detach('inputLocalized:localeChanged', onLocaleChange);
-					Liferay.detach('destroyPortlet', onDestroyPortlet);
+			var {dispose} = Liferay.State.__unsafe__.subscribe(
+				'frontend-js-web:active-portlet-ids',
+				(ids) => {
+					if ('<%= portletDisplay.getId() %>' in ids) {
+						liferayDDMForm.destroy();
+
+						Liferay.detach('inputLocalized:localeChanged', onLocaleChange);
+
+						dispose();
+					}
 				}
-			};
-
-			Liferay.on('destroyPortlet', onDestroyPortlet);
+			);
 		</aui:script>
 	</c:if>
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -12,6 +12,31 @@
  * details.
  */
 
+const ACTIVE_PORTLET_IDS = 'frontend-js-web:active-portlet-ids';
+
+// Note: This won't actually work; it's just a demo. This is
+// an AUI module that doesn't get processed by the Bundler's
+// Babel transforms (see the .npmbundlerc), and is loaded via the
+// `Liferay-JS-Resources-Top-Head` mechanism (see the bnd.bnd). So
+// for now we are just pretending that we can/could load/acess
+// `Liferay.State` from here. This is a general problem with trying to
+// access "new" modules from legacy places like this module.
+//
+// And note how the fact that we can't load modules properly means we'd
+// be forced to use the `__unsafe__` API anyway... I'm just assigning it
+// to a local binding here to make the code further down more readable.
+//
+// All of this suggests to me that it might be better to start with
+// adopting global state in more "modern" parts of the codebase.
+
+const State = Liferay.State.__unsafe__;
+
+// Assuming for now that we define the atom here, and that everybody accesses it
+// `__unsafe__`-ly, due to the difficulty of loading/exporting modules in AUI vs
+// AMD.
+
+Liferay.State.atom(ACTIVE_PORTLET_IDS, {});
+
 (function (A) {
 	var Lang = A.Lang;
 
@@ -151,6 +176,33 @@
 			}
 		},
 	};
+
+	function destroyPortlet(options) {
+
+		// NOTE: Will have to vet all the current listeners to see what
+		// `options` they might care about. A cursory examination suggests that
+		// it is probably only ever (or mostly) `portletId`.
+
+		const {portletId} = options;
+
+		let activeIds = State.readKey(ACTIVE_PORTLET_IDS);
+
+		if (!(portletId in activeIds)) {
+			console.warn(
+				`destroyPortlet(): ${portletId} is not in the set of active portlet IDs`
+			);
+		}
+
+		activeIds = {...activeIds};
+
+		delete activeIds[portletId];
+
+		State.writeKey(ACTIVE_PORTLET_IDS, activeIds);
+
+		// Backwards compatibility.
+
+		Liferay.fire('destroyPortlet', options);
+	}
 
 	Liferay.provide(
 		Portlet,
@@ -448,7 +500,7 @@
 
 				Portlet.destroyComponents(portletId);
 
-				Liferay.fire('destroyPortlet', options);
+				destroyPortlet(options);
 
 				Liferay.fire('closePortlet', options);
 			}
@@ -471,10 +523,7 @@
 
 				Portlet.destroyComponents(portletId);
 
-				Liferay.fire(
-					'destroyPortlet',
-					Portlet._mergeOptions(portlet, options)
-				);
+				destroyPortlet(Portlet._mergeOptions(portlet, options));
 			}
 		},
 		['aui-node-base']
@@ -532,6 +581,21 @@
 					});
 				}
 			}
+
+			const activeIds = State.readKey(ACTIVE_PORTLET_IDS);
+
+			if (portletId in activeIds) {
+				console.warn(
+					`Liferay.Portlet.onLoad(): ${portletId} is already in the set of active portlet IDs`
+				);
+			}
+
+			State.writeKey(ACTIVE_PORTLET_IDS, {
+				...activeIds,
+				[portletId]: true,
+			});
+
+			// Backwards compatibility.
 
 			Liferay.fire('portletReady', {
 				portlet,


### PR DESCRIPTION
Just putting this here for discussion. Context:

- https://issues.liferay.com/browse/LPS-127084
- https://liferay.slack.com/archives/C3JBR21HA/p1617959223380700

Some concerns are expressed inline in comments in here and in JIRA. The comment that I allude to about SPA on LPS-127084 is actually [this one](https://issues.liferay.com/browse/LPS-127083?focusedCommentId=2382526&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2382526), which we then went on to discuss in some more detail in [this Google doc](https://docs.google.com/document/d/1T1KqhUNar5ze7JI-xhWX0fLZ3IAZxeS0XRRYy1--YtA/edit).

So, with all that out the way; this is just to show one possible/minimal shape that a global-state-based model for portlet lifecycle could begin. Doing this piecemeal (one event at a time) may not be the right approach as it doesn't feel like a step forward (more like a lateral step). It may be that we should consider a more dramatic overhaul, but that is also pretty difficult, if we're anchoring it in the context of a legacy AUI module that is loaded by a pretty esoteric mechanism, _and_ happens to be mostly consumed from JSPs, which have their own legacy baggage.

Anyway, not for merging; just for discussion.