### PR TITLE
LPS-130706 Migrate asset categories selection modals

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
@@ -495,18 +495,6 @@ public class AssetCategoriesDisplayContext {
 		).build();
 	}
 
-	public String getEventName() {
-		if (_eventName != null) {
-			return _eventName;
-		}
-
-		_eventName = ParamUtil.getString(
-			_httpServletRequest, "eventName",
-			_renderResponse.getNamespace() + "selectVocabularies");
-
-		return _eventName;
-	}
-
 	public String getGroupName() throws Exception {
 		Group group = GroupLocalServiceUtil.getGroup(
 			_themeDisplay.getScopeGroupId());
@@ -959,7 +947,6 @@ public class AssetCategoriesDisplayContext {
 	private AssetCategory _category;
 	private Long _categoryId;
 	private String _displayStyle;
-	private String _eventName;
 	private final HttpServletRequest _httpServletRequest;
 	private Map<String, List<AssetVocabulary>> _inheritedVocabularies;
 	private String _keywords;

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
@@ -204,7 +204,7 @@ renderResponse.setTitle(title);
 						"redirect", redirect
 					).build()
 				%>'
-				module="js/DetailsItemSelector"
+				module="js/ItemSelectorAddCategory"
 				servletContext="<%= application %>"
 			/>
 		</c:otherwise>

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -28,7 +28,7 @@ const ACTIONS = {
 			buttonAddLabel: Liferay.Language.get('delete'),
 			multiple: true,
 			onSelect: (selectedItems) => {
-				if (selectedItems) {
+				if (selectedItems.length) {
 					if (
 						confirm(
 							Liferay.Language.get(
@@ -36,15 +36,17 @@ const ACTIONS = {
 							)
 						)
 					) {
-						selectedItems.forEach((item) => {
-							vocabulariesForm.appendChild(item.cloneNode(true));
-						});
+						const input = document.createElement('input');
+
+						input.name = `${portletNamespace}rowIds`;
+						input.value = selectedItems.map((item) => item.value);
+
+						vocabulariesForm.appendChild(input);
 
 						submitForm(vocabulariesForm, deleteVocabulariesURL);
 					}
 				}
 			},
-			selectEventName: `${portletNamespace}selectVocabularies`,
 			title: Liferay.Language.get('delete-vocabulary'),
 			url: viewVocabulariesURL,
 		});

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view_vocabularies.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view_vocabularies.jsp
@@ -101,18 +101,3 @@
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get(
-		'<portlet:namespace />assetVocabularies'
-	);
-
-	searchContainer.on('rowToggled', (event) => {
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(assetCategoriesDisplayContext.getEventName()) %>',
-			{
-				data: event.elements.allSelectedElements.getDOMNodes(),
-			}
-		);
-	});
-</aui:script>

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -191,7 +191,7 @@ function SelectCategory({
 }
 
 SelectCategory.propTypes = {
-	addCategoryURL: PropTypes.string.isRequired,
+	addCategoryURL: PropTypes.string,
 	moveCategory: PropTypes.bool,
 };
 

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -17,8 +17,9 @@ import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import {Treeview} from 'frontend-js-components-web';
+import {navigate} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React, {useMemo, useRef, useState} from 'react';
 
 function visit(nodes, callback) {
 	nodes.forEach((node) => {
@@ -62,44 +63,6 @@ function SelectCategory({
 
 	const selectedNodesRef = useRef(null);
 
-	const handleAddCategoryClick = useCallback(() => {
-		const dialog = Liferay.Util.getWindow(itemSelectorSaveEvent);
-		const footer = dialog.getToolbar('footer');
-
-		footer.get('boundingBox').one('#addButton').hide();
-
-		footer.get('boundingBox').one('#cancelButton').hide();
-
-		Liferay.Util.navigate(addCategoryURL);
-	}, [addCategoryURL, itemSelectorSaveEvent]);
-
-	useEffect(() => {
-		const dialog = Liferay.Util.getWindow(itemSelectorSaveEvent);
-		const footer = dialog.getToolbar('footer');
-
-		if (!dialog.get('initialTitle')) {
-			dialog.set(
-				'initialTitle',
-				dialog.headerNode.one('.modal-title').text()
-			);
-		}
-
-		footer.get('boundingBox').all('.add-category-toolbar-button').hide();
-
-		footer.get('boundingBox').one('#addButton').show();
-
-		footer.get('boundingBox').one('#cancelButton').show();
-
-		if (
-			dialog.get('initialTitle') !==
-			dialog.headerNode.one('.modal-title').text()
-		) {
-			dialog.headerNode
-				.one('.modal-title')
-				.text(dialog.get('initialTitle'));
-		}
-	}, [itemSelectorSaveEvent]);
-
 	const handleSelectionChange = (selectedNodes) => {
 		const data = {};
 
@@ -131,7 +94,9 @@ function SelectCategory({
 
 		selectedNodesRef.current = data;
 
-		Liferay.Util.getOpener().Liferay.fire(itemSelectorSaveEvent, {data});
+		const openerWindow = Liferay.Util.getOpener();
+
+		openerWindow.Liferay.fire(itemSelectorSaveEvent, {data});
 	};
 
 	const initialSelectedNodeIds = useMemo(() => {
@@ -183,7 +148,9 @@ function SelectCategory({
 						<ClayButton
 							className="btn-monospaced ml-3 nav-btn nav-btn-monospaced"
 							displayType="primary"
-							onClick={handleAddCategoryClick}
+							onClick={() => {
+								navigate(addCategoryURL);
+							}}
 						>
 							<ClayIcon symbol="plus" />
 						</ClayButton>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -19,7 +19,7 @@ import ClayIcon from '@clayui/icon';
 import ClayMultiSelect from '@clayui/multi-select';
 import {usePrevious} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -140,39 +140,34 @@ function AssetVocabulariesCategoriesSelector({
 			vocabularyIds: sourceItemsVocabularyIds.concat(),
 		});
 
-		const itemSelectorDialog = new ItemSelectorDialog({
+		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
-			dialogClasses: 'modal-lg',
-			eventName,
+			multiple: true,
+			onSelect: (selectedItems) => {
+				if (selectedItems?.length) {
+					const newValues = Object.keys(selectedItems).reduce(
+						(acc, itemKey) => {
+							const item = selectedItems[itemKey];
+							if (!item.unchecked) {
+								acc.push({
+									label: item.value,
+									value: item.categoryId,
+								});
+							}
+
+							return acc;
+						},
+						[]
+					);
+
+					onSelectedItemsChange(newValues);
+				}
+			},
+			selectEventName: eventName,
 			title: label
 				? Liferay.Util.sub(Liferay.Language.get('select-x'), label)
 				: Liferay.Language.get('select-categories'),
 			url,
-		});
-
-		itemSelectorDialog.open();
-
-		itemSelectorDialog.on('selectedItemChange', (event) => {
-			const dialogSelectedItems = event.selectedItem;
-
-			if (dialogSelectedItems) {
-				const newValues = Object.keys(dialogSelectedItems).reduce(
-					(acc, itemKey) => {
-						const item = dialogSelectedItems[itemKey];
-						if (!item.unchecked) {
-							acc.push({
-								label: item.value,
-								value: item.categoryId,
-							});
-						}
-
-						return acc;
-					},
-					[]
-				);
-
-				onSelectedItemsChange(newValues);
-			}
 		});
 	};
 


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-130706

@jonmak08 @kresimir-coko 

In this PR, we are migrating asset categories selection modals, a part of asset-related modals. It contains all remaining code from https://github.com/liferay-frontend/liferay-portal/pull/951, as well as part of code from https://github.com/liferay-frontend/liferay-portal/pull/967.

After this PR, https://github.com/liferay-frontend/liferay-portal/pull/967 should contain only changes on content-dashboard module. That PR can be on hold until this one is merged.

I'm setting this as draft:
- it has a migration type that we've not done before
- it modifies risky `asset` module, we are pausing all PRs on it until the big release

The code for vocabulary deletion is the same as in https://github.com/liferay-frontend/liferay-portal/pull/951. See comments on it there. New code, related to category selection, is in a separate commit, https://github.com/liferay-frontend/liferay-portal/commit/f7b18df3d610959b2d2565f2ac99e1b2f5aca1f3 . Here are notes on that code:
- I renamed `ItemSelectorDetails` to `ItemSelectorAddCategory`, as it is very much specific to this case.
- I moved all code related to 'add category' feature from more general `SelectCategory` to `ItemSelectorAddCategory`. @jonmak08 When you modified content dashboard in https://github.com/liferay-frontend/liferay-portal/pull/967, there was no need for completely unrelated code to break. This way we will have better separation.
- We are adding a wrapper around buttons. This is to match Clay buttons markup.
- The existing solution, as well as the solution in this PR, contains a lot of hacky code, where we directly modify modal buttons and title. This may be a case for `useLiferayState`, where it would contain modal buttons and title. I am not sure if we can sync state in and out of `iframe` with `useLiferayState`. In any case, it would require a large restructure of both modal util and this solution, beyond the scope of this epic. I am not sure how often we directly modify modal frame from inside. If often, it may be something to have in mind @wincent  @jbalsas 

Test case 1:
1. Categorization > Categories > create a Vocabulary
2. Test deleting a vocabulary (see gif)
![after2](https://user-images.githubusercontent.com/5435511/115029545-5f07ec00-9ec6-11eb-9070-fd8be0e084d5.gif)


Test case 2:
1. Have a Vocabulary
2. Web Content > new Basic Web Content > 'Select' next to Vocabulary
3. Test selecting categories (see gif)
4. Test creating a new category (see gif)
![after1](https://user-images.githubusercontent.com/5435511/115029433-413a8700-9ec6-11eb-82a4-b82d5f135a76.gif)

