### PR TITLE
LPS-131653 scroll event does not work with new delegate utility

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -77,9 +77,9 @@ class DynamicInlineScroll extends PortletBase {
 	addListItem_(listElement, pageIndex) {
 		const listItem = document.createElement('li');
 
-		listItem.append(
-			`<a href="${this.getHREF_(pageIndex)}">${pageIndex}</a>`
-		);
+		listItem.innerHTML = `<a class="dropdown-item" href="${this.getHREF_(
+			pageIndex
+		)}">${pageIndex}</a>`;
 
 		pageIndex++;
 
@@ -102,7 +102,7 @@ class DynamicInlineScroll extends PortletBase {
 		let href = `javascript:document.${formName}.${namespace}${curParam}.value = "${pageIndex}; ${jsCall}`;
 
 		if (this.url !== null) {
-			href = `${url}${namespace}${curParam}=${pageIndex}${urlAnchor}`;
+			href = `${url}&${namespace}${curParam}=${pageIndex}${urlAnchor}`;
 		}
 
 		return href;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/delegate/delegate.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/delegate/delegate.es.js
@@ -12,6 +12,15 @@
  * details.
  */
 
+const USE_CAPTURE = {
+	blur: true,
+	error: true,
+	focus: true,
+	invalid: true,
+	load: true,
+	scroll: true,
+};
+
 /**
  * Checks if element is disabled or whether it exists in a disabled element tree
  * @param {!Element} element The DOM element to check.
@@ -50,7 +59,7 @@ function delegate(element, eventName, selector, callback) {
 		}
 	};
 
-	element.addEventListener(eventName, eventHandler);
+	element.addEventListener(eventName, eventHandler, !!USE_CAPTURE[eventName]);
 
 	return {
 		dispose() {

--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -337,20 +337,26 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 </c:if>
 
 <c:if test="<%= pages > initialPages %>">
-	<aui:script require="frontend-js-web/liferay/DynamicInlineScroll.es">
-		new frontendJsWebLiferayDynamicInlineScrollEs.default(
+	<aui:script require="frontend-js-web/liferay/DynamicInlineScroll.es as DynamicInlineScroll">
+		Liferay.component(
+			'<%= randomNamespace %>dynamicInlineScroll',
+			new DynamicInlineScroll.default(
+				{
+					cur: '<%= cur %>',
+					curParam: '<%= curParam %>',
+					forcePost: <%= forcePost %>,
+					formName: '<%= formName %>',
+					initialPages: '<%= initialPages %>',
+					jsCall: '<%= jsCall %>',
+					namespace: '<%= namespace %>',
+					pages: '<%= pages %>',
+					randomNamespace: '<%= randomNamespace %>',
+					url: '<%= HtmlUtil.escapeJS(url) %>',
+					urlAnchor: '<%= urlAnchor %>'
+				}
+			),
 			{
-				cur: '<%= cur %>',
-				curParam: '<%= curParam %>',
-				forcePost: <%= forcePost %>,
-				formName: '<%= formName %>',
-				initialPages: '<%= initialPages %>',
-				jsCall: '<%= jsCall %>',
-				namespace: '<%= namespace %>',
-				pages: '<%= pages %>',
-				randomNamespace: '<%= randomNamespace %>',
-				url: '<%= HtmlUtil.escapeJS(url) %>',
-				urlAnchor: '<%= urlAnchor %>'
+				portletId: '<%= themeDisplay.getPortletDisplay().getPortletName() %>'
 			}
 		);
 	</aui:script>

--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -351,7 +351,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					namespace: '<%= namespace %>',
 					pages: '<%= pages %>',
 					randomNamespace: '<%= randomNamespace %>',
-					url: '<%= HtmlUtil.escapeJS(url) %>',
+					url: '<%= HtmlUtil.escapeJS(HttpUtil.removeParameter(url, curParam)) %>',
 					urlAnchor: '<%= urlAnchor %>'
 				}
 			),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-131653

## Steps to reproduce

1. Generate 200 documents with the word 'test' and upload them to the documents and media portlet
``` bash
for i in $(seq 0 199); do
  echo 'test' > $(printf '%03d' ${i}).txt
done
```
2. Change the pagination to 4 results per page
3. Click on the ... and scroll

Expected behavior is that additional intermediate pages will populate, up until around 50. Actual behavior is that nothing happens.

## Debugging notes

Issue was discovered while investigating an issue with the same paginator in 7.3.x (though this other issue is due to something in 7.3 failing to unregister the component that was created). The fix for this is also included in the pull request, since it's all related (might as well address both issues).

https://issues.liferay.com/browse/LPS-131653

Issue is suspected to be a regression introduced by some refactoring done to remove our dependency on metal.

https://issues.liferay.com/browse/LPS-122448

I'm not sure this is the right way to fix it, or if there is some other way to get scroll to delegate as it used to. Even then, it looks like we can't just append text, like we did with metal, and we have to append actual HTML nodes.