### PR TITLE
LPS-131777 call getStaticResourceUrl to get timestamp and perform correct redeploys to cdn's

### DIFF
--- a/modules/apps/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
@@ -66,9 +66,9 @@ LPS-30525.
 	file_name
 >
 	<#if file_name == css_main_file>
-		<link class="lfr-css-file" href="${htmlUtil.escape(portalUtil.getStaticResourceURL(request,file_name))}" id="mainLiferayThemeCSS" rel="stylesheet" type="text/css" />
+		<link class="lfr-css-file" href="${htmlUtil.escape(portalUtil.getStaticResourceURL(request, file_name))}" id="mainLiferayThemeCSS" rel="stylesheet" type="text/css" />
 	<#else>
-		<link class="lfr-css-file" href="${htmlUtil.escape(portalUtil.getStaticResourceURL(request,file_name))}" rel="stylesheet" type="text/css" />
+		<link class="lfr-css-file" href="${htmlUtil.escape(portalUtil.getStaticResourceURL(request, file_name))}" rel="stylesheet" type="text/css" />
 	</#if>
 </#macro>
 
@@ -81,9 +81,9 @@ ${dateUtil.getCurrentDate(format, locale)}</#macro>
 	file_name
 >
 	<#if file_name == js_main_file>
-		<script id="mainLiferayThemeJavaScript" src="${htmlUtil.escape(portalUtil.getStaticResourceURL(request,file_name))}" type="text/javascript"></script>
+		<script id="mainLiferayThemeJavaScript" src="${htmlUtil.escape(portalUtil.getStaticResourceURL(request, file_name))}" type="text/javascript"></script>
 	<#else>
-		<script src="${htmlUtil.escape(portalUtil.getStaticResourceURL(request,file_name))}" type="text/javascript"></script>
+		<script src="${htmlUtil.escape(portalUtil.getStaticResourceURL(request, file_name))}" type="text/javascript"></script>
 	</#if>
 </#macro>
 

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
@@ -66,9 +66,9 @@ LPS-30525.
 	file_name
 >
 	<#if file_name == css_main_file>
-		<link class="lfr-css-file" href="${file_name}" id="mainLiferayThemeCSS" rel="stylesheet" type="text/css" />
+		<link class="lfr-css-file" href="${htmlUtil.escape(portalUtil.getStaticResourceURL(request,file_name))}" id="mainLiferayThemeCSS" rel="stylesheet" type="text/css" />
 	<#else>
-		<link class="lfr-css-file" href="${file_name}" rel="stylesheet" type="text/css" />
+		<link class="lfr-css-file" href="${htmlUtil.escape(portalUtil.getStaticResourceURL(request,file_name))}" rel="stylesheet" type="text/css" />
 	</#if>
 </#macro>
 
@@ -81,9 +81,9 @@ ${dateUtil.getCurrentDate(format, locale)}</#macro>
 	file_name
 >
 	<#if file_name == js_main_file>
-		<script id="mainLiferayThemeJavaScript" src="${file_name}" type="text/javascript"></script>
+		<script id="mainLiferayThemeJavaScript" src="${htmlUtil.escape(portalUtil.getStaticResourceURL(request,file_name))}" type="text/javascript"></script>
 	<#else>
-		<script src="${file_name}" type="text/javascript"></script>
+		<script src="${htmlUtil.escape(portalUtil.getStaticResourceURL(request,file_name))}" type="text/javascript"></script>
 	</#if>
 </#macro>
 


### PR DESCRIPTION
Hello Frontend Team,

Description of the issue:

When you use `<@liferay.js file_name>` or `<@liferay.css file_name>` macros, those imports doesn't have a timestamp.

This is causing that when you redeploy the theme, files imported with those macros, doesn't always show latest version and causes problems with some cdn's (pex dxp-cloud cdn)
 
Things I've tried.

Created a new theme.

Inside portal-normal.ftl import two different js files with the macro and with other mechanism provided by liferay.

1. Using the macro:
 `<@liferay.js file_name="${javascript_folder}/unav/unav72.js"/>`
 
2. Using portalUtil.getStaticResourceURL

```
<#if themeDisplay??>
 <#assign
 fundraising_carousel = htmlUtil.escape(portalUtil.getStaticResourceURL(request, "${themeDisplay.getPathThemeJavaScript()}/unav/fundraising_carousel.js"))>
 <script src="${fundraising_carousel}" type="text/javascript"></script>
```


For the first case, a <script tag is created. src attribute, contains the filename, without any parameters.
For the second case, the source of the script tag has a timestamp and browserId parameters.

Test plan

    Deploy [my-liferay-theme](https://issues.liferay.com/secure/attachment/404645/my-liferay-theme.war) inside a portal bundle
    Create a new Site Site1
    Set my-liferay-theme as theme for this site
    Navigate to Site Builder > Pages
    Created a new Content Page
    Publish the page
    Navigate to the page you just published
    In network panel, just second request has parameters (fundraising_carousel.js) request has parameters.


After applying this change both requests have parameters and those parameters are updated with each redeployment of the theme