### PR TITLE
LRQA-64445 | Fix failing test UIInfrastructureUsecase#ViewPortletBoundaries

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
@@ -315,6 +315,8 @@ definition {
 
 		Portlet.addPG(portletName = "Documents and Media");
 
+		Navigator.gotoPage(pageName = "Test Page");
+
 		Portlet.dragAndDropPortletToColumnPG(
 			columnNumberFrom = "1",
 			columnNumberTo = "2",


### PR DESCRIPTION
**Description:**
The test is failing fairly often but passes when run locally. It's possible that this test needed some timing correction on maybe a slower CI environment before dragging and dropping the portlets to the other columns on the page. I added a page renavigation before the test starts to drag and drop the portlets and it passed a few times in https://github.com/john-co/liferay-portal/pull/393#issuecomment-820752533 So I'm going to put this in and monitor CI results for the next day or so to check the test stabilizes.

**Test Plan:**
- Run UIInfrastructureUsecase#ViewPortletBoundaries a few times to make sure it passes consistently

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-64445