### PR TITLE
LPS-130587 Remove chatty SPA logging in DEV

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
@@ -25,7 +25,6 @@ import {
 	getUrlPathWithoutHash,
 	getUrlPathWithoutHashAndSearch,
 	isCurrentBrowserPath,
-	log,
 	removePathTrailingSlash,
 	setReferrer,
 } from '../util/utils';
@@ -357,14 +356,10 @@ class App extends EventEmitter {
 			const path = getUrlPath(url);
 
 			if (!this.isLinkSameOrigin_(uri.host)) {
-				log('Offsite link clicked');
-
 				return false;
 			}
 
 			if (!this.isSameBasePath_(path)) {
-				log("Link clicked outside app's base path");
-
 				return false;
 			}
 
@@ -375,8 +370,6 @@ class App extends EventEmitter {
 			}
 
 			if (!this.findRoute(path)) {
-				log('No route for ' + path);
-
 				return false;
 			}
 
@@ -414,8 +407,6 @@ class App extends EventEmitter {
 	 */
 	createScreenInstance(path, route) {
 		if (!this.pendingNavigate && path === this.activePath) {
-			log('Already at destination, refresh navigation');
-
 			return this.activeScreen;
 		}
 		/* jshint newcap: false */
@@ -431,7 +422,6 @@ class App extends EventEmitter {
 			else {
 				screen = handler(route) || new Screen();
 			}
-			log('Create screen for [' + path + '] [' + screen + ']');
 		}
 
 		return screen;
@@ -471,8 +461,6 @@ class App extends EventEmitter {
 		if (!route) {
 			return Promise.reject(new Error('No route for ' + path));
 		}
-
-		log('Navigate to [' + path + ']');
 
 		this.stopPendingNavigate_();
 		this.isNavigationPending = true;
@@ -561,7 +549,6 @@ class App extends EventEmitter {
 		this.pendingNavigate = null;
 		Liferay.SPA.__capturedFormElement__ = null;
 		Liferay.SPA.__capturedFormButtonElement__ = null;
-		log('Navigation done');
 	}
 
 	/**
@@ -676,7 +663,6 @@ class App extends EventEmitter {
 	 * @protected
 	 */
 	handleNavigateError_(path, nextScreen, error) {
-		log('Navigation error for [' + nextScreen + '] (' + error.stack + ')');
 		this.emit('navigationError', {
 			error,
 			nextScreen,
@@ -1010,8 +996,6 @@ class App extends EventEmitter {
 				this.pendingNavigate.path === event.path ||
 				this.navigationStrategy === NavigationStrategy.SCHEDULE_LAST
 			) {
-				log('Waiting...');
-
 				return;
 			}
 		}
@@ -1052,10 +1036,6 @@ class App extends EventEmitter {
 			event.shiftKey ||
 			event.button
 		) {
-			log(
-				'Navigate aborted, invalid mouse button or modifier key pressed.'
-			);
-
 			return;
 		}
 		this.maybeNavigate_(event.delegateTarget.href, event);
@@ -1070,8 +1050,6 @@ class App extends EventEmitter {
 	onDocSubmitDelegate_(event) {
 		var form = event.delegateTarget;
 		if (form.method === 'get') {
-			log('GET method not supported');
-
 			return;
 		}
 		event.capturedFormElement = form;
@@ -1161,7 +1139,6 @@ class App extends EventEmitter {
 		}
 
 		if (state.senna) {
-			log('History navigation to [' + state.path + ']');
 			this.popstateScrollTop = state.scrollTop;
 			this.popstateScrollLeft = state.scrollLeft;
 			if (!this.nativeScrollRestorationSupported) {
@@ -1254,8 +1231,6 @@ class App extends EventEmitter {
 			return Promise.reject(new Error('No route for ' + path));
 		}
 
-		log('Prefetching [' + path + ']');
-
 		var nextScreen = this.createScreenInstance(path, route);
 
 		return nextScreen
@@ -1320,16 +1295,6 @@ class App extends EventEmitter {
 		Object.keys(surfaces).forEach((id) => {
 			var surfaceContent = nextScreen.getSurfaceContent(id, params);
 			surfaces[id].addContent(nextScreen.getId(), surfaceContent);
-			log(
-				'Screen [' +
-					nextScreen.getId() +
-					'] add content to surface ' +
-					'[' +
-					surfaces[id] +
-					'] [' +
-					(surfaceContent ? '...' : 'empty') +
-					']'
-			);
 		});
 	}
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/screen/Screen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/screen/Screen.js
@@ -15,7 +15,7 @@
 import {runScriptsInElement} from 'frontend-js-web';
 
 import Cacheable from '../cacheable/Cacheable';
-import {getUid, log} from '../util/utils';
+import {getUid} from '../util/utils';
 
 class Screen extends Cacheable {
 
@@ -54,9 +54,7 @@ class Screen extends Cacheable {
 	 * Fires when the screen is active. Allows a screen to perform any setup
 	 * that requires its DOM to be visible. Lifecycle.
 	 */
-	activate() {
-		log('Screen [' + this + '] activate');
-	}
+	activate() {}
 
 	/**
 	 * Gives the Screen a chance to cancel the navigation and stop itself from
@@ -65,9 +63,7 @@ class Screen extends Cacheable {
 	 * @return {boolean=|?Promise=} If returns or resolves to true,
 	 *     the current screen is locked and the next nagivation interrupted.
 	 */
-	beforeActivate() {
-		log('Screen [' + this + '] beforeActivate');
-	}
+	beforeActivate() {}
 
 	/**
 	 * Gives the Screen a chance to cancel the navigation and stop itself from
@@ -77,9 +73,7 @@ class Screen extends Cacheable {
 	 * @return {boolean=|?Promise=} If returns or resolves to true,
 	 *     the current screen is locked and the next nagivation interrupted.
 	 */
-	beforeDeactivate() {
-		log('Screen [' + this + '] beforeDeactivate');
-	}
+	beforeDeactivate() {}
 
 	/**
 	 * Gives the Screen a chance format the path before history update.
@@ -104,9 +98,7 @@ class Screen extends Cacheable {
 	 * deactivated, for example cancelling outstanding requests or stopping
 	 * timers. Lifecycle.
 	 */
-	deactivate() {
-		log('Screen [' + this + '] deactivate');
-	}
+	deactivate() {}
 
 	/**
 	 * Dispose a screen, either after it is deactivated (in the case of a
@@ -115,7 +107,6 @@ class Screen extends Cacheable {
 	 */
 	disposeInternal() {
 		super.disposeInternal();
-		log('Screen [' + this + '] dispose');
 	}
 
 	/**
@@ -154,8 +145,6 @@ class Screen extends Cacheable {
 	 *     navigation until it is resolved.
 	 */
 	flip(surfaces) {
-		log('Screen [' + this + '] flip');
-
 		var transitions = [];
 
 		Object.keys(surfaces).forEach((sId) => {
@@ -193,9 +182,7 @@ class Screen extends Cacheable {
 	 *     the content of the surface. If returns falsy values surface default
 	 *     content is restored.
 	 */
-	getSurfaceContent() {
-		log('Screen [' + this + '] getSurfaceContent');
-	}
+	getSurfaceContent() {}
 
 	/**
 	 * Gets the screen title.
@@ -215,8 +202,6 @@ class Screen extends Cacheable {
 	 *     until it is resolved. This is useful for loading async content.
 	 */
 	load() {
-		log('Screen [' + this + '] load');
-
 		return Promise.resolve();
 	}
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/util/utils.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/util/utils.js
@@ -166,17 +166,6 @@ export function isCurrentBrowserPath(url) {
 }
 
 /**
- * Logs the provided message in DEV environments
- * @param {String} message
- */
-export function log(message) {
-	if (process.env.NODE_ENV === 'development') {
-		// eslint-disable-next-line
-		console.log(message);
-	}
-}
-
-/**
  * Removes trailing slash in path.
  * @param {!string}
  * @return {string}

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/app/App.js
@@ -52,7 +52,6 @@ describe('App', function () {
 
 		jest.resetAllMocks();
 
-		jest.spyOn(console, 'log').mockImplementation(() => {});
 		jest.spyOn(window, 'scrollTo').mockImplementation((top, left) => {
 			window.history.state.scrollTop = top;
 			window.history.state.scrollLeft = left;

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/screen/HtmlScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/screen/HtmlScreen.js
@@ -26,8 +26,6 @@ describe('HtmlScreen', () => {
 
 	beforeEach(() => {
 		Liferay.SPA = {};
-
-		jest.spyOn(console, 'log').mockImplementation(() => {});
 	});
 
 	it('gets title selector', () => {


### PR DESCRIPTION
In DEV, we see endless console spam on any navigation:

```
Screen [screen_2] beforeDeactivate
Screen [screen_4] beforeActivate
Screen [screen_2] deactivate
Screen [screen_4] add content to surface [senna_surface1] [...]
Screen [screen_4] flip
Screen [screen_4] activate
Screen [screen_2] dispose
Navigation done
Screen [screen_4] deactivate
Screen [screen_3] add content to surface [senna_surface1] [...]
Screen [screen_3] flip
Screen [screen_3] activate
Navigation done
```

The upsides (debug output) are massively outweighed by the downside (degrading the quality and usefulness of the console output 99.99% of the time). I [asked about this in Slack](https://liferay.slack.com/archives/C3JBR21HA/p1618311455495300) and got broad support for the idea of removing it.

Back before Senna was merged into the liferay-portal repo, nobody saw this output (because the logging code was stripped from the npm package), so this represents no change for customers. Nobody is going to miss this after it's gone, so I went with the "kill it with fire" approach as opposed to more gentle options like leaving a stub (no-op) `log()` function around that could still be called, or providing a session storage option that could be used to temporarily turn it back on. If anybody ever finds an actual use case where having permanent logging infrastructure in our SPA library would be beneficial, we can easily add some or all of it back by reverting this commit.