### PR TITLE
LPS-128735 Update liferay-ckeditor to v4.14.1-liferay.21

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"ckeditor4-react": "1.3.0",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.14.1-liferay.20",
+		"liferay-ckeditor": "4.14.1-liferay.21",
 		"prop-types": "15.7.2"
 	},
 	"main": "index.js",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -9537,10 +9537,10 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
-liferay-ckeditor@4.14.1-liferay.20:
-  version "4.14.1-liferay.20"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.14.1-liferay.20.tgz#a6a2ef4f46184806f15cb66b2b5cd55156873d56"
-  integrity sha512-Z7RjtjbweLA3+CB3L7Ij87UVkYP+O5XfppOJyTuOjDjpdDjapOt0tgcxuQaxnCevN87Z/CGq8nCgmUtWbC/zCw==
+liferay-ckeditor@4.14.1-liferay.21:
+  version "4.14.1-liferay.21"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.14.1-liferay.21.tgz#d294b4786b039cfedee3abc216278566fa5ef455"
+  integrity sha512-C9Hlgu3wnGh+CeWEKwRlb493XdJVjx5THe7XvOVDcsexm9foDBDWEesbtDAXllguWXeEpoW9PQ6KWHEOffSyqQ==
 
 liferay-font-awesome@3.4.0:
   version "3.4.0"


### PR DESCRIPTION
This release, fixes [LPS-128735](https://issues.liferay.com/browse/LPS-128735)

**Release notes**

[Full changelog](https://github.com/liferay/liferay-ckeditor/compare/v4.14.1-liferay.20...v4.14.1-liferay.21)

-   fix: initialize codemirror with the editor data and update it on data ready ([\#161](https://github.com/liferay/liferay-ckeditor/pull/161))
