### PR TITLE
Test admin controls for documents and media (cards view) 319KB (35KB gziped)

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_admin.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_admin.scss
@@ -1,0 +1,14797 @@
+@charset "UTF-8";
+/**
+ * Clay 3.26.0
+ *
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/**
+ * Bootstrap v4.4.1
+ *
+ * SPDX-FileCopyrightText: © 2019 Twitter, Inc. <https://twitter.com>
+ * SPDX-FileCopyrightText: © 2019 The Bootstrap Authors <https://getbootstrap.com/>
+ *
+ * SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
+ */
+:root {
+  --blue: #4b9fff;
+  --indigo: #7785ff;
+  --purple: #af78ff;
+  --pink: #ff73c3;
+  --red: #ff5f5f;
+  --orange: #ffb46e;
+  --yellow: #ffd76e;
+  --green: #9be169;
+  --teal: #50d2a0;
+  --cyan: #5fc8ff;
+  --white: #fff;
+  --gray: #6b6c7e;
+  --gray-dark: #393a4a;
+  --primary: #0b5fff;
+  --secondary: #6b6c7e;
+  --success: #287d3c;
+  --info: #2e5aac;
+  --warning: #b95000;
+  --danger: #da1414;
+  --light: #f1f2f5;
+  --dark: #272833;
+  --breakpoint-xs: 0;
+  --breakpoint-sm: 576px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 992px;
+  --breakpoint-xl: 1280px;
+  --font-family-sans-serif: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+/* REUSE-Snippet-Begin
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: © 2016 Nicolas Gallagher and Jonathan Neal <https://github.com/necolas/normalize.css>
+ */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+main {
+  display: block;
+}
+
+body {
+  background-color: #fff;
+  color: #272833;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-size: 1rem;
+  font-weight: 400;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  line-height: 1.5;
+  margin: 0;
+  -ms-overflow-style: scrollbar;
+  text-align: inherit;
+}
+
+@media (max-width: 767.98px) {
+  body {
+    font-size: 1rem;
+  }
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+
+p {
+  margin-bottom: 1rem;
+  margin-top: 0;
+}
+
+abbr[title],
+abbr[data-original-title] {
+  cursor: help;
+  text-decoration: underline;
+  text-decoration: underline dotted;
+  text-decoration-skip-ink: none;
+}
+
+address {
+  font-style: normal;
+  margin-bottom: 1rem;
+}
+
+ol,
+ul,
+dl {
+  margin-bottom: 1rem;
+  margin-top: 0;
+}
+
+ol ol,
+ul ul,
+ol ul,
+ul ol {
+  margin-bottom: 0;
+}
+
+dt {
+  font-weight: 700;
+}
+
+dd {
+  margin-bottom: 0.5rem;
+  margin-left: 0;
+}
+
+blockquote {
+  margin: 0 0 1rem;
+}
+
+b,
+strong {
+  font-weight: 900;
+}
+
+sub,
+sup {
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+a {
+  color: #0b5fff;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+a:hover {
+  color: #004ad7;
+  text-decoration: underline;
+}
+
+[tabindex^='-'] {
+  outline: 0;
+}
+
+pre,
+code,
+kbd,
+samp {
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+pre {
+  margin-bottom: 1rem;
+  margin-top: 0;
+  overflow: auto;
+}
+
+figure {
+  margin: 0 0 1rem;
+}
+
+img {
+  vertical-align: middle;
+}
+
+svg {
+  overflow: hidden;
+  vertical-align: middle;
+}
+
+label {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+}
+
+input,
+button,
+select,
+optgroup,
+textarea {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  margin: 0;
+}
+
+button,
+input {
+  overflow: visible;
+}
+
+select {
+  word-wrap: normal;
+}
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  cursor: pointer;
+  -webkit-appearance: button;
+}
+
+button::-moz-focus-inner,
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner {
+  border-style: none;
+}
+
+input[type='date'],
+input[type='time'],
+input[type='datetime-local'],
+input[type='month'] {
+  -webkit-appearance: listbox;
+}
+
+textarea {
+  overflow: auto;
+}
+
+fieldset {
+  border: 0;
+  margin: 0;
+  min-width: 0;
+  padding: 0;
+}
+
+legend {
+  color: inherit;
+  display: block;
+  font-size: 1.5rem;
+  line-height: inherit;
+  margin-bottom: 0.5rem;
+  max-width: 100%;
+  padding: 0;
+  white-space: normal;
+  width: 100%;
+}
+
+progress {
+  vertical-align: baseline;
+}
+
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
+  height: auto;
+}
+
+[type='search'] {
+  outline-offset: -2px;
+  -webkit-appearance: none;
+}
+
+[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+output {
+  display: inline-block;
+}
+
+summary {
+  display: list-item;
+  cursor: pointer;
+}
+
+template {
+  display: none;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+/* REUSE-Snippet-End */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  font-weight: 700;
+  line-height: 1.2;
+  margin-bottom: 0.5rem;
+}
+
+h1,
+.h1 {
+  font-size: 1.625rem;
+}
+
+h2,
+.h2 {
+  font-size: 1.375rem;
+}
+
+h3,
+.h3 {
+  font-size: 1.1875rem;
+}
+
+h4,
+.h4 {
+  font-size: 1rem;
+}
+
+h5,
+.h5 {
+  font-size: 0.875rem;
+}
+
+h6,
+.h6 {
+  font-size: 0.8125rem;
+}
+
+.lead {
+  font-size: 1.25rem;
+  font-weight: 300;
+}
+
+.display-1 {
+  font-size: 6rem;
+  font-weight: 300;
+  line-height: 1.2;
+}
+
+.display-2 {
+  font-size: 5.5rem;
+  font-weight: 300;
+  line-height: 1.2;
+}
+
+.display-3 {
+  font-size: 4.5rem;
+  font-weight: 300;
+  line-height: 1.2;
+}
+
+.display-4 {
+  font-size: 3.5rem;
+  font-weight: 300;
+  line-height: 1.2;
+}
+
+hr {
+  border-color: rgba(0, 0, 0, 0.1);
+  border-style: solid;
+  border-width: 0.0625rem 0 0 0;
+  margin-bottom: 1rem;
+  margin-top: 1rem;
+}
+
+small,
+.small {
+  font-size: 80%;
+  font-weight: 400;
+}
+
+mark,
+.mark {
+  background-color: #fcf8e3;
+  box-decoration-break: clone;
+  box-shadow: -0.25em 0 0 #fcf8e3;
+  display: inline;
+  line-height: normal;
+  padding: 2px 0.25em 3px 0;
+  position: relative;
+  white-space: pre-wrap;
+}
+
+mark:before,
+.mark:before {
+  background-color: #fcf8e3;
+  bottom: 0;
+  content: '';
+  display: block;
+  position: absolute;
+  right: 100%;
+  top: 0;
+  width: 0.25em;
+  z-index: -1;
+}
+
+.list-unstyled {
+  list-style: none;
+  padding-left: 0;
+}
+
+.list-inline {
+  list-style: none;
+  padding-left: 0;
+}
+
+.list-inline-item {
+  display: inline-block;
+}
+
+.list-inline-item:not(:last-child) {
+  margin-right: 0.5rem;
+}
+
+.initialism {
+  font-size: 90%;
+  text-transform: uppercase;
+}
+
+.blockquote {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.blockquote-footer {
+  color: #6b6c7e;
+  display: block;
+  font-size: 80%;
+}
+
+.blockquote-footer::before {
+  content: '\2014\00A0';
+}
+
+b {
+  font-weight: 600;
+}
+
+strong {
+  font-weight: 600;
+}
+
+.reference-mark {
+  display: inline-block;
+  font-size: 0.75rem;
+  position: relative;
+  vertical-align: super;
+}
+
+.c-kbd-group {
+  font-size: 0.875rem;
+}
+
+.c-kbd-group > .c-kbd {
+  font-size: inherit;
+}
+
+.c-kbd {
+  background-color: transparent;
+  border-radius: 2px;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: none;
+  color: inherit;
+  display: inline-block;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 600;
+  height: 1.5rem;
+  line-height: 1.375rem;
+  min-width: 1.5rem;
+  padding-bottom: 0;
+  padding-left: 0.3125rem;
+  padding-right: 0.3125rem;
+  padding-top: 0;
+  text-align: center;
+  text-transform: capitalize;
+}
+
+.c-kbd > .c-kbd {
+  border-width: 0;
+  font-size: inherit;
+  font-weight: inherit;
+  height: auto;
+  line-height: inherit;
+  min-width: 0;
+  padding: 0;
+}
+
+.c-kbd > .c-kbd[class*='c-kbd-'] {
+  border-width: inherit;
+  height: inherit;
+  min-width: inherit;
+  padding: inherit;
+}
+
+.c-kbd > .c-kbd[class*='c-kbd-']:first-child {
+  margin-left: -0.3125rem;
+}
+
+.c-kbd > .c-kbd[class*='c-kbd-']:last-child {
+  margin-right: -0.3125rem;
+}
+
+.c-kbd > .c-kbd.c-kbd-monospaced {
+  padding: 0;
+}
+
+.c-kbd > .c-kbd-separator {
+  font-weight: 400;
+}
+
+.c-kbd-monospaced {
+  padding: 0;
+}
+
+.c-kbd-inline {
+  border-width: 0;
+  font-weight: 300;
+  height: auto;
+  line-height: inherit;
+  min-width: 0;
+  padding: 0;
+}
+
+.c-kbd-inline .c-kbd-separator {
+  font-weight: inherit;
+}
+
+.c-kbd-sm,
+.c-kbd.c-kbd-sm {
+  font-size: 0.75rem;
+}
+
+.c-kbd-group-sm {
+  font-size: 0.75rem;
+}
+
+.c-kbd-lg,
+.c-kbd.c-kbd-lg {
+  font-size: 1rem;
+}
+
+.c-kbd-group-lg {
+  font-size: 1rem;
+}
+
+.c-kbd-group-light {
+  color: #6b6c7e;
+}
+
+.c-kbd-light {
+  background-color: #fff;
+  border-color: #cdced9;
+  color: #6b6c7e;
+}
+
+.c-kbd-group-dark {
+  color: #fff;
+}
+
+.c-kbd-dark {
+  background-color: #393a4a;
+  border-color: #393a4a;
+  color: #fff;
+}
+
+.text-truncate {
+  display: block;
+}
+
+.text-truncate-inline {
+  display: inline-flex;
+  max-width: 100%;
+}
+
+.text-truncate-inline .text-truncate {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.lexicon-icon {
+  display: inline-block;
+  fill: currentColor;
+  height: 1em;
+  margin-top: -3px;
+  vertical-align: middle;
+  width: 1em;
+}
+
+.lexicon-icon-sm {
+  font-size: 0.5rem;
+}
+
+.lexicon-icon-lg {
+  font-size: 2rem;
+}
+
+.lexicon-icon-xl {
+  font-size: 8rem;
+}
+
+.order-arrow-down-active .order-arrow-arrow-down {
+  fill: #a7a9bc;
+}
+
+.order-arrow-up-active .order-arrow-arrow-up {
+  fill: #a7a9bc;
+}
+
+a.collapse-icon,
+button.collapse-icon {
+  padding-right: 2.28125rem;
+}
+
+a.collapse-icon .c-inner,
+button.collapse-icon .c-inner {
+  margin-right: -2.28125rem;
+}
+
+.collapse-icon-closed .lexicon-icon,
+.collapse-icon-open .lexicon-icon {
+  display: block;
+}
+
+.collapse-icon .collapse-icon-closed,
+.collapse-icon .collapse-icon-open {
+  height: 1em;
+  position: absolute;
+  right: 0.9375rem;
+  top: calc(0.625rem + 0.0625rem + (((0.9375em * 1.5) - 1em) / 2));
+  width: 1em;
+}
+
+.collapse-icon .collapse-icon-closed .lexicon-icon,
+.collapse-icon .collapse-icon-open .lexicon-icon {
+  margin-top: 0;
+}
+
+.collapse-icon .collapse-icon-closed {
+  display: none;
+}
+
+.collapse-icon .collapse-icon-open {
+  display: inline-block;
+}
+
+.collapsed .collapse-icon-closed {
+  display: inline-block;
+}
+
+.collapsed .collapse-icon-open {
+  display: none;
+}
+
+.collapse-icon.collapse-icon-middle .collapse-icon-closed,
+.collapse-icon.collapse-icon-middle .collapse-icon-open {
+  margin-top: 0;
+  top: 50%;
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.aspect-ratio {
+  display: block;
+  overflow: hidden;
+  position: relative;
+  padding-bottom: 100%;
+}
+
+.aspect-ratio-item {
+  left: 0;
+  position: absolute;
+  word-wrap: break-word;
+}
+
+.aspect-ratio-item-fluid, .sticker-img {
+  max-width: 100%;
+  position: absolute;
+  word-wrap: break-word;
+}
+
+.aspect-ratio-item-vertical-fluid {
+  max-height: 100%;
+  position: absolute;
+  word-wrap: break-word;
+}
+
+.aspect-ratio-item-flush {
+  max-width: none;
+  position: absolute;
+  width: 100.6%;
+}
+
+.aspect-ratio-item-vertical-flush {
+  height: 100.6%;
+  max-height: none;
+  position: absolute;
+}
+
+.aspect-ratio-item-top-left {
+  position: absolute;
+  bottom: auto;
+  left: 0;
+  right: auto;
+  top: 0;
+}
+
+.aspect-ratio-item-top-center {
+  position: absolute;
+  bottom: auto;
+  left: 50%;
+  right: auto;
+  top: 0;
+  transform: translateX(-50%) ;
+}
+
+.aspect-ratio-item-top-right {
+  position: absolute;
+  bottom: auto;
+  left: auto;
+  right: 0;
+  top: 0;
+}
+
+.aspect-ratio-item-right-middle {
+  position: absolute;
+  bottom: auto;
+  left: auto;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%) ;
+}
+
+.aspect-ratio-item-bottom-right {
+  position: absolute;
+  bottom: 0;
+  left: auto;
+  right: 0;
+  top: auto;
+}
+
+.aspect-ratio-item-bottom-center {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  right: auto;
+  transform: translateX(-50%) ;
+}
+
+.aspect-ratio-item-bottom-left {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: auto;
+  top: auto;
+}
+
+.aspect-ratio-item-left-middle {
+  position: absolute;
+  bottom: auto;
+  left: 0;
+  right: auto;
+  top: 50%;
+  transform: translateY(-50%) ;
+}
+
+.aspect-ratio-item-center-middle, .sticker-img {
+  position: absolute;
+  bottom: auto;
+  left: 50%;
+  right: auto;
+  top: 50%;
+  transform: translate(-50%, -50%) ;
+}
+
+.aspect-ratio-3-to-2 {
+  padding-bottom: 66.66666667%;
+}
+
+.aspect-ratio-4-to-3 {
+  padding-bottom: 75%;
+}
+
+.aspect-ratio-8-to-5 {
+  padding-bottom: 62.5%;
+}
+
+.aspect-ratio-16-to-9 {
+  padding-bottom: 56.25%;
+}
+
+.aspect-ratio-bg-contain {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+.aspect-ratio-bg-cover {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.aspect-ratio-bg-center {
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.container {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 12px;
+  padding-right: 12px;
+  width: 100%;
+}
+
+@media (min-width: 576px) {
+  .container {
+    max-width: 540px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 720px;
+  }
+}
+
+@media (min-width: 992px) {
+  .container {
+    max-width: 960px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1248px;
+  }
+}
+
+.container-fluid, .container-sm, .container-md, .container-lg, .container-xl {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 12px;
+  padding-right: 12px;
+  width: 100%;
+}
+
+@media (min-width: 576px) {
+  .container, .container-sm {
+    max-width: 540px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container, .container-sm, .container-md {
+    max-width: 720px;
+  }
+}
+
+@media (min-width: 992px) {
+  .container, .container-sm, .container-md, .container-lg {
+    max-width: 960px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container, .container-sm, .container-md, .container-lg, .container-xl {
+    max-width: 1248px;
+  }
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-left: -12px;
+  margin-right: -12px;
+}
+
+.no-gutters {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.no-gutters > .col,
+.no-gutters > [class*='col-'] {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col,
+.col-auto, .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12, .col-sm,
+.col-sm-auto, .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12, .col-md,
+.col-md-auto, .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12, .col-lg,
+.col-lg-auto, .col-xl-1, .col-xl-2, .col-xl-3, .col-xl-4, .col-xl-5, .col-xl-6, .col-xl-7, .col-xl-8, .col-xl-9, .col-xl-10, .col-xl-11, .col-xl-12, .col-xl,
+.col-xl-auto {
+  padding-left: 12px;
+  padding-right: 12px;
+  position: relative;
+  width: 100%;
+}
+
+.col {
+  flex-basis: 0;
+  flex-grow: 1;
+  max-width: 100%;
+}
+
+.row-cols-1 > * {
+  flex: 0 0 100%;
+  max-width: 100%;
+}
+
+.row-cols-2 > * {
+  flex: 0 0 50%;
+  max-width: 50%;
+}
+
+.row-cols-3 > * {
+  flex: 0 0 33.33333333%;
+  max-width: 33.33333333%;
+}
+
+.row-cols-4 > * {
+  flex: 0 0 25%;
+  max-width: 25%;
+}
+
+.row-cols-5 > * {
+  flex: 0 0 20%;
+  max-width: 20%;
+}
+
+.row-cols-6 > * {
+  flex: 0 0 16.66666667%;
+  max-width: 16.66666667%;
+}
+
+.col-auto {
+  flex: 0 0 auto;
+  max-width: 100%;
+  width: auto;
+}
+
+.col-1 {
+  flex: 0 0 8.33333333%;
+  max-width: 8.33333333%;
+}
+
+.col-2 {
+  flex: 0 0 16.66666667%;
+  max-width: 16.66666667%;
+}
+
+.col-3 {
+  flex: 0 0 25%;
+  max-width: 25%;
+}
+
+.col-4 {
+  flex: 0 0 33.33333333%;
+  max-width: 33.33333333%;
+}
+
+.col-5 {
+  flex: 0 0 41.66666667%;
+  max-width: 41.66666667%;
+}
+
+.col-6 {
+  flex: 0 0 50%;
+  max-width: 50%;
+}
+
+.col-7 {
+  flex: 0 0 58.33333333%;
+  max-width: 58.33333333%;
+}
+
+.col-8 {
+  flex: 0 0 66.66666667%;
+  max-width: 66.66666667%;
+}
+
+.col-9 {
+  flex: 0 0 75%;
+  max-width: 75%;
+}
+
+.col-10 {
+  flex: 0 0 83.33333333%;
+  max-width: 83.33333333%;
+}
+
+.col-11 {
+  flex: 0 0 91.66666667%;
+  max-width: 91.66666667%;
+}
+
+.col-12 {
+  flex: 0 0 100%;
+  max-width: 100%;
+}
+
+.order-first {
+  order: -1;
+}
+
+.order-last {
+  order: 13;
+}
+
+.order-0 {
+  order: 0;
+}
+
+.order-1 {
+  order: 1;
+}
+
+.order-2 {
+  order: 2;
+}
+
+.order-3 {
+  order: 3;
+}
+
+.order-4 {
+  order: 4;
+}
+
+.order-5 {
+  order: 5;
+}
+
+.order-6 {
+  order: 6;
+}
+
+.order-7 {
+  order: 7;
+}
+
+.order-8 {
+  order: 8;
+}
+
+.order-9 {
+  order: 9;
+}
+
+.order-10 {
+  order: 10;
+}
+
+.order-11 {
+  order: 11;
+}
+
+.order-12 {
+  order: 12;
+}
+
+.offset-1 {
+  margin-left: 8.33333333%;
+}
+
+.offset-2 {
+  margin-left: 16.66666667%;
+}
+
+.offset-3 {
+  margin-left: 25%;
+}
+
+.offset-4 {
+  margin-left: 33.33333333%;
+}
+
+.offset-5 {
+  margin-left: 41.66666667%;
+}
+
+.offset-6 {
+  margin-left: 50%;
+}
+
+.offset-7 {
+  margin-left: 58.33333333%;
+}
+
+.offset-8 {
+  margin-left: 66.66666667%;
+}
+
+.offset-9 {
+  margin-left: 75%;
+}
+
+.offset-10 {
+  margin-left: 83.33333333%;
+}
+
+.offset-11 {
+  margin-left: 91.66666667%;
+}
+
+@media (min-width: 576px) {
+  .col-sm {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+  .row-cols-sm-1 > * {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .row-cols-sm-2 > * {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .row-cols-sm-3 > * {
+    flex: 0 0 33.33333333%;
+    max-width: 33.33333333%;
+  }
+  .row-cols-sm-4 > * {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .row-cols-sm-5 > * {
+    flex: 0 0 20%;
+    max-width: 20%;
+  }
+  .row-cols-sm-6 > * {
+    flex: 0 0 16.66666667%;
+    max-width: 16.66666667%;
+  }
+  .col-sm-auto {
+    flex: 0 0 auto;
+    max-width: 100%;
+    width: auto;
+  }
+  .col-sm-1 {
+    flex: 0 0 8.33333333%;
+    max-width: 8.33333333%;
+  }
+  .col-sm-2 {
+    flex: 0 0 16.66666667%;
+    max-width: 16.66666667%;
+  }
+  .col-sm-3 {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .col-sm-4 {
+    flex: 0 0 33.33333333%;
+    max-width: 33.33333333%;
+  }
+  .col-sm-5 {
+    flex: 0 0 41.66666667%;
+    max-width: 41.66666667%;
+  }
+  .col-sm-6 {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .col-sm-7 {
+    flex: 0 0 58.33333333%;
+    max-width: 58.33333333%;
+  }
+  .col-sm-8 {
+    flex: 0 0 66.66666667%;
+    max-width: 66.66666667%;
+  }
+  .col-sm-9 {
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+  .col-sm-10 {
+    flex: 0 0 83.33333333%;
+    max-width: 83.33333333%;
+  }
+  .col-sm-11 {
+    flex: 0 0 91.66666667%;
+    max-width: 91.66666667%;
+  }
+  .col-sm-12 {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .order-sm-first {
+    order: -1;
+  }
+  .order-sm-last {
+    order: 13;
+  }
+  .order-sm-0 {
+    order: 0;
+  }
+  .order-sm-1 {
+    order: 1;
+  }
+  .order-sm-2 {
+    order: 2;
+  }
+  .order-sm-3 {
+    order: 3;
+  }
+  .order-sm-4 {
+    order: 4;
+  }
+  .order-sm-5 {
+    order: 5;
+  }
+  .order-sm-6 {
+    order: 6;
+  }
+  .order-sm-7 {
+    order: 7;
+  }
+  .order-sm-8 {
+    order: 8;
+  }
+  .order-sm-9 {
+    order: 9;
+  }
+  .order-sm-10 {
+    order: 10;
+  }
+  .order-sm-11 {
+    order: 11;
+  }
+  .order-sm-12 {
+    order: 12;
+  }
+  .offset-sm-0 {
+    margin-left: 0;
+  }
+  .offset-sm-1 {
+    margin-left: 8.33333333%;
+  }
+  .offset-sm-2 {
+    margin-left: 16.66666667%;
+  }
+  .offset-sm-3 {
+    margin-left: 25%;
+  }
+  .offset-sm-4 {
+    margin-left: 33.33333333%;
+  }
+  .offset-sm-5 {
+    margin-left: 41.66666667%;
+  }
+  .offset-sm-6 {
+    margin-left: 50%;
+  }
+  .offset-sm-7 {
+    margin-left: 58.33333333%;
+  }
+  .offset-sm-8 {
+    margin-left: 66.66666667%;
+  }
+  .offset-sm-9 {
+    margin-left: 75%;
+  }
+  .offset-sm-10 {
+    margin-left: 83.33333333%;
+  }
+  .offset-sm-11 {
+    margin-left: 91.66666667%;
+  }
+}
+
+@media (min-width: 768px) {
+  .col-md {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+  .row-cols-md-1 > * {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .row-cols-md-2 > * {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .row-cols-md-3 > * {
+    flex: 0 0 33.33333333%;
+    max-width: 33.33333333%;
+  }
+  .row-cols-md-4 > * {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .row-cols-md-5 > * {
+    flex: 0 0 20%;
+    max-width: 20%;
+  }
+  .row-cols-md-6 > * {
+    flex: 0 0 16.66666667%;
+    max-width: 16.66666667%;
+  }
+  .col-md-auto {
+    flex: 0 0 auto;
+    max-width: 100%;
+    width: auto;
+  }
+  .col-md-1 {
+    flex: 0 0 8.33333333%;
+    max-width: 8.33333333%;
+  }
+  .col-md-2 {
+    flex: 0 0 16.66666667%;
+    max-width: 16.66666667%;
+  }
+  .col-md-3 {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .col-md-4 {
+    flex: 0 0 33.33333333%;
+    max-width: 33.33333333%;
+  }
+  .col-md-5 {
+    flex: 0 0 41.66666667%;
+    max-width: 41.66666667%;
+  }
+  .col-md-6 {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .col-md-7 {
+    flex: 0 0 58.33333333%;
+    max-width: 58.33333333%;
+  }
+  .col-md-8 {
+    flex: 0 0 66.66666667%;
+    max-width: 66.66666667%;
+  }
+  .col-md-9 {
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+  .col-md-10 {
+    flex: 0 0 83.33333333%;
+    max-width: 83.33333333%;
+  }
+  .col-md-11 {
+    flex: 0 0 91.66666667%;
+    max-width: 91.66666667%;
+  }
+  .col-md-12 {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .order-md-first {
+    order: -1;
+  }
+  .order-md-last {
+    order: 13;
+  }
+  .order-md-0 {
+    order: 0;
+  }
+  .order-md-1 {
+    order: 1;
+  }
+  .order-md-2 {
+    order: 2;
+  }
+  .order-md-3 {
+    order: 3;
+  }
+  .order-md-4 {
+    order: 4;
+  }
+  .order-md-5 {
+    order: 5;
+  }
+  .order-md-6 {
+    order: 6;
+  }
+  .order-md-7 {
+    order: 7;
+  }
+  .order-md-8 {
+    order: 8;
+  }
+  .order-md-9 {
+    order: 9;
+  }
+  .order-md-10 {
+    order: 10;
+  }
+  .order-md-11 {
+    order: 11;
+  }
+  .order-md-12 {
+    order: 12;
+  }
+  .offset-md-0 {
+    margin-left: 0;
+  }
+  .offset-md-1 {
+    margin-left: 8.33333333%;
+  }
+  .offset-md-2 {
+    margin-left: 16.66666667%;
+  }
+  .offset-md-3 {
+    margin-left: 25%;
+  }
+  .offset-md-4 {
+    margin-left: 33.33333333%;
+  }
+  .offset-md-5 {
+    margin-left: 41.66666667%;
+  }
+  .offset-md-6 {
+    margin-left: 50%;
+  }
+  .offset-md-7 {
+    margin-left: 58.33333333%;
+  }
+  .offset-md-8 {
+    margin-left: 66.66666667%;
+  }
+  .offset-md-9 {
+    margin-left: 75%;
+  }
+  .offset-md-10 {
+    margin-left: 83.33333333%;
+  }
+  .offset-md-11 {
+    margin-left: 91.66666667%;
+  }
+}
+
+@media (min-width: 992px) {
+  .col-lg {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+  .row-cols-lg-1 > * {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .row-cols-lg-2 > * {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .row-cols-lg-3 > * {
+    flex: 0 0 33.33333333%;
+    max-width: 33.33333333%;
+  }
+  .row-cols-lg-4 > * {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .row-cols-lg-5 > * {
+    flex: 0 0 20%;
+    max-width: 20%;
+  }
+  .row-cols-lg-6 > * {
+    flex: 0 0 16.66666667%;
+    max-width: 16.66666667%;
+  }
+  .col-lg-auto {
+    flex: 0 0 auto;
+    max-width: 100%;
+    width: auto;
+  }
+  .col-lg-1 {
+    flex: 0 0 8.33333333%;
+    max-width: 8.33333333%;
+  }
+  .col-lg-2 {
+    flex: 0 0 16.66666667%;
+    max-width: 16.66666667%;
+  }
+  .col-lg-3 {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .col-lg-4 {
+    flex: 0 0 33.33333333%;
+    max-width: 33.33333333%;
+  }
+  .col-lg-5 {
+    flex: 0 0 41.66666667%;
+    max-width: 41.66666667%;
+  }
+  .col-lg-6 {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .col-lg-7 {
+    flex: 0 0 58.33333333%;
+    max-width: 58.33333333%;
+  }
+  .col-lg-8 {
+    flex: 0 0 66.66666667%;
+    max-width: 66.66666667%;
+  }
+  .col-lg-9 {
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+  .col-lg-10 {
+    flex: 0 0 83.33333333%;
+    max-width: 83.33333333%;
+  }
+  .col-lg-11 {
+    flex: 0 0 91.66666667%;
+    max-width: 91.66666667%;
+  }
+  .col-lg-12 {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .order-lg-first {
+    order: -1;
+  }
+  .order-lg-last {
+    order: 13;
+  }
+  .order-lg-0 {
+    order: 0;
+  }
+  .order-lg-1 {
+    order: 1;
+  }
+  .order-lg-2 {
+    order: 2;
+  }
+  .order-lg-3 {
+    order: 3;
+  }
+  .order-lg-4 {
+    order: 4;
+  }
+  .order-lg-5 {
+    order: 5;
+  }
+  .order-lg-6 {
+    order: 6;
+  }
+  .order-lg-7 {
+    order: 7;
+  }
+  .order-lg-8 {
+    order: 8;
+  }
+  .order-lg-9 {
+    order: 9;
+  }
+  .order-lg-10 {
+    order: 10;
+  }
+  .order-lg-11 {
+    order: 11;
+  }
+  .order-lg-12 {
+    order: 12;
+  }
+  .offset-lg-0 {
+    margin-left: 0;
+  }
+  .offset-lg-1 {
+    margin-left: 8.33333333%;
+  }
+  .offset-lg-2 {
+    margin-left: 16.66666667%;
+  }
+  .offset-lg-3 {
+    margin-left: 25%;
+  }
+  .offset-lg-4 {
+    margin-left: 33.33333333%;
+  }
+  .offset-lg-5 {
+    margin-left: 41.66666667%;
+  }
+  .offset-lg-6 {
+    margin-left: 50%;
+  }
+  .offset-lg-7 {
+    margin-left: 58.33333333%;
+  }
+  .offset-lg-8 {
+    margin-left: 66.66666667%;
+  }
+  .offset-lg-9 {
+    margin-left: 75%;
+  }
+  .offset-lg-10 {
+    margin-left: 83.33333333%;
+  }
+  .offset-lg-11 {
+    margin-left: 91.66666667%;
+  }
+}
+
+@media (min-width: 1280px) {
+  .col-xl {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+  .row-cols-xl-1 > * {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .row-cols-xl-2 > * {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .row-cols-xl-3 > * {
+    flex: 0 0 33.33333333%;
+    max-width: 33.33333333%;
+  }
+  .row-cols-xl-4 > * {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .row-cols-xl-5 > * {
+    flex: 0 0 20%;
+    max-width: 20%;
+  }
+  .row-cols-xl-6 > * {
+    flex: 0 0 16.66666667%;
+    max-width: 16.66666667%;
+  }
+  .col-xl-auto {
+    flex: 0 0 auto;
+    max-width: 100%;
+    width: auto;
+  }
+  .col-xl-1 {
+    flex: 0 0 8.33333333%;
+    max-width: 8.33333333%;
+  }
+  .col-xl-2 {
+    flex: 0 0 16.66666667%;
+    max-width: 16.66666667%;
+  }
+  .col-xl-3 {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .col-xl-4 {
+    flex: 0 0 33.33333333%;
+    max-width: 33.33333333%;
+  }
+  .col-xl-5 {
+    flex: 0 0 41.66666667%;
+    max-width: 41.66666667%;
+  }
+  .col-xl-6 {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .col-xl-7 {
+    flex: 0 0 58.33333333%;
+    max-width: 58.33333333%;
+  }
+  .col-xl-8 {
+    flex: 0 0 66.66666667%;
+    max-width: 66.66666667%;
+  }
+  .col-xl-9 {
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+  .col-xl-10 {
+    flex: 0 0 83.33333333%;
+    max-width: 83.33333333%;
+  }
+  .col-xl-11 {
+    flex: 0 0 91.66666667%;
+    max-width: 91.66666667%;
+  }
+  .col-xl-12 {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .order-xl-first {
+    order: -1;
+  }
+  .order-xl-last {
+    order: 13;
+  }
+  .order-xl-0 {
+    order: 0;
+  }
+  .order-xl-1 {
+    order: 1;
+  }
+  .order-xl-2 {
+    order: 2;
+  }
+  .order-xl-3 {
+    order: 3;
+  }
+  .order-xl-4 {
+    order: 4;
+  }
+  .order-xl-5 {
+    order: 5;
+  }
+  .order-xl-6 {
+    order: 6;
+  }
+  .order-xl-7 {
+    order: 7;
+  }
+  .order-xl-8 {
+    order: 8;
+  }
+  .order-xl-9 {
+    order: 9;
+  }
+  .order-xl-10 {
+    order: 10;
+  }
+  .order-xl-11 {
+    order: 11;
+  }
+  .order-xl-12 {
+    order: 12;
+  }
+  .offset-xl-0 {
+    margin-left: 0;
+  }
+  .offset-xl-1 {
+    margin-left: 8.33333333%;
+  }
+  .offset-xl-2 {
+    margin-left: 16.66666667%;
+  }
+  .offset-xl-3 {
+    margin-left: 25%;
+  }
+  .offset-xl-4 {
+    margin-left: 33.33333333%;
+  }
+  .offset-xl-5 {
+    margin-left: 41.66666667%;
+  }
+  .offset-xl-6 {
+    margin-left: 50%;
+  }
+  .offset-xl-7 {
+    margin-left: 58.33333333%;
+  }
+  .offset-xl-8 {
+    margin-left: 66.66666667%;
+  }
+  .offset-xl-9 {
+    margin-left: 75%;
+  }
+  .offset-xl-10 {
+    margin-left: 83.33333333%;
+  }
+  .offset-xl-11 {
+    margin-left: 91.66666667%;
+  }
+}
+
+.container-fluid-max-sm {
+  max-width: 540px;
+}
+
+.container-fluid-max-md {
+  max-width: 720px;
+}
+
+.container-fluid-max-lg {
+  max-width: 960px;
+}
+
+.container-fluid-max-xl {
+  max-width: 1248px;
+}
+
+.container-no-gutters {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.container-no-gutters > .row {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.container-no-gutters > .row > .col,
+.container-no-gutters > .row > [class*='col-'] {
+  padding-right: 0;
+  padding-left: 0;
+}
+
+@media (max-width: 575.98px) {
+  .container-no-gutters-sm-down {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .container-no-gutters-sm-down > .row {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .container-no-gutters-sm-down > .row > .col,
+  .container-no-gutters-sm-down > .row > [class*='col-'] {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .container-no-gutters-md-down {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .container-no-gutters-md-down > .row {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .container-no-gutters-md-down > .row > .col,
+  .container-no-gutters-md-down > .row > [class*='col-'] {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .container-no-gutters-lg-down {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .container-no-gutters-lg-down > .row {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .container-no-gutters-lg-down > .row > .col,
+  .container-no-gutters-lg-down > .row > [class*='col-'] {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .container-no-gutters-xl-down {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .container-no-gutters-xl-down > .row {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .container-no-gutters-xl-down > .row > .col,
+  .container-no-gutters-xl-down > .row > [class*='col-'] {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+
+.card-page {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  margin-bottom: 0;
+  padding-left: 0;
+}
+
+.container .card-page,
+.container-fluid .card-page {
+  margin-left: -12px;
+  margin-right: -12px;
+}
+
+.container-form-lg {
+  padding-bottom: 3rem;
+  padding-top: 3rem;
+}
+
+@media (max-width: 991.98px) {
+  .container-form-lg {
+    padding-bottom: 1rem;
+    padding-top: 1rem;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .container-form-lg .menubar-vertical-expand-lg {
+    margin-top: -1rem;
+  }
+}
+
+.container-view {
+  padding-bottom: 1.5rem;
+  padding-top: 1.5rem;
+}
+
+.sticker {
+  align-items: center;
+  border-radius: 0.25rem;
+  height: 2rem;
+  line-height: 2rem;
+  width: 2rem;
+  display: inline-flex;
+  font-size: 1rem;
+  font-weight: 700;
+  justify-content: center;
+  position: relative;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.sticker > .inline-item {
+  justify-content: center;
+}
+
+.sticker > .inline-item .lexicon-icon,
+.sticker .lexicon-icon {
+  margin-top: 0;
+}
+
+.sticker.rounded .sticker-overlay {
+  border-radius: 0.25rem;
+}
+
+.sticker.rounded-circle .sticker-overlay {
+  border-radius: 5000px;
+}
+
+.sticker.rounded-0 .sticker-overlay {
+  border-radius: 0;
+}
+
+.sticker-overlay {
+  align-items: center;
+  border-radius: 0.25rem;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.sticker-bottom-left {
+  bottom: 1rem;
+  left: 1rem;
+  position: absolute;
+  right: auto;
+  top: auto;
+}
+
+.sticker-bottom-right {
+  bottom: 1rem;
+  left: auto;
+  position: absolute;
+  right: 1rem;
+  top: auto;
+}
+
+.sticker-top-left {
+  left: 1rem;
+  position: absolute;
+  top: 1rem;
+}
+
+.sticker-top-right {
+  left: auto;
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+}
+
+.sticker-outside {
+  left: -1rem;
+  top: -1rem;
+}
+
+.sticker-outside.sticker-bottom-left {
+  bottom: -1rem;
+  top: auto;
+}
+
+.sticker-outside.sticker-bottom-right {
+  bottom: -1rem;
+  left: auto;
+  right: -1rem;
+  top: auto;
+}
+
+.sticker-outside.sticker-top-right {
+  left: auto;
+  right: -1rem;
+}
+
+.sticker-user-icon {
+  border-radius: 5000px;
+  box-shadow: 0 0 0 1px #e7e7ed;
+  background-color: #fff;
+}
+
+.sticker-user-icon .sticker-overlay {
+  border-radius: 5000px;
+}
+
+.sticker-sm {
+  font-size: 0.75rem;
+  height: 1.5rem;
+  line-height: 1.5rem;
+  width: 1.5rem;
+}
+
+.sticker-sm.sticker-outside {
+  left: -0.75rem;
+  top: -0.75rem;
+}
+
+.sticker-sm.sticker-outside.sticker-bottom-left {
+  bottom: -0.75rem;
+  top: auto;
+}
+
+.sticker-sm.sticker-outside.sticker-bottom-right {
+  bottom: -0.75rem;
+  left: auto;
+  right: -0.75rem;
+  top: auto;
+}
+
+.sticker-sm.sticker-outside.sticker-top-right {
+  left: auto;
+  right: -0.75rem;
+}
+
+.sticker-lg {
+  font-size: 1.25rem;
+  height: 2.5rem;
+  line-height: 2.5rem;
+  width: 2.5rem;
+}
+
+.sticker-lg.sticker-outside {
+  left: -1.25rem;
+  top: -1.25rem;
+}
+
+.sticker-lg.sticker-outside.sticker-bottom-left {
+  bottom: -1.25rem;
+  top: auto;
+}
+
+.sticker-lg.sticker-outside.sticker-bottom-right {
+  bottom: -1.25rem;
+  left: auto;
+  right: -1.25rem;
+  top: auto;
+}
+
+.sticker-lg.sticker-outside.sticker-top-right {
+  left: auto;
+  right: -1.25rem;
+}
+
+.sticker-xl {
+  font-size: 1.5rem;
+  height: 3rem;
+  line-height: 3rem;
+  width: 3rem;
+}
+
+.sticker-xl.sticker-outside {
+  left: -1.5rem;
+  top: -1.5rem;
+}
+
+.sticker-xl.sticker-outside.sticker-bottom-left {
+  bottom: -1.5rem;
+  top: auto;
+}
+
+.sticker-xl.sticker-outside.sticker-bottom-right {
+  bottom: -1.5rem;
+  left: auto;
+  right: -1.5rem;
+  top: auto;
+}
+
+.sticker-xl.sticker-outside.sticker-top-right {
+  left: auto;
+  right: -1.5rem;
+}
+
+.sticker-primary {
+  background-color: #fff;
+  color: #0b5fff;
+}
+
+.sticker-secondary {
+  background-color: #fff;
+  color: #6b6c7e;
+}
+
+.sticker-success {
+  background-color: #fff;
+  color: #287d3c;
+}
+
+.sticker-info {
+  background-color: #fff;
+  color: #2e5aac;
+}
+
+.sticker-warning {
+  background-color: #fff;
+  color: #b95000;
+}
+
+.sticker-danger {
+  background-color: #fff;
+  color: #da1414;
+}
+
+.sticker-light {
+  background-color: #fff;
+  color: #272833;
+}
+
+.sticker-dark {
+  background-color: #272833;
+  color: #fff;
+}
+
+.sticker-circle,
+.sticker-circle .sticker-overlay {
+  border-radius: 5000px;
+}
+
+.breadcrumb {
+  background-color: transparent;
+  border-radius: 0.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.875rem;
+  list-style: none;
+  margin-bottom: 0;
+  padding: 0.59375rem 0.125rem;
+}
+
+.breadcrumb-link {
+  color: #6b6c7e;
+  display: block;
+  text-decoration: none;
+  border-radius: 1px;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.breadcrumb-link:hover {
+  color: #6b6c7e;
+  text-decoration: underline;
+}
+
+.breadcrumb-link:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  color: #6b6c7e;
+  outline: 0;
+  text-decoration: underline;
+}
+
+.breadcrumb-link > .breadcrumb-text-truncate {
+  text-decoration: none;
+}
+
+.breadcrumb-link > .breadcrumb-text-truncate:hover, .breadcrumb-link > .breadcrumb-text-truncate:focus {
+  text-decoration: underline;
+}
+
+.breadcrumb-item {
+  font-size: 0.875rem;
+  margin-right: 0.5em;
+  position: relative;
+}
+
+.breadcrumb-item.active,
+.breadcrumb-item .active {
+  color: #272833;
+  font-weight: 600;
+}
+
+.breadcrumb-item + .breadcrumb-item {
+  padding-left: 1em;
+}
+
+.breadcrumb-item + .breadcrumb-item::before {
+  color: #6b6c7e;
+  display: block;
+  float: left;
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M375.2%20239.2L173.3%2037c-23.6-23-59.9%2011.9-36%2035.1l183%20183.9-182.9%20183.8c-24%2023.5%2012.5%2058.2%2036.1%2035.2l201.7-202.1c10.2-10.1%209.3-24.4%200-33.7z'%20fill='%236b6c7e'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: 100%;
+  content: '';
+  height: 0.6em;
+  left: 0;
+  margin-top: -0.3em;
+  padding: 0;
+  position: absolute;
+  top: 50%;
+  width: 0.6em;
+}
+
+.breadcrumb-item + .breadcrumb-item:hover::before {
+  text-decoration: underline;
+}
+
+.breadcrumb-item + .breadcrumb-item:hover::before {
+  text-decoration: none;
+}
+
+.breadcrumb-item .dropdown-toggle {
+  text-decoration: none;
+}
+
+.breadcrumb-item .dropdown-toggle:hover, .breadcrumb-item .dropdown-toggle:focus {
+  text-decoration: none;
+}
+
+.breadcrumb-text-truncate {
+  display: inline-block;
+  max-width: 17.875rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
+
+@media (max-width: 767.98px) {
+  .breadcrumb-text-truncate {
+    max-width: 8.5rem;
+  }
+}
+
+.card,
+.card-horizontal {
+  background-color: #fff;
+  border-color: rgba(0, 0, 0, 0.125);
+  border-style: solid;
+  border-width: 0;
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 3px -1px rgba(0, 0, 0, 0.6);
+  display: block;
+  margin-bottom: 1.5rem;
+  min-width: 0;
+  position: relative;
+  word-wrap: break-word;
+}
+
+.card .autofit-col:first-child,
+.card-horizontal .autofit-col:first-child {
+  border-bottom-left-radius: 0.25rem;
+  border-top-left-radius: 0.25rem;
+}
+
+.card .autofit-col:last-child,
+.card-horizontal .autofit-col:last-child {
+  border-bottom-right-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.card .aspect-ratio .label,
+.card-horizontal .aspect-ratio .label {
+  display: block;
+  margin-bottom: 0.5rem;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0.5rem;
+}
+
+.card .aspect-ratio-item-top-left,
+.card-horizontal .aspect-ratio-item-top-left {
+  left: 1rem;
+  top: 1rem;
+}
+
+.card .aspect-ratio-item-top-center,
+.card-horizontal .aspect-ratio-item-top-center {
+  top: 1rem;
+}
+
+.card .aspect-ratio-item-top-right,
+.card-horizontal .aspect-ratio-item-top-right {
+  right: 1rem;
+  top: 1rem;
+}
+
+.card .aspect-ratio-item-right-middle,
+.card-horizontal .aspect-ratio-item-right-middle {
+  right: 1rem;
+}
+
+.card .aspect-ratio-item-bottom-right,
+.card-horizontal .aspect-ratio-item-bottom-right {
+  bottom: 1rem;
+  right: 1rem;
+}
+
+.card .aspect-ratio-item-bottom-center,
+.card-horizontal .aspect-ratio-item-bottom-center {
+  bottom: 1rem;
+}
+
+.card .aspect-ratio-item-bottom-left,
+.card-horizontal .aspect-ratio-item-bottom-left {
+  bottom: 1rem;
+  left: 1rem;
+}
+
+.card > hr,
+.card-horizontal > hr {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.card > .list-group:first-child .list-group-item:first-child,
+.card-horizontal > .list-group:first-child .list-group-item:first-child {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.card > .list-group:last-child .list-group-item:last-child,
+.card-horizontal > .list-group:last-child .list-group-item:last-child {
+  border-bottom-left-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.card-body {
+  flex: 1 1 auto;
+  min-height: 1px;
+  padding-bottom: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 1rem;
+}
+
+.card-section-header {
+  color: #6b6c7e;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 2.5;
+  margin-bottom: 1.5rem;
+  padding: 0 12px;
+  text-transform: uppercase;
+}
+
+.card-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.5;
+  margin-bottom: 0;
+  color: #272833;
+}
+
+.card-title a {
+  color: #272833;
+}
+
+.card-title a:hover {
+  color: #272833;
+}
+
+.card-subtitle {
+  color: #6b6c7e;
+  font-size: 0.875rem;
+  font-weight: 400;
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.card-subtitle a {
+  color: #6b6c7e;
+}
+
+.card-subtitle a:hover {
+  color: #6b6c7e;
+}
+
+.card-text:last-child {
+  margin-bottom: 0;
+}
+
+.card-link {
+  color: #6b6c7e;
+  font-size: 0.875rem;
+}
+
+.card-link:hover {
+  text-decoration: underline;
+  color: #6b6c7e;
+}
+
+.card-link.btn-unstyled {
+  white-space: normal;
+}
+
+.card-link + .card-link {
+  margin-left: 0;
+}
+
+.card-divider {
+  background-color: rgba(0, 0, 0, 0.125);
+  height: 1px;
+  margin-bottom: 10px;
+  margin-top: 10px;
+}
+
+.card-header {
+  background-color: rgba(0, 0, 0, 0.03);
+  border-bottom: 0 solid rgba(0, 0, 0, 0.125);
+  margin-bottom: 0;
+  padding: 0.75rem 1.25rem;
+}
+
+.card-header:first-child {
+  border-radius: 0.25rem 0.25rem 0 0;
+}
+
+.card-header + .list-group .list-group-item:first-child {
+  border-top: 0;
+}
+
+.card-header-tabs {
+  border-bottom: 0;
+  margin-bottom: -0.75rem;
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+}
+
+.card-header-pills {
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+}
+
+.card-footer {
+  background-color: rgba(0, 0, 0, 0.03);
+  border-top: 0 solid rgba(0, 0, 0, 0.125);
+  padding: 0.75rem 1.25rem;
+}
+
+.card-footer:last-child {
+  border-radius: 0 0 0.25rem 0.25rem;
+}
+
+.card-img-overlay {
+  bottom: 0;
+  left: 0;
+  padding: 1.25rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.card-img,
+.card-img-top,
+.card-img-bottom {
+  flex-shrink: 0;
+  width: 100%;
+}
+
+.card-img,
+.card-img-top {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.card-img,
+.card-img-bottom {
+  border-bottom-left-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.card-row {
+  display: flex;
+  width: 100%;
+}
+
+.card-row .autofit-col {
+  justify-content: center;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.card-row .autofit-col-expand {
+  min-width: 25px;
+}
+
+.card-row .autofit-col-gutters {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.card-row .autofit-col-gutters .card-divider {
+  margin-left: -10px;
+  margin-right: -10px;
+}
+
+.justify-content-center .autofit-col {
+  justify-content: center;
+}
+
+.justify-content-start .autofit-col {
+  justify-content: flex-start;
+}
+
+.justify-content-end .autofit-col {
+  justify-content: flex-end;
+}
+
+.text-center .autofit-col {
+  text-align: center;
+}
+
+.text-left .autofit-col {
+  text-align: left;
+}
+
+.text-right .autofit-col {
+  text-align: right;
+}
+
+.card-item-first {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+  width: 100%;
+}
+
+.autofit-col:first-child .card-item-first {
+  border-radius: 0.25rem 0 0 0.25rem;
+}
+
+.card-item-last {
+  border-bottom-left-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+  width: 100%;
+}
+
+.autofit-col:last-child .card-item-last {
+  border-radius: 0 0.25rem 0.25rem 0;
+}
+
+.rounded .card-header,
+.rounded .card-item-first {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.rounded .card-footer,
+.rounded .card-item-last {
+  border-bottom-left-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.rounded .autofit-col:first-child {
+  border-bottom-left-radius: 0.25rem;
+  border-top-left-radius: 0.25rem;
+}
+
+.rounded .autofit-col:first-child .card-item-first {
+  border-radius: 0.25rem 0 0 0.25rem;
+}
+
+.rounded .autofit-col:last-child {
+  border-bottom-right-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.rounded .autofit-col:last-child .card-item-last {
+  border-radius: 0 0.25rem 0.25rem 0;
+}
+
+.rounded-0 .card-header,
+.rounded-0 .card-item-first {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.rounded-0 .card-footer,
+.rounded-0 .card-item-last {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.rounded-0 .autofit-col:first-child {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.rounded-0 .autofit-col:first-child .card-item-first {
+  border-radius: 0 0 0 0;
+}
+
+.rounded-0 .autofit-col:last-child {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.rounded-0 .autofit-col:last-child .card-item-last {
+  border-radius: 0 0 0 0;
+}
+
+.rounded-circle .card-header,
+.rounded-circle .card-item-first {
+  border-top-left-radius: 5000px;
+  border-top-right-radius: 5000px;
+}
+
+.rounded-circle .card-footer,
+.rounded-circle .card-item-last {
+  border-bottom-left-radius: 5000px;
+  border-bottom-right-radius: 5000px;
+}
+
+.rounded-circle .autofit-col:first-child {
+  border-bottom-left-radius: 5000px;
+  border-top-left-radius: 5000px;
+}
+
+.rounded-circle .autofit-col:first-child .card-item-first {
+  border-radius: 5000px 0 0 5000px;
+}
+
+.rounded-circle .autofit-col:last-child {
+  border-bottom-right-radius: 5000px;
+  border-top-right-radius: 5000px;
+}
+
+.rounded-circle .autofit-col:last-child .card-item-last {
+  border-radius: 0 5000px 5000px 0;
+}
+
+.card-deck .card {
+  margin-bottom: 12px;
+}
+
+@media (min-width: 576px) {
+  .card-deck {
+    display: flex;
+    flex-flow: row wrap;
+    margin-left: -12px;
+    margin-right: -12px;
+  }
+  .card-deck .card {
+    flex: 1 0 0%;
+    margin-bottom: 0;
+    margin-left: 12px;
+    margin-right: 12px;
+  }
+}
+
+.card-group > .card {
+  margin-bottom: 12px;
+}
+
+@media (min-width: 576px) {
+  .card-group {
+    display: flex;
+    flex-flow: row wrap;
+  }
+  .card-group > .card {
+    flex: 1 0 0%;
+    margin-bottom: 0;
+  }
+  .card-group > .card + .card {
+    border-left: 0;
+    margin-left: 0;
+  }
+  .card-group > .card:not(:last-child) {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+  }
+  .card-group > .card:not(:last-child) .card-img-top,
+  .card-group > .card:not(:last-child) .card-header {
+    border-top-right-radius: 0;
+  }
+  .card-group > .card:not(:last-child) .card-img-bottom,
+  .card-group > .card:not(:last-child) .card-footer {
+    border-bottom-right-radius: 0;
+  }
+  .card-group > .card:not(:first-child) {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+  }
+  .card-group > .card:not(:first-child) .card-img-top,
+  .card-group > .card:not(:first-child) .card-header {
+    border-top-left-radius: 0;
+  }
+  .card-group > .card:not(:first-child) .card-img-bottom,
+  .card-group > .card:not(:first-child) .card-footer {
+    border-bottom-left-radius: 0;
+  }
+}
+
+.card-columns .card {
+  margin-bottom: 0.75rem;
+}
+
+@media (min-width: 576px) {
+  .card-columns {
+    column-count: 3;
+    column-gap: 1.25rem;
+    orphans: 1;
+    widows: 1;
+  }
+  .card-columns .card {
+    display: inline-block;
+    width: 100%;
+  }
+}
+
+.accordion > .card {
+  overflow: hidden;
+}
+
+.accordion > .card:not(:last-of-type) {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.accordion > .card:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.accordion > .card > .card-header {
+  border-radius: 0;
+  margin-bottom: 0;
+}
+
+.form-check-card {
+  margin-bottom: 1.5rem;
+  margin-top: 0;
+  padding-left: 0;
+}
+
+.form-check-card .card {
+  margin-bottom: 0;
+}
+
+.form-check-card .custom-control {
+  display: inline;
+  margin-right: 0;
+  position: static;
+}
+
+.form-check-card .custom-control > label {
+  font-weight: 400;
+  padding-left: 0;
+}
+
+.form-check-card .custom-control-input {
+  z-index: 2;
+}
+
+.form-check-card .custom-control-label {
+  position: absolute;
+  z-index: 1;
+}
+
+.form-check-card .custom-control-label::before, .form-check-card .custom-control-label::after {
+  top: 0;
+}
+
+.form-check-card .form-check-input {
+  margin-left: 0;
+  margin-top: 0;
+  position: absolute;
+  z-index: 1;
+}
+
+.form-check-card .form-check-label {
+  color: #272833;
+  display: inline;
+  font-weight: 400;
+  padding-left: 0;
+  position: static;
+}
+
+.form-check-card.active .card,
+.form-check-card .custom-control-input:checked ~ .card,
+.form-check-card .form-check-input:checked ~ .card {
+  box-shadow: 0 0 0 2px #80acff;
+}
+
+.form-check-card:hover .card {
+  box-shadow: 0 0 0 2px #80acff;
+}
+
+.custom-control-input:hover ~ .card,
+.form-check-input:hover ~ .card {
+  box-shadow: 0 0 0 2px #80acff;
+}
+
+.form-check-bottom-left .card-horizontal > .card-body,
+.form-check-middle-left .card-horizontal > .card-body,
+.form-check-top-left .card-horizontal > .card-body {
+  padding-left: 50px;
+}
+
+.form-check-bottom-right .card-horizontal > .card-body,
+.form-check-middle-right .card-horizontal > .card-body,
+.form-check-top-right .card-horizontal > .card-body {
+  padding-right: 50px;
+}
+
+.form-check-bottom-left .custom-control-input,
+.form-check-bottom-left .custom-control-label,
+.form-check-bottom-left .form-check-input {
+  bottom: 1rem;
+  left: 1rem;
+  top: auto;
+  transform: none;
+}
+
+.form-check-bottom-right .custom-control-input,
+.form-check-bottom-right .custom-control-label,
+.form-check-bottom-right .form-check-input {
+  bottom: 1rem;
+  left: auto;
+  right: 1rem;
+  top: auto;
+  transform: none;
+}
+
+.form-check-middle-left .custom-control-input,
+.form-check-middle-left .custom-control-label,
+.form-check-middle-left .form-check-input {
+  left: 1rem;
+  margin-top: 0;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.form-check-middle-right .custom-control-input,
+.form-check-middle-right .custom-control-label,
+.form-check-middle-right .form-check-input {
+  left: auto;
+  margin-top: 0;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.form-check-top-left .custom-control-input,
+.form-check-top-left .custom-control-label,
+.form-check-top-left .form-check-input {
+  left: 1rem;
+  top: 1rem;
+  transform: none;
+}
+
+.form-check-top-right .custom-control-input,
+.form-check-top-right .custom-control-label,
+.form-check-top-right .form-check-input {
+  left: auto;
+  right: 1rem;
+  top: 1rem;
+  transform: none;
+}
+
+.card-page.card-page-equal-height .card-page-item,
+.card-page.card-page-equal-height .card-page-item-asset,
+.card-page.card-page-equal-height .card-page-item-directory {
+  display: flex;
+  flex-direction: column;
+}
+
+.card-page.card-page-equal-height .form-check-card {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.card-page.card-page-equal-height .card {
+  flex-grow: 1;
+}
+
+.card-page-item-header {
+  padding-left: 12px;
+  padding-right: 12px;
+  width: 100%;
+}
+
+.card-page-item-directory {
+  display: block;
+  flex-grow: 1;
+  min-width: 193px;
+  padding-left: 12px;
+  padding-right: 12px;
+  position: relative;
+  width: 100%;
+}
+
+@media (min-width: 0) {
+  .card-page-item-directory {
+    min-width: 193px;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media (min-width: 576px) {
+  .card-page-item-directory {
+    flex-basis: 50%;
+    max-width: 50%;
+  }
+}
+
+@media (min-width: 768px) {
+  .card-page-item-directory {
+    flex-basis: 33.3333%;
+    max-width: 33.3333%;
+  }
+}
+
+@media (min-width: 992px) {
+  .card-page-item-directory {
+    flex-basis: 25%;
+    max-width: 25%;
+  }
+}
+
+.card-page-item-asset {
+  display: block;
+  flex-grow: 1;
+  min-width: 193px;
+  padding-left: 12px;
+  padding-right: 12px;
+  position: relative;
+  width: 100%;
+}
+
+@media (min-width: 0) {
+  .card-page-item-asset {
+    min-width: 193px;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media (min-width: 576px) {
+  .card-page-item-asset {
+    flex-basis: 50%;
+    max-width: 50%;
+  }
+}
+
+@media (min-width: 768px) {
+  .card-page-item-asset {
+    flex-basis: 33.3333%;
+    max-width: 33.3333%;
+  }
+}
+
+@media (min-width: 992px) {
+  .card-page-item-asset {
+    flex-basis: 25%;
+    max-width: 25%;
+  }
+}
+
+.card-page-item-user {
+  display: block;
+  flex-basis: 50%;
+  flex-grow: 1;
+  max-width: 50%;
+  padding-left: 12px;
+  padding-right: 12px;
+  position: relative;
+  width: 100%;
+}
+
+@media (min-width: 0) {
+  .card-page-item-user {
+    flex-basis: 50%;
+    max-width: 50%;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media (min-width: 576px) {
+  .card-page-item-user {
+    flex-basis: 33.33333%;
+    max-width: 33.33333%;
+    min-width: 200px;
+  }
+}
+
+@media (min-width: 992px) {
+  .card-page-item-user {
+    flex-basis: 20%;
+    max-width: 20%;
+  }
+}
+
+.card-interactive.card,
+.card-interactive .card {
+  cursor: pointer;
+  outline: 0;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.card-interactive.card:hover,
+.card-interactive .card:hover {
+  background-color: #f7f8f9;
+  text-decoration: none;
+}
+
+.card-interactive.card:focus,
+.card-interactive .card:focus {
+  box-shadow: 0 0 0 2px #FFF, 0 0 0 4px #719aff;
+}
+
+.card-interactive.card:active, .card-interactive.card.active,
+.card-interactive .card:active,
+.card-interactive .card.active {
+  background-color: #f1f2f5;
+}
+
+.card-interactive::after {
+  border-radius: 0 0 0.25rem 0.25rem;
+  bottom: 0;
+  content: "";
+  height: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  transition: height 0.15s ease-out;
+}
+
+.card-interactive:hover::after, .card-interactive.hover::after {
+  height: 4px;
+}
+
+.card-interactive:focus::after, .card-interactive.focus::after {
+  height: 4px;
+}
+
+.card-interactive:active::after, .card-interactive.active::after {
+  height: 4px;
+}
+
+.card-interactive .card-body {
+  display: block;
+}
+
+.card-interactive label {
+  cursor: pointer;
+}
+
+.card-interactive-primary.card:focus,
+.card-interactive-primary .card:focus {
+  background-color: #f7f8f9;
+}
+
+.card-interactive-primary.card:active, .card-interactive-primary.card.active,
+.card-interactive-primary .card:active,
+.card-interactive-primary .card.active {
+  background-color: #f1f2f5;
+}
+
+.card-interactive-primary:hover::after, .card-interactive-primary.hover::after {
+  background-color: #0b5fff;
+}
+
+.card-interactive-primary:active::after, .card-interactive-primary.active::after {
+  background-color: #0b5fff;
+}
+
+.card-interactive-secondary.card,
+.card-interactive-secondary .card {
+  color: #272833;
+}
+
+.card-interactive-secondary.card:hover,
+.card-interactive-secondary .card:hover {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: 0 0 0 2px #719aff;
+  color: #272833;
+}
+
+.card-interactive-secondary.card:focus,
+.card-interactive-secondary .card:focus {
+  border-color: transparent;
+  box-shadow: 0 0 0 2px #719aff;
+}
+
+.card-interactive-secondary.card:active, .card-interactive-secondary.card.active,
+.card-interactive-secondary .card:active,
+.card-interactive-secondary .card.active {
+  background-color: #fff;
+}
+
+.card-type-asset .aspect-ratio {
+  border-color: #e7e7ed;
+  border-style: solid;
+  border-width: 0 0 0.0625rem 0;
+  padding-bottom: 56.25%;
+}
+
+.card-type-asset .aspect-ratio .custom-control label,
+.card-type-asset .aspect-ratio .form-check-label {
+  bottom: 0;
+  cursor: pointer;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.card-type-asset .card-body {
+  padding-top: 0.75rem;
+}
+
+.card-type-asset .card-row {
+  align-items: flex-start;
+}
+
+.card-type-asset .card-type-asset-icon {
+  width: 22.225%;
+}
+
+.card-type-asset .card-type-asset-icon .inline-item {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.card-type-asset .card-type-asset-icon > .lexicon-icon {
+  height: 100%;
+  width: 100%;
+}
+
+.card-type-asset .card-type-asset-icon > .sticker {
+  border-radius: 50%;
+  display: block;
+  font-size: 2vw;
+  padding-bottom: 100%;
+  width: 100%;
+}
+
+.card-type-asset .card-type-asset-icon .sticker-overlay {
+  border-radius: 50%;
+}
+
+.card-type-asset .dropdown-action {
+  margin-right: -0.5rem;
+  margin-top: -0.1875rem;
+}
+
+.image-card .aspect-ratio {
+  background-image: linear-gradient(45deg, #e7e7ed 25%, transparent 25%), linear-gradient(-45deg, #e7e7ed 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #e7e7ed 75%), linear-gradient(-45deg, transparent 75%, #e7e7ed 75%);
+  background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+  background-size: 20px 20px;
+}
+
+.file-card .card-type-asset-icon {
+  color: #cdced9;
+}
+
+.product-card .aspect-ratio {
+  background-color: #fff;
+  background-image: linear-gradient(0deg, #ebebeb, #ebebeb);
+}
+
+.product-card .card-body {
+  text-align: center;
+}
+
+.product-card .card-title {
+  font-size: 1rem;
+}
+
+.product-card .card-subtitle {
+  font-size: 0.75rem;
+}
+
+.product-card .card-text {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.user-card .card-type-asset-icon {
+  max-width: 80px;
+  min-width: 48px;
+  width: 30%;
+}
+
+.user-card .card-type-asset-icon .lexicon-icon {
+  height: auto;
+  width: 50%;
+}
+
+.card-type-directory .dropdown-action {
+  margin-right: -0.5rem;
+}
+
+.card-type-directory .sticker {
+  font-size: 1.125rem;
+}
+
+.card-type-template.card,
+.card-type-template .card {
+  border-width: 1px;
+  box-shadow: none;
+  color: #272833;
+}
+
+.card-type-template.card:hover,
+.card-type-template .card:hover {
+  color: #272833;
+}
+
+.card-type-template::after {
+  bottom: -1px;
+  left: -1px;
+  right: -1px;
+}
+
+.card-type-template .aspect-ratio {
+  background-image: none;
+  border-width: 0;
+  color: #6b6c7e;
+  text-align: center;
+  padding-bottom: 56.25%;
+}
+
+.card-type-template .aspect-ratio .lexicon-icon {
+  height: auto;
+  width: 28%;
+}
+
+.card-type-template .aspect-ratio-item {
+  color: #6b6c7e;
+  width: 100.6%;
+}
+
+.card-type-template .card-title {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.card-type-template .card-text {
+  display: block;
+}
+
+.template-card .card-body {
+  padding-top: 0;
+  text-align: center;
+}
+
+.template-card-horizontal.card,
+.template-card-horizontal .card {
+  color: #6b6c7e;
+}
+
+.template-card-horizontal.card:hover,
+.template-card-horizontal .card:hover {
+  color: #6b6c7e;
+}
+
+.template-card-horizontal .sticker {
+  font-size: 1.25rem;
+}
+
+.template-card-horizontal .card-row {
+  margin-left: -4px;
+  margin-right: -4px;
+  width: auto;
+}
+
+.template-card-horizontal .card-row .autofit-col {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+.template-card-horizontal .card-title {
+  color: inherit;
+  margin-bottom: 0;
+}
+
+.btn {
+  background-color: transparent;
+  border: 0.0625rem solid transparent;
+  border-radius: 0.25rem;
+  box-shadow: none;
+  color: #272833;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5;
+  padding: 0.4375rem 0.9375rem;
+  text-align: center;
+  text-transform: none;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  user-select: none;
+  vertical-align: middle;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn {
+    transition: none;
+  }
+}
+
+.btn:hover {
+  color: #272833;
+  text-decoration: none;
+}
+
+.btn:focus, .btn.focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  outline: 0;
+}
+
+.btn:active, .btn.active {
+  box-shadow: none;
+}
+
+.btn:active:focus, .btn.active:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.btn.disabled, .btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.btn.disabled:focus, .btn.disabled:focus:active, .btn:disabled:focus, .btn:disabled:focus:active {
+  box-shadow: none;
+}
+
+.btn.disabled:active, .btn:disabled:active {
+  pointer-events: none;
+}
+
+fieldset:disabled a.btn {
+  box-shadow: none;
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+fieldset:disabled a.btn:active {
+  pointer-events: none;
+}
+
+.btn .inline-item {
+  font-size: 1rem;
+}
+
+.btn-section {
+  display: block;
+  font-size: 0.6875rem;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.btn-lg {
+  border-radius: 0.25rem;
+  font-size: 1.125rem;
+  line-height: 1.5;
+  padding-bottom: 0.59375rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-top: 0.59375rem;
+}
+
+.btn-lg .inline-item {
+  font-size: 1.125rem;
+}
+
+.btn-lg .btn-section {
+  font-size: 0.8125rem;
+}
+
+.btn-sm, .form-group-sm .btn {
+  border-radius: 0.1875rem;
+  font-size: 0.875rem;
+  line-height: 1.15;
+  padding-bottom: 0.4375rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.4375rem;
+}
+
+.btn-sm .btn-section, .form-group-sm .btn .btn-section {
+  font-size: 0.5625rem;
+}
+
+.btn-block {
+  display: block;
+  width: 100%;
+}
+
+.btn-block + .btn-block {
+  margin-top: 0.5rem;
+}
+
+input[type='submit'].btn-block,
+input[type='reset'].btn-block,
+input[type='button'].btn-block {
+  width: 100%;
+}
+
+.btn-unstyled, .menubar-toggler {
+  background-color: rgba(0, 0, 0, 0.001);
+  border-width: 0;
+  cursor: pointer;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  max-width: 100%;
+  padding: 0;
+  text-align: left;
+  text-transform: inherit;
+  vertical-align: baseline;
+}
+
+.btn-monospaced {
+  height: 2.5rem;
+  line-height: 1;
+  overflow: hidden;
+  padding-bottom: 0.25rem;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0.25rem;
+  text-align: center;
+  white-space: normal;
+  width: 2.5rem;
+  word-wrap: break-word;
+}
+
+.btn-monospaced.btn .lexicon-icon {
+  margin-top: 0;
+}
+
+.btn-monospaced.btn-lg {
+  height: 3rem;
+  padding-bottom: 0.375rem;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0.375rem;
+  width: 3rem;
+}
+
+.btn-monospaced.btn-sm {
+  height: 2rem;
+  padding-bottom: 0.1875rem;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0.1875rem;
+  width: 2rem;
+}
+
+.btn .c-inner {
+  margin: -0.4375rem -0.9375rem;
+}
+
+@media (max-width: 767.98px) {
+  .btn .c-inner {
+  }
+}
+
+.btn-unstyled .c-inner {
+  margin: 0;
+  max-width: none;
+}
+
+.btn-monospaced .c-inner {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: calc(100% + 0.5rem);
+  justify-content: center;
+  margin: -0.25rem 0;
+  padding: 0;
+  width: 100%;
+}
+
+.btn-sm .c-inner {
+  margin: -0.4375rem -0.75rem;
+}
+
+@media (max-width: 767.98px) {
+  .btn-sm .c-inner {
+  }
+}
+
+.btn-sm.btn-monospaced .c-inner {
+  height: calc(100% + 0.375rem);
+  margin: -0.1875rem 0;
+}
+
+.btn-lg .c-inner {
+  margin: -0.59375rem -1.5rem;
+}
+
+@media (max-width: 767.98px) {
+  .btn-lg .c-inner {
+  }
+}
+
+.btn-lg.btn-monospaced .c-inner {
+  height: calc(100% + 0.75rem);
+  margin: -0.375rem 0;
+}
+
+.btn-primary {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background-color: #0053f0;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-primary:focus, .btn-primary.focus {
+  background-color: #0053f0;
+  border-color: #004ad7;
+  color: #fff;
+}
+
+.btn-primary:active {
+  background-color: #004ad7;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-primary[aria-expanded='true'], .btn-primary.active, .btn-primary.show,
+.show > .btn-primary.dropdown-toggle {
+  background-color: #004ad7;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-primary:disabled, .btn-primary.disabled {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+  color: #fff;
+}
+
+.form-file-input:focus + .btn-primary {
+  background-color: #0053f0;
+  box-shadow: clay-unset;
+}
+
+.btn-secondary {
+  background-color: #fff;
+  border-color: #cdced9;
+  color: #6b6c7e;
+}
+
+.btn-secondary:hover {
+  background-color: #f7f8f9;
+  border-color: #cdced9;
+  color: #272833;
+}
+
+.btn-secondary:focus, .btn-secondary.focus {
+  background-color: #f7f8f9;
+  border-color: #cdced9;
+  color: #272833;
+}
+
+.btn-secondary:active {
+  background-color: #f1f2f5;
+  border-color: #cdced9;
+  color: #272833;
+}
+
+.btn-secondary[aria-expanded='true'], .btn-secondary.active, .btn-secondary.show,
+.show > .btn-secondary.dropdown-toggle {
+  background-color: #f1f2f5;
+  border-color: #cdced9;
+  color: #272833;
+}
+
+.btn-secondary:disabled, .btn-secondary.disabled {
+  background-color: #fff;
+  border-color: #cdced9;
+  color: #6b6c7e;
+}
+
+.form-file-input:focus + .btn-secondary {
+  background-color: #f7f8f9;
+  border-color: #cdced9;
+  box-shadow: clay-unset;
+  color: #272833;
+}
+
+.btn-success {
+  background-color: #287d3c;
+  border-color: #287d3c;
+  color: #fff;
+}
+
+.btn-success:hover {
+  background-color: #226a33;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-success:focus, .btn-success.focus {
+  background-color: #226a33;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-success:active {
+  background-color: #1c5629;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-success[aria-expanded='true'], .btn-success.active, .btn-success.show,
+.show > .btn-success.dropdown-toggle {
+  background-color: #1c5629;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-success:disabled, .btn-success.disabled {
+  background-color: #287d3c;
+  border-color: #287d3c;
+  color: #fff;
+}
+
+.form-file-input:focus + .btn-success {
+  background-color: #226a33;
+  border-color: transparent;
+  box-shadow: clay-unset;
+}
+
+.btn-info {
+  background-color: #2e5aac;
+  border-color: #2e5aac;
+  color: #fff;
+}
+
+.btn-info:hover {
+  background-color: #294f98;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-info:focus, .btn-info.focus {
+  background-color: #294f98;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-info:active {
+  background-color: #234584;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-info[aria-expanded='true'], .btn-info.active, .btn-info.show,
+.show > .btn-info.dropdown-toggle {
+  background-color: #234584;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-info:disabled, .btn-info.disabled {
+  background-color: #2e5aac;
+  border-color: #2e5aac;
+  color: #fff;
+}
+
+.btn-warning {
+  background-color: #b95000;
+  border-color: #b95000;
+  color: #fff;
+}
+
+.btn-warning:hover {
+  background-color: #9f4500;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-warning:focus, .btn-warning.focus {
+  background-color: #9f4500;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-warning:active {
+  background-color: #863a00;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-warning[aria-expanded='true'], .btn-warning.active, .btn-warning.show,
+.show > .btn-warning.dropdown-toggle {
+  background-color: #863a00;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-warning:disabled, .btn-warning.disabled {
+  background-color: #b95000;
+  border-color: #b95000;
+  color: #fff;
+}
+
+.form-file-input:focus + .btn-warning {
+  background-color: #9f4500;
+  border-color: transparent;
+  box-shadow: clay-unset;
+}
+
+.btn-danger {
+  background-color: #da1414;
+  border-color: #da1414;
+  color: #fff;
+}
+
+.btn-danger:hover {
+  background-color: #c31212;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-danger:focus, .btn-danger.focus {
+  background-color: #c31212;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-danger:active {
+  background-color: #ab1010;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-danger[aria-expanded='true'], .btn-danger.active, .btn-danger.show,
+.show > .btn-danger.dropdown-toggle {
+  background-color: #ab1010;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-danger:disabled, .btn-danger.disabled {
+  background-color: #da1414;
+  border-color: #da1414;
+  color: #fff;
+}
+
+.form-file-input:focus + .btn-danger {
+  background-color: #c31212;
+  border-color: transparent;
+  box-shadow: clay-unset;
+}
+
+.btn-light {
+  background-color: #f1f2f5;
+  border-color: #f1f2f5;
+  color: #272833;
+}
+
+.btn-light:hover {
+  background-color: #e2e4ea;
+  border-color: transparent;
+  color: #272833;
+}
+
+.btn-light:focus, .btn-light.focus {
+  background-color: #e2e4ea;
+  border-color: transparent;
+  color: #272833;
+}
+
+.btn-light:active {
+  background-color: #d3d6e0;
+  border-color: transparent;
+  color: #272833;
+}
+
+.btn-light[aria-expanded='true'], .btn-light.active, .btn-light.show,
+.show > .btn-light.dropdown-toggle {
+  background-color: #d3d6e0;
+  border-color: transparent;
+  color: #272833;
+}
+
+.btn-light:disabled, .btn-light.disabled {
+  background-color: #f1f2f5;
+  border-color: #f1f2f5;
+  color: #272833;
+}
+
+.form-file-input:focus + .btn-light {
+  background-color: #e2e4ea;
+  border-color: transparent;
+  box-shadow: clay-unset;
+}
+
+.btn-dark {
+  background-color: #272833;
+  border-color: #272833;
+  color: #fff;
+}
+
+.btn-dark:hover {
+  background-color: #1c1c24;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-dark:focus, .btn-dark.focus {
+  background-color: #1c1c24;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-dark:active {
+  background-color: #111116;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-dark[aria-expanded='true'], .btn-dark.active, .btn-dark.show,
+.show > .btn-dark.dropdown-toggle {
+  background-color: #111116;
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-dark:disabled, .btn-dark.disabled {
+  background-color: #272833;
+  border-color: #272833;
+  color: #fff;
+}
+
+.form-file-input:focus + .btn-dark {
+  background-color: #1c1c24;
+  border-color: transparent;
+  box-shadow: clay-unset;
+}
+
+.btn-link {
+  border-radius: 1px;
+  box-shadow: none;
+  color: #0b5fff;
+  font-weight: 400;
+  text-decoration: none;
+}
+
+.btn-link:hover {
+  color: #004ad7;
+  text-decoration: underline;
+}
+
+.btn-link:focus, .btn-link.focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  text-decoration: none;
+}
+
+.btn-link:active {
+  box-shadow: none;
+}
+
+.btn-link:active:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.btn-link[aria-expanded='true'], .btn-link.active, .btn-link.show,
+.show > .btn-link.dropdown-toggle {
+  box-shadow: none;
+}
+
+.btn-link:disabled, .btn-link.disabled {
+  box-shadow: none;
+  color: #0b5fff;
+  text-decoration: none;
+}
+
+.btn-outline-primary {
+  border-color: #0b5fff;
+  color: #0b5fff;
+}
+
+.btn-outline-primary:hover {
+  background-color: #f0f5ff;
+  border-color: #0b5fff;
+  color: #0b5fff;
+}
+
+.btn-outline-primary:focus, .btn-outline-primary.focus {
+  background-color: #f0f5ff;
+  color: #0b5fff;
+}
+
+.btn-outline-primary:active {
+  background-color: #e6edf8;
+  border-color: #0b5fff;
+  color: #0b5fff;
+}
+
+.btn-outline-primary[aria-expanded='true'], .btn-outline-primary.active, .btn-outline-primary.show,
+.show > .btn-outline-primary.dropdown-toggle {
+  background-color: #e6edf8;
+  border-color: #0b5fff;
+  color: #0b5fff;
+}
+
+.btn-outline-primary:disabled, .btn-outline-primary.disabled {
+  background-color: transparent;
+  color: #0b5fff;
+}
+
+.btn-outline-secondary {
+  border-color: #cdced9;
+  color: #6b6c7e;
+}
+
+.btn-outline-secondary:hover {
+  background-color: rgba(39, 40, 51, 0.03);
+  border-color: transparent;
+  color: #272833;
+}
+
+.btn-outline-secondary:focus, .btn-outline-secondary.focus {
+  background-color: rgba(39, 40, 51, 0.03);
+  border-color: transparent;
+  color: #272833;
+}
+
+.btn-outline-secondary:active {
+  background-color: rgba(39, 40, 51, 0.06);
+  border-color: transparent;
+  color: #272833;
+}
+
+.btn-outline-secondary[aria-expanded='true'], .btn-outline-secondary.active, .btn-outline-secondary.show,
+.show > .btn-outline-secondary.dropdown-toggle {
+  background-color: rgba(39, 40, 51, 0.06);
+  border-color: transparent;
+  color: #272833;
+}
+
+.btn-outline-secondary:disabled, .btn-outline-secondary.disabled {
+  background-color: transparent;
+  color: #6b6c7e;
+  border-color: #6b6c7e;
+}
+
+.btn-outline-success {
+  border-color: #287d3c;
+  color: #287d3c;
+}
+
+.btn-outline-success:hover {
+  background-color: #226a33;
+  border-color: #287d3c;
+  color: #fff;
+}
+
+.btn-outline-success:focus, .btn-outline-success.focus {
+  background-color: #226a33;
+  color: #fff;
+}
+
+.btn-outline-success:active {
+  background-color: #1c5629;
+  border-color: #287d3c;
+  color: #fff;
+}
+
+.btn-outline-success[aria-expanded='true'], .btn-outline-success.active, .btn-outline-success.show,
+.show > .btn-outline-success.dropdown-toggle {
+  background-color: #1c5629;
+  border-color: #287d3c;
+  color: #fff;
+}
+
+.btn-outline-success:disabled, .btn-outline-success.disabled {
+  background-color: transparent;
+  color: #287d3c;
+}
+
+.btn-outline-info {
+  border-color: #2e5aac;
+  color: #2e5aac;
+}
+
+.btn-outline-info:hover {
+  background-color: #294f98;
+  border-color: #2e5aac;
+  color: #fff;
+}
+
+.btn-outline-info:focus, .btn-outline-info.focus {
+  background-color: #294f98;
+  color: #fff;
+}
+
+.btn-outline-info:active {
+  background-color: #234584;
+  border-color: #2e5aac;
+  color: #fff;
+}
+
+.btn-outline-info[aria-expanded='true'], .btn-outline-info.active, .btn-outline-info.show,
+.show > .btn-outline-info.dropdown-toggle {
+  background-color: #234584;
+  border-color: #2e5aac;
+  color: #fff;
+}
+
+.btn-outline-info:disabled, .btn-outline-info.disabled {
+  background-color: transparent;
+  color: #2e5aac;
+}
+
+.btn-outline-warning {
+  border-color: #b95000;
+  color: #b95000;
+}
+
+.btn-outline-warning:hover {
+  background-color: #9f4500;
+  border-color: #b95000;
+  color: #fff;
+}
+
+.btn-outline-warning:focus, .btn-outline-warning.focus {
+  background-color: #9f4500;
+  color: #fff;
+}
+
+.btn-outline-warning:active {
+  background-color: #863a00;
+  border-color: #b95000;
+  color: #fff;
+}
+
+.btn-outline-warning[aria-expanded='true'], .btn-outline-warning.active, .btn-outline-warning.show,
+.show > .btn-outline-warning.dropdown-toggle {
+  background-color: #863a00;
+  border-color: #b95000;
+  color: #fff;
+}
+
+.btn-outline-warning:disabled, .btn-outline-warning.disabled {
+  background-color: transparent;
+  color: #b95000;
+}
+
+.btn-outline-danger {
+  border-color: #da1414;
+  color: #da1414;
+}
+
+.btn-outline-danger:hover {
+  background-color: #c31212;
+  border-color: #da1414;
+  color: #fff;
+}
+
+.btn-outline-danger:focus, .btn-outline-danger.focus {
+  background-color: #c31212;
+  color: #fff;
+}
+
+.btn-outline-danger:active {
+  background-color: #ab1010;
+  border-color: #da1414;
+  color: #fff;
+}
+
+.btn-outline-danger[aria-expanded='true'], .btn-outline-danger.active, .btn-outline-danger.show,
+.show > .btn-outline-danger.dropdown-toggle {
+  background-color: #ab1010;
+  border-color: #da1414;
+  color: #fff;
+}
+
+.btn-outline-danger:disabled, .btn-outline-danger.disabled {
+  background-color: transparent;
+  color: #da1414;
+}
+
+.btn-outline-light {
+  border-color: #f1f2f5;
+  color: #f1f2f5;
+}
+
+.btn-outline-light:hover {
+  background-color: #e2e4ea;
+  border-color: #f1f2f5;
+  color: #272833;
+}
+
+.btn-outline-light:focus, .btn-outline-light.focus {
+  background-color: #e2e4ea;
+  color: #272833;
+}
+
+.btn-outline-light:active {
+  background-color: #d3d6e0;
+  border-color: #f1f2f5;
+  color: #272833;
+}
+
+.btn-outline-light[aria-expanded='true'], .btn-outline-light.active, .btn-outline-light.show,
+.show > .btn-outline-light.dropdown-toggle {
+  background-color: #d3d6e0;
+  border-color: #f1f2f5;
+  color: #272833;
+}
+
+.btn-outline-light:disabled, .btn-outline-light.disabled {
+  background-color: transparent;
+  color: #f1f2f5;
+}
+
+.btn-outline-dark {
+  border-color: #272833;
+  color: #272833;
+}
+
+.btn-outline-dark:hover {
+  background-color: #1c1c24;
+  border-color: #272833;
+  color: #fff;
+}
+
+.btn-outline-dark:focus, .btn-outline-dark.focus {
+  background-color: #1c1c24;
+  color: #fff;
+}
+
+.btn-outline-dark:active {
+  background-color: #111116;
+  border-color: #272833;
+  color: #fff;
+}
+
+.btn-outline-dark[aria-expanded='true'], .btn-outline-dark.active, .btn-outline-dark.show,
+.show > .btn-outline-dark.dropdown-toggle {
+  background-color: #111116;
+  border-color: #272833;
+  color: #fff;
+}
+
+.btn-outline-dark:disabled, .btn-outline-dark.disabled {
+  background-color: transparent;
+  color: #272833;
+}
+
+.btn-outline-borderless {
+  border-color: transparent;
+}
+
+.btn-outline-borderless:hover, .btn-outline-borderless:focus {
+  border-color: transparent;
+}
+
+.btn-outline-borderless:disabled, .btn-outline-borderless.disabled {
+  border-color: transparent;
+}
+
+.btn-outline-borderless:not(:disabled):not(.disabled):active {
+  border-color: transparent;
+}
+
+.show > .btn-outline-borderless.dropdown-toggle {
+  border-color: transparent;
+}
+
+.btn .loading-animation {
+  font-size: 1em;
+  margin-top: -0.1em;
+}
+
+.dropup,
+.dropright,
+.dropdown,
+.dropleft {
+  position: relative;
+}
+
+.dropdown-toggle {
+  white-space: nowrap;
+}
+
+.dropdown-header {
+  color: #272833;
+  display: block;
+  font-size: 0.875rem;
+  margin-top: 0.625rem;
+  padding-bottom: 0.375rem;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  padding-top: 0.375rem;
+  position: relative;
+  word-wrap: break-word;
+}
+
+.dropdown-header:first-child {
+  margin-top: 0;
+}
+
+.dropdown-subheader {
+  color: #272833;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-top: 0.625rem;
+  padding-bottom: 0.375rem;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  padding-top: 0.375rem;
+  text-transform: uppercase;
+  white-space: normal;
+  word-wrap: break-word;
+}
+
+.dropdown-subheader:first-child {
+  margin-top: 0;
+}
+
+.dropdown-caption {
+  color: #6b6c7e;
+  font-size: 0.875rem;
+  padding: 0.5rem 1.25rem;
+  white-space: normal;
+  word-wrap: break-word;
+}
+
+.dropdown-item {
+  background-color: transparent;
+  border-radius: 0;
+  border-width: 0;
+  clear: both;
+  color: #6b6c7e;
+  cursor: pointer;
+  display: block;
+  font-weight: 400;
+  overflow: hidden;
+  padding-bottom: 0.5rem;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  padding-top: 0.5rem;
+  position: relative;
+  text-align: inherit;
+  transition: none;
+  white-space: normal;
+  width: 100%;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  font-size: inherit;
+}
+
+.dropdown-item:hover {
+  background-color: #f0f5ff;
+  color: #272833;
+  text-decoration: none;
+}
+
+.dropdown-item:focus {
+  background-color: #f0f5ff;
+  color: #272833;
+  text-decoration: none;
+  box-shadow: inset 0 0 0 0.125rem #80acff, inset 0 0 0 0.25rem #fff;
+  outline: 0;
+}
+
+.dropdown-item:active {
+  background-color: #f0f5ff;
+  color: #272833;
+  text-decoration: none;
+}
+
+.dropdown-item:active label {
+  color: #272833;
+}
+
+.dropdown-item:active .form-check-label {
+  color: #272833;
+}
+
+.dropdown-item.active {
+  background-color: #f0f5ff;
+  color: #272833;
+  text-decoration: none;
+  font-weight: 600;
+  pointer-events: none;
+}
+
+.dropdown-item.active label {
+  color: #272833;
+}
+
+.dropdown-item.active .form-check-label {
+  color: #272833;
+  font-weight: 600;
+}
+
+.dropdown-item.active .custom-control-label {
+  font-weight: 600;
+}
+
+.dropdown-item.active .c-kbd-inline {
+  color: #272833;
+}
+
+.dropdown-item.btn:not([disabled]):not(.disabled):active:focus, .dropdown-item.btn:not([disabled]):not(.disabled).active:focus {
+  box-shadow: inset 0 0 0 0.125rem #80acff, inset 0 0 0 0.25rem #fff;
+}
+
+.dropdown-item:disabled, .dropdown-item.disabled {
+  background-color: transparent;
+  color: #a7a9bc;
+  cursor: not-allowed;
+  opacity: 1;
+  outline: 0;
+  box-shadow: none;
+}
+
+.dropdown-item:disabled label,
+.dropdown-item:disabled .form-check-label, .dropdown-item.disabled label,
+.dropdown-item.disabled .form-check-label {
+  color: #a7a9bc;
+}
+
+.dropdown-item:disabled .c-kbd-inline, .dropdown-item.disabled .c-kbd-inline {
+  color: #a7a9bc;
+}
+
+.dropdown-item:disabled:active, .dropdown-item.disabled:active {
+  pointer-events: none;
+}
+
+.dropdown-item .c-inner {
+  flex-grow: 1;
+  margin-bottom: -0.5rem;
+  margin-left: -1.25rem;
+  margin-right: -1.25rem;
+  margin-top: -0.5rem;
+  width: auto;
+}
+
+.dropdown-item .c-kbd-inline {
+  line-height: 1.3125rem;
+  color: #a7a9bc;
+}
+
+.dropdown-item .form-check-label {
+  font-weight: 400;
+}
+
+.dropdown-item .custom-control-label {
+  font-weight: 400;
+}
+
+.dropdown-item .form-check {
+  margin-bottom: 0;
+}
+
+.dropdown-item .custom-control {
+  margin-bottom: 0;
+  margin-right: 0;
+  min-height: 1rem;
+}
+
+.dropdown-item-text {
+  color: #6b6c7e;
+  display: block;
+  font-weight: 400;
+  padding-bottom: 0.5rem;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  padding-top: 0.5rem;
+}
+
+.dropdown-section {
+  padding: 0.5rem 1.25rem;
+}
+
+.dropdown-section .form-group + .form-group {
+  margin-top: 1rem;
+}
+
+.dropdown-section .custom-control {
+  margin-bottom: 0;
+}
+
+.dropdown-section .custom-control-label {
+  color: #6b6c7e;
+}
+
+.dropdown-section .custom-control-label-text {
+  padding-left: 1rem;
+}
+
+.dropdown-section.active .custom-control-label {
+  color: #272833;
+}
+
+.dropdown-footer {
+  box-shadow: -1px -2px 3px -3px rgba(0, 0, 0, 0.5);
+  padding: 0.5rem 1.25rem 0;
+  position: relative;
+}
+
+.dropdown-menu {
+  background-clip: padding-box;
+  background-color: #fff;
+  border-color: #e7e7ed;
+  border-style: solid;
+  border-width: 0;
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 5px -1px rgba(0, 0, 0, 0.3);
+  color: #272833;
+  display: none;
+  float: left;
+  font-size: 0.875rem;
+  left: 0;
+  list-style: none;
+  margin: 0.3125rem 0 0;
+  max-height: 500px;
+  max-width: 240px;
+  min-height: 40px;
+  min-width: 240px;
+  overflow: auto;
+  padding: 0.375rem 0 0;
+  position: absolute;
+  text-align: left;
+  top: 100%;
+  z-index: 1000;
+}
+
+.dropdown-menu::after {
+  content: '';
+  display: block;
+  padding-top: 0.375rem;
+}
+
+@media (max-width: 991.98px) {
+  .dropdown-menu {
+    max-height: 295px;
+    max-width: 230px;
+  }
+}
+
+.dropdown-menu .alert {
+  line-height: normal;
+  margin: 0.5rem;
+  padding: 0.375rem 1.25rem;
+}
+
+.dropdown-menu .alert:first-child {
+  margin-top: 0;
+}
+
+.dropdown-menu .alert:last-child {
+  margin-bottom: 0;
+}
+
+.dropdown-menu .alert-fluid {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.dropdown-menu .alert-fluid:first-child {
+  margin-top: -0.375rem;
+}
+
+.dropdown-menu .alert-fluid:last-child {
+  margin-bottom: -0.375rem;
+}
+
+.dropdown-menu .form-group {
+  margin-bottom: 0;
+}
+
+.dropdown-menu .inline-scroller {
+  max-height: 200px;
+}
+
+@media (max-width: 991.98px) {
+  .dropdown-menu .inline-scroller {
+    max-height: none;
+  }
+}
+
+.dropdown-menu > .list-unstyled {
+  margin-bottom: 0;
+}
+
+.dropdown-menu.show {
+  display: block;
+}
+
+.dropdown-menu-left {
+  left: 0;
+  right: auto;
+}
+
+.dropdown-menu-right {
+  left: auto;
+  right: 0;
+}
+
+@media (min-width: 576px) {
+  .dropdown-menu-sm-left {
+    left: 0;
+    right: auto;
+  }
+  .dropdown-menu-sm-right {
+    left: auto;
+    right: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .dropdown-menu-md-left {
+    left: 0;
+    right: auto;
+  }
+  .dropdown-menu-md-right {
+    left: auto;
+    right: 0;
+  }
+}
+
+@media (min-width: 992px) {
+  .dropdown-menu-lg-left {
+    left: 0;
+    right: auto;
+  }
+  .dropdown-menu-lg-right {
+    left: auto;
+    right: 0;
+  }
+}
+
+@media (min-width: 1280px) {
+  .dropdown-menu-xl-left {
+    left: 0;
+    right: auto;
+  }
+  .dropdown-menu-xl-right {
+    left: auto;
+    right: 0;
+  }
+}
+
+.dropup .dropdown-menu {
+  bottom: 100%;
+  margin-bottom: 0.3125rem;
+  margin-top: 0;
+  top: auto;
+}
+
+.dropright .dropdown-menu {
+  left: 100%;
+  margin-left: 0.3125rem;
+  margin-top: 0;
+  right: auto;
+  top: 0;
+}
+
+.dropright .dropdown-toggle::after {
+  vertical-align: 0;
+}
+
+.dropleft .dropdown-menu {
+  left: auto;
+  margin-right: 0.3125rem;
+  margin-top: 0;
+  right: 100%;
+  top: 0;
+}
+
+.dropleft .dropdown-toggle::before {
+  vertical-align: 0;
+}
+
+.dropdown-menu[x-placement^='top'], .dropdown-menu[x-placement^='right'], .dropdown-menu[x-placement^='bottom'], .dropdown-menu[x-placement^='left'] {
+  bottom: auto;
+  right: auto;
+}
+
+.dropdown-divider {
+  border-top: 1px solid #e7e7ed;
+  height: 0;
+  margin: 0.5rem 0;
+  overflow: hidden;
+}
+
+.dropdown-action {
+  display: inline-block;
+  font-size: 1rem;
+  vertical-align: middle;
+}
+
+.dropdown-action > .dropdown-toggle {
+  align-items: center;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: flex;
+  height: 2rem;
+  line-height: 2rem;
+  width: 2rem;
+  font-size: inherit;
+  font-weight: inherit;
+  justify-content: center;
+  line-height: inherit;
+  padding: 0;
+  text-transform: inherit;
+  vertical-align: baseline;
+}
+
+.dropdown-action > .dropdown-toggle:disabled, .dropdown-action > .dropdown-toggle.disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.dropdown-action > .dropdown-toggle .inline-item .lexicon-icon,
+.dropdown-action > .dropdown-toggle .lexicon-icon {
+  margin-top: 0;
+}
+
+.dropdown-menu-indicator-start .dropdown-item-indicator {
+  height: 1rem;
+  left: 1.25rem;
+  position: absolute;
+  top: 0.5rem;
+  width: 1rem;
+}
+
+.dropdown-menu-indicator-start .dropdown-item-indicator-text-start {
+  padding-left: 0;
+}
+
+.dropdown-menu-indicator-start .dropdown-header,
+.dropdown-menu-indicator-start .dropdown-subheader,
+.dropdown-menu-indicator-start .dropdown-caption,
+.dropdown-menu-indicator-start .dropdown-item {
+  padding-left: 3.25rem;
+}
+
+.dropdown-menu-indicator-start .dropdown-item .c-inner {
+  margin-left: -3.25rem;
+}
+
+.dropdown-item-indicator-start {
+  align-items: center;
+  color: inherit;
+  display: inline-flex;
+  height: 1rem;
+  justify-content: center;
+  left: 1.25rem;
+  position: absolute;
+  right: auto;
+  top: calc( 0.5rem - (( 1rem - (1em * 1.5) ) / 2));
+  width: 1rem;
+}
+
+.dropdown-item-indicator-start .lexicon-icon {
+  margin-top: 0;
+}
+
+.dropdown-item-indicator-text-start {
+  color: inherit;
+  display: block;
+  padding-left: 2rem;
+  text-decoration: inherit;
+  width: 100%;
+}
+
+.dropdown-item-indicator-text-start:hover {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+.dropdown-item-indicator-text-start:focus {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+.dropdown-item-indicator-text-start > .c-inner {
+  margin-left: -2rem;
+}
+
+.dropdown-menu-indicator-end .dropdown-item-indicator {
+  position: absolute;
+  right: 1.25rem;
+  top: 0.5rem;
+}
+
+.dropdown-menu-indicator-end .dropdown-item-indicator-text-end {
+  padding-right: 0;
+}
+
+.dropdown-menu-indicator-end .dropdown-item {
+  padding-right: 3.25rem;
+}
+
+.dropdown-menu-indicator-end .dropdown-item .c-inner {
+  margin-right: -3.25rem;
+}
+
+.dropdown-item-indicator-end {
+  align-items: center;
+  color: inherit;
+  display: inline-flex;
+  height: 1rem;
+  justify-content: center;
+  left: auto;
+  position: absolute;
+  right: 1.25rem;
+  top: calc( 0.5rem - (( 1rem - (1em * 1.5) ) / 2));
+  width: 1rem;
+}
+
+.dropdown-item-indicator-end .lexicon-icon {
+  margin-top: 0;
+}
+
+.dropdown-item-indicator-text-end {
+  color: inherit;
+  display: block;
+  padding-right: 2rem;
+  text-decoration: inherit;
+  width: 100%;
+}
+
+.dropdown-item-indicator-text-end:hover {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+.dropdown-item-indicator-text-end:focus {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+.dropdown-item-indicator-text-end > .c-inner {
+  margin-right: -2rem;
+}
+
+.dropdown-menu-top {
+  bottom: 100% !important;
+  left: 0 !important;
+  margin-top: 0;
+  margin-bottom: 0.3125rem;
+  right: auto !important;
+  top: auto !important;
+  transform: none !important;
+  will-change: auto !important;
+}
+
+.dropdown-menu-top-right {
+  bottom: 100% !important;
+  left: auto !important;
+  margin-top: 0;
+  margin-bottom: 0.3125rem;
+  right: 0 !important;
+  top: auto !important;
+  transform: none !important;
+  will-change: auto !important;
+}
+
+.dropdown-menu-top-center {
+  bottom: 100% !important;
+  left: 50% !important;
+  margin-top: 0;
+  margin-bottom: 0.3125rem;
+  right: auto !important;
+  top: auto !important;
+  transform: translateX(-50%) !important;
+  will-change: auto !important;
+}
+
+.dropdown-menu-center {
+  bottom: auto !important;
+  left: 50% !important;
+  right: auto !important;
+  top: 100% !important;
+  transform: translateX(-50%) !important;
+  will-change: auto !important;
+}
+
+.dropdown-menu-left-side {
+  bottom: auto !important;
+  left: auto !important;
+  margin-right: 0.3125rem;
+  margin-top: 0;
+  right: 100% !important;
+  top: 0 !important;
+  transform: none !important;
+  will-change: auto !important;
+}
+
+.dropdown-menu-left-side-bottom {
+  bottom: 0 !important;
+  left: auto !important;
+  margin-right: 0.3125rem;
+  margin-top: 0;
+  right: 100% !important;
+  top: auto !important;
+  transform: none !important;
+  will-change: auto !important;
+}
+
+.dropdown-menu-left-side-middle {
+  bottom: auto !important;
+  left: auto !important;
+  margin-right: 0.3125rem;
+  margin-top: 0;
+  right: 100% !important;
+  top: 50% !important;
+  transform: translate(0, -50%) !important;
+  will-change: auto !important;
+}
+
+.dropdown-menu-right-side {
+  bottom: auto !important;
+  left: 100% !important;
+  margin-left: 0.3125rem;
+  margin-top: 0;
+  right: auto !important;
+  top: 0 !important;
+  transform: none !important;
+  will-change: auto !important;
+}
+
+.dropdown-menu-right-side-bottom {
+  bottom: 0 !important;
+  left: 100% !important;
+  margin-left: 0.3125rem;
+  margin-top: 0;
+  right: auto !important;
+  top: auto !important;
+  transform: none !important;
+  will-change: auto !important;
+}
+
+.dropdown-menu-right-side-middle {
+  bottom: auto !important;
+  left: 100% !important;
+  margin-left: 0.3125rem;
+  margin-top: 0;
+  right: auto !important;
+  top: 50% !important;
+  transform: translate(0, -50%) !important;
+  will-change: auto !important;
+}
+
+.dropdown-full .dropdown-menu,
+.dropdown-wide .dropdown-menu {
+  max-width: none;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .dropdown-full .dropdown-menu,
+  .dropdown-wide .dropdown-menu {
+    max-height: none;
+    width: 100%;
+  }
+}
+
+.dropdown-full .dropdown-header ~ .dropdown-header,
+.dropdown-wide .dropdown-header ~ .dropdown-header {
+  margin-top: 20px;
+}
+
+.dropdown-full .dropdown-menu > .row,
+.dropdown-wide .dropdown-menu > .row {
+  margin-left: 0;
+  margin-right: 0;
+  min-width: 500px;
+}
+
+@media (min-width: 992px) {
+  .dropdown-wide .dropdown-menu {
+    min-width: 500px;
+  }
+}
+
+.dropdown-menu-width-full {
+  left: 12px !important;
+  right: 12px !important;
+  max-width: none;
+  min-width: 0;
+  width: calc(100% - 24px);
+}
+
+.dropdown-menu-width-sm {
+  max-width: none;
+  min-width: 0;
+  width: 500px;
+}
+
+@media (max-width: 767.98px) {
+  .dropdown-menu-width-sm {
+    left: 12px !important;
+    right: 12px !important;
+    width: calc(100% - 24px);
+  }
+}
+
+.dropdown-menu-height-auto {
+  height: auto;
+  max-height: none;
+  min-height: 0;
+}
+
+@media (min-width: 768px) {
+  .dropdown-full .autocomplete-dropdown-menu,
+  .dropdown-full .dropdown-menu-autocomplete {
+    max-height: 10rem;
+  }
+}
+
+.autocomplete-dropdown-menu,
+.dropdown-menu-autocomplete {
+  max-height: 10rem;
+  max-width: none;
+  width: 100%;
+  padding-bottom: 0;
+}
+
+.nav-item.dropdown-full {
+  position: static;
+}
+
+@media (max-width: 991.98px) {
+  .nav-item.dropdown-wide {
+    position: static;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .navbar-nav .dropdown-menu-center {
+    -ms-transform: none;
+    transform: none;
+  }
+}
+
+.navbar-right .dropdown-menu-center {
+  left: 50%;
+  right: auto;
+}
+
+[type='checkbox'] {
+  cursor: pointer;
+  height: 14px;
+  width: 14px;
+}
+
+[type='checkbox']:disabled {
+  cursor: not-allowed;
+}
+
+[type='radio'] {
+  cursor: pointer;
+  height: 15px;
+  width: 14px;
+}
+
+[type='radio']:disabled {
+  cursor: not-allowed;
+}
+
+fieldset {
+  word-wrap: break-word;
+}
+
+label {
+  color: #272833;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  max-width: 100%;
+  word-wrap: break-word;
+}
+
+label[for] {
+  cursor: pointer;
+}
+
+label + .form-text {
+  margin-bottom: 0.25rem;
+  margin-top: 0;
+}
+
+label .reference-mark {
+  color: #b95000;
+  font-size: 6px;
+}
+
+.form-control-label {
+  display: inline;
+  margin-bottom: 0;
+}
+
+.form-control-label-text {
+  cursor: pointer;
+  display: inline-block;
+  margin-bottom: 0.25rem;
+  max-width: 100%;
+  word-wrap: break-word;
+}
+
+.form-control {
+  background-color: #f1f2f5;
+  border-color: #e7e7ed;
+  border-style: solid;
+  border-bottom-width: 0.0625rem;
+  border-left-width: 0.0625rem;
+  border-right-width: 0.0625rem;
+  border-top-width: 0.0625rem;
+  border-radius: 0.25rem;
+  box-shadow: 0 0 rgba(0, 0, 0, 0);
+  color: #272833;
+  display: block;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.5rem;
+  line-height: 1.5;
+  min-width: 0;
+  padding-bottom: 0.4375rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.4375rem;
+  width: 100%;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .form-control {
+    transition: none;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .form-control {
+    font-size: 1rem;
+  }
+}
+
+.form-control::placeholder {
+  color: #6b6c7e;
+  opacity: 1;
+}
+
+.form-control:focus, .form-control.focus {
+  background-color: #f0f5ff;
+  border-color: #80acff;
+  box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  color: #272833;
+  outline: 0;
+}
+
+.form-control:disabled, .form-control.disabled {
+  background-color: #f1f2f5;
+  border-color: #f1f2f5;
+  color: #a7a9bc;
+  cursor: not-allowed;
+  opacity: 1;
+}
+
+.form-control:not([type='range']) {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.form-control::-ms-clear, .form-control::-ms-reveal {
+  display: none;
+  height: 0;
+  width: 0;
+}
+
+.form-control .label {
+  border-width: 0.0625rem;
+  font-size: 0.75rem;
+  height: auto;
+  margin-bottom: 0.3125rem;
+  margin-right: 0.625rem;
+  margin-top: 0.3125rem;
+  min-height: 1.5rem;
+  padding-bottom: 0.3125rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.3125rem;
+  text-transform: none;
+}
+
+.form-control .label .inline-item .lexicon-icon {
+  height: 1em;
+  width: 1em;
+}
+
+.form-control .label .label-item {
+  margin-bottom: -0.0625rem;
+  margin-top: -0.0625rem;
+}
+
+.form-control .label .label-item .lexicon-icon {
+  height: 1em;
+  width: 1em;
+}
+
+.form-control .label .sticker {
+  height: 0.875rem;
+  line-height: 0.875rem;
+  width: 0.875rem;
+}
+
+.form-control .label > .c-inner {
+  margin-bottom: -0.3125rem;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+  margin-top: -0.3125rem;
+}
+
+.form-control-plaintext {
+  background-clip: border-box;
+  background-color: transparent;
+  border-color: transparent;
+  border-style: solid;
+  border-bottom-width: 0.0625rem;
+  border-left-width: 0.0625rem;
+  border-right-width: 0.0625rem;
+  border-top-width: 0.0625rem;
+  color: #272833;
+  display: block;
+  font-size: 1rem;
+  height: 2.5rem;
+  line-height: 1.5;
+  margin-bottom: 0;
+  min-width: 0;
+  padding-bottom: 0.4375rem;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0.4375rem;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+@media (max-width: 767.98px) {
+  .form-control-plaintext {
+    font-size: 1rem;
+  }
+}
+
+.form-control-plaintext.form-control-sm, .form-control-plaintext.form-control-lg {
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.form-control-hidden {
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  z-index: -1;
+}
+
+div.form-control {
+  height: auto;
+  min-height: 2.5rem;
+}
+
+div.form-control-lg {
+  min-height: 3rem;
+}
+
+div.form-control-sm {
+  min-height: 2rem;
+}
+
+.form-control-tag-group {
+  align-items: center;
+  color: #6b6c7e;
+  display: flex;
+  flex-wrap: wrap;
+  height: auto;
+  padding-bottom: 0.125rem;
+  padding-right: 0.5rem;
+  padding-top: 0.125rem;
+}
+
+.form-control-tag-group .autofit-row {
+  align-items: center;
+  flex-grow: 1;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+  width: auto;
+}
+
+.form-control-tag-group .autofit-col {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.form-control-tag-group .autofit-col .form-control-inset {
+  width: auto;
+}
+
+.form-control-tag-group .input-group-item {
+  align-items: center;
+}
+
+.form-control-tag-group .inline-item {
+  height: 1.5rem;
+  margin-bottom: 0.3125rem;
+  margin-top: 0.3125rem;
+}
+
+.form-control-tag-group .btn {
+  height: 1.5rem;
+  line-height: 1;
+  margin-bottom: 0.3125rem;
+  margin-top: 0.3125rem;
+  padding-bottom: 0;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0;
+}
+
+.form-control-tag-group .btn .c-inner {
+  margin-bottom: 0;
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: 0;
+}
+
+.form-control-tag-group .btn-monospaced {
+  height: 1.5rem;
+  line-height: 1;
+  margin-bottom: 0.3125rem;
+  margin-top: 0.3125rem;
+  padding-left: 0;
+  padding-right: 0;
+  width: 1.5rem;
+}
+
+.form-control-tag-group .btn-monospaced .c-inner {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.form-control-tag-group .component-action {
+  height: 100%;
+  margin-bottom: 0;
+  margin-top: 0;
+  width: 2rem;
+}
+
+.form-control-inset {
+  background-color: transparent;
+  border-width: 0;
+  color: #272833;
+  flex-grow: 1;
+  margin-bottom: 0.3125rem;
+  margin-top: 0.3125rem;
+  min-height: 1.5rem;
+  padding: 0;
+  width: 50px;
+}
+
+.form-control-inset:focus, .form-control-inset.focus {
+  outline: 0;
+}
+
+.form-control-inset:disabled, .form-control-inset.disabled {
+  background-color: #f1f2f5;
+  border-color: #f1f2f5;
+  color: #a7a9bc;
+  cursor: not-allowed;
+  opacity: 1;
+}
+
+.form-control-inset::-ms-clear, .form-control-inset::-ms-reveal {
+  display: none;
+  height: 0;
+  width: 0;
+}
+
+select.form-control {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline%20caret-double-l-top'%20d='M347.913%20199.336l-81.538-85c-5.413-5.642-14.188-5.642-19.6%200l-81.538%2085c-8.731%209.101-2.548%2024.664%209.8%2024.664h163.077c12.348%200%2018.531-15.563%209.8-24.664z'%20fill='%236b6c7e'/%3E%3Cpath%20class='lexicon-icon-outline%20caret-double-l-bottom'%20d='M165.236%20312.664l81.538%2085c5.412%205.642%2014.188%205.642%2019.6%200l81.538-85c8.731-9.101%202.548-24.664-9.8-24.664H175.035c-12.347%200-18.531%2015.563-9.8%2024.664z'%20fill='%236b6c7e'/%3E%3C/svg%3E");
+  background-position: right 0.5em center;
+  background-repeat: no-repeat;
+  background-size: 1.5em 1.5em;
+  cursor: pointer;
+  padding-right: 2em;
+  color: #272833;
+}
+
+select.form-control:focus, select.form-control.focus {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline%20caret-double-l-top'%20d='M347.913%20199.336l-81.538-85c-5.413-5.642-14.188-5.642-19.6%200l-81.538%2085c-8.731%209.101-2.548%2024.664%209.8%2024.664h163.077c12.348%200%2018.531-15.563%209.8-24.664z'%20fill='%236b6c7e'/%3E%3Cpath%20class='lexicon-icon-outline%20caret-double-l-bottom'%20d='M165.236%20312.664l81.538%2085c5.412%205.642%2014.188%205.642%2019.6%200l81.538-85c8.731-9.101%202.548-24.664-9.8-24.664H175.035c-12.347%200-18.531%2015.563-9.8%2024.664z'%20fill='%236b6c7e'/%3E%3C/svg%3E");
+}
+
+select.form-control:disabled, select.form-control.disabled {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline%20caret-double-l-top'%20d='M347.913%20199.336l-81.538-85c-5.413-5.642-14.188-5.642-19.6%200l-81.538%2085c-8.731%209.101-2.548%2024.664%209.8%2024.664h163.077c12.348%200%2018.531-15.563%209.8-24.664z'%20fill='%23a7a9bc'/%3E%3Cpath%20class='lexicon-icon-outline%20caret-double-l-bottom'%20d='M165.236%20312.664l81.538%2085c5.412%205.642%2014.188%205.642%2019.6%200l81.538-85c8.731-9.101%202.548-24.664-9.8-24.664H175.035c-12.347%200-18.531%2015.563-9.8%2024.664z'%20fill='%23a7a9bc'/%3E%3C/svg%3E");
+}
+
+select.form-control:disabled > option, select.form-control.disabled > option {
+  cursor: not-allowed;
+}
+
+select.form-control option {
+  cursor: pointer;
+}
+
+select.form-control::-ms-expand {
+  display: none;
+}
+
+select.form-control:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #272833;
+}
+
+select.form-control:focus::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.form-control-select {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline%20caret-double-l-top'%20d='M347.913%20199.336l-81.538-85c-5.413-5.642-14.188-5.642-19.6%200l-81.538%2085c-8.731%209.101-2.548%2024.664%209.8%2024.664h163.077c12.348%200%2018.531-15.563%209.8-24.664z'%20fill='%236b6c7e'/%3E%3Cpath%20class='lexicon-icon-outline%20caret-double-l-bottom'%20d='M165.236%20312.664l81.538%2085c5.412%205.642%2014.188%205.642%2019.6%200l81.538-85c8.731-9.101%202.548-24.664-9.8-24.664H175.035c-12.347%200-18.531%2015.563-9.8%2024.664z'%20fill='%236b6c7e'/%3E%3C/svg%3E");
+  background-position: right 0.5em center;
+  background-repeat: no-repeat;
+  background-size: 1.5em 1.5em;
+  padding-right: 2em;
+}
+
+select.form-control[size] {
+  background-image: none;
+  height: auto;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  scrollbar-width: thin;
+  color: #272833;
+}
+
+select.form-control[size]:focus, select.form-control[size].focus {
+  background-image: none;
+}
+
+select.form-control[size] option {
+  padding: 0.25rem 0.5rem;
+}
+
+select.form-control[multiple] {
+  background-image: none;
+  height: auto;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  scrollbar-width: thin;
+  color: #272833;
+}
+
+select.form-control[multiple]:focus, select.form-control[multiple].focus {
+  background-image: none;
+}
+
+select.form-control[multiple] option {
+  padding: 0.25rem 0.5rem;
+}
+
+textarea.form-control,
+textarea.form-control-plaintext,
+.form-control.form-control-textarea {
+  height: 100px;
+  resize: vertical;
+}
+
+.form-control-file {
+  cursor: pointer;
+  display: block;
+  width: 100%;
+}
+
+.form-control-file::-webkit-file-upload-button {
+  cursor: pointer;
+}
+
+.form-control[type='range'] {
+  background-color: transparent;
+  border-color: transparent;
+  padding: 0;
+}
+
+.form-control[type='range']:focus {
+  box-shadow: none;
+}
+
+.form-control[type='range']:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.form-control[type='range']::-webkit-slider-thumb {
+  border-radius: 100px;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.form-control-range {
+  display: block;
+  width: 100%;
+}
+
+.form-check {
+  display: block;
+  padding-left: 0;
+  position: relative;
+}
+
+.form-check-label {
+  cursor: pointer;
+  display: inline;
+  margin-bottom: 0;
+  position: relative;
+}
+
+.form-check-input {
+  margin-left: 0;
+  margin-top: 0;
+  position: static;
+}
+
+.form-check-input[disabled], .form-check-input:disabled {
+  cursor: not-allowed;
+}
+
+.form-check-input[disabled] ~ .form-check-label,
+.form-check-input[disabled] + .form-check-label-text, .form-check-input:disabled ~ .form-check-label,
+.form-check-input:disabled + .form-check-label-text {
+  color: #a7a9bc;
+  cursor: not-allowed;
+}
+
+.form-check-label-text {
+  margin-left: -0.1875rem;
+  padding-left: 0.5rem;
+}
+
+.form-check-inline {
+  align-items: center;
+  display: inline-flex;
+  margin-right: 0.75rem;
+  padding-left: 0;
+}
+
+.form-check-inline .form-check-input {
+  margin-left: 0;
+  margin-right: auto;
+  margin-top: 0;
+  position: static;
+}
+
+fieldset[disabled] label,
+label.disabled {
+  color: #a7a9bc;
+  cursor: not-allowed;
+  opacity: 1;
+}
+
+fieldset[disabled] label .form-control {
+  font-weight: normal;
+  opacity: 1;
+}
+
+fieldset[disabled] .form-control, .form-control[disabled] {
+  border-color: #f1f2f5;
+  color: #a7a9bc;
+  cursor: not-allowed;
+  opacity: 1;
+}
+
+fieldset[disabled] .form-control::placeholder, .form-control[disabled]::placeholder {
+  color: #a7a9bc;
+}
+
+@media (-webkit-min-device-pixel-ratio: 0) {
+  .form-control[disabled] > option {
+    color: #a7a9bc;
+  }
+}
+
+.form-control-file:disabled {
+  cursor: not-allowed;
+}
+
+.form-control-file:disabled::-webkit-file-upload-button {
+  cursor: not-allowed;
+}
+
+.form-control[readonly] {
+  border-color: #e7e7ed;
+  opacity: 1;
+  background-color: #fff;
+}
+
+.form-control[readonly]:focus, .form-control[readonly].focus {
+  border-color: #80acff;
+  box-shadow: none;
+}
+
+.form-control-plaintext[readonly] {
+  border-radius: 0.25rem;
+  outline: 0;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.form-control-plaintext[readonly]:focus, .form-control-plaintext[readonly].focus {
+  border-color: #80acff;
+  box-shadow: none;
+}
+
+.form-control-lg {
+  border-radius: 0.375rem;
+  font-size: 1.125rem;
+  height: 3rem;
+  padding-bottom: 0.4375rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.4375rem;
+}
+
+textarea.form-control-lg,
+.form-control-lg.form-control-textarea {
+  height: 120px;
+}
+
+.form-control-sm {
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  height: 2rem;
+  line-height: 1.5;
+  padding: 0.25rem 0.75rem;
+}
+
+.form-control-lg {
+  border-radius: 0.375rem;
+  font-size: 1.125rem;
+  height: 3rem;
+  line-height: 1.5;
+  padding: 0.4375rem 1rem;
+}
+
+.form-control-sm, .form-group-sm .form-control,
+.form-group-sm .form-control-plaintext {
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  height: 2rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.form-group-sm select.form-control {
+  height: 2rem;
+}
+
+.form-group-sm textarea.form-control,
+.form-group-sm .form-control.form-control-textarea {
+  height: 80px;
+}
+
+textarea.form-control-sm,
+.form-control-sm.form-control-textarea {
+  height: 80px;
+}
+
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.col-form-label {
+  font-size: inherit;
+  line-height: 1.5;
+  margin-bottom: 0;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.col-form-label-lg {
+  font-size: 1.125rem;
+  line-height: 1.5;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.col-form-label-sm {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  padding-bottom: 0.3125rem;
+  padding-top: 0.3125rem;
+}
+
+.form-row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-left: -5px;
+  margin-right: -5px;
+}
+
+.form-row > .col,
+.form-row > [class*='col-'] {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+.form-inline {
+  align-items: center;
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.form-inline .form-check {
+  width: 100%;
+}
+
+@media (min-width: 576px) {
+  .form-inline label {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    margin-bottom: 0;
+  }
+  .form-inline .form-group {
+    align-items: center;
+    display: flex;
+    flex-flow: row wrap;
+    flex: 0 0 auto;
+    margin-bottom: 0;
+  }
+  .form-inline .form-control {
+    display: inline-block;
+    vertical-align: middle;
+    width: auto;
+  }
+  .form-inline .form-control-plaintext {
+    display: inline-block;
+  }
+  .form-inline .input-group,
+  .form-inline .custom-select {
+    width: auto;
+  }
+  .form-inline .form-check {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    padding-left: 0;
+    width: auto;
+  }
+  .form-inline .form-check-input {
+    flex-shrink: 0;
+    margin-left: 0;
+    margin-right: 0.25rem;
+    margin-top: 0;
+    position: relative;
+  }
+  .form-inline .custom-control {
+    align-items: center;
+    justify-content: center;
+  }
+  .form-inline .custom-control-label {
+    margin-bottom: 0;
+  }
+}
+
+.form-group-autofit {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 576px) {
+  .form-group-autofit {
+    flex-direction: row;
+    width: 100%;
+  }
+}
+
+.form-group-autofit label {
+  align-self: flex-start;
+}
+
+.form-group-autofit .form-group-item {
+  display: flex;
+  flex-basis: auto;
+  flex-direction: column;
+  flex-grow: 0;
+  flex-shrink: 1;
+  min-width: 25px;
+  position: relative;
+  width: 100%;
+}
+
+.form-group-autofit .form-group-item:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+
+@media (max-width: 575.98px) {
+  .form-group-autofit .form-group-item:not(:last-child) {
+    margin-bottom: 1rem;
+  }
+}
+
+@media (min-width: 576px) {
+  .form-group-autofit > .form-group-item:not(:last-child) {
+    margin-bottom: 0;
+    margin-right: 12px;
+  }
+}
+
+.form-group-autofit .form-group-item-shrink {
+  flex-shrink: 0;
+  max-width: 100%;
+  width: auto;
+}
+
+@media (max-width: 575.98px) {
+  .form-group-autofit .form-group-item-label:not(:last-child) {
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width: 576px) {
+  .form-group-item-label {
+    justify-content: center;
+    min-height: 2.5rem;
+  }
+  .form-group-item-label > label {
+    margin-bottom: 0;
+    max-width: 12.5rem;
+  }
+}
+
+@media (min-width: 576px) {
+  .form-group-item-label-spacer {
+    margin-top: 1.5625rem;
+  }
+}
+
+.form-group {
+  position: relative;
+}
+
+@media (max-width: 767.98px) {
+  .form-group {
+    margin-bottom: 1rem;
+  }
+}
+
+.form-group-sm {
+  margin-bottom: 1rem;
+}
+
+.form-group-sm label {
+  margin-bottom: 0.1875rem;
+}
+
+.form-group-sm select[multiple],
+.form-group-sm .form-control[size] {
+  height: auto;
+}
+
+.form-group-sm .form-feedback-item ~ .form-feedback-item,
+.form-group-sm .form-feedback-item ~ .form-text,
+.form-group-sm .form-text ~ .form-feedback-item,
+.form-group-sm .form-text ~ .form-text {
+  margin-top: 0;
+}
+
+@media (min-width: 576px) {
+  .form-group-sm .form-group-item-label {
+    min-height: 2rem;
+  }
+  .form-group-sm .form-group-item-label > label {
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width: 576px) {
+  .form-group-sm .form-group-item-label-spacer {
+    margin-top: 1.5625rem;
+  }
+}
+
+.component-link {
+  color: #6b6c7e;
+  border-radius: 1px;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.component-link:hover {
+  color: #484955;
+}
+
+.component-link:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  color: #484955;
+  outline: 0;
+}
+
+.single-link {
+  font-weight: 600;
+}
+
+.link-primary {
+  color: #0b5fff;
+  border-radius: 1px;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.link-primary:hover {
+  color: #0041be;
+}
+
+.link-primary:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  color: #0041be;
+  outline: 0;
+}
+
+.link-secondary {
+  color: #6b6c7e;
+  border-radius: 1px;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.link-secondary:hover {
+  color: #272833;
+}
+
+.link-secondary:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  color: #272833;
+  outline: 0;
+}
+
+button.link-outline {
+  cursor: pointer;
+}
+
+.link-outline {
+  align-items: center;
+  border-color: transparent;
+  border-radius: 0.25rem;
+  border-style: solid;
+  border-width: 0.0625rem;
+  display: inline-flex;
+  font-size: 0.875rem;
+  font-weight: 600;
+  justify-content: center;
+  line-height: 1.15;
+  padding-bottom: 0.4375rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.4375rem;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  vertical-align: middle;
+  background-color: transparent;
+}
+
+.link-outline:hover {
+  text-decoration: none;
+}
+
+.link-outline:disabled:active, .link-outline.disabled:active {
+  pointer-events: none;
+}
+
+.link-outline > .c-inner {
+  margin-bottom: -0.4375rem;
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: -0.4375rem;
+}
+
+.link-outline .lexicon-icon {
+  margin-top: 0;
+}
+
+.link-outline-primary {
+  border-color: #0b5fff;
+  color: #0b5fff;
+}
+
+.link-outline-primary:hover {
+  background-color: #f0f5ff;
+  color: #0b5fff;
+}
+
+button.link-outline-primary:focus {
+  outline: 0;
+}
+
+.link-outline-primary:focus {
+  background-color: #f0f5ff;
+  color: #0b5fff;
+  outline: 0;
+}
+
+.link-outline-primary:active {
+  background-color: #e6edf8;
+  color: #0b5fff;
+}
+
+.link-outline-primary.active {
+  background-color: #e6edf8;
+  color: #0b5fff;
+}
+
+.link-outline-primary[aria-expanded='true'], .link-outline-primary.show,
+.show > .link-outline-primary {
+  background-color: #e6edf8;
+  color: #0b5fff;
+}
+
+.link-outline-primary:disabled, .link-outline-primary.disabled {
+  background-color: transparent;
+  box-shadow: none;
+  color: #0b5fff;
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.link-outline-secondary {
+  border-color: #cdced9;
+  color: #6b6c7e;
+}
+
+.link-outline-secondary:hover {
+  background-color: rgba(39, 40, 51, 0.03);
+  color: #272833;
+}
+
+button.link-outline-secondary:focus {
+  outline: 0;
+}
+
+.link-outline-secondary:focus {
+  background-color: rgba(39, 40, 51, 0.03);
+  color: #272833;
+  outline: 0;
+}
+
+.link-outline-secondary:active {
+  background-color: rgba(39, 40, 51, 0.06);
+  color: #272833;
+}
+
+.link-outline-secondary.active {
+  background-color: rgba(39, 40, 51, 0.06);
+  color: #272833;
+}
+
+.link-outline-secondary[aria-expanded='true'], .link-outline-secondary.show,
+.show > .link-outline-secondary {
+  background-color: rgba(39, 40, 51, 0.06);
+  color: #272833;
+}
+
+.link-outline-secondary:disabled, .link-outline-secondary.disabled {
+  background-color: transparent;
+  box-shadow: none;
+  color: #6b6c7e;
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.link-outline-borderless {
+  border-color: transparent;
+}
+
+.link-monospaced {
+  align-items: center;
+  display: inline-flex;
+  height: 2rem;
+  justify-content: center;
+  overflow: hidden;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  vertical-align: middle;
+  width: 2rem;
+}
+
+.link-monospaced > .c-inner {
+  margin-bottom: 0;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+}
+
+.link-monospaced .lexicon-icon {
+  margin-top: 0;
+}
+
+.component-title {
+  color: #272833;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
+  margin-bottom: calc((2rem - (1em * 1.25)) / 2);
+  margin-top: calc((2rem - (1em * 1.25)) / 2);
+}
+
+.component-title a {
+  color: #272833;
+  border-radius: 1px;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.component-title a:hover {
+  color: #060608;
+}
+
+.component-title a:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  color: #060608;
+  outline: 0;
+}
+
+.component-subtitle {
+  color: #6b6c7e;
+  margin-bottom: 0;
+  font-weight: 600;
+  line-height: 1.45;
+}
+
+.component-subtitle a {
+  color: #6b6c7e;
+  border-radius: 1px;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.component-subtitle a:hover {
+  color: #272833;
+}
+
+.component-subtitle a:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  color: #272833;
+  outline: 0;
+}
+
+.component-action {
+  align-items: center;
+  border-color: transparent;
+  border-radius: 0.25rem;
+  border-width: 0;
+  color: #6b6c7e;
+  display: inline-flex;
+  height: 2rem;
+  justify-content: center;
+  overflow: hidden;
+  padding: 0;
+  vertical-align: middle;
+  width: 2rem;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  font-size: 1rem;
+  background-color: transparent;
+}
+
+.component-action:hover {
+  background-color: rgba(39, 40, 51, 0.03);
+  color: #272833;
+}
+
+button.component-action:focus {
+  outline: 0;
+}
+
+.component-action:focus {
+  background-color: rgba(39, 40, 51, 0.03);
+  color: #272833;
+  outline: 0;
+}
+
+.component-action:active {
+  background-color: rgba(39, 40, 51, 0.06);
+  color: #272833;
+}
+
+.component-action.active {
+  background-color: rgba(39, 40, 51, 0.06);
+  color: #272833;
+}
+
+.component-action[aria-expanded='true'], .component-action.show,
+.show > .component-action {
+  background-color: rgba(39, 40, 51, 0.06);
+  color: #272833;
+}
+
+.component-action:disabled, .component-action.disabled {
+  background-color: transparent;
+  box-shadow: none;
+  color: #6b6c7e;
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.component-action:disabled:active, .component-action.disabled:active {
+  pointer-events: none;
+}
+
+.component-action .lexicon-icon {
+  margin-top: 0;
+}
+
+.clay-color > .input-group-item > .input-group-inset-item-before {
+  color: #6b6c7e;
+  font-size: inherit;
+  padding-left: 1rem;
+  padding-right: 0.5rem;
+}
+
+.clay-color > .input-group-item > .input-group-text {
+  border-color: #e7e7ed;
+  padding-left: 0;
+  padding-right: 0;
+  background-color: #fff;
+}
+
+.clay-color-dropdown-menu {
+  max-height: 400px;
+  max-width: none;
+  padding-bottom: 0;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 1rem;
+  width: 272px;
+  padding-bottom: 0;
+}
+
+.clay-color-dropdown-menu::after {
+  padding-top: 0;
+}
+
+.clay-color-dropdown-menu .close {
+  color: #6b6c7e;
+  font-size: 1rem;
+  opacity: 1;
+}
+
+.clay-color-dropdown-menu .close:hover {
+  background-color: rgba(39, 40, 51, 0.03);
+}
+
+.clay-color-dropdown-menu .close:focus {
+  background-color: rgba(39, 40, 51, 0.03);
+}
+
+.clay-color-dropdown-menu .close:active {
+  background-color: rgba(39, 40, 51, 0.06);
+}
+
+.show > .clay-color-dropdown-menu .close, .clay-color-dropdown-menu .close.active {
+  background-color: rgba(39, 40, 51, 0.06);
+}
+
+.clay-color-dropdown-menu .close:disabled, .clay-color-dropdown-menu .close.disabled {
+  background-color: transparent;
+}
+
+.clay-color-dropdown-menu .form-control {
+  font-size: 0.875rem;
+  height: 2rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.clay-color-dropdown-menu .form-group {
+  margin-bottom: 1rem;
+}
+
+.clay-color-dropdown-menu .input-group .input-group-inset-item-before {
+  color: #6b6c7e;
+  font-size: 0.875rem;
+  padding-left: 0.75rem;
+  padding-right: 0.5rem;
+}
+
+.clay-color-btn {
+  border-radius: 2px;
+  height: 1.5rem;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  width: 1.5rem;
+}
+
+.clay-color-btn:active {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.clay-color-btn[aria-expanded='true'], .clay-color-btn.active, .clay-color-btn.show,
+.show > .clay-color-btn.dropdown-toggle {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.clay-color-btn .c-inner {
+  margin-bottom: 0;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+}
+
+.clay-color-btn-bordered {
+  border-color: #e7e7ed;
+}
+
+.clay-color-pointer {
+  border-radius: 100px;
+  border-color: #fff;
+  border-style: solid;
+  border-width: 2px;
+  height: 0.875rem;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  position: absolute;
+  transition: box-shadow 0.15s ease-in-out;
+  width: 0.875rem;
+  background-color: transparent;
+}
+
+.clay-color-pointer:focus, .clay-color-pointer.focus {
+  box-shadow: 0 0 0 0.125rem #80acff;
+  outline: 0;
+}
+
+.clay-color-pointer:active:focus {
+  box-shadow: 0 0 0 0.125rem #80acff;
+}
+
+.clay-color-pointer .c-inner {
+  margin-bottom: 0;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+}
+
+.clay-color-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  margin-right: -0.25rem;
+}
+
+.clay-color-header .component-title {
+  color: #6b6c7e;
+  display: inline-block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  max-width: calc(100% - 2rem);
+}
+
+.clay-color-footer {
+  margin-bottom: 1rem;
+}
+
+.clay-color-swatch {
+  display: flex;
+  flex-wrap: wrap;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+  margin-top: 0.5rem;
+}
+
+.clay-color-swatch + .clay-color-swatch {
+  margin-top: 0;
+}
+
+.clay-color-swatch-item {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding-bottom: 1rem;
+  width: 16.66667%;
+}
+
+.clay-color-map-group {
+  display: flex;
+  margin-top: 0.5rem;
+}
+
+.clay-color-map {
+  flex-shrink: 0;
+  height: 128px;
+  margin-bottom: 1rem;
+  margin-right: 1rem;
+  position: relative;
+  touch-action: none;
+  -ms-user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  user-select: none;
+  width: 144px;
+}
+
+.clay-color-map-hsb {
+  background-image: linear-gradient(to top, #000, rgba(0, 0, 0, 0)), linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
+}
+
+.clay-color-map-values {
+  flex-grow: 1;
+  flex-shrink: 1;
+  width: 1%;
+}
+
+.clay-color-map-values .form-control {
+  padding-left: 0;
+  padding-right: 10%;
+  text-align: right;
+}
+
+.clay-color-map-values .input-group .input-group-inset-item-before {
+  font-weight: 600;
+  padding-left: 10%;
+  padding-right: 0;
+  min-width: 1.125rem;
+}
+
+.clay-color-range {
+  border-radius: 100px;
+  height: 0.5rem;
+  margin-bottom: 1.25rem;
+  margin-top: 0.25rem;
+  position: relative;
+  touch-action: none;
+  -ms-user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.clay-color-range-hue {
+  background-image: linear-gradient(270deg, #fc0d1b 0%, #fc22d6 18.23%, #1824fb 34.25%, #2bf6fd 50.28%, #2bfd2e 67.58%, #fcfd37 81.22%, #fc121b 100%);
+}
+
+.clay-color-range-pointer {
+  margin-top: -7px;
+  top: 50%;
+}
+
+.clay-color.input-group-sm > .input-group-item > .input-group-inset-item-before, .form-group-sm .clay-color.input-group > .input-group-item > .input-group-inset-item-before {
+  padding-left: 0.75rem;
+}
+
+.clay-color.input-group-sm > .input-group-item > .input-group-text, .form-group-sm .clay-color.input-group > .input-group-item > .input-group-text {
+  padding: 0;
+}
+
+.clay-color.input-group-sm > .input-group-item > .input-group-text > .clay-color-btn, .form-group-sm .clay-color.input-group > .input-group-item > .input-group-text > .clay-color-btn {
+  border-radius: 2px;
+  height: 1.25rem;
+  padding: 0;
+  width: 1.25rem;
+}
+
+.form-file {
+  display: flex;
+  position: relative;
+}
+
+.form-file-input {
+  cursor: pointer;
+  height: 100%;
+  opacity: 0;
+  overflow: hidden;
+  position: absolute;
+  width: 100%;
+  z-index: 10;
+}
+
+.form-file-input::-webkit-file-upload-button {
+  cursor: pointer;
+}
+
+.form-file-input:focus + .input-group {
+  border-radius: 1px;
+  box-shadow: 0 0 0 0.075rem #fff, 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.form-file-input:disabled {
+  cursor: not-allowed;
+}
+
+.form-file-input:disabled::-webkit-file-upload-button {
+  cursor: not-allowed;
+}
+
+.custom-control {
+  display: block;
+  margin-bottom: 1rem;
+  min-height: 1.25rem;
+  position: relative;
+  text-align: left;
+  line-height: 1;
+}
+
+.custom-control:only-child {
+  margin-bottom: 0;
+}
+
+.custom-control label {
+  cursor: pointer;
+  display: inline;
+  font-size: 1rem;
+  margin-bottom: 0;
+}
+
+.custom-control-label {
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin-bottom: 0;
+  position: static;
+  vertical-align: top;
+}
+
+label.custom-control-label {
+  font-size: 0.875rem;
+}
+
+.custom-control-label-text {
+  padding-left: 0.5rem;
+}
+
+.custom-control-label-text small,
+.custom-control-label-text .small {
+  font-size: 100%;
+}
+
+.custom-control-primary .custom-control-label-text {
+  font-weight: 600;
+}
+
+.custom-control-label::before {
+  background-color: #fff;
+  border-color: #cdced9;
+  border-style: solid;
+  border-width: 0.0625rem;
+  box-shadow: none;
+  content: '';
+  display: block;
+  float: left;
+  font-size: 1rem;
+  height: 1rem;
+  left: 0;
+  position: relative;
+  top: 0.125rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  width: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .custom-control-label::before {
+    transition: none;
+  }
+}
+
+.custom-control-label::after {
+  background: no-repeat 50% / 50% 50%;
+  content: '';
+  display: block;
+  height: 1rem;
+  left: 0;
+  position: absolute;
+  top: 0.125rem;
+  width: 1rem;
+}
+
+.custom-control-input {
+  cursor: pointer;
+  height: 1rem;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0.125rem;
+  width: 1rem;
+  z-index: 1;
+}
+
+.custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.custom-control-input:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #cdced9;
+}
+
+.custom-control-input:active ~ .custom-control-label::before {
+  background-color: #fff;
+  border-color: #cdced9;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  color: #fff;
+}
+
+.custom-control-input:active:checked ~ .custom-control-label::before {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+
+.custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+  border-color: #0b5fff;
+  box-shadow: none;
+  color: #fff;
+}
+
+.custom-control-input[disabled], .custom-control-input:disabled {
+  cursor: not-allowed;
+}
+
+.custom-control-input[disabled] ~ .custom-control-label::before, .custom-control-input:disabled ~ .custom-control-label::before {
+  background-color: #f1f2f5;
+  border-color: #f1f2f5;
+  box-shadow: none;
+}
+
+.custom-control-input[disabled] ~ .custom-control-label, .custom-control-input:disabled ~ .custom-control-label {
+  color: #a7a9bc;
+  cursor: not-allowed;
+}
+
+.custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: #b3cdff;
+  border-color: #b3cdff;
+}
+
+.custom-control .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.custom-checkbox .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M220.9%20377.2c-8%200-15.8-3.2-21.5-8.9l-91-91c-28.1-28.1%2014.8-71%2042.9-42.9l68.2%2068.2%20139.8-157.2c26.4-30%2072%2010.1%2045.6%2040.1L243.7%20366.9c-5.5%206.3-13.4%2010-21.8%2010.3h-1z'%20fill='%23fff'/%3E%3C/svg%3E");
+  background-size: 100%;
+}
+
+.custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::before {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+  box-shadow: none;
+}
+
+.custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M384%20288H128c-42.7%200-42.7-64%200-64h256c42.7%200%2042.7%2064%200%2064z'%20fill='%23fff'/%3E%3C/svg%3E");
+  background-size: 100%;
+}
+
+.custom-checkbox .custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: #b3cdff;
+}
+
+.custom-checkbox .custom-control-input:disabled:indeterminate ~ .custom-control-label::before {
+  background-color: #b3cdff;
+  border-color: #b3cdff;
+}
+
+.custom-checkbox .custom-control-label::before {
+  border-radius: 0.125rem;
+}
+
+.custom-radio .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Ccircle%20class='lexicon-icon-outline'%20cx='256'%20cy='256'%20r='256'%20fill='%23fff'/%3E%3C/svg%3E");
+  background-size: 50%;
+}
+
+.custom-radio .custom-control-input:disabled ~ .custom-control-label::before {
+  border-color: #f1f2f5;
+}
+
+.custom-radio .custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: #b3cdff;
+  border-color: #b3cdff;
+}
+
+.custom-radio .custom-control-label::before {
+  border-radius: 50%;
+}
+
+.custom-control-inline {
+  display: inline-flex;
+}
+
+.custom-control-inline + .custom-control-inline {
+  margin-left: 1rem;
+}
+
+.custom-switch {
+  padding-left: 2.25rem;
+}
+
+.custom-switch .custom-control-label::before {
+  border-radius: 0.5rem;
+  left: -2.25rem;
+  pointer-events: all;
+  width: 1.75rem;
+}
+
+.custom-switch .custom-control-label::after {
+  background-color: #cdced9;
+  border-radius: 0.5rem;
+  height: 0.75rem;
+  left: -2.125rem;
+  transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  top: 0.375rem;
+  width: 0.75rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .custom-switch .custom-control-label::after {
+    transition: none;
+  }
+}
+
+.custom-switch .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #fff;
+  transform: translateX(0.75rem);
+}
+
+.custom-switch .custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: #b3cdff;
+}
+
+.custom-select {
+  -webkit-appearance: none;
+  appearance: none;
+  background: #f1f2f5 url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23393a4a' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 1rem center/8px 10px;
+  border: 0.0625rem solid #e7e7ed;
+  border-radius: 0.25rem;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075);
+  color: #272833;
+  display: inline-block;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.5rem;
+  line-height: 1.5;
+  padding: 0.4375rem 2rem 0.4375rem 1rem;
+  vertical-align: middle;
+  width: 100%;
+}
+
+.custom-select:focus {
+  border-color: #80acff;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.2rem rgba(11, 95, 255, 0.25);
+  outline: 0;
+}
+
+.custom-select:focus::-ms-value {
+  background-color: #f1f2f5;
+  color: #272833;
+}
+
+.custom-select[multiple], .custom-select[size]:not([size='1']) {
+  background-image: none;
+  height: auto;
+  padding-right: 1rem;
+}
+
+.custom-select:disabled {
+  background-color: #f1f2f5;
+  color: #6b6c7e;
+}
+
+.custom-select::-ms-expand {
+  display: none;
+}
+
+.custom-select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #272833;
+}
+
+.custom-select-sm {
+  font-size: 0.875rem;
+  height: 2rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.custom-select-lg {
+  font-size: 1.125rem;
+  height: 3rem;
+  padding-bottom: 0.4375rem;
+  padding-left: 1rem;
+  padding-top: 0.4375rem;
+}
+
+.custom-file {
+  display: inline-block;
+  height: 2.5rem;
+  margin-bottom: 0;
+  position: relative;
+  width: 100%;
+}
+
+.custom-file-input {
+  height: 2.5rem;
+  margin: 0;
+  opacity: 0;
+  position: relative;
+  width: 100%;
+  z-index: 2;
+}
+
+.custom-file-input:focus ~ .custom-file-label {
+  border-color: #80acff;
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.custom-file-input[disabled] ~ .custom-file-label,
+.custom-file-input:disabled ~ .custom-file-label {
+  background-color: #f1f2f5;
+}
+
+.custom-file-input:lang(en) ~ .custom-file-label::after {
+  content: "Browse";
+}
+
+.custom-file-input ~ .custom-file-label[data-browse]::after {
+  content: attr(data-browse);
+}
+
+.custom-file-label {
+  background-color: #f1f2f5;
+  border: 0.0625rem solid #e7e7ed;
+  border-radius: 0.25rem;
+  box-shadow: 0 0 rgba(0, 0, 0, 0);
+  color: #272833;
+  font-weight: 400;
+  height: 2.5rem;
+  left: 0;
+  line-height: 1.5;
+  padding: 0.4375rem 1rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 1;
+}
+
+.custom-file-label::after {
+  background-color: #e7e7ed;
+  border-left: inherit;
+  border-radius: 0 0.25rem 0.25rem 0;
+  bottom: 0;
+  color: #272833;
+  content: 'Browse';
+  display: block;
+  height: 2.375rem;
+  line-height: 1.5;
+  padding: 0.4375rem 1rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 3;
+}
+
+.custom-range {
+  appearance: none;
+  background-color: transparent;
+  height: 1.4rem;
+  padding: 0;
+  width: 100%;
+}
+
+.custom-range:focus {
+  outline: none;
+}
+
+.custom-range:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.custom-range:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.custom-range:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.custom-range::-moz-focus-outer {
+  border: 0;
+}
+
+.custom-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: #0b5fff;
+  border: 0;
+  border-radius: 1rem;
+  box-shadow: 0 0.1rem 0.25rem rgba(0, 0, 0, 0.1);
+  height: 1rem;
+  margin-top: -0.25rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  width: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .custom-range::-webkit-slider-thumb {
+    transition: none;
+  }
+}
+
+.custom-range::-webkit-slider-thumb:active {
+  background-color: #bed4ff;
+}
+
+.custom-range::-webkit-slider-runnable-track {
+  border-radius: 1rem;
+  box-shadow: inset 0 0.25rem 0.25rem rgba(0, 0, 0, 0.1);
+  background-color: #e7e7ed;
+  border-color: transparent;
+  color: transparent;
+  cursor: pointer;
+  height: 0.5rem;
+  width: 100%;
+}
+
+.custom-range::-moz-range-thumb {
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #0b5fff;
+  border-radius: 1rem;
+  border: 0;
+  box-shadow: 0 0.1rem 0.25rem rgba(0, 0, 0, 0.1);
+  height: 1rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  width: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .custom-range::-moz-range-thumb {
+    transition: none;
+  }
+}
+
+.custom-range::-moz-range-thumb:active {
+  background-color: #bed4ff;
+}
+
+.custom-range::-moz-range-track {
+  background-color: #e7e7ed;
+  border-color: transparent;
+  border-radius: 1rem;
+  box-shadow: inset 0 0.25rem 0.25rem rgba(0, 0, 0, 0.1);
+  color: transparent;
+  cursor: pointer;
+  height: 0.5rem;
+  width: 100%;
+}
+
+.custom-range::-ms-thumb {
+  appearance: none;
+  background-color: #0b5fff;
+  border: 0;
+  border-radius: 1rem;
+  box-shadow: 0 0.1rem 0.25rem rgba(0, 0, 0, 0.1);
+  height: 1rem;
+  margin-left: 0.2rem;
+  margin-right: 0.2rem;
+  margin-top: 0;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  width: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .custom-range::-ms-thumb {
+    transition: none;
+  }
+}
+
+.custom-range::-ms-thumb:active {
+  background-color: #bed4ff;
+}
+
+.custom-range::-ms-track {
+  background-color: transparent;
+  border-color: transparent;
+  border-width: 0.5rem;
+  box-shadow: inset 0 0.25rem 0.25rem rgba(0, 0, 0, 0.1);
+  color: transparent;
+  cursor: pointer;
+  height: 0.5rem;
+  width: 100%;
+}
+
+.custom-range::-ms-fill-lower {
+  background-color: #e7e7ed;
+  border-radius: 1rem;
+}
+
+.custom-range::-ms-fill-upper {
+  border-radius: 1rem;
+  background-color: #e7e7ed;
+  margin-right: 15px;
+}
+
+.custom-range:disabled::-webkit-slider-thumb {
+  background-color: #a7a9bc;
+}
+
+.custom-range:disabled::-webkit-slider-runnable-track {
+  cursor: default;
+}
+
+.custom-range:disabled::-moz-range-thumb {
+  background-color: #a7a9bc;
+}
+
+.custom-range:disabled::-moz-range-track {
+  cursor: default;
+}
+
+.custom-range:disabled::-ms-thumb {
+  background-color: #a7a9bc;
+}
+
+.custom-file-label,
+.custom-select {
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .custom-file-label,
+  .custom-select {
+    transition: none;
+  }
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.875rem;
+  list-style: none;
+  margin-bottom: 0;
+  padding-left: 0;
+}
+
+.nav-link {
+  display: block;
+  padding-bottom: 0.625rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.625rem;
+  position: relative;
+}
+
+.nav-link:hover {
+  text-decoration: none;
+}
+
+.nav-link:focus {
+  text-decoration: none;
+  z-index: 1;
+}
+
+.nav-link:disabled, .nav-link.disabled {
+  box-shadow: none;
+  color: #a7a9bc;
+  cursor: not-allowed;
+}
+
+.nav-link:disabled:active, .nav-link.disabled:active {
+  pointer-events: none;
+}
+
+.nav-link > .c-inner {
+  margin-bottom: -0.625rem;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  margin-top: -0.625rem;
+}
+
+.nav-link.btn-unstyled {
+  width: 100%;
+}
+
+.nav-link.btn-unstyled:focus, .nav-link.btn-unstyled.focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.nav-link.btn-unstyled:active:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.nav-link.btn-unstyled:disabled, .nav-link.btn-unstyled.disabled {
+  opacity: 1;
+}
+
+.nav-link.btn-unstyled .c-inner {
+  width: auto;
+}
+
+.nav-btn {
+  align-items: center;
+  display: flex;
+  height: 2rem;
+  justify-content: center;
+  line-height: 1.5;
+  margin: 0.375rem 0.25rem;
+  min-width: 2rem;
+  padding: 0 0.75rem;
+  position: relative;
+  text-align: center;
+  width: auto;
+}
+
+.nav-btn:focus, .nav-btn.focus {
+  z-index: 1;
+}
+
+.nav-btn:disabled, .nav-btn.disabled {
+  opacity: 1;
+}
+
+.nav-btn .c-inner {
+  margin-bottom: 0;
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: -0.0625rem;
+}
+
+.nav-btn .lexicon-icon {
+  margin-top: 0;
+}
+
+.nav-btn.btn-link {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.nav-btn-monospaced {
+  padding: 0;
+}
+
+.nav-btn-monospaced .c-inner {
+  margin-left: -0.0625rem;
+  margin-right: -0.0625rem;
+}
+
+.nav-link-monospaced {
+  align-items: center;
+  display: flex;
+  height: 2rem;
+  justify-content: center;
+  margin: 0.375rem 0.25rem;
+  min-width: 2rem;
+  padding: 0;
+}
+
+.nav-link-monospaced .lexicon-icon {
+  margin-top: 0;
+}
+
+.nav-item {
+  word-wrap: break-word;
+}
+
+.nav-item[class*='col-'] {
+  padding-left: 0;
+  padding-right: 0;
+  text-align: center;
+}
+
+.nav-text-truncate {
+  display: inline-block;
+  margin-bottom: -6px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dropdown-toggle .nav-text-truncate {
+  max-width: calc(100% - 24px);
+}
+
+.nav-form {
+  padding-bottom: 0.625rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.625rem;
+}
+
+.nav .nav-form {
+  padding-bottom: 0;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0;
+}
+
+.nav-fill .nav-item {
+  flex: 1 1 auto;
+  text-align: center;
+}
+
+.nav-justified .nav-item {
+  flex-basis: 0;
+  flex-grow: 1;
+  text-align: center;
+}
+
+.nav-justified button.nav-link {
+  text-align: center;
+  width: 100%;
+}
+
+.nav-stacked {
+  display: block;
+}
+
+.nav-stacked .nav-form {
+  padding-bottom: 0.625rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.625rem;
+}
+
+.nav-unstyled {
+  flex-wrap: nowrap;
+}
+
+.nav-unstyled .nav-btn {
+  margin: 0 4px;
+  padding: 0 4px;
+}
+
+.nav-unstyled .nav-link {
+  line-height: 2rem;
+  padding: 0 4px;
+}
+
+.nav-unstyled .nav-link-monospaced {
+  margin: 0 4px;
+}
+
+.nav-nested {
+  flex-direction: column;
+  flex-wrap: nowrap;
+}
+
+.nav-nested .nav > li > a {
+  padding-left: 2rem;
+}
+
+.nav-nested .nav > li > .nav-equal-height-heading {
+  padding-left: 1rem;
+}
+
+.nav-nested .nav .nav > li > a {
+  padding-left: 3rem;
+}
+
+.nav-nested .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 2rem;
+}
+
+.nav-nested .nav .nav .nav > li > a {
+  padding-left: 4rem;
+}
+
+.nav-nested .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 3rem;
+}
+
+.nav-nested .nav .nav .nav .nav > li > a {
+  padding-left: 5rem;
+}
+
+.nav-nested .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 4rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav > li > a {
+  padding-left: 6rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 5rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav > li > a {
+  padding-left: 7rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 6rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav > li > a {
+  padding-left: 8rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 7rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav > li > a {
+  padding-left: 9rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 8rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > a {
+  padding-left: 10rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 9rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > a {
+  padding-left: 11rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 10rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > a {
+  padding-left: 12rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 11rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > a {
+  padding-left: 13rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 12rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > a {
+  padding-left: 14rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 13rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > a {
+  padding-left: 15rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 14rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > a {
+  padding-left: 16rem;
+}
+
+.nav-nested .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav .nav > li > .nav-equal-height-heading {
+  padding-left: 15rem;
+}
+
+.nav-nested-margins {
+  flex-direction: column;
+  flex-wrap: nowrap;
+}
+
+.nav-nested-margins > li .nav > li {
+  margin-left: 1rem;
+}
+
+.nav-tabs {
+  border-bottom: 0.0625rem solid transparent;
+  font-size: 0.875rem;
+}
+
+.nav-tabs .nav-item {
+  margin-bottom: -0.0625rem;
+}
+
+.nav-tabs .nav-link {
+  border-color: transparent;
+  border-style: solid;
+  border-width: 0.0625rem;
+  border-radius: 0.25rem 0.25rem 0 0;
+  color: #6b6c7e;
+  padding-bottom: 0.28125rem;
+  padding-top: 0.28125rem;
+  white-space: nowrap;
+  font-weight: 600;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.nav-tabs .nav-link:hover {
+  border-color: transparent;
+}
+
+.nav-tabs .nav-link:focus {
+  border-color: transparent;
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  outline: 0;
+}
+
+.nav-tabs .nav-link:active {
+  background-color: #fff;
+  border-color: transparent transparent #fff;
+  color: #272833;
+}
+
+.nav-tabs .nav-link.active {
+  background-color: #fff;
+  border-color: transparent transparent #fff;
+  color: #272833;
+}
+
+.nav-tabs .nav-link[aria-expanded='true'], .nav-tabs .nav-link.show,
+.show > .nav-tabs .nav-link {
+  background-color: #fff;
+  border-color: transparent transparent #fff;
+  color: #272833;
+}
+
+.nav-tabs .nav-link:disabled, .nav-tabs .nav-link.disabled {
+  background-color: transparent;
+  border-color: transparent;
+  color: #a7a9bc;
+  box-shadow: none;
+}
+
+.nav-tabs .nav-link > .c-inner {
+  margin-bottom: -0.28125rem;
+  margin-top: -0.28125rem;
+}
+
+.nav-tabs .nav-item.show .nav-link {
+  border-color: transparent transparent transparent transparent;
+  color: #272833;
+  background-color: transparent;
+}
+
+.nav-tabs .dropdown-menu {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  margin-top: -0.0625rem;
+}
+
+.nav-tabs + .tab-content .tab-pane {
+  background-color: #fff;
+  border-radius: 4px;
+  padding: 2rem;
+}
+
+.nav-tabs + .tab-content .tab-pane.active:first-child {
+  border-top-left-radius: 0;
+}
+
+.tab-content > .tab-pane {
+  display: none;
+}
+
+.tab-content > .active {
+  display: block;
+}
+
+.dropdown-item[data-toggle='tab'] .dropdown-item-indicator,
+.dropdown-item[data-toggle='tab'] .dropdown-item-indicator-start,
+.dropdown-item[data-toggle='tab'] .dropdown-item-indicator-end {
+  display: none;
+}
+
+.dropdown-item[data-toggle='tab'].active .dropdown-item-indicator,
+.dropdown-item[data-toggle='tab'].active .dropdown-item-indicator-start,
+.dropdown-item[data-toggle='tab'].active .dropdown-item-indicator-end {
+  display: block;
+}
+
+.nav-pills .nav-link {
+  border-radius: 0.25rem;
+}
+
+.nav-pills .nav-link.active,
+.nav-pills .show > .nav-link {
+  background-color: #0b5fff;
+  color: #fff;
+}
+
+.nav-underline .nav-link {
+  color: #6b6c7e;
+  padding-bottom: 0.5625rem;
+  padding-top: 0.5625rem;
+  border-radius: 1px;
+  font-weight: 600;
+  line-height: 1;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.nav-underline .nav-link:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  outline: 0;
+}
+
+.nav-underline .nav-link.active {
+  color: #272833;
+}
+
+.nav-underline .nav-link[aria-expanded='true'], .nav-underline .nav-link.show,
+.show > .nav-underline .nav-link {
+  color: #272833;
+}
+
+.nav-underline .nav-link:disabled, .nav-underline .nav-link.disabled {
+  box-shadow: none;
+  color: #a7a9bc;
+}
+
+.nav-underline .nav-link > .c-inner {
+  margin-bottom: -0.5625rem;
+  margin-top: -0.5625rem;
+}
+
+.nav-underline .nav-item.show .nav-link {
+  color: #272833;
+}
+
+.nav-underline .nav-link::after {
+  bottom: 0;
+  display: block;
+  position: absolute;
+  left: 0;
+  right: 0;
+  width: auto;
+}
+
+.nav-underline .nav-item .nav-link.active:after {
+  background-color: #80acff;
+}
+
+.nav-underline .nav-link.active:after,
+.nav-underline .nav-item.show .nav-link:after {
+  content: "";
+  height: 0.125rem;
+}
+
+.menubar {
+  position: relative;
+}
+
+.menubar-toggler {
+  display: none;
+}
+
+.menubar-vertical-expand-md {
+  max-width: 15.625rem;
+}
+
+@media (max-width: 767.98px) {
+  .menubar-vertical-expand-md {
+    align-items: center;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0.0625rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+    margin-left: -12px;
+    margin-right: -12px;
+    max-width: none;
+    min-height: 3rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+}
+
+.menubar-vertical-expand-md .menubar-collapse {
+  display: block;
+}
+
+@media (max-width: 767.98px) {
+  .menubar-vertical-expand-md .menubar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0.0625rem;
+    display: none;
+    left: -0.0625rem;
+    position: absolute;
+    right: -0.0625rem;
+    top: 100%;
+    z-index: 499;
+  }
+  .menubar-vertical-expand-md .menubar-collapse > .nav {
+    margin-bottom: 0.5rem;
+    margin-top: 0.5rem;
+  }
+}
+
+.menubar-vertical-expand-md .menubar-collapse.collapsing, .menubar-vertical-expand-md .menubar-collapse.show {
+  display: block;
+}
+
+@media (max-width: 767.98px) {
+  .menubar-vertical-expand-md .menubar-toggler {
+    align-items: center;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0.0625rem;
+    display: flex;
+    height: 2rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  .menubar-vertical-expand-md .menubar-toggler .c-inner {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    max-width: none;
+  }
+  .menubar-vertical-expand-md .menubar-toggler .lexicon-icon {
+    margin-top: 0;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .menubar-vertical-expand-md .nav-nested-margins > li .nav > li {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .menubar-vertical-expand-md.menubar-transparent {
+    background-color: #fff;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .menubar-vertical-expand-md.menubar-transparent .menubar-collapse {
+    background-color: #fff;
+    border-color: #e7e7ed;
+    border-radius: 0.25rem;
+    box-shadow: 0 1px 5px -1px rgba(0, 0, 0, 0.3);
+  }
+}
+
+@media (max-width: 767.98px) {
+  .menubar-vertical-expand-md.menubar-transparent .menubar-toggler {
+    color: #272833;
+    font-size: 0.875rem;
+    font-weight: 600;
+    border-radius: 0.375rem;
+    transition: box-shadow 0.15s ease-in-out;
+  }
+  .menubar-vertical-expand-md.menubar-transparent .menubar-toggler:focus, .menubar-vertical-expand-md.menubar-transparent .menubar-toggler.focus {
+    box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+    outline: 0;
+  }
+  .menubar-vertical-expand-md.menubar-transparent .menubar-toggler:active:focus {
+    box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  }
+  .menubar-vertical-expand-md.menubar-transparent .menubar-toggler:disabled, .menubar-vertical-expand-md.menubar-transparent .menubar-toggler.disabled {
+    box-shadow: none;
+  }
+}
+
+.menubar-vertical-expand-md.menubar-transparent .nav-link {
+  border-radius: 0.375rem;
+  color: #6b6c7e;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.menubar-vertical-expand-md.menubar-transparent .nav-link:hover {
+  background-color: rgba(39, 40, 51, 0.03);
+  color: #272833;
+}
+
+.menubar-vertical-expand-md.menubar-transparent .nav-link:focus {
+  background-color: rgba(39, 40, 51, 0.03);
+  box-shadow: inset 0 0 0 0.125rem #80acff, inset 0 0 0 0.25rem #fff;
+  color: #272833;
+  outline: 0;
+}
+
+.menubar-vertical-expand-md.menubar-transparent .nav-link:active {
+  color: #272833;
+}
+
+.menubar-vertical-expand-md.menubar-transparent .nav-link.active {
+  background-color: #f0f5ff;
+  color: #0b5fff;
+  font-weight: 600;
+}
+
+.menubar-vertical-expand-md.menubar-transparent .nav-link[aria-expanded='true'], .menubar-vertical-expand-md.menubar-transparent .nav-link.show,
+.show > .menubar-vertical-expand-md.menubar-transparent .nav-link {
+  color: #272833;
+  font-weight: 600;
+}
+
+.menubar-vertical-expand-md.menubar-transparent .nav-link:disabled, .menubar-vertical-expand-md.menubar-transparent .nav-link.disabled {
+  box-shadow: none;
+  color: #a7a9bc;
+}
+
+@media (max-width: 767.98px) {
+  .menubar-vertical-expand-md.menubar-transparent .nav-link {
+    border-radius: 0;
+    color: #6b6c7e;
+    transition: none;
+  }
+  .menubar-vertical-expand-md.menubar-transparent .nav-link:hover {
+    background-color: #f0f5ff;
+    color: #272833;
+  }
+  .menubar-vertical-expand-md.menubar-transparent .nav-link:focus {
+    background-color: #f0f5ff;
+  }
+  .menubar-vertical-expand-md.menubar-transparent .nav-link:active {
+    background-color: #f0f5ff;
+    color: #272833;
+  }
+  .menubar-vertical-expand-md.menubar-transparent .nav-link.active {
+    background-color: #f0f5ff;
+    color: #272833;
+    font-weight: 600;
+  }
+  .menubar-vertical-expand-md.menubar-transparent .nav-link[aria-expanded='true'], .menubar-vertical-expand-md.menubar-transparent .nav-link.show,
+  .show > .menubar-vertical-expand-md.menubar-transparent .nav-link {
+    background-color: #f0f5ff;
+    color: #272833;
+    font-weight: 600;
+  }
+  .menubar-vertical-expand-md.menubar-transparent .nav-link:disabled, .menubar-vertical-expand-md.menubar-transparent .nav-link.disabled {
+    background-color: transparent;
+    color: #a7a9bc;
+  }
+}
+
+@media (min-width: 768px) {
+  .menubar-vertical-expand-md.menubar-decorated .nav {
+    border-left-color: #e7e7ed;
+    border-left-style: solid;
+    border-left-width: 0.125rem;
+    display: block;
+    padding-left: 0.5rem;
+  }
+  .menubar-vertical-expand-md.menubar-decorated .nav > .nav-item .nav {
+    margin-bottom: 0.25rem;
+    margin-left: 1rem;
+    margin-top: 0.25rem;
+  }
+  .menubar-vertical-expand-md.menubar-decorated .nav-link {
+    padding-left: 1rem !important;
+  }
+  .menubar-vertical-expand-md.menubar-decorated .nav-link.active::after {
+    background-color: #b3cdff;
+    bottom: 0;
+    content: "";
+    display: block;
+    left: -0.625rem;
+    position: absolute;
+    top: 0;
+    width: 0.125rem;
+  }
+}
+
+.menubar-vertical-expand-lg {
+  max-width: 15.625rem;
+}
+
+@media (max-width: 991.98px) {
+  .menubar-vertical-expand-lg {
+    align-items: center;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0.0625rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+    margin-left: -12px;
+    margin-right: -12px;
+    max-width: none;
+    min-height: 3rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+}
+
+.menubar-vertical-expand-lg .menubar-collapse {
+  display: block;
+}
+
+@media (max-width: 991.98px) {
+  .menubar-vertical-expand-lg .menubar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0.0625rem;
+    display: none;
+    left: -0.0625rem;
+    position: absolute;
+    right: -0.0625rem;
+    top: 100%;
+    z-index: 499;
+  }
+  .menubar-vertical-expand-lg .menubar-collapse > .nav {
+    margin-bottom: 0.5rem;
+    margin-top: 0.5rem;
+  }
+}
+
+.menubar-vertical-expand-lg .menubar-collapse.collapsing, .menubar-vertical-expand-lg .menubar-collapse.show {
+  display: block;
+}
+
+@media (max-width: 991.98px) {
+  .menubar-vertical-expand-lg .menubar-toggler {
+    align-items: center;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0.0625rem;
+    display: flex;
+    height: 2rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  .menubar-vertical-expand-lg .menubar-toggler .c-inner {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    max-width: none;
+  }
+  .menubar-vertical-expand-lg .menubar-toggler .lexicon-icon {
+    margin-top: 0;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .menubar-vertical-expand-lg .nav-nested-margins > li .nav > li {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .menubar-vertical-expand-lg.menubar-transparent {
+    background-color: #fff;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .menubar-vertical-expand-lg.menubar-transparent .menubar-collapse {
+    background-color: #fff;
+    border-color: #e7e7ed;
+    border-radius: 0.25rem;
+    box-shadow: 0 1px 5px -1px rgba(0, 0, 0, 0.3);
+  }
+}
+
+@media (max-width: 991.98px) {
+  .menubar-vertical-expand-lg.menubar-transparent .menubar-toggler {
+    color: #272833;
+    font-size: 0.875rem;
+    font-weight: 600;
+    border-radius: 0.375rem;
+    transition: box-shadow 0.15s ease-in-out;
+  }
+  .menubar-vertical-expand-lg.menubar-transparent .menubar-toggler:focus, .menubar-vertical-expand-lg.menubar-transparent .menubar-toggler.focus {
+    box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+    outline: 0;
+  }
+  .menubar-vertical-expand-lg.menubar-transparent .menubar-toggler:active:focus {
+    box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  }
+  .menubar-vertical-expand-lg.menubar-transparent .menubar-toggler:disabled, .menubar-vertical-expand-lg.menubar-transparent .menubar-toggler.disabled {
+    box-shadow: none;
+  }
+}
+
+.menubar-vertical-expand-lg.menubar-transparent .nav-link {
+  border-radius: 0.375rem;
+  color: #6b6c7e;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.menubar-vertical-expand-lg.menubar-transparent .nav-link:hover {
+  background-color: rgba(39, 40, 51, 0.03);
+  color: #272833;
+}
+
+.menubar-vertical-expand-lg.menubar-transparent .nav-link:focus {
+  background-color: rgba(39, 40, 51, 0.03);
+  box-shadow: inset 0 0 0 0.125rem #80acff, inset 0 0 0 0.25rem #fff;
+  color: #272833;
+  outline: 0;
+}
+
+.menubar-vertical-expand-lg.menubar-transparent .nav-link:active {
+  color: #272833;
+}
+
+.menubar-vertical-expand-lg.menubar-transparent .nav-link.active {
+  background-color: #f0f5ff;
+  color: #0b5fff;
+  font-weight: 600;
+}
+
+.menubar-vertical-expand-lg.menubar-transparent .nav-link[aria-expanded='true'], .menubar-vertical-expand-lg.menubar-transparent .nav-link.show,
+.show > .menubar-vertical-expand-lg.menubar-transparent .nav-link {
+  color: #272833;
+  font-weight: 600;
+}
+
+.menubar-vertical-expand-lg.menubar-transparent .nav-link:disabled, .menubar-vertical-expand-lg.menubar-transparent .nav-link.disabled {
+  box-shadow: none;
+  color: #a7a9bc;
+}
+
+@media (max-width: 991.98px) {
+  .menubar-vertical-expand-lg.menubar-transparent .nav-link {
+    border-radius: 0;
+    color: #6b6c7e;
+    transition: none;
+  }
+  .menubar-vertical-expand-lg.menubar-transparent .nav-link:hover {
+    background-color: #f0f5ff;
+    color: #272833;
+  }
+  .menubar-vertical-expand-lg.menubar-transparent .nav-link:focus {
+    background-color: #f0f5ff;
+  }
+  .menubar-vertical-expand-lg.menubar-transparent .nav-link:active {
+    background-color: #f0f5ff;
+    color: #272833;
+  }
+  .menubar-vertical-expand-lg.menubar-transparent .nav-link.active {
+    background-color: #f0f5ff;
+    color: #272833;
+    font-weight: 600;
+  }
+  .menubar-vertical-expand-lg.menubar-transparent .nav-link[aria-expanded='true'], .menubar-vertical-expand-lg.menubar-transparent .nav-link.show,
+  .show > .menubar-vertical-expand-lg.menubar-transparent .nav-link {
+    background-color: #f0f5ff;
+    color: #272833;
+    font-weight: 600;
+  }
+  .menubar-vertical-expand-lg.menubar-transparent .nav-link:disabled, .menubar-vertical-expand-lg.menubar-transparent .nav-link.disabled {
+    background-color: transparent;
+    color: #a7a9bc;
+  }
+}
+
+@media (min-width: 992px) {
+  .menubar-vertical-expand-lg.menubar-decorated .nav {
+    border-left-color: #e7e7ed;
+    border-left-style: solid;
+    border-left-width: 0.125rem;
+    display: block;
+    padding-left: 0.5rem;
+  }
+  .menubar-vertical-expand-lg.menubar-decorated .nav > .nav-item .nav {
+    margin-bottom: 0.25rem;
+    margin-left: 1rem;
+    margin-top: 0.25rem;
+  }
+  .menubar-vertical-expand-lg.menubar-decorated .nav-link {
+    padding-left: 1rem !important;
+  }
+  .menubar-vertical-expand-lg.menubar-decorated .nav-link.active::after {
+    background-color: #b3cdff;
+    bottom: 0;
+    content: "";
+    display: block;
+    left: -0.625rem;
+    position: absolute;
+    top: 0;
+    width: 0.125rem;
+  }
+}
+
+.navbar {
+  align-items: center;
+  border-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.875rem;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  position: relative;
+}
+
+.navbar .container,
+.navbar .container-fluid, .navbar > .container-sm, .navbar > .container-md, .navbar > .container-lg, .navbar > .container-xl {
+  align-items: inherit;
+  background-color: inherit;
+  display: inherit;
+  flex-wrap: inherit;
+  justify-content: inherit;
+}
+
+.navbar-nowrap {
+  flex-wrap: nowrap;
+}
+
+.navbar-nowrap .navbar-text {
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.navbar-nav .dropdown-menu-right,
+.navbar-form .dropdown-menu-right {
+  left: auto;
+  right: 0;
+}
+
+.navbar-nav {
+  display: flex;
+  flex-wrap: inherit;
+  list-style: none;
+  margin-bottom: 0;
+  padding-left: 0;
+}
+
+.navbar-nav .dropdown-menu {
+  float: none;
+}
+
+.navbar-nav .nav-item,
+.navbar-nav .nav-item .dropdown {
+  align-items: center;
+  display: flex;
+  word-wrap: normal;
+}
+
+.navbar-nav .nav-item > .custom-control,
+.navbar-nav .nav-item > .form-check {
+  margin-bottom: 0;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.navbar-nav .nav-link {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.navbar-nav-expand {
+  flex-grow: 1;
+  min-width: 0;
+}
+
+.navbar-nav-last {
+  margin-left: auto;
+}
+
+.nav-item-expand {
+  flex-grow: 1;
+  min-width: 0;
+}
+
+.nav-item-shrink {
+  min-width: 0;
+}
+
+.navbar-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0;
+}
+
+.navbar-text {
+  display: inline-block;
+  padding-bottom: 0.625rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.625rem;
+}
+
+.navbar-collapse {
+  align-items: center;
+  flex-grow: 1;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.navbar-collapse .container,
+.navbar-collapse .container-fluid {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.navbar-collapse .dropdown-toggle .navbar-text-truncate {
+  max-width: calc(100% - 1.5625rem);
+}
+
+.navbar-text-truncate {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  white-space: nowrap;
+}
+
+.navbar-toggler-icon {
+  background-size: 100% 100%;
+  background: no-repeat center center;
+  content: '';
+  display: inline-block;
+  height: 1.5em;
+  vertical-align: middle;
+  width: 1.5em;
+}
+
+.navbar-toggler {
+  background-color: transparent;
+  border: 0.0625rem solid transparent;
+  border-radius: 0.25rem;
+  font-size: 1.125rem;
+  line-height: 1;
+  padding: 0.25rem 0.75rem;
+}
+
+.navbar-toggler:hover {
+  text-decoration: none;
+}
+
+.navbar-toggler:focus {
+  text-decoration: none;
+  z-index: 525;
+}
+
+.navbar-toggler-link {
+  align-items: center;
+  display: flex;
+  border-width: 0;
+  line-height: 1.5;
+  max-width: 100%;
+  padding: 0.53125rem 0.5rem;
+  position: relative;
+}
+
+.navbar-toggler-link .lexicon-icon {
+  min-width: 1em;
+  margin-left: 3px;
+  margin-top: 0;
+}
+
+.navbar-brand {
+  display: inline-block;
+  font-size: 1.125rem;
+  line-height: inherit;
+  max-width: calc(100% - 72px);
+  padding-bottom: 0.53125rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.53125rem;
+  white-space: nowrap;
+}
+
+.navbar-brand:hover, .navbar-brand:focus {
+  text-decoration: none;
+}
+
+.navbar-form {
+  align-items: center;
+  display: flex;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.navbar-form > form {
+  width: 100%;
+}
+
+.navbar-form-autofit {
+  flex-basis: 100px;
+  flex-grow: 1;
+}
+
+.navbar-form-autofit form {
+  display: flex;
+  width: 100%;
+}
+
+.navbar-overlay {
+  background-color: inherit;
+  flex-wrap: inherit;
+}
+
+.navbar-breakpoint-d-block,
+.navbar-breakpoint-d-inline-block,
+.navbar-breakpoint-d-flex {
+  display: none !important;
+}
+
+.navbar-expand-sm .nav-item .navbar-text-truncate {
+  max-width: 12.5rem;
+}
+
+@media (max-width: 575.98px) {
+  .navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    background-color: inherit;
+    left: 0;
+    padding: 0 1rem;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    z-index: 500;
+  }
+  .navbar-expand-sm.navbar-collapse-absolute .navbar-collapse .container,
+  .navbar-expand-sm.navbar-collapse-absolute .navbar-collapse .container-fluid {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+  .navbar-expand-sm.navbar-collapse-absolute .navbar-collapse .navbar-nav:last-child,
+  .navbar-expand-sm.navbar-collapse-absolute .navbar-collapse .navbar-form:last-child {
+    padding-bottom: 0.5rem;
+  }
+  .navbar-expand-sm .navbar-collapse .nav-item,
+  .navbar-expand-sm .navbar-collapse .nav-item .dropdown {
+    display: block;
+  }
+  .navbar-expand-sm .navbar-collapse .navbar-text-truncate {
+    max-width: 100%;
+  }
+  .navbar-expand-sm .navbar-collapse .navbar-nav {
+    flex-direction: column;
+  }
+  .navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-toggle .navbar-text-truncate {
+    max-width: calc( 100% - 1.5625rem);
+  }
+  .navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+  .navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item:hover, .navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item:focus {
+    background-color: transparent;
+  }
+  .navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.active {
+    background-color: transparent;
+  }
+  .navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-menu {
+    background-color: transparent;
+    border-width: 0;
+    box-shadow: none;
+    margin: 0;
+    max-height: none;
+    max-width: none;
+    overflow: visible;
+    padding: 0;
+    position: static;
+  }
+  .navbar-expand-sm .show-dropdown-on-collapse .dropdown-header,
+  .navbar-expand-sm .show-dropdown-on-collapse .dropdown-item {
+    padding: 0.625rem 0.5rem;
+  }
+  .navbar-expand-sm .show-dropdown-on-collapse .dropdown-menu {
+    display: block;
+  }
+  .navbar-expand-sm .show-dropdown-on-collapse .dropdown-toggle {
+    display: none;
+  }
+  .navbar-expand-sm .navbar-breakpoint-down-d-block {
+    display: block !important;
+  }
+  .navbar-expand-sm .navbar-breakpoint-down-d-inline-block {
+    display: inline-block !important;
+  }
+  .navbar-expand-sm .navbar-breakpoint-down-d-flex {
+    display: flex !important;
+  }
+  .navbar-expand-sm .navbar-breakpoint-down-d-none {
+    display: none !important;
+  }
+}
+
+@media (min-width: 576px) {
+  .navbar-expand-sm .navbar-brand .navbar-text-truncate {
+    max-width: 12.5rem;
+  }
+  .navbar-expand-sm .navbar-collapse {
+    display: flex !important;
+    width: auto;
+  }
+  .navbar-expand-sm .navbar-collapse .dropdown-toggle .navbar-text-truncate {
+    max-width: 10.9375rem;
+  }
+  .navbar-expand-sm .navbar-toggler {
+    display: none;
+  }
+  .navbar-expand-sm .navbar-breakpoint-d-block {
+    display: block !important;
+  }
+  .navbar-expand-sm .navbar-breakpoint-d-inline-block {
+    display: inline-block !important;
+  }
+  .navbar-expand-sm .navbar-breakpoint-d-flex {
+    display: flex !important;
+  }
+  .navbar-expand-sm .navbar-breakpoint-d-none {
+    display: none !important;
+  }
+}
+
+.navbar-expand-md .nav-item .navbar-text-truncate {
+  max-width: 12.5rem;
+}
+
+@media (max-width: 767.98px) {
+  .navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    background-color: inherit;
+    left: 0;
+    padding: 0 1rem;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    z-index: 500;
+  }
+  .navbar-expand-md.navbar-collapse-absolute .navbar-collapse .container,
+  .navbar-expand-md.navbar-collapse-absolute .navbar-collapse .container-fluid {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+  .navbar-expand-md.navbar-collapse-absolute .navbar-collapse .navbar-nav:last-child,
+  .navbar-expand-md.navbar-collapse-absolute .navbar-collapse .navbar-form:last-child {
+    padding-bottom: 0.5rem;
+  }
+  .navbar-expand-md .navbar-collapse .nav-item,
+  .navbar-expand-md .navbar-collapse .nav-item .dropdown {
+    display: block;
+  }
+  .navbar-expand-md .navbar-collapse .navbar-text-truncate {
+    max-width: 100%;
+  }
+  .navbar-expand-md .navbar-collapse .navbar-nav {
+    flex-direction: column;
+  }
+  .navbar-expand-md .navbar-collapse .navbar-nav .dropdown-toggle .navbar-text-truncate {
+    max-width: calc( 100% - 1.5625rem);
+  }
+  .navbar-expand-md .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+  .navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item:hover, .navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item:focus {
+    background-color: transparent;
+  }
+  .navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.active {
+    background-color: transparent;
+  }
+  .navbar-expand-md .navbar-collapse .navbar-nav .dropdown-menu {
+    background-color: transparent;
+    border-width: 0;
+    box-shadow: none;
+    margin: 0;
+    max-height: none;
+    max-width: none;
+    overflow: visible;
+    padding: 0;
+    position: static;
+  }
+  .navbar-expand-md .show-dropdown-on-collapse .dropdown-header,
+  .navbar-expand-md .show-dropdown-on-collapse .dropdown-item {
+    padding: 0.625rem 0.5rem;
+  }
+  .navbar-expand-md .show-dropdown-on-collapse .dropdown-menu {
+    display: block;
+  }
+  .navbar-expand-md .show-dropdown-on-collapse .dropdown-toggle {
+    display: none;
+  }
+  .navbar-expand-md .navbar-breakpoint-down-d-block {
+    display: block !important;
+  }
+  .navbar-expand-md .navbar-breakpoint-down-d-inline-block {
+    display: inline-block !important;
+  }
+  .navbar-expand-md .navbar-breakpoint-down-d-flex {
+    display: flex !important;
+  }
+  .navbar-expand-md .navbar-breakpoint-down-d-none {
+    display: none !important;
+  }
+}
+
+@media (min-width: 768px) {
+  .navbar-expand-md .navbar-brand .navbar-text-truncate {
+    max-width: 12.5rem;
+  }
+  .navbar-expand-md .navbar-collapse {
+    display: flex !important;
+    width: auto;
+  }
+  .navbar-expand-md .navbar-collapse .dropdown-toggle .navbar-text-truncate {
+    max-width: 10.9375rem;
+  }
+  .navbar-expand-md .navbar-toggler {
+    display: none;
+  }
+  .navbar-expand-md .navbar-breakpoint-d-block {
+    display: block !important;
+  }
+  .navbar-expand-md .navbar-breakpoint-d-inline-block {
+    display: inline-block !important;
+  }
+  .navbar-expand-md .navbar-breakpoint-d-flex {
+    display: flex !important;
+  }
+  .navbar-expand-md .navbar-breakpoint-d-none {
+    display: none !important;
+  }
+}
+
+.navbar-expand-lg .nav-item .navbar-text-truncate {
+  max-width: 12.5rem;
+}
+
+@media (max-width: 991.98px) {
+  .navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    background-color: inherit;
+    left: 0;
+    padding: 0 1rem;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    z-index: 500;
+  }
+  .navbar-expand-lg.navbar-collapse-absolute .navbar-collapse .container,
+  .navbar-expand-lg.navbar-collapse-absolute .navbar-collapse .container-fluid {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+  .navbar-expand-lg.navbar-collapse-absolute .navbar-collapse .navbar-nav:last-child,
+  .navbar-expand-lg.navbar-collapse-absolute .navbar-collapse .navbar-form:last-child {
+    padding-bottom: 0.5rem;
+  }
+  .navbar-expand-lg .navbar-collapse .nav-item,
+  .navbar-expand-lg .navbar-collapse .nav-item .dropdown {
+    display: block;
+  }
+  .navbar-expand-lg .navbar-collapse .navbar-text-truncate {
+    max-width: 100%;
+  }
+  .navbar-expand-lg .navbar-collapse .navbar-nav {
+    flex-direction: column;
+  }
+  .navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-toggle .navbar-text-truncate {
+    max-width: calc( 100% - 1.5625rem);
+  }
+  .navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+  .navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item:hover, .navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item:focus {
+    background-color: transparent;
+  }
+  .navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.active {
+    background-color: transparent;
+  }
+  .navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-menu {
+    background-color: transparent;
+    border-width: 0;
+    box-shadow: none;
+    margin: 0;
+    max-height: none;
+    max-width: none;
+    overflow: visible;
+    padding: 0;
+    position: static;
+  }
+  .navbar-expand-lg .show-dropdown-on-collapse .dropdown-header,
+  .navbar-expand-lg .show-dropdown-on-collapse .dropdown-item {
+    padding: 0.625rem 0.5rem;
+  }
+  .navbar-expand-lg .show-dropdown-on-collapse .dropdown-menu {
+    display: block;
+  }
+  .navbar-expand-lg .show-dropdown-on-collapse .dropdown-toggle {
+    display: none;
+  }
+  .navbar-expand-lg .navbar-breakpoint-down-d-block {
+    display: block !important;
+  }
+  .navbar-expand-lg .navbar-breakpoint-down-d-inline-block {
+    display: inline-block !important;
+  }
+  .navbar-expand-lg .navbar-breakpoint-down-d-flex {
+    display: flex !important;
+  }
+  .navbar-expand-lg .navbar-breakpoint-down-d-none {
+    display: none !important;
+  }
+}
+
+@media (min-width: 992px) {
+  .navbar-expand-lg .navbar-brand .navbar-text-truncate {
+    max-width: 12.5rem;
+  }
+  .navbar-expand-lg .navbar-collapse {
+    display: flex !important;
+    width: auto;
+  }
+  .navbar-expand-lg .navbar-collapse .dropdown-toggle .navbar-text-truncate {
+    max-width: 10.9375rem;
+  }
+  .navbar-expand-lg .navbar-toggler {
+    display: none;
+  }
+  .navbar-expand-lg .navbar-breakpoint-d-block {
+    display: block !important;
+  }
+  .navbar-expand-lg .navbar-breakpoint-d-inline-block {
+    display: inline-block !important;
+  }
+  .navbar-expand-lg .navbar-breakpoint-d-flex {
+    display: flex !important;
+  }
+  .navbar-expand-lg .navbar-breakpoint-d-none {
+    display: none !important;
+  }
+}
+
+.navbar-expand-xl .nav-item .navbar-text-truncate {
+  max-width: 12.5rem;
+}
+
+@media (max-width: 1279.98px) {
+  .navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    background-color: inherit;
+    left: 0;
+    padding: 0 1rem;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    z-index: 500;
+  }
+  .navbar-expand-xl.navbar-collapse-absolute .navbar-collapse .container,
+  .navbar-expand-xl.navbar-collapse-absolute .navbar-collapse .container-fluid {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+  .navbar-expand-xl.navbar-collapse-absolute .navbar-collapse .navbar-nav:last-child,
+  .navbar-expand-xl.navbar-collapse-absolute .navbar-collapse .navbar-form:last-child {
+    padding-bottom: 0.5rem;
+  }
+  .navbar-expand-xl .navbar-collapse .nav-item,
+  .navbar-expand-xl .navbar-collapse .nav-item .dropdown {
+    display: block;
+  }
+  .navbar-expand-xl .navbar-collapse .navbar-text-truncate {
+    max-width: 100%;
+  }
+  .navbar-expand-xl .navbar-collapse .navbar-nav {
+    flex-direction: column;
+  }
+  .navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-toggle .navbar-text-truncate {
+    max-width: calc( 100% - 1.5625rem);
+  }
+  .navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+  .navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item:hover, .navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item:focus {
+    background-color: transparent;
+  }
+  .navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.active {
+    background-color: transparent;
+  }
+  .navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-menu {
+    background-color: transparent;
+    border-width: 0;
+    box-shadow: none;
+    margin: 0;
+    max-height: none;
+    max-width: none;
+    overflow: visible;
+    padding: 0;
+    position: static;
+  }
+  .navbar-expand-xl .show-dropdown-on-collapse .dropdown-header,
+  .navbar-expand-xl .show-dropdown-on-collapse .dropdown-item {
+    padding: 0.625rem 0.5rem;
+  }
+  .navbar-expand-xl .show-dropdown-on-collapse .dropdown-menu {
+    display: block;
+  }
+  .navbar-expand-xl .show-dropdown-on-collapse .dropdown-toggle {
+    display: none;
+  }
+  .navbar-expand-xl .navbar-breakpoint-down-d-block {
+    display: block !important;
+  }
+  .navbar-expand-xl .navbar-breakpoint-down-d-inline-block {
+    display: inline-block !important;
+  }
+  .navbar-expand-xl .navbar-breakpoint-down-d-flex {
+    display: flex !important;
+  }
+  .navbar-expand-xl .navbar-breakpoint-down-d-none {
+    display: none !important;
+  }
+}
+
+@media (min-width: 1280px) {
+  .navbar-expand-xl .navbar-brand .navbar-text-truncate {
+    max-width: 12.5rem;
+  }
+  .navbar-expand-xl .navbar-collapse {
+    display: flex !important;
+    width: auto;
+  }
+  .navbar-expand-xl .navbar-collapse .dropdown-toggle .navbar-text-truncate {
+    max-width: 10.9375rem;
+  }
+  .navbar-expand-xl .navbar-toggler {
+    display: none;
+  }
+  .navbar-expand-xl .navbar-breakpoint-d-block {
+    display: block !important;
+  }
+  .navbar-expand-xl .navbar-breakpoint-d-inline-block {
+    display: inline-block !important;
+  }
+  .navbar-expand-xl .navbar-breakpoint-d-flex {
+    display: flex !important;
+  }
+  .navbar-expand-xl .navbar-breakpoint-d-none {
+    display: none !important;
+  }
+}
+
+.navbar-expand .nav-item .navbar-text-truncate {
+  max-width: 12.5rem;
+}
+
+@media (max-width: 575.98px) {
+  .navbar-overlay-xs-down {
+    bottom: 0;
+    display: none;
+    justify-content: space-between;
+    left: 0;
+    margin-left: 0;
+    margin-right: 0;
+    padding-bottom: 0.5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.5rem;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 450;
+  }
+  .navbar-overlay-xs-down.show {
+    display: flex;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .navbar-overlay-sm-down {
+    bottom: 0;
+    display: none;
+    justify-content: space-between;
+    left: 0;
+    margin-left: 0;
+    margin-right: 0;
+    padding-bottom: 0.5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.5rem;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 450;
+  }
+  .navbar-overlay-sm-down.show {
+    display: flex;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .navbar-overlay-md-down {
+    bottom: 0;
+    display: none;
+    justify-content: space-between;
+    left: 0;
+    margin-left: 0;
+    margin-right: 0;
+    padding-bottom: 0.5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.5rem;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 450;
+  }
+  .navbar-overlay-md-down.show {
+    display: flex;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .navbar-overlay-lg-down {
+    bottom: 0;
+    display: none;
+    justify-content: space-between;
+    left: 0;
+    margin-left: 0;
+    margin-right: 0;
+    padding-bottom: 0.5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.5rem;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 450;
+  }
+  .navbar-overlay-lg-down.show {
+    display: flex;
+  }
+}
+
+.navbar-overlay-up {
+  bottom: 0;
+  display: none;
+  justify-content: space-between;
+  left: 0;
+  margin-left: 0;
+  margin-right: 0;
+  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 450;
+}
+
+.navbar-overlay-up.show {
+  display: flex;
+}
+
+.navbar-light .navbar-brand {
+  color: #272833;
+}
+
+.navbar-light .navbar-brand:hover, .navbar-light .navbar-brand:focus {
+  color: #272833;
+}
+
+.navbar-light .navbar-nav .nav-link {
+  color: #6b6c7e;
+}
+
+.navbar-light .navbar-nav .nav-link:hover, .navbar-light .navbar-nav .nav-link:focus {
+  color: #6b6c7e;
+}
+
+.navbar-light .navbar-nav .nav-link.disabled {
+  color: #a7a9bc;
+}
+
+.navbar-light .navbar-nav .show > .nav-link,
+.navbar-light .navbar-nav .active > .nav-link,
+.navbar-light .navbar-nav .nav-link.show,
+.navbar-light .navbar-nav .nav-link.active {
+  color: #272833;
+}
+
+.navbar-light .navbar-toggler {
+  border-color: rgba(0, 0, 0, 0.1);
+  color: #6b6c7e;
+}
+
+.navbar-light .navbar-toggler-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='%236b6c7e' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+.navbar-light .navbar-text {
+  color: #6b6c7e;
+}
+
+.navbar-light .navbar-text a {
+  color: #272833;
+}
+
+.navbar-light .navbar-text a:hover, .navbar-light .navbar-text a:focus {
+  color: #272833;
+}
+
+.navbar-dark .navbar-brand {
+  color: #fff;
+}
+
+.navbar-dark .navbar-brand:hover, .navbar-dark .navbar-brand:focus {
+  color: #fff;
+}
+
+.navbar-dark .navbar-nav .nav-link {
+  color: #fff;
+}
+
+.navbar-dark .navbar-nav .nav-link:hover, .navbar-dark .navbar-nav .nav-link:focus {
+  color: #fff;
+}
+
+.navbar-dark .navbar-nav .nav-link.disabled {
+  color: #a7a9bc;
+}
+
+.navbar-dark .navbar-nav .show > .nav-link,
+.navbar-dark .navbar-nav .active > .nav-link,
+.navbar-dark .navbar-nav .nav-link.show,
+.navbar-dark .navbar-nav .nav-link.active {
+  color: #fff;
+}
+
+.navbar-dark .navbar-toggler {
+  border-color: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.navbar-dark .navbar-toggler-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+.navbar-dark .navbar-text {
+  color: #fff;
+}
+
+.navbar-dark .navbar-text a {
+  color: #fff;
+}
+
+.navbar-dark .navbar-text a:hover, .navbar-dark .navbar-text a:focus {
+  color: #fff;
+}
+
+.navbar-underline .navbar-toggler-link:after {
+  background-color: #80acff;
+  bottom: -0.5rem;
+  content: '';
+  display: block;
+  height: 0.125rem;
+  left: 0;
+  position: absolute;
+  right: 0;
+  width: auto;
+}
+
+@media (min-width: 576px) {
+  .navbar-underline.navbar-expand-sm .navbar-nav .nav-link.active:after {
+    background-color: #80acff;
+    bottom: -0.5rem;
+    content: '';
+    display: block;
+    height: 0.125rem;
+    left: 0;
+    position: absolute;
+    right: 0;
+    width: auto;
+  }
+}
+
+@media (min-width: 768px) {
+  .navbar-underline.navbar-expand-md .navbar-nav .nav-link.active:after {
+    background-color: #80acff;
+    bottom: -0.5rem;
+    content: '';
+    display: block;
+    height: 0.125rem;
+    left: 0;
+    position: absolute;
+    right: 0;
+    width: auto;
+  }
+}
+
+@media (min-width: 992px) {
+  .navbar-underline.navbar-expand-lg .navbar-nav .nav-link.active:after {
+    background-color: #80acff;
+    bottom: -0.5rem;
+    content: '';
+    display: block;
+    height: 0.125rem;
+    left: 0;
+    position: absolute;
+    right: 0;
+    width: auto;
+  }
+}
+
+@media (min-width: 1280px) {
+  .navbar-underline.navbar-expand-xl .navbar-nav .nav-link.active:after {
+    background-color: #80acff;
+    bottom: -0.5rem;
+    content: '';
+    display: block;
+    height: 0.125rem;
+    left: 0;
+    position: absolute;
+    right: 0;
+    width: auto;
+  }
+}
+
+.navbar-underline.navbar-expand .navbar-nav .nav-link.active:after {
+  background-color: #80acff;
+  bottom: -0.5rem;
+  content: '';
+  display: block;
+  height: 0.125rem;
+  left: 0;
+  position: absolute;
+  right: 0;
+  width: auto;
+}
+
+.application-bar {
+  flex-wrap: nowrap;
+  border-width: 0 0 0 0;
+  font-size: 0.875rem;
+  padding: 0 0;
+  border-color: transparent;
+  border-style: solid;
+}
+
+.application-bar .navbar-toggler {
+  font-size: 1.125rem;
+  height: 2.00001rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.application-bar .navbar-toggler .c-inner {
+  margin-bottom: -0.25rem;
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: -0.25rem;
+}
+
+.application-bar .navbar-toggler-link {
+  font-size: 0.875rem;
+  height: auto;
+  line-height: 1.5;
+  margin-left: 0;
+  margin-right: 0;
+  padding-bottom: 0.84375rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.84375rem;
+}
+
+.application-bar .navbar-toggler-link .c-inner {
+  margin-bottom: -0.84375rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.84375rem;
+}
+
+.application-bar .navbar-brand {
+  font-size: 1.125rem;
+  margin-right: 0;
+  padding-bottom: 0.65625rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.65625rem;
+}
+
+.application-bar .navbar-brand .c-inner {
+  margin-bottom: -0.65625rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.65625rem;
+}
+
+.application-bar .navbar-title {
+  font-size: 1.125rem;
+}
+
+.application-bar .navbar-nav .nav-btn {
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  margin-top: 0.5rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.25rem;
+}
+
+.application-bar .navbar-nav .nav-btn .c-inner {
+  margin-bottom: -0.25rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.25rem;
+}
+
+.application-bar .navbar-nav .nav-btn-monospaced {
+  font-size: 1rem;
+  padding: 0;
+}
+
+.application-bar .navbar-nav .nav-btn-monospaced .c-inner {
+  margin: 0;
+}
+
+.application-bar .navbar-nav .nav-item > .custom-control,
+.application-bar .navbar-nav .nav-item > .form-check {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.application-bar .navbar-nav .nav-link,
+.application-bar .navbar-nav .navbar-text {
+  margin-bottom: 0.5rem;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  margin-top: 0.5rem;
+  padding-bottom: 0.34375rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.34375rem;
+}
+
+.application-bar .navbar-nav .nav-link .c-inner,
+.application-bar .navbar-nav .navbar-text .c-inner {
+  margin-bottom: -0.34375rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.34375rem;
+}
+
+.application-bar .navbar-nav .nav-link-monospaced {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  margin-top: 0.5rem;
+  padding: 0;
+}
+
+.application-bar .navbar-nav .nav-link-monospaced .c-inner {
+  margin: 0;
+}
+
+@media (max-width: 575.98px) {
+  .application-bar.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0 0;
+    left: 0;
+    margin-top: 0;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .application-bar.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .application-bar.navbar-expand-sm .navbar-form {
+    height: 3rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-sm .navbar-form .form-control {
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (min-width: 576px) {
+  .application-bar.navbar-expand-sm .navbar-brand {
+    font-size: 1.125rem;
+    margin-right: 0.25rem;
+    padding-bottom: 0.90625rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.90625rem;
+  }
+  .application-bar.navbar-expand-sm .navbar-brand .c-inner {
+    margin-bottom: -0.90625rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.90625rem;
+  }
+  .application-bar.navbar-expand-sm .navbar-form {
+    height: 3.5rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+  }
+  .application-bar.navbar-expand-sm .navbar-form > .container,
+  .application-bar.navbar-expand-sm .navbar-form > .container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .application-bar.navbar-expand-sm .nav-btn {
+    font-size: 0.875rem;
+    margin-bottom: 0.75rem;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+    margin-top: 0.75rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-sm .nav-btn .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.34375rem;
+  }
+  .application-bar.navbar-expand-sm .nav-btn-monospaced {
+    font-size: 1rem;
+    padding: 0;
+  }
+  .application-bar.navbar-expand-sm .nav-btn-monospaced .c-inner {
+    margin: 0;
+  }
+  .application-bar.navbar-expand-sm .nav-item > .custom-control,
+  .application-bar.navbar-expand-sm .nav-item > .form-check {
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+  }
+  .application-bar.navbar-expand-sm .nav-link,
+  .application-bar.navbar-expand-sm .navbar-text {
+    margin-bottom: 0.75rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.75rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-sm .nav-link .c-inner,
+  .application-bar.navbar-expand-sm .navbar-text .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.34375rem;
+  }
+  .application-bar.navbar-expand-sm .nav-link-monospaced {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+    margin-top: 0.75rem;
+    padding: 0;
+  }
+  .application-bar.navbar-expand-sm .nav-link-monospaced .c-inner {
+    margin: 0;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .application-bar.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0 0;
+    left: 0;
+    margin-top: 0;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .application-bar.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .application-bar.navbar-expand-md .navbar-form {
+    height: 3rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-md .navbar-form .form-control {
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .application-bar.navbar-expand-md .navbar-brand {
+    font-size: 1.125rem;
+    margin-right: 0.25rem;
+    padding-bottom: 0.90625rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.90625rem;
+  }
+  .application-bar.navbar-expand-md .navbar-brand .c-inner {
+    margin-bottom: -0.90625rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.90625rem;
+  }
+  .application-bar.navbar-expand-md .navbar-form {
+    height: 3.5rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+  }
+  .application-bar.navbar-expand-md .navbar-form > .container,
+  .application-bar.navbar-expand-md .navbar-form > .container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .application-bar.navbar-expand-md .nav-btn {
+    font-size: 0.875rem;
+    margin-bottom: 0.75rem;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+    margin-top: 0.75rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-md .nav-btn .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.34375rem;
+  }
+  .application-bar.navbar-expand-md .nav-btn-monospaced {
+    font-size: 1rem;
+    padding: 0;
+  }
+  .application-bar.navbar-expand-md .nav-btn-monospaced .c-inner {
+    margin: 0;
+  }
+  .application-bar.navbar-expand-md .nav-item > .custom-control,
+  .application-bar.navbar-expand-md .nav-item > .form-check {
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+  }
+  .application-bar.navbar-expand-md .nav-link,
+  .application-bar.navbar-expand-md .navbar-text {
+    margin-bottom: 0.75rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.75rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-md .nav-link .c-inner,
+  .application-bar.navbar-expand-md .navbar-text .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.34375rem;
+  }
+  .application-bar.navbar-expand-md .nav-link-monospaced {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+    margin-top: 0.75rem;
+    padding: 0;
+  }
+  .application-bar.navbar-expand-md .nav-link-monospaced .c-inner {
+    margin: 0;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .application-bar.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0 0;
+    left: 0;
+    margin-top: 0;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .application-bar.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .application-bar.navbar-expand-lg .navbar-form {
+    height: 3rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-lg .navbar-form .form-control {
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (min-width: 992px) {
+  .application-bar.navbar-expand-lg .navbar-brand {
+    font-size: 1.125rem;
+    margin-right: 0.25rem;
+    padding-bottom: 0.90625rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.90625rem;
+  }
+  .application-bar.navbar-expand-lg .navbar-brand .c-inner {
+    margin-bottom: -0.90625rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.90625rem;
+  }
+  .application-bar.navbar-expand-lg .navbar-form {
+    height: 3.5rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+  }
+  .application-bar.navbar-expand-lg .navbar-form > .container,
+  .application-bar.navbar-expand-lg .navbar-form > .container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .application-bar.navbar-expand-lg .nav-btn {
+    font-size: 0.875rem;
+    margin-bottom: 0.75rem;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+    margin-top: 0.75rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-lg .nav-btn .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.34375rem;
+  }
+  .application-bar.navbar-expand-lg .nav-btn-monospaced {
+    font-size: 1rem;
+    padding: 0;
+  }
+  .application-bar.navbar-expand-lg .nav-btn-monospaced .c-inner {
+    margin: 0;
+  }
+  .application-bar.navbar-expand-lg .nav-item > .custom-control,
+  .application-bar.navbar-expand-lg .nav-item > .form-check {
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+  }
+  .application-bar.navbar-expand-lg .nav-link,
+  .application-bar.navbar-expand-lg .navbar-text {
+    margin-bottom: 0.75rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.75rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-lg .nav-link .c-inner,
+  .application-bar.navbar-expand-lg .navbar-text .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.34375rem;
+  }
+  .application-bar.navbar-expand-lg .nav-link-monospaced {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+    margin-top: 0.75rem;
+    padding: 0;
+  }
+  .application-bar.navbar-expand-lg .nav-link-monospaced .c-inner {
+    margin: 0;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .application-bar.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0 0;
+    left: 0;
+    margin-top: 0;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .application-bar.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .application-bar.navbar-expand-xl .navbar-form {
+    height: 3rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-xl .navbar-form .form-control {
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (min-width: 1280px) {
+  .application-bar.navbar-expand-xl .navbar-brand {
+    font-size: 1.125rem;
+    margin-right: 0.25rem;
+    padding-bottom: 0.90625rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.90625rem;
+  }
+  .application-bar.navbar-expand-xl .navbar-brand .c-inner {
+    margin-bottom: -0.90625rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.90625rem;
+  }
+  .application-bar.navbar-expand-xl .navbar-form {
+    height: 3.5rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+  }
+  .application-bar.navbar-expand-xl .navbar-form > .container,
+  .application-bar.navbar-expand-xl .navbar-form > .container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .application-bar.navbar-expand-xl .nav-btn {
+    font-size: 0.875rem;
+    margin-bottom: 0.75rem;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+    margin-top: 0.75rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-xl .nav-btn .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.34375rem;
+  }
+  .application-bar.navbar-expand-xl .nav-btn-monospaced {
+    font-size: 1rem;
+    padding: 0;
+  }
+  .application-bar.navbar-expand-xl .nav-btn-monospaced .c-inner {
+    margin: 0;
+  }
+  .application-bar.navbar-expand-xl .nav-item > .custom-control,
+  .application-bar.navbar-expand-xl .nav-item > .form-check {
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+  }
+  .application-bar.navbar-expand-xl .nav-link,
+  .application-bar.navbar-expand-xl .navbar-text {
+    margin-bottom: 0.75rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.75rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .application-bar.navbar-expand-xl .nav-link .c-inner,
+  .application-bar.navbar-expand-xl .navbar-text .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    margin-top: -0.34375rem;
+  }
+  .application-bar.navbar-expand-xl .nav-link-monospaced {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+    margin-top: 0.75rem;
+    padding: 0;
+  }
+  .application-bar.navbar-expand-xl .nav-link-monospaced .c-inner {
+    margin: 0;
+  }
+}
+
+.application-bar.navbar-expand .navbar-brand {
+  font-size: 1.125rem;
+  margin-right: 0.25rem;
+  padding-bottom: 0.90625rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.90625rem;
+}
+
+.application-bar.navbar-expand .navbar-brand .c-inner {
+  margin-bottom: -0.90625rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.90625rem;
+}
+
+.application-bar.navbar-expand .navbar-form {
+  height: 3.5rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
+.application-bar.navbar-expand .navbar-form > .container,
+.application-bar.navbar-expand .navbar-form > .container-fluid {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.application-bar.navbar-expand .nav-btn {
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  margin-top: 0.75rem;
+  padding-bottom: 0.34375rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.34375rem;
+}
+
+.application-bar.navbar-expand .nav-btn .c-inner {
+  margin-bottom: -0.34375rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.34375rem;
+}
+
+.application-bar.navbar-expand .nav-btn-monospaced {
+  font-size: 1rem;
+  padding: 0;
+}
+
+.application-bar.navbar-expand .nav-btn-monospaced .c-inner {
+  margin: 0;
+}
+
+.application-bar.navbar-expand .nav-item > .custom-control,
+.application-bar.navbar-expand .nav-item > .form-check {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.application-bar.navbar-expand .nav-link,
+.application-bar.navbar-expand .navbar-text {
+  margin-bottom: 0.75rem;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  margin-top: 0.75rem;
+  padding-bottom: 0.34375rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.34375rem;
+}
+
+.application-bar.navbar-expand .nav-link .c-inner,
+.application-bar.navbar-expand .navbar-text .c-inner {
+  margin-bottom: -0.34375rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.34375rem;
+}
+
+.application-bar.navbar-expand .nav-link-monospaced {
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  margin-top: 0.75rem;
+  padding: 0;
+}
+
+.application-bar.navbar-expand .nav-link-monospaced .c-inner {
+  margin: 0;
+}
+
+@media (max-width: 575.98px) {
+  .application-bar .navbar-overlay-xs-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .application-bar .navbar-overlay-sm-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .application-bar .navbar-overlay-md-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .application-bar .navbar-overlay-lg-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+.application-bar .navbar-overlay-up {
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+}
+
+.application-bar.navbar-underline .navbar-toggler-link:after {
+  bottom: -0.5rem;
+  height: 0.125rem;
+}
+
+@media (min-width: 576px) {
+  .application-bar.navbar-underline.navbar-expand-sm .navbar-nav .nav-link.active:after {
+    bottom: -0.75rem;
+    height: 0.125rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .application-bar.navbar-underline.navbar-expand-md .navbar-nav .nav-link.active:after {
+    bottom: -0.75rem;
+    height: 0.125rem;
+  }
+}
+
+@media (min-width: 992px) {
+  .application-bar.navbar-underline.navbar-expand-lg .navbar-nav .nav-link.active:after {
+    bottom: -0.75rem;
+    height: 0.125rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  .application-bar.navbar-underline.navbar-expand-xl .navbar-nav .nav-link.active:after {
+    bottom: -0.75rem;
+    height: 0.125rem;
+  }
+}
+
+.application-bar.navbar-underline.navbar-expand .navbar-nav .nav-link.active:after {
+  bottom: -0.75rem;
+  height: 0.125rem;
+}
+
+.application-bar .nav-link,
+.application-bar .navbar-nav .btn-unstyled {
+  border-radius: 0.25rem;
+  outline: 0;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.application-bar .nav-link:focus,
+.application-bar .navbar-nav .btn-unstyled:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.application-bar .nav-link.disabled, .application-bar .nav-link:disabled,
+.application-bar .navbar-nav .btn-unstyled.disabled,
+.application-bar .navbar-nav .btn-unstyled:disabled {
+  box-shadow: none;
+}
+
+.application-bar .navbar-brand {
+  border-radius: 0.25rem;
+  outline: 0;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.application-bar .navbar-brand:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.application-bar .navbar-toggler {
+  outline: 0;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.application-bar .navbar-toggler:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+@media (max-width: 575.98px) {
+  .application-bar.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .application-bar.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .application-bar.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .application-bar.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+.application-bar .container,
+.application-bar .container-fluid {
+  flex-wrap: nowrap;
+}
+
+.application-bar .navbar-nav {
+  flex-wrap: nowrap;
+}
+
+.application-bar-dark {
+  background-color: #30313f;
+  border-color: transparent;
+  border-style: solid;
+  color: #fff;
+}
+
+.application-bar-dark .nav-link,
+.application-bar-dark .navbar-nav .btn-unstyled {
+  color: #fff;
+  font-weight: 600;
+}
+
+.application-bar-dark .nav-link:hover,
+.application-bar-dark .navbar-nav .btn-unstyled:hover {
+  background-color: rgba(255, 255, 255, 0.03);
+  color: #fff;
+}
+
+.application-bar-dark .nav-link:focus,
+.application-bar-dark .navbar-nav .btn-unstyled:focus {
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+.application-bar-dark .nav-link.active, .application-bar-dark .nav-link[aria-expanded='true'],
+.application-bar-dark .navbar-nav .btn-unstyled.active,
+.application-bar-dark .navbar-nav .btn-unstyled[aria-expanded='true'] {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: #fff;
+}
+
+.application-bar-dark .nav-link.disabled, .application-bar-dark .nav-link:disabled,
+.application-bar-dark .navbar-nav .btn-unstyled.disabled,
+.application-bar-dark .navbar-nav .btn-unstyled:disabled {
+  background-color: transparent;
+  color: #a7a9bc;
+  opacity: 0.5;
+}
+
+.application-bar-dark .nav-btn {
+  font-weight: 600;
+}
+
+.application-bar-dark .navbar-toggler {
+  color: #fff;
+  font-weight: 600;
+}
+
+.application-bar-dark .navbar-toggler-link[aria-expanded='true'] {
+  color: #fff;
+}
+
+.application-bar-dark .navbar-overlay {
+  background-color: #30313f;
+}
+
+@media (max-width: 575.98px) {
+  .application-bar-dark.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    background-color: #30313f;
+    border-color: transparent;
+  }
+  .application-bar-dark.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-header,
+  .application-bar-dark.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item {
+    color: #fff;
+    font-weight: 600;
+  }
+  .application-bar-dark.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #fff;
+  }
+  .application-bar-dark.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #fff;
+  }
+  .application-bar-dark.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #fff;
+  }
+  .application-bar-dark.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .application-bar-dark.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    background-color: #30313f;
+    border-color: transparent;
+  }
+  .application-bar-dark.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-header,
+  .application-bar-dark.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item {
+    color: #fff;
+    font-weight: 600;
+  }
+  .application-bar-dark.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #fff;
+  }
+  .application-bar-dark.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #fff;
+  }
+  .application-bar-dark.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #fff;
+  }
+  .application-bar-dark.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .application-bar-dark.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    background-color: #30313f;
+    border-color: transparent;
+  }
+  .application-bar-dark.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-header,
+  .application-bar-dark.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item {
+    color: #fff;
+    font-weight: 600;
+  }
+  .application-bar-dark.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #fff;
+  }
+  .application-bar-dark.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #fff;
+  }
+  .application-bar-dark.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #fff;
+  }
+  .application-bar-dark.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .application-bar-dark.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    background-color: #30313f;
+    border-color: transparent;
+  }
+  .application-bar-dark.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-header,
+  .application-bar-dark.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item {
+    color: #fff;
+    font-weight: 600;
+  }
+  .application-bar-dark.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #fff;
+  }
+  .application-bar-dark.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #fff;
+  }
+  .application-bar-dark.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #fff;
+  }
+  .application-bar-dark.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+.management-bar {
+  border-width: 0 0 0.0625rem 0;
+  font-size: 0.875rem;
+  min-height: 4rem;
+  padding: 0 0;
+  border-color: transparent;
+  border-style: solid;
+}
+
+.management-bar .navbar-toggler {
+  font-size: 1.125rem;
+  height: 2.00001rem;
+  margin-left: 0.875rem;
+  margin-right: 0.875rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.management-bar .navbar-toggler .c-inner {
+  margin-bottom: -0.25rem;
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: -0.25rem;
+}
+
+.management-bar .navbar-toggler-link {
+  font-size: 0.875rem;
+  height: auto;
+  line-height: 1.5;
+  margin-left: 0;
+  margin-right: 0;
+  padding-bottom: 0.8125rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.8125rem;
+}
+
+.management-bar .navbar-toggler-link .c-inner {
+  margin-bottom: -0.8125rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.8125rem;
+}
+
+.management-bar .navbar-brand {
+  font-size: 1.125rem;
+  margin-right: 0;
+  padding-bottom: 0.625rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.625rem;
+}
+
+.management-bar .navbar-brand .c-inner {
+  margin-bottom: -0.625rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.625rem;
+}
+
+.management-bar .navbar-nav .nav-btn {
+  font-size: 0.875rem;
+  margin-bottom: 0.46875rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  margin-top: 0.46875rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.25rem;
+}
+
+.management-bar .navbar-nav .nav-btn .c-inner {
+  margin-bottom: -0.25rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.25rem;
+}
+
+.management-bar .navbar-nav .nav-btn-monospaced {
+  font-size: 1rem;
+  padding: 0;
+}
+
+.management-bar .navbar-nav .nav-btn-monospaced .c-inner {
+  margin: 0;
+}
+
+.management-bar .navbar-nav .nav-item > .custom-control,
+.management-bar .navbar-nav .nav-item > .form-check {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.management-bar .navbar-nav .nav-link,
+.management-bar .navbar-nav .navbar-text {
+  margin-bottom: 0.46875rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  margin-top: 0.46875rem;
+  padding-bottom: 0.34375rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.34375rem;
+}
+
+.management-bar .navbar-nav .nav-link .c-inner,
+.management-bar .navbar-nav .navbar-text .c-inner {
+  margin-bottom: -0.34375rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.34375rem;
+}
+
+.management-bar .navbar-nav .nav-link-monospaced {
+  font-size: 1rem;
+  margin-bottom: 0.46875rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  margin-top: 0.46875rem;
+  padding: 0;
+}
+
+.management-bar .navbar-nav .nav-link-monospaced .c-inner {
+  margin: 0;
+}
+
+.management-bar .dropdown-menu {
+  margin-top: 0;
+}
+
+@media (max-width: 575.98px) {
+  .management-bar.navbar-expand-sm {
+    min-height: 3rem;
+  }
+  .management-bar.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0.0625rem 0;
+    left: 0;
+    margin-top: 0.0625rem;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .management-bar.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .management-bar.navbar-expand-sm .navbar-form {
+    height: 2.9375rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-sm .navbar-form .form-control {
+    height: 2rem;
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (min-width: 576px) {
+  .management-bar.navbar-expand-sm .navbar-brand {
+    font-size: 1.125rem;
+    margin-right: 0.5rem;
+    padding-bottom: 1.125rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 1.125rem;
+  }
+  .management-bar.navbar-expand-sm .navbar-brand .c-inner {
+    margin-bottom: -1.125rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -1.125rem;
+  }
+  .management-bar.navbar-expand-sm .navbar-form {
+    height: 3.9375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  .management-bar.navbar-expand-sm .navbar-form > .container,
+  .management-bar.navbar-expand-sm .navbar-form > .container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .management-bar.navbar-expand-sm .nav-btn {
+    font-size: 0.875rem;
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-sm .nav-btn .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -0.34375rem;
+  }
+  .management-bar.navbar-expand-sm .nav-btn-monospaced {
+    font-size: 1rem;
+    padding: 0;
+  }
+  .management-bar.navbar-expand-sm .nav-btn-monospaced .c-inner {
+    margin: 0;
+  }
+  .management-bar.navbar-expand-sm .nav-item > .custom-control,
+  .management-bar.navbar-expand-sm .nav-item > .form-check {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+  }
+  .management-bar.navbar-expand-sm .nav-link,
+  .management-bar.navbar-expand-sm .navbar-text {
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-sm .nav-link .c-inner,
+  .management-bar.navbar-expand-sm .navbar-text .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -0.34375rem;
+  }
+  .management-bar.navbar-expand-sm .nav-link-monospaced {
+    font-size: 1rem;
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding: 0;
+  }
+  .management-bar.navbar-expand-sm .nav-link-monospaced .c-inner {
+    margin: 0;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .management-bar.navbar-expand-md {
+    min-height: 3rem;
+  }
+  .management-bar.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0.0625rem 0;
+    left: 0;
+    margin-top: 0.0625rem;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .management-bar.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .management-bar.navbar-expand-md .navbar-form {
+    height: 2.9375rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-md .navbar-form .form-control {
+    height: 2rem;
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .management-bar.navbar-expand-md .navbar-brand {
+    font-size: 1.125rem;
+    margin-right: 0.5rem;
+    padding-bottom: 1.125rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 1.125rem;
+  }
+  .management-bar.navbar-expand-md .navbar-brand .c-inner {
+    margin-bottom: -1.125rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -1.125rem;
+  }
+  .management-bar.navbar-expand-md .navbar-form {
+    height: 3.9375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  .management-bar.navbar-expand-md .navbar-form > .container,
+  .management-bar.navbar-expand-md .navbar-form > .container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .management-bar.navbar-expand-md .nav-btn {
+    font-size: 0.875rem;
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-md .nav-btn .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -0.34375rem;
+  }
+  .management-bar.navbar-expand-md .nav-btn-monospaced {
+    font-size: 1rem;
+    padding: 0;
+  }
+  .management-bar.navbar-expand-md .nav-btn-monospaced .c-inner {
+    margin: 0;
+  }
+  .management-bar.navbar-expand-md .nav-item > .custom-control,
+  .management-bar.navbar-expand-md .nav-item > .form-check {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+  }
+  .management-bar.navbar-expand-md .nav-link,
+  .management-bar.navbar-expand-md .navbar-text {
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-md .nav-link .c-inner,
+  .management-bar.navbar-expand-md .navbar-text .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -0.34375rem;
+  }
+  .management-bar.navbar-expand-md .nav-link-monospaced {
+    font-size: 1rem;
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding: 0;
+  }
+  .management-bar.navbar-expand-md .nav-link-monospaced .c-inner {
+    margin: 0;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .management-bar.navbar-expand-lg {
+    min-height: 3rem;
+  }
+  .management-bar.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0.0625rem 0;
+    left: 0;
+    margin-top: 0.0625rem;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .management-bar.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .management-bar.navbar-expand-lg .navbar-form {
+    height: 2.9375rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-lg .navbar-form .form-control {
+    height: 2rem;
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (min-width: 992px) {
+  .management-bar.navbar-expand-lg .navbar-brand {
+    font-size: 1.125rem;
+    margin-right: 0.5rem;
+    padding-bottom: 1.125rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 1.125rem;
+  }
+  .management-bar.navbar-expand-lg .navbar-brand .c-inner {
+    margin-bottom: -1.125rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -1.125rem;
+  }
+  .management-bar.navbar-expand-lg .navbar-form {
+    height: 3.9375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  .management-bar.navbar-expand-lg .navbar-form > .container,
+  .management-bar.navbar-expand-lg .navbar-form > .container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .management-bar.navbar-expand-lg .nav-btn {
+    font-size: 0.875rem;
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-lg .nav-btn .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -0.34375rem;
+  }
+  .management-bar.navbar-expand-lg .nav-btn-monospaced {
+    font-size: 1rem;
+    padding: 0;
+  }
+  .management-bar.navbar-expand-lg .nav-btn-monospaced .c-inner {
+    margin: 0;
+  }
+  .management-bar.navbar-expand-lg .nav-item > .custom-control,
+  .management-bar.navbar-expand-lg .nav-item > .form-check {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+  }
+  .management-bar.navbar-expand-lg .nav-link,
+  .management-bar.navbar-expand-lg .navbar-text {
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-lg .nav-link .c-inner,
+  .management-bar.navbar-expand-lg .navbar-text .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -0.34375rem;
+  }
+  .management-bar.navbar-expand-lg .nav-link-monospaced {
+    font-size: 1rem;
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding: 0;
+  }
+  .management-bar.navbar-expand-lg .nav-link-monospaced .c-inner {
+    margin: 0;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .management-bar.navbar-expand-xl {
+    min-height: 3rem;
+  }
+  .management-bar.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0.0625rem 0;
+    left: 0;
+    margin-top: 0.0625rem;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .management-bar.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .management-bar.navbar-expand-xl .navbar-form {
+    height: 2.9375rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-xl .navbar-form .form-control {
+    height: 2rem;
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (min-width: 1280px) {
+  .management-bar.navbar-expand-xl .navbar-brand {
+    font-size: 1.125rem;
+    margin-right: 0.5rem;
+    padding-bottom: 1.125rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 1.125rem;
+  }
+  .management-bar.navbar-expand-xl .navbar-brand .c-inner {
+    margin-bottom: -1.125rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -1.125rem;
+  }
+  .management-bar.navbar-expand-xl .navbar-form {
+    height: 3.9375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  .management-bar.navbar-expand-xl .navbar-form > .container,
+  .management-bar.navbar-expand-xl .navbar-form > .container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .management-bar.navbar-expand-xl .nav-btn {
+    font-size: 0.875rem;
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-xl .nav-btn .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -0.34375rem;
+  }
+  .management-bar.navbar-expand-xl .nav-btn-monospaced {
+    font-size: 1rem;
+    padding: 0;
+  }
+  .management-bar.navbar-expand-xl .nav-btn-monospaced .c-inner {
+    margin: 0;
+  }
+  .management-bar.navbar-expand-xl .nav-item > .custom-control,
+  .management-bar.navbar-expand-xl .nav-item > .form-check {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+  }
+  .management-bar.navbar-expand-xl .nav-link,
+  .management-bar.navbar-expand-xl .navbar-text {
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 0.34375rem;
+  }
+  .management-bar.navbar-expand-xl .nav-link .c-inner,
+  .management-bar.navbar-expand-xl .navbar-text .c-inner {
+    margin-bottom: -0.34375rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    margin-top: -0.34375rem;
+  }
+  .management-bar.navbar-expand-xl .nav-link-monospaced {
+    font-size: 1rem;
+    margin-bottom: 0.96875rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    margin-top: 0.96875rem;
+    padding: 0;
+  }
+  .management-bar.navbar-expand-xl .nav-link-monospaced .c-inner {
+    margin: 0;
+  }
+}
+
+.management-bar.navbar-expand .navbar-brand {
+  font-size: 1.125rem;
+  margin-right: 0.5rem;
+  padding-bottom: 1.125rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 1.125rem;
+}
+
+.management-bar.navbar-expand .navbar-brand .c-inner {
+  margin-bottom: -1.125rem;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+  margin-top: -1.125rem;
+}
+
+.management-bar.navbar-expand .navbar-form {
+  height: 3.9375rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.management-bar.navbar-expand .navbar-form > .container,
+.management-bar.navbar-expand .navbar-form > .container-fluid {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.management-bar.navbar-expand .nav-btn {
+  font-size: 0.875rem;
+  margin-bottom: 0.96875rem;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  margin-top: 0.96875rem;
+  padding-bottom: 0.34375rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.34375rem;
+}
+
+.management-bar.navbar-expand .nav-btn .c-inner {
+  margin-bottom: -0.34375rem;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+  margin-top: -0.34375rem;
+}
+
+.management-bar.navbar-expand .nav-btn-monospaced {
+  font-size: 1rem;
+  padding: 0;
+}
+
+.management-bar.navbar-expand .nav-btn-monospaced .c-inner {
+  margin: 0;
+}
+
+.management-bar.navbar-expand .nav-item > .custom-control,
+.management-bar.navbar-expand .nav-item > .form-check {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.management-bar.navbar-expand .nav-link,
+.management-bar.navbar-expand .navbar-text {
+  margin-bottom: 0.96875rem;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  margin-top: 0.96875rem;
+  padding-bottom: 0.34375rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.34375rem;
+}
+
+.management-bar.navbar-expand .nav-link .c-inner,
+.management-bar.navbar-expand .navbar-text .c-inner {
+  margin-bottom: -0.34375rem;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+  margin-top: -0.34375rem;
+}
+
+.management-bar.navbar-expand .nav-link-monospaced {
+  font-size: 1rem;
+  margin-bottom: 0.96875rem;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  margin-top: 0.96875rem;
+  padding: 0;
+}
+
+.management-bar.navbar-expand .nav-link-monospaced .c-inner {
+  margin: 0;
+}
+
+@media (max-width: 575.98px) {
+  .management-bar .navbar-overlay-xs-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .management-bar .navbar-overlay-sm-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .management-bar .navbar-overlay-md-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .management-bar .navbar-overlay-lg-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+.management-bar .navbar-overlay-up {
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+}
+
+.management-bar.navbar-underline .navbar-toggler-link:after {
+  bottom: -0.53125rem;
+  height: 0.25rem;
+}
+
+@media (min-width: 576px) {
+  .management-bar.navbar-underline.navbar-expand-sm .navbar-nav .nav-link.active:after {
+    bottom: -1.03125rem;
+    height: 0.25rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .management-bar.navbar-underline.navbar-expand-md .navbar-nav .nav-link.active:after {
+    bottom: -1.03125rem;
+    height: 0.25rem;
+  }
+}
+
+@media (min-width: 992px) {
+  .management-bar.navbar-underline.navbar-expand-lg .navbar-nav .nav-link.active:after {
+    bottom: -1.03125rem;
+    height: 0.25rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  .management-bar.navbar-underline.navbar-expand-xl .navbar-nav .nav-link.active:after {
+    bottom: -1.03125rem;
+    height: 0.25rem;
+  }
+}
+
+.management-bar.navbar-underline.navbar-expand .navbar-nav .nav-link.active:after {
+  bottom: -1.03125rem;
+  height: 0.25rem;
+}
+
+.management-bar .nav-link,
+.management-bar .navbar-nav .btn-unstyled {
+  border-radius: 0.25rem;
+  outline: 0;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.management-bar .nav-link:focus,
+.management-bar .navbar-nav .btn-unstyled:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.management-bar .nav-link.disabled, .management-bar .nav-link:disabled,
+.management-bar .navbar-nav .btn-unstyled.disabled,
+.management-bar .navbar-nav .btn-unstyled:disabled {
+  box-shadow: none;
+}
+
+.management-bar .navbar-brand {
+  border-radius: 0.25rem;
+  outline: 0;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.management-bar .navbar-brand:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.management-bar .navbar-toggler {
+  outline: 0;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.management-bar .navbar-toggler:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+@media (max-width: 575.98px) {
+  .management-bar.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .management-bar.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .management-bar.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .management-bar.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+.management-bar.navbar-nowrap .navbar-text {
+  white-space: normal;
+  word-wrap: break-word;
+}
+
+.management-bar-light {
+  background-color: #fff;
+  border-color: transparent;
+  border-style: solid;
+}
+
+.management-bar-light .nav-link,
+.management-bar-light .navbar-nav .btn-unstyled {
+  color: #6b6c7e;
+  font-weight: 600;
+}
+
+.management-bar-light .nav-link:hover,
+.management-bar-light .navbar-nav .btn-unstyled:hover {
+  background-color: rgba(39, 40, 51, 0.03);
+  color: #272833;
+}
+
+.management-bar-light .nav-link:focus,
+.management-bar-light .navbar-nav .btn-unstyled:focus {
+  background-color: rgba(39, 40, 51, 0.03);
+  color: #272833;
+}
+
+.management-bar-light .nav-link.active, .management-bar-light .nav-link[aria-expanded='true'],
+.management-bar-light .navbar-nav .btn-unstyled.active,
+.management-bar-light .navbar-nav .btn-unstyled[aria-expanded='true'] {
+  background-color: rgba(39, 40, 51, 0.06);
+  color: #272833;
+}
+
+.management-bar-light .nav-link.disabled, .management-bar-light .nav-link:disabled,
+.management-bar-light .navbar-nav .btn-unstyled.disabled,
+.management-bar-light .navbar-nav .btn-unstyled:disabled {
+  background-color: transparent;
+  color: #a7a9bc;
+  opacity: 1;
+}
+
+.management-bar-light .nav-btn {
+  font-weight: 600;
+}
+
+.management-bar-light .navbar-brand:focus {
+  color: #272833;
+}
+
+.management-bar-light .navbar-toggler {
+  color: #6b6c7e;
+  font-weight: 600;
+}
+
+.management-bar-light .navbar-toggler:focus {
+  color: #272833;
+}
+
+.management-bar-light .navbar-toggler-link[aria-expanded='true'] {
+  color: #272833;
+}
+
+.management-bar-light .navbar-overlay {
+  background-color: #fff;
+}
+
+@media (max-width: 575.98px) {
+  .management-bar-light.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: transparent;
+  }
+  .management-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-header,
+  .management-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .management-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .management-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .management-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .management-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .management-bar-light.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: transparent;
+  }
+  .management-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-header,
+  .management-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .management-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .management-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .management-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .management-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .management-bar-light.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: transparent;
+  }
+  .management-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-header,
+  .management-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .management-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .management-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .management-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .management-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .management-bar-light.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: transparent;
+  }
+  .management-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-header,
+  .management-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .management-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .management-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .management-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .management-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+.management-bar-primary {
+  background-color: #f0f5ff;
+  border-color: #0b5fff;
+  border-style: solid;
+  color: #6b6c7e;
+}
+
+.management-bar-primary .nav-link,
+.management-bar-primary .navbar-nav .btn-unstyled {
+  border-radius: 0.25rem;
+  color: #6b6c7e;
+  font-weight: 600;
+}
+
+.management-bar-primary .nav-link:hover,
+.management-bar-primary .navbar-nav .btn-unstyled:hover {
+  background-color: rgba(39, 40, 51, 0.03);
+  color: #272833;
+}
+
+.management-bar-primary .nav-link:focus,
+.management-bar-primary .navbar-nav .btn-unstyled:focus {
+  background-color: rgba(39, 40, 51, 0.03);
+  color: #272833;
+}
+
+.management-bar-primary .nav-link.active, .management-bar-primary .nav-link[aria-expanded='true'],
+.management-bar-primary .navbar-nav .btn-unstyled.active,
+.management-bar-primary .navbar-nav .btn-unstyled[aria-expanded='true'] {
+  background-color: rgba(39, 40, 51, 0.06);
+  color: #272833;
+}
+
+.management-bar-primary .nav-link.disabled, .management-bar-primary .nav-link:disabled,
+.management-bar-primary .navbar-nav .btn-unstyled.disabled,
+.management-bar-primary .navbar-nav .btn-unstyled:disabled {
+  background-color: transparent;
+  color: #a7a9bc;
+  opacity: 1;
+}
+
+.management-bar-primary .nav-btn {
+  font-weight: 600;
+}
+
+.management-bar-primary .navbar-brand {
+  border-radius: 0.25rem;
+}
+
+.management-bar-primary .navbar-brand:focus {
+  color: #272833;
+}
+
+.management-bar-primary .navbar-toggler {
+  color: #6b6c7e;
+  font-weight: 600;
+}
+
+.management-bar-primary .navbar-toggler:focus {
+  color: #272833;
+}
+
+.management-bar-primary .navbar-toggler-link[aria-expanded='true'] {
+  color: #272833;
+}
+
+.management-bar-primary .navbar-overlay {
+  background-color: #f0f5ff;
+}
+
+@media (max-width: 575.98px) {
+  .management-bar-primary.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    background-color: #f0f5ff;
+    border-color: #0b5fff;
+  }
+  .management-bar-primary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-header,
+  .management-bar-primary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .management-bar-primary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .management-bar-primary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .management-bar-primary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .management-bar-primary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .management-bar-primary.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    background-color: #f0f5ff;
+    border-color: #0b5fff;
+  }
+  .management-bar-primary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-header,
+  .management-bar-primary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .management-bar-primary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .management-bar-primary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .management-bar-primary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .management-bar-primary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .management-bar-primary.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    background-color: #f0f5ff;
+    border-color: #0b5fff;
+  }
+  .management-bar-primary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-header,
+  .management-bar-primary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .management-bar-primary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .management-bar-primary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .management-bar-primary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .management-bar-primary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .management-bar-primary.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    background-color: #f0f5ff;
+    border-color: #0b5fff;
+  }
+  .management-bar-primary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-header,
+  .management-bar-primary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .management-bar-primary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .management-bar-primary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .management-bar-primary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .management-bar-primary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+.navigation-bar {
+  border-width: 0 0 0.0625rem 0;
+  font-size: 0.875rem;
+  padding: 0 0;
+  border-color: transparent;
+  border-style: solid;
+}
+
+.navigation-bar .navbar-toggler {
+  font-size: 1.125rem;
+  height: 2.00001rem;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.navigation-bar .navbar-toggler .c-inner {
+  margin-bottom: -0.25rem;
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: -0.25rem;
+}
+
+.navigation-bar .navbar-toggler-link {
+  font-size: 0.875rem;
+  height: 2rem;
+  line-height: 1.5;
+  margin-bottom: 0.46875rem;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0.46875rem;
+  padding-bottom: 0;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0;
+}
+
+.navigation-bar .navbar-toggler-link .c-inner {
+  margin-bottom: 0;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  margin-top: 0;
+}
+
+.navigation-bar .navbar-brand {
+  font-size: 1.125rem;
+  margin-right: 0;
+  padding-bottom: 0.625rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.625rem;
+}
+
+.navigation-bar .navbar-brand .c-inner {
+  margin-bottom: -0.625rem;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  margin-top: -0.625rem;
+}
+
+.navigation-bar .navbar-nav .nav-btn {
+  font-size: 0.875rem;
+  margin-bottom: 0.46875rem;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  margin-top: 0.46875rem;
+  padding-bottom: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 1rem;
+}
+
+.navigation-bar .navbar-nav .nav-btn .c-inner {
+  margin-bottom: -1rem;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  margin-top: -1rem;
+}
+
+.navigation-bar .navbar-nav .nav-btn-monospaced {
+  padding: 0;
+}
+
+.navigation-bar .navbar-nav .nav-btn-monospaced .c-inner {
+  margin: 0;
+}
+
+.navigation-bar .navbar-nav .nav-item > .custom-control,
+.navigation-bar .navbar-nav .nav-item > .form-check {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.navigation-bar .navbar-nav .nav-link,
+.navigation-bar .navbar-nav .navbar-text {
+  margin-bottom: 0.46875rem;
+  margin-top: 0.46875rem;
+  padding-bottom: 0.34375rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.34375rem;
+}
+
+.navigation-bar .navbar-nav .nav-link .c-inner,
+.navigation-bar .navbar-nav .navbar-text .c-inner {
+  margin-bottom: -0.34375rem;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  margin-top: -0.34375rem;
+}
+
+.navigation-bar .navbar-nav .nav-link-monospaced {
+  margin-bottom: 0.46875rem;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  margin-top: 0.46875rem;
+  padding: 0;
+}
+
+.navigation-bar .navbar-nav .nav-link-monospaced .c-inner {
+  margin: 0;
+}
+
+.navigation-bar .dropdown-menu {
+  margin-top: 0;
+}
+
+@media (max-width: 575.98px) {
+  .navigation-bar.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0.0625rem 0;
+    left: 0;
+    margin-top: 0.0625rem;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .navigation-bar.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .navigation-bar.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item {
+    padding-bottom: 0.8125rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.8125rem;
+  }
+  .navigation-bar.navbar-expand-sm .navbar-form {
+    height: 2.9375rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.34375rem;
+  }
+  .navigation-bar.navbar-expand-sm .navbar-form .form-control {
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .navigation-bar.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0.0625rem 0;
+    left: 0;
+    margin-top: 0.0625rem;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .navigation-bar.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .navigation-bar.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item {
+    padding-bottom: 0.8125rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.8125rem;
+  }
+  .navigation-bar.navbar-expand-md .navbar-form {
+    height: 2.9375rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.34375rem;
+  }
+  .navigation-bar.navbar-expand-md .navbar-form .form-control {
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .navigation-bar.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0.0625rem 0;
+    left: 0;
+    margin-top: 0.0625rem;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .navigation-bar.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .navigation-bar.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item {
+    padding-bottom: 0.8125rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.8125rem;
+  }
+  .navigation-bar.navbar-expand-lg .navbar-form {
+    height: 2.9375rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.34375rem;
+  }
+  .navigation-bar.navbar-expand-lg .navbar-form .form-control {
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .navigation-bar.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0 0 0.0625rem 0;
+    left: 0;
+    margin-top: 0.0625rem;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    right: 0;
+  }
+  .navigation-bar.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .navigation-bar.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item {
+    padding-bottom: 0.8125rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.8125rem;
+  }
+  .navigation-bar.navbar-expand-xl .navbar-form {
+    height: 2.9375rem;
+    padding-bottom: 0.34375rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.34375rem;
+  }
+  .navigation-bar.navbar-expand-xl .navbar-form .form-control {
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .navigation-bar .navbar-overlay-xs-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .navigation-bar .navbar-overlay-sm-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .navigation-bar .navbar-overlay-md-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .navigation-bar .navbar-overlay-lg-down {
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+}
+
+.navigation-bar .navbar-overlay-up {
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+}
+
+.navigation-bar.navbar-underline .navbar-toggler-link:after {
+  bottom: -0.53125rem;
+  height: 0.25rem;
+}
+
+@media (min-width: 576px) {
+  .navigation-bar.navbar-underline.navbar-expand-sm .navbar-nav .nav-link.active:after {
+    bottom: -0.53125rem;
+    height: 0.25rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .navigation-bar.navbar-underline.navbar-expand-md .navbar-nav .nav-link.active:after {
+    bottom: -0.53125rem;
+    height: 0.25rem;
+  }
+}
+
+@media (min-width: 992px) {
+  .navigation-bar.navbar-underline.navbar-expand-lg .navbar-nav .nav-link.active:after {
+    bottom: -0.53125rem;
+    height: 0.25rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  .navigation-bar.navbar-underline.navbar-expand-xl .navbar-nav .nav-link.active:after {
+    bottom: -0.53125rem;
+    height: 0.25rem;
+  }
+}
+
+.navigation-bar.navbar-underline.navbar-expand .navbar-nav .nav-link.active:after {
+  bottom: -0.53125rem;
+  height: 0.25rem;
+}
+
+.navigation-bar .nav-link,
+.navigation-bar .navbar-nav .btn-unstyled {
+  border-radius: 0;
+  outline: 0;
+}
+
+.navigation-bar .nav-link:focus,
+.navigation-bar .navbar-nav .btn-unstyled:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.navigation-bar .nav-link.disabled, .navigation-bar .nav-link:disabled,
+.navigation-bar .navbar-nav .btn-unstyled.disabled,
+.navigation-bar .navbar-nav .btn-unstyled:disabled {
+  box-shadow: none;
+}
+
+.navigation-bar .navbar-brand {
+  border-radius: 0;
+  outline: 0;
+}
+
+.navigation-bar .navbar-brand:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.navigation-bar .navbar-toggler {
+  outline: 0;
+}
+
+.navigation-bar .navbar-toggler:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+@media (max-width: 575.98px) {
+  .navigation-bar.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .navigation-bar.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .navigation-bar.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .navigation-bar.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    border-color: transparent;
+  }
+}
+
+.navigation-bar-light {
+  background-color: #fff;
+  border-color: #f1f2f5;
+  border-style: solid;
+}
+
+.navigation-bar-light .nav-link,
+.navigation-bar-light .navbar-nav .btn-unstyled {
+  color: #6b6c7e;
+  font-weight: 600;
+}
+
+.navigation-bar-light .nav-link:hover,
+.navigation-bar-light .navbar-nav .btn-unstyled:hover {
+  color: #272833;
+}
+
+.navigation-bar-light .nav-link:focus,
+.navigation-bar-light .navbar-nav .btn-unstyled:focus {
+  color: #272833;
+}
+
+.navigation-bar-light .nav-link.active, .navigation-bar-light .nav-link[aria-expanded='true'],
+.navigation-bar-light .navbar-nav .btn-unstyled.active,
+.navigation-bar-light .navbar-nav .btn-unstyled[aria-expanded='true'] {
+  color: #272833;
+}
+
+.navigation-bar-light .nav-link.disabled, .navigation-bar-light .nav-link:disabled,
+.navigation-bar-light .navbar-nav .btn-unstyled.disabled,
+.navigation-bar-light .navbar-nav .btn-unstyled:disabled {
+  color: #6b6c7e;
+  opacity: 0.4;
+}
+
+.navigation-bar-light .nav-btn {
+  font-weight: 600;
+}
+
+.navigation-bar-light .navbar-brand:focus {
+  color: #272833;
+}
+
+.navigation-bar-light .navbar-toggler {
+  color: #6b6c7e;
+  font-weight: 600;
+}
+
+.navigation-bar-light .navbar-toggler:focus {
+  color: #272833;
+}
+
+.navigation-bar-light .navbar-toggler-link[aria-expanded='true'] {
+  color: #272833;
+}
+
+.navigation-bar-light .navbar-overlay {
+  background-color: #fff;
+}
+
+@media (max-width: 575.98px) {
+  .navigation-bar-light.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: #f1f2f5;
+  }
+  .navigation-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-header,
+  .navigation-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .navigation-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .navigation-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .navigation-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .navigation-bar-light.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #6b6c7e;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .navigation-bar-light.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: #f1f2f5;
+  }
+  .navigation-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-header,
+  .navigation-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .navigation-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .navigation-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .navigation-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .navigation-bar-light.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #6b6c7e;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .navigation-bar-light.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: #f1f2f5;
+  }
+  .navigation-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-header,
+  .navigation-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .navigation-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .navigation-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .navigation-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .navigation-bar-light.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #6b6c7e;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .navigation-bar-light.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: #f1f2f5;
+  }
+  .navigation-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-header,
+  .navigation-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+    font-weight: 600;
+  }
+  .navigation-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .navigation-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #272833;
+  }
+  .navigation-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .navigation-bar-light.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #6b6c7e;
+  }
+}
+
+.navigation-bar-secondary {
+  background-color: #393a4a;
+  border-color: transparent;
+  border-style: solid;
+  color: #fff;
+}
+
+.navigation-bar-secondary .nav-link,
+.navigation-bar-secondary .navbar-nav .btn-unstyled {
+  color: #cdced9;
+  font-weight: 600;
+}
+
+.navigation-bar-secondary .nav-link:hover,
+.navigation-bar-secondary .navbar-nav .btn-unstyled:hover {
+  color: #fff;
+}
+
+.navigation-bar-secondary .nav-link:focus,
+.navigation-bar-secondary .navbar-nav .btn-unstyled:focus {
+  color: #fff;
+}
+
+.navigation-bar-secondary .nav-link.active, .navigation-bar-secondary .nav-link[aria-expanded='true'],
+.navigation-bar-secondary .navbar-nav .btn-unstyled.active,
+.navigation-bar-secondary .navbar-nav .btn-unstyled[aria-expanded='true'] {
+  color: #fff;
+}
+
+.navigation-bar-secondary .nav-link.disabled, .navigation-bar-secondary .nav-link:disabled,
+.navigation-bar-secondary .navbar-nav .btn-unstyled.disabled,
+.navigation-bar-secondary .navbar-nav .btn-unstyled:disabled {
+  color: #cdced9;
+  opacity: 0.4;
+}
+
+.navigation-bar-secondary .nav-btn {
+  font-weight: 600;
+}
+
+.navigation-bar-secondary .navbar-brand {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.navigation-bar-secondary .navbar-brand:hover {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.navigation-bar-secondary .navbar-brand:focus {
+  color: #fff;
+}
+
+.navigation-bar-secondary .navbar-toggler {
+  color: #cdced9;
+  font-weight: 600;
+}
+
+.navigation-bar-secondary .navbar-toggler:focus {
+  color: #fff;
+}
+
+.navigation-bar-secondary .navbar-toggler-link[aria-expanded='true'] {
+  color: #fff;
+}
+
+.navigation-bar-secondary .navbar-overlay {
+  background-color: #393a4a;
+}
+
+@media (max-width: 575.98px) {
+  .navigation-bar-secondary.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    background-color: #393a4a;
+    border-color: transparent;
+  }
+  .navigation-bar-secondary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-header,
+  .navigation-bar-secondary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item {
+    color: #cdced9;
+    font-weight: 600;
+  }
+  .navigation-bar-secondary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #cdced9;
+  }
+  .navigation-bar-secondary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #fff;
+  }
+  .navigation-bar-secondary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #fff;
+  }
+  .navigation-bar-secondary.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #cdced9;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .navigation-bar-secondary.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    background-color: #393a4a;
+    border-color: transparent;
+  }
+  .navigation-bar-secondary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-header,
+  .navigation-bar-secondary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item {
+    color: #cdced9;
+    font-weight: 600;
+  }
+  .navigation-bar-secondary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #cdced9;
+  }
+  .navigation-bar-secondary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #fff;
+  }
+  .navigation-bar-secondary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #fff;
+  }
+  .navigation-bar-secondary.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #cdced9;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .navigation-bar-secondary.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    background-color: #393a4a;
+    border-color: transparent;
+  }
+  .navigation-bar-secondary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-header,
+  .navigation-bar-secondary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item {
+    color: #cdced9;
+    font-weight: 600;
+  }
+  .navigation-bar-secondary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #cdced9;
+  }
+  .navigation-bar-secondary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #fff;
+  }
+  .navigation-bar-secondary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #fff;
+  }
+  .navigation-bar-secondary.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #cdced9;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .navigation-bar-secondary.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    background-color: #393a4a;
+    border-color: transparent;
+  }
+  .navigation-bar-secondary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-header,
+  .navigation-bar-secondary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item {
+    color: #cdced9;
+    font-weight: 600;
+  }
+  .navigation-bar-secondary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #cdced9;
+  }
+  .navigation-bar-secondary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #fff;
+  }
+  .navigation-bar-secondary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #fff;
+  }
+  .navigation-bar-secondary.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #cdced9;
+  }
+}
+
+.input-group > .form-control,
+.input-group > .form-control-plaintext,
+.input-group > .custom-select,
+.input-group > .custom-file {
+  flex: 1 1 0%;
+  margin-bottom: 0;
+  min-width: 0;
+  position: relative;
+}
+
+.input-group > .form-control + .form-control,
+.input-group > .form-control + .custom-select,
+.input-group > .form-control + .custom-file,
+.input-group > .form-control-plaintext + .form-control,
+.input-group > .form-control-plaintext + .custom-select,
+.input-group > .form-control-plaintext + .custom-file,
+.input-group > .custom-select + .form-control,
+.input-group > .custom-select + .custom-select,
+.input-group > .custom-select + .custom-file,
+.input-group > .custom-file + .form-control,
+.input-group > .custom-file + .custom-select,
+.input-group > .custom-file + .custom-file {
+  margin-left: -0.0625rem;
+}
+
+.input-group > .form-control:focus,
+.input-group > .custom-select:focus,
+.input-group > .custom-file .custom-file-input:focus ~ .custom-file-label {
+  z-index: 3;
+}
+
+.input-group > .custom-file .custom-file-input:focus {
+  z-index: 4;
+}
+
+.input-group > .form-control:not(:last-child),
+.input-group > .custom-select:not(:last-child) {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.input-group > .form-control:not(:first-child),
+.input-group > .custom-select:not(:first-child) {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.input-group > .custom-file {
+  align-items: center;
+  display: flex;
+}
+
+.input-group > .custom-file:not(:last-child) .custom-file-label,
+.input-group > .custom-file:not(:last-child) .custom-file-label::after {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.input-group > .custom-file:not(:first-child) .custom-file-label {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.input-group-lg > .custom-select {
+  border-radius: 0.375rem;
+  font-size: 1.125rem;
+  height: 3rem;
+  line-height: 1.5;
+  padding: 0.4375rem 1rem;
+}
+
+.input-group-sm > .custom-select {
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  height: 2rem;
+  line-height: 1.5;
+  padding: 0.25rem 0.75rem;
+}
+
+.input-group-lg > .custom-select,
+.input-group-sm > .custom-select {
+  padding-right: 2rem;
+}
+
+.input-group-prepend > .btn + .btn,
+.input-group-prepend > .btn + .input-group-text,
+.input-group-prepend > .input-group-text + .input-group-text,
+.input-group-prepend > .input-group-text + .btn,
+.input-group-append > .btn + .btn,
+.input-group-append > .btn + .input-group-text,
+.input-group-append > .input-group-text + .input-group-text,
+.input-group-append > .input-group-text + .btn {
+  margin-left: -0.0625rem;
+}
+
+.input-group {
+  align-items: stretch;
+  display: flex;
+  flex-wrap: wrap;
+  position: relative;
+  width: 100%;
+}
+
+.input-group .btn {
+  position: relative;
+  z-index: 1;
+}
+
+.input-group .btn:hover {
+  z-index: 3;
+}
+
+.input-group .btn:focus,
+.input-group .form-control:focus {
+  z-index: 4;
+}
+
+.input-group .btn-unstyled {
+  color: inherit;
+}
+
+.input-group-item {
+  display: flex;
+  flex-grow: 1;
+  flex-wrap: wrap;
+  margin-left: 0.5rem;
+  width: 1%;
+  word-wrap: break-word;
+}
+
+.input-group-item:first-child {
+  margin-left: 0;
+}
+
+.input-group-item > .btn {
+  align-self: flex-start;
+}
+
+.input-group-item > .dropdown {
+  display: flex;
+  flex-wrap: wrap;
+  word-wrap: break-word;
+  width: 100%;
+}
+
+.input-group-item-shrink {
+  flex-grow: 0;
+  width: auto;
+}
+
+.input-group-text {
+  align-items: center;
+  background-color: #e7e7ed;
+  border-color: #e7e7ed;
+  border-style: solid;
+  border-bottom-width: 0.0625rem;
+  border-left-width: 0.0625rem;
+  border-right-width: 0.0625rem;
+  border-top-width: 0.0625rem;
+  border-radius: 0.25rem;
+  color: #6b6c7e;
+  display: flex;
+  font-size: 1rem;
+  font-weight: 600;
+  height: 2.5rem;
+  justify-content: center;
+  line-height: 1.5;
+  margin-bottom: 0;
+  min-width: 2.5rem;
+  padding-bottom: 0.4375rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.4375rem;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.input-group-text label {
+  color: #6b6c7e;
+}
+
+.input-group-text input[type='radio'],
+.input-group-text input[type='checkbox'] {
+  margin-top: 0;
+}
+
+.input-group-text .custom-control,
+.input-group-text .form-check {
+  margin-bottom: 0;
+}
+
+.input-group-text .lexicon-icon {
+  margin-top: 0;
+}
+
+.input-group-text-secondary {
+  background-color: #fff;
+  border-color: #cdced9;
+  border-width: 0.0625rem;
+  color: #6b6c7e;
+  z-index: 2;
+}
+
+.input-group-text-secondary label {
+  color: #6b6c7e;
+}
+
+@media (max-width: 575.98px) {
+  .input-group-stacked-sm-down > .input-group-item {
+    margin-bottom: 0.5rem;
+    margin-left: 0;
+    width: 100%;
+  }
+  .input-group-stacked-sm-down > .input-group-item-shrink {
+    margin-right: 0.5rem;
+    width: auto;
+  }
+}
+
+.input-group-lg > .input-group-item > .btn {
+  font-size: 1.125rem;
+}
+
+.input-group-lg > .input-group-item > .btn .inline-item {
+  font-size: 1.125rem;
+}
+
+.input-group-lg > .input-group-item > .btn .btn-section {
+  font-size: 0.8125rem;
+}
+
+.input-group-lg > .input-group-item > .btn-monospaced {
+  height: 3rem;
+  line-height: 1;
+  padding-bottom: 0.375rem;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0.375rem;
+  width: 3rem;
+}
+
+.input-group-lg > .input-group-item > .btn-monospaced .c-inner {
+  margin-bottom: -0.375rem;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: -0.375rem;
+}
+
+.input-group-lg > .input-group-item > .form-control,
+.input-group-lg > .input-group-item > .form-file .btn {
+  border-radius: 0.375rem;
+  font-size: 1.125rem;
+  height: 3rem;
+  line-height: 1.5;
+  padding-bottom: 0.4375rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.4375rem;
+}
+
+.input-group-lg > .input-group-item > textarea.form-control,
+.input-group-lg > .input-group-item > .form-control-textarea {
+  height: 120px;
+}
+
+.input-group-lg > .input-group-item > .form-control-plaintext {
+  font-size: 1.125rem;
+  height: 3rem;
+  line-height: 1.5;
+  padding-bottom: 0.4375rem;
+  padding-top: 0.4375rem;
+}
+
+.input-group-lg > .input-group-item > .input-group-text {
+  border-radius: 0.375rem;
+  font-size: 1.125rem;
+  height: 3rem;
+  min-width: 3rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.input-group-lg > .input-group-inset-item > .form-file {
+  height: 75%;
+}
+
+.input-group-lg > .input-group-inset-item > .form-file .btn {
+  height: 100%;
+  line-height: 1;
+  padding-bottom: 0;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0;
+}
+
+.input-group-lg > .input-group-inset-item > .form-file .btn .c-inner {
+  margin-bottom: 0;
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: 0;
+}
+
+.input-group-sm > .input-group-item > .btn, .form-group-sm .input-group > .input-group-item > .btn {
+  font-size: 0.875rem;
+}
+
+.input-group-sm > .input-group-item > .btn .btn-section, .form-group-sm .input-group > .input-group-item > .btn .btn-section {
+  font-size: 0.5625rem;
+}
+
+.input-group-sm > .input-group-item > .btn-monospaced, .form-group-sm .input-group > .input-group-item > .btn-monospaced {
+  height: 2rem;
+  line-height: 1;
+  padding-bottom: 0.1875rem;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0.1875rem;
+  width: 2rem;
+}
+
+.input-group-sm > .input-group-item > .btn-monospaced .c-inner, .form-group-sm .input-group > .input-group-item > .btn-monospaced .c-inner {
+  margin-bottom: -0.1875rem;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: -0.1875rem;
+}
+
+.input-group-sm > .input-group-item > .form-control, .form-group-sm .input-group > .input-group-item > .form-control,
+.input-group-sm > .input-group-item > .form-file .btn,
+.form-group-sm .input-group > .input-group-item > .form-file .btn {
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  height: 2rem;
+  line-height: 1.5;
+  padding-bottom: 0.25rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.input-group-sm > .input-group-item > .form-control-plaintext, .form-group-sm .input-group > .input-group-item > .form-control-plaintext {
+  font-size: 0.875rem;
+  height: 2rem;
+  line-height: 1.5;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
+}
+
+.input-group-sm > .input-group-item > textarea.form-control, .form-group-sm .input-group > .input-group-item > textarea.form-control,
+.input-group-sm > .input-group-item > .form-control-textarea,
+.form-group-sm .input-group > .input-group-item > .form-control-textarea {
+  height: 80px;
+}
+
+.input-group-sm > .input-group-item > .input-group-text, .form-group-sm .input-group > .input-group-item > .input-group-text {
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  height: 2rem;
+  min-width: 2rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.input-group-sm > .input-group-inset-item > .btn, .form-group-sm .input-group > .input-group-inset-item > .btn {
+  line-height: 1;
+  padding-bottom: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0;
+}
+
+.input-group-sm > .input-group-inset-item > .btn .c-inner, .form-group-sm .input-group > .input-group-inset-item > .btn .c-inner {
+  margin-bottom: 0;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+  margin-top: 0;
+}
+
+.input-group-sm > .input-group-inset-item > .form-file, .form-group-sm .input-group > .input-group-inset-item > .form-file {
+  height: 75%;
+}
+
+.input-group-sm > .input-group-inset-item > .form-file .btn, .form-group-sm .input-group > .input-group-inset-item > .form-file .btn {
+  height: 100%;
+  line-height: 1;
+  padding-bottom: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0;
+}
+
+.input-group-sm > .input-group-inset-item > .form-file .btn .c-inner, .form-group-sm .input-group > .input-group-inset-item > .form-file .btn .c-inner {
+  margin-bottom: 0;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+  margin-top: 0;
+}
+
+.input-group-item.focus {
+  border-radius: 0.25rem;
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.input-group-item.focus .form-control,
+.input-group-item.focus .form-control[readonly] ~ .input-group-inset-item,
+.input-group-item.focus .input-group-inset-item {
+  background-color: #f0f5ff;
+  border-color: #80acff;
+}
+
+.input-group-item.input-group-prepend.focus {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  z-index: 1;
+}
+
+.input-group-item.input-group-append.focus {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.input-group-inset {
+  flex-grow: 1;
+  order: 5;
+  width: 1%;
+}
+
+.input-group-inset[readonly] ~ .input-group-inset-item {
+  background-color: #fff;
+}
+
+.input-group-inset:focus {
+  box-shadow: none;
+}
+
+.input-group-inset:focus ~ .input-group-inset-item {
+  background-color: #f0f5ff;
+  border-color: #80acff;
+}
+
+.input-group-inset:disabled ~ .input-group-inset-item {
+  background-color: #f1f2f5;
+  border-color: #f1f2f5;
+}
+
+.input-group-inset ~ .form-feedback-group {
+  order: 13;
+}
+
+.input-group .input-group-inset-item {
+  align-items: center;
+  background-color: #f1f2f5;
+  border-bottom-width: 0.0625rem;
+  border-color: #e7e7ed;
+  border-left-width: 0.0625rem;
+  border-right-width: 0.0625rem;
+  border-style: solid;
+  border-top-width: 0.0625rem;
+  display: flex;
+  margin-bottom: 0;
+  padding-left: 5px;
+  padding-right: 5px;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.input-group .input-group-inset-item .btn {
+  display: block;
+  height: 75%;
+  line-height: 1;
+  margin-left: 0.125rem;
+  margin-right: 0.125rem;
+  padding-bottom: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0;
+}
+
+.input-group .input-group-inset-item .btn .c-inner {
+  margin-bottom: 0;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+  margin-top: 0;
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+}
+
+.input-group .input-group-inset-item .btn .c-inner .lexicon-icon {
+  margin-top: 0;
+}
+
+.input-group .input-group-inset-item .form-file {
+  height: 75%;
+}
+
+.input-group .input-group-inset-item .form-file .btn {
+  height: 100%;
+}
+
+.input-group .input-group-item .input-group-inset-before.form-control {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-bottom-right-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+  border-left-width: 0;
+  padding-left: 0;
+}
+
+.input-group .input-group-inset-item-before {
+  border-bottom-left-radius: 0.25rem;
+  border-top-left-radius: 0.25rem;
+  border-right-width: 0;
+  color: #6b6c7e;
+  order: 3;
+}
+
+.input-group .input-group-append > .input-group-inset-item-before {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.input-group .input-group-item .input-group-inset-after.form-control {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  border-right-width: 0;
+  padding-right: 0;
+}
+
+.input-group .input-group-inset-item-after {
+  border-bottom-right-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+  border-left-width: 0;
+  color: #6b6c7e;
+  order: 9;
+}
+
+.input-group-prepend .input-group .input-group-inset-item-after {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  z-index: 1;
+}
+
+.input-group > .input-group-item.input-group-prepend {
+  align-items: stretch;
+  display: flex;
+  margin-right: -0.0625rem;
+}
+
+.input-group > .input-group-item.input-group-prepend:not(:last-child) > .btn,
+.input-group > .input-group-item.input-group-prepend:not(:last-child) > .form-control,
+.input-group > .input-group-item.input-group-prepend:not(:last-child) > .input-group-text {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.input-group > .input-group-item.input-group-prepend:not(:last-child) > .btn + .btn {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.input-group > .input-group-item.input-group-prepend + .input-group-prepend {
+  margin-left: 0;
+}
+
+.input-group > .input-group-item.input-group-prepend + .input-group-prepend > .btn,
+.input-group > .input-group-item.input-group-prepend + .input-group-prepend > .form-control,
+.input-group > .input-group-item.input-group-prepend + .input-group-prepend > .input-group-text {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.input-group > .input-group-item.input-group-append {
+  align-items: stretch;
+  display: flex;
+  margin-right: -0.0625rem;
+}
+
+.input-group > .input-group-item.input-group-append:first-child > .btn,
+.input-group > .input-group-item.input-group-append:first-child > .form-control,
+.input-group > .input-group-item.input-group-append:first-child > .input-group-text {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.input-group > .input-group-item.input-group-append:not(:first-child) > .btn,
+.input-group > .input-group-item.input-group-append:not(:first-child) > .form-control,
+.input-group > .input-group-item.input-group-append:not(:first-child) > .form-file .btn,
+.input-group > .input-group-item.input-group-append:not(:first-child) > .input-group-text {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.input-group > .input-group-item.input-group-append + .input-group-append,
+.input-group > .input-group-item.input-group-prepend + .input-group-append {
+  margin-left: 0;
+}
+
+.input-group-password .form-control[type='text'] ~ .input-group-inset-item .input-password-label {
+  display: none;
+}
+
+.input-group-password .form-control[type='password'] ~ .input-group-inset-item .input-text-label {
+  display: none;
+}
+
+.pagination {
+  border-radius: 0.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.875rem;
+  list-style: none;
+  margin-bottom: 0.5rem;
+  padding-left: 0;
+}
+
+.pagination-bar {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 767.98px) {
+  .pagination-bar {
+    flex-direction: column;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .pagination-bar .pagination {
+    margin-top: 0.5rem;
+  }
+}
+
+.page-link {
+  align-items: center;
+  border-radius: 4px;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 0.0625rem;
+  color: #6b6c7e;
+  display: inline-flex;
+  height: 2rem;
+  justify-content: center;
+  line-height: 1;
+  margin-left: 0;
+  padding-bottom: 0;
+  padding-left: 0.625rem;
+  padding-right: 0.625rem;
+  padding-top: 0;
+  position: relative;
+  transition: box-shadow 0.15s ease-in-out;
+  background-color: transparent;
+}
+
+.page-link > .c-inner {
+  margin-bottom: 0;
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+  margin-top: 0;
+}
+
+.page-link .lexicon-icon {
+  margin-top: 0;
+}
+
+.page-link:hover {
+  border-color: transparent;
+  color: #272833;
+  text-decoration: none;
+  z-index: 2;
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.page-link:focus {
+  box-shadow: 0 0 0 0.2rem rgba(11, 95, 255, 0.25);
+  outline: 0;
+  z-index: 4;
+  border-color: transparent;
+  color: #272833;
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.page-link:active, .page-link.active {
+  border-color: transparent;
+  color: #272833;
+  cursor: default;
+  z-index: 3;
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.page-link:disabled, .page-link.disabled {
+  border-color: transparent;
+  box-shadow: none;
+  color: #6b6c7e;
+  cursor: not-allowed;
+  opacity: 0.5;
+  pointer-events: auto;
+  z-index: 0;
+  background-color: transparent;
+}
+
+.page-item.active .page-link,
+.page-item.show .page-link {
+  border-color: transparent;
+  color: #272833;
+  cursor: default;
+  z-index: 3;
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.page-item.disabled .page-link {
+  border-color: transparent;
+  box-shadow: none;
+  color: #6b6c7e;
+  cursor: not-allowed;
+  opacity: 0.5;
+  pointer-events: auto;
+  z-index: 0;
+  background-color: transparent;
+}
+
+.page-item {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.page-item:first-child .page-link,
+.page-link-first {
+  border-radius: 4px;
+}
+
+.page-item:last-child .page-link,
+.page-link-last {
+  border-radius: 4px;
+}
+
+.pagination-items-per-page {
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+}
+
+.pagination-items-per-page > a,
+.pagination-items-per-page > button {
+  align-items: center;
+  border-color: transparent;
+  border-radius: 0.25rem;
+  border-style: solid;
+  border-width: 0.0625rem;
+  color: #6b6c7e;
+  display: inline-flex;
+  height: 2rem;
+  justify-content: center;
+  line-height: 1;
+  padding-bottom: 0;
+  padding-left: 0.625rem;
+  padding-right: 0.625rem;
+  padding-top: 0;
+  text-decoration: none;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.pagination-items-per-page > a > .c-inner,
+.pagination-items-per-page > button > .c-inner {
+  margin-bottom: 0;
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+  margin-top: 0;
+}
+
+.pagination-items-per-page > a .lexicon-icon,
+.pagination-items-per-page > button .lexicon-icon {
+  margin-left: 0.125rem;
+  margin-top: 0.125rem;
+}
+
+.pagination-items-per-page > a:hover,
+.pagination-items-per-page > button:hover {
+  border-color: transparent;
+  color: #272833;
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.pagination-items-per-page > a:focus,
+.pagination-items-per-page > button:focus {
+  box-shadow: 0 0 0 0.2rem rgba(11, 95, 255, 0.25);
+  outline: 0;
+  border-color: transparent;
+  color: #272833;
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.pagination-items-per-page > a:active, .pagination-items-per-page > a.active,
+.pagination-items-per-page > button:active,
+.pagination-items-per-page > button.active {
+  border-color: transparent;
+  color: #272833;
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.pagination-items-per-page > a:disabled, .pagination-items-per-page > a.disabled,
+.pagination-items-per-page > button:disabled,
+.pagination-items-per-page > button.disabled {
+  border-color: transparent;
+  box-shadow: none;
+  color: #6b6c7e;
+  cursor: not-allowed;
+  opacity: 0.5;
+  pointer-events: auto;
+  background-color: transparent;
+}
+
+.pagination-items-per-page.active > a,
+.pagination-items-per-page.active > button, .pagination-items-per-page.show > a,
+.pagination-items-per-page.show > button {
+  border-color: transparent;
+  color: #272833;
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.pagination-items-per-page.disabled > a,
+.pagination-items-per-page.disabled > button {
+  border-color: transparent;
+  box-shadow: none;
+  color: #6b6c7e;
+  cursor: not-allowed;
+  opacity: 0.5;
+  pointer-events: auto;
+  background-color: transparent;
+}
+
+@media (max-width: 767.98px) {
+  .pagination-items-per-page + .pagination-results {
+    margin-left: auto;
+  }
+}
+
+.page-item .dropdown-menu,
+.pagination-items-per-page .dropdown-menu {
+  margin-bottom: 0.625rem;
+  margin-top: 0.625rem;
+}
+
+.pagination-results {
+  border-color: transparent;
+  border-style: solid;
+  border-width: 0.0625rem;
+  color: #6b6c7e;
+  font-size: 0.875rem;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+  margin-right: auto;
+  max-width: 100%;
+  padding: 0 0.625rem;
+  word-wrap: break-word;
+}
+
+.pagination-sm .pagination-items-per-page {
+  border-radius: 0.3125rem;
+}
+
+.pagination-sm .pagination-items-per-page > a,
+.pagination-sm .pagination-items-per-page > .btn-unstyled {
+  font-size: 0.75rem;
+  height: 1.5rem;
+  line-height: 1;
+  padding: 0 0.625rem;
+}
+
+.pagination-sm .pagination-items-per-page > a .c-inner,
+.pagination-sm .pagination-items-per-page > .btn-unstyled .c-inner {
+  margin: 0 -0.625rem;
+}
+
+.pagination-sm .pagination-results {
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0 0.625rem;
+}
+
+.pagination-sm .page-link {
+  font-size: 0.75rem;
+  height: 1.5rem;
+  line-height: 1;
+  padding-bottom: 0;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+  padding-top: 0;
+}
+
+.pagination-sm .page-link .c-inner {
+  margin: 0 -0.5rem;
+}
+
+.pagination-sm .page-link.btn-unstyled {
+  padding: 0 0.5rem;
+}
+
+.pagination-sm .page-item:first-child .page-link,
+.pagination-sm .page-link-first {
+  border-bottom-left-radius: 0.3125rem;
+  border-top-left-radius: 0.3125rem;
+}
+
+.pagination-sm .page-item:last-child .page-link,
+.pagination-sm .page-link-last {
+  border-bottom-right-radius: 0.3125rem;
+  border-top-right-radius: 0.3125rem;
+}
+
+.pagination-lg .pagination-items-per-page {
+  border-radius: 0.3125rem;
+}
+
+.pagination-lg .pagination-items-per-page > a,
+.pagination-lg .pagination-items-per-page > .btn-unstyled {
+  font-size: 1.125rem;
+  height: 2.75rem;
+  line-height: 1;
+  padding: 0 0.625rem;
+}
+
+.pagination-lg .pagination-items-per-page > a .c-inner,
+.pagination-lg .pagination-items-per-page > .btn-unstyled .c-inner {
+  margin: 0 -0.625rem;
+}
+
+.pagination-lg .pagination-results {
+  font-size: 1.125rem;
+  line-height: 1;
+  padding: 0 0.625rem;
+}
+
+.pagination-lg .page-link {
+  font-size: 1.125rem;
+  height: 2.75rem;
+  line-height: 1;
+  padding-bottom: 0;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0;
+}
+
+.pagination-lg .page-link .c-inner {
+  margin: 0 -1rem;
+}
+
+.pagination-lg .page-link.btn-unstyled {
+  padding: 0 1rem;
+}
+
+.pagination-lg .page-item:first-child .page-link,
+.pagination-lg .page-link-first {
+  border-bottom-left-radius: 0.3125rem;
+  border-top-left-radius: 0.3125rem;
+}
+
+.pagination-lg .page-item:last-child .page-link,
+.pagination-lg .page-link-last {
+  border-bottom-right-radius: 0.3125rem;
+  border-top-right-radius: 0.3125rem;
+}
+
+.sheet {
+  background-color: #fff;
+  border-color: #e7e7ed;
+  border-style: solid;
+  border-width: 0.0625rem;
+  border-radius: 0.25rem;
+  padding-bottom: 0.0625rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-top: 1.5rem;
+}
+
+@media (max-width: 767.98px) {
+  .sheet {
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 1rem;
+  }
+}
+
+.sheet::after {
+  content: '';
+  display: block;
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 767.98px) {
+  .sheet::after {
+    margin-top: 1rem;
+  }
+}
+
+.sheet + .sheet {
+  margin-top: 3rem;
+}
+
+.sheet .component-title {
+  color: inherit;
+  display: inline-block;
+  font-size: inherit;
+  font-weight: inherit;
+  max-width: 100%;
+}
+
+.sheet .panel-group,
+.sheet .panel-group .panel:last-child .panel-body {
+  margin-bottom: 1.5rem;
+}
+
+@media (max-width: 767.98px) {
+  .sheet .panel-group,
+  .sheet .panel-group .panel:last-child .panel-body {
+    margin-bottom: 1rem;
+  }
+}
+
+.sheet .panel-group .panel-body {
+  margin-bottom: 3rem;
+}
+
+@media (max-width: 767.98px) {
+  .sheet .panel-group .panel-body {
+    margin-bottom: 2rem;
+  }
+}
+
+.sheet-header {
+  margin-bottom: 3rem;
+}
+
+@media (max-width: 767.98px) {
+  .sheet-header {
+    margin-bottom: 2rem;
+  }
+}
+
+.sheet-header::after {
+  clear: both;
+  content: '';
+  display: block;
+}
+
+.sheet-section {
+  margin-bottom: 3rem;
+}
+
+@media (max-width: 767.98px) {
+  .sheet-section {
+    margin-bottom: 2rem;
+  }
+}
+
+.sheet-section > fieldset {
+  margin-bottom: -3rem;
+}
+
+@media (max-width: 767.98px) {
+  .sheet-section > fieldset {
+    margin-bottom: -2rem;
+  }
+}
+
+.sheet-section > .card-page:last-child,
+.sheet-section .card-page-last {
+  margin-bottom: -1.5rem;
+}
+
+.sheet-section::after {
+  clear: both;
+  content: '';
+  display: block;
+}
+
+fieldset + .sheet-footer {
+  margin-top: 0;
+}
+
+.sheet-footer {
+  display: flex;
+  margin-bottom: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 767.98px) {
+  .sheet-footer {
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+  }
+}
+
+.sheet-footer::after {
+  clear: both;
+  content: '';
+  display: block;
+}
+
+@media (max-width: 767.98px) {
+  .sheet-footer-btn-block-sm-down {
+    display: block;
+  }
+  .sheet-footer-btn-block-sm-down .btn {
+    display: block;
+    margin-bottom: 1rem;
+    width: 100%;
+  }
+  .sheet-footer-btn-block-sm-down .btn-group {
+    display: block;
+  }
+  .sheet-footer-btn-block-sm-down .btn-group-item {
+    display: block;
+    margin-right: 0;
+  }
+}
+
+.sheet-lg {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 800px;
+}
+
+.sheet-title {
+  display: block;
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-bottom: 1.5rem;
+  word-wrap: break-word;
+}
+
+@media (max-width: 767.98px) {
+  .sheet-title {
+    font-size: 1.25rem;
+    margin-bottom: 1rem;
+  }
+}
+
+.sheet-subtitle {
+  border-color: #a7a9bc;
+  border-style: solid;
+  border-width: 0 0 1px 0;
+  color: #272833;
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.2;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
+  position: relative;
+  text-transform: uppercase;
+  word-wrap: break-word;
+}
+
+@media (max-width: 767.98px) {
+  .sheet-subtitle {
+    margin-bottom: 1rem;
+  }
+}
+
+.sheet-subtitle .c-inner {
+  margin-bottom: -0.5rem;
+  margin-top: -0.5rem;
+}
+
+.sheet-subtitle.autofit-row {
+  padding-bottom: 0;
+}
+
+.sheet-subtitle.autofit-row .autofit-col {
+  margin-bottom: 0.5rem;
+}
+
+.sheet-subtitle .collapse-icon-closed,
+.sheet-subtitle .collapse-icon-open {
+  font-size: 0.75rem;
+  top: calc(0.5rem + (((1em * 1.2) - 1em) / 2));
+}
+
+.sheet-subtitle .component-title,
+.sheet-subtitle .heading-text {
+  margin-bottom: 0;
+  margin-top: auto;
+}
+
+.sheet-subtitle a,
+.sheet-subtitle .btn {
+  text-transform: none;
+}
+
+a.sheet-subtitle {
+  color: #272833;
+  border-radius: 1px;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+a.sheet-subtitle:hover {
+  text-decoration: none;
+}
+
+a.sheet-subtitle:focus {
+  box-shadow: 0 0 0 0.25rem #fff, 0 0 0 0.375rem #80acff;
+  outline: 0;
+}
+
+.sheet-tertiary-title {
+  color: #272833;
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.2;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
+  text-transform: uppercase;
+  word-wrap: break-word;
+}
+
+@media (max-width: 767.98px) {
+  .sheet-tertiary-title {
+    margin-bottom: 0.5rem;
+  }
+}
+
+.sheet-tertiary-title .component-title {
+  margin-bottom: 0;
+}
+
+.sheet-text {
+  color: #6b6c7e;
+  margin-bottom: 1.5rem;
+  word-wrap: break-word;
+}
+
+@media (max-width: 767.98px) {
+  .sheet-text {
+    margin-bottom: 1rem;
+  }
+}
+
+.sheet-multiple-form .sheet-header {
+  border-color: #e7e7ed;
+  border-style: solid;
+  border-width: 0 0 1px;
+  margin: -1.5rem -1.5rem 1.5rem;
+  padding: 1rem 1.5rem;
+}
+
+@media (max-width: 767.98px) {
+  .sheet-multiple-form .sheet-header {
+    margin: -1rem -1rem 1rem;
+    padding: 1rem;
+  }
+}
+
+.sheet-multiple-form .sheet-header .sheet-title {
+  margin-bottom: 0;
+}
+
+.sheet-dataset-content .sheet-header {
+  border-width: 0;
+  margin: -1.5rem -1.5rem 1.5rem;
+  padding: 1rem 1.5rem;
+}
+
+@media (max-width: 767.98px) {
+  .sheet-dataset-content .sheet-header {
+    margin: -1rem -1rem 1rem;
+    padding: 1rem;
+  }
+}
+
+.sheet-dataset-content .sheet-header .sheet-title {
+  margin-bottom: 0;
+}
+
+.card-page-equal-height .sheet {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.card-page-equal-height .sheet > .autofit-row {
+  flex-grow: 1;
+}
+
+.card-page-item .sheet {
+  margin-bottom: 24px;
+}
+
+.container-fluid-1280.sidenav-container {
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.sidenav-container {
+  position: relative;
+}
+
+.sidenav-container > .sidenav-menu-slider {
+  visibility: hidden;
+  width: 0;
+}
+
+.sidenav-container > .sidenav-content {
+  left: 0;
+}
+
+.sidenav-container.open.sidenav-transition > .sidenav-menu-slider {
+  overflow: hidden;
+}
+
+.sidenav-container.open > .sidenav-menu-slider {
+  overflow: visible;
+  visibility: visible;
+}
+
+.sidenav-content {
+  position: relative;
+}
+
+@media (min-width: 768px) {
+  .sidenav-content {
+    position: static;
+  }
+  .sidenav-content::after {
+    clear: both;
+    content: '';
+    display: block;
+  }
+}
+
+.sidenav-menu {
+  height: 100%;
+  position: relative;
+}
+
+.sidenav-menu-slider {
+  overflow: hidden;
+  position: absolute;
+  width: 320px;
+  z-index: 10;
+}
+
+.sidenav-fixed > .sidenav-menu-slider {
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  top: 0;
+  z-index: 1035;
+}
+
+.sidenav-right > .sidenav-content {
+  left: auto;
+  right: 0;
+}
+
+.sidenav-right > .sidenav-menu-slider {
+  left: auto;
+  right: 0;
+}
+
+.sidenav-right > .sidenav-menu-slider .sidenav-menu {
+  right: 0;
+}
+
+.sidenav-js-fouc > .sidenav-menu-slider {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.sidenav-transition .sidenav-content,
+.sidenav-transition .sidenav-menu,
+.sidenav-transition .sidenav-menu-slider {
+  transition: all 0.5s ease;
+}
+
+.sidenav-transition {
+  transition: all 0.5s ease;
+}
+
+.sidenav-fixed.sidenav-menu-slider {
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  top: 0;
+  visibility: hidden;
+  width: 0;
+}
+
+.sidenav-fixed.sidenav-menu-slider.open {
+  visibility: visible;
+  width: 320px;
+}
+
+.sidenav-fixed.sidenav-menu-slider .sidenav-menu {
+  position: absolute;
+}
+
+.sidenav-menu-slider .sidenav-menu {
+  width: 320px;
+}
+
+.sidenav-menu-slider.sidenav-right {
+  left: auto;
+  right: 0;
+}
+
+.sidenav-menu-slider.sidenav-right .sidenav-menu {
+  right: 0;
+}
+
+.sidebar {
+  height: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.sidebar .container-fluid {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.sidebar-header,
+.sidebar-footer {
+  padding-bottom: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 1rem;
+}
+
+.sidebar-header .component-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.sidebar-header .component-title a {
+  color: #272833;
+}
+
+.sidebar-header .component-subtitle {
+  font-size: 0.75rem;
+  font-weight: 400;
+  margin-bottom: 0;
+}
+
+.sidebar-body {
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 1rem;
+}
+
+.sidebar-body > .sidebar-section {
+  margin-bottom: 2rem;
+}
+
+.sidebar-body > .sidebar-section:last-child {
+  margin-bottom: 0;
+}
+
+.sidebar-section {
+  position: relative;
+  word-wrap: break-word;
+}
+
+.sidebar-list-group {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.875rem;
+  margin-bottom: 0;
+  padding-left: 0;
+}
+
+.sidebar-list-group .autofit-col {
+  padding-bottom: 1rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 1rem;
+}
+
+.sidebar-list-group .autofit-col .list-group-title:only-child {
+  min-height: 1.5rem;
+}
+
+.sidebar-list-group .list-group-item {
+  background-color: transparent;
+  border-color: #cdced9;
+  padding: 0;
+}
+
+.sidebar-list-group .sticker {
+  font-size: 0.75rem;
+  height: 1.5rem;
+  line-height: 1.5rem;
+  width: 1.5rem;
+}
+
+.sidebar-list-group .sticker.sticker-outside {
+  left: -0.75rem;
+  top: -0.75rem;
+}
+
+.sidebar-list-group .sticker.sticker-outside.sticker-bottom-left {
+  bottom: -0.75rem;
+  top: auto;
+}
+
+.sidebar-list-group .sticker.sticker-outside.sticker-bottom-right {
+  bottom: -0.75rem;
+  left: auto;
+  right: -0.75rem;
+  top: auto;
+}
+
+.sidebar-list-group .sticker.sticker-outside.sticker-top-right {
+  left: auto;
+  right: -0.75rem;
+}
+
+.sidebar-panel {
+  margin-bottom: 1rem;
+  position: relative;
+}
+
+.sidebar-dt {
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+}
+
+.sidebar-dd {
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+}
+
+.sidebar-light {
+  background-color: #fff;
+  border-color: #e7e7ed;
+  border-bottom-width: 0;
+  border-left-width: 0;
+  border-right-width: 0;
+  border-top-width: 0;
+  box-shadow: -0.25rem 0 0.5rem -0.25rem rgba(0, 0, 0, 0.1);
+  color: #272833;
+}
+
+.sidebar-light .sidebar-list-group .list-group-title {
+  font-size: 1rem;
+}
+
+.sidebar-light .sidebar-list-group .list-group-title a {
+  color: #272833;
+}
+
+.sidebar-light .sidebar-panel {
+  background-color: #f1f2f5;
+}
+
+.sidebar-light .sidebar-dt {
+  color: #6b6c7e;
+}
+
+.sidebar-light .sidebar-dd a {
+  color: #272833;
+}
+
+.sidebar-light .panel-unstyled .panel-header.panel-header-link:focus {
+  box-shadow: 0 0 0 0.25rem #fff, 0 0 0 0.375rem #80acff;
+}
+
+.sidebar-light .component-navigation-bar {
+  background-color: #fff;
+  border-color: #cdced9;
+  border-style: solid;
+}
+
+.sidebar-light .component-navigation-bar .nav-link,
+.sidebar-light .component-navigation-bar .navbar-nav .btn-unstyled {
+  color: #6b6c7e;
+}
+
+.sidebar-light .component-navigation-bar .nav-link:hover,
+.sidebar-light .component-navigation-bar .navbar-nav .btn-unstyled:hover {
+  color: #6b6c7e;
+}
+
+.sidebar-light .component-navigation-bar .nav-link.active, .sidebar-light .component-navigation-bar .nav-link[aria-expanded='true'],
+.sidebar-light .component-navigation-bar .navbar-nav .btn-unstyled.active,
+.sidebar-light .component-navigation-bar .navbar-nav .btn-unstyled[aria-expanded='true'] {
+  color: #272833;
+}
+
+.sidebar-light .component-navigation-bar .nav-link.disabled, .sidebar-light .component-navigation-bar .nav-link:disabled,
+.sidebar-light .component-navigation-bar .navbar-nav .btn-unstyled.disabled,
+.sidebar-light .component-navigation-bar .navbar-nav .btn-unstyled:disabled {
+  color: #a7a9bc;
+}
+
+.sidebar-light .component-navigation-bar .navbar-toggler {
+  color: #6b6c7e;
+}
+
+.sidebar-light .component-navigation-bar .navbar-toggler-link[aria-expanded='true'] {
+  color: #272833;
+}
+
+.sidebar-light .component-navigation-bar .navbar-overlay {
+  background-color: #fff;
+}
+
+@media (max-width: 575.98px) {
+  .sidebar-light .component-navigation-bar.navbar-expand-sm.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: #cdced9;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-header,
+  .sidebar-light .component-navigation-bar.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-sm .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .sidebar-light .component-navigation-bar.navbar-expand-md.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: #cdced9;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-header,
+  .sidebar-light .component-navigation-bar.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-md .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .sidebar-light .component-navigation-bar.navbar-expand-lg.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: #cdced9;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-header,
+  .sidebar-light .component-navigation-bar.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-lg .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .sidebar-light .component-navigation-bar.navbar-expand-xl.navbar-collapse-absolute .navbar-collapse {
+    background-color: #fff;
+    border-color: #cdced9;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-header,
+  .sidebar-light .component-navigation-bar.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item {
+    color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-divider {
+    border-color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item:hover {
+    color: #6b6c7e;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.active {
+    color: #272833;
+  }
+  .sidebar-light .component-navigation-bar.navbar-expand-xl .navbar-collapse .navbar-nav .dropdown-item.disabled {
+    color: #a7a9bc;
+  }
+}
+
+.sidebar-dark {
+  background-color: #272833;
+  border-bottom-width: 0;
+  border-left-width: 0;
+  border-right-width: 0;
+  border-top-width: 0;
+  color: #fff;
+}
+
+.sidebar-dark .close {
+  color: #a7a9bc;
+}
+
+.sidebar-dark .close:hover {
+  color: #fff;
+}
+
+.sidebar-dark .sidebar-header .component-title {
+  color: inherit;
+}
+
+.sidebar-dark .sidebar-header .component-title a {
+  color: inherit;
+}
+
+.sidebar-dark .sidebar-header .component-subtitle {
+  color: inherit;
+}
+
+.sidebar-dark .sidebar-header .component-subtitle a {
+  color: inherit;
+}
+
+.sidebar-dark .nav-nested .nav-link {
+  border-radius: 0.25rem;
+  color: #a7a9bc;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+.sidebar-dark .nav-nested .nav-link:hover {
+  color: #fff;
+}
+
+.sidebar-dark .nav-nested .nav-link:focus {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+  outline: 0;
+}
+
+.sidebar-dark .nav-nested .nav-link:active {
+  color: #fff;
+}
+
+.sidebar-dark .nav-nested .nav-link.active {
+  color: #fff;
+}
+
+.sidebar-dark .nav-nested .nav-link[aria-expanded='true'], .sidebar-dark .nav-nested .nav-link.show,
+.show > .sidebar-dark .nav-nested .nav-link {
+  color: #fff;
+}
+
+.sidebar-dark .nav-nested .nav-link:disabled, .sidebar-dark .nav-nested .nav-link.disabled {
+  box-shadow: none;
+  color: #a7a9bc;
+  opacity: 0.65;
+}
+
+.sidebar-dark .nav-nested .nav-link:disabled:active, .sidebar-dark .nav-nested .nav-link.disabled:active {
+  pointer-events: none;
+}
+
+.tbar {
+  display: flex;
+}
+
+.tbar > .container,
+.tbar > .container-fluid {
+  display: flex;
+}
+
+.tbar-nav {
+  display: flex;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-wrap: nowrap;
+  list-style: none;
+  margin-bottom: 0;
+  min-width: 3.125rem;
+  padding-left: 0;
+  word-wrap: break-word;
+}
+
+.tbar-nav > .tbar-item {
+  justify-content: center;
+}
+
+.tbar-nav-shrink {
+  flex-grow: 0;
+  flex-shrink: 0;
+  width: auto;
+}
+
+.tbar-nav-wrap {
+  flex-wrap: wrap;
+}
+
+.tbar-item {
+  max-width: 100%;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.tbar-item:first-child {
+  padding-left: 0;
+}
+
+.tbar-item:last-child {
+  padding-right: 0;
+}
+
+.tbar-item-expand {
+  text-align: center;
+}
+
+.tbar-link {
+  display: inline-block;
+}
+
+.tbar-btn-monospaced,
+.tbar-link-monospaced {
+  align-items: center;
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+  padding: 0;
+  text-align: center;
+}
+
+.tbar-btn-monospaced .inline-item .lexicon-icon,
+.tbar-btn-monospaced .lexicon-icon,
+.tbar-link-monospaced .inline-item .lexicon-icon,
+.tbar-link-monospaced .lexicon-icon {
+  margin-top: 0;
+}
+
+@media (max-width: 575.98px) {
+  .tbar-inline-xs-down {
+    display: block;
+  }
+  .tbar-inline-xs-down .container,
+  .tbar-inline-xs-down .container-fluid {
+    display: block;
+  }
+  .tbar-inline-xs-down .component-title,
+  .tbar-inline-xs-down .tbar-nav,
+  .tbar-inline-xs-down .tbar-section {
+    display: inline;
+  }
+  .tbar-inline-xs-down .tbar-item {
+    display: inline;
+    padding-left: 0;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .tbar-inline-sm-down {
+    display: block;
+  }
+  .tbar-inline-sm-down .container,
+  .tbar-inline-sm-down .container-fluid {
+    display: block;
+  }
+  .tbar-inline-sm-down .component-title,
+  .tbar-inline-sm-down .tbar-nav,
+  .tbar-inline-sm-down .tbar-section {
+    display: inline;
+  }
+  .tbar-inline-sm-down .tbar-item {
+    display: inline;
+    padding-left: 0;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .tbar-inline-md-down {
+    display: block;
+  }
+  .tbar-inline-md-down .container,
+  .tbar-inline-md-down .container-fluid {
+    display: block;
+  }
+  .tbar-inline-md-down .component-title,
+  .tbar-inline-md-down .tbar-nav,
+  .tbar-inline-md-down .tbar-section {
+    display: inline;
+  }
+  .tbar-inline-md-down .tbar-item {
+    display: inline;
+    padding-left: 0;
+  }
+}
+
+@media (max-width: 1279.98px) {
+  .tbar-inline-lg-down {
+    display: block;
+  }
+  .tbar-inline-lg-down .container,
+  .tbar-inline-lg-down .container-fluid {
+    display: block;
+  }
+  .tbar-inline-lg-down .component-title,
+  .tbar-inline-lg-down .tbar-nav,
+  .tbar-inline-lg-down .tbar-section {
+    display: inline;
+  }
+  .tbar-inline-lg-down .tbar-item {
+    display: inline;
+    padding-left: 0;
+  }
+}
+
+.tbar-inline-xl-down {
+  display: block;
+}
+
+.tbar-inline-xl-down .container,
+.tbar-inline-xl-down .container-fluid {
+  display: block;
+}
+
+.tbar-inline-xl-down .component-title,
+.tbar-inline-xl-down .tbar-nav,
+.tbar-inline-xl-down .tbar-section {
+  display: inline;
+}
+
+.tbar-inline-xl-down .tbar-item {
+  display: inline;
+  padding-left: 0;
+}
+
+.component-tbar {
+  border-color: #e7e7ed;
+  border-style: solid;
+  border-width: 0 0 0.0625rem 0;
+  height: 3.5rem;
+  color: #6b6c7e;
+}
+
+.component-tbar .tbar-label {
+  border-width: 0.0625rem;
+  height: auto;
+}
+
+.subnav-tbar {
+  font-size: 0.875rem;
+}
+
+.subnav-tbar .btn-unstyled {
+  color: #0b5fff;
+  text-decoration: none;
+}
+
+.subnav-tbar .btn-unstyled:hover {
+  color: #004ad7;
+  text-decoration: underline;
+}
+
+.subnav-tbar strong {
+  font-weight: 600;
+}
+
+.subnav-tbar .component-link {
+  color: #0b5fff;
+  font-weight: 600;
+}
+
+.subnav-tbar .component-link:hover {
+  color: #004ad7;
+}
+
+.subnav-tbar .tbar-item {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.subnav-tbar .tbar-btn {
+  height: 1.5rem;
+  line-height: 1;
+  margin-bottom: 0.125rem;
+  margin-top: 0.125rem;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
+.subnav-tbar .tbar-btn .c-inner {
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.subnav-tbar .tbar-btn .c-inner {
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.subnav-tbar .tbar-link {
+  margin-bottom: 0.125rem;
+  margin-top: 0.125rem;
+  padding-bottom: 0.09375rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.09375rem;
+}
+
+.subnav-tbar .tbar-link > .c-inner {
+  margin-bottom: -0.09375rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.09375rem;
+}
+
+.subnav-tbar .tbar-link .c-inner {
+  margin-bottom: -0.09375rem;
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  margin-top: -0.09375rem;
+}
+
+.subnav-tbar .tbar-btn-monospaced {
+  height: 1.5rem;
+  margin-bottom: 0.125rem;
+  margin-top: 0.125rem;
+  padding: 0.25rem;
+  width: 1.5rem;
+}
+
+.subnav-tbar .tbar-btn-monospaced .c-inner {
+  margin: -0.25rem;
+}
+
+.subnav-tbar .tbar-link-monospaced {
+  height: 1.5rem;
+  margin-bottom: 0.125rem;
+  margin-top: 0.125rem;
+  width: 1.5rem;
+}
+
+.subnav-tbar .tbar-section {
+  text-align: left;
+}
+
+.subnav-tbar .component-title {
+  display: inline-block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.45;
+  margin-bottom: 0.25rem;
+  margin-top: 0.25rem;
+  max-width: 100%;
+}
+
+.subnav-tbar .component-text {
+  display: inline-block;
+  line-height: 1.45;
+  margin-bottom: 0.25rem;
+  margin-top: 0.25rem;
+  max-width: 100%;
+}
+
+.subnav-tbar .tbar-label {
+  border-width: 0.0625rem;
+  height: auto;
+}
+
+.subnav-tbar-primary {
+  background-color: #b3cdff;
+  padding-bottom: 0.625rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  padding-top: 0.625rem;
+}
+
+.subnav-tbar-primary .component-link {
+  color: #272833;
+}
+
+.subnav-tbar-primary .component-link:hover {
+  color: #272833;
+}
+
+.subnav-tbar-primary .component-link:disabled, .subnav-tbar-primary .component-link.disabled {
+  color: #6b6c7e;
+  cursor: not-allowed;
+  opacity: 0.65;
+  text-decoration: none;
+}
+
+.subnav-tbar-primary .tbar-item {
+  justify-content: flex-start;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
+.subnav-tbar-primary .tbar-link-monospaced {
+  border-radius: 0;
+  border-width: 0;
+  height: 3rem;
+  margin-bottom: -0.625rem;
+  margin-top: -0.625rem;
+  width: 3rem;
+}
+
+.subnav-tbar-primary .component-label .close:focus {
+  color: inherit;
+}
+
+.subnav-tbar-primary .component-label .close:disabled, .subnav-tbar-primary .component-label .close.disabled {
+  color: #6b6c7e;
+  opacity: 0.65;
+}
+
+.subnav-tbar-primary .tbar-label {
+  border-width: 0.0625rem;
+  font-size: 0.75rem;
+  height: auto;
+  margin-right: 0;
+  padding-bottom: 0.3125rem;
+  padding-left: 0.625rem;
+  padding-right: 0.625rem;
+  padding-top: 0.3125rem;
+  text-transform: none;
+}
+
+.subnav-tbar-primary .tbar-label > .c-inner {
+  margin-bottom: -0.3125rem;
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+  margin-top: -0.3125rem;
+}
+
+.subnav-tbar-primary.subnav-tbar-disabled {
+  color: #8e94aa;
+  background-color: #cfddf8;
+}
+
+.subnav-tbar-primary.subnav-tbar-disabled .component-label {
+  border-color: #8e94aa;
+}
+
+.subnav-tbar-primary.subnav-tbar-disabled .tbar-label {
+  border-width: 0.0625rem;
+  height: auto;
+}
+
+.subnav-tbar-light {
+  color: #6b6c7e;
+  background-color: white;
+  padding-bottom: 0.125rem;
+  padding-top: 0.125rem;
+}
+
+.subnav-tbar-light .tbar-label {
+  border-width: 0.0625rem;
+  height: auto;
+}
+
+.tbar-stacked {
+  display: inline-flex;
+  height: 100%;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.tbar-stacked .tbar-nav {
+  flex-direction: column;
+  min-width: 0;
+}
+
+.tbar-stacked .tbar-item {
+  align-items: center;
+  justify-content: flex-start;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.tbar-stacked .tbar-divider-before::before {
+  background-color: #272833;
+  content: "";
+  display: block;
+  height: 1px;
+  margin-bottom: 0.25rem;
+  margin-top: 0.25rem;
+  width: 2.5rem;
+}
+
+.tbar-stacked .tbar-divider-after::after {
+  background-color: #272833;
+  content: "";
+  display: block;
+  height: 1px;
+  margin-bottom: 0.25rem;
+  margin-top: 0.25rem;
+  width: 2.5rem;
+}
+
+.tbar-stacked .tbar-item-expand {
+  flex-shrink: 0;
+  min-width: 0;
+}
+
+.tbar-stacked .tbar-btn-monospaced {
+  border-color: transparent;
+  border-radius: 0;
+  border-width: 0;
+  color: inherit;
+  height: 2.5rem;
+  margin-bottom: 0;
+  margin-top: 0;
+  overflow: visible;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  position: relative;
+  width: 2.5rem;
+}
+
+.tbar-stacked .tbar-btn-monospaced:focus, .tbar-stacked .tbar-btn-monospaced.focus {
+  box-shadow: inset 0 0 0 0.125rem #80acff, inset 0 0 0 0.25rem #fff;
+}
+
+.tbar-stacked .tbar-btn-monospaced:active:focus {
+  box-shadow: inset 0 0 0 0.125rem #80acff, inset 0 0 0 0.25rem #fff;
+}
+
+.tbar-stacked .tbar-btn-monospaced .c-inner {
+  margin-bottom: 0;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+}
+
+.tbar-stacked .tbar-label {
+  border-width: 0.0625rem;
+  height: auto;
+}
+
+.tbar-light {
+  background-color: #fff;
+  box-shadow: inset 1px 0 0 0 #f1f2f5, inset -1px 0 0 0 #f1f2f5;
+  color: #6b6c7e;
+}
+
+.tbar-light .tbar-divider-before::before {
+  background-color: #f1f2f5;
+}
+
+.tbar-light .tbar-divider-after::after {
+  background-color: #f1f2f5;
+}
+
+.tbar-light .tbar-btn-monospaced:hover {
+  color: #272833;
+}
+
+.tbar-light .tbar-btn-monospaced:focus, .tbar-light .tbar-btn-monospaced.focus {
+  color: #272833;
+}
+
+.tbar-light .tbar-btn-monospaced:active {
+  background-color: #f1f2f5;
+  color: #272833;
+}
+
+.tbar-light .tbar-btn-monospaced[aria-expanded='true'], .tbar-light .tbar-btn-monospaced.active, .tbar-light .tbar-btn-monospaced.show,
+.show > .tbar-light .tbar-btn-monospaced.dropdown-toggle {
+  background-color: #f1f2f5;
+  color: #272833;
+}
+
+.tbar-light .tbar-btn-monospaced:disabled, .tbar-light .tbar-btn-monospaced.disabled {
+  color: inherit;
+}
+
+.tbar-light .tbar-label {
+  border-width: 0.0625rem;
+  height: auto;
+}
+
+.tbar-dark-l2 {
+  background-color: #393a4a;
+  box-shadow: inset 1px 0 0 0 rgba(255, 255, 255, 0.06) , inset -1px 0 0 0 rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.06);
+  color: #a7a9bc;
+}
+
+.tbar-dark-l2 .tbar-divider-before::before {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.tbar-dark-l2 .tbar-divider-after::after {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.tbar-dark-l2 .tbar-btn-monospaced:hover {
+  color: #fff;
+}
+
+.tbar-dark-l2 .tbar-btn-monospaced:focus, .tbar-dark-l2 .tbar-btn-monospaced.focus {
+  color: #fff;
+}
+
+.tbar-dark-l2 .tbar-btn-monospaced:active {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: #fff;
+}
+
+.tbar-dark-l2 .tbar-btn-monospaced[aria-expanded='true'], .tbar-dark-l2 .tbar-btn-monospaced.active, .tbar-dark-l2 .tbar-btn-monospaced.show,
+.show > .tbar-dark-l2 .tbar-btn-monospaced.dropdown-toggle {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: #fff;
+}
+
+.tbar-dark-l2 .tbar-btn-monospaced:disabled, .tbar-dark-l2 .tbar-btn-monospaced.disabled {
+  color: inherit;
+}
+
+.tbar-dark-l2 .tbar-label {
+  border-width: 0.0625rem;
+  height: auto;
+}
+
+.tbar-dark-d1 {
+  background-color: #1c1c24;
+  box-shadow: inset 1px 0 0 0 rgba(255, 255, 255, 0.06) , inset -1px 0 0 0 rgba(255, 255, 255, 0.06);
+  color: #a7a9bc;
+}
+
+.tbar-dark-d1 .tbar-divider-before::before {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.tbar-dark-d1 .tbar-divider-after::after {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.tbar-dark-d1 .tbar-btn-monospaced:hover {
+  color: #fff;
+}
+
+.tbar-dark-d1 .tbar-btn-monospaced:focus, .tbar-dark-d1 .tbar-btn-monospaced.focus {
+  color: #fff;
+}
+
+.tbar-dark-d1 .tbar-btn-monospaced:active {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: #fff;
+}
+
+.tbar-dark-d1 .tbar-btn-monospaced[aria-expanded='true'], .tbar-dark-d1 .tbar-btn-monospaced.active, .tbar-dark-d1 .tbar-btn-monospaced.show,
+.show > .tbar-dark-d1 .tbar-btn-monospaced.dropdown-toggle {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: #fff;
+}
+
+.tbar-dark-d1 .tbar-btn-monospaced[aria-expanded='true']::after, .tbar-dark-d1 .tbar-btn-monospaced.active::after, .tbar-dark-d1 .tbar-btn-monospaced.show::after,
+.show > .tbar-dark-d1 .tbar-btn-monospaced.dropdown-toggle::after {
+  background-color: #80acff;
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 0.25rem;
+}
+
+.tbar-dark-d1 .tbar-btn-monospaced:disabled, .tbar-dark-d1 .tbar-btn-monospaced.disabled {
+  color: inherit;
+}
+
+.tbar-dark-d1 .tbar-label {
+  border-width: 0.0625rem;
+  height: auto;
+}
+
+.timeline {
+  list-style: none;
+  padding-left: 0;
+  padding-left: 25px;
+}
+
+.timeline .panel,
+.timeline .panel-group {
+  margin-bottom: 0;
+}
+
+.timeline-icon {
+  background-color: #fff;
+  border: 2px solid #6b6c7e;
+  border-radius: 50%;
+  display: block;
+  height: 10px;
+  line-height: 10px;
+  width: 10px;
+}
+
+.timeline-increment {
+  background-color: #fff;
+  left: -39px;
+  position: absolute;
+  text-align: center;
+  top: 50%;
+  -ms-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+  z-index: 1;
+}
+
+.timeline-increment-text {
+  display: block;
+  max-width: 65px;
+}
+
+.timeline-item-label {
+  color: #272833;
+}
+
+.timeline-item {
+  padding-bottom: 5px;
+  padding-left: 40px;
+  padding-top: 5px;
+  position: relative;
+}
+
+.timeline-item:before {
+  background-color: #272833;
+  bottom: 0;
+  content: '';
+  display: block;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 2px;
+}
+
+.timeline-item.active .timeline-icon {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+
+.timeline-item .panel,
+.timeline-item .panel-heading {
+  position: relative;
+}
+
+.timeline-item .panel .timeline-increment {
+  margin-left: 0;
+}
+
+.timeline-right {
+  padding-left: 0;
+  padding-right: 25px;
+}
+
+.timeline-right .timeline-item {
+  padding-left: 0;
+  padding-right: 40px;
+}
+
+.timeline-right .timeline-item:before {
+  left: auto;
+  right: -2px;
+}
+
+.timeline-right .timeline-item .panel .timeline-increment {
+  margin-left: auto;
+  margin-right: 0;
+}
+
+.timeline-right .timeline-item .timeline-increment {
+  left: auto;
+  right: -41px;
+  -ms-transform: translate(50%, -50%);
+  transform: translate(50%, -50%);
+}
+
+@media (max-width: 575.98px) {
+  .timeline-right-xs-only {
+    padding-left: 0;
+    padding-right: 25px;
+  }
+  .timeline-right-xs-only .timeline-item {
+    padding-left: 0;
+    padding-right: 40px;
+  }
+  .timeline-right-xs-only .timeline-item:before {
+    left: auto;
+    right: -2px;
+  }
+  .timeline-right-xs-only .timeline-item .panel .timeline-increment {
+    margin-left: auto;
+    margin-right: 0;
+  }
+  .timeline-right-xs-only .timeline-item .timeline-increment {
+    left: auto;
+    right: -41px;
+    -ms-transform: translate(50%, -50%);
+    transform: translate(50%, -50%);
+  }
+}
+
+@media (min-width: 768px) {
+  .timeline-center {
+    padding-left: 0;
+  }
+  .timeline-center .timeline-item {
+    margin-left: 50%;
+    width: 50%;
+  }
+  .timeline-center .timeline-item .timeline-item-label {
+    left: -100%;
+    margin-left: -80px;
+    position: absolute;
+    text-align: right;
+    top: 50%;
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+    width: 100%;
+  }
+  .timeline-center .timeline-item.timeline-item-reverse {
+    padding-left: 0;
+    padding-right: 40px;
+    margin-left: 0;
+  }
+  .timeline-center .timeline-item.timeline-item-reverse:before {
+    left: auto;
+    right: -2px;
+  }
+  .timeline-center .timeline-item.timeline-item-reverse .panel .timeline-increment {
+    margin-left: auto;
+    margin-right: 0;
+  }
+  .timeline-center .timeline-item.timeline-item-reverse .timeline-increment {
+    left: auto;
+    right: -41px;
+    -ms-transform: translate(50%, -50%);
+    transform: translate(50%, -50%);
+  }
+  .timeline-center .timeline-item.timeline-item-reverse .timeline-item-label {
+    margin-left: auto;
+    margin-right: -80px;
+    right: -100%;
+    text-align: left;
+  }
+}
+
+@media (min-width: 768px) {
+  .timeline-even .timeline-item:nth-of-type(even),
+  .timeline-odd .timeline-item:nth-of-type(odd) {
+    padding-left: 0;
+    padding-right: 40px;
+    margin-left: 0;
+  }
+  .timeline-even .timeline-item:nth-of-type(even):before,
+  .timeline-odd .timeline-item:nth-of-type(odd):before {
+    left: auto;
+    right: -2px;
+  }
+  .timeline-even .timeline-item:nth-of-type(even) .panel .timeline-increment,
+  .timeline-odd .timeline-item:nth-of-type(odd) .panel .timeline-increment {
+    margin-left: auto;
+    margin-right: 0;
+  }
+  .timeline-even .timeline-item:nth-of-type(even) .timeline-increment,
+  .timeline-odd .timeline-item:nth-of-type(odd) .timeline-increment {
+    left: auto;
+    right: -41px;
+    -ms-transform: translate(50%, -50%);
+    transform: translate(50%, -50%);
+  }
+  .timeline-even .timeline-item:nth-of-type(even) .timeline-item-label,
+  .timeline-odd .timeline-item:nth-of-type(odd) .timeline-item-label {
+    margin-left: auto;
+    margin-right: -80px;
+    right: -100%;
+    text-align: left;
+  }
+}
+
+.timeline-spacing-xl.timeline {
+  padding-left: 25px;
+}
+
+@media (min-width: 768px) {
+  .timeline-spacing-xl.timeline-center {
+    padding-left: 0;
+  }
+  .timeline-spacing-xl.timeline-center .timeline-item .timeline-item-label {
+    margin-left: -100px;
+  }
+  .timeline-spacing-xl.timeline-center .timeline-item.timeline-item-reverse {
+    padding-right: 50px;
+  }
+  .timeline-spacing-xl.timeline-center .timeline-item.timeline-item-reverse .timeline-increment {
+    right: -51px;
+  }
+  .timeline-spacing-xl.timeline-center .timeline-item.timeline-item-reverse .timeline-item-label {
+    margin-left: auto;
+    margin-right: -100px;
+  }
+}
+
+@media (min-width: 768px) {
+  .timeline-spacing-xl.timeline-even .timeline-item:nth-of-type(even),
+  .timeline-spacing-xl.timeline-odd .timeline-item:nth-of-type(odd) {
+    padding-right: 50px;
+  }
+  .timeline-spacing-xl.timeline-even .timeline-item:nth-of-type(even) .timeline-increment,
+  .timeline-spacing-xl.timeline-odd .timeline-item:nth-of-type(odd) .timeline-increment {
+    right: -51px;
+  }
+  .timeline-spacing-xl.timeline-even .timeline-item:nth-of-type(even) .timeline-item-label,
+  .timeline-spacing-xl.timeline-odd .timeline-item:nth-of-type(odd) .timeline-item-label {
+    margin-left: auto;
+    margin-right: -100px;
+  }
+}
+
+.timeline-spacing-xl.timeline-right {
+  padding-right: 25px;
+}
+
+.timeline-spacing-xl.timeline-right .timeline-item {
+  padding-right: 50px;
+}
+
+.timeline-spacing-xl.timeline-right .timeline-item .timeline-increment {
+  right: -51px;
+}
+
+@media (max-width: 575.98px) {
+  .timeline-spacing-xl.timeline-right-xs-only {
+    padding-left: 0;
+    padding-right: 25px;
+  }
+  .timeline-spacing-xl.timeline-right-xs-only .timeline-item {
+    padding-left: 0;
+    padding-right: 50px;
+  }
+  .timeline-spacing-xl.timeline-right-xs-only .timeline-item .timeline-increment {
+    left: auto;
+    right: -51px;
+  }
+}
+
+.timeline-spacing-xl .timeline-item {
+  padding-bottom: 15px;
+  padding-left: 50px;
+  padding-top: 15px;
+}
+
+.timeline-spacing-xl .timeline-item .timeline-increment {
+  left: -49px;
+}
+
+.timeline-spacing-xl .timeline-increment-text {
+  max-width: 75px;
+}
+
+.simple-toggle-switch.toggle-switch {
+  align-items: center;
+  display: inline-flex;
+}
+
+.simple-toggle-switch .toggle-switch-check + .toggle-switch-label {
+  margin-right: 0.5rem;
+}
+
+.simple-toggle-switch .toggle-switch-label + .toggle-switch-check-bar {
+  margin-left: 0.5rem;
+}
+
+.simple-toggle-switch .toggle-switch-label {
+  line-height: 1;
+  margin-bottom: 0;
+  max-width: calc( 100% - 48px);
+}
+
+@media (max-width: 767.98px) {
+  .simple-toggle-switch .toggle-switch-label {
+    max-width: calc( 100% - 48px);
+  }
+}
+
+.simple-toggle-switch-reverse .toggle-switch-label {
+  margin-right: 0.5rem;
+}
+
+.simple-toggle-switch-reverse .toggle-switch-check-bar {
+  order: 5;
+}
+
+.simple-toggle-switch-reverse .toggle-switch-check-bar .toggle-switch-bar {
+  order: 0;
+}
+
+.simple-toggle-switch-reverse .toggle-switch-bar {
+  order: 5;
+}
+
+label.toggle-switch {
+  cursor: pointer;
+}
+
+label.toggle-switch.disabled {
+  cursor: not-allowed;
+}
+
+.toggle-switch {
+  display: inline-block;
+  font-weight: 600;
+  max-width: 100%;
+  position: relative;
+}
+
+.toggle-switch.disabled .toggle-switch-label {
+  color: #a7a9bc;
+  cursor: not-allowed;
+}
+
+.toggle-switch.disabled .toggle-switch-text {
+  color: #a7a9bc;
+}
+
+.toggle-switch-check-bar {
+  display: inline-flex;
+  position: relative;
+}
+
+.toggle-switch-bar .toggle-switch-handle {
+  display: block;
+  min-width: 40px;
+  text-transform: uppercase;
+}
+
+.toggle-switch-bar .toggle-switch-icon {
+  font-size: 0.625rem;
+}
+
+.toggle-switch-bar .toggle-switch-icon .lexicon-icon {
+  margin-top: -0.2em;
+}
+
+.toggle-switch-bar .button-icon {
+  font-size: 0.625rem;
+}
+
+.toggle-switch-check {
+  bottom: 0;
+  font-size: 62.5%;
+  height: 24px;
+  opacity: 0;
+  position: absolute;
+  width: 40px;
+  z-index: 2;
+}
+
+@media (max-width: 767.98px) {
+  .toggle-switch-check {
+    height: 24px;
+    width: 40px;
+  }
+}
+
+.toggle-switch-check:empty ~ .toggle-switch-bar {
+  display: inline-flex;
+  font-size: 0.625rem;
+  height: 24px;
+  line-height: 24px;
+  position: relative;
+  text-indent: 0;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.toggle-switch-check:empty ~ .toggle-switch-bar:after {
+  background-color: #fff;
+  border-color: #fff;
+  border-radius: 50%;
+  border-style: solid;
+  border-width: 1px;
+  bottom: 4px;
+  content: '';
+  display: block;
+  height: 16px;
+  left: 4px;
+  position: absolute;
+  top: 4px;
+  transition: background-color 100ms ease-in, border-color 100ms ease-in, box-shadow 150ms ease-in-out, color 100ms ease-in, left 100ms ease-in, right 100ms ease-in;
+  width: 16px;
+}
+
+.toggle-switch-check:empty ~ .toggle-switch-bar:before {
+  background-color: #a7a9bc;
+  border-color: #a7a9bc;
+  border-radius: 20px;
+  border-style: solid;
+  border-width: 1px;
+  bottom: 0;
+  content: ' ';
+  display: block;
+  left: 0;
+  position: absolute;
+  top: 0;
+  transition: background-color 100ms ease-in, border-color 100ms ease-in, box-shadow 150ms ease-in-out, color 100ms ease-in, left 100ms ease-in, right 100ms ease-in;
+  width: 40px;
+}
+
+.toggle-switch-check:empty ~ .toggle-switch-bar .toggle-switch-handle:after {
+  content: attr(data-label-off);
+  margin-left: 48px;
+  transition: background-color 100ms ease-in, border-color 100ms ease-in, box-shadow 150ms ease-in-out, color 100ms ease-in, left 100ms ease-in, right 100ms ease-in;
+  white-space: nowrap;
+}
+
+.toggle-switch-check:empty ~ .toggle-switch-bar .toggle-switch-handle:before {
+  transition: background-color 100ms ease-in, border-color 100ms ease-in, box-shadow 150ms ease-in-out, color 100ms ease-in, left 100ms ease-in, right 100ms ease-in;
+}
+
+.toggle-switch-check:empty ~ .toggle-switch-bar .toggle-switch-icon {
+  color: #fff;
+  left: 4px;
+  line-height: 16px;
+  position: absolute;
+  text-align: center;
+  text-indent: 0;
+  top: 4px;
+  transition: background-color 100ms ease-in, border-color 100ms ease-in, box-shadow 150ms ease-in-out, color 100ms ease-in, left 100ms ease-in, right 100ms ease-in;
+  width: 16px;
+  z-index: 1;
+}
+
+.toggle-switch-check:empty ~ .toggle-switch-bar .toggle-switch-icon-on {
+  left: 4px;
+  opacity: 0;
+}
+
+.toggle-switch-check:empty ~ .toggle-switch-bar .toggle-switch-icon-off {
+  left: 20px;
+}
+
+.toggle-switch-check:empty ~ .toggle-switch-bar .button-icon {
+  color: #272833;
+}
+
+.toggle-switch-check:empty ~ .toggle-switch-bar .button-icon-on {
+  opacity: 0;
+}
+
+.toggle-switch-check:checked ~ .toggle-switch-bar:after {
+  background-color: #fff;
+  border-color: #fff;
+  border-radius: 50%;
+  border-style: solid;
+  border-width: 1px;
+  left: 20px;
+}
+
+.toggle-switch-check:checked ~ .toggle-switch-bar:before {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+  border-radius: 20px;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.toggle-switch-check:checked ~ .toggle-switch-bar .toggle-switch-handle:after {
+  content: attr(data-label-on);
+}
+
+.toggle-switch-check:checked ~ .toggle-switch-bar .toggle-switch-icon {
+  color: #fff;
+}
+
+.toggle-switch-check:checked ~ .toggle-switch-bar .button-icon {
+  color: #0b5fff;
+  left: 20px;
+}
+
+.toggle-switch-check:checked ~ .toggle-switch-bar .button-icon-on,
+.toggle-switch-check:checked ~ .toggle-switch-bar .toggle-switch-icon-on {
+  opacity: 1;
+}
+
+.toggle-switch-check:checked ~ .toggle-switch-bar .button-icon-off,
+.toggle-switch-check:checked ~ .toggle-switch-bar .toggle-switch-icon-off {
+  opacity: 0;
+}
+
+.toggle-switch-check:disabled ~ .toggle-switch-bar, .toggle-switch-check.disabled ~ .toggle-switch-bar {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.toggle-switch-check:focus ~ .toggle-switch-bar:before {
+  box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
+}
+
+.toggle-switch-label {
+  display: block;
+  margin-bottom: 2px;
+}
+
+.toggle-switch-text {
+  display: block;
+  font-size: 0.75rem;
+}
+
+.toggle-switch-text-left {
+  display: inline-flex;
+  line-height: 24px;
+  margin-right: 8px;
+}
+
+.toggle-switch-text-right {
+  display: inline-flex;
+  line-height: 24px;
+  margin-left: 8px;
+}
+
+@media (max-width: 767.98px) {
+  .toggle-switch-bar .toggle-switch-handle {
+    min-width: 40px;
+  }
+  .toggle-switch-bar .toggle-switch-icon {
+    font-size: 0.625rem;
+  }
+  .toggle-switch-bar .button-icon {
+    font-size: 0.625rem;
+  }
+  .toggle-switch-check:empty ~ .toggle-switch-bar {
+    height: 24px;
+    line-height: 24px;
+    text-indent: 0;
+  }
+  .toggle-switch-check:empty ~ .toggle-switch-bar:after {
+    bottom: 4px;
+    height: 16px;
+    left: 4px;
+    top: 4px;
+    width: 16px;
+  }
+  .toggle-switch-check:empty ~ .toggle-switch-bar:before {
+    width: 40px;
+  }
+  .toggle-switch-check:empty ~ .toggle-switch-bar .toggle-switch-handle:after {
+    margin-left: 48px;
+  }
+  .toggle-switch-check:empty ~ .toggle-switch-bar .toggle-switch-icon {
+    left: 4px;
+    line-height: 16px;
+    top: 4px;
+    width: 16px;
+  }
+  .toggle-switch-check:empty ~ .toggle-switch-bar .toggle-switch-icon-on {
+    left: 4px;
+  }
+  .toggle-switch-check:empty ~ .toggle-switch-bar .toggle-switch-icon-off {
+    left: 20px;
+  }
+  .toggle-switch-check:checked ~ .toggle-switch-bar:after {
+    left: 20px;
+  }
+  .toggle-switch-check:checked ~ .toggle-switch-bar .toggle-switch-handle:after {
+    margin-left: 48px;
+  }
+  .toggle-switch-check:checked ~ .toggle-switch-bar .button-icon {
+    left: 20px;
+  }
+  .toggle-switch-text-left,
+  .toggle-switch-text-right {
+    line-height: 24px;
+  }
+}
+
+/*# sourceMappingURL=admin.css.map */

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/clay.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/clay.scss
@@ -1,1 +1,3 @@
-@import 'clay/atlas';
+//@import 'clay/atlas';
+
+@import 'admin';


### PR DESCRIPTION
319KB (35KB gzip) of CSS to see all admin controls and cards view without full clay loaded:
It includes some general styles like grids, icons, etc. those styles should be loaded as general styles, in that case, we could have a CSS around 180KB (13KB gziped).

![image](https://user-images.githubusercontent.com/7963804/116116855-e66e1000-a6bb-11eb-8b41-46d81c80dd04.png)

![image](https://user-images.githubusercontent.com/7963804/116116808-d81ff400-a6bb-11eb-8daf-0306fe4c31c8.png)

The rest of portal is broken because we are not loading all Clay (it should be supported by clay-admin):

![image](https://user-images.githubusercontent.com/7963804/116116925-fdacfd80-a6bb-11eb-9231-3a4aab83b9a1.png)

