### PR TITLE
LPS-130738 Copy the content inside the dropdown menu when cloning

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -167,7 +167,7 @@ AUI.add(
 
 						trigger.placeAfter(list);
 
-						list.append(palette);
+						list.append(palette.cloneNode(true));
 					}
 
 					if (instance.url) {


### PR DESCRIPTION
Hey guys,

Can you review this pull request, please?

Original message from @orsolyaDekany

> LPS: https://issues.liferay.com/browse/LPS-130738
> Fix: copy the palette and deep copy all of the content inside of that.

Thanks.

Regards.