### PR TITLE
LPS-114272 versions

### DIFF
--- a/modules/apps/headless/headless-admin-content/headless-admin-content-api/src/main/java/com/liferay/headless/admin/content/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-api/src/main/java/com/liferay/headless/admin/content/resource/v1_0/StructuredContentResource.java
@@ -56,10 +56,6 @@ public interface StructuredContentResource {
 				Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception;
 
-	public Page<com.liferay.headless.delivery.dto.v1_0.StructuredContent>
-			getStructuredContentsStructuredContentPage(Long structuredContentId)
-		throws Exception;
-
 	public void deleteStructuredContentByVersion(
 			Long structuredContentId, Double version)
 		throws Exception;
@@ -67,6 +63,10 @@ public interface StructuredContentResource {
 	public com.liferay.headless.delivery.dto.v1_0.StructuredContent
 			getStructuredContentByVersion(
 				Long structuredContentId, Double version)
+		throws Exception;
+
+	public Page<com.liferay.headless.delivery.dto.v1_0.StructuredContent>
+			getStructuredContentsVersionsPage(Long structuredContentId)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-api/src/main/resources/com/liferay/headless/admin/content/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-api/src/main/resources/com/liferay/headless/admin/content/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 1.3.0

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/resource/v1_0/StructuredContentResource.java
@@ -53,15 +53,6 @@ public interface StructuredContentResource {
 			Pagination pagination, String sortString)
 		throws Exception;
 
-	public Page<StructuredContent> getStructuredContentsStructuredContentPage(
-			Long structuredContentId)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse
-			getStructuredContentsStructuredContentPageHttpResponse(
-				Long structuredContentId)
-		throws Exception;
-
 	public void deleteStructuredContentByVersion(
 			Long structuredContentId, Double version)
 		throws Exception;
@@ -77,6 +68,15 @@ public interface StructuredContentResource {
 
 	public HttpInvoker.HttpResponse getStructuredContentByVersionHttpResponse(
 			Long structuredContentId, Double version)
+		throws Exception;
+
+	public Page<StructuredContent> getStructuredContentsVersionsPage(
+			Long structuredContentId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getStructuredContentsVersionsPageHttpResponse(
+				Long structuredContentId)
 		throws Exception;
 
 	public static class Builder {
@@ -263,91 +263,6 @@ public interface StructuredContentResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<StructuredContent>
-				getStructuredContentsStructuredContentPage(
-					Long structuredContentId)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				getStructuredContentsStructuredContentPageHttpResponse(
-					structuredContentId);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return Page.of(content, StructuredContentSerDes::toDTO);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				getStructuredContentsStructuredContentPageHttpResponse(
-					Long structuredContentId)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
-						"/o/headless-admin-content/v1.0/structured-contents/{structuredContentId}");
-
-			httpInvoker.path("structuredContentId", structuredContentId);
-
-			httpInvoker.userNameAndPassword(
-				_builder._login + ":" + _builder._password);
-
-			return httpInvoker.invoke();
-		}
-
 		public void deleteStructuredContentByVersion(
 				Long structuredContentId, Double version)
 			throws Exception {
@@ -511,6 +426,90 @@ public interface StructuredContentResource {
 
 			httpInvoker.path("structuredContentId", structuredContentId);
 			httpInvoker.path("version", version);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<StructuredContent> getStructuredContentsVersionsPage(
+				Long structuredContentId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getStructuredContentsVersionsPageHttpResponse(
+					structuredContentId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, StructuredContentSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getStructuredContentsVersionsPageHttpResponse(
+					Long structuredContentId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port +
+						"/o/headless-admin-content/v1.0/structured-contents/{structuredContentId}/versions");
+
+			httpInvoker.path("structuredContentId", structuredContentId);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -363,39 +363,6 @@ paths:
                     description:
                         ""
             tags: ["StructuredContent"]
-    "/structured-contents/{structuredContentId}":
-        get:
-            # @review
-            description:
-                Retrieves all versions of a structured content via its ID.
-            operationId: getStructuredContentsStructuredContentPage
-            parameters:
-                - in: path
-                  name: structuredContentId
-                  required: true
-                  schema:
-                      format: int64
-                      type: integer
-                - in: header
-                  name: Accept-Language
-                  schema:
-                      type: string
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                items:
-                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
-                                type: array
-                        application/xml:
-                            schema:
-                                items:
-                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
-                                type: array
-                    description:
-                        ""
-            tags: ["StructuredContent"]
     "/structured-contents/{structuredContentId}/by-version/{version}":
         delete:
             # @review
@@ -450,6 +417,39 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                    description:
+                        ""
+            tags: ["StructuredContent"]
+    "/structured-contents/{structuredContentId}/versions":
+        get:
+            # @review
+            description:
+                Retrieves all versions of a structured content via its ID.
+            operationId: getStructuredContentsVersionsPage
+            parameters:
+                - in: path
+                  name: structuredContentId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: header
+                  name: Accept-Language
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                                type: array
                     description:
                         ""
             tags: ["StructuredContent"]

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/graphql/query/v1_0/Query.java
@@ -151,27 +151,6 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {structuredContentsStructuredContent(structuredContentId: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
-	 */
-	@GraphQLField(
-		description = "Retrieves all versions of a structured content via its ID."
-	)
-	public StructuredContentPage structuredContentsStructuredContent(
-			@GraphQLName("structuredContentId") Long structuredContentId)
-		throws Exception {
-
-		return _applyComponentServiceObjects(
-			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
-			structuredContentResource -> new StructuredContentPage(
-				structuredContentResource.
-					getStructuredContentsStructuredContentPage(
-						structuredContentId)));
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
 	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {structuredContentByVersion(structuredContentId: ___, version: ___){}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves a version of a structured content")
@@ -187,6 +166,26 @@ public class Query {
 			structuredContentResource ->
 				structuredContentResource.getStructuredContentByVersion(
 					structuredContentId, version));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {structuredContentsVersions(structuredContentId: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves all versions of a structured content via its ID."
+	)
+	public StructuredContentPage structuredContentsVersions(
+			@GraphQLName("structuredContentId") Long structuredContentId)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_structuredContentResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			structuredContentResource -> new StructuredContentPage(
+				structuredContentResource.getStructuredContentsVersionsPage(
+					structuredContentId)));
 	}
 
 	@GraphQLName("DisplayPageTemplatePage")

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -109,34 +109,6 @@ public abstract class BaseStructuredContentResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-content/v1.0/structured-contents/{structuredContentId}'  -u 'test@liferay.com:test'
-	 */
-	@GET
-	@Operation(
-		description = "Retrieves all versions of a structured content via its ID."
-	)
-	@Override
-	@Parameters(
-		value = {
-			@Parameter(in = ParameterIn.PATH, name = "structuredContentId")
-		}
-	)
-	@Path("/structured-contents/{structuredContentId}")
-	@Produces({"application/json", "application/xml"})
-	@Tags(value = {@Tag(name = "StructuredContent")})
-	public Page<com.liferay.headless.delivery.dto.v1_0.StructuredContent>
-			getStructuredContentsStructuredContentPage(
-				@NotNull @Parameter(hidden = true)
-				@PathParam("structuredContentId")
-				Long structuredContentId)
-		throws Exception {
-
-		return Page.of(Collections.emptyList());
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
 	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-content/v1.0/structured-contents/{structuredContentId}/by-version/{version}'  -u 'test@liferay.com:test'
 	 */
 	@DELETE
@@ -188,6 +160,34 @@ public abstract class BaseStructuredContentResourceImpl
 		throws Exception {
 
 		return new com.liferay.headless.delivery.dto.v1_0.StructuredContent();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-content/v1.0/structured-contents/{structuredContentId}/versions'  -u 'test@liferay.com:test'
+	 */
+	@GET
+	@Operation(
+		description = "Retrieves all versions of a structured content via its ID."
+	)
+	@Override
+	@Parameters(
+		value = {
+			@Parameter(in = ParameterIn.PATH, name = "structuredContentId")
+		}
+	)
+	@Path("/structured-contents/{structuredContentId}/versions")
+	@Produces({"application/json", "application/xml"})
+	@Tags(value = {@Tag(name = "StructuredContent")})
+	public Page<com.liferay.headless.delivery.dto.v1_0.StructuredContent>
+			getStructuredContentsVersionsPage(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("structuredContentId")
+				Long structuredContentId)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -196,7 +196,7 @@ public class StructuredContentResourceImpl
 	}
 
 	@Override
-	public Page<StructuredContent> getStructuredContentsStructuredContentPage(
+	public Page<StructuredContent> getStructuredContentsVersionsPage(
 			Long structuredContentId)
 		throws Exception {
 

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -572,85 +572,6 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
-	public void testGetStructuredContentsStructuredContentPage()
-		throws Exception {
-
-		Page<StructuredContent> page =
-			structuredContentResource.
-				getStructuredContentsStructuredContentPage(
-					testGetStructuredContentsStructuredContentPage_getStructuredContentId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
-		Long structuredContentId =
-			testGetStructuredContentsStructuredContentPage_getStructuredContentId();
-		Long irrelevantStructuredContentId =
-			testGetStructuredContentsStructuredContentPage_getIrrelevantStructuredContentId();
-
-		if (irrelevantStructuredContentId != null) {
-			StructuredContent irrelevantStructuredContent =
-				testGetStructuredContentsStructuredContentPage_addStructuredContent(
-					irrelevantStructuredContentId,
-					randomIrrelevantStructuredContent());
-
-			page =
-				structuredContentResource.
-					getStructuredContentsStructuredContentPage(
-						irrelevantStructuredContentId);
-
-			Assert.assertEquals(1, page.getTotalCount());
-
-			assertEquals(
-				Arrays.asList(irrelevantStructuredContent),
-				(List<StructuredContent>)page.getItems());
-			assertValid(page);
-		}
-
-		StructuredContent structuredContent1 =
-			testGetStructuredContentsStructuredContentPage_addStructuredContent(
-				structuredContentId, randomStructuredContent());
-
-		StructuredContent structuredContent2 =
-			testGetStructuredContentsStructuredContentPage_addStructuredContent(
-				structuredContentId, randomStructuredContent());
-
-		page =
-			structuredContentResource.
-				getStructuredContentsStructuredContentPage(structuredContentId);
-
-		Assert.assertEquals(2, page.getTotalCount());
-
-		assertEqualsIgnoringOrder(
-			Arrays.asList(structuredContent1, structuredContent2),
-			(List<StructuredContent>)page.getItems());
-		assertValid(page);
-	}
-
-	protected StructuredContent
-			testGetStructuredContentsStructuredContentPage_addStructuredContent(
-				Long structuredContentId, StructuredContent structuredContent)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected Long
-			testGetStructuredContentsStructuredContentPage_getStructuredContentId()
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected Long
-			testGetStructuredContentsStructuredContentPage_getIrrelevantStructuredContentId()
-		throws Exception {
-
-		return null;
-	}
-
-	@Test
 	public void testDeleteStructuredContentByVersion() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		StructuredContent structuredContent =
@@ -752,6 +673,79 @@ public abstract class BaseStructuredContentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	@Test
+	public void testGetStructuredContentsVersionsPage() throws Exception {
+		Page<StructuredContent> page =
+			structuredContentResource.getStructuredContentsVersionsPage(
+				testGetStructuredContentsVersionsPage_getStructuredContentId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
+		Long structuredContentId =
+			testGetStructuredContentsVersionsPage_getStructuredContentId();
+		Long irrelevantStructuredContentId =
+			testGetStructuredContentsVersionsPage_getIrrelevantStructuredContentId();
+
+		if (irrelevantStructuredContentId != null) {
+			StructuredContent irrelevantStructuredContent =
+				testGetStructuredContentsVersionsPage_addStructuredContent(
+					irrelevantStructuredContentId,
+					randomIrrelevantStructuredContent());
+
+			page = structuredContentResource.getStructuredContentsVersionsPage(
+				irrelevantStructuredContentId);
+
+			Assert.assertEquals(1, page.getTotalCount());
+
+			assertEquals(
+				Arrays.asList(irrelevantStructuredContent),
+				(List<StructuredContent>)page.getItems());
+			assertValid(page);
+		}
+
+		StructuredContent structuredContent1 =
+			testGetStructuredContentsVersionsPage_addStructuredContent(
+				structuredContentId, randomStructuredContent());
+
+		StructuredContent structuredContent2 =
+			testGetStructuredContentsVersionsPage_addStructuredContent(
+				structuredContentId, randomStructuredContent());
+
+		page = structuredContentResource.getStructuredContentsVersionsPage(
+			structuredContentId);
+
+		Assert.assertEquals(2, page.getTotalCount());
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(structuredContent1, structuredContent2),
+			(List<StructuredContent>)page.getItems());
+		assertValid(page);
+	}
+
+	protected StructuredContent
+			testGetStructuredContentsVersionsPage_addStructuredContent(
+				Long structuredContentId, StructuredContent structuredContent)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long
+			testGetStructuredContentsVersionsPage_getStructuredContentId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long
+			testGetStructuredContentsVersionsPage_getIrrelevantStructuredContentId()
+		throws Exception {
+
+		return null;
 	}
 
 	@Rule

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
@@ -82,9 +82,8 @@ public class StructuredContentResourceTest
 			testGroup.getGroupId(), randomStructuredContent());
 
 		Page<StructuredContent> structuredContentsVersionsPage =
-			structuredContentResource.
-				getStructuredContentsStructuredContentPage(
-					structuredContent.getId());
+			structuredContentResource.getStructuredContentsVersionsPage(
+				structuredContent.getId());
 
 		Assert.assertEquals(1L, structuredContentsVersionsPage.getTotalCount());
 
@@ -112,17 +111,14 @@ public class StructuredContentResourceTest
 
 	@Override
 	@Test
-	public void testGetStructuredContentsStructuredContentPage()
-		throws Exception {
-
+	public void testGetStructuredContentsVersionsPage() throws Exception {
 		StructuredContent structuredContent = _postSiteStructuredContent(
 			testGroup.getGroupId(), randomStructuredContent());
 
 		Long id = structuredContent.getId();
 
 		Page<StructuredContent> structuredContentsVersionsPage =
-			structuredContentResource.
-				getStructuredContentsStructuredContentPage(id);
+			structuredContentResource.getStructuredContentsVersionsPage(id);
 
 		Assert.assertEquals(1L, structuredContentsVersionsPage.getTotalCount());
 
@@ -130,8 +126,7 @@ public class StructuredContentResourceTest
 			id, _toStructuredContent(structuredContent));
 
 		structuredContentsVersionsPage =
-			structuredContentResource.
-				getStructuredContentsStructuredContentPage(id);
+			structuredContentResource.getStructuredContentsVersionsPage(id);
 
 		Assert.assertEquals(2L, structuredContentsVersionsPage.getTotalCount());
 	}


### PR DESCRIPTION
Back to the old name in the collection endpoint. We need to use `/structured-contents/{structuredContentId}` to modify all the fields of the StructuredContent. 

The `StructuredContentVersion` exists but only in code, we create it with `EntityExtensionUtil.extend` (adding `StructuredContent` + `Version`.

An alternative would be creating another pattern for this kind of endpoints.