### PR TITLE
LPS-130263 LPS-130263 Balloon editor text toolbar's configuration

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
@@ -16,15 +16,15 @@ package com.liferay.frontend.editor.ckeditor.web.internal.editor.configuration;
 
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Validator;
-import org.osgi.service.component.annotations.Component;
 
 import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
 
 /**
  * @author Ambrín Chaudhary
@@ -46,9 +46,7 @@ public class CKEditorBalloonEditorConfigContributor
 			jsonObject, inputEditorTaglibAttributes, themeDisplay,
 			requestBackedPortletURLFactory);
 
-		jsonObject.put(
-			"extraAllowedContent", Boolean.TRUE
-		);
+		jsonObject.put("extraAllowedContent", Boolean.TRUE);
 
 		String extraPlugins = jsonObject.getString("extraPlugins");
 
@@ -61,40 +59,42 @@ public class CKEditorBalloonEditorConfigContributor
 
 		jsonObject.put("extraPlugins", extraPlugins);
 
+		JSONArray toolbarsJSONArray = JSONUtil.putAll(
+			getToolbarImageJSONObject(), getToolbarLinkJSONObject(),
+			getToolbarTextJSONObject());
 
-		JSONArray toolbars = JSONUtil.putAll(
-			getToolbarImage(), getToolbarLink(), getToolbarText()
+		jsonObject.put("toolbars", toolbarsJSONArray);
+	}
+
+	protected JSONObject getToolbarImageJSONObject() {
+		return JSONUtil.put(
+			"buttons", "JustifyLeft,JustifyCenter,JustifyRight,Link,Unlink"
+		).put(
+			"priority", Boolean.TRUE
+		).put(
+			"widgets", "image,image2"
 		);
-
-		jsonObject.put("toolbars", toolbars);
 	}
 
-	protected JSONObject getToolbarImage() {
-		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
-
-		jsonObject.put("buttons", "JustifyLeft,JustifyCenter,JustifyRight,Link,Unlink");
-		jsonObject.put("priority", Boolean.TRUE);
-		jsonObject.put("widgets", "image,image2");
-
-		return jsonObject;
+	protected JSONObject getToolbarLinkJSONObject() {
+		return JSONUtil.put(
+			"buttons", "Link,Unlink"
+		).put(
+			"cssSelector", "a"
+		).put(
+			"priority", Boolean.TRUE
+		);
 	}
 
-	protected JSONObject getToolbarLink() {
-		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
-
-		jsonObject.put("buttons", "Link,Unlink");
-		jsonObject.put("priority", Boolean.TRUE);
-		jsonObject.put("cssSelector", "a");
-
-		return jsonObject;
+	protected JSONObject getToolbarTextJSONObject() {
+		return JSONUtil.put(
+			"buttons",
+			"Bold,Italic,Underline,RemoveFormat,Link,NumberedList," +
+				"BulletedList,JustifyLeft,JustifyCenter,JustifyRight," +
+					"JustifyBlock,Anchor"
+		).put(
+			"cssSelector", "*"
+		);
 	}
 
-	protected JSONObject getToolbarText() {
-		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
-
-		jsonObject.put("buttons", "Bold,Italic,Underline,RemoveFormat,Link,NumberedList,BulletedList,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,Anchor");
-		jsonObject.put("cssSelector", "*");
-
-		return jsonObject;
-	}
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
@@ -57,30 +57,23 @@ public class CKEditorBalloonEditorConfigContributor
 			jsonObject, inputEditorTaglibAttributes, themeDisplay,
 			requestBackedPortletURLFactory);
 
-		jsonObject.put("extraAllowedContent", Boolean.TRUE);
-
-		String balloonToolbarPlugins =
-			"balloontoolbar,floatingspace,stylescombo";
-
 		String extraPlugins = jsonObject.getString("extraPlugins");
 
 		if (Validator.isNotNull(extraPlugins)) {
-			extraPlugins += "," + balloonToolbarPlugins;
+			extraPlugins += ",stylescombo";
 		}
 		else {
-			extraPlugins = balloonToolbarPlugins;
+			extraPlugins = "stylescombo";
 		}
 
-		jsonObject.put("extraPlugins", extraPlugins);
-
-		JSONArray toolbarsJSONArray = JSONUtil.putAll(
-			getToolbarImageJSONObject(), getToolbarLinkJSONObject(),
-			getToolbarTextJSONObject());
-
 		jsonObject.put(
+			"extraPlugins", extraPlugins
+		).put(
 			"stylesSet", getStyleFormatsJSONArray(themeDisplay.getLocale())
 		).put(
-			"toolbars", toolbarsJSONArray
+			"toolbarImage", "JustifyLeft,JustifyCenter,JustifyRight,Link,Unlink"
+		).put(
+			"toolbarText", getToolbarText()
 		);
 	}
 
@@ -123,35 +116,9 @@ public class CKEditorBalloonEditorConfigContributor
 				LanguageUtil.get(resourceBundle, "computer-code"), "code"));
 	}
 
-	protected JSONObject getToolbarImageJSONObject() {
-		return JSONUtil.put(
-			"buttons", "JustifyLeft,JustifyCenter,JustifyRight,Link,Unlink"
-		).put(
-			"priority", Boolean.TRUE
-		).put(
-			"widgets", "image,image2"
-		);
-	}
-
-	protected JSONObject getToolbarLinkJSONObject() {
-		return JSONUtil.put(
-			"buttons", "Link,Unlink"
-		).put(
-			"cssSelector", "a"
-		).put(
-			"priority", Boolean.TRUE
-		);
-	}
-
-	protected JSONObject getToolbarTextJSONObject() {
-		return JSONUtil.put(
-			"buttons",
-			"Styles,Bold,Italic,Underline,BulletedList,NumberedList,Link," +
-				"JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock," +
-					"RemoveFormat"
-		).put(
-			"cssSelector", "cite,code,h1,h2,h3,p,pre,span,strong,li"
-		);
+	protected String getToolbarText() {
+		return "Styles,Bold,Italic,Underline,BulletedList,NumberedList,Link," +
+			"JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,RemoveFormat";
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
@@ -74,6 +74,8 @@ public class CKEditorBalloonEditorConfigContributor
 			"toolbarImage", "JustifyLeft,JustifyCenter,JustifyRight,Link,Unlink"
 		).put(
 			"toolbarText", getToolbarText()
+		).put(
+			"toolbarVideo", "JustifyLeft,JustifyCenter,JustifyRight"
 		);
 	}
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
@@ -15,7 +15,10 @@
 package com.liferay.frontend.editor.ckeditor.web.internal.editor.configuration;
 
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Validator;
@@ -57,5 +60,41 @@ public class CKEditorBalloonEditorConfigContributor
 		}
 
 		jsonObject.put("extraPlugins", extraPlugins);
+
+
+		JSONArray toolbars = JSONUtil.putAll(
+			getToolbarImage(), getToolbarLink(), getToolbarText()
+		);
+
+		jsonObject.put("toolbars", toolbars);
+	}
+
+	protected JSONObject getToolbarImage() {
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+
+		jsonObject.put("buttons", "JustifyLeft,JustifyCenter,JustifyRight,Link,Unlink");
+		jsonObject.put("priority", Boolean.TRUE);
+		jsonObject.put("widgets", "image,image2");
+
+		return jsonObject;
+	}
+
+	protected JSONObject getToolbarLink() {
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+
+		jsonObject.put("buttons", "Link,Unlink");
+		jsonObject.put("priority", Boolean.TRUE);
+		jsonObject.put("cssSelector", "a");
+
+		return jsonObject;
+	}
+
+	protected JSONObject getToolbarText() {
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+
+		jsonObject.put("buttons", "Bold,Italic,Underline,RemoveFormat,Link,NumberedList,BulletedList,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,Anchor");
+		jsonObject.put("cssSelector", "*");
+
+		return jsonObject;
 	}
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.editor.ckeditor.web.internal.editor.configuration;
+
+import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Validator;
+import org.osgi.service.component.annotations.Component;
+
+import java.util.Map;
+
+/**
+ * @author Ambrín Chaudhary
+ */
+@Component(
+	property = "editor.name=ballooneditor",
+	service = EditorConfigContributor.class
+)
+public class CKEditorBalloonEditorConfigContributor
+	extends BaseCKEditorConfigContributor {
+
+	@Override
+	public void populateConfigJSONObject(
+		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
+		ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		super.populateConfigJSONObject(
+			jsonObject, inputEditorTaglibAttributes, themeDisplay,
+			requestBackedPortletURLFactory);
+
+		jsonObject.put(
+			"extraAllowedContent", Boolean.TRUE
+		);
+
+		String extraPlugins = jsonObject.getString("extraPlugins");
+
+		if (Validator.isNotNull(extraPlugins)) {
+			extraPlugins = extraPlugins + ",balloontoolbar,floatingspace";
+		}
+		else {
+			extraPlugins = "balloontoolbar,floatingspace";
+		}
+
+		jsonObject.put("extraPlugins", extraPlugins);
+	}
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
@@ -18,13 +18,24 @@ import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.Locale;
 import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Ambrín Chaudhary
@@ -48,13 +59,16 @@ public class CKEditorBalloonEditorConfigContributor
 
 		jsonObject.put("extraAllowedContent", Boolean.TRUE);
 
+		String balloonToolbarPlugins =
+			"balloontoolbar,floatingspace,stylescombo";
+
 		String extraPlugins = jsonObject.getString("extraPlugins");
 
 		if (Validator.isNotNull(extraPlugins)) {
-			extraPlugins = extraPlugins + ",balloontoolbar,floatingspace";
+			extraPlugins += "," + balloonToolbarPlugins;
 		}
 		else {
-			extraPlugins = "balloontoolbar,floatingspace";
+			extraPlugins = balloonToolbarPlugins;
 		}
 
 		jsonObject.put("extraPlugins", extraPlugins);
@@ -63,7 +77,50 @@ public class CKEditorBalloonEditorConfigContributor
 			getToolbarImageJSONObject(), getToolbarLinkJSONObject(),
 			getToolbarTextJSONObject());
 
