### PR TITLE
[TS] LPS-131814: Escape available languages display names to avoid JS parsing errors

### DIFF
--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -142,7 +142,7 @@
 				String selLanguageId = LocaleUtil.toLanguageId(curLocale);
 			%>
 
-				available['<%= selLanguageId %>'] = '<%= curLocale.getDisplayName(locale) %>';
+				available['<%= selLanguageId %>'] = '<%= HtmlUtil.escapeJS(curLocale.getDisplayName(locale)) %>';
 				direction['<%= selLanguageId %>'] = '<%= LanguageUtil.get(curLocale, "lang.dir") %>';
 
 			<%


### PR DESCRIPTION
Steps to reproduce:

1. In portal-ext.properties include _fr_CI_ (_Cote d'Ivoire_ language) in `locales `and `locales.enabled` properties.
2. Start the server.
3. Navigate, in the default language (en_US), to localhost:8080/web/guest

**Expected result:** no errors in console.

**Current result:** you can see a js error in the console: "Uncaught syntax error: Unexpected identifier".

It is caused by fr_CI English (and French) display name: _French (Cote d'Ivoire)_, which is included with the unescaped apostrophe in _top_js.jspf_.

You can check the details in: https://issues.liferay.com/browse/LPS-131814

I've simply escaped (JS) each available language displayName to avoid apostrophes, which may be frequently found in some languages names (especially french ones, L'Antartique also, for example), from being interpreted as closing quotes and provoque navigation errors.