### PR TITLE
LPS-130743 Allow make configurable the absolute maximum allowed delta | master

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2588,6 +2588,10 @@ public class PropsValues {
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.SEARCH_CONTAINER_PAGE_ITERATOR_MAX_PAGES));
 
+	public static final int SEARCH_CONTAINER_PAGE_MAX_DELTA =
+		GetterUtil.getInteger(
+			PropsUtil.get(PropsKeys.SEARCH_CONTAINER_PAGE_MAX_DELTA), 200);
+
 	/**
 	 * @deprecated As of Judson (7.1.x), with no direct replacement
 	 */

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9270,8 +9270,7 @@
     search.container.page.iterator.max.pages=25
 
     #
-    # Set the maximum allowed delta.
-    # See: "search.container.page.delta.values"
+    # Set the maximum allowed delta. See: "search.container.page.delta.values"
     #
     # Env: LIFERAY_SEARCH_PERIOD_CONTAINER_PERIOD_PAGE_PERIOD_MAX_PERIOD_DELTA
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9249,7 +9249,8 @@
     #
     # Always include the value specified in the property
     # "search.container.page.default.delta", since it is the default page size
-    # when no delta is specified. The absolute maximum allowed delta is 200.
+    # when no delta is specified. The absolute maximum allowed delta is
+    # "search.container.page.max.delta".
     #
     # Env: LIFERAY_SEARCH_PERIOD_CONTAINER_PERIOD_PAGE_PERIOD_DELTA_PERIOD_VALUES
     #
@@ -9267,6 +9268,14 @@
     # Env: LIFERAY_SEARCH_PERIOD_CONTAINER_PERIOD_PAGE_PERIOD_ITERATOR_PERIOD_MAX_PERIOD_PAGES
     #
     search.container.page.iterator.max.pages=25
+
+    #
+    # Set the maximum allowed delta.
+    # See: "search.container.page.delta.values"
+    #
+    # Env: LIFERAY_SEARCH_PERIOD_CONTAINER_PERIOD_PAGE_PERIOD_MAX_PERIOD_DELTA
+    #
+    search.container.page.max.delta=200
 
     #
     # These properties are deprecated and will be removed in a future release.

