### PR TITLE
LPS-129376 Limit list items in sidebar dropdown

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/css/main.scss
@@ -53,3 +53,7 @@
 		margin-bottom: 0.5rem;
 	}
 }
+
+.dropdown-menu__translation {
+	max-height: 295px;
+}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Translation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Translation.js
@@ -49,6 +49,9 @@ export default function Translation({onSelectedLanguageClick, viewURLs}) {
 				<ClayDropDown
 					active={active}
 					hasLeftSymbols
+					menuElementAttrs={{
+						className: 'dropdown-menu__translation',
+					}}
 					onActiveChange={setActive}
 					trigger={
 						<ClayButton


### PR DESCRIPTION
**Description**

The translations dropdown in the sidebar does not have any scroll, all the available translations appear in a huge list

**Solution**

As we are in a small place (sidebar with limited width), we decide to limit the height of the translations dropdown to show a scroll. We saw that in other screen sizes, these dropdowns change the height using `max-height: 295px` so we follow the same approach for the sidebar.

**Screenshot**

![Screenshot 2021-04-26 at 15 52 11](https://user-images.githubusercontent.com/15845466/116093921-5faf3800-a6a7-11eb-847f-2961d6443975.png)
