### PR TITLE
LPS-129589 Migrate asset tag selection modals

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
@@ -25,7 +25,6 @@ const noop = () => {};
 
 function AssetTagsSelector({
 	addCallback,
-	eventName,
 	groupIds = [],
 	id,
 	inputName,
@@ -132,44 +131,42 @@ function AssetTagsSelector({
 			buttonAddLabel: Liferay.Language.get('done'),
 			multiple: true,
 			onSelect: (dialogSelectedItems) => {
-				if (dialogSelectedItems && dialogSelectedItems.items.length) {
-					const newValues = dialogSelectedItems.items
-						.split(',')
-						.map((value) => {
-							return {
-								label: value,
-								value,
-							};
-						});
-
-					const addedItems = newValues.filter(
-						(newValue) =>
-							!selectedItems.find(
-								(selectedItem) =>
-									selectedItem.label === newValue.label
-							)
-					);
-
-					const removedItems = selectedItems.filter(
-						(selectedItem) =>
-							!newValues.find(
-								(newValue) =>
-									newValue.label === selectedItem.label
-							)
-					);
-
-					onSelectedItemsChange(newValues);
-
-					addedItems.forEach((item) =>
-						callGlobalCallback(addCallback, item)
-					);
-
-					removedItems.forEach((item) =>
-						callGlobalCallback(removeCallback, item)
-					);
+				if (!dialogSelectedItems?.length) {
+					return;
 				}
+
+				const newValues = dialogSelectedItems.map((item) => {
+					return {
+						label: item.value,
+						value: item.value,
+					};
+				});
+
+				const addedItems = newValues.filter(
+					(newValue) =>
+						!selectedItems.find(
+							(selectedItem) =>
+								selectedItem.label === newValue.label
+						)
+				);
+
+				const removedItems = selectedItems.filter(
+					(selectedItem) =>
+						!newValues.find(
+							(newValue) => newValue.label === selectedItem.label
+						)
+				);
+
+				onSelectedItemsChange(newValues);
+
+				addedItems.forEach((item) =>
+					callGlobalCallback(addCallback, item)
+				);
+
+				removedItems.forEach((item) =>
+					callGlobalCallback(removeCallback, item)
+				);
 			},
-			selectEventName: eventName,
 			title: Liferay.Language.get('tags'),
 			url,
 		});
@@ -220,7 +217,6 @@ function AssetTagsSelector({
 
 AssetTagsSelector.propTypes = {
 	addCallback: PropTypes.string,
-	eventName: PropTypes.string,
 	groupIds: PropTypes.array,
 	id: PropTypes.string,
 	inputName: PropTypes.string,

--- a/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,7 +24,6 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.asset.tags.selector.web.internal.display.context.AssetTagsSelectorDisplayContext" %><%@
 page import="com.liferay.asset.tags.selector.web.internal.display.context.AssetTagsSelectorManagementToolbarDisplayContext" %><%@
-page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %>
 

--- a/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/select_single.jsp
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/select_single.jsp
@@ -62,11 +62,3 @@ assetTagsSelectorDisplayContext = new AssetTagsSelectorDisplayContext(request, r
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectAssetTagFm',
-		'<%= HtmlUtil.escapeJS(assetTagsSelectorDisplayContext.getEventName()) %>',
-		true
-	);
-</aui:script>

--- a/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -44,34 +44,3 @@
 		/>
 	</liferay-ui:search-container>
 </clay:container-fluid>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get('<portlet:namespace />tags');
-
-	var searchContainerData = searchContainer.getData(true);
-
-	var selectedTagNames = <%= JSONFactoryUtil.serialize(assetTagsSelectorDisplayContext.getSelectedTagNames()) %>;
-
-	selectedTagNames = selectedTagNames.filter((tag) => {
-		return searchContainerData.indexOf(tag) === -1;
-	});
-
-	searchContainer.on('rowToggled', (event) => {
-		var items = '';
-
-		var selectedItems = event.elements.allSelectedElements;
-
-		if (selectedItems.size() > 0) {
-			items = selectedTagNames.concat(selectedItems.attr('value')).join(',');
-		}
-
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(assetTagsSelectorDisplayContext.getEventName()) %>',
-			{
-				data: {
-					items: items,
-				},
-			}
-		);
-	});
-</aui:script>


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-129589

@jonmak08 @kresimir-coko

In this PR, we are migrating asset categories selection modals, a part of asset-related modals. 

I'm setting this as draft. It modifies risky asset module, we are pausing all PRs on it until the big release.

Notes:
- We are not cleaning up single target event names, because they require it. In theory we could change this, but it will require some gymnastics in the utility. We can consider this later in the epic, or at some other point in the future.

Test case 1, single target tag. The only use is in segments:
- People > Segmens > (+) > drag & drop 'User / Tag' > Select (see gif)

![after1](https://user-images.githubusercontent.com/5435511/115052913-cb8ee500-9ede-11eb-9560-66eaf2d3dd94.gif)

Test case 2, multiselect. There a lot of places where we have this, as a part of `<AssetTagsSelector>`. Here is one example:
- Asset Publisher > Configuration > Asset Selection - Dynamic > Filter > Select a Tag (see gif)

![after2](https://user-images.githubusercontent.com/5435511/115052927-d184c600-9ede-11eb-8e65-5318afe895f1.gif)

