### PR TITLE
LPS-131318 - Make sure first child of TooltipProvider accepts onMouseOver and onMouseOut

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/control-menu/ControlMenu.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/control-menu/ControlMenu.es.js
@@ -15,7 +15,7 @@
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
 import React, {useContext, useEffect, useState} from 'react';
-import {createPortal} from 'react-dom';
+import {ReactPortal} from '@liferay/frontend-js-react-web';
 import {Link as InternalLink, withRouter} from 'react-router-dom';
 
 import {AppContext} from '../../AppContext.es';
@@ -47,19 +47,20 @@ const BackButton = ({backURL}) => {
 		return <></>;
 	}
 
-	return createPortal(
-		<li className="control-menu-nav-item">
-			<Link
-				className="control-menu-icon lfr-icon-item"
-				tabIndex={1}
-				to={backURL}
-			>
-				<span className="icon-monospaced">
-					<ClayIcon symbol="angle-left" />
-				</span>
-			</Link>
-		</li>,
-		backButtonContainer
+	return (
+		<ReactPortal container={backButtonContainer}>
+			<li className="control-menu-nav-item">
+				<Link
+					className="control-menu-icon lfr-icon-item"
+					tabIndex={1}
+					to={backURL}
+				>
+					<span className="icon-monospaced">
+						<ClayIcon symbol="angle-left" />
+					</span>
+				</Link>
+			</li>
+		</ReactPortal>
 	);
 };
 
@@ -135,7 +136,9 @@ export const InlineControlMenu = ({backURL, title, url}) => {
 	);
 
 	return controlMenuContainer ? (
-		createPortal(<ControlMenu />, controlMenuContainer)
+		<ReactPortal container={controlMenuContainer}>
+			<ControlMenu />
+		</ReactPortal>
 	) : (
 		<ControlMenu />
 	);

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/entry/PortalEntry.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/entry/PortalEntry.es.js
@@ -15,7 +15,7 @@
 import {getItem} from 'data-engine-js-components-web/js/utils/client.es';
 import {TranslationManager} from 'data-engine-taglib';
 import React, {useContext, useEffect, useState} from 'react';
-import {createPortal} from 'react-dom';
+import {ReactPortal} from '@liferay/frontend-js-react-web';
 
 import {AppContext} from '../../AppContext.es';
 import usePermissions from '../../hooks/usePermissions.es';
