### PR TITLE
LPS-128217 [A/B Testing] AB Test description is not displayed anywhere in the sidebar

### DIFF
--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsDetails.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsDetails.es.js
@@ -18,6 +18,7 @@ import {STATUS_DRAFT} from '../util/statuses.es';
 function SegmentsExperimentsDetails({segmentsExperiment}) {
 	const {
 		confidenceLevel,
+		description,
 		goal,
 		segmentsEntryName,
 		status,
@@ -30,22 +31,39 @@ function SegmentsExperimentsDetails({segmentsExperiment}) {
 			</h4>
 
 			<dl>
-				<div className="d-flex">
-					<dt>{Liferay.Language.get('segment') + ':'} </dt>
-					<dd className="ml-2 text-secondary">{segmentsEntryName}</dd>
+				<div className="c-my-2">
+					<dt className="d-inline-block">
+						{Liferay.Language.get('description') + ':'}{' '}
+					</dt>
+					<dd className="d-inline inline-item-after text-secondary">
+						{description}
+					</dd>
 				</div>
 
-				<div className="d-flex">
-					<dt>{Liferay.Language.get('goal') + ':'} </dt>
-					<dd className="ml-2 text-secondary">{goal.label}</dd>
+				<div className="c-my-2">
+					<dt className="d-inline-block">
+						{Liferay.Language.get('segment') + ':'}{' '}
+					</dt>
+					<dd className="d-inline inline-item-after text-secondary">
+						{segmentsEntryName}
+					</dd>
+				</div>
+
+				<div className="c-my-2">
+					<dt className="d-inline-block">
+						{Liferay.Language.get('goal') + ':'}{' '}
+					</dt>
+					<dd className="d-inline inline-item-after text-secondary">
+						{goal.label}
+					</dd>
 				</div>
 
 				{status.value !== STATUS_DRAFT && (
-					<div className="d-flex">
-						<dt>
+					<div className="c-my-2">
+						<dt className="d-inline-block">
 							{Liferay.Language.get('confidence-level') + ':'}{' '}
 						</dt>
-						<dd className="ml-2 text-secondary">
+						<dd className="d-inline inline-item-after text-secondary">
 							{indexToPercentageString(confidenceLevel)}
 						</dd>
 					</div>

--- a/modules/dxp/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
@@ -85,6 +85,9 @@ describe('SegmentsExperimentsSidebar', () => {
 		expect(defaultExperience).not.toBe(null);
 
 		getByText(segmentsExperiment.name);
+		getByText(segmentsExperiment.description);
+		getByText(segmentsExperiment.segmentsEntryName);
+		getByText(segmentsExperiment.goal.label);
 
 		getByText('edit');
 		getByText('delete');


### PR DESCRIPTION
**Description**

The A/B Test description is not displayed in the sidebar

**Solution**

- Add A/B Test description in the sidebar in details section
- Fix markup to conform the Figma design (`Description: description` in the same line)
- Update frontend test to check the description

**Screenshot**

<img width="318" alt="Screenshot 2021-04-12 at 12 23 22" src="https://user-images.githubusercontent.com/15845466/114381402-6019e000-9b8b-11eb-843f-99c912dbb998.png">