### PR TITLE
LPS-131179 add GraphQL update endpoint for Object 

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
@@ -185,6 +185,62 @@ public class ObjectDefinitionGraphQLTest {
 				"Object/" + _objectFieldName));
 	}
 
+	@Test
+	public void testUpdateObjectEntry() throws Exception {
+		String value = RandomTestUtil.randomString();
+
+		JSONObject jsonObject = _invoke(
+			new GraphQLField(
+				"mutation",
+				new GraphQLField(
+					"create" + _objectDefinitionName,
+					HashMapBuilder.<String, Object>put(
+						_objectDefinitionName,
+						StringBundler.concat(
+							"{", _objectFieldName, ": \"", value, "\"}")
+					).put(
+						"siteId", TestPropsValues.getGroupId()
+					).build(),
+					new GraphQLField(_objectFieldName),
+					new GraphQLField(
+						_objectDefinition.getPrimaryKeyColumnName()))));
+
+		Assert.assertEquals(
+			value,
+			JSONUtil.getValueAsString(
+				jsonObject, "JSONObject/data",
+				"JSONObject/create" + _objectDefinitionName,
+				"Object/" + _objectFieldName));
+
+		value = RandomTestUtil.randomString();
+
+		Long id = JSONUtil.getValueAsLong(
+			jsonObject, "JSONObject/data",
+			"JSONObject/create" + _objectDefinitionName,
+			"Object/" + _objectDefinition.getPrimaryKeyColumnName());
+
+		jsonObject = _invoke(
+			new GraphQLField(
+				"mutation",
+				new GraphQLField(
+					"update" + _objectDefinitionName,
+					HashMapBuilder.<String, Object>put(
+						_objectDefinitionName,
+						StringBundler.concat(
+							"{", _objectDefinition.getPrimaryKeyColumnName(),
+							": ", String.valueOf(id), ", ", _objectFieldName,
+							": \"", value, "\"}")
+					).build(),
+					new GraphQLField(_objectFieldName))));
+
+		Assert.assertEquals(
+			value,
+			JSONUtil.getValueAsString(
+				jsonObject, "JSONObject/data",
+				"JSONObject/update" + _objectDefinitionName,
+				"Object/" + _objectFieldName));
+	}
+
 	private ObjectField _createObjectField(String name, String type) {
 		ObjectField objectField = ObjectFieldLocalServiceUtil.createObjectField(
 			0);


### PR DESCRIPTION
Let's see what happens sending PRs to this repository :D

Adding update to GraphQL Endpoint generated automatically based on the `Object` (app builder 2) registered. Previous PR adding all the GraphQL implementation did not have an update because the service did not expose it.

Added a test to check it, it can also be tested adding an `ObjectDefinition` and an `ObjectEntry` and using /o/api to update it passing the id (the name depends on the `ObjectDefinition` name).