### PR TITLE
LPS-127012, LPS-129571 Create BalloonEditor component and sample portlet

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/.npmbundlerrc
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/.npmbundlerrc
@@ -1,0 +1,9 @@
+{
+	"config": {
+		"imports": {
+			"frontend-editor-ckeditor-web": {
+				"/": ">=4.0.0"
+			}
+		}
+	}
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/bnd.bnd
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Frontend Editor CKEditor Sample Web
+Bundle-SymbolicName: com.liferay.frontend.editor.ckeditor.sample.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /frontend-editor-ckeditor-sample-web

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
@@ -1,0 +1,12 @@
+dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "4.2.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
+	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-sql-dsl-api")
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/package.json
@@ -4,7 +4,7 @@
 		"react": "16.12.0",
 		"react-dom": "16.12.0"
 	},
-	"name": "frontend-editor-ckeditor-sample-web",
+	"name": "@liferay/frontend-editor-ckeditor-sample-web",
 	"private": true,
 	"scripts": {
 		"build": "liferay-npm-scripts build",

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/package.json
@@ -1,0 +1,15 @@
+{
+	"dependencies": {
+		"frontend-editor-ckeditor-web": "*",
+		"react": "16.12.0",
+		"react-dom": "16.12.0"
+	},
+	"name": "frontend-editor-ckeditor-sample-web",
+	"private": true,
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "1.0.0"
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/constants/CKEditorSamplePortletKeys.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/constants/CKEditorSamplePortletKeys.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.editor.ckeditor.sample.web.internal.constants;
+
+/**
+ * @author Julien Castelain
+ */
+public class CKEditorSamplePortletKeys {
+
+	public static final String CKEDITOR_SAMPLE =
+		"com_liferay_editor_ckeditor_sample_web_internal_portlet_" +
+			"CKEditorSamplePortlet";
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/portlet/CKEditorSamplePortlet.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/portlet/CKEditorSamplePortlet.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.editor.ckeditor.sample.web.internal.portlet;
+
+import com.liferay.frontend.editor.ckeditor.sample.web.internal.constants.CKEditorSamplePortletKeys;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+
+import javax.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Julien Castelain
+ */
+@Component(
+	immediate = true,
+	property = {
+		"com.liferay.portlet.css-class-wrapper=portlet-ckeditor-sample",
+		"com.liferay.portlet.display-category=category.sample",
+		"com.liferay.portlet.instanceable=true",
+		"com.liferay.portlet.layout-cacheable=true",
+		"com.liferay.portlet.private-request-attributes=false",
+		"com.liferay.portlet.private-session-attributes=false",
+		"com.liferay.portlet.render-weight=50",
+		"com.liferay.portlet.use-default-template=true",
+		"javax.portlet.display-name=CKEditor Sample",
+		"javax.portlet.expiration-cache=0",
+		"javax.portlet.init-param.template-path=/META-INF/resources/",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.name=" + CKEditorSamplePortletKeys.CKEDITOR_SAMPLE,
+		"javax.portlet.resource-bundle=content.Language",
+		"javax.portlet.security-role-ref=power-user,user"
+	},
+	service = Portlet.class
+)
+public class CKEditorSamplePortlet extends MVCPortlet {
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init-ext.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init-ext.jsp
@@ -1,0 +1,15 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,22 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+
+<liferay-theme:defineObjects />
+
+<%@ include file="/init-ext.jsp" %>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/index.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {BalloonEditor} from 'frontend-editor-ckeditor-web';
+import React from 'react';
+
+export default function ({portletNamespace, ...otherProps}) {
+	return <BalloonEditor name={`${portletNamespace}editor`} {...otherProps} />;
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,26 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<div>
+	<liferay-editor:editor
+		contents="<h1>Balloon Editor</h1><p>This is a sample portlet with a <a href=\"https://example.com\">link</a>.</p><img src=\"https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=800\">"
+		editorName="ballooneditor"
+		name="contentEditor"
+		placeholder="content"
+	/>
+</div>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/content/Language.properties
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/content/Language.properties
@@ -1,0 +1,1 @@
+javax.portlet.title.com_liferay_editor_ckeditor_sample_web_internal_portlet_CKEditorSamplePortlet=CKEditor Sample

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorBalloonEditor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorBalloonEditor.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.editor.ckeditor.web.internal;
+
+import com.liferay.frontend.editor.EditorRenderer;
+import com.liferay.frontend.editor.ckeditor.web.internal.constants.CKEditorConstants;
+import com.liferay.portal.kernel.editor.Editor;
+import com.liferay.portal.kernel.servlet.PortalWebResourceConstants;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Julien Castelain
+ */
+@Component(
+	property = "name=ballooneditor",
+	service = {Editor.class, EditorRenderer.class}
+)
+public class CKEditorBalloonEditor implements Editor, EditorRenderer {
+
+	@Override
+	public String getAttributeNamespace() {
+		return CKEditorConstants.ATTRIBUTE_NAMESPACE;
+	}
+
+	@Override
+	public String[] getJavaScriptModules() {
+		return new String[0];
+	}
+
+	@Override
+	public String getJspPath() {
+		return "/ckeditor_balloon.jsp";
+	}
+
+	@Override
+	public String getName() {
+		return _name;
+	}
+
+	@Override
+	public String getResourcesJspPath() {
+		return null;
+	}
+
+	@Override
+	public String getResourceType() {
+		return PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR;
+	}
+
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		_name = (String)properties.get("name");
+	}
+
+	private String _name;
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_balloon.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_balloon.jsp
@@ -1,0 +1,38 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+String contents = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":contents");
+Map<String, Object> editorData = (Map<String, Object>)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":data");
+String name = namespace + GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":name"));
+%>
+
+<div>
+	<react:component
+		module="editor/BalloonEditor"
+		props='<%=
+			HashMapBuilder.<String, Object>put(
+				"config", (editorData == null) ? null : (JSONObject)editorData.get("editorConfig")
+			).put(
+				"contents", contents
+			).put(
+				"name", HtmlUtil.escapeAttribute(name)
+			).build()
+		%>'
+	/>
+</div>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,0 +1,3 @@
+.lfr_balloon_editor .cke_inner .cke_top {
+	display: none;
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,3 +1,3 @@
-.lfr_balloon_editor .cke_inner .cke_top {
+.lfr-balloon-editor .cke_inner .cke_top {
 	display: none;
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -45,7 +45,7 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 
 				initialCssClass = CKEDITOR.env.cssClass;
 
-				CKEDITOR.env.cssClass = 'lfr_balloon_editor';
+				CKEDITOR.env.cssClass = `${CKEDITOR.env.cssClass} lfr-balloon-editor`;
 			}}
 			onDestroy={() => {
 				CKEDITOR.env.cssClass = initialCssClass;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -58,27 +58,7 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 				balloonToolbars.create({
 					buttons:
 						'Bold,Italic,Underline,RemoveFormat,Link,NumberedList,BulletedList,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,Anchor',
-					refresh(editor, path) {
-						const tags = new Set([
-							'h1',
-							'h2',
-							'h3',
-							'p',
-							'span',
-							'strong',
-							'li',
-						]);
-
-						let result = false;
-
-						tags.forEach((tag) => {
-							if (path.contains(tag)) {
-								result = true;
-							}
-						});
-
-						return result;
-					},
+					cssSelector: '*',
 				});
 
 				balloonToolbars.create({

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -13,13 +13,15 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState} from 'react';
 
 import {Editor} from './Editor';
 
 import '../css/main.scss';
 
 const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
+	const [cssClass, setCssClass] = useState('');
+
 	const defaultExtraPlugins = 'balloontoolbar,floatingspace';
 
 	const getConfig = () => {
@@ -34,8 +36,6 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 		};
 	};
 
-	let initialCssClass;
-
 	return (
 		<Editor
 			config={getConfig()}
@@ -43,12 +43,12 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 			onBeforeLoad={(CKEDITOR) => {
 				CKEDITOR.disableAutoInline = true;
 
-				initialCssClass = CKEDITOR.env.cssClass;
+				setCssClass(CKEDITOR.env.cssClass);
 
 				CKEDITOR.env.cssClass = `${CKEDITOR.env.cssClass} lfr-balloon-editor`;
 			}}
 			onDestroy={() => {
-				CKEDITOR.env.cssClass = initialCssClass;
+				CKEDITOR.env.cssClass = cssClass;
 			}}
 			onInstanceReady={(event) => {
 				const editor = event.editor;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {Editor} from './Editor';
+
+import '../css/main.scss';
+
+const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
+	const defaultExtraPlugins = 'balloontoolbar,floatingspace';
+
+	const getConfig = () => {
+		const extraPlugins = config.extraPlugins
+			? `${config.extraPlugins}`
+			: '';
+
+		return {
+			...config,
+			extraAllowedContent: '*',
+			extraPlugins: `${extraPlugins}${defaultExtraPlugins}`,
+		};
+	};
+
+	let initialCssClass;
+
+	return (
+		<Editor
+			config={getConfig()}
+			name={name}
+			onBeforeLoad={(CKEDITOR) => {
+				CKEDITOR.disableAutoInline = true;
+
+				initialCssClass = CKEDITOR.env.cssClass;
+
+				CKEDITOR.env.cssClass = 'lfr_balloon_editor';
+			}}
+			onDestroy={() => {
+				CKEDITOR.env.cssClass = initialCssClass;
+			}}
+			onInstanceReady={(event) => {
+				const editor = event.editor;
+
+				const balloonToolbars = editor.balloonToolbars;
+
+				balloonToolbars.create({
+					buttons:
+						'Bold,Italic,Underline,RemoveFormat,Link,NumberedList,BulletedList,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,Anchor',
+					refresh(editor, path) {
+						const tags = new Set([
+							'h1',
+							'h2',
+							'h3',
+							'p',
+							'span',
+							'strong',
+							'li',
+						]);
+
+						let result = false;
+
+						tags.forEach((tag) => {
+							if (path.contains(tag)) {
+								result = true;
+							}
+						});
+
+						return result;
+					},
+				});
+
+				balloonToolbars.create({
+					buttons: 'Link,Unlink',
+					priority:
+						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
+					refresh(editor, path) {
+						return path.contains('a');
+					},
+				});
+
+				balloonToolbars.create({
+					buttons:
+						'JustifyLeft,JustifyCenter,JustifyRight,Link,Unlink',
+					priority:
+						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
+					widgets: 'image,image2',
+				});
+
+				if (contents) {
+					editor.setData(contents);
+				}
+			}}
+			type="inline"
+			{...otherProps}
+		/>
+	);
+};
+
+BalloonEditor.propTypes = {
+	config: PropTypes.object,
+	name: PropTypes.string,
+};
+
+export default BalloonEditor;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+export {BalloonEditor} from './editor/BalloonEditor';
 export {ClassicEditor} from './editor/ClassicEditor';
 export {Editor} from './editor/Editor';
 export {InlineEditor} from './editor/InlineEditor';


### PR DESCRIPTION
These are just the base files for our `BalloonEditor` component, which
contains a React component using CKEditor's `balloontoolbar` plugin with the
minimum required configuration, a Java class and its corresponding JSP.

Additionally this PR contains a sample portlet in the `frontend-editor-ckeditor-sample-web`
module: the purpose of this portlet, is to be able to test our changes
during the implementation of the `BalloonEditor` component.

To add this portlet, edit the main page (or either create another widget page)
and look for CKEditor Sample in the widgets section.

For the moment this is what it looks like:

![frontend-editor-ckeditor-sample-web](https://user-images.githubusercontent.com/5572/114551106-3d5afa80-9c63-11eb-8048-583787abb02f.png)

**Notes**
- This PR was originally sent and reviewed [here](https://github.com/liferay-frontend/liferay-portal/pull/932),
but got reverted [here](https://github.com/liferay-frontend/liferay-portal/pull/964) to fix [LPS-130399](https.//issues.liferay.com/browse/LPS-130399)

- For the moment I think this should be a draft PR to avoid it from being 
forwarded before everyone has had a change to have a look at it
 
 
