### PR TITLE
LPS-130360 Migrate selection modals in commerce-channel-web

### DIFF
--- a/modules/apps/commerce/commerce-channel-web/package.json
+++ b/modules/apps/commerce/commerce-channel-web/package.json
@@ -1,0 +1,13 @@
+{
+	"dependencies": {
+		"frontend-js-web": "*"
+	},
+	"name": "@liferay/commerce-channel-web",
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix",
+		"test": "liferay-npm-scripts test"
+	},
+	"version": "4.0.2"
+}

--- a/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/channel/site.jsp
+++ b/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/channel/site.jsp
@@ -35,6 +35,8 @@ boolean isViewOnly = false;
 if (commerceChannel != null) {
 	isViewOnly = !siteCommerceChannelTypeDisplayContext.hasPermission(commerceChannel.getCommerceChannelId(), ActionKeys.UPDATE);
 }
+
+String searchContainerId = "CommerceChannelSitesSearchContainer";
 %>
 
 <liferay-util:buffer
@@ -72,7 +74,7 @@ if (commerceChannel != null) {
 				<liferay-ui:search-container
 					curParam="commerceChannelSiteCur"
 					headerNames="null,null"
-					id="CommerceChannelSitesSearchContainer"
+					id="<%= searchContainerId %>"
 					iteratorURL="<%= currentURLObj %>"
 					total="<%= siteAsList.size() %>"
 				>
@@ -110,88 +112,17 @@ if (commerceChannel != null) {
 	</div>
 </aui:form>
 
-<aui:script use="aui-base,liferay-item-selector-dialog">
-	var selectSiteButton = window.document.querySelector(
-		'#<portlet:namespace />selectSite'
-	);
-
-	if (selectSiteButton) {
-		selectSiteButton.addEventListener('click', (event) => {
-			event.preventDefault();
-
-			Liferay.Util.selectEntity({
-				dialog: {
-					constrain: true,
-					modal: true,
-				},
-				eventName: 'sitesSelectItem',
-				title: '<liferay-ui:message arguments="site" key="select-x" />',
-				uri:
-					'<%= siteCommerceChannelTypeDisplayContext.getItemSelectorUrl() %>',
-			});
-		});
-	}
-</aui:script>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get(
-		'<portlet:namespace />CommerceChannelSitesSearchContainer'
-	);
-
-	var searchContainerContentBox = searchContainer.get('contentBox');
-
-	searchContainerContentBox.delegate(
-		'click',
-		(event) => {
-			var link = event.currentTarget;
-
-			var rowId = link.attr('data-rowId');
-
-			var tr = link.ancestor('tr');
-
-			searchContainer.deleteRow(tr, link.getAttribute('data-rowId'));
-
-			A.one('#<portlet:namespace />siteGroupId').val(0);
-		},
-		'.modify-link'
-	);
-
-	var sitesSelectItemHandle = Liferay.on('sitesSelectItem', (event) => {
-		var item = event.data;
-
-		if (item) {
-			var searchContainer = Liferay.SearchContainer.get(
-				'<portlet:namespace />CommerceChannelSitesSearchContainer'
-			);
-
-			var link = A.one('[data-rowid=' + searchContainer.getData() + ']');
-
-			if (link !== null) {
-				var tr = link.ancestor('tr');
-
-				searchContainer.deleteRow(tr, link.getAttribute('data-rowId'));
-			}
-
-			if (!searchContainer.getData().includes(item.id)) {
-				var rowColumns = [];
-
-				rowColumns.push(item.name);
-				rowColumns.push(
-					'<a class="float-right modify-link" data-rowId="' +
-						item.id +
-						'" href="javascript:;"><%= UnicodeFormatter.toString(removeCommerceChannelSiteIcon) %></a>'
-				);
-
-				A.one('#<portlet:namespace />siteGroupId').val(item.id);
-
-				searchContainer.addRow(rowColumns, item.id);
-
-				searchContainer.updateDataStore();
-			}
-		}
-	});
-
-	Liferay.on('beforeNavigate', (event) => {
-		sitesSelectItemHandle.detach();
-	});
-</aui:script>
+<liferay-frontend:component
+	context='<%=
+		HashMapBuilder.<String, Object>put(
+			"itemSelectorUrl", siteCommerceChannelTypeDisplayContext.getItemSelectorUrl()
+		).put(
+			"portletNamespace", liferayPortletResponse.getNamespace()
+		).put(
+			"removeCommerceChannelSiteIcon", removeCommerceChannelSiteIcon
+		).put(
+			"searchContainerId", searchContainerId
+		).build()
+	%>'
+	module="js/CommerceChannelSite"
+/>

--- a/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/init.jsp
@@ -55,7 +55,6 @@ page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
-page import="com.liferay.portal.kernel.util.UnicodeFormatter" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowDefinition" %>

--- a/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/js/CommerceChannelSite.js
+++ b/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/js/CommerceChannelSite.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {delegate, openSelectionModal} from 'frontend-js-web';
+
+export default function ({
+	itemSelectorUrl,
+	portletNamespace,
+	removeCommerceChannelSiteIcon,
+	searchContainerId,
+}) {
+	Liferay.componentReady(`${portletNamespace}${searchContainerId}`).then(
+		(searchContainer) => {
+			const selectSiteButton = document.getElementById(
+				`${portletNamespace}selectSite`
+			);
+
+			if (selectSiteButton) {
+				selectSiteButton.addEventListener('click', (event) => {
+					event.preventDefault();
+
+					openSelectionModal({
+						onSelect: (selectedItem) => {
+							if (!selectedItem) {
+								return;
+							}
+
+							const searchContainerData = searchContainer.getData();
+
+							const link = document.querySelector(
+								`a[data-rowid="${searchContainerData}"]`
+							);
+
+							if (link) {
+								const row = link.closest('tr');
+
+								if (row) {
+									searchContainer.deleteRow(
+										row,
+										link.dataset.rowid
+									);
+								}
+							}
+
+							const rowColumns = [];
+
+							rowColumns.push(selectedItem.name);
+							rowColumns.push(
+								`<a class="float-right modify-link" data-rowId="${selectedItem.id}" href="javascript:;">${removeCommerceChannelSiteIcon}</a>`
+							);
+
+							const siteGroupInput = document.getElementById(
+								`${portletNamespace}siteGroupId`
+							);
+
+							if (siteGroupInput) {
+								siteGroupInput.value = selectedItem.id;
+							}
+
+							searchContainer.addRow(rowColumns, selectedItem.id);
+
+							searchContainer.updateDataStore();
+						},
+						selectEventName: 'sitesSelectItem',
+						title: Liferay.Util.sub(
+							Liferay.Language.get('select-x'),
+							Liferay.Language.get('site')
+						),
+						url: itemSelectorUrl,
+					});
+				});
+			}
+
+			const searchContainerContentBox = searchContainer.get('contentBox');
+
+			delegate(
+				searchContainerContentBox.getDOMNode(),
+				'click',
+				'.modify-link',
+				(event) => {
+					var link = event.delegateTarget;
+
+					const tr = link.closest('tr');
+
+					searchContainer.deleteRow(tr, link.dataset.rowid);
+
+					const siteGroupInput = document.getElementById(
+						`${portletNamespace}siteGroupId`
+					);
+
+					if (siteGroupInput) {
+						siteGroupInput.value = 0;
+					}
+				}
+			);
+		}
+	);
+}

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/site_item_selector.jsp
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/site_item_selector.jsp
@@ -18,8 +18,6 @@
 
 <%
 SimpleSiteItemSelectorViewDisplayContext simpleSiteItemSelectorViewDisplayContext = (SimpleSiteItemSelectorViewDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
-
-String itemSelectedEventName = simpleSiteItemSelectorViewDisplayContext.getItemSelectedEventName();
 %>
 
 <liferay-frontend:management-bar
@@ -66,21 +64,12 @@ String itemSelectedEventName = simpleSiteItemSelectorViewDisplayContext.getItemS
 				value="<%= HtmlUtil.escape(simpleSiteItemSelectorViewDisplayContext.getChannelUsingSite(group.getGroupId())) %>"
 			/>
 
-			<%
-			row.setData(
-				HashMapBuilder.<String, Object>put(
-					"id", group.getGroupId()
-				).put(
-					"name", group.getName(locale)
-				).build());
-			%>
-
 			<liferay-ui:search-container-column-text
 				cssClass="table-cell-expand"
 			>
 				<c:choose>
 					<c:when test="<%= simpleSiteItemSelectorViewDisplayContext.isSiteAvailable(group.getGroupId()) %>">
-						<aui:button cssClass="selector-button" value="choose" />
+						<aui:button cssClass="selector-button" data='<%= HashMapBuilder.<String, Object>put("id", group.getGroupId()).put("name", group.getName(locale)).build() %>' value="choose" />
 					</c:when>
 					<c:otherwise>
 						<liferay-ui:message key="that-site-is-already-associated-with-another-channel" />
@@ -94,28 +83,3 @@ String itemSelectedEventName = simpleSiteItemSelectorViewDisplayContext.getItemS
 		/>
 	</liferay-ui:search-container>
 </div>
-
-<aui:script use="aui-base">
-	A.one('#<portlet:namespace />sites').delegate(
-		'click',
-		function (event) {
-			var row = this.ancestor('tr');
-
-			var data = row.getDOM().dataset;
-
-			Liferay.Util.getOpener().Liferay.fire(
-				'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
-				{
-					data: {id: data.id, name: data.name},
-				}
-			);
-
-			var popupWindow = Liferay.Util.getWindow();
-
-			if (popupWindow !== null) {
-				Liferay.Util.getWindow().hide();
-			}
-		},
-		'.selector-button'
-	);
-</aui:script>


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-130360

@jonmak08 @kresimir-coko 

I'm opening this as a draft for a quick review, before forwarding to commerce team: 
- I opted to change how data is represented in the search container, form `dataset` on row to `dataset` on button. With this, it fits our standard case for single selection, so we don't need custom events firing. This is a bit controversial, as it is not something we should normally do. Normally, we should leave data representation as it is and see if our utility handles it. I chose to it in this case because it was simple to do. It's on borderline of what the migration epic should do.
- Our frontend-js-web `delegate` utility has a pretty odd usage in JSPs, with `<aui:script require`. Because I needed the `liferay-search-container` module, I did
```js
<aui:script require="frontend-js-web/liferay/delegate/delegate.es as delegateModule">
	AUI().use('liferay-search-container', () => {
        ...
```
I am not sure if there is a better way. I would expect `delegate` to be exposed as `Liferay.Util.delegate`, is there a reason why we are not doing it that way?


Test case:
1. Have a site created using Minium template. This is a prerequisite for all commerce tasks:
   1.   Contol Panel > Sites > (+) Minium
   1.   Contol Panel > Search > Index Actions > Reindex all search indexes.
1. Create a blank site, Contol Panel > Sites > Blank Site
1. Commerce > Channels > open a channel > Type > Select Site. Save.
1. Delete a site. Save.

![after](https://user-images.githubusercontent.com/5435511/116121630-19ff6900-a6c1-11eb-89dc-c21a2ab9d0e7.gif)

