### PR TITLE
LPS-131581 Remove null value elements in the DOM with class hide-accessible

### DIFF
--- a/portal-web/docroot/html/taglib/ui/icon/link_content.jspf
+++ b/portal-web/docroot/html/taglib/ui/icon/link_content.jspf
@@ -47,6 +47,8 @@
 		<span class="taglib-text-icon"><%= localizeMessage ? LanguageUtil.get(resourceBundle, message) : message %></span>
 	</c:when>
 	<c:otherwise>
-		<span class="taglib-text <%= label ? StringPool.BLANK : "hide-accessible" %>"><%= localizeMessage ? LanguageUtil.get(resourceBundle, message) : message %></span>
+		<c:if test="<%= Validator.isNotNull(message) %>">
+			<span class="taglib-text <%= label ? StringPool.BLANK : "hide-accessible" %>"><%= localizeMessage ? LanguageUtil.get(resourceBundle, message) : message %></span>
+		</c:if>
 	</c:otherwise>
 </c:choose>


### PR DESCRIPTION
Remove elements in the DOM with class hide-accessible having null value inside
Check ticket description for more details https://issues.liferay.com/browse/LPS-131581
Note: Seems to affect only 7.2.x, in master I could not find in a clean bundle this element, but I think we should fix the code in master as well 
![image](https://user-images.githubusercontent.com/59687465/117020604-e17e1180-acf6-11eb-9d9b-89b9c72ca3e8.png)
