### PR TITLE
LPS-129363 - Update @clayui/* dependencies

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/package.json
+++ b/modules/apps/adaptive-media/adaptive-media-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/form": "3.14.4",
 		"@clayui/icon": "3.1.0",

--- a/modules/apps/change-tracking/change-tracking-web/package.json
+++ b/modules/apps/change-tracking/change-tracking-web/package.json
@@ -1,9 +1,9 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/breadcrumb": "3.25.1",
 		"@clayui/button": "3.6.0",
-		"@clayui/date-picker": "3.25.4",
+		"@clayui/date-picker": "3.26.0",
 		"@clayui/drop-down": "3.25.1",
 		"@clayui/form": "3.14.4",
 		"@clayui/icon": "3.1.0",

--- a/modules/apps/commerce/commerce-frontend-js/package.json
+++ b/modules/apps/commerce/commerce-frontend-js/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/autocomplete": "3.25.1",
 		"@clayui/badge": "3.2.0",
 		"@clayui/button": "3.6.0",

--- a/modules/apps/content-dashboard/content-dashboard-web/package.json
+++ b/modules/apps/content-dashboard/content-dashboard-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/empty-state": "3.2.0",
 		"@clayui/form": "3.14.4",

--- a/modules/apps/depot/depot-web/package.json
+++ b/modules/apps/depot/depot-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/drop-down": "3.25.1",
 		"@clayui/form": "3.14.4",

--- a/modules/apps/document-library/document-library-web/package.json
+++ b/modules/apps/document-library/document-library-web/package.json
@@ -1,8 +1,8 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
-		"@clayui/css": "3.25.3",
+		"@clayui/css": "3.26.0",
 		"@clayui/form": "3.14.4",
 		"@clayui/icon": "3.1.0",
 		"@clayui/loading-indicator": "3.2.0",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/__snapshots__/DatePicker.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/__snapshots__/DatePicker.es.js.snap
@@ -27,17 +27,18 @@ exports[`DatePicker has a predefinedValue 1`] = `
           <input
             name="datePicker"
             type="hidden"
-            value="06/02/2020"
+            value="Tue Jun 02 2020 00:00:00 GMT-0700 (Pacific Daylight Time)"
           />
           <input
             class="form-control input-group-inset input-group-inset-after"
             type="text"
-            value="06/02/2020"
+            value="Tue Jun 02 2020 00:00:00 GMT-0700 (Pacific Daylight Time)"
           />
           <div
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               type="button"
             >

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/data-provider": "3.3.10",
 		"@clayui/form": "3.14.4",

--- a/modules/apps/flags/flags-taglib/package.json
+++ b/modules/apps/flags/flags-taglib/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/icon": "3.1.0",
 		"@clayui/modal": "3.8.5",

--- a/modules/apps/frontend-js/frontend-js-clay-sample-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-clay-sample-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/icon": "3.1.0",
 		"react": "16.12.0",
 		"react-dom": "16.12.0"

--- a/modules/apps/frontend-js/frontend-js-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/form": "3.14.4",
 		"@clayui/icon": "3.1.0",
 		"@clayui/modal": "3.8.5",

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-test-alert-toast-sample-web/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-test-alert-toast-sample-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"frontend-js-web": "*",
 		"react": "16.12.0",

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/autocomplete": "3.25.1",
 		"@clayui/badge": "3.2.0",
 		"@clayui/breadcrumb": "3.25.1",
@@ -8,9 +8,9 @@
 		"@clayui/card": "3.25.1",
 		"@clayui/charts": "3.25.1",
 		"@clayui/color-picker": "3.25.1",
-		"@clayui/css": "3.25.3",
+		"@clayui/css": "3.26.0",
 		"@clayui/data-provider": "3.3.10",
-		"@clayui/date-picker": "3.25.4",
+		"@clayui/date-picker": "3.26.0",
 		"@clayui/drop-down": "3.25.1",
 		"@clayui/empty-state": "3.2.0",
 		"@clayui/form": "3.14.4",

--- a/modules/apps/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/card": "3.25.1",
 		"@clayui/drop-down": "3.25.1",

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/package.json
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/css": "3.25.3"
+		"@clayui/css": "3.26.0"
 	},
 	"name": "liferay-frontend-theme-unstyled",
 	"scripts": {

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/badge": "3.2.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/drop-down": "3.25.1",

--- a/modules/apps/item-selector/item-selector-taglib/package.json
+++ b/modules/apps/item-selector/item-selector-taglib/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/icon": "3.1.0",
 		"@clayui/layout": "3.3.0",

--- a/modules/apps/journal/journal-web/package.json
+++ b/modules/apps/journal/journal-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/drop-down": "3.25.1",
 		"@clayui/form": "3.14.4",

--- a/modules/apps/layout/layout-admin-web/package.json
+++ b/modules/apps/layout/layout-admin-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/drop-down": "3.25.1",
 		"@clayui/form": "3.14.4",

--- a/modules/apps/layout/layout-content-page-editor-web/package.json
+++ b/modules/apps/layout/layout-content-page-editor-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/card": "3.25.1",
 		"@clayui/drop-down": "3.25.1",

--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/badge": "3.2.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/form": "3.14.4",

--- a/modules/apps/sharing/sharing-web/package.json
+++ b/modules/apps/sharing/sharing-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/autocomplete": "3.25.1",
 		"@clayui/button": "3.6.0",
 		"@clayui/data-provider": "3.3.10",

--- a/modules/apps/style-book/style-book-web/package.json
+++ b/modules/apps/style-book/style-book-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/color-picker": "3.25.1",
 		"@clayui/drop-down": "3.25.1",

--- a/modules/dxp/apps/commerce/commerce-dashboard-web/package.json
+++ b/modules/dxp/apps/commerce/commerce-dashboard-web/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/charts": "3.25.1",
-		"@clayui/css": "3.25.3",
+		"@clayui/css": "3.26.0",
 		"@liferay/frontend-js-react-web": "*",
 		"frontend-js-web": "*",
 		"react": "16.12.0",

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/autocomplete": "3.25.1",
 		"@clayui/button": "3.6.0",
 		"@clayui/charts": "3.25.1",

--- a/modules/dxp/apps/segments/segments-experiment-web/package.json
+++ b/modules/dxp/apps/segments/segments-experiment-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.5.1",
+		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
 		"@clayui/drop-down": "3.25.1",
 		"@clayui/form": "3.14.4",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -881,10 +881,10 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-5.0.0.tgz#3ba791f37b90e7f6170d252b63aacfcae943c039"
   integrity sha512-WmKrB/575EJCzbeSJR3YQ5sET5FaizeljLRw1382qVUeGqzuWBgIS+AF5a0FO51uQTrDpoRgvuHC2IWVsgwkkA==
 
-"@clayui/alert@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@clayui/alert/-/alert-3.5.1.tgz#01a72041b0e89a99a478a51bb9156a6d19f1a531"
-  integrity sha512-VcwtVCLRaFA2HwvoXpua/hm1u3M/j3KNqcATqDwc28ok9pkVZKQRkSAz8/dpRV2v6xrsawSftJZ9pPiZ0nJaZA==
+"@clayui/alert@3.26.0":
+  version "3.26.0"
+  resolved "https://registry.yarnpkg.com/@clayui/alert/-/alert-3.26.0.tgz#18e8195d877cf67c0781f1f8a8b2f053d9adce05"
+  integrity sha512-/+8dTejJJZ+7wVNAf4zc8hdHIfeiK81FMzhtQ4HRK1C/ZDN7E2F2WwDeaSulRhEjNAeFZT+ed167AtyBoheDpw==
   dependencies:
     "@clayui/icon" "^3.1.0"
     "@clayui/layout" "^3.3.0"
@@ -966,10 +966,10 @@
     classnames "^2.2.6"
     tinycolor2 "^1.4.1"
 
-"@clayui/css@3.25.3":
-  version "3.25.3"
-  resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.25.3.tgz#5c68e4f98ddf40664d06e8517fbdcf65493ca3d0"
-  integrity sha512-BWMkPn0nMpqhog3iCc9ktazoKKG3oChoNr2zzAzF9LusDGZVVo2pamQjdlAZfkfD/daAC5Bo5rlOLazHc45oKg==
+"@clayui/css@3.26.0":
+  version "3.26.0"
+  resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.26.0.tgz#4d50f675bf3e97c2b9c3f27f5cdf16d94f53bc8d"
+  integrity sha512-QCKMkXcWHe5mtx6+eJirEkal6zcHzFyHPViUVxXe+1xvHw+vh9Mk+rTd+iYHh/IdU9IH9adXe0HmEOzY6pmL0w==
 
 "@clayui/data-provider@3.3.10":
   version "3.3.10"
@@ -980,10 +980,10 @@
     fast-json-stable-stringify "^2.0.0"
     warning "^4.0.3"
 
-"@clayui/date-picker@3.25.4":
-  version "3.25.4"
-  resolved "https://registry.yarnpkg.com/@clayui/date-picker/-/date-picker-3.25.4.tgz#f59ddbba0b46c94ed99bb9d061346cd558ffc3ff"
-  integrity sha512-u71vq5fb0uRFUXkHvrx9TVNBZfncVmXh5kC/iUaFUpqWvM02htKkiKIpSwGC0nhsLghavjkGwG3Q+iFodUrmFQ==
+"@clayui/date-picker@3.26.0":
+  version "3.26.0"
+  resolved "https://registry.yarnpkg.com/@clayui/date-picker/-/date-picker-3.26.0.tgz#a60a1f4a5171ddcb53af40911ce6881163d1c61b"
+  integrity sha512-ukF2Ggwiu/3Z34Hrk7exgnqsRs1fZqzpFThjVAr1ry/5uT7wPnVdEct80OplOO4WvIsx351Sgb/OsJaROYFyQw==
   dependencies:
     "@clayui/button" "^3.6.0"
     "@clayui/drop-down" "^3.25.1"


### PR DESCRIPTION
https://github.com/liferay-frontend/liferay-portal/pull/985



# [3.26.0](https://github.com/liferay/clay/compare/v3.25.4...v3.26.0) (2021-04-21)

### Bug Fixes

-   **@clayui/date-picker:** Adjusts the behaviour of date range when clicking on the dot button ([f6db982](https://github.com/liferay/clay/commit/f6db982)), closes [/github.com/liferay/clay/pull/4008#issuecomment-819244473](https://github.com//github.com/liferay/clay/pull/4008/issues/issuecomment-819244473)
-   **@clayui/date-picker:** fixes error when not selecting date when the time is invalid ([861de91](https://github.com/liferay/clay/commit/861de91))
-   **@clayui/date-picker:** fixes error when reflecting the time without having selected the date ([80409f5](https://github.com/liferay/clay/commit/80409f5))
-   **@clayui/date-picker:** fixes normalization error for the day selected and button to change to the current day ([a058e7f](https://github.com/liferay/clay/commit/a058e7f))
-   **@clayui/date-picker:** fixes normalization of the date ([cdbad89](https://github.com/liferay/clay/commit/cdbad89))
-   **@clayui/date-picker:** resets the range when selecting a new date ([639d2af](https://github.com/liferay/clay/commit/639d2af))
-   **@clayui/date-picker:** Small tweaks ([d6ead55](https://github.com/liferay/clay/commit/d6ead55))
-   **@clayui/date-picker:** Use `toDateString` instead of `toLocaleDateString` on Day button ([2710760](https://github.com/liferay/clay/commit/2710760))
-   **@clayui/date-picker:** When having a range and clicking on end date again the start date will be the same as the end date ([4e1cd07](https://github.com/liferay/clay/commit/4e1cd07)), closes [/github.com/liferay/clay/pull/4008#issuecomment-819244473](https://github.com//github.com/liferay/clay/pull/4008/issues/issuecomment-819244473)
-   **@clayui/date-picker:** When using `fromStringToRange` function, when not finding a endDate, just use the startDate ([a6c1d00](https://github.com/liferay/clay/commit/a6c1d00))
-   **@clayui/date-picker:** Wrap day and weekdays in `<div class="date-picker-col">` to prep for Date Range feature ([512c2a4](https://github.com/liferay/clay/commit/512c2a4))

### Features

-   **@clayui/alert:** Adds the new feedback variant ([1e0a65a](https://github.com/liferay/clay/commit/1e0a65a))
-   **@clayui/css:** Alerts adds `alert-feedback` modifier ([51b57e6](https://github.com/liferay/clay/commit/51b57e6)), closes [#3968](https://github.com/liferay/clay/issues/3968)
-   **@clayui/css:** Date Picker adds Date Range styles ([a385e6a](https://github.com/liferay/clay/commit/a385e6a))
-   **@clayui/date-picker:** Adds ClayDatePicker Range variation ([eee769d](https://github.com/liferay/clay/commit/eee769d))