### PR TITLE
LPS-130836 Fix header and background page disappear when opening a modal using ItemSelectorDialog

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -525,7 +525,7 @@ AUI.add(
 
 				instance._bindDOMWinResizeIfNeeded();
 
-				modal.render();
+				modal.render('body > div:last-child');
 
 				instance._setWindowDefaultSizeIfNeeded(modal);
 

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
@@ -61,3 +61,13 @@
 		}
 	}
 }
+
+html.modal-open {
+	overflow: initial;
+}
+
+.modal-open {
+	.modal {
+		overflow: hidden;
+	}
+}


### PR DESCRIPTION
LPS-130836 Fix header and background page disappear when opening a modal using ItemSelectorDialogdal when there is a scroll on the page

First fix `modal.render('body > div:last-child');` is making modal render in a separate DIV element at the end, in the body and not first as now.

Second we change the overflow added on the html element and on the modal. 
We leave overflow:hidden only on the body.


https://user-images.githubusercontent.com/59687465/115567487-9b1ec080-a2bb-11eb-93b0-6dffc62b0f06.mp4

