### PR TITLE
LRQA-66067 | Create new automation that checks CKEditor can add a hyperlink to existing text

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/CKEditor.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/CKEditor.macro
@@ -34,10 +34,12 @@ definition {
 			key_fieldLabel = "${fieldLabel}",
 			locator1 = "CKEditor#TOOLBAR_LINK_BUTTON");
 
-		Type(
-			key_text = "Display Text",
-			locator1 = "TextInput#ANY",
-			value1 = "${displayText}");
+		if (isSet(displayText)) {
+			Type(
+				key_text = "Display Text",
+				locator1 = "TextInput#ANY",
+				value1 = "${displayText}");
+		}
 
 		Type(
 			key_text = "URL",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/CKEditor.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/CKEditor.macro
@@ -49,6 +49,22 @@ definition {
 		Click(locator1 = "CKEditor#OK_BUTTON");
 	}
 
+	macro addEntryExternalURLToExistingText {
+		SelectFrame.selectFrameNoLoading(
+			key_fieldLabel = "${fieldLabel}",
+			locator1 = "CKEditor#FIELD_LABEL_IFRAME");
+
+		SelectFieldText(locator1 = "CKEditor#BODY");
+
+		SelectFrame(value1 = "relative=top");
+
+		CKEditor.addEntryExternalURL(
+			entryExternalURL = "${entryExternalURL}",
+			fieldLabel = "${fieldLabel}");
+
+		SelectFrame(value1 = "relative=top");
+	}
+
 	macro addSourceContent {
 		Click(locator1 = "CKEditor#TOOLBAR_SOURCE_BUTTON");
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
@@ -59,6 +59,16 @@
 	<td></td>
 </tr>
 <tr>
+	<td>BODY_TEXT_HREF</td>
+	<td>//body//a[normalize-space(text()) = '${key_text}' and contains(@href, '${key_href}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FIELD_LABEL_IFRAME</td>
+	<td>//label[contains(.,'${key_fieldLabel}')]//following-sibling::div//div[contains(@id,'cke')]/iframe</td>
+	<td></td>
+</tr>
+<tr>
 	<td>OK_BUTTON</td>
 	<td>//a[contains(@role,'button')][normalize-space()='OK']</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -22,6 +22,8 @@ definition {
 		}
 		else {
 			Page.tearDownCP();
+
+			JSONGroup.deleteGroupByName(groupName = "Test Site Name");
 		}
 	}
 
@@ -199,30 +201,29 @@ definition {
 
 	@priority = "4"
 	test CanAddHyperlinkToExistingText {
-		ProductMenu.gotoPortlet(
-			category = "Content & Data",
-			portlet = "Web Content");
+		JSONGroup.addGroup(groupName = "Test Site Name");
 
-		WebContentNavigator.gotoAddCP();
+		JSONWebcontent.addWebContent(
+			content = "Test Link",
+			groupName = "Test Site Name",
+			title = "Test Web Content");
 
-		WebContent.addCP(
-			webContentTitle = "Test Web Content",
-			webContentContent = "Test Link");
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
 
-		SelectFrame.selectFrameNoLoading(locator1 = "CKEditor#BODY_FIELD_IFRAME_2");
+		WebContent.viewTitle(webContentTitle = "Test Web Content");
 
-		SelectFieldText(locator1 = "CKEditor#BODY");
+		WebContentNavigator.gotoEditCP(webContentTitle = "Test Web Content");
 
-		SelectFrame(value1 = "relative=top");
-
-		CKEditor.addEntryExternalURL(
+		CKEditor.addEntryExternalURLToExistingText(
 			entryExternalURL = "/web/guest/home",
-			fieldLabel = "content"
-		);
+			fieldLabel = "content");
 
 		SelectFrame.selectFrameNoLoading(locator1 = "CKEditor#BODY_FIELD_IFRAME_2");
 
-		AssertElementPresent(locator1 = "//a[normalize-space(text()) = 'Test Link' and contains(@href, '/web/guest/home')]");
+		AssertElementPresent(
+			key_href = "/web/guest/home",
+			key_text = "Test Link",
+			locator1 = "CKEditor#BODY_TEXT_HREF");
 	}
 
 	@priority = "4"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -198,6 +198,34 @@ definition {
 	}
 
 	@priority = "4"
+	test CanAddHyperlinkToExistingText {
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			portlet = "Web Content");
+
+		WebContentNavigator.gotoAddCP();
+
+		WebContent.addCP(
+			webContentTitle = "Test Web Content",
+			webContentContent = "Test Link");
+
+		SelectFrame.selectFrameNoLoading(locator1 = "CKEditor#BODY_FIELD_IFRAME_2");
+
+		SelectFieldText(locator1 = "CKEditor#BODY");
+
+		SelectFrame(value1 = "relative=top");
+
+		CKEditor.addEntryExternalURL(
+			entryExternalURL = "/web/guest/home",
+			fieldLabel = "content"
+		);
+
+		SelectFrame.selectFrameNoLoading(locator1 = "CKEditor#BODY_FIELD_IFRAME_2");
+
+		AssertElementPresent(locator1 = "//a[normalize-space(text()) = 'Test Link' and contains(@href, '/web/guest/home')]");
+	}
+
+	@priority = "4"
 	test PreviewSourceContent {
 		ProductMenu.gotoPortlet(
 			category = "Content & Data",


### PR DESCRIPTION
**Jira Ticket**
https://issues.liferay.com/browse/LRQA-66067

**Description**
This adds an automated functional test to check that a usecase of the ckeditor link plugin works

**Test Plan**
1. Navigate to Content & Data > Web Content
2. Click the + button and add Basic Web Content
3. Add text to CKEditor
4. Highlight text in CKEditor and click on the Link button on the CKEditor toolbar
5. Add /web/guest/home to URL section and click OK
6. Assert that href /web/guest/home is attributed to the text