### PR TITLE
LPS-129061 Change put...Permissions endpoints to return the list of updated permissions permission

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-api/bnd.bnd
+++ b/modules/apps/data-engine/data-engine-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Data Engine REST API
 Bundle-SymbolicName: com.liferay.data.engine.rest.api
-Bundle-Version: 18.0.2
+Bundle-Version: 19.0.0
 Export-Package:\
 	com.liferay.data.engine.rest.dto.v2_0,\
 	com.liferay.data.engine.rest.dto.v2_0.util,\

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionResource.java
@@ -86,9 +86,10 @@ public interface DataDefinitionResource {
 				Long dataDefinitionId, String roleNames)
 		throws Exception;
 
-	public void putDataDefinitionPermission(
-			Long dataDefinitionId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putDataDefinitionPermission(
+				Long dataDefinitionId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<DataDefinition>

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataRecordCollectionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataRecordCollectionResource.java
@@ -91,9 +91,10 @@ public interface DataRecordCollectionResource {
 				Long dataRecordCollectionId, String roleNames)
 		throws Exception;
 
-	public void putDataRecordCollectionPermission(
-			Long dataRecordCollectionId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putDataRecordCollectionPermission(
+				Long dataRecordCollectionId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public String getDataRecordCollectionPermissionByCurrentUser(

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/resources/com/liferay/data/engine/rest/resource/v2_0/packageinfo
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/resources/com/liferay/data/engine/rest/resource/v2_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.4.0
+version 5.0.0

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionResource.java
@@ -121,7 +121,7 @@ public interface DataDefinitionResource {
 				Long dataDefinitionId, String roleNames)
 		throws Exception;
 
-	public void putDataDefinitionPermission(
+	public Page<Permission> putDataDefinitionPermission(
 			Long dataDefinitionId, Permission[] permissions)
 		throws Exception;
 
@@ -1065,7 +1065,7 @@ public interface DataDefinitionResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putDataDefinitionPermission(
+		public Page<Permission> putDataDefinitionPermission(
 				Long dataDefinitionId, Permission[] permissions)
 			throws Exception {
 
@@ -1099,7 +1099,7 @@ public interface DataDefinitionResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataRecordCollectionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataRecordCollectionResource.java
@@ -130,7 +130,7 @@ public interface DataRecordCollectionResource {
 				Long dataRecordCollectionId, String roleNames)
 		throws Exception;
 
-	public void putDataRecordCollectionPermission(
+	public Page<Permission> putDataRecordCollectionPermission(
 			Long dataRecordCollectionId, Permission[] permissions)
 		throws Exception;
 
@@ -1073,7 +1073,7 @@ public interface DataRecordCollectionResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putDataRecordCollectionPermission(
+		public Page<Permission> putDataRecordCollectionPermission(
 				Long dataRecordCollectionId, Permission[] permissions)
 			throws Exception {
 
@@ -1107,7 +1107,7 @@ public interface DataRecordCollectionResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/mutation/v2_0/Mutation.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/mutation/v2_0/Mutation.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.function.BiFunction;
 
@@ -179,20 +180,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateDataDefinitionPermission(
-			@GraphQLName("dataDefinitionId") Long dataDefinitionId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateDataDefinitionPermission(
+				@GraphQLName("dataDefinitionId") Long dataDefinitionId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_dataDefinitionResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			dataDefinitionResource ->
-				dataDefinitionResource.putDataDefinitionPermission(
-					dataDefinitionId, permissions));
+			dataDefinitionResource -> {
+				Page paginationPage =
+					dataDefinitionResource.putDataDefinitionPermission(
+						dataDefinitionId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -634,20 +639,26 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateDataRecordCollectionPermission(
-			@GraphQLName("dataRecordCollectionId") Long dataRecordCollectionId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateDataRecordCollectionPermission(
+				@GraphQLName("dataRecordCollectionId") Long
+					dataRecordCollectionId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_dataRecordCollectionResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			dataRecordCollectionResource ->
-				dataRecordCollectionResource.putDataRecordCollectionPermission(
-					dataRecordCollectionId, permissions));
+			dataRecordCollectionResource -> {
+				Page paginationPage =
+					dataRecordCollectionResource.
+						putDataRecordCollectionPermission(
+							dataRecordCollectionId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	private <T, R, E1 extends Throwable, E2 extends Throwable> R

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -428,10 +428,12 @@ public abstract class BaseDataDefinitionResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "DataDefinition")})
-	public void putDataDefinitionPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("dataDefinitionId")
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putDataDefinitionPermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("dataDefinitionId")
 				Long dataDefinitionId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -443,12 +445,15 @@ public abstract class BaseDataDefinitionResourceImpl
 			getPermissionCheckerGroupId(dataDefinitionId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(dataDefinitionId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -402,11 +402,12 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "DataRecordCollection")})
-	public void putDataRecordCollectionPermission(
-			@NotNull @Parameter(hidden = true)
-			@PathParam("dataRecordCollectionId")
-			Long dataRecordCollectionId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putDataRecordCollectionPermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("dataRecordCollectionId")
+				Long dataRecordCollectionId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -419,12 +420,15 @@ public abstract class BaseDataRecordCollectionResourceImpl
 			getPermissionCheckerGroupId(dataRecordCollectionId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(dataRecordCollectionId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
@@ -122,7 +122,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
 import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
@@ -670,27 +669,6 @@ public class DataDefinitionResourceImpl
 			));
 
 		return _updateDataDefinition(dataDefinition, dataDefinitionId, ddmForm);
-	}
-
-	@Override
-	public void putDataDefinitionPermission(
-			Long dataDefinitionId, Permission[] permissions)
-		throws Exception {
-
-		_dataDefinitionModelResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(), dataDefinitionId,
-			ActionKeys.PERMISSIONS);
-
-		String resourceName = getPermissionCheckerResourceName(
-			dataDefinitionId);
-
-		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
-			String.valueOf(dataDefinitionId),
-			ModelPermissionsUtil.toModelPermissions(
-				contextCompany.getCompanyId(), permissions, dataDefinitionId,
-				resourceName, resourceActionLocalService,
-				resourcePermissionLocalService, roleLocalService));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataRecordCollectionResourceImpl.java
@@ -46,7 +46,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
 import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
@@ -237,31 +236,6 @@ public class DataRecordCollectionResourceImpl
 		return _updateDataRecordCollection(
 			dataRecordCollectionId, dataRecordCollection.getDescription(),
 			dataRecordCollection.getName());
-	}
-
-	@Override
-	public void putDataRecordCollectionPermission(
-			Long dataRecordCollectionId, Permission[] permissions)
-		throws Exception {
-
-		DataRecordCollection dataRecordCollection = _getDataRecordCollection(
-			dataRecordCollectionId);
-
-		_dataDefinitionModelResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(),
-			dataRecordCollection.getDataDefinitionId(), ActionKeys.PERMISSIONS);
-
-		String resourceName = getPermissionCheckerResourceName(
-			dataRecordCollectionId);
-
-		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
-			String.valueOf(dataRecordCollectionId),
-			ModelPermissionsUtil.toModelPermissions(
-				contextCompany.getCompanyId(), permissions,
-				dataRecordCollectionId, resourceName,
-				resourceActionLocalService, resourcePermissionLocalService,
-				roleLocalService));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
@@ -723,7 +723,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			dataDefinitionResource.putDataDefinitionPermissionHttpResponse(
 				dataDefinition.getId(),
 				new Permission[] {

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
@@ -638,7 +638,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			dataRecordCollectionResource.
 				putDataRecordCollectionPermissionHttpResponse(
 					dataRecordCollection.getId(),

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
@@ -68,9 +68,10 @@ public interface KeywordResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryKeywordPermission(
-			Long assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryKeywordPermission(
+				Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<Keyword> getKeywordsRankedPage(
@@ -93,9 +94,10 @@ public interface KeywordResource {
 			getKeywordPermissionsPage(Long keywordId, String roleNames)
 		throws Exception;
 
-	public void putKeywordPermission(
-			Long keywordId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putKeywordPermission(
+				Long keywordId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<Keyword> getSiteKeywordsPage(
@@ -114,9 +116,10 @@ public interface KeywordResource {
 			getSiteKeywordPermissionsPage(Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteKeywordPermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteKeywordPermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
@@ -90,9 +90,10 @@ public interface TaxonomyCategoryResource {
 				String taxonomyCategoryId, String roleNames)
 		throws Exception;
 
-	public void putTaxonomyCategoryPermission(
-			String taxonomyCategoryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putTaxonomyCategoryPermission(
+				String taxonomyCategoryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<TaxonomyCategory> getTaxonomyVocabularyTaxonomyCategoriesPage(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
@@ -69,9 +69,10 @@ public interface TaxonomyVocabularyResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryTaxonomyVocabularyPermission(
-			Long assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryTaxonomyVocabularyPermission(
+				Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<TaxonomyVocabulary> getSiteTaxonomyVocabulariesPage(
@@ -92,9 +93,10 @@ public interface TaxonomyVocabularyResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteTaxonomyVocabularyPermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteTaxonomyVocabularyPermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void deleteTaxonomyVocabulary(Long taxonomyVocabularyId)
@@ -124,9 +126,10 @@ public interface TaxonomyVocabularyResource {
 				Long taxonomyVocabularyId, String roleNames)
 		throws Exception;
 
-	public void putTaxonomyVocabularyPermission(
-			Long taxonomyVocabularyId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putTaxonomyVocabularyPermission(
+				Long taxonomyVocabularyId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/KeywordResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/KeywordResource.java
@@ -77,7 +77,7 @@ public interface KeywordResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryKeywordPermission(
+	public Page<Permission> putAssetLibraryKeywordPermission(
 			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -132,7 +132,8 @@ public interface KeywordResource {
 			Long keywordId, String roleNames)
 		throws Exception;
 
-	public void putKeywordPermission(Long keywordId, Permission[] permissions)
+	public Page<Permission> putKeywordPermission(
+			Long keywordId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse putKeywordPermissionHttpResponse(
@@ -172,7 +173,8 @@ public interface KeywordResource {
 			Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteKeywordPermission(Long siteId, Permission[] permissions)
+	public Page<Permission> putSiteKeywordPermission(
+			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse putSiteKeywordPermissionHttpResponse(
@@ -607,7 +609,7 @@ public interface KeywordResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putAssetLibraryKeywordPermission(
+		public Page<Permission> putAssetLibraryKeywordPermission(
 				Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
@@ -641,7 +643,7 @@ public interface KeywordResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1270,7 +1272,7 @@ public interface KeywordResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putKeywordPermission(
+		public Page<Permission> putKeywordPermission(
 				Long keywordId, Permission[] permissions)
 			throws Exception {
 
@@ -1303,7 +1305,7 @@ public interface KeywordResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1714,7 +1716,7 @@ public interface KeywordResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteKeywordPermission(
+		public Page<Permission> putSiteKeywordPermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -1747,7 +1749,7 @@ public interface KeywordResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyCategoryResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyCategoryResource.java
@@ -125,7 +125,7 @@ public interface TaxonomyCategoryResource {
 				String taxonomyCategoryId, String roleNames)
 		throws Exception;
 
-	public void putTaxonomyCategoryPermission(
+	public Page<Permission> putTaxonomyCategoryPermission(
 			String taxonomyCategoryId, Permission[] permissions)
 		throws Exception;
 
@@ -1092,7 +1092,7 @@ public interface TaxonomyCategoryResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putTaxonomyCategoryPermission(
+		public Page<Permission> putTaxonomyCategoryPermission(
 				String taxonomyCategoryId, Permission[] permissions)
 			throws Exception {
 
@@ -1126,7 +1126,7 @@ public interface TaxonomyCategoryResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyVocabularyResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyVocabularyResource.java
@@ -81,7 +81,7 @@ public interface TaxonomyVocabularyResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryTaxonomyVocabularyPermission(
+	public Page<Permission> putAssetLibraryTaxonomyVocabularyPermission(
 			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -125,7 +125,7 @@ public interface TaxonomyVocabularyResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteTaxonomyVocabularyPermission(
+	public Page<Permission> putSiteTaxonomyVocabularyPermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -187,7 +187,7 @@ public interface TaxonomyVocabularyResource {
 				Long taxonomyVocabularyId, String roleNames)
 		throws Exception;
 
-	public void putTaxonomyVocabularyPermission(
+	public Page<Permission> putTaxonomyVocabularyPermission(
 			Long taxonomyVocabularyId, Permission[] permissions)
 		throws Exception;
 
@@ -628,7 +628,7 @@ public interface TaxonomyVocabularyResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putAssetLibraryTaxonomyVocabularyPermission(
+		public Page<Permission> putAssetLibraryTaxonomyVocabularyPermission(
 				Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
@@ -662,7 +662,7 @@ public interface TaxonomyVocabularyResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1080,7 +1080,7 @@ public interface TaxonomyVocabularyResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteTaxonomyVocabularyPermission(
+		public Page<Permission> putSiteTaxonomyVocabularyPermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -1114,7 +1114,7 @@ public interface TaxonomyVocabularyResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1750,7 +1750,7 @@ public interface TaxonomyVocabularyResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putTaxonomyVocabularyPermission(
+		public Page<Permission> putTaxonomyVocabularyPermission(
 				Long taxonomyVocabularyId, Permission[] permissions)
 			throws Exception {
 
@@ -1784,7 +1784,7 @@ public interface TaxonomyVocabularyResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/mutation/v1_0/Mutation.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.function.BiFunction;
 
@@ -102,19 +103,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateAssetLibraryKeywordPermission(
-			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateAssetLibraryKeywordPermission(
+				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_keywordResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			keywordResource -> keywordResource.putAssetLibraryKeywordPermission(
-				Long.valueOf(assetLibraryId), permissions));
+			keywordResource -> {
+				Page paginationPage =
+					keywordResource.putAssetLibraryKeywordPermission(
+						Long.valueOf(assetLibraryId), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -172,19 +178,23 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateKeywordPermission(
-			@GraphQLName("keywordId") Long keywordId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateKeywordPermission(
+				@GraphQLName("keywordId") Long keywordId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_keywordResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			keywordResource -> keywordResource.putKeywordPermission(
-				keywordId, permissions));
+			keywordResource -> {
+				Page paginationPage = keywordResource.putKeywordPermission(
+					keywordId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(description = "Inserts a new keyword in a Site.")
@@ -215,19 +225,23 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteKeywordPermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteKeywordPermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_keywordResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			keywordResource -> keywordResource.putSiteKeywordPermission(
-				Long.valueOf(siteKey), permissions));
+			keywordResource -> {
+				Page paginationPage = keywordResource.putSiteKeywordPermission(
+					Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(description = "Inserts a new child taxonomy category.")
@@ -323,20 +337,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateTaxonomyCategoryPermission(
-			@GraphQLName("taxonomyCategoryId") String taxonomyCategoryId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateTaxonomyCategoryPermission(
+				@GraphQLName("taxonomyCategoryId") String taxonomyCategoryId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			taxonomyCategoryResource ->
-				taxonomyCategoryResource.putTaxonomyCategoryPermission(
-					taxonomyCategoryId, permissions));
+			taxonomyCategoryResource -> {
+				Page paginationPage =
+					taxonomyCategoryResource.putTaxonomyCategoryPermission(
+						taxonomyCategoryId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -403,21 +421,25 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateAssetLibraryTaxonomyVocabularyPermission(
-			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateAssetLibraryTaxonomyVocabularyPermission(
+				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_taxonomyVocabularyResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			taxonomyVocabularyResource ->
-				taxonomyVocabularyResource.
-					putAssetLibraryTaxonomyVocabularyPermission(
-						Long.valueOf(assetLibraryId), permissions));
+			taxonomyVocabularyResource -> {
+				Page paginationPage =
+					taxonomyVocabularyResource.
+						putAssetLibraryTaxonomyVocabularyPermission(
+							Long.valueOf(assetLibraryId), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(description = "Inserts a new taxonomy vocabulary in a Site.")
@@ -451,20 +473,25 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteTaxonomyVocabularyPermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteTaxonomyVocabularyPermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_taxonomyVocabularyResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			taxonomyVocabularyResource ->
-				taxonomyVocabularyResource.putSiteTaxonomyVocabularyPermission(
-					Long.valueOf(siteKey), permissions));
+			taxonomyVocabularyResource -> {
+				Page paginationPage =
+					taxonomyVocabularyResource.
+						putSiteTaxonomyVocabularyPermission(
+							Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -547,20 +574,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateTaxonomyVocabularyPermission(
-			@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateTaxonomyVocabularyPermission(
+				@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_taxonomyVocabularyResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			taxonomyVocabularyResource ->
-				taxonomyVocabularyResource.putTaxonomyVocabularyPermission(
-					taxonomyVocabularyId, permissions));
+			taxonomyVocabularyResource -> {
+				Page paginationPage =
+					taxonomyVocabularyResource.putTaxonomyVocabularyPermission(
+						taxonomyVocabularyId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	private <T, R, E1 extends Throwable, E2 extends Throwable> R

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -231,10 +231,11 @@ public abstract class BaseKeywordResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "Keyword")})
-	public void putAssetLibraryKeywordPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId") Long
-				assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryKeywordPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId")
+					Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -250,6 +251,8 @@ public abstract class BaseKeywordResourceImpl
 				contextCompany.getCompanyId(), permissions, assetLibraryId,
 				portletName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(assetLibraryId, portletName, null);
 	}
 
 	/**
@@ -460,10 +463,11 @@ public abstract class BaseKeywordResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "Keyword")})
-	public void putKeywordPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("keywordId") Long
-				keywordId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putKeywordPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("keywordId") Long
+					keywordId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(keywordId);
@@ -474,12 +478,15 @@ public abstract class BaseKeywordResourceImpl
 			getPermissionCheckerGroupId(keywordId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(keywordId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**
@@ -620,9 +627,11 @@ public abstract class BaseKeywordResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "Keyword")})
-	public void putSiteKeywordPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteKeywordPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -638,6 +647,8 @@ public abstract class BaseKeywordResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -461,10 +461,12 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "TaxonomyCategory")})
-	public void putTaxonomyCategoryPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("taxonomyCategoryId")
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putTaxonomyCategoryPermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("taxonomyCategoryId")
 				String taxonomyCategoryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -476,12 +478,15 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 			getPermissionCheckerGroupId(taxonomyCategoryId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(taxonomyCategoryId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -232,10 +232,11 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "TaxonomyVocabulary")})
-	public void putAssetLibraryTaxonomyVocabularyPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId") Long
-				assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryTaxonomyVocabularyPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId")
+					Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -251,6 +252,8 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				contextCompany.getCompanyId(), permissions, assetLibraryId,
 				portletName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(assetLibraryId, portletName, null);
 	}
 
 	/**
@@ -391,9 +394,11 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "TaxonomyVocabulary")})
-	public void putSiteTaxonomyVocabularyPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteTaxonomyVocabularyPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -409,6 +414,8 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	/**
@@ -707,11 +714,12 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "TaxonomyVocabulary")})
-	public void putTaxonomyVocabularyPermission(
-			@NotNull @Parameter(hidden = true)
-			@PathParam("taxonomyVocabularyId")
-			Long taxonomyVocabularyId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putTaxonomyVocabularyPermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("taxonomyVocabularyId")
+				Long taxonomyVocabularyId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -723,12 +731,15 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 			getPermissionCheckerGroupId(taxonomyVocabularyId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(taxonomyVocabularyId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -561,7 +561,7 @@ public abstract class BaseKeywordResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			keywordResource.putAssetLibraryKeywordPermissionHttpResponse(
 				testDepotEntry.getDepotEntryId(),
 				new Permission[] {
@@ -818,7 +818,7 @@ public abstract class BaseKeywordResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			keywordResource.putKeywordPermissionHttpResponse(
 				keyword.getId(),
 				new Permission[] {
@@ -1211,7 +1211,7 @@ public abstract class BaseKeywordResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			keywordResource.putSiteKeywordPermissionHttpResponse(
 				keyword.getSiteId(),
 				new Permission[] {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -894,7 +894,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			taxonomyCategoryResource.putTaxonomyCategoryPermissionHttpResponse(
 				taxonomyCategory.getId(),
 				new Permission[] {
@@ -909,7 +909,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			taxonomyCategoryResource.putTaxonomyCategoryPermissionHttpResponse(
-				RandomTestUtil.randomString(),
+				0L,
 				new Permission[] {
 					new Permission() {
 						{

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -620,7 +620,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			taxonomyVocabularyResource.
 				putAssetLibraryTaxonomyVocabularyPermissionHttpResponse(
 					testDepotEntry.getDepotEntryId(),
@@ -1089,7 +1089,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			taxonomyVocabularyResource.
 				putSiteTaxonomyVocabularyPermissionHttpResponse(
 					taxonomyVocabulary.getSiteId(),
@@ -1353,7 +1353,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			taxonomyVocabularyResource.
 				putTaxonomyVocabularyPermissionHttpResponse(
 					taxonomyVocabulary.getId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
@@ -84,9 +84,10 @@ public interface BlogPostingResource {
 			getBlogPostingPermissionsPage(Long blogPostingId, String roleNames)
 		throws Exception;
 
-	public void putBlogPostingPermission(
-			Long blogPostingId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putBlogPostingPermission(
+				Long blogPostingId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public String getBlogPostingRenderedContentByDisplayPageDisplayPageKey(
@@ -110,9 +111,10 @@ public interface BlogPostingResource {
 			getSiteBlogPostingPermissionsPage(Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteBlogPostingPermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteBlogPostingPermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void putSiteBlogPostingSubscribe(Long siteId) throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentStructureResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentStructureResource.java
@@ -61,9 +61,10 @@ public interface ContentStructureResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryContentStructurePermission(
-			Long assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryContentStructurePermission(
+				Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public ContentStructure getContentStructure(Long contentStructureId)
@@ -74,9 +75,10 @@ public interface ContentStructureResource {
 				Long contentStructureId, String roleNames)
 		throws Exception;
 
-	public void putContentStructurePermission(
-			Long contentStructureId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putContentStructurePermission(
+				Long contentStructureId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<ContentStructure> getSiteContentStructuresPage(
@@ -90,9 +92,10 @@ public interface ContentStructureResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteContentStructurePermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteContentStructurePermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
@@ -70,9 +70,10 @@ public interface DocumentFolderResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryDocumentFolderPermission(
-			Long assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryDocumentFolderPermission(
+				Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void deleteDocumentFolder(Long documentFolderId) throws Exception;
@@ -99,9 +100,10 @@ public interface DocumentFolderResource {
 				Long documentFolderId, String roleNames)
 		throws Exception;
 
-	public void putDocumentFolderPermission(
-			Long documentFolderId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putDocumentFolderPermission(
+				Long documentFolderId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void putDocumentFolderSubscribe(Long documentFolderId)
@@ -138,9 +140,10 @@ public interface DocumentFolderResource {
 			getSiteDocumentFolderPermissionsPage(Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteDocumentFolderPermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteDocumentFolderPermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentResource.java
@@ -73,9 +73,10 @@ public interface DocumentResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryDocumentPermission(
-			Long assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryDocumentPermission(
+				Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<Document> getDocumentFolderDocumentsPage(
@@ -124,9 +125,10 @@ public interface DocumentResource {
 			getDocumentPermissionsPage(Long documentId, String roleNames)
 		throws Exception;
 
-	public void putDocumentPermission(
-			Long documentId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putDocumentPermission(
+				Long documentId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public String getDocumentRenderedContentByDisplayPageDisplayPageKey(
@@ -151,9 +153,10 @@ public interface DocumentResource {
 			getSiteDocumentPermissionsPage(Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteDocumentPermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteDocumentPermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseArticleResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseArticleResource.java
@@ -96,9 +96,10 @@ public interface KnowledgeBaseArticleResource {
 				Long knowledgeBaseArticleId, String roleNames)
 		throws Exception;
 
-	public void putKnowledgeBaseArticlePermission(
-			Long knowledgeBaseArticleId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putKnowledgeBaseArticlePermission(
+				Long knowledgeBaseArticleId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void putKnowledgeBaseArticleSubscribe(Long knowledgeBaseArticleId)
@@ -155,9 +156,10 @@ public interface KnowledgeBaseArticleResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteKnowledgeBaseArticlePermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteKnowledgeBaseArticlePermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void putSiteKnowledgeBaseArticleSubscribe(Long siteId)

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseFolderResource.java
@@ -77,9 +77,10 @@ public interface KnowledgeBaseFolderResource {
 				Long knowledgeBaseFolderId, String roleNames)
 		throws Exception;
 
-	public void putKnowledgeBaseFolderPermission(
-			Long knowledgeBaseFolderId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putKnowledgeBaseFolderPermission(
+				Long knowledgeBaseFolderId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<KnowledgeBaseFolder>
@@ -109,9 +110,10 @@ public interface KnowledgeBaseFolderResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteKnowledgeBaseFolderPermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteKnowledgeBaseFolderPermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
@@ -94,9 +94,10 @@ public interface MessageBoardMessageResource {
 				Long messageBoardMessageId, String roleNames)
 		throws Exception;
 
-	public void putMessageBoardMessagePermission(
-			Long messageBoardMessageId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putMessageBoardMessagePermission(
+				Long messageBoardMessageId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void putMessageBoardMessageSubscribe(Long messageBoardMessageId)
@@ -163,9 +164,10 @@ public interface MessageBoardMessageResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteMessageBoardMessagePermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteMessageBoardMessagePermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardSectionResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardSectionResource.java
@@ -79,9 +79,10 @@ public interface MessageBoardSectionResource {
 				Long messageBoardSectionId, String roleNames)
 		throws Exception;
 
-	public void putMessageBoardSectionPermission(
-			Long messageBoardSectionId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putMessageBoardSectionPermission(
+				Long messageBoardSectionId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void putMessageBoardSectionSubscribe(Long messageBoardSectionId)
@@ -121,9 +122,10 @@ public interface MessageBoardSectionResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteMessageBoardSectionPermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteMessageBoardSectionPermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardThreadResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardThreadResource.java
@@ -114,9 +114,10 @@ public interface MessageBoardThreadResource {
 				Long messageBoardThreadId, String roleNames)
 		throws Exception;
 
-	public void putMessageBoardThreadPermission(
-			Long messageBoardThreadId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putMessageBoardThreadPermission(
+				Long messageBoardThreadId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void putMessageBoardThreadSubscribe(Long messageBoardThreadId)
@@ -148,9 +149,10 @@ public interface MessageBoardThreadResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteMessageBoardThreadPermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteMessageBoardThreadPermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/NavigationMenuResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/NavigationMenuResource.java
@@ -69,9 +69,10 @@ public interface NavigationMenuResource {
 				Long navigationMenuId, String roleNames)
 		throws Exception;
 
-	public void putNavigationMenuPermission(
-			Long navigationMenuId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putNavigationMenuPermission(
+				Long navigationMenuId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<NavigationMenu> getSiteNavigationMenusPage(
@@ -90,9 +91,10 @@ public interface NavigationMenuResource {
 			getSiteNavigationMenuPermissionsPage(Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteNavigationMenuPermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteNavigationMenuPermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentFolderResource.java
@@ -72,9 +72,10 @@ public interface StructuredContentFolderResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryStructuredContentFolderPermission(
-			Long assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryStructuredContentFolderPermission(
+				Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<StructuredContentFolder> getSiteStructuredContentFoldersPage(
@@ -96,9 +97,10 @@ public interface StructuredContentFolderResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteStructuredContentFolderPermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteStructuredContentFolderPermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
@@ -106,9 +108,10 @@ public interface StructuredContentFolderResource {
 				Long structuredContentFolderId, String roleNames)
 		throws Exception;
 
-	public void putStructuredContentFolderPermission(
-			Long structuredContentFolderId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putStructuredContentFolderPermission(
+				Long structuredContentFolderId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<StructuredContentFolder>

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentResource.java
@@ -71,9 +71,10 @@ public interface StructuredContentResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryStructuredContentPermission(
-			Long assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryStructuredContentPermission(
+				Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<StructuredContent> getContentStructureStructuredContentsPage(
@@ -109,9 +110,10 @@ public interface StructuredContentResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteStructuredContentPermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteStructuredContentPermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<StructuredContent>
@@ -169,9 +171,10 @@ public interface StructuredContentResource {
 				Long structuredContentId, String roleNames)
 		throws Exception;
 
-	public void putStructuredContentPermission(
-			Long structuredContentId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putStructuredContentPermission(
+				Long structuredContentId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public String

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiNodeResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiNodeResource.java
@@ -68,9 +68,10 @@ public interface WikiNodeResource {
 			getSiteWikiNodePermissionsPage(Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteWikiNodePermission(
-			Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteWikiNodePermission(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void deleteWikiNode(Long wikiNodeId) throws Exception;
@@ -90,9 +91,10 @@ public interface WikiNodeResource {
 			getWikiNodePermissionsPage(Long wikiNodeId, String roleNames)
 		throws Exception;
 
-	public void putWikiNodePermission(
-			Long wikiNodeId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putWikiNodePermission(
+				Long wikiNodeId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void putWikiNodeSubscribe(Long wikiNodeId) throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageResource.java
@@ -88,9 +88,10 @@ public interface WikiPageResource {
 			getWikiPagePermissionsPage(Long wikiPageId, String roleNames)
 		throws Exception;
 
-	public void putWikiPagePermission(
-			Long wikiPageId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putWikiPagePermission(
+				Long wikiPageId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void putWikiPageSubscribe(Long wikiPageId) throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingResource.java
@@ -122,7 +122,7 @@ public interface BlogPostingResource {
 			Long blogPostingId, String roleNames)
 		throws Exception;
 
-	public void putBlogPostingPermission(
+	public Page<Permission> putBlogPostingPermission(
 			Long blogPostingId, Permission[] permissions)
 		throws Exception;
 
@@ -173,7 +173,7 @@ public interface BlogPostingResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteBlogPostingPermission(
+	public Page<Permission> putSiteBlogPostingPermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -1154,7 +1154,7 @@ public interface BlogPostingResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putBlogPostingPermission(
+		public Page<Permission> putBlogPostingPermission(
 				Long blogPostingId, Permission[] permissions)
 			throws Exception {
 
@@ -1188,7 +1188,7 @@ public interface BlogPostingResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1688,7 +1688,7 @@ public interface BlogPostingResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteBlogPostingPermission(
+		public Page<Permission> putSiteBlogPostingPermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -1721,7 +1721,7 @@ public interface BlogPostingResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentStructureResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentStructureResource.java
@@ -64,7 +64,7 @@ public interface ContentStructureResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryContentStructurePermission(
+	public Page<Permission> putAssetLibraryContentStructurePermission(
 			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -89,7 +89,7 @@ public interface ContentStructureResource {
 				Long contentStructureId, String roleNames)
 		throws Exception;
 
-	public void putContentStructurePermission(
+	public Page<Permission> putContentStructurePermission(
 			Long contentStructureId, Permission[] permissions)
 		throws Exception;
 
@@ -116,7 +116,7 @@ public interface ContentStructureResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteContentStructurePermission(
+	public Page<Permission> putSiteContentStructurePermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -392,7 +392,7 @@ public interface ContentStructureResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putAssetLibraryContentStructurePermission(
+		public Page<Permission> putAssetLibraryContentStructurePermission(
 				Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
@@ -426,7 +426,7 @@ public interface ContentStructureResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -655,7 +655,7 @@ public interface ContentStructureResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putContentStructurePermission(
+		public Page<Permission> putContentStructurePermission(
 				Long contentStructureId, Permission[] permissions)
 			throws Exception {
 
@@ -689,7 +689,7 @@ public interface ContentStructureResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -944,7 +944,7 @@ public interface ContentStructureResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteContentStructurePermission(
+		public Page<Permission> putSiteContentStructurePermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -978,7 +978,7 @@ public interface ContentStructureResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentFolderResource.java
@@ -83,7 +83,7 @@ public interface DocumentFolderResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryDocumentFolderPermission(
+	public Page<Permission> putAssetLibraryDocumentFolderPermission(
 			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -144,7 +144,7 @@ public interface DocumentFolderResource {
 				Long documentFolderId, String roleNames)
 		throws Exception;
 
-	public void putDocumentFolderPermission(
+	public Page<Permission> putDocumentFolderPermission(
 			Long documentFolderId, Permission[] permissions)
 		throws Exception;
 
@@ -225,7 +225,7 @@ public interface DocumentFolderResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteDocumentFolderPermission(
+	public Page<Permission> putSiteDocumentFolderPermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -671,7 +671,7 @@ public interface DocumentFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putAssetLibraryDocumentFolderPermission(
+		public Page<Permission> putAssetLibraryDocumentFolderPermission(
 				Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
@@ -705,7 +705,7 @@ public interface DocumentFolderResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1332,7 +1332,7 @@ public interface DocumentFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putDocumentFolderPermission(
+		public Page<Permission> putDocumentFolderPermission(
 				Long documentFolderId, Permission[] permissions)
 			throws Exception {
 
@@ -1366,7 +1366,7 @@ public interface DocumentFolderResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -2151,7 +2151,7 @@ public interface DocumentFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteDocumentFolderPermission(
+		public Page<Permission> putSiteDocumentFolderPermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -2185,7 +2185,7 @@ public interface DocumentFolderResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentResource.java
@@ -89,7 +89,7 @@ public interface DocumentResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryDocumentPermission(
+	public Page<Permission> putAssetLibraryDocumentPermission(
 			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -211,7 +211,8 @@ public interface DocumentResource {
 			Long documentId, String roleNames)
 		throws Exception;
 
-	public void putDocumentPermission(Long documentId, Permission[] permissions)
+	public Page<Permission> putDocumentPermission(
+			Long documentId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse putDocumentPermissionHttpResponse(
@@ -265,7 +266,8 @@ public interface DocumentResource {
 			Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteDocumentPermission(Long siteId, Permission[] permissions)
+	public Page<Permission> putSiteDocumentPermission(
+			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse putSiteDocumentPermissionHttpResponse(
@@ -721,7 +723,7 @@ public interface DocumentResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putAssetLibraryDocumentPermission(
+		public Page<Permission> putAssetLibraryDocumentPermission(
 				Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
@@ -755,7 +757,7 @@ public interface DocumentResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -2008,7 +2010,7 @@ public interface DocumentResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putDocumentPermission(
+		public Page<Permission> putDocumentPermission(
 				Long documentId, Permission[] permissions)
 			throws Exception {
 
@@ -2041,7 +2043,7 @@ public interface DocumentResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -2558,7 +2560,7 @@ public interface DocumentResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteDocumentPermission(
+		public Page<Permission> putSiteDocumentPermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -2591,7 +2593,7 @@ public interface DocumentResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseArticleResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseArticleResource.java
@@ -137,7 +137,7 @@ public interface KnowledgeBaseArticleResource {
 				Long knowledgeBaseArticleId, String roleNames)
 		throws Exception;
 
-	public void putKnowledgeBaseArticlePermission(
+	public Page<Permission> putKnowledgeBaseArticlePermission(
 			Long knowledgeBaseArticleId, Permission[] permissions)
 		throws Exception;
 
@@ -260,7 +260,7 @@ public interface KnowledgeBaseArticleResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteKnowledgeBaseArticlePermission(
+	public Page<Permission> putSiteKnowledgeBaseArticlePermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -1275,7 +1275,7 @@ public interface KnowledgeBaseArticleResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putKnowledgeBaseArticlePermission(
+		public Page<Permission> putKnowledgeBaseArticlePermission(
 				Long knowledgeBaseArticleId, Permission[] permissions)
 			throws Exception {
 
@@ -1309,7 +1309,7 @@ public interface KnowledgeBaseArticleResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -2400,7 +2400,7 @@ public interface KnowledgeBaseArticleResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteKnowledgeBaseArticlePermission(
+		public Page<Permission> putSiteKnowledgeBaseArticlePermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -2434,7 +2434,7 @@ public interface KnowledgeBaseArticleResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseFolderResource.java
@@ -98,7 +98,7 @@ public interface KnowledgeBaseFolderResource {
 				Long knowledgeBaseFolderId, String roleNames)
 		throws Exception;
 
-	public void putKnowledgeBaseFolderPermission(
+	public Page<Permission> putKnowledgeBaseFolderPermission(
 			Long knowledgeBaseFolderId, Permission[] permissions)
 		throws Exception;
 
@@ -162,7 +162,7 @@ public interface KnowledgeBaseFolderResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteKnowledgeBaseFolderPermission(
+	public Page<Permission> putSiteKnowledgeBaseFolderPermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -821,7 +821,7 @@ public interface KnowledgeBaseFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putKnowledgeBaseFolderPermission(
+		public Page<Permission> putKnowledgeBaseFolderPermission(
 				Long knowledgeBaseFolderId, Permission[] permissions)
 			throws Exception {
 
@@ -855,7 +855,7 @@ public interface KnowledgeBaseFolderResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1442,7 +1442,7 @@ public interface KnowledgeBaseFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteKnowledgeBaseFolderPermission(
+		public Page<Permission> putSiteKnowledgeBaseFolderPermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -1476,7 +1476,7 @@ public interface KnowledgeBaseFolderResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardMessageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardMessageResource.java
@@ -132,7 +132,7 @@ public interface MessageBoardMessageResource {
 				Long messageBoardMessageId, String roleNames)
 		throws Exception;
 
-	public void putMessageBoardMessagePermission(
+	public Page<Permission> putMessageBoardMessagePermission(
 			Long messageBoardMessageId, Permission[] permissions)
 		throws Exception;
 
@@ -275,7 +275,7 @@ public interface MessageBoardMessageResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteMessageBoardMessagePermission(
+	public Page<Permission> putSiteMessageBoardMessagePermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -1273,7 +1273,7 @@ public interface MessageBoardMessageResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putMessageBoardMessagePermission(
+		public Page<Permission> putMessageBoardMessagePermission(
 				Long messageBoardMessageId, Permission[] permissions)
 			throws Exception {
 
@@ -1307,7 +1307,7 @@ public interface MessageBoardMessageResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -2572,7 +2572,7 @@ public interface MessageBoardMessageResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteMessageBoardMessagePermission(
+		public Page<Permission> putSiteMessageBoardMessagePermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -2606,7 +2606,7 @@ public interface MessageBoardMessageResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardSectionResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardSectionResource.java
@@ -99,7 +99,7 @@ public interface MessageBoardSectionResource {
 				Long messageBoardSectionId, String roleNames)
 		throws Exception;
 
-	public void putMessageBoardSectionPermission(
+	public Page<Permission> putMessageBoardSectionPermission(
 			Long messageBoardSectionId, Permission[] permissions)
 		throws Exception;
 
@@ -186,7 +186,7 @@ public interface MessageBoardSectionResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteMessageBoardSectionPermission(
+	public Page<Permission> putSiteMessageBoardSectionPermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -845,7 +845,7 @@ public interface MessageBoardSectionResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putMessageBoardSectionPermission(
+		public Page<Permission> putMessageBoardSectionPermission(
 				Long messageBoardSectionId, Permission[] permissions)
 			throws Exception {
 
@@ -879,7 +879,7 @@ public interface MessageBoardSectionResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1678,7 +1678,7 @@ public interface MessageBoardSectionResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteMessageBoardSectionPermission(
+		public Page<Permission> putSiteMessageBoardSectionPermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -1712,7 +1712,7 @@ public interface MessageBoardSectionResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardThreadResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardThreadResource.java
@@ -179,7 +179,7 @@ public interface MessageBoardThreadResource {
 				Long messageBoardThreadId, String roleNames)
 		throws Exception;
 
-	public void putMessageBoardThreadPermission(
+	public Page<Permission> putMessageBoardThreadPermission(
 			Long messageBoardThreadId, Permission[] permissions)
 		throws Exception;
 
@@ -248,7 +248,7 @@ public interface MessageBoardThreadResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteMessageBoardThreadPermission(
+	public Page<Permission> putSiteMessageBoardThreadPermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -1638,7 +1638,7 @@ public interface MessageBoardThreadResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putMessageBoardThreadPermission(
+		public Page<Permission> putMessageBoardThreadPermission(
 				Long messageBoardThreadId, Permission[] permissions)
 			throws Exception {
 
@@ -1672,7 +1672,7 @@ public interface MessageBoardThreadResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -2354,7 +2354,7 @@ public interface MessageBoardThreadResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteMessageBoardThreadPermission(
+		public Page<Permission> putSiteMessageBoardThreadPermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -2388,7 +2388,7 @@ public interface MessageBoardThreadResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/NavigationMenuResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/NavigationMenuResource.java
@@ -87,7 +87,7 @@ public interface NavigationMenuResource {
 				Long navigationMenuId, String roleNames)
 		throws Exception;
 
-	public void putNavigationMenuPermission(
+	public Page<Permission> putNavigationMenuPermission(
 			Long navigationMenuId, Permission[] permissions)
 		throws Exception;
 
@@ -128,7 +128,7 @@ public interface NavigationMenuResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteNavigationMenuPermission(
+	public Page<Permission> putSiteNavigationMenuPermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -690,7 +690,7 @@ public interface NavigationMenuResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putNavigationMenuPermission(
+		public Page<Permission> putNavigationMenuPermission(
 				Long navigationMenuId, Permission[] permissions)
 			throws Exception {
 
@@ -724,7 +724,7 @@ public interface NavigationMenuResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1123,7 +1123,7 @@ public interface NavigationMenuResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteNavigationMenuPermission(
+		public Page<Permission> putSiteNavigationMenuPermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -1157,7 +1157,7 @@ public interface NavigationMenuResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentFolderResource.java
@@ -88,7 +88,7 @@ public interface StructuredContentFolderResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryStructuredContentFolderPermission(
+	public Page<Permission> putAssetLibraryStructuredContentFolderPermission(
 			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -136,7 +136,7 @@ public interface StructuredContentFolderResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteStructuredContentFolderPermission(
+	public Page<Permission> putSiteStructuredContentFolderPermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -154,7 +154,7 @@ public interface StructuredContentFolderResource {
 				Long structuredContentFolderId, String roleNames)
 		throws Exception;
 
-	public void putStructuredContentFolderPermission(
+	public Page<Permission> putStructuredContentFolderPermission(
 			Long structuredContentFolderId, Permission[] permissions)
 		throws Exception;
 
@@ -702,8 +702,9 @@ public interface StructuredContentFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putAssetLibraryStructuredContentFolderPermission(
-				Long assetLibraryId, Permission[] permissions)
+		public Page<Permission>
+				putAssetLibraryStructuredContentFolderPermission(
+					Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
@@ -736,7 +737,7 @@ public interface StructuredContentFolderResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1165,7 +1166,7 @@ public interface StructuredContentFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteStructuredContentFolderPermission(
+		public Page<Permission> putSiteStructuredContentFolderPermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -1199,7 +1200,7 @@ public interface StructuredContentFolderResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1348,7 +1349,7 @@ public interface StructuredContentFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putStructuredContentFolderPermission(
+		public Page<Permission> putStructuredContentFolderPermission(
 				Long structuredContentFolderId, Permission[] permissions)
 			throws Exception {
 
@@ -1382,7 +1383,7 @@ public interface StructuredContentFolderResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentResource.java
@@ -86,7 +86,7 @@ public interface StructuredContentResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public void putAssetLibraryStructuredContentPermission(
+	public Page<Permission> putAssetLibraryStructuredContentPermission(
 			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -160,7 +160,7 @@ public interface StructuredContentResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteStructuredContentPermission(
+	public Page<Permission> putSiteStructuredContentPermission(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -286,7 +286,7 @@ public interface StructuredContentResource {
 				Long structuredContentId, String roleNames)
 		throws Exception;
 
-	public void putStructuredContentPermission(
+	public Page<Permission> putStructuredContentPermission(
 			Long structuredContentId, Permission[] permissions)
 		throws Exception;
 
@@ -765,7 +765,7 @@ public interface StructuredContentResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putAssetLibraryStructuredContentPermission(
+		public Page<Permission> putAssetLibraryStructuredContentPermission(
 				Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
@@ -799,7 +799,7 @@ public interface StructuredContentResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1501,7 +1501,7 @@ public interface StructuredContentResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteStructuredContentPermission(
+		public Page<Permission> putSiteStructuredContentPermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -1535,7 +1535,7 @@ public interface StructuredContentResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -2790,7 +2790,7 @@ public interface StructuredContentResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putStructuredContentPermission(
+		public Page<Permission> putStructuredContentPermission(
 				Long structuredContentId, Permission[] permissions)
 			throws Exception {
 
@@ -2824,7 +2824,7 @@ public interface StructuredContentResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiNodeResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiNodeResource.java
@@ -77,7 +77,8 @@ public interface WikiNodeResource {
 			Long siteId, String roleNames)
 		throws Exception;
 
-	public void putSiteWikiNodePermission(Long siteId, Permission[] permissions)
+	public Page<Permission> putSiteWikiNodePermission(
+			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse putSiteWikiNodePermissionHttpResponse(
@@ -123,7 +124,8 @@ public interface WikiNodeResource {
 			Long wikiNodeId, String roleNames)
 		throws Exception;
 
-	public void putWikiNodePermission(Long wikiNodeId, Permission[] permissions)
+	public Page<Permission> putWikiNodePermission(
+			Long wikiNodeId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse putWikiNodePermissionHttpResponse(
@@ -566,7 +568,7 @@ public interface WikiNodeResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putSiteWikiNodePermission(
+		public Page<Permission> putSiteWikiNodePermission(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -599,7 +601,7 @@ public interface WikiNodeResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(
@@ -1132,7 +1134,7 @@ public interface WikiNodeResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putWikiNodePermission(
+		public Page<Permission> putWikiNodePermission(
 				Long wikiNodeId, Permission[] permissions)
 			throws Exception {
 
@@ -1165,7 +1167,7 @@ public interface WikiNodeResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiPageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiPageResource.java
@@ -123,7 +123,8 @@ public interface WikiPageResource {
 			Long wikiPageId, String roleNames)
 		throws Exception;
 
-	public void putWikiPagePermission(Long wikiPageId, Permission[] permissions)
+	public Page<Permission> putWikiPagePermission(
+			Long wikiPageId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse putWikiPagePermissionHttpResponse(
@@ -1119,7 +1120,7 @@ public interface WikiPageResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putWikiPagePermission(
+		public Page<Permission> putWikiPagePermission(
 				Long wikiPageId, Permission[] permissions)
 			throws Exception {
 
@@ -1152,7 +1153,7 @@ public interface WikiPageResource {
 			}
 
 			try {
-				return;
+				return Page.of(content, Permission::toDTO);
 			}
 			catch (Exception e) {
 				_logger.log(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -61,6 +61,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
+import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.function.BiFunction;
 
@@ -356,19 +357,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateBlogPostingPermission(
-			@GraphQLName("blogPostingId") Long blogPostingId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateBlogPostingPermission(
+				@GraphQLName("blogPostingId") Long blogPostingId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			blogPostingResource -> blogPostingResource.putBlogPostingPermission(
-				blogPostingId, permissions));
+			blogPostingResource -> {
+				Page paginationPage =
+					blogPostingResource.putBlogPostingPermission(
+						blogPostingId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(description = "Creates a new blog post.")
@@ -399,20 +405,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteBlogPostingPermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteBlogPostingPermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			blogPostingResource ->
-				blogPostingResource.putSiteBlogPostingPermission(
-					Long.valueOf(siteKey), permissions));
+			blogPostingResource -> {
+				Page paginationPage =
+					blogPostingResource.putSiteBlogPostingPermission(
+						Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -664,55 +674,67 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateAssetLibraryContentStructurePermission(
-			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateAssetLibraryContentStructurePermission(
+				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_contentStructureResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			contentStructureResource ->
-				contentStructureResource.
-					putAssetLibraryContentStructurePermission(
-						Long.valueOf(assetLibraryId), permissions));
+			contentStructureResource -> {
+				Page paginationPage =
+					contentStructureResource.
+						putAssetLibraryContentStructurePermission(
+							Long.valueOf(assetLibraryId), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
-	public boolean updateContentStructurePermission(
-			@GraphQLName("contentStructureId") Long contentStructureId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateContentStructurePermission(
+				@GraphQLName("contentStructureId") Long contentStructureId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_contentStructureResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			contentStructureResource ->
-				contentStructureResource.putContentStructurePermission(
-					contentStructureId, permissions));
+			contentStructureResource -> {
+				Page paginationPage =
+					contentStructureResource.putContentStructurePermission(
+						contentStructureId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
-	public boolean updateSiteContentStructurePermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteContentStructurePermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_contentStructureResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			contentStructureResource ->
-				contentStructureResource.putSiteContentStructurePermission(
-					Long.valueOf(siteKey), permissions));
+			contentStructureResource -> {
+				Page paginationPage =
+					contentStructureResource.putSiteContentStructurePermission(
+						Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -749,20 +771,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateAssetLibraryDocumentPermission(
-			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateAssetLibraryDocumentPermission(
+				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			documentResource ->
-				documentResource.putAssetLibraryDocumentPermission(
-					Long.valueOf(assetLibraryId), permissions));
+			documentResource -> {
+				Page paginationPage =
+					documentResource.putAssetLibraryDocumentPermission(
+						Long.valueOf(assetLibraryId), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -926,19 +952,23 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateDocumentPermission(
-			@GraphQLName("documentId") Long documentId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateDocumentPermission(
+				@GraphQLName("documentId") Long documentId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			documentResource -> documentResource.putDocumentPermission(
-				documentId, permissions));
+			documentResource -> {
+				Page paginationPage = documentResource.putDocumentPermission(
+					documentId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -976,19 +1006,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteDocumentPermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteDocumentPermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			documentResource -> documentResource.putSiteDocumentPermission(
-				Long.valueOf(siteKey), permissions));
+			documentResource -> {
+				Page paginationPage =
+					documentResource.putSiteDocumentPermission(
+						Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -1021,20 +1056,25 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateAssetLibraryDocumentFolderPermission(
-			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateAssetLibraryDocumentFolderPermission(
+				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			documentFolderResource ->
-				documentFolderResource.putAssetLibraryDocumentFolderPermission(
-					Long.valueOf(assetLibraryId), permissions));
+			documentFolderResource -> {
+				Page paginationPage =
+					documentFolderResource.
+						putAssetLibraryDocumentFolderPermission(
+							Long.valueOf(assetLibraryId), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -1113,20 +1153,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateDocumentFolderPermission(
-			@GraphQLName("documentFolderId") Long documentFolderId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateDocumentFolderPermission(
+				@GraphQLName("documentFolderId") Long documentFolderId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			documentFolderResource ->
-				documentFolderResource.putDocumentFolderPermission(
-					documentFolderId, permissions));
+			documentFolderResource -> {
+				Page paginationPage =
+					documentFolderResource.putDocumentFolderPermission(
+						documentFolderId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -1205,20 +1249,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteDocumentFolderPermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteDocumentFolderPermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			documentFolderResource ->
-				documentFolderResource.putSiteDocumentFolderPermission(
-					Long.valueOf(siteKey), permissions));
+			documentFolderResource -> {
+				Page paginationPage =
+					documentFolderResource.putSiteDocumentFolderPermission(
+						Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -1350,20 +1398,26 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateKnowledgeBaseArticlePermission(
-			@GraphQLName("knowledgeBaseArticleId") Long knowledgeBaseArticleId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateKnowledgeBaseArticlePermission(
+				@GraphQLName("knowledgeBaseArticleId") Long
+					knowledgeBaseArticleId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			knowledgeBaseArticleResource ->
-				knowledgeBaseArticleResource.putKnowledgeBaseArticlePermission(
-					knowledgeBaseArticleId, permissions));
+			knowledgeBaseArticleResource -> {
+				Page paginationPage =
+					knowledgeBaseArticleResource.
+						putKnowledgeBaseArticlePermission(
+							knowledgeBaseArticleId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -1480,21 +1534,25 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteKnowledgeBaseArticlePermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteKnowledgeBaseArticlePermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			knowledgeBaseArticleResource ->
-				knowledgeBaseArticleResource.
-					putSiteKnowledgeBaseArticlePermission(
-						Long.valueOf(siteKey), permissions));
+			knowledgeBaseArticleResource -> {
+				Page paginationPage =
+					knowledgeBaseArticleResource.
+						putSiteKnowledgeBaseArticlePermission(
+							Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -1682,20 +1740,26 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateKnowledgeBaseFolderPermission(
-			@GraphQLName("knowledgeBaseFolderId") Long knowledgeBaseFolderId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateKnowledgeBaseFolderPermission(
+				@GraphQLName("knowledgeBaseFolderId") Long
+					knowledgeBaseFolderId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			knowledgeBaseFolderResource ->
-				knowledgeBaseFolderResource.putKnowledgeBaseFolderPermission(
-					knowledgeBaseFolderId, permissions));
+			knowledgeBaseFolderResource -> {
+				Page paginationPage =
+					knowledgeBaseFolderResource.
+						putKnowledgeBaseFolderPermission(
+							knowledgeBaseFolderId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -1748,21 +1812,25 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteKnowledgeBaseFolderPermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteKnowledgeBaseFolderPermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			knowledgeBaseFolderResource ->
-				knowledgeBaseFolderResource.
-					putSiteKnowledgeBaseFolderPermission(
-						Long.valueOf(siteKey), permissions));
+			knowledgeBaseFolderResource -> {
+				Page paginationPage =
+					knowledgeBaseFolderResource.
+						putSiteKnowledgeBaseFolderPermission(
+							Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -2007,20 +2075,26 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateMessageBoardMessagePermission(
-			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateMessageBoardMessagePermission(
+				@GraphQLName("messageBoardMessageId") Long
+					messageBoardMessageId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardMessageResource ->
-				messageBoardMessageResource.putMessageBoardMessagePermission(
-					messageBoardMessageId, permissions));
+			messageBoardMessageResource -> {
+				Page paginationPage =
+					messageBoardMessageResource.
+						putMessageBoardMessagePermission(
+							messageBoardMessageId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -2148,21 +2222,25 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteMessageBoardMessagePermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteMessageBoardMessagePermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardMessageResource ->
-				messageBoardMessageResource.
-					putSiteMessageBoardMessagePermission(
-						Long.valueOf(siteKey), permissions));
+			messageBoardMessageResource -> {
+				Page paginationPage =
+					messageBoardMessageResource.
+						putSiteMessageBoardMessagePermission(
+							Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -2245,20 +2323,26 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateMessageBoardSectionPermission(
-			@GraphQLName("messageBoardSectionId") Long messageBoardSectionId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateMessageBoardSectionPermission(
+				@GraphQLName("messageBoardSectionId") Long
+					messageBoardSectionId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardSectionResource ->
-				messageBoardSectionResource.putMessageBoardSectionPermission(
-					messageBoardSectionId, permissions));
+			messageBoardSectionResource -> {
+				Page paginationPage =
+					messageBoardSectionResource.
+						putMessageBoardSectionPermission(
+							messageBoardSectionId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -2341,21 +2425,25 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteMessageBoardSectionPermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteMessageBoardSectionPermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardSectionResource ->
-				messageBoardSectionResource.
-					putSiteMessageBoardSectionPermission(
-						Long.valueOf(siteKey), permissions));
+			messageBoardSectionResource -> {
+				Page paginationPage =
+					messageBoardSectionResource.
+						putSiteMessageBoardSectionPermission(
+							Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -2519,20 +2607,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateMessageBoardThreadPermission(
-			@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateMessageBoardThreadPermission(
+				@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardThreadResource ->
-				messageBoardThreadResource.putMessageBoardThreadPermission(
-					messageBoardThreadId, permissions));
+			messageBoardThreadResource -> {
+				Page paginationPage =
+					messageBoardThreadResource.putMessageBoardThreadPermission(
+						messageBoardThreadId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -2596,20 +2688,25 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteMessageBoardThreadPermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteMessageBoardThreadPermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardThreadResource ->
-				messageBoardThreadResource.putSiteMessageBoardThreadPermission(
-					Long.valueOf(siteKey), permissions));
+			messageBoardThreadResource -> {
+				Page paginationPage =
+					messageBoardThreadResource.
+						putSiteMessageBoardThreadPermission(
+							Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -2672,20 +2769,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateNavigationMenuPermission(
-			@GraphQLName("navigationMenuId") Long navigationMenuId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateNavigationMenuPermission(
+				@GraphQLName("navigationMenuId") Long navigationMenuId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_navigationMenuResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			navigationMenuResource ->
-				navigationMenuResource.putNavigationMenuPermission(
-					navigationMenuId, permissions));
+			navigationMenuResource -> {
+				Page paginationPage =
+					navigationMenuResource.putNavigationMenuPermission(
+						navigationMenuId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(description = "Creates a new navigation menu.")
@@ -2718,20 +2819,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteNavigationMenuPermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteNavigationMenuPermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_navigationMenuResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			navigationMenuResource ->
-				navigationMenuResource.putSiteNavigationMenuPermission(
-					Long.valueOf(siteKey), permissions));
+			navigationMenuResource -> {
+				Page paginationPage =
+					navigationMenuResource.putSiteNavigationMenuPermission(
+						Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -2766,21 +2871,25 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateAssetLibraryStructuredContentPermission(
-			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateAssetLibraryStructuredContentPermission(
+				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			structuredContentResource ->
-				structuredContentResource.
-					putAssetLibraryStructuredContentPermission(
-						Long.valueOf(assetLibraryId), permissions));
+			structuredContentResource -> {
+				Page paginationPage =
+					structuredContentResource.
+						putAssetLibraryStructuredContentPermission(
+							Long.valueOf(assetLibraryId), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(description = "Creates a new structured content.")
@@ -2814,20 +2923,25 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteStructuredContentPermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteStructuredContentPermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			structuredContentResource ->
-				structuredContentResource.putSiteStructuredContentPermission(
-					Long.valueOf(siteKey), permissions));
+			structuredContentResource -> {
+				Page paginationPage =
+					structuredContentResource.
+						putSiteStructuredContentPermission(
+							Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -2993,20 +3107,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateStructuredContentPermission(
-			@GraphQLName("structuredContentId") Long structuredContentId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateStructuredContentPermission(
+				@GraphQLName("structuredContentId") Long structuredContentId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			structuredContentResource ->
-				structuredContentResource.putStructuredContentPermission(
-					structuredContentId, permissions));
+			structuredContentResource -> {
+				Page paginationPage =
+					structuredContentResource.putStructuredContentPermission(
+						structuredContentId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -3072,21 +3190,25 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateAssetLibraryStructuredContentFolderPermission(
-			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateAssetLibraryStructuredContentFolderPermission(
+				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			structuredContentFolderResource ->
-				structuredContentFolderResource.
-					putAssetLibraryStructuredContentFolderPermission(
-						Long.valueOf(assetLibraryId), permissions));
+			structuredContentFolderResource -> {
+				Page paginationPage =
+					structuredContentFolderResource.
+						putAssetLibraryStructuredContentFolderPermission(
+							Long.valueOf(assetLibraryId), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(description = "Creates a new structured content folder.")
@@ -3121,40 +3243,48 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteStructuredContentFolderPermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteStructuredContentFolderPermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			structuredContentFolderResource ->
-				structuredContentFolderResource.
-					putSiteStructuredContentFolderPermission(
-						Long.valueOf(siteKey), permissions));
+			structuredContentFolderResource -> {
+				Page paginationPage =
+					structuredContentFolderResource.
+						putSiteStructuredContentFolderPermission(
+							Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
-	public boolean updateStructuredContentFolderPermission(
-			@GraphQLName("structuredContentFolderId") Long
-				structuredContentFolderId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateStructuredContentFolderPermission(
+				@GraphQLName("structuredContentFolderId") Long
+					structuredContentFolderId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			structuredContentFolderResource ->
-				structuredContentFolderResource.
-					putStructuredContentFolderPermission(
-						structuredContentFolderId, permissions));
+			structuredContentFolderResource -> {
+				Page paginationPage =
+					structuredContentFolderResource.
+						putStructuredContentFolderPermission(
+							structuredContentFolderId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -3322,19 +3452,24 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateSiteWikiNodePermission(
-			@GraphQLName("siteKey") @NotEmpty String siteKey,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteWikiNodePermission(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_wikiNodeResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			wikiNodeResource -> wikiNodeResource.putSiteWikiNodePermission(
-				Long.valueOf(siteKey), permissions));
+			wikiNodeResource -> {
+				Page paginationPage =
+					wikiNodeResource.putSiteWikiNodePermission(
+						Long.valueOf(siteKey), permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -3393,19 +3528,23 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateWikiNodePermission(
-			@GraphQLName("wikiNodeId") Long wikiNodeId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateWikiNodePermission(
+				@GraphQLName("wikiNodeId") Long wikiNodeId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_wikiNodeResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			wikiNodeResource -> wikiNodeResource.putWikiNodePermission(
-				wikiNodeId, permissions));
+			wikiNodeResource -> {
+				Page paginationPage = wikiNodeResource.putWikiNodePermission(
+					wikiNodeId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField
@@ -3534,19 +3673,23 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean updateWikiPagePermission(
-			@GraphQLName("wikiPageId") Long wikiPageId,
-			@GraphQLName("permissions")
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateWikiPagePermission(
+				@GraphQLName("wikiPageId") Long wikiPageId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
-		_applyVoidComponentServiceObjects(
+		return _applyComponentServiceObjects(
 			_wikiPageResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			wikiPageResource -> wikiPageResource.putWikiPagePermission(
-				wikiPageId, permissions));
+			wikiPageResource -> {
+				Page paginationPage = wikiPageResource.putWikiPagePermission(
+					wikiPageId, permissions);
 
-		return true;
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -476,10 +476,11 @@ public abstract class BaseBlogPostingResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "BlogPosting")})
-	public void putBlogPostingPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("blogPostingId") Long
-				blogPostingId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putBlogPostingPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("blogPostingId")
+					Long blogPostingId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(blogPostingId);
@@ -490,12 +491,15 @@ public abstract class BaseBlogPostingResourceImpl
 			getPermissionCheckerGroupId(blogPostingId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(blogPostingId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**
@@ -667,9 +671,11 @@ public abstract class BaseBlogPostingResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "BlogPosting")})
-	public void putSiteBlogPostingPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteBlogPostingPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -685,6 +691,8 @@ public abstract class BaseBlogPostingResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -165,10 +165,11 @@ public abstract class BaseContentStructureResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "ContentStructure")})
-	public void putAssetLibraryContentStructurePermission(
-			@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId") Long
-				assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryContentStructurePermission(
+				@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId")
+					Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -184,6 +185,8 @@ public abstract class BaseContentStructureResourceImpl
 				contextCompany.getCompanyId(), permissions, assetLibraryId,
 				portletName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(assetLibraryId, portletName, null);
 	}
 
 	/**
@@ -257,10 +260,12 @@ public abstract class BaseContentStructureResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "ContentStructure")})
-	public void putContentStructurePermission(
-			@NotNull @Parameter(hidden = true) @PathParam("contentStructureId")
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putContentStructurePermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("contentStructureId")
 				Long contentStructureId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -272,12 +277,15 @@ public abstract class BaseContentStructureResourceImpl
 			getPermissionCheckerGroupId(contentStructureId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(contentStructureId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**
@@ -359,9 +367,11 @@ public abstract class BaseContentStructureResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "ContentStructure")})
-	public void putSiteContentStructurePermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteContentStructurePermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -377,6 +387,8 @@ public abstract class BaseContentStructureResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -236,10 +236,11 @@ public abstract class BaseDocumentFolderResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "DocumentFolder")})
-	public void putAssetLibraryDocumentFolderPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId") Long
-				assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryDocumentFolderPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId")
+					Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -255,6 +256,8 @@ public abstract class BaseDocumentFolderResourceImpl
 				contextCompany.getCompanyId(), permissions, assetLibraryId,
 				portletName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(assetLibraryId, portletName, null);
 	}
 
 	/**
@@ -536,10 +539,12 @@ public abstract class BaseDocumentFolderResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "DocumentFolder")})
-	public void putDocumentFolderPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("documentFolderId")
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putDocumentFolderPermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("documentFolderId")
 				Long documentFolderId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -551,12 +556,15 @@ public abstract class BaseDocumentFolderResourceImpl
 			getPermissionCheckerGroupId(documentFolderId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(documentFolderId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**
@@ -807,9 +815,11 @@ public abstract class BaseDocumentFolderResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "DocumentFolder")})
-	public void putSiteDocumentFolderPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteDocumentFolderPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -825,6 +835,8 @@ public abstract class BaseDocumentFolderResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -240,10 +240,11 @@ public abstract class BaseDocumentResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "Document")})
-	public void putAssetLibraryDocumentPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId") Long
-				assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryDocumentPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId")
+					Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -259,6 +260,8 @@ public abstract class BaseDocumentResourceImpl
 				contextCompany.getCompanyId(), permissions, assetLibraryId,
 				portletName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(assetLibraryId, portletName, null);
 	}
 
 	/**
@@ -679,10 +682,11 @@ public abstract class BaseDocumentResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "Document")})
-	public void putDocumentPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("documentId") Long
-				documentId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putDocumentPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("documentId") Long
+					documentId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(documentId);
@@ -693,12 +697,15 @@ public abstract class BaseDocumentResourceImpl
 			getPermissionCheckerGroupId(documentId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(documentId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**
@@ -875,9 +882,11 @@ public abstract class BaseDocumentResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "Document")})
-	public void putSiteDocumentPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteDocumentPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -893,6 +902,8 @@ public abstract class BaseDocumentResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -516,11 +516,12 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "KnowledgeBaseArticle")})
-	public void putKnowledgeBaseArticlePermission(
-			@NotNull @Parameter(hidden = true)
-			@PathParam("knowledgeBaseArticleId")
-			Long knowledgeBaseArticleId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putKnowledgeBaseArticlePermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("knowledgeBaseArticleId")
+				Long knowledgeBaseArticleId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -533,12 +534,15 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			getPermissionCheckerGroupId(knowledgeBaseArticleId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(knowledgeBaseArticleId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**
@@ -923,9 +927,11 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "KnowledgeBaseArticle")})
-	public void putSiteKnowledgeBaseArticlePermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteKnowledgeBaseArticlePermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -941,6 +947,8 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -377,11 +377,12 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "KnowledgeBaseFolder")})
-	public void putKnowledgeBaseFolderPermission(
-			@NotNull @Parameter(hidden = true)
-			@PathParam("knowledgeBaseFolderId")
-			Long knowledgeBaseFolderId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putKnowledgeBaseFolderPermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("knowledgeBaseFolderId")
+				Long knowledgeBaseFolderId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -393,12 +394,15 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			getPermissionCheckerGroupId(knowledgeBaseFolderId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(knowledgeBaseFolderId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**
@@ -602,9 +606,11 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "KnowledgeBaseFolder")})
-	public void putSiteKnowledgeBaseFolderPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteKnowledgeBaseFolderPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -620,6 +626,8 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -530,11 +530,12 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "MessageBoardMessage")})
-	public void putMessageBoardMessagePermission(
-			@NotNull @Parameter(hidden = true)
-			@PathParam("messageBoardMessageId")
-			Long messageBoardMessageId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putMessageBoardMessagePermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("messageBoardMessageId")
+				Long messageBoardMessageId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -546,12 +547,15 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			getPermissionCheckerGroupId(messageBoardMessageId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(messageBoardMessageId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**
@@ -994,9 +998,11 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "MessageBoardMessage")})
-	public void putSiteMessageBoardMessagePermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteMessageBoardMessagePermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1012,6 +1018,8 @@ public abstract class BaseMessageBoardMessageResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -383,11 +383,12 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "MessageBoardSection")})
-	public void putMessageBoardSectionPermission(
-			@NotNull @Parameter(hidden = true)
-			@PathParam("messageBoardSectionId")
-			Long messageBoardSectionId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putMessageBoardSectionPermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("messageBoardSectionId")
+				Long messageBoardSectionId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -399,12 +400,15 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			getPermissionCheckerGroupId(messageBoardSectionId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(messageBoardSectionId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**
@@ -668,9 +672,11 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "MessageBoardSection")})
-	public void putSiteMessageBoardSectionPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteMessageBoardSectionPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -686,6 +692,8 @@ public abstract class BaseMessageBoardSectionResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -687,11 +687,12 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "MessageBoardThread")})
-	public void putMessageBoardThreadPermission(
-			@NotNull @Parameter(hidden = true)
-			@PathParam("messageBoardThreadId")
-			Long messageBoardThreadId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putMessageBoardThreadPermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("messageBoardThreadId")
+				Long messageBoardThreadId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -703,12 +704,15 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			getPermissionCheckerGroupId(messageBoardThreadId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(messageBoardThreadId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**
@@ -924,9 +928,11 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "MessageBoardThread")})
-	public void putSiteMessageBoardThreadPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteMessageBoardThreadPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -942,6 +948,8 @@ public abstract class BaseMessageBoardThreadResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -281,10 +281,12 @@ public abstract class BaseNavigationMenuResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "NavigationMenu")})
-	public void putNavigationMenuPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("navigationMenuId")
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putNavigationMenuPermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("navigationMenuId")
 				Long navigationMenuId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -296,12 +298,15 @@ public abstract class BaseNavigationMenuResourceImpl
 			getPermissionCheckerGroupId(navigationMenuId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(navigationMenuId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**
@@ -435,9 +440,11 @@ public abstract class BaseNavigationMenuResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "NavigationMenu")})
-	public void putSiteNavigationMenuPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteNavigationMenuPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -453,6 +460,8 @@ public abstract class BaseNavigationMenuResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -243,10 +243,11 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "StructuredContentFolder")})
-	public void putAssetLibraryStructuredContentFolderPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId") Long
-				assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryStructuredContentFolderPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId")
+					Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -262,6 +263,8 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				contextCompany.getCompanyId(), permissions, assetLibraryId,
 				portletName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(assetLibraryId, portletName, null);
 	}
 
 	/**
@@ -407,9 +410,11 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "StructuredContentFolder")})
-	public void putSiteStructuredContentFolderPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteStructuredContentFolderPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -425,6 +430,8 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	/**
@@ -483,11 +490,12 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "StructuredContentFolder")})
-	public void putStructuredContentFolderPermission(
-			@NotNull @Parameter(hidden = true)
-			@PathParam("structuredContentFolderId")
-			Long structuredContentFolderId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putStructuredContentFolderPermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("structuredContentFolderId")
+				Long structuredContentFolderId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -500,12 +508,15 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			getPermissionCheckerGroupId(structuredContentFolderId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
-			String.valueOf(resourceId),
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(structuredContentFolderId),
+			resourceName, String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -238,10 +238,11 @@ public abstract class BaseStructuredContentResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "StructuredContent")})
-	public void putAssetLibraryStructuredContentPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId") Long
-				assetLibraryId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryStructuredContentPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("assetLibraryId")
+					Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -257,6 +258,8 @@ public abstract class BaseStructuredContentResourceImpl
 				contextCompany.getCompanyId(), permissions, assetLibraryId,
 				portletName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(assetLibraryId, portletName, null);
 	}
 
 	/**
@@ -489,9 +492,11 @@ public abstract class BaseStructuredContentResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "StructuredContent")})
-	public void putSiteStructuredContentPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteStructuredContentPermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -507,6 +512,8 @@ public abstract class BaseStructuredContentResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	/**
@@ -1067,10 +1074,12 @@ public abstract class BaseStructuredContentResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "StructuredContent")})
-	public void putStructuredContentPermission(
-			@NotNull @Parameter(hidden = true) @PathParam("structuredContentId")
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putStructuredContentPermission(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("structuredContentId")
 				Long structuredContentId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -1082,12 +1091,15 @@ public abstract class BaseStructuredContentResourceImpl
 			getPermissionCheckerGroupId(structuredContentId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(structuredContentId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -230,9 +230,11 @@ public abstract class BaseWikiNodeResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "WikiNode")})
-	public void putSiteWikiNodePermission(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteWikiNodePermission(
+				@NotNull @Parameter(hidden = true) @PathParam("siteId") Long
+					siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -248,6 +250,8 @@ public abstract class BaseWikiNodeResourceImpl
 				contextCompany.getCompanyId(), permissions, siteId, portletName,
 				resourceActionLocalService, resourcePermissionLocalService,
 				roleLocalService));
+
+		return toPermissionPage(siteId, portletName, null);
 	}
 
 	/**
@@ -439,10 +443,11 @@ public abstract class BaseWikiNodeResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "WikiNode")})
-	public void putWikiNodePermission(
-			@NotNull @Parameter(hidden = true) @PathParam("wikiNodeId") Long
-				wikiNodeId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putWikiNodePermission(
+				@NotNull @Parameter(hidden = true) @PathParam("wikiNodeId") Long
+					wikiNodeId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(wikiNodeId);
@@ -453,12 +458,15 @@ public abstract class BaseWikiNodeResourceImpl
 			getPermissionCheckerGroupId(wikiNodeId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(wikiNodeId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -428,10 +428,11 @@ public abstract class BaseWikiPageResourceImpl
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "WikiPage")})
-	public void putWikiPagePermission(
-			@NotNull @Parameter(hidden = true) @PathParam("wikiPageId") Long
-				wikiPageId,
-			com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putWikiPagePermission(
+				@NotNull @Parameter(hidden = true) @PathParam("wikiPageId") Long
+					wikiPageId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(wikiPageId);
@@ -442,12 +443,15 @@ public abstract class BaseWikiPageResourceImpl
 			getPermissionCheckerGroupId(wikiPageId));
 
 		resourcePermissionLocalService.updateResourcePermissions(
-			contextCompany.getCompanyId(), 0, resourceName,
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(wikiPageId), resourceName,
 			String.valueOf(resourceId),
 			ModelPermissionsUtil.toModelPermissions(
 				contextCompany.getCompanyId(), permissions, resourceId,
 				resourceName, resourceActionLocalService,
 				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(resourceId, resourceName, null);
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -437,7 +437,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			blogPostingResource.putBlogPostingPermissionHttpResponse(
 				blogPosting.getId(),
 				new Permission[] {
@@ -858,7 +858,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			blogPostingResource.putSiteBlogPostingPermissionHttpResponse(
 				blogPosting.getSiteId(),
 				new Permission[] {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -581,7 +581,7 @@ public abstract class BaseContentStructureResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			contentStructureResource.
 				putAssetLibraryContentStructurePermissionHttpResponse(
 					testDepotEntry.getDepotEntryId(),
@@ -713,7 +713,7 @@ public abstract class BaseContentStructureResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			contentStructureResource.putContentStructurePermissionHttpResponse(
 				contentStructure.getId(),
 				new Permission[] {
@@ -1134,7 +1134,7 @@ public abstract class BaseContentStructureResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			contentStructureResource.
 				putSiteContentStructurePermissionHttpResponse(
 					contentStructure.getSiteId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -606,7 +606,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			documentFolderResource.
 				putAssetLibraryDocumentFolderPermissionHttpResponse(
 					testDepotEntry.getDepotEntryId(),
@@ -857,7 +857,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			documentFolderResource.putDocumentFolderPermissionHttpResponse(
 				documentFolder.getId(),
 				new Permission[] {
@@ -1710,7 +1710,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			documentFolderResource.putSiteDocumentFolderPermissionHttpResponse(
 				documentFolder.getSiteId(),
 				new Permission[] {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -586,7 +586,7 @@ public abstract class BaseDocumentResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			documentResource.putAssetLibraryDocumentPermissionHttpResponse(
 				testDepotEntry.getDepotEntryId(),
 				new Permission[] {
@@ -1173,7 +1173,7 @@ public abstract class BaseDocumentResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			documentResource.putDocumentPermissionHttpResponse(
 				document.getId(),
 				new Permission[] {
@@ -1579,7 +1579,7 @@ public abstract class BaseDocumentResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			documentResource.putSiteDocumentPermissionHttpResponse(
 				document.getSiteId(),
 				new Permission[] {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -480,7 +480,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			knowledgeBaseArticleResource.
 				putKnowledgeBaseArticlePermissionHttpResponse(
 					knowledgeBaseArticle.getId(),
@@ -1790,7 +1790,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			knowledgeBaseArticleResource.
 				putSiteKnowledgeBaseArticlePermissionHttpResponse(
 					knowledgeBaseArticle.getSiteId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -430,7 +430,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			knowledgeBaseFolderResource.
 				putKnowledgeBaseFolderPermissionHttpResponse(
 					knowledgeBaseFolder.getId(),
@@ -873,7 +873,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			knowledgeBaseFolderResource.
 				putSiteKnowledgeBaseFolderPermissionHttpResponse(
 					knowledgeBaseFolder.getSiteId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -475,7 +475,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			messageBoardMessageResource.
 				putMessageBoardMessagePermissionHttpResponse(
 					messageBoardMessage.getId(),
@@ -1985,7 +1985,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			messageBoardMessageResource.
 				putSiteMessageBoardMessagePermissionHttpResponse(
 					messageBoardMessage.getSiteId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -436,7 +436,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			messageBoardSectionResource.
 				putMessageBoardSectionPermissionHttpResponse(
 					messageBoardSection.getId(),
@@ -1346,7 +1346,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			messageBoardSectionResource.
 				putSiteMessageBoardSectionPermissionHttpResponse(
 					messageBoardSection.getSiteId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -1077,7 +1077,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			messageBoardThreadResource.
 				putMessageBoardThreadPermissionHttpResponse(
 					messageBoardThread.getId(),
@@ -1685,7 +1685,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			messageBoardThreadResource.
 				putSiteMessageBoardThreadPermissionHttpResponse(
 					messageBoardThread.getSiteId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -381,7 +381,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			navigationMenuResource.putNavigationMenuPermissionHttpResponse(
 				navigationMenu.getId(),
 				new Permission[] {
@@ -630,7 +630,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			navigationMenuResource.putSiteNavigationMenuPermissionHttpResponse(
 				navigationMenu.getSiteId(),
 				new Permission[] {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -653,7 +653,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			structuredContentFolderResource.
 				putAssetLibraryStructuredContentFolderPermissionHttpResponse(
 					testDepotEntry.getDepotEntryId(),
@@ -1151,7 +1151,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			structuredContentFolderResource.
 				putSiteStructuredContentFolderPermissionHttpResponse(
 					structuredContentFolder.getSiteId(),
@@ -1220,7 +1220,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			structuredContentFolderResource.
 				putStructuredContentFolderPermissionHttpResponse(
 					structuredContentFolder.getId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -622,7 +622,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			structuredContentResource.
 				putAssetLibraryStructuredContentPermissionHttpResponse(
 					testDepotEntry.getDepotEntryId(),
@@ -1587,7 +1587,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			structuredContentResource.
 				putSiteStructuredContentPermissionHttpResponse(
 					structuredContent.getSiteId(),
@@ -2260,7 +2260,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			structuredContentResource.
 				putStructuredContentPermissionHttpResponse(
 					structuredContent.getId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -571,7 +571,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			wikiNodeResource.putSiteWikiNodePermissionHttpResponse(
 				wikiNode.getSiteId(),
 				new Permission[] {
@@ -761,7 +761,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			wikiNodeResource.putWikiNodePermissionHttpResponse(
 				wikiNode.getId(),
 				new Permission[] {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -760,7 +760,7 @@ public abstract class BaseWikiPageResourceTestCase {
 			RoleConstants.TYPE_REGULAR);
 
 		assertHttpResponseStatusCode(
-			204,
+			200,
 			wikiPageResource.putWikiPagePermissionHttpResponse(
 				wikiPage.getId(),
 				new Permission[] {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -944,7 +944,7 @@ public class ResourceOpenAPIParser {
 				return void.class.getName();
 			}
 
-			if ((operation instanceof Get) && path.endsWith("permissions")) {
+			if (path.endsWith("permissions")) {
 				return _getPageClassName(
 					"[L" + Permission.class.getName() + ";");
 			}

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -214,11 +214,11 @@ public abstract class Base${schemaName}ResourceImpl
 					String resourceName = getPermissionCheckerResourceName(${schemaVarName}Id);
 					Long resourceId = getPermissionCheckerResourceId(${schemaVarName}Id);
 
-					PermissionUtil.checkPermission(ActionKeys.PERMISSIONS, groupLocalService, resourceName, resourceId, getPermissionCheckerGroupId(${schemaVarName}Id));
-
-					resourcePermissionLocalService.updateResourcePermissions(contextCompany.getCompanyId(), 0, resourceName, String.valueOf(resourceId), ModelPermissionsUtil.toModelPermissions(contextCompany.getCompanyId(), permissions, resourceId, resourceName, resourceActionLocalService, resourcePermissionLocalService, roleLocalService));
-
-					return toPermissionPage(resourceId, resourceName, null);
+					<@updatePermissions
+						groupId="getPermissionCheckerGroupId(${schemaVarName}Id)"
+						resourceId="resourceId"
+						resourceName="resourceName"
+					/>
 				<#else>
 					throw new UnsupportedOperationException("This method needs to be implemented");
 				</#if>
@@ -227,21 +227,21 @@ public abstract class Base${schemaName}ResourceImpl
 
 				String portletName = getPermissionCheckerPortletName(assetLibraryId);
 
-				PermissionUtil.checkPermission(ActionKeys.PERMISSIONS, groupLocalService, portletName, assetLibraryId, assetLibraryId);
-
-				resourcePermissionLocalService.updateResourcePermissions(contextCompany.getCompanyId(), assetLibraryId, portletName, String.valueOf(assetLibraryId), ModelPermissionsUtil.toModelPermissions(contextCompany.getCompanyId(), permissions, assetLibraryId, portletName, resourceActionLocalService, resourcePermissionLocalService, roleLocalService));
-
-				return toPermissionPage(assetLibraryId, portletName, null);
+				<@updatePermissions
+					groupId="assetLibraryId"
+					resourceId="assetLibraryId"
+					resourceName="portletName"
+				/>
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "putSite" + schemaName + "Permission")>
 				<#assign generateGetPermissionCheckerMethods = true />
 
 				String portletName = getPermissionCheckerPortletName(siteId);
 
-				PermissionUtil.checkPermission(ActionKeys.PERMISSIONS, groupLocalService, portletName, siteId, siteId);
-
-				resourcePermissionLocalService.updateResourcePermissions(contextCompany.getCompanyId(), siteId, portletName, String.valueOf(siteId), ModelPermissionsUtil.toModelPermissions(contextCompany.getCompanyId(), permissions, siteId, portletName, resourceActionLocalService, resourcePermissionLocalService, roleLocalService));
-
-				return toPermissionPage(siteId, portletName, null);
+				<@updatePermissions
+					groupId="siteId"
+					resourceId="siteId"
+					resourceName="portletName"
+				/>
 			<#elseif stringUtil.equals(javaMethodSignature.returnType, "java.lang.Boolean")>
 				return false;
 			<#elseif stringUtil.equals(javaMethodSignature.returnType, "java.lang.Double") ||
@@ -579,4 +579,14 @@ public abstract class Base${schemaName}ResourceImpl
 	</#if>
 
 	)
+</#macro>
+
+<#macro updatePermissions
+	groupId resourceId resourceName
+>
+	PermissionUtil.checkPermission(ActionKeys.PERMISSIONS, groupLocalService, ${resourceName}, ${resourceId}, ${groupId});
+
+	resourcePermissionLocalService.updateResourcePermissions(contextCompany.getCompanyId(), ${groupId}, ${resourceName}, String.valueOf(${resourceId}), ModelPermissionsUtil.toModelPermissions(contextCompany.getCompanyId(), permissions, ${resourceId}, ${resourceName}, resourceActionLocalService, resourcePermissionLocalService, roleLocalService));
+
+	return toPermissionPage(${resourceId}, ${resourceName}, null);
 </#macro>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -217,6 +217,8 @@ public abstract class Base${schemaName}ResourceImpl
 					PermissionUtil.checkPermission(ActionKeys.PERMISSIONS, groupLocalService, resourceName, resourceId, getPermissionCheckerGroupId(${schemaVarName}Id));
 
 					resourcePermissionLocalService.updateResourcePermissions(contextCompany.getCompanyId(), 0, resourceName, String.valueOf(resourceId), ModelPermissionsUtil.toModelPermissions(contextCompany.getCompanyId(), permissions, resourceId, resourceName, resourceActionLocalService, resourcePermissionLocalService, roleLocalService));
+
+					return toPermissionPage(resourceId, resourceName, null);
 				<#else>
 					throw new UnsupportedOperationException("This method needs to be implemented");
 				</#if>
@@ -228,6 +230,8 @@ public abstract class Base${schemaName}ResourceImpl
 				PermissionUtil.checkPermission(ActionKeys.PERMISSIONS, groupLocalService, portletName, assetLibraryId, assetLibraryId);
 
 				resourcePermissionLocalService.updateResourcePermissions(contextCompany.getCompanyId(), assetLibraryId, portletName, String.valueOf(assetLibraryId), ModelPermissionsUtil.toModelPermissions(contextCompany.getCompanyId(), permissions, assetLibraryId, portletName, resourceActionLocalService, resourcePermissionLocalService, roleLocalService));
+
+				return toPermissionPage(assetLibraryId, portletName, null);
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "putSite" + schemaName + "Permission")>
 				<#assign generateGetPermissionCheckerMethods = true />
 
@@ -236,6 +240,8 @@ public abstract class Base${schemaName}ResourceImpl
 				PermissionUtil.checkPermission(ActionKeys.PERMISSIONS, groupLocalService, portletName, siteId, siteId);
 
 				resourcePermissionLocalService.updateResourcePermissions(contextCompany.getCompanyId(), siteId, portletName, String.valueOf(siteId), ModelPermissionsUtil.toModelPermissions(contextCompany.getCompanyId(), permissions, siteId, portletName, resourceActionLocalService, resourcePermissionLocalService, roleLocalService));
+
+				return toPermissionPage(siteId, portletName, null);
 			<#elseif stringUtil.equals(javaMethodSignature.returnType, "java.lang.Boolean")>
 				return false;
 			<#elseif stringUtil.equals(javaMethodSignature.returnType, "java.lang.Double") ||

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -301,17 +301,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 						<#list getJavaMethodSignature.javaMethodParameters as javaMethodParameter>
 							<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
-								<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Double")>
-									0D
-								<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Integer")>
-									0
-								<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Long")>
-									0L
-								<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-									"-"
-								<#else>
-									null
-								</#if>
+								<@getDefaultParameter javaMethodParameter=javaMethodParameter />
 							<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
 								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
 							<#else>
@@ -1152,34 +1142,21 @@ public abstract class Base${schemaName}ResourceTestCase {
 				200,
 				${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
 					<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
-						<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
-							${schemaVarName}.getId()
-						<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
-							${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
-						<#elseif stringUtil.equals(javaMethodParameter.parameterName, "assetLibraryId")>
-							testDepotEntry.getDepotEntryId()
-						<#elseif stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
-							testGroup.getGroupId()
-						<#elseif stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
-							${schemaVarName}
-						<#elseif stringUtil.equals(javaMethodParameter.parameterType, "[Lcom.liferay.portal.vulcan.permission.Permission;")>
-							new Permission[] {
-								new Permission() {
-									{
-										setActionIds(new String[] {
-											<#if javaMethodSignature.methodName?contains("AssetLibrary") || javaMethodSignature.methodName?contains("Site")>
-												"PERMISSIONS"
-											<#else>
-												"VIEW"
-											</#if>
-										});
-										setRoleName(role.getName());
-									}
-								}
-							}
-						<#else>
-							null
-						</#if>
+
+						<@selectPermissionParameter
+							javaMethodParameter=javaMethodParameter
+							javaMethodSignature=javaMethodSignature
+							properties=properties
+							roleName="role.getName()"
+							schemaVarName=schemaVarName
+							schemaVarNameId="${schemaVarName}.getId()"
+						>
+							<#if javaMethodSignature.methodName?contains("AssetLibrary") || javaMethodSignature.methodName?contains("Site")>
+								"PERMISSIONS"
+							<#else>
+								"VIEW"
+							</#if>
+						</@selectPermissionParameter>
 						<#sep>, </#sep>
 					</#list>
 					));
@@ -1188,38 +1165,16 @@ public abstract class Base${schemaName}ResourceTestCase {
 					404,
 					${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
 					<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
-						<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
-							<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Double")>
-								0D
-							<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Integer")>
-								0
-							<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Long")>
-								0L
-							<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-								RandomTestUtil.randomString()
-							<#else>
-								null
-							</#if>
-						<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
-							${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
-						<#elseif stringUtil.equals(javaMethodParameter.parameterName, "assetLibraryId")>
-							testDepotEntry.getDepotEntryId()
-						<#elseif stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
-							testGroup.getGroupId()
-						<#elseif stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
-							${schemaVarName}
-						<#elseif stringUtil.startsWith(javaMethodParameter.parameterType, "[Lcom.liferay.portal.vulcan.permission.Permission;")>
-							new Permission[]{
-								new Permission() {
-									{
-										setActionIds(new String[] {"-"});
-										setRoleName("-");
-									}
-								}
-							}
-						<#else>
-							null
-						</#if>
+						<@selectPermissionParameter
+							javaMethodParameter=javaMethodParameter
+							javaMethodSignature=javaMethodSignature
+							properties=properties
+							roleName="\"-\""
+							schemaVarName=schemaVarName
+							schemaVarNameId="0L"
+						>
+							"-"
+						</@selectPermissionParameter>
 						<#sep>, </#sep>
 					</#list>
 				));
@@ -1358,21 +1313,6 @@ public abstract class Base${schemaName}ResourceTestCase {
 								testGroup.getGroupId()
 							<#elseif stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
 								${schemaVarName}
-							<#elseif stringUtil.equals(javaMethodParameter.parameterType, "[Lcom.liferay.portal.vulcan.permission.Permission;")>
-								new Permission[] {
-									new Permission() {
-										{
-											setActionIds(new String[] {
-												<#if javaMethodSignature.methodName?contains("AssetLibrary") || javaMethodSignature.methodName?contains("Site")>
-													"PERMISSIONS"
-												<#else>
-													"VIEW"
-												</#if>
-												});
-											setRoleName(role.getName());
-										}
-									}
-								}
 							<#else>
 								null
 							</#if>
@@ -1385,17 +1325,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 					${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
 						<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
 							<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
-								<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Double")>
-									0D
-								<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Integer")>
-									0
-								<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Long")>
-									0L
-								<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-									RandomTestUtil.randomString()
-								<#else>
-									null
-								</#if>
+								<@getDefaultParameter javaMethodParameter=javaMethodParameter />
 							<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
 								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
 							<#elseif stringUtil.equals(javaMethodParameter.parameterName, "assetLibraryId")>
@@ -1404,15 +1334,6 @@ public abstract class Base${schemaName}ResourceTestCase {
 								testGroup.getGroupId()
 							<#elseif stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
 								${schemaVarName}
-						 	<#elseif stringUtil.startsWith(javaMethodParameter.parameterType, "[Lcom.liferay.portal.vulcan.permission.Permission;")>
-								new Permission[]{
-									new Permission() {
-										{
-											setActionIds(new String[] {"-"});
-											setRoleName("-");
-										}
-									}
-								}
 							<#else>
 								null
 							</#if>
@@ -2513,3 +2434,48 @@ public abstract class Base${schemaName}ResourceTestCase {
 	private ${configYAML.apiPackagePath}.resource.${escapedVersion}.${schemaName}Resource _${schemaVarName}Resource;
 
 }
+
+<#macro getDefaultParameter
+	javaMethodParameter
+>
+	<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Double")>
+		0D
+	<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Integer")>
+		0
+	<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Long")>
+		0L
+	<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
+		"-"
+	<#else>
+		null
+	</#if>
+</#macro>
+
+<#macro selectPermissionParameter
+	javaMethodParameter javaMethodSignature properties roleName schemaVarName schemaVarNameId
+>
+	<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
+		 ${schemaVarNameId}
+	<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
+		 ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+	<#elseif stringUtil.equals(javaMethodParameter.parameterName, "assetLibraryId")>
+		 testDepotEntry.getDepotEntryId()
+	<#elseif stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
+		testGroup.getGroupId()
+	<#elseif stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
+		${schemaVarName}
+	<#elseif stringUtil.equals(javaMethodParameter.parameterType, "[Lcom.liferay.portal.vulcan.permission.Permission;")>
+		new Permission[] {
+			new Permission() {
+				{
+					setActionIds(new String[] {
+						<#nested>
+					});
+					setRoleName(${roleName});
+				}
+			}
+		}
+	<#else>
+		null
+	</#if>
+</#macro>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -1139,6 +1139,121 @@ public abstract class Base${schemaName}ResourceTestCase {
 					throw new UnsupportedOperationException("This method needs to be implemented");
 				</#if>
 			}
+		<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "put") && javaMethodSignature.methodName?contains("Permission")>
+			@Test
+			public void test${javaMethodSignature.methodName?cap_first}() throws Exception {
+
+				@SuppressWarnings("PMD.UnusedLocalVariable")
+				${schemaName} ${schemaVarName} = test${javaMethodSignature.methodName?cap_first}_add${schemaName}();
+
+				com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+				assertHttpResponseStatusCode(
+				200,
+				${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
+					<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
+						<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
+							${schemaVarName}.getId()
+						<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
+							${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+						<#elseif stringUtil.equals(javaMethodParameter.parameterName, "assetLibraryId")>
+							testDepotEntry.getDepotEntryId()
+						<#elseif stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
+							testGroup.getGroupId()
+						<#elseif stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
+							${schemaVarName}
+						<#elseif stringUtil.equals(javaMethodParameter.parameterType, "[Lcom.liferay.portal.vulcan.permission.Permission;")>
+							new Permission[] {
+								new Permission() {
+									{
+										setActionIds(new String[] {
+											<#if javaMethodSignature.methodName?contains("AssetLibrary") || javaMethodSignature.methodName?contains("Site")>
+												"PERMISSIONS"
+											<#else>
+												"VIEW"
+											</#if>
+										});
+										setRoleName(role.getName());
+									}
+								}
+							}
+						<#else>
+							null
+						</#if>
+						<#sep>, </#sep>
+					</#list>
+					));
+
+					assertHttpResponseStatusCode(
+					404,
+					${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
+					<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
+						<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
+							<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Double")>
+								0D
+							<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Integer")>
+								0
+							<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Long")>
+								0L
+							<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
+								RandomTestUtil.randomString()
+							<#else>
+								null
+							</#if>
+						<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
+							${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+						<#elseif stringUtil.equals(javaMethodParameter.parameterName, "assetLibraryId")>
+							testDepotEntry.getDepotEntryId()
+						<#elseif stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
+							testGroup.getGroupId()
+						<#elseif stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
+							${schemaVarName}
+						<#elseif stringUtil.startsWith(javaMethodParameter.parameterType, "[Lcom.liferay.portal.vulcan.permission.Permission;")>
+							new Permission[]{
+								new Permission() {
+									{
+										setActionIds(new String[] {"-"});
+										setRoleName("-");
+									}
+								}
+							}
+						<#else>
+							null
+						</#if>
+						<#sep>, </#sep>
+					</#list>
+				));
+			}
+
+			protected ${schemaName} test${javaMethodSignature.methodName?cap_first}_add${schemaName}() throws Exception {
+				<#if javaMethodSignature.methodName?contains("AssetLibrary") && freeMarkerTool.hasPostSchemaJavaMethodSignature(javaMethodSignatures, "assetLibraryId", schemaName)>
+					<#assign postSchemaJavaMethodSignature = freeMarkerTool.getPostSchemaJavaMethodSignature(javaMethodSignatures, "assetLibraryId", schemaName) />
+
+					return ${schemaVarName}Resource.postAssetLibrary${schemaName}(testDepotEntry.getDepotEntryId(), random${schemaName}()
+
+					<#if freeMarkerTool.hasRequestBodyMediaType(postSchemaJavaMethodSignature, "multipart/form-data")>
+						<#assign generateGetMultipartFilesMethod = true />
+
+						, getMultipartFiles()
+					</#if>
+
+					);
+				<#elseif freeMarkerTool.hasPostSchemaJavaMethodSignature(javaMethodSignatures, "siteId", schemaName)>
+					<#assign postSchemaJavaMethodSignature = freeMarkerTool.getPostSchemaJavaMethodSignature(javaMethodSignatures, "siteId", schemaName) />
+
+					return ${schemaVarName}Resource.postSite${schemaName}(testGroup.getGroupId(), random${schemaName}()
+
+					<#if freeMarkerTool.hasRequestBodyMediaType(postSchemaJavaMethodSignature, "multipart/form-data")>
+						<#assign generateGetMultipartFilesMethod = true />
+
+						, getMultipartFiles()
+					</#if>
+
+					);
+				<#else>
+					throw new UnsupportedOperationException("This method needs to be implemented");
+				</#if>
+			}
 		<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "put") && javaMethodSignature.returnType?ends_with(schemaName)>
 			@Test
 			public void test${javaMethodSignature.methodName?cap_first}() throws Exception {


### PR DESCRIPTION
Requested by Pablo, I've made a test to return the list of updated permissions from the permissions endpoints, put method.

I think this add consistency with the usual PUT usage that we have in the Portal but it also changes an existent behavior of the APIS (don't know why baseline does not bump major, but I think it has to)

Creating this PR to discuss with @nhpatt and check if it worth changing an existent behavior with the benefits of consistency with other PUT operations in the portal