### PR TITLE
LPS-131310 Avoid duplicate headers

### DIFF
--- a/modules/.eslintrc.js
+++ b/modules/.eslintrc.js
@@ -40,6 +40,8 @@ config = {
 		'notice/notice': [
 			'error',
 			{
+				nonMatchingTolerance: 0.7,
+				onNonMatchingHeader: 'replace',
 				templateFile: path.join(__dirname, 'copyright.js'),
 			},
 		],

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/js/utils/numeric.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/js/utils/numeric.es.js
@@ -12,17 +12,6 @@
  * details.
  */
 
-/**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Liferay Enterprise
- * Subscription License ("License"). You may not use this file except in
- * compliance with the License. You can obtain a copy of the License by
- * contacting Liferay, Inc. See the License for the specific language governing
- * permissions and limitations under the License, including but not limited to
- * distribution rights of the Software.
- */
-
 import ellipsize from './ellipsize.es';
 
 const _MAX_DELIMITED_NUMBER_LENGTH = 10;

--- a/modules/apps/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/js/index.es.js
+++ b/modules/apps/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/js/index.es.js
@@ -12,17 +12,6 @@
  * details.
  */
 
-/**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Liferay Enterprise
- * Subscription License ("License"). You may not use this file except in
- * compliance with the License. You can obtain a copy of the License by
- * contacting Liferay, Inc. See the License for the specific language governing
- * permissions and limitations under the License, including but not limited to
- * distribution rights of the Software.
- */
-
 import {ItemSelectorRepositoryEntryBrowser} from 'item-selector-taglib';
 
 export default function (props) {

--- a/modules/dxp/.eslintrc.js
+++ b/modules/dxp/.eslintrc.js
@@ -16,6 +16,8 @@ module.exports = {
 		'notice/notice': [
 			'error',
 			{
+				nonMatchingTolerance: 0.7,
+				onNonMatchingHeader: 'replace',
 				templateFile: path.join(__dirname, 'copyright.js'),
 			},
 		],

--- a/modules/dxp/apps/analytics/analytics-reports-web/npmscripts.config.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/npmscripts.config.js
@@ -9,18 +9,4 @@
  * distribution rights of the Software.
  */
 
-/**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
- */
-
 module.exports = {};

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/npmscripts.config.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/npmscripts.config.js
@@ -9,18 +9,4 @@
  * distribution rights of the Software.
  */
 
-/**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
- */
-
 module.exports = {};

--- a/modules/dxp/apps/commerce/commerce-bom-admin-web/npmscripts.config.js
+++ b/modules/dxp/apps/commerce/commerce-bom-admin-web/npmscripts.config.js
@@ -9,20 +9,6 @@
  * distribution rights of the Software.
  */
 
-/**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
- */
-
 module.exports = {
 	build: {
 		bundler: {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/npmscripts.config.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/npmscripts.config.js
@@ -9,20 +9,6 @@
  * distribution rights of the Software.
  */
 
-/**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
- */
-
 module.exports = {
 	build: {
 		bundler: {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/npmscripts.config.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/npmscripts.config.js
@@ -9,20 +9,6 @@
  * distribution rights of the Software.
  */
 
-/**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
- */
-
 module.exports = {
 	build: {
 		bundler: {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/setup.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/setup.js
@@ -9,20 +9,6 @@
  * distribution rights of the Software.
  */
 
-/**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
- */
-
 const fs = require('fs');
 const path = require('path');
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/npmscripts.config.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/npmscripts.config.js
@@ -9,20 +9,6 @@
  * distribution rights of the Software.
  */
 
-/**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
- */
-
 module.exports = {
 	build: {
 		bundler: {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/npmscripts.config.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/npmscripts.config.js
@@ -9,20 +9,6 @@
  * distribution rights of the Software.
  */
 
-/**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
- */
-
 module.exports = {
 	build: {
 		bundler: {


### PR DESCRIPTION
So, trying to fix the problem with duplicate headers by using some settings documented in [the `eslint-plugin-notice` README](https://www.npmjs.com/package/eslint-plugin-notice).

The root cause for most of these is that a file was copied from the `modules/apps/` directory into `modules/dxp/`, or vice versa. As the plugin was configured to be dumb/conservative, it just checks to see if the header matches expectations, and if it does not, it _prepends_ the correct header.

So, in the case of copying a file from `modules/apps/` into `modules/dxp/`, we wind up with a file that has an enterprise license header followed by a GPL header. When copying in the opposite direction, we get the headers in the opposite order.

Fix then, is to set it to replace rather than prepend. We didn't do this originally because we were a bit scared that it might be a bit destructive, but I've run it across all of `liferay-portal` and it didn't mangle anything in an untoward way.

I found all the JS files with dupe headers with:

```bash
git grep --all-match -e "This library is free" --or -e "Subscription License" -- '**/*.js'
```

I then removed the duplicates manually. That's what you see in this commit.

Finally, to test that the lint rule works as expected, I went back into those files and _swapped_ the headers (ie. putting the GPL in instead of the enterprise license under `modules/dxp/`, and putting the enterprise license instead of the GPL under `modules/`). Then I ran `yarn format` and saw that everything was corrected back to the desired state (ie. `git diff` produced no output).

One final observation: the reason we're not baking this into the default config that comes in via `@liferay/npm-scripts` is that we send that to potentially multiple branches that may want to have their own `notice/notice` config, and we don't want to hard-code too much knowledge of DXP-specific paths into that package.

Original report: https://github.com/brianchandotcom/liferay-portal/pull/101191#issuecomment-828438958