-		jsonObject.put("toolbars", toolbarsJSONArray);
+		jsonObject.put(
+			"stylesSet", getStyleFormatsJSONArray(themeDisplay.getLocale())
+		).put(
+			"toolbars", toolbarsJSONArray
+		);
+	}
+
+	protected JSONObject getStyleFormatJSONObject(
+		String styleFormatName, String element) {
+
+		return JSONUtil.put(
+			"element", element
+		).put(
+			"name", styleFormatName
+		);
+	}
+
+	protected JSONArray getStyleFormatsJSONArray(Locale locale) {
+		ResourceBundle resourceBundle = null;
+
+		try {
+			resourceBundle = _resourceBundleLoader.loadResourceBundle(locale);
+		}
+		catch (MissingResourceException missingResourceException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(missingResourceException, missingResourceException);
+			}
+
+			resourceBundle = ResourceBundleUtil.EMPTY_RESOURCE_BUNDLE;
+		}
+
+		return JSONUtil.putAll(
+			getStyleFormatJSONObject(
+				LanguageUtil.get(resourceBundle, "normal"), "p"),
+			getStyleFormatJSONObject(
+				LanguageUtil.format(resourceBundle, "heading-x", "1"), "h1"),
+			getStyleFormatJSONObject(
+				LanguageUtil.format(resourceBundle, "heading-x", "2"), "h2"),
+			getStyleFormatJSONObject(
+				LanguageUtil.get(resourceBundle, "preformatted-text"), "pre"),
+			getStyleFormatJSONObject(
+				LanguageUtil.get(resourceBundle, "cited-work"), "cite"),
+			getStyleFormatJSONObject(
+				LanguageUtil.get(resourceBundle, "computer-code"), "code"));
 	}
 
 	protected JSONObject getToolbarImageJSONObject() {
@@ -89,12 +146,22 @@ public class CKEditorBalloonEditorConfigContributor
 	protected JSONObject getToolbarTextJSONObject() {
 		return JSONUtil.put(
 			"buttons",
-			"Bold,Italic,Underline,BulletedList,NumberedList,Link," +
+			"Styles,Bold,Italic,Underline,BulletedList,NumberedList,Link," +
 				"JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock," +
-				"RemoveFormat"
+					"RemoveFormat"
 		).put(
-			"cssSelector", "*"
+			"cssSelector", "cite,code,h1,h2,h3,p,pre,span,strong,li"
 		);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CKEditorBalloonEditorConfigContributor.class);
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.frontend.editor.lang)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
@@ -89,9 +89,9 @@ public class CKEditorBalloonEditorConfigContributor
 	protected JSONObject getToolbarTextJSONObject() {
 		return JSONUtil.put(
 			"buttons",
-			"Bold,Italic,Underline,RemoveFormat,Link,NumberedList," +
-				"BulletedList,JustifyLeft,JustifyCenter,JustifyRight," +
-					"JustifyBlock,Anchor"
+			"Bold,Italic,Underline,BulletedList,NumberedList,Link," +
+				"JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock," +
+				"RemoveFormat"
 		).put(
 			"cssSelector", "*"
 		);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -79,6 +79,16 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
 				});
 
