### PR TITLE
LPS-130722 Using rowId as part of id HTML attribute for every row in search container

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container.js
@@ -119,7 +119,10 @@ AUI.add(
 
 							row.removeClass(CSS_TEMPLATE);
 
-							row.attr('id', instance._originalConfig.id + '_' + id);
+							row.attr(
+								'id',
+								instance._originalConfig.id + '_' + id
+							);
 
 							instance._ids.push(id);
 						}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container.js
@@ -119,6 +119,8 @@ AUI.add(
 
 							row.removeClass(CSS_TEMPLATE);
 
+							row.attr('id', instance._originalConfig.id + '_' + id);
+
 							instance._ids.push(id);
 						}
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container.js
@@ -119,10 +119,7 @@ AUI.add(
 
 							row.removeClass(CSS_TEMPLATE);
 
-							row.attr(
-								'id',
-								instance._originalConfig.id + '_' + id
-							);
+							row.attr('id', instance.get('id') + '_' + id);
 
 							instance._ids.push(id);
 						}

--- a/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
@@ -46,5 +46,5 @@ String summary = searchContainer.getSummary();
 
 JSONArray primaryKeysJSONArray = JSONFactoryUtil.createJSONArray();
 
-String rowIdProperty = (String)request.getAttribute("rowIdProperty");
+String rowIdProperty = (String)request.getAttribute("liferay-ui:search-container-row:rowIdProperty");
 %>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
