### PR TITLE
LPS-131442 Look and Feel Configuration color changes don't work

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
@@ -15,13 +15,21 @@
 import ClayColorPicker from '@clayui/color-picker';
 import React, {useState} from 'react';
 
+const HEX_COLOR_REGEX = /^#?[0-9A-F]{3}(?:[0-9A-F]{3})?$/i;
+
 const ColorPicker = ({color, label, name}) => {
 	const [colorValue, setColorValue] = useState(color);
 	const [customColors, setCustomColors] = useState([]);
 
+	const isHex = HEX_COLOR_REGEX.test(colorValue);
+
 	return (
 		<div className="form-group">
-			<input name={name} type="hidden" value={colorValue} />
+			<input
+				name={name}
+				type="hidden"
+				value={colorValue ? `${isHex ? '#' : ''}${colorValue}` : ''}
+			/>
 
 			<ClayColorPicker
 				colors={customColors}


### PR DESCRIPTION
### Steps to reproduce

1. Go to default site.
2. Add a widget page.
3. On the widget page, place a Hello Velocity by clicking "+" from the upper right corner.
4. Click on Portlet's 3 dot menu and select "Look and Feel Configuration" --> Border Styles
5. Under Border Width add to the Right border 100 px, Under Border Style --> Right --> Select "Solid" from the drop-down menu and under Border Color Right --> select one of the default colors
6. Save and refresh the Page.

### Solution overview

Related to fix for [LPS-129438](https://issues.liferay.com/browse/LPS-129438). Turns out the Clay 3.4.0+ changes cause the color value in the state to be different from the value that's stored in the ColorPicker input field, and the ColorPicker input field's value is what we actually need. Working around it by mimicking the logic used to generate the ColorPicker input field.

https://github.com/liferay/clay/blob/v3.27.0/packages/clay-color-picker/src/index.tsx#L205