+				if (editorConfig.toolbarVideo) {
+					balloonToolbars.create({
+						buttons: editorConfig.toolbarVideo,
+						cssSelector: 'div[data-widget="videoembed"]',
+						priority:
+							window.CKEDITOR.plugins.balloontoolbar.PRIORITY
+								.HIGH,
+					});
+				}
+
 				if (contents) {
 					editor.setData(contents);
 				}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -47,10 +47,11 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 					toolbars.forEach((toolbar) => {
 						if (toolbar.priority) {
 							toolbar = {
-								...toolbar, 
+								...toolbar,
 								priority:
-									window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH
-							}
+									window.CKEDITOR.plugins.balloontoolbar
+										.PRIORITY.HIGH,
+							};
 						}
 						balloonToolbars.create(toolbar);
 					});

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -20,11 +20,30 @@ import {Editor} from './Editor';
 import '../css/main.scss';
 
 const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
+	const defaultExtraPlugins = 'balloontoolbar,floatingspace';
+
 	const [cssClass, setCssClass] = useState('');
+
+	const extraPlugins = config.extraPlugins ? `${config.extraPlugins},` : '';
+
+	const basicToolbars = {
+		toolbarImage: 'JustifyLeft,JustifyCenter,JustifyRight',
+		toolbarLink: 'Link,Unlink',
+		toolbarText:
+			'Bold,Italic,Underline,BulletedList,NumberedList,Link' +
+			'JustifyLeft,JustifyCenter,JustifyRight,RemoveFormat',
+	};
+
+	const editorConfig = {
+		...basicToolbars,
+		...config,
+		extraAllowedContent: '*',
+		extraPlugins: `${extraPlugins}${defaultExtraPlugins}`,
+	};
 
 	return (
 		<Editor
-			config={config}
+			config={editorConfig}
 			name={name}
 			onBeforeLoad={(CKEDITOR) => {
 				CKEDITOR.disableAutoInline = true;
@@ -39,23 +58,26 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 			onInstanceReady={(event) => {
 				const editor = event.editor;
 
-				const toolbars = config.toolbars;
+				const balloonToolbars = editor.balloonToolbars;
 
-				if (toolbars) {
-					const balloonToolbars = editor.balloonToolbars;
+				balloonToolbars.create({
+					buttons: editorConfig.toolbarText,
+					cssSelector: '*',
+				});
 
-					toolbars.forEach((toolbar) => {
-						if (toolbar.priority) {
-							toolbar = {
-								...toolbar,
-								priority:
-									window.CKEDITOR.plugins.balloontoolbar
-										.PRIORITY.HIGH,
-							};
-						}
-						balloonToolbars.create(toolbar);
-					});
-				}
+				balloonToolbars.create({
+					buttons: editorConfig.toolbarImage,
+					priority:
+						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
+					widgets: 'image,image2',
+				});
+
+				balloonToolbars.create({
+					buttons: editorConfig.toolbarLink,
+					cssSelector: 'a',
+					priority:
+						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
+				});
 
 				if (contents) {
 					editor.setData(contents);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -39,30 +39,22 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 			onInstanceReady={(event) => {
 				const editor = event.editor;
 
-				const balloonToolbars = editor.balloonToolbars;
+				const toolbars = config.toolbars;
 
-				balloonToolbars.create({
-					buttons:
-						'Bold,Italic,Underline,RemoveFormat,Link,NumberedList,BulletedList,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,Anchor',
-					cssSelector: '*',
-				});
+				if (toolbars) {
+					const balloonToolbars = editor.balloonToolbars;
 
-				balloonToolbars.create({
-					buttons: 'Link,Unlink',
-					priority:
-						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
-					refresh(editor, path) {
-						return path.contains('a');
-					},
-				});
-
-				balloonToolbars.create({
-					buttons:
-						'JustifyLeft,JustifyCenter,JustifyRight,Link,Unlink',
-					priority:
-						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
-					widgets: 'image,image2',
-				});
+					toolbars.forEach((toolbar) => {
+						if (toolbar.priority) {
+							toolbar = {
+								...toolbar, 
+								priority:
+									window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH
+							}
+						}
+						balloonToolbars.create(toolbar);
+					});
+				}
 
 				if (contents) {
 					editor.setData(contents);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -22,23 +22,9 @@ import '../css/main.scss';
 const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 	const [cssClass, setCssClass] = useState('');
 
-	const defaultExtraPlugins = 'balloontoolbar,floatingspace';
-
-	const getConfig = () => {
-		const extraPlugins = config.extraPlugins
-			? `${config.extraPlugins}`
-			: '';
-
-		return {
-			...config,
-			extraAllowedContent: '*',
-			extraPlugins: `${extraPlugins}${defaultExtraPlugins}`,
-		};
-	};
-
 	return (
 		<Editor
-			config={getConfig()}
+			config={config}
 			name={name}
 			onBeforeLoad={(CKEDITOR) => {
 				CKEDITOR.disableAutoInline = true;


### PR DESCRIPTION
Now, the _BalloonEditor_ component has its basic configuration and a default set of toolbars (still waiting to define which buttons should be configure here, this is just a first approximation), which allows as to use this component in a simple JS app, but we still keep the _ConfigContributor_ pattern for DXP. 

/cc @julien 