@@ -28,6 +28,8 @@ boolean fixedHeader = GetterUtil.getBoolean((String)request.getAttribute("lifera
 String markupView = (String)request.getAttribute("liferay-ui:search-iterator:markupView");
 boolean paginate = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:search-iterator:paginate"));
 ResultRowSplitter resultRowSplitter = (ResultRowSplitter)request.getAttribute("liferay-ui:search-iterator:resultRowSplitter");
+String rowIdProperty = (String)request.getAttribute("liferay-ui:search-container-row:rowIdProperty");
+String searchContainerRowCssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:search-container-row:cssClass"));
 String searchResultCssClass = (String)request.getAttribute("liferay-ui:search-iterator:searchResultCssClass");
 String type = (String)request.getAttribute("liferay-ui:search:type");
 
@@ -45,6 +47,4 @@ List resultRows = searchContainer.getResultRows();
 String summary = searchContainer.getSummary();
 
 JSONArray primaryKeysJSONArray = JSONFactoryUtil.createJSONArray();
-
-String rowIdProperty = (String)request.getAttribute("liferay-ui:search-container-row:rowIdProperty");
 %>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
@@ -45,4 +45,6 @@ List resultRows = searchContainer.getResultRows();
 String summary = searchContainer.getSummary();
 
 JSONArray primaryKeysJSONArray = JSONFactoryUtil.createJSONArray();
+
+String rowIdProperty = (String)request.getAttribute("rowIdProperty");
 %>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
@@ -276,7 +276,14 @@ if (fixedHeader) {
 					}
 				%>
 
-					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
+					<c:choose>
+						<c:when test="<%= Validator.isNotNull(rowIdProperty) %>">
+							<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" id="<portlet:namespace /><%= id %>_<%= row.getRowId() %>" <%= AUIUtil.buildData(data) %>>
+						</c:when>
+						<c:otherwise>
+							<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
+						</c:otherwise>
+					</c:choose>
 
 						<%
 						for (int j = 0; j < entries.size(); j++) {

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
@@ -363,7 +363,7 @@ if (fixedHeader) {
 			%>
 
 			<c:if test="<%= headerNames != null %>">
-				<tr class="lfr-template">
+				<tr class="lfr-template <%= searchContainerRowCssClass %>" data-qa-id="row">
 
 					<%
 					for (int i = 0; i < headerNames.size(); i++) {

--- a/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
@@ -314,7 +314,7 @@ if (iteratorURL != null) {
 		%>
 
 		<c:if test="<%= headerNames != null %>">
-			<tr class="lfr-template">
+			<tr class="lfr-template <%= searchContainerRowCssClass %>">
 
 				<%
 				for (int i = 0; i < headerNames.size(); i++) {

--- a/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
@@ -243,7 +243,14 @@ if (iteratorURL != null) {
 			Map<String, Object> data = row.getData();
 		%>
 
-			<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" <%= AUIUtil.buildData(data) %>>
+			<c:choose>
+				<c:when test="<%= Validator.isNotNull(rowIdProperty) %>">
+					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" id="<portlet:namespace /><%= id %>_<%= row.getRowId() %>" <%= AUIUtil.buildData(data) %>>
+				</c:when>
+				<c:otherwise>
+					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" <%= AUIUtil.buildData(data) %>>
+				</c:otherwise>
+			</c:choose>
 
 			<%
 			for (int j = 0; j < entries.size(); j++) {

--- a/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
@@ -138,7 +138,7 @@ public class SearchContainerRowTag<R>
 		_results = _searchContainer.getResults();
 
 		request.setAttribute(
-		    "liferay-ui:search-container-row:cssClass", _cssClass);
+			"liferay-ui:search-container-row:cssClass", _cssClass);
 
 		if ((_results != null) && !_results.isEmpty()) {
 			processRow();
@@ -336,7 +336,8 @@ public class SearchContainerRowTag<R>
 			}
 
 			request.setAttribute(
-				"liferay-ui:search-container-row:rowIdProperty", _rowIdProperty);
+				"liferay-ui:search-container-row:rowIdProperty",
+				_rowIdProperty);
 		}
 
 		_resultRow = new com.liferay.taglib.search.ResultRow(

--- a/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
@@ -331,6 +331,8 @@ public class SearchContainerRowTag<R>
 					FriendlyURLNormalizerUtil.normalizeWithPeriodsAndSlashes(
 						String.valueOf(rowIdObject));
 			}
+
+			request.setAttribute("rowIdProperty", rowId);
 		}
 
 		_resultRow = new com.liferay.taglib.search.ResultRow(

--- a/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
@@ -333,7 +333,7 @@ public class SearchContainerRowTag<R>
 			}
 
 			request.setAttribute(
-				"liferay-ui:search-container-row:rowIdProperty", rowId);
+				"liferay-ui:search-container-row:rowIdProperty", _rowIdProperty);
 		}
 
 		_resultRow = new com.liferay.taglib.search.ResultRow(

--- a/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
@@ -137,6 +137,9 @@ public class SearchContainerRowTag<R>
 
 		_results = _searchContainer.getResults();
 
+		request.setAttribute(
+		    "liferay-ui:search-container-row:cssClass", _cssClass);
+
 		if ((_results != null) && !_results.isEmpty()) {
 			processRow();
 

--- a/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
@@ -332,7 +332,8 @@ public class SearchContainerRowTag<R>
 						String.valueOf(rowIdObject));
 			}
 
-			request.setAttribute("rowIdProperty", rowId);
+			request.setAttribute(
+				"liferay-ui:search-container-row:rowIdProperty", rowId);
 		}
 
 		_resultRow = new com.liferay.taglib.search.ResultRow(


### PR DESCRIPTION
Hey guys,

This is a new try for #1006. 

[Here](https://github.com/liferay-frontend/liferay-portal/commit/6350373193d4361052605ad0322864a634122d7b) I tried to avoid swapping names as [Brian noticed](https://github.com/brianchandotcom/liferay-portal/pull/101253#issuecomment-829055624).

In [this new commit](https://github.com/liferay-frontend/liferay-portal/commit/d461148842c5a508b266621e9aa0fe4231ee81fd) I'm trying to fix a new issue related with missing id attribute in Search Container. Basically if you add a new row via javascript to some Search Container it is not going to include any id attribute, cssClass for the search container's row, etc. So I tried to make new rows similar to existing ones. 

If you want to test, after following the steps in LPS-130722 and getting a Search Container, you can type from your browser console something like:
```
var customSearchContainer = Liferay.SearchContainer.get('WhateverTheSearchContainerIdIs');
var newRow = ["New Role Name", 1, 12345];
customSearchContainer.addRow(newRow, 12345);
```
Before the changes in that commit that's going to add a new row with no id or css class. After this change is going to include both. The ids for the new row are following the same pattern {portletNamespace}_{searchContainerId}_{rowId}.

Thanks.

Regards.