@@ -139,27 +139,26 @@ const TranslationManagerPortal = ({
 
 	return (
 		<div>
-			{showAppName &&
-				standaloneNameContainer &&
-				createPortal(
-					getLocalizedUserPreferenceValue(
+			{showAppName && standaloneNameContainer && (
+				<ReactPortal container={standaloneNameContainer}>
+					{getLocalizedUserPreferenceValue(
 						app.name,
 						userLanguageId,
 						defaultLanguageId
-					),
-					standaloneNameContainer
-				)}
+					)}
+				</ReactPortal>
+			)}
 
-			{translationManagerContainer &&
-				createPortal(
+			{translationManagerContainer && (
+				<ReactPortal container={translationManagerContainer}>
 					<TranslationManager
 						availableLanguageIds={availableLanguageIds}
 						editingLanguageId={getEditingLanguageId()}
 						onEditingLanguageIdChange={onEditingLanguageIdChange}
 						showUserView
-					/>,
-					translationManagerContainer
-				)}
+					/>
+				</ReactPortal>
+			)}
 		</div>
 	);
 };
@@ -179,9 +178,8 @@ export default (props) => {
 
 	return (
 		<>
-			{appPersonalContainer &&
-				themeDisplay.isSignedIn() &&
-				createPortal(
+			{appPersonalContainer && themeDisplay.isSignedIn() && (
+				<ReactPortal container={appPersonalContainer}>
 					<PersonalMenu
 						items={[
 							{
@@ -199,9 +197,9 @@ export default (props) => {
 							},
 						]}
 						portraitURL={portraitURL}
-					/>,
-					appPersonalContainer
-				)}
+					/>
+				</ReactPortal>
+			)}
 			<TranslationManagerPortal appId={appId} {...props} />
 		</>
 	);

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormView.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormView.es.js
@@ -15,7 +15,7 @@
 import React, {useContext, useState} from 'react';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
-import {createPortal} from 'react-dom';
+import {ReactPortal} from '@liferay/frontend-js-react-web';
 
 import {AppContext} from '../../AppContext.es';
 import {ControlMenuBase} from '../../components/control-menu/ControlMenu.es';
@@ -80,12 +80,13 @@ const EditFormView = (props) => {
 						popUpWindow={popUpWindow}
 					/>
 
-					{createPortal(
-						<CustomObjectSidebar />,
-						document.querySelector(
+					<ReactPortal
+						container={document.querySelector(
 							`#${customObjectSidebarElementId}`
-						)
-					)}
+						)}
+					>
+						<CustomObjectSidebar />
+					</ReactPortal>
 				</WrapperComponent>
 			</FormViewContextProvider>
 		</DndProvider>

--- a/modules/apps/commerce/commerce-frontend-js/package.json
+++ b/modules/apps/commerce/commerce-frontend-js/package.json
@@ -20,11 +20,11 @@
 		"@clayui/shared": "3.5.1",
 		"@clayui/sticker": "3.3.0",
 		"@clayui/table": "3.1.0",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",
-		"prop-types": "15.7.2"
+		"prop-types": "15.7.2",
+		"react-dom": "16.12.0"
 	},
 	"devDependencies": {
 		"clay-css": "^2.16.2",

--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/autocomplete/Autocomplete.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/autocomplete/Autocomplete.js
@@ -15,10 +15,9 @@
 import ClayAutocomplete from '@clayui/autocomplete';
 import ClayDropDown from '@clayui/drop-down';
 import {FocusScope} from '@clayui/shared';
-import {useIsMounted} from '@liferay/frontend-js-react-web';
+import {useIsMounted, ReactPortal} from '@liferay/frontend-js-react-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
-import {createPortal} from 'react-dom';
 
 import {debouncePromise} from '../../utilities/debounce';
 import {AUTOCOMPLETE_VALUE_UPDATED} from '../../utilities/eventsDefinitions';
@@ -294,10 +293,12 @@ function Autocomplete({onItemsUpdated, onValueUpdated, ...props}) {
 			{CustomView &&
 				!props.disabled &&
 				(props.contentWrapperRef
-					? props.contentWrapperRef.current &&
-					  createPortal(
-							wrappedResults,
-							props.contentWrapperRef.current
+					? props.contentWrapperRef.current && (
+							<ReactPortal
+								container={props.contentWrapperRef.current}
+							>
+								{wrappedResults}
+							</ReactPortal>
 					  )
 					: wrappedResults)}
 		</>

--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/data_renderers/TooltipPriceRenderer.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/data_renderers/TooltipPriceRenderer.js
@@ -13,7 +13,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
+import ReactDOMServer from 'react-dom/server';
 import Proptypes from 'prop-types';
 import React from 'react';
 
@@ -58,17 +58,15 @@ function TooltipPriceRenderer(props) {
 		<>
 			{props.value.final.value}
 			{props.value.details && (
-				<ClayTooltipProvider
-					contentRenderer={() => <TooltipTable {...props} />}
-					delay={0}
+				<span
+					className="tooltip-provider"
+					title={ReactDOMServer.renderToString(
+						<TooltipTable {...props} />
+					)}
+					data-tooltip-delay="0"
 				>
-					<span
-						className="tooltip-provider"
-						title={Liferay.Language.get('price-summary')}
-					>
-						<ClayIcon symbol="info-circle" />
-					</span>
-				</ClayTooltipProvider>
+					<ClayIcon symbol="info-circle" />
+				</span>
 			)}
 		</>
 	);

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldType.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldType.es.js
@@ -17,7 +17,6 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClaySticker from '@clayui/sticker';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classnames from 'classnames';
 import React, {useEffect, useState} from 'react';
 import {useDrag} from 'react-dnd';
@@ -89,97 +88,95 @@ const FieldType = (props) => {
 	const fieldIcon = ICONS[icon] ? ICONS[icon] : icon;
 
 	return (
-		<ClayTooltipProvider>
-			<ClayLayout.ContentRow
-				className={classnames(className, 'field-type', {
-					active,
-					disabled,
-					dragging,
-					loading,
+		<ClayLayout.ContentRow
+			className={classnames(className, 'field-type', {
+				active,
+				disabled,
+				dragging,
+				loading,
+			})}
+			data-field-type-name={name}
+			onClick={onClick && handleOnClick}
+			onDoubleClick={handleOnDoubleClick}
+			ref={drag}
+			title={label}
+			verticalAlign="center"
+		>
+			{draggable && dragAlignment === 'left' && (
+				<ClayLayout.ContentCol className="pl-2 pr-2">
+					<ClayIcon symbol="drag" />
+				</ClayLayout.ContentCol>
+			)}
+
+			<ClayLayout.ContentCol
+				className={classnames('pr-2', {
+					'pl-2': dragAlignment === 'right',
 				})}
-				data-field-type-name={name}
-				onClick={onClick && handleOnClick}
-				onDoubleClick={handleOnDoubleClick}
-				ref={drag}
-				title={label}
-				verticalAlign="center"
 			>
-				{draggable && dragAlignment === 'left' && (
-					<ClayLayout.ContentCol className="pl-2 pr-2">
-						<ClayIcon symbol="drag" />
-					</ClayLayout.ContentCol>
-				)}
-
-				<ClayLayout.ContentCol
-					className={classnames('pr-2', {
-						'pl-2': dragAlignment === 'right',
-					})}
+				<ClaySticker
+					className="data-layout-builder-field-sticker"
+					displayType="light"
+					size="md"
 				>
-					<ClaySticker
-						className="data-layout-builder-field-sticker"
-						displayType="light"
-						size="md"
-					>
-						<ClayIcon symbol={fieldIcon} />
-					</ClaySticker>
-				</ClayLayout.ContentCol>
-				<ClayLayout.ContentCol className="pr-2" expand>
-					<div className="d-flex list-group-title">
-						<span className="text-truncate">{label}</span>
-						{required && (
-							<span className="reference-mark">
-								<ClayIcon symbol="asterisk" />
-							</span>
-						)}
-					</div>
-					{description && (
-						<p className="list-group-subtitle text-truncate">
-							<small>{description}</small>
-						</p>
+					<ClayIcon symbol={fieldIcon} />
+				</ClaySticker>
+			</ClayLayout.ContentCol>
+			<ClayLayout.ContentCol className="pr-2" expand>
+				<div className="d-flex list-group-title">
+					<span className="text-truncate">{label}</span>
+					{required && (
+						<span className="reference-mark">
+							<ClayIcon symbol="asterisk" />
+						</span>
 					)}
-				</ClayLayout.ContentCol>
-
-				<div className="autofit-col pr-2">
-					{actions && <DropDown actions={actions} />}
 				</div>
-
-				{draggable && dragAlignment === 'right' && (
-					<ClayLayout.ContentCol className="pr-2">
-						<ClayIcon symbol="drag" />
-					</ClayLayout.ContentCol>
+				{description && (
+					<p className="list-group-subtitle text-truncate">
+						<small>{description}</small>
+					</p>
 				)}
+			</ClayLayout.ContentCol>
 
-				{onDelete && (
-					<div className="field-type-remove-icon">
-						{loading ? (
-							<ClayLoadingIndicator />
-						) : (
-							<ClayButtonWithIcon
-								borderless
-								data-tooltip-align="right"
-								data-tooltip-delay="200"
-								displayType="secondary"
-								onClick={(event) => {
-									event.stopPropagation();
+			<div className="autofit-col pr-2">
+				{actions && <DropDown actions={actions} />}
+			</div>
 
-									setLoading(true);
+			{draggable && dragAlignment === 'right' && (
+				<ClayLayout.ContentCol className="pr-2">
+					<ClayIcon symbol="drag" />
+				</ClayLayout.ContentCol>
+			)}
 
-									onDelete(name)
-										.then(() => setLoading(false))
-										.catch((error) => {
-											setLoading(false);
+			{onDelete && (
+				<div className="field-type-remove-icon">
+					{loading ? (
+						<ClayLoadingIndicator />
+					) : (
+						<ClayButtonWithIcon
+							borderless
+							data-tooltip-align="right"
+							data-tooltip-delay="200"
+							displayType="secondary"
+							onClick={(event) => {
+								event.stopPropagation();
 
-											throw error;
-										});
-								}}
-								symbol="times-circle"
-								title={deleteLabel}
-							/>
-						)}
-					</div>
-				)}
-			</ClayLayout.ContentRow>
-		</ClayTooltipProvider>
+								setLoading(true);
+
+								onDelete(name)
+									.then(() => setLoading(false))
+									.catch((error) => {
+										setLoading(false);
+
+										throw error;
+									});
+							}}
+							symbol="times-circle"
+							title={deleteLabel}
+						/>
+					)}
+				</div>
+			)}
+		</ClayLayout.ContentRow>
 	);
 };
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Options/DragPreview.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Options/DragPreview.es.js
@@ -14,7 +14,7 @@
 
 import React, {useRef} from 'react';
 import {useDragLayer} from 'react-dnd';
-import ReactDOM from 'react-dom';
+import {ReactPortal} from '@liferay/frontend-js-react-web';
 
 import {OPTIONS_TYPES} from './DnD.es';
 
@@ -59,17 +59,18 @@ export default function DragPreview({children, component: Component}) {
 		return null;
 	}
 
-	return ReactDOM.createPortal(
-		<div style={layerStyles}>
-			<Component
-				{...item.option}
-				className="dragging"
-				ref={ref}
-				style={getItemStyles(currentOffset, ref, initialOffset)}
-			>
-				{children({index: item.position, option: item.option})}
-			</Component>
-		</div>,
-		document.body
+	return (
+		<ReactPortal>
+			<div style={layerStyles}>
+				<Component
+					{...item.option}
+					className="dragging"
+					ref={ref}
+					style={getItemStyles(currentOffset, ref, initialOffset)}
+				>
+					{children({index: item.position, option: item.option})}
+				</Component>
+			</div>
+		</ReactPortal>
 	);
 }

--- a/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -1,7 +1,6 @@
 {
 	"dependencies": {
 		"@clayui/icon": "3.1.0",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-state-web": "*",
 		"classnames": "2.2.6",
 		"formik": "2.1.4",

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/ReactPortal.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/ReactPortal.tsx
@@ -20,16 +20,16 @@ const ReactPortal: React.FunctionComponent<
 	React.HTMLAttributes<HTMLDivElement> & {
 
 		/**
-		 * Ref of element to render portal into.
+		 * Element to render portal into.
 		 */
-		containerRef?: React.RefObject<Element>;
+		container?: Element;
 
 		/**
 		 * Ref of element to render nested portals into.
 		 */
 		subPortalRef?: React.RefObject<Element>;
 	}
-> = ({children, containerRef, subPortalRef}) => {
+> = ({children, container, subPortalRef}) => {
 	const parentPortalRef = React.useContext(ReactPortalContext);
 	const portalRef = React.useRef(
 		typeof document !== 'undefined' ? rootPortalElement : null
@@ -41,10 +41,7 @@ const ReactPortal: React.FunctionComponent<
 				? parentPortalRef.current
 				: document.body;
 
-		const elToMountTo =
-			containerRef && containerRef.current
-				? containerRef.current
-				: closestParent;
+		const elToMountTo = container || closestParent;
 
 		if (elToMountTo && portalRef.current) {
 			elToMountTo.appendChild(portalRef.current);
@@ -60,7 +57,7 @@ const ReactPortal: React.FunctionComponent<
 				}
 			}
 		};
-	}, [containerRef, parentPortalRef]);
+	}, [container, parentPortalRef]);
 
 	const content = (
 		<ReactPortalContext.Provider

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/ReactPortal.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/ReactPortal.tsx
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+import {createPortal} from 'react-dom';
+
+const ReactPortalContext = React.createContext<React.RefObject<Element | null> | null>(
+	null
+);
+
+ReactPortalContext.displayName = 'ReactPortalContext';
+
+const rootPortalElement = document.createElement('div');
+
+rootPortalElement.classList.add('lfr-tooltip-scope');
+
+const ReactPortal: React.FunctionComponent<
+	React.HTMLAttributes<HTMLDivElement> & {
+
+		/**
+		 * Ref of element to render portal into.
+		 */
+		containerRef?: React.RefObject<Element>;
+
+		/**
+		 * Ref of element to render nested portals into.
+		 */
+		subPortalRef?: React.RefObject<Element>;
+	}
+> = ({children, containerRef, subPortalRef}) => {
+	const parentPortalRef = React.useContext(ReactPortalContext);
+	const portalRef = React.useRef(
+		typeof document !== 'undefined' ? rootPortalElement : null
+	);
+
+	React.useEffect(() => {
+		const closestParent =
+			parentPortalRef && parentPortalRef.current
+				? parentPortalRef.current
+				: document.body;
+
+		const elToMountTo =
+			containerRef && containerRef.current
+				? containerRef.current
+				: closestParent;
+
+		if (elToMountTo && portalRef.current) {
+			elToMountTo.appendChild(portalRef.current);
+		}
+
+		return () => {
+			if (portalRef.current) {
+				if (typeof portalRef.current.remove === 'function') {
+					portalRef.current.remove();
+				}
+				else if (elToMountTo) {
+					elToMountTo.removeChild(portalRef.current);
+				}
+			}
+		};
+	}, [containerRef, parentPortalRef]);
+
+	const content = (
+		<ReactPortalContext.Provider
+			value={subPortalRef ? subPortalRef : portalRef}
+		>
+			{children}
+		</ReactPortalContext.Provider>
+	);
+
+	return portalRef.current
+		? createPortal(content, portalRef.current)
+		: content;
+};
+
+export default ReactPortal;

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts
@@ -15,6 +15,7 @@
 import process from 'process';
 
 export {default as render} from './render';
+export {default as ReactPortal} from './ReactPortal';
 export {default as useEventListener} from './hooks/useEventListener';
 export {default as useInterval} from './hooks/useInterval';
 export {default as useIsMounted} from './hooks/useIsMounted';

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
@@ -13,7 +13,6 @@
  */
 
 import {ClayIconSpriteContext} from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -87,11 +86,9 @@ export default function render(
 
 		// eslint-disable-next-line @liferay/portal/no-react-dom-render
 		ReactDOM.render(
-			<ClayTooltipProvider>
-				<ClayIconSpriteContext.Provider value={spritemap}>
-					{Component ? <Component {...renderData} /> : renderable}
-				</ClayIconSpriteContext.Provider>
-			</ClayTooltipProvider>,
+			<ClayIconSpriteContext.Provider value={spritemap}>
+				{Component ? <Component {...renderData} /> : renderable}
+			</ClayIconSpriteContext.Provider>,
 			container
 		);
 	}

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
@@ -46,7 +46,7 @@ export default function render(
 		portletId?: string;
 		[key: string]: unknown;
 	},
-	container: Element | DocumentFragment
+	container: Element
 ) {
 	if (!(window.Liferay as any).SPA || (window.Liferay as any).SPA.app) {
 		const {portletId} = renderData;
@@ -66,6 +66,8 @@ export default function render(
 			componentId,
 			{
 				destroy: () => {
+					container.classList.remove('lfr-tooltip-scope');
+
 					ReactDOM.unmountComponentAtNode(container);
 				},
 			},
@@ -80,6 +82,8 @@ export default function render(
 			(renderable as any).$$typeof === Symbol.for('react.forward_ref')
 				? (renderable as any)
 				: null;
+
+		container.classList.add('lfr-tooltip-scope');
 
 		// eslint-disable-next-line @liferay/portal/no-react-dom-render
 		ReactDOM.render(

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/ReactPortal.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/ReactPortal.d.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+declare const ReactPortal: React.FunctionComponent<
+	React.HTMLAttributes<HTMLDivElement> & {
+
+		/**
+		 * Ref of element to render portal into.
+		 */
+		containerRef?: React.RefObject<Element>;
+
+		/**
+		 * Ref of element to render nested portals into.
+		 */
+		subPortalRef?: React.RefObject<Element>;
+	}
+>;
+export default ReactPortal;

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/ReactPortal.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/ReactPortal.d.ts
@@ -8,9 +8,9 @@ declare const ReactPortal: React.FunctionComponent<
 	React.HTMLAttributes<HTMLDivElement> & {
 
 		/**
-		 * Ref of element to render portal into.
+		 * Element to render portal into.
 		 */
-		containerRef?: React.RefObject<Element>;
+		container?: Element;
 
 		/**
 		 * Ref of element to render nested portals into.

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/index.d.ts
@@ -13,6 +13,7 @@
  */
 
 export {default as render} from './render';
+export {default as ReactPortal} from './ReactPortal';
 export {default as useEventListener} from './hooks/useEventListener';
 export {default as useInterval} from './hooks/useInterval';
 export {default as useIsMounted} from './hooks/useIsMounted';

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/render.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/render.d.ts
@@ -41,5 +41,5 @@ export default function render(
 		portletId?: string;
 		[key: string]: unknown;
 	},
-	container: Element | DocumentFragment
+	container: Element
 ): void;

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.tsx
@@ -57,7 +57,10 @@ const SELECTOR_TRIGGER = `
 	.source-editor__fixed-text__help[data-title],
 	.upper-tbar [data-title]:not(.lfr-portal-tooltip),
 	.upper-tbar [title]:not(.lfr-portal-tooltip),
-	.upper-tbar [data-restore-title]
+	.upper-tbar [data-restore-title],
+	.lfr-tooltip-scope [title],
+	.lfr-tooltip-scope [data-title],
+	.lfr-tooltip-scope [data-restore-title]
 `;
 
 const TRIGGER_HIDE_EVENTS = [
@@ -114,23 +117,15 @@ const TooltipProvider = () => {
 
 	const saveTitle = (element: HTMLElement) => {
 		if (element) {
-			const title = element.getAttribute('title');
+			const title =
+				element.getAttribute('title') ||
+				element.getAttribute('data-title');
 
 			if (title) {
 				element.setAttribute('data-restore-title', title);
+
+				element.removeAttribute('data-title');
 				element.removeAttribute('title');
-			}
-			else if (element.tagName === 'svg') {
-				const titleTag = element.querySelector('title');
-
-				if (titleTag) {
-					element.setAttribute(
-						'data-restore-title',
-						titleTag.innerHTML
-					);
-
-					titleTag.remove();
-				}
 			}
 		}
 	};
@@ -140,16 +135,7 @@ const TooltipProvider = () => {
 			const title = element.getAttribute('data-restore-title');
 
 			if (title) {
-				if (element.tagName === 'svg') {
-					const titleTag = document.createElement('title');
-
-					titleTag.innerHTML = title;
-
-					element.appendChild(titleTag);
-				}
-				else {
-					element.setAttribute('title', title);
-				}
+				element.setAttribute('title', title);
 
 				element.removeAttribute('data-restore-title');
 			}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Multiselect.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Multiselect.js
@@ -14,7 +14,6 @@
 
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayMultiSelect from '@clayui/multi-select';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useState} from 'react';
 
 export default function Multiselect({
@@ -43,40 +42,36 @@ export default function Multiselect({
 	const [selectedItems, setSelectedItems] = useState(_selectedItems);
 
 	return (
-		<ClayTooltipProvider>
-			<ClayForm.Group className={!isValid ? 'has-error' : ''}>
-				{label && <label htmlFor={id}>{label}</label>}
+		<ClayForm.Group className={!isValid ? 'has-error' : ''}>
+			{label && <label htmlFor={id}>{label}</label>}
 
-				<ClayInput.Group>
-					<ClayInput.GroupItem>
-						<ClayMultiSelect
-							className={cssClass}
-							clearAllTitle={clearAllTitle}
-							closeButtonAriaLabel={Liferay.Language.get(
-								'remove-x'
-							)}
-							disabled={disabled}
-							disabledClearAll={disabledClearAll}
-							id={id}
-							inputName={inputName}
-							inputValue={inputValue}
-							isValid={isValid}
-							items={selectedItems}
-							locator={multiselectLocator}
-							onChange={setInputValue}
-							onItemsChange={setSelectedItems}
-							sourceItems={sourceItems}
-							{...otherProps}
-						/>
+			<ClayInput.Group>
+				<ClayInput.GroupItem>
+					<ClayMultiSelect
+						className={cssClass}
+						clearAllTitle={clearAllTitle}
+						closeButtonAriaLabel={Liferay.Language.get('remove-x')}
+						disabled={disabled}
+						disabledClearAll={disabledClearAll}
+						id={id}
+						inputName={inputName}
+						inputValue={inputValue}
+						isValid={isValid}
+						items={selectedItems}
+						locator={multiselectLocator}
+						onChange={setInputValue}
+						onItemsChange={setSelectedItems}
+						sourceItems={sourceItems}
+						{...otherProps}
+					/>
 
-						{helpText && (
-							<ClayForm.FeedbackGroup>
-								<ClayForm.Text>{helpText}</ClayForm.Text>
-							</ClayForm.FeedbackGroup>
-						)}
-					</ClayInput.GroupItem>
-				</ClayInput.Group>
-			</ClayForm.Group>
-		</ClayTooltipProvider>
+					{helpText && (
+						<ClayForm.FeedbackGroup>
+							<ClayForm.Text>{helpText}</ClayForm.Text>
+						</ClayForm.FeedbackGroup>
+					)}
+				</ClayInput.GroupItem>
+			</ClayInput.Group>
+		</ClayForm.Group>
 	);
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/TooltipSummaryRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/TooltipSummaryRenderer.js
@@ -13,10 +13,10 @@
  */
 
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import Proptypes from 'prop-types';
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 
 import {getDataRendererById} from '../utils/dataRenderers';
 import {getSchemaString} from '../utils/index';
@@ -84,8 +84,10 @@ function TooltipSummaryRenderer({itemData, options, value}) {
 		<>
 			{value}
 			{tooltipTableRows.length && (
-				<ClayTooltipProvider
-					contentRenderer={() => (
+				<span
+					className="tooltip-provider"
+					data-tooltip-delay="0"
+					title={ReactDOMServer.renderToString(
 						<table className="tooltip-table">
 							<tbody>
 								{tooltipTableRows.map((rowData) => (
@@ -97,15 +99,9 @@ function TooltipSummaryRenderer({itemData, options, value}) {
 							</tbody>
 						</table>
 					)}
-					delay={0}
 				>
-					<span
-						className="tooltip-provider"
-						title={Liferay.Language.get('info')}
-					>
-						<ClayIcon symbol="info-circle" />
-					</span>
-				</ClayTooltipProvider>
+					<ClayIcon symbol="info-circle" />
+				</span>
 			)}
 		</>
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/side_panel/SidePanel.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/side_panel/SidePanel.js
@@ -18,7 +18,6 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import Modal from '../modal/Modal';
 import debounce from '../utils/debounce';
@@ -435,7 +434,9 @@ export default class SidePanel extends React.Component {
 			</>
 		);
 
-		return ReactDOM.createPortal(content, this.state.wrapper);
+		return (
+			<ReactPortal container={this.state.wrapper}>{content}</ReactPortal>
+		);
 	}
 }
 

--- a/modules/apps/journal/journal-web/package.json
+++ b/modules/apps/journal/journal-web/package.json
@@ -7,7 +7,6 @@
 		"@clayui/icon": "3.1.0",
 		"@clayui/label": "3.4.1",
 		"@clayui/panel": "3.25.0",
-		"@clayui/tooltip": "3.4.5",
 		"codemirror": "^5.52.2",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template_editor/components/Button.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template_editor/components/Button.js
@@ -13,7 +13,6 @@
  */
 
 import ClayButton from '@clayui/button';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -21,24 +20,18 @@ const noop = () => {};
 
 export const Button = ({label, onClick = noop, tooltip}) => {
 	return (
-		<ClayTooltipProvider
-			contentRenderer={({title}) => (
-				<div dangerouslySetInnerHTML={{__html: title}} />
-			)}
-			delay={0}
+		<ClayButton
+			borderless
+			className="font-weight-normal text-left text-truncate w-100"
+			data-tooltip-align="right"
+			data-tooltip-delay="0"
+			displayType="unstyled"
+			key={label}
+			onClick={onClick}
+			title={tooltip}
 		>
-			<ClayButton
-				borderless
-				className="font-weight-normal text-left text-truncate w-100"
-				data-tooltip-align="right"
-				displayType="unstyled"
-				key={label}
-				onClick={onClick}
-				title={tooltip}
-			>
-				{label}
-			</ClayButton>
-		</ClayTooltipProvider>
+			{label}
+		</ClayButton>
 	);
 };
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/App.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/App.js
@@ -14,7 +14,7 @@
 
 import PropTypes from 'prop-types';
 import React, {useEffect, useMemo} from 'react';
-import {createPortal} from 'react-dom';
+import {ReactPortal} from '@liferay/frontend-js-react-web';
 
 import {StyleBookContextProvider} from '../../plugins/page-design-options/hooks/useStyleBook';
 import {INIT} from '../actions/types';
@@ -71,14 +71,15 @@ export default function App({state}) {
 					<DragAndDropContextProvider>
 						<EditableProcessorContextProvider>
 							<DisplayPagePreviewItemContextProvider>
-								{displayPagePreviewItemSelectorWrapper
-									? createPortal(
-											<DisplayPagePreviewItemSelector
-												dark
-											/>,
+								{displayPagePreviewItemSelectorWrapper ? (
+									<ReactPortal
+										container={
 											displayPagePreviewItemSelectorWrapper
-									  )
-									: null}
+										}
+									>
+										<DisplayPagePreviewItemSelector dark />
+									</ReactPortal>
+								) : null}
 
 								<DragPreview />
 								<Toolbar />

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
@@ -22,7 +22,7 @@ import React, {
 	useRef,
 	useState,
 } from 'react';
-import {createPortal} from 'react-dom';
+import {ReactPortal} from '@liferay/frontend-js-react-web';
 
 import {useSelectItem} from '../contexts/ControlsContext';
 import {useGlobalContext} from '../contexts/GlobalContext';
@@ -194,28 +194,28 @@ const DisabledArea = () => {
 	}, [globalContext, isDisabled, withinIframe]);
 
 	return (
-		show &&
-		createPortal(
-			<ClayPopover alignPosition={position} ref={popoverRef} show>
-				<div
-					dangerouslySetInnerHTML={{
-						__html: Liferay.Util.sub(
-							Liferay.Language.get(
-								'this-area-is-defined-by-the-theme.-you-can-change-the-theme-settings-by-clicking-x-in-the-x-panel-on-the-sidebar'
+		show && (
+			<ReactPortal container={globalContext.document.body}>
+				<ClayPopover alignPosition={position} ref={popoverRef} show>
+					<div
+						dangerouslySetInnerHTML={{
+							__html: Liferay.Util.sub(
+								Liferay.Language.get(
+									'this-area-is-defined-by-the-theme.-you-can-change-the-theme-settings-by-clicking-x-in-the-x-panel-on-the-sidebar'
+								),
+								[
+									`<strong>${Liferay.Language.get(
+										'more'
+									)}</strong>`,
+									`<strong>${Liferay.Language.get(
+										'page-design-options'
+									)}</strong>`,
+								]
 							),
-							[
-								`<strong>${Liferay.Language.get(
-									'more'
-								)}</strong>`,
-								`<strong>${Liferay.Language.get(
-									'page-design-options'
-								)}</strong>`,
-							]
-						),
-					}}
-				/>
-			</ClayPopover>,
-			globalContext.document.body
+						}}
+					/>
+				</ClayPopover>
+			</ReactPortal>
 		)
 	);
 };

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
@@ -15,10 +15,13 @@
 import {ClayButtonWithIcon, default as ClayButton} from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import {useIsMounted, useStateSafe} from '@liferay/frontend-js-react-web';
+import {
+	useIsMounted,
+	useStateSafe,
+	ReactPortal,
+} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
 import React from 'react';
-import {createPortal} from 'react-dom';
 
 import useLazy from '../../core/hooks/useLazy';
 import useLoad from '../../core/hooks/useLoad';
@@ -204,129 +207,131 @@ export default function Sidebar() {
 		);
 	};
 
-	return createPortal(
-		<div
-			className="page-editor__sidebar page-editor__theme-adapter-forms"
-			ref={dropClearRef}
-		>
+	return (
+		<ReactPortal>
 			<div
-				className={classNames('page-editor__sidebar__buttons', {
-					light: true,
-				})}
-				onClick={deselectItem}
+				className="page-editor__sidebar page-editor__theme-adapter-forms"
+				ref={dropClearRef}
 			>
-				{panels.reduce((elements, group, groupIndex) => {
-					const buttons = group.map((panelId) => {
-						const panel = sidebarPanels[panelId];
+				<div
+					className={classNames('page-editor__sidebar__buttons', {
+						light: true,
+					})}
+					onClick={deselectItem}
+				>
+					{panels.reduce((elements, group, groupIndex) => {
+						const buttons = group.map((panelId) => {
+							const panel = sidebarPanels[panelId];
 
-						const active =
-							sidebarOpen && sidebarPanelId === panelId;
-						const {
-							icon,
-							isLink,
-							label,
-							pluginEntryPoint,
-							url,
-						} = panel;
+							const active =
+								sidebarOpen && sidebarPanelId === panelId;
+							const {
+								icon,
+								isLink,
+								label,
+								pluginEntryPoint,
+								url,
+							} = panel;
 
-						if (isLink) {
+							if (isLink) {
+								return (
+									<a
+										className={classNames({active})}
+										data-tooltip-align="left"
+										href={url}
+										key={panel.sidebarPanelId}
+										title={label}
+									>
+										<ClayIcon symbol={icon} />
+									</a>
+								);
+							}
+
+							const prefetch = () =>
+								load(
+									panel.sidebarPanelId,
+									pluginEntryPoint
+								).then(...swallow);
+
 							return (
-								<a
+								<ClayButtonWithIcon
+									aria-pressed={active}
 									className={classNames({active})}
 									data-tooltip-align="left"
-									href={url}
+									displayType="unstyled"
+									id={`${sidebarId}${panel.sidebarPanelId}`}
 									key={panel.sidebarPanelId}
+									onClick={() => handleClick(panel)}
+									onFocus={prefetch}
+									onMouseEnter={prefetch}
+									small={true}
+									symbol={icon}
 									title={label}
-								>
-									<ClayIcon symbol={icon} />
-								</a>
+								/>
 							);
+						});
+
+						// Add separator between groups.
+
+						if (groupIndex === panels.length - 1) {
+							return elements.concat(buttons);
 						}
-
-						const prefetch = () =>
-							load(panel.sidebarPanelId, pluginEntryPoint).then(
-								...swallow
-							);
-
-						return (
-							<ClayButtonWithIcon
-								aria-pressed={active}
-								className={classNames({active})}
-								data-tooltip-align="left"
-								displayType="unstyled"
-								id={`${sidebarId}${panel.sidebarPanelId}`}
-								key={panel.sidebarPanelId}
-								onClick={() => handleClick(panel)}
-								onFocus={prefetch}
-								onMouseEnter={prefetch}
-								small={true}
-								symbol={icon}
-								title={label}
-							/>
-						);
-					});
-
-					// Add separator between groups.
-
-					if (groupIndex === panels.length - 1) {
-						return elements.concat(buttons);
-					}
-					else {
-						return elements.concat([
-							...buttons,
-							<hr key={`separator-${groupIndex}`} />,
-						]);
-					}
-				}, [])}
-			</div>
-			<div
-				className={classNames({
-					'page-editor__sidebar__content': true,
-					'page-editor__sidebar__content--open': sidebarOpen,
-					rtl:
-						Liferay.Language.direction[
-							themeDisplay?.getLanguageId()
-						] === 'rtl',
-				})}
-				onClick={deselectItem}
-			>
-				{hasError ? (
-					<div>
-						<ClayButton
-							block
-							displayType="secondary"
-							onClick={() => {
-								dispatch(
-									Actions.switchSidebarPanel({
-										sidebarOpen: false,
-										sidebarPanelId:
-											panels[0] && panels[0][0],
-									})
-								);
-								setHasError(false);
+						else {
+							return elements.concat([
+								...buttons,
+								<hr key={`separator-${groupIndex}`} />,
+							]);
+						}
+					}, [])}
+				</div>
+				<div
+					className={classNames({
+						'page-editor__sidebar__content': true,
+						'page-editor__sidebar__content--open': sidebarOpen,
+						rtl:
+							Liferay.Language.direction[
+								themeDisplay?.getLanguageId()
+							] === 'rtl',
+					})}
+					onClick={deselectItem}
+				>
+					{hasError ? (
+						<div>
+							<ClayButton
+								block
+								displayType="secondary"
+								onClick={() => {
+									dispatch(
+										Actions.switchSidebarPanel({
+											sidebarOpen: false,
+											sidebarPanelId:
+												panels[0] && panels[0][0],
+										})
+									);
+									setHasError(false);
+								}}
+								small
+							>
+								{Liferay.Language.get('refresh')}
+							</ClayButton>
+						</div>
+					) : (
+						<ErrorBoundary
+							handleError={() => {
+								setHasError(true);
 							}}
-							small
 						>
-							{Liferay.Language.get('refresh')}
-						</ClayButton>
-					</div>
-				) : (
-					<ErrorBoundary
-						handleError={() => {
-							setHasError(true);
-						}}
-					>
-						<Suspense fallback={<ClayLoadingIndicator />}>
-							<SidebarPanel
-								getInstance={getInstance}
-								pluginId={sidebarPanelId}
-							/>
-						</Suspense>
-					</ErrorBoundary>
-				)}
+							<Suspense fallback={<ClayLoadingIndicator />}>
+								<SidebarPanel
+									getInstance={getInstance}
+									pluginId={sidebarPanelId}
+								/>
+							</Suspense>
+						</ErrorBoundary>
+					)}
+				</div>
 			</div>
-		</div>,
-		document.body
+		</ReactPortal>
 	);
 }
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
@@ -15,9 +15,8 @@
 import {ClayButtonWithIcon, default as ClayButton} from '@clayui/button';
 import ClayLayout from '@clayui/layout';
 import {useModal} from '@clayui/modal';
-import {useIsMounted} from '@liferay/frontend-js-react-web';
+import {useIsMounted, ReactPortal} from '@liferay/frontend-js-react-web';
 import React, {useEffect, useState} from 'react';
-import ReactDOM from 'react-dom';
 
 import useLazy from '../../core/hooks/useLazy';
 import useLoad from '../../core/hooks/useLoad';
@@ -374,5 +373,9 @@ export default function Toolbar() {
 		}
 	}
 
-	return ReactDOM.createPortal(<ToolbarBody />, container);
+	return (
+		<ReactPortal container={container}>
+			<ToolbarBody />
+		</ReactPortal>
+	);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/UnsafeHTML.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/UnsafeHTML.js
@@ -14,7 +14,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import RawDOM from '../../common/components/RawDOM';
 
@@ -152,9 +151,11 @@ export default class UnsafeHTML extends React.PureComponent {
 					elementRef={this._updateRef}
 				/>
 
-				{this.state.portals.map(({Component, element}) =>
-					ReactDOM.createPortal(<Component />, element)
-				)}
+				{this.state.portals.map(({Component, element}) => (
+					<ReactPortal container={element}>
+						<Component />
+					</ReactPortal>
+				))}
 			</>
 		);
 	}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/UndoHistory.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/UndoHistory.js
@@ -17,7 +17,6 @@ import ClayDropDown, {Align} from '@clayui/drop-down';
 import ClayDropDownDivider from '@clayui/drop-down/lib/Divider';
 import {useEventListener, useIsMounted} from '@liferay/frontend-js-react-web';
 import React, {useState} from 'react';
-import ReactDOM from 'react-dom';
 
 import {SELECT_SEGMENTS_EXPERIENCE} from '../../../plugins/experience/actions';
 import {UNDO_TYPES} from '../../config/constants/undoTypes';
@@ -103,7 +102,11 @@ export default function UndoHistory() {
 				</ClayDropDown.ItemList>
 			</ClayDropDown>
 
-			{loading && ReactDOM.createPortal(<Overlay />, document.body)}
+			{loading && (
+				<ReactPortal>
+					<Overlay />
+				</ReactPortal>
+			)}
 		</>
 	);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/GlobalContext.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/GlobalContext.js
@@ -12,10 +12,9 @@
  * details.
  */
 
-import {useIsMounted} from '@liferay/frontend-js-react-web';
+import {useIsMounted, ReactPortal} from '@liferay/frontend-js-react-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useMemo, useState} from 'react';
-import {createPortal} from 'react-dom';
 
 import RawDOM from '../../common/components/RawDOM';
 import {config} from '../config/index';
@@ -104,7 +103,7 @@ export function GlobalContextFrame({children, useIframe}) {
 	let content;
 
 	if (useIframe && baseElement && iframeContext) {
-		content = createPortal(<>{children}</>, baseElement);
+		content = <ReactPortal container={baseElement}>{children}</ReactPortal>;
 		context = iframeContext;
 
 		iframeElement.classList.remove(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -17,10 +17,9 @@ import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import {useModal} from '@clayui/modal';
-import {useIsMounted} from '@liferay/frontend-js-react-web';
+import {useIsMounted, ReactPortal} from '@liferay/frontend-js-react-web';
 import {openToast} from 'frontend-js-web';
 import React, {useEffect, useRef, useState} from 'react';
-import {createPortal} from 'react-dom';
 
 import {config} from '../../../app/config/index';
 import {useDispatch, useSelector} from '../../../app/contexts/StoreContext';
@@ -371,8 +370,8 @@ const ExperienceSelector = ({
 				</ClayLayout.ContentRow>
 			</ClayButton>
 
-			{open &&
-				createPortal(
+			{open && (
+				<ReactPortal>
 					<div
 						className="dropdown-menu p-4 page-editor__toolbar-experience__dropdown-menu toggled"
 						onBlur={handleDropdownBlur}
@@ -408,9 +407,9 @@ const ExperienceSelector = ({
 								onPriorityIncrease={increasePriority}
 							/>
 						)}
-					</div>,
-					document.body
-				)}
+					</div>
+				</ReactPortal>
+			)}
 
 			{openModal && (
 				<ExperienceModal

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/Popover.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/Popover.js
@@ -16,7 +16,6 @@ import ClayPopover from '@clayui/popover';
 import {ALIGN_POSITIONS, align} from 'frontend-js-web';
 import Proptypes from 'prop-types';
 import React, {useRef} from 'react';
-import ReactDOM from 'react-dom';
 
 /**
  * Tailored implementation of a ClayPopover for Experiences
@@ -25,9 +24,10 @@ import ReactDOM from 'react-dom';
  * scroll or any other event
  */
 const Popover = (props) => {
-	return ReactDOM.createPortal(
-		<PopoverComponent {...props} />,
-		document.body
+	return (
+		<ReactPortal>
+			<PopoverComponent {...props} />
+		</ReactPortal>
 	);
 };
 

--- a/modules/apps/layout/layout-reports-web/package.json
+++ b/modules/apps/layout/layout-reports-web/package.json
@@ -7,7 +7,6 @@
 		"@clayui/label": "3.4.1",
 		"@clayui/layout": "3.3.0",
 		"@clayui/loading-indicator": "3.2.0",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -13,7 +13,6 @@
  */
 
 import ClayLayout from '@clayui/layout';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
@@ -54,30 +53,26 @@ export default function BasicInformation({canonicalURLs, defaultLanguageId}) {
 			</ClayLayout.ContentCol>
 			<ClayLayout.ContentCol expand>
 				<ClayLayout.ContentRow>
-					<ClayTooltipProvider>
-						<span className="font-weight-semi-bold text-truncate-inline">
-							<span
-								className="text-truncate"
-								data-tooltip-align="bottom"
-								title={selectedCanonicalURL.title}
-							>
-								{selectedCanonicalURL.title}
-							</span>
+					<span className="font-weight-semi-bold text-truncate-inline">
+						<span
+							className="text-truncate"
+							data-tooltip-align="bottom"
+							title={selectedCanonicalURL.title}
+						>
+							{selectedCanonicalURL.title}
 						</span>
-					</ClayTooltipProvider>
+					</span>
 				</ClayLayout.ContentRow>
 				<ClayLayout.ContentRow>
-					<ClayTooltipProvider>
-						<span
-							className="text-truncate text-truncate-reverse"
-							data-tooltip-align="bottom"
-							title={selectedCanonicalURL.canonicalURL}
-						>
-							<bdi className="text-secondary">
-								{selectedCanonicalURL.canonicalURL}
-							</bdi>
-						</span>
-					</ClayTooltipProvider>
+					<span
+						className="text-truncate text-truncate-reverse"
+						data-tooltip-align="bottom"
+						title={selectedCanonicalURL.canonicalURL}
+					>
+						<bdi className="text-secondary">
+							{selectedCanonicalURL.canonicalURL}
+						</bdi>
+					</span>
 				</ClayLayout.ContentRow>
 			</ClayLayout.ContentCol>
 		</ClayLayout.ContentRow>

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/DragAndDrop.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/DragAndDrop.js
@@ -13,7 +13,7 @@
  */
 
 import React, {useState} from 'react';
-import {createPortal} from 'react-dom';
+import {ReactPortal} from '@liferay/frontend-js-react-web';
 
 import {
 	DragAndDropProvider,
@@ -47,11 +47,11 @@ const DragAndDropElements = () => {
 				setDropTargetItem,
 			}}
 		>
-			{columnHasChildren &&
-				createPortal(
-					<DragIndicator position={dragIndicatorPosition} />,
-					document.body
-				)}
+			{columnHasChildren && (
+				<ReactPortal>
+					<DragIndicator position={dragIndicatorPosition} />
+				</ReactPortal>
+			)}
 
 			{dropItems.map((dropItem, index) => (
 				<DropTarget dropItem={dropItem} key={index} />

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/entry/EditEntry.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/entry/EditEntry.es.js
@@ -10,7 +10,7 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
-import {useTimeout} from '@liferay/frontend-js-react-web';
+import {useTimeout, ReactPortal} from '@liferay/frontend-js-react-web';
 import {AppContext} from 'app-builder-web/js/AppContext.es';
 import {ControlMenuBase} from 'app-builder-web/js/components/control-menu/ControlMenu.es';
 import useDataDefinition from 'app-builder-web/js/hooks/useDataDefinition.es';
@@ -29,7 +29,6 @@ import React, {
 	useMemo,
 	useState,
 } from 'react';
-import {createPortal} from 'react-dom';
 
 import WorkflowInfoBar from '../../components/workflow-info-bar/WorkflowInfoBar.es';
 import useAppWorkflow from '../../hooks/useAppWorkflow.es';
@@ -63,7 +62,7 @@ const WorkflowInfoPortal = ({children}) => {
 
 	portalContainer.insertBefore(portalElement, targetElement);
 
-	return createPortal(children, portalElement);
+	return <ReactPortal container={portalElement}>{children}</ReactPortal>;
 };
 
 export default function EditEntry({

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/portal/Portal.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/portal/Portal.es.js
@@ -10,7 +10,6 @@
  */
 
 import React, {useEffect, useMemo} from 'react';
-import ReactDOM from 'react-dom';
 
 const Portal = ({
 	children,
@@ -53,7 +52,7 @@ const Portal = ({
 		return null;
 	}
 
-	return <>{ReactDOM.createPortal(children, portalElement)}</>;
+	return <ReactPortal container={portalElement}>children</ReactPortal>;
 };
 
 export default Portal;

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -17,7 +17,6 @@ import classNames from 'classnames';
 import {throttle} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import {StateContext as GlobalStateContext} from './../../state/context.es';
 import {StateContext, getInitialState, reducer} from './reducer.es';
@@ -417,13 +416,14 @@ function OverlayContainer({allowEdit, root}) {
 	useEventListener('mousedown', handleMouseDown, false, document);
 	useEventListener('mouseup', handleMouseUp, false, document);
 
-	return ReactDOM.createPortal(
-		<ClickGoalPicker.Overlay
-			allowEdit={allowEdit}
-			root={root}
-			targetableElements={targetableElements.current}
-		/>,
-		root
+	return (
+		<ReactPortal container={root}>
+			<ClickGoalPicker.Overlay
+				allowEdit={allowEdit}
+				root={root}
+				targetableElements={targetableElements.current}
+			/>
+		</ReactPortal>
 	);
 }
 


### PR DESCRIPTION
Follow up from the tooltip issues, https://github.com/liferay-frontend/liferay-portal/pull/1003

Okay so I got to the root of the problem, `ClayTooltipProvider` expects that the child passed in accepts `onMouseOut` and `onMouseOver`. In our case, we were at times wrapping a component that didn't accept those props. By adding this `div`, we can ensure that we always have an element those props can be bubbled up to.

I looked into adding this directly to ClayTooltipProvider but I couldn't find a method of doing this that was satisfactory. Anyone know of a way to ensure that a child element supports certain props?