### PR TITLE
LPS-130629 clay:button is not adding type="button" as before

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -51,6 +51,10 @@ public class ButtonTag extends BaseContainerTag {
 					title));
 		}
 
+		if (dynamicAttributes.get("type") == null) {
+			setDynamicAttribute(StringPool.BLANK, "type", "button");
+		}
+
 		return super.doStartTag();
 	}
 


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-130629

See descriptions and steps to reproduce in the ticket.

In `ClayButton`, we are [setting](https://github.com/liferay/clay/blob/master/packages/clay-button/src/Button.tsx#L62) `type="button"` as default. This is a good default behavior, as we are preventing unintended form submissions.

But, `<clay:button>` tag does not always use `ClayButton` to hydrate. If we [don't have a reason to](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java#L146-L148), we are only doing server-side rendering. This optimization makes sense, as we are almost always rendering simple buttons. The problem is that SSR does not set `type="button"` as default. In this PR, we are adding that, matching SSR with Clay markup.