### PR TITLE
LPS-130364 Migrate item-selector-dialog to openSelectionModal

### DIFF
--- a/modules/apps/commerce/commerce-product-asset-categories-web/package.json
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/package.json
@@ -1,0 +1,13 @@
+{
+	"dependencies": {
+		"frontend-js-web": "*"
+	},
+	"name": "@liferay/commerce-product-asset-categories-web",
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix",
+		"test": "liferay-npm-scripts test"
+	},
+	"version": "4.0.3"
+}

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/display_layout/edit_asset_category_cp_display_layout.jsp
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/display_layout/edit_asset_category_cp_display_layout.jsp
@@ -99,173 +99,19 @@ if (cpDisplayLayout != null) {
 	</aui:form>
 </commerce-ui:side-panel-content>
 
-<aui:script use="liferay-item-selector-dialog">
-	var displayPageItemContainer = window.document.querySelector(
-		'#<portlet:namespace />displayPageItemContainer'
-	);
-	var displayPageItemRemove = window.document.querySelector(
-		'#<portlet:namespace />displayPageItemRemove'
-	);
-	var displayPageNameInput = window.document.querySelector(
-		'#<portlet:namespace />displayPageNameInput'
-	);
-	var pagesContainerInput = window.document.querySelector(
-		'#<portlet:namespace />pagesContainerInput'
-	);
-
-	window.document
-		.querySelector('#<portlet:namespace />chooseDisplayPage')
-		.addEventListener('click', (event) => {
-			var itemSelectorDialog = new A.LiferayItemSelectorDialog({
-				eventName: 'selectDisplayPage',
-				on: {
-					selectedItemChange: function (event) {
-						var selectedItem = event.newVal;
-
-						if (selectedItem) {
-							pagesContainerInput.value = selectedItem.id;
-
-							displayPageNameInput.innerHTML = selectedItem.name;
-
-							displayPageItemRemove.classList.remove('hide');
-						}
-					},
-				},
-				'strings.add': '<liferay-ui:message key="done" />',
-				title: '<liferay-ui:message key="select-category-display-page" />',
-				url:
-					'<%= categoryCPDisplayLayoutDisplayContext.getItemSelectorUrl(renderRequest) %>',
-			});
-
-			itemSelectorDialog.open();
-		});
-
-	displayPageItemRemove.addEventListener('click', () => {
-		displayPageNameInput.innerHTML = '<liferay-ui:message key="none" />';
-
-		pagesContainerInput.value = '';
-
-		displayPageItemRemove.classList.add('hide');
-	});
-</aui:script>
-
-<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
-	var assetCategoryId = <%= (assetCategory == null) ? "null" : assetCategory.getCategoryId() %>;
-
-	var assetCategoryName =
-		'<%= (assetCategory == null) ? "" : assetCategory.getTitle(locale) %>';
-
-	var categoriesContainer = document.querySelector(
-		'#<portlet:namespace />categoriesContainer'
-	);
-
-	var classPK = document.querySelector('#<portlet:namespace />classPK');
-
-	function createLabel(id, title) {
-		var labelContainer = document.createElement('span');
-		labelContainer.classList.add('label');
-		labelContainer.classList.add('label-dismissible');
-		labelContainer.classList.add('label-secondary');
-		labelContainer.setAttribute('id', id);
-
-		var linkContainer = document.createElement('span');
-		linkContainer.classList.add('label-item');
-		linkContainer.classList.add('label-item-expand');
-
-		var link = document.createElement('a');
-		link.setAttribute('href', '#' + id);
-		link.innerText = title;
-		linkContainer.appendChild(link);
-
-		var buttonContainer = document.createElement('span');
-		buttonContainer.classList.add('label-item');
-		buttonContainer.classList.add('label-item-after');
-
-		var button = document.createElement('button');
-		button.classList.add('close');
-		button.setAttribute('aria-label', 'Close');
-		button.setAttribute('type', 'button');
-		button.addEventListener('click', handleCloseButtonClick);
-
-		var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-		svg.classList.add('lexicon-icon');
-		svg.classList.add('lexicon-icon-times');
-		svg.setAttribute('focusable', false);
-		svg.setAttribute('role', 'presentation');
-
-		var use = document.createElementNS('http://www.w3.org/2000/svg', 'use');
-		use.setAttribute(
-			'href',
-			Liferay.ThemeDisplay.getPathThemeImages() + '/clay/icons.svg#times'
-		);
-
-		svg.appendChild(use);
-		button.appendChild(svg);
-		buttonContainer.appendChild(button);
-
-		labelContainer.appendChild(linkContainer);
-		labelContainer.appendChild(buttonContainer);
-
-		return labelContainer;
-	}
-
-	function handleCloseButtonClick(event) {
-		var button = event.currentTarget;
-		categoriesContainer.removeChild(button.parentElement.parentElement);
-	}
-
-	if (assetCategoryId) {
-		var categoryNode = createLabel(
-			'category-' + assetCategoryId,
-			assetCategoryName
-		);
-		categoriesContainer.appendChild(categoryNode);
-		classPK.value = assetCategoryId;
-	}
-
-	window.document
-		.querySelector('#<portlet:namespace />selectCategories')
-		.addEventListener('click', (event) => {
-			var itemSelectorDialog = new ItemSelectorDialog.default({
-				eventName: '<portlet:namespace />selectCategory',
-				'strings.add': '<liferay-ui:message key="done" />',
-				title: '<liferay-ui:message key="select-category-display-page" />',
-				url:
-					'<%= categoryCPDisplayLayoutDisplayContext.getCategorySelectorURL(renderResponse) %>',
-			});
-
-			itemSelectorDialog.open();
-
-			itemSelectorDialog.on('selectedItemChange', (event) => {
-				if (event.selectedItem) {
-					var selectedItem = event.selectedItem;
-
-					Object.keys(selectedItem).forEach((key) => {
-						var item = selectedItem[key];
-
-						if (!item.unchecked) {
-							var categoryNodes = categoriesContainer.children;
-
-							for (var i = 0; i < categoryNodes.length; i++) {
-								categoriesContainer.removeChild(
-									categoryNodes.item(i)
-								);
-							}
-
-							delete selectedItem.key;
-
-							var categoryNode = createLabel(
-								'category-' + item.categoryId,
-								item.value
-							);
-
-							categoriesContainer.appendChild(categoryNode);
-							classPK.value = item.categoryId;
-
-							return;
-						}
-					});
-				}
-			});
-		});
-</aui:script>
+<liferay-frontend:component
+	context='<%=
+		HashMapBuilder.<String, Object>put(
+			"assetCategory", assetCategory
+		).put(
+			"categorySelectorUrl", categoryCPDisplayLayoutDisplayContext.getCategorySelectorURL(renderResponse)
+		).put(
+			"itemSelectorUrl", categoryCPDisplayLayoutDisplayContext.getItemSelectorUrl(renderRequest)
+		).put(
+			"locale", locale
+		).put(
+			"portletNamespace", liferayPortletResponse.getNamespace()
+		).build()
+	%>'
+	module="js/EditAssetCategoryCPDisplayLayout"
+/>

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/js/EditAssetCategoryCPDisplayLayout.js
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/js/EditAssetCategoryCPDisplayLayout.js
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {openSelectionModal} from 'frontend-js-web';
+
+export default function ({
+	assetCategory,
+	categorySelectorUrl,
+	itemSelectorUrl,
+	locale,
+	portletNamespace,
+}) {
+	const displayPageItemRemove = document.getElementById(
+		`${portletNamespace}displayPageItemRemove`
+	);
+
+	const displayPageNameInput = document.getElementById(
+		`${portletNamespace}displayPageNameInput`
+	);
+
+	const pagesContainerInput = document.getElementById(
+		`${portletNamespace}pagesContainerInput`
+	);
+
+	const chooseDisplayPageButton = document.getElementById(
+		`${portletNamespace}chooseDisplayPage`
+	);
+
+	chooseDisplayPageButton?.addEventListener('click', () => {
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				if (
+					selectedItem &&
+					displayPageNameInput &&
+					pagesContainerInput
+				) {
+					pagesContainerInput.value = selectedItem.id;
+
+					displayPageNameInput.innerHTML = selectedItem.name;
+
+					displayPageItemRemove?.classList.remove('hide');
+				}
+			},
+			selectEventName: 'selectDisplayPage',
+			title: Liferay.Language.get('select-category-display-page'),
+			url: itemSelectorUrl,
+		});
+	});
+
+	if (displayPageItemRemove && displayPageNameInput && pagesContainerInput) {
+		displayPageItemRemove.addEventListener('click', () => {
+			displayPageNameInput.innerHTML = Liferay.Language.get('none');
+
+			pagesContainerInput.value = '';
+
+			displayPageItemRemove.classList.add('hide');
+		});
+	}
+
+	function createLabel(id, title) {
+		const labelContainer = document.createElement('span');
+
+		labelContainer.classList.add(
+			'label',
+			'label-dismissible',
+			'label-secondary'
+		);
+		labelContainer.setAttribute('id', id);
+
+		const linkContainer = document.createElement('span');
+
+		linkContainer.classList.add('label-item', 'label-item-expand');
+
+		const link = document.createElement('a');
+
+		link.setAttribute('href', '#' + id);
+		link.innerText = title;
+		linkContainer.appendChild(link);
+
+		const buttonContainer = document.createElement('span');
+
+		buttonContainer.classList.add('label-item', 'label-item-after');
+
+		const button = document.createElement('button');
+
+		button.classList.add('close');
+		button.setAttribute('aria-label', 'Close');
+		button.setAttribute('type', 'button');
+		button.addEventListener('click', handleCloseButtonClick);
+
+		const svg = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'svg'
+		);
+
+		svg.classList.add('lexicon-icon', 'lexicon-icon-times');
+		svg.setAttribute('focusable', false);
+		svg.setAttribute('role', 'presentation');
+
+		const use = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'use'
+		);
+
+		use.setAttribute(
+			'href',
+			`${Liferay.ThemeDisplay.getPathThemeImages()}/clay/icons.svg#times`
+		);
+
+		svg.appendChild(use);
+		button.appendChild(svg);
+		buttonContainer.appendChild(button);
+
+		labelContainer.appendChild(linkContainer);
+		labelContainer.appendChild(buttonContainer);
+
+		return labelContainer;
+	}
+
+	const categoriesContainer = document.getElementById(
+		`${portletNamespace}categoriesContainer`
+	);
+
+	function handleCloseButtonClick(event) {
+		const button = event.currentTarget;
+
+		categoriesContainer?.removeChild(button.parentElement.parentElement);
+	}
+
+	const classPK = document.getElementById(`${portletNamespace}classPK`);
+
+	const assetCategoryId = assetCategory?.getCategoryId();
+
+	if (assetCategoryId) {
+		const categoryNode = createLabel(
+			`category-${assetCategoryId}`,
+			assetCategory.getTitle(locale)
+		);
+
+		categoriesContainer?.appendChild(categoryNode);
+		classPK.value = assetCategoryId;
+	}
+
+	const selectCategoriesButton = document.getElementById(
+		`${portletNamespace}selectCategories`
+	);
+
+	selectCategoriesButton?.addEventListener('click', () => {
+		openSelectionModal({
+			buttonAddLabel: Liferay.Language.get('done'),
+			multiple: true,
+			onSelect: (selectedItems) => {
+				if (selectedItems) {
+					Object.keys(selectedItems).forEach((key) => {
+						const item = selectedItems[key];
+
+						if (item.unchecked && !categoriesContainer) {
+							return;
+						}
+
+						const categoryNodes = categoriesContainer.children;
+
+						if (categoryNodes.length) {
+							for (let i = 0; i < categoryNodes.length; i++) {
+								categoriesContainer.removeChild(
+									categoryNodes.item(i)
+								);
+							}
+						}
+
+						delete selectedItems.key;
+
+						const categoryNode = createLabel(
+							`category-${item.categoryId}`,
+							item.value
+						);
+
+						categoriesContainer.appendChild(categoryNode);
+						classPK.value = item.categoryId;
+
+						return;
+					});
+				}
+			},
+			selectEventName: `${portletNamespace}selectCategory`,
+			title: Liferay.Language.get('select-category-display-page'),
+			url: categorySelectorUrl,
+		});
+	});
+}


### PR DESCRIPTION
This is another PR as part of the modal migration, this time inside Commerce.

I'm sending it here first because it's dependant on https://github.com/liferay-echo/liferay-portal/pull/4436#issuecomment-832592594 being merged.

# 🧪 Testing steps

1. Have a site created using Minium template. This is a prerequisite for all commerce tasks:
    - Control Panel > Sites > (+) Minium
    - Control Panel > Search > Index Actions > Reindex all search indexes.
2. Application Menu > Commerce > Channels
    - Create a new Channel
3. Edit created channel > Category Display Pages tab
    - Add a new category
    - Both of the modals are handled in this file