### PR TITLE
LPS-131381 Fix site selection in asset-libraries

### DIFF
--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/AddConnectedSitesButtonPropsTransformer.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/AddConnectedSitesButtonPropsTransformer.js
@@ -25,7 +25,6 @@ export default function propsTransformer({
 			const {currentURL, itemSelectorURL} = additionalProps;
 
 			openSelectionModal({
-				customSelectEvent: true,
 				id: `${portletNamespace}selectSite`,
 				onSelect: (event) => {
 					const toGroupIdInput = document.getElementById(


### PR DESCRIPTION
We were using the `customSelectEvent` prop in our `openSelectionModal`,
but in this case, it will cause the issue described in
[LPS-131831](https://issues.liferay.com/browse/LPS-131381).

**Before**
![](https://user-images.githubusercontent.com/5572/116412198-bd25bf00-a836-11eb-828f-a0171d1daebd.gif)

**After**
![](https://user-images.githubusercontent.com/5572/116412246-c7e05400-a836-11eb-9146-433aad2f1d60.gif)

**Test plan**:
- From the **Global Menu**, select the **Control Panel** tab
- Navigate to **Sites** > **Sites**
- Create a new **Site**
- From the **Global Menu**, select the **Applications** tab
- Navigate to **Content** > **Asset Libraries**
- Create a new **Asset Library**
- Select the **Sites** tab
- Click on the **Add** button to the right of **Connected Sites**
- Select the **Site** you created previously
- Assert that the site you created previously is listed in the
  **Connected Sites** section.