### PR TITLE
LPS-126475 Forms title is cropped when copying and pasting a long title but it keeps the long title when save the Form (this can be seen on Forms list)

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
@@ -78,6 +78,8 @@ body .ddm-user-view-content {
 .portlet-forms .ddm-form-basic-info .ddm-form-name {
 	color: #000;
 	font-weight: 500;
+	margin-top: 40px;
+	padding: 0;
 }
 
 .lfr-ddm-form-field-container label,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/autosize/autosize.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/autosize/autosize.es.js
@@ -24,6 +24,10 @@ class AutoSize {
 			10
 		);
 
+		this.paddingHeight =
+			parseInt(this.computedStyle.paddingTop.replace('px', ''), 10) +
+			parseInt(this.computedStyle.paddingBottom.replace('px', ''), 10);
+
 		this.template = this.createTemplate(this.computedStyle);
 		document.body.appendChild(this.template);
 
@@ -74,9 +78,9 @@ class AutoSize {
 			DEFAULT_APPEND_CONTENT;
 
 		inputElement.style.height = `${
-			this.template.scrollHeight < this.minHeight
+			this.template.scrollHeight + this.paddingHeight < this.minHeight
 				? this.minHeight
-				: this.template.scrollHeight
+				: this.template.scrollHeight + this.paddingHeight
 		}px`;
 	}
 }


### PR DESCRIPTION
[LPS-126475](https://issues.liferay.com/browse/LPS-126475) 
Autosize didn't take padding into account to adjust element height accordingly. This PR changes autosize.es.js so that it takes padding into account and the issue isn't reproducible anymore.

Before change. Title get's cropped after a page refresh (which occurs when the current form is saved):
![Screenshot from 2021-04-20 11-29-43](https://user-images.githubusercontent.com/52260710/115413728-c924d780-a1cb-11eb-93ef-77eb0c242b51.png)

![Screenshot from 2021-04-20 11-32-05](https://user-images.githubusercontent.com/52260710/115414180-35074000-a1cc-11eb-9db7-d504e9d044fb.png)

After Change. Title no longer gets cropped:

![Screenshot from 2021-04-20 11-31-17](https://user-images.githubusercontent.com/52260710/115414237-3f293e80-a1cc-11eb-91a5-8a3482dcb0c4.png)

![Screenshot from 2021-04-20 11-31-30](https://user-images.githubusercontent.com/52260710/115414257-42242f00-a1cc-11eb-8272-9aa433d61164.png)

Check the Jira ticket for more details and video evidence of the bug and solution