--- a/portal-impl/test/unit/com/liferay/portal/kernel/dao/search/SearchContainerTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/dao/search/SearchContainerTest.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.kernel.dao.search;
 
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ProxyFactory;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -113,6 +116,21 @@ public class SearchContainerTest {
 
 		Assert.assertEquals(20, _searchContainer.getStart());
 		Assert.assertEquals(40, _searchContainer.getEnd());
+	}
+
+	@SuppressWarnings("static-access")
+	@Test
+	public void testMaxDelta() {
+		buildSearchContainer(1);
+
+		int maxDelta = GetterUtil.getInteger(
+				PropsUtil.get(PropsKeys.SEARCH_CONTAINER_PAGE_MAX_DELTA), 200);
+
+		if (maxDelta <= 0) {
+			Assert.assertEquals(200, _searchContainer.MAX_DELTA);
+		} else {
+			Assert.assertEquals(maxDelta, _searchContainer.MAX_DELTA);
+		}
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/kernel/dao/search/SearchContainerTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/dao/search/SearchContainerTest.java
@@ -124,11 +124,12 @@ public class SearchContainerTest {
 		buildSearchContainer(1);
 
 		int maxDelta = GetterUtil.getInteger(
-				PropsUtil.get(PropsKeys.SEARCH_CONTAINER_PAGE_MAX_DELTA), 200);
+			PropsUtil.get(PropsKeys.SEARCH_CONTAINER_PAGE_MAX_DELTA), 200);
 
 		if (maxDelta <= 0) {
 			Assert.assertEquals(200, _searchContainer.MAX_DELTA);
-		} else {
+		}
+		else {
 			Assert.assertEquals(maxDelta, _searchContainer.MAX_DELTA);
 		}
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +67,18 @@ public class SearchContainer<R> {
 
 	public static final String DEFAULT_VAR = "searchContainer";
 
-	public static final int MAX_DELTA = 200;
+	public static final int MAX_DELTA;
+	
+	static {
+		int maxDelta = GetterUtil.getInteger(
+			PropsUtil.get(PropsKeys.SEARCH_CONTAINER_PAGE_MAX_DELTA), 200);
+
+		if (maxDelta <= 0) {
+			maxDelta = 200;
+		}
+
+		MAX_DELTA = maxDelta;
+	}
 
 	public SearchContainer() {
 		_curParam = DEFAULT_CUR_PARAM;

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +67,7 @@ public class SearchContainer<R> {
 	public static final String DEFAULT_VAR = "searchContainer";
 
 	public static final int MAX_DELTA;
-	
+
 	static {
 		int maxDelta = GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.SEARCH_CONTAINER_PAGE_MAX_DELTA), 200);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2873,7 +2873,7 @@ public interface PropsKeys {
 		"search.container.page.iterator.max.pages";
 
 	public static final String SEARCH_CONTAINER_PAGE_MAX_DELTA =
-		"search.container.page.max.delta";	
+		"search.container.page.max.delta";
 
 	/**
 	 * @deprecated As of Judson (7.1.x), with no direct replacement

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2872,6 +2872,9 @@ public interface PropsKeys {
 	public static final String SEARCH_CONTAINER_PAGE_ITERATOR_MAX_PAGES =
 		"search.container.page.iterator.max.pages";
 
+	public static final String SEARCH_CONTAINER_PAGE_MAX_DELTA =
+		"search.container.page.max.delta";	
+
 	/**
 	 * @deprecated As of Judson (7.1.x), with no direct replacement
 	 */


### PR DESCRIPTION
### **Description:**
Currently the absolute maximum allowed delta value is hardcoded and there is no way to change it. Its value is 200.
Thus, property `search.container.page.default.delta` can not define a value bigger than 200.

### **Steps to reproduce:**
Define  `search.container.page.default.delta=300` in _portal-ext.properties_ file.

Create 300 web content assets using the attached groovy script available in [LPS-130743](https://issues.liferay.com/secure/attachment/402079/LPS-130743-master.groovy).

**Checkpoint A**
Navigate to _Content & Data -> Web Content_

- **Observed behavior:**

>  200 assets are showed: delta = 200.

- **Expected behavior:**

> 300 assets are showed: delta = 300.

**Checkpoint B**
In a new widget page, add _Search Bar_, _Search Options_ and _Search Results_ widgets.
In _Search Options_ configuration, set _'Allow Empty Searchs'_ check.
In _Search Results_ configuration, set '_Pagination Delta_' parameter value to 300.
In _Search Bar,_ click on search with no terms (empty search) to get all assets (web contents).

- **Observed behavior:**
> 200 assets are showed: delta = 200.

- **Expected behavior:**
> 300 assets are showed: delta = 300.


### Solution proposed:
A new property is defined in _portal-ext.properties_ to set the absolute maximum allowed delta value.
The new property is **`search.container.page.max.delta`** 
This new property works together with _search.container.page.default.delta_ property in the following way:
- `search.container.page.max.delta` default value is 200.
- `search.container.page.default.delta `default value remains in 200.
 Default values apply when either property is not defined or property is defined with a value <= 0
- If `search.container.page.max.delta` > `search.container.page.default.delta` then _delta_ = `search.container.page.default.delta`
- If `search.container.page.max.delta` < `search.container.page.default.delta` then _delta_ = `search.container.page.max.delta`

So a basic example testing case would be:
- Define `search.container.page.default.delta=300` in _portal-ext.properties_ file.
- Define `search.container.page.max.delta=350` in _portal-ext.properties_ file.
- Create 400 web content assets using the referred-to groovy script.

**Checkpoint A**
Navigate to _Content & Data -> Web Content_

- **Observed and expected behavior:**
300 assets are showed: delta = 300.

**Checkpoint B**

1. In a new widget page, add _Search Bar, Search Options_ and _Search Results _widgets.
2. In _Search Options _configuration, set _'Allow Empty Searchs'_ check.
3. In _Search Results_ configuration, set '_Pagination Delta'_ parameter value to 300.
Please, note that if a value greater than `search.container.page.max.delta` is set (i.e. 400) then `search.container.page.max.delta` is used.
4. In _Search Bar_, click on search with no terms (empty search) to get all assets (web contents).

- **Observed and expected behavior:**
 300 assets are showed: delta = 300.


### References:
https://issues.liferay.com/browse/PTR-1500
https://issues.liferay.com/browse/LPS-105522
https://issues.liferay.com/browse/LPS-130743

