### PR TITLE
LRQA-66546 | Increase test coverage on frontend-ckeditor module

### DIFF
--- a/modules/apps/frontend-editor/test.properties
+++ b/modules/apps/frontend-editor/test.properties
@@ -14,5 +14,5 @@
     #
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
-        (portal.acceptance == true) AND \
+        (portal.acceptance != quarantine) AND \
         (testray.component.names ~ "WYSIWYG")


### PR DESCRIPTION
**Description:**
This is to increase general test coverage in frontnd-ckeditor module to catch regressions such as CKEditor toolbar is missing, which was a blocker issue reported in https://issues.liferay.com/browse/LPS-130399

**Test Plan:**
1. Run ci:test:relevant
2. All WYSIWYG testcases are run except those quarantined.

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-66546