### PR TITLE
LPS-131283 extract the identifier to an argument instead of using the…

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
@@ -227,9 +227,10 @@ public class ObjectDefinitionGraphQLTest {
 					HashMapBuilder.<String, Object>put(
 						_objectDefinitionName,
 						StringBundler.concat(
-							"{", _objectDefinition.getPrimaryKeyColumnName(),
-							": ", String.valueOf(objectEntryId), ", ",
-							_objectFieldName, ": \"", value, "\"}")
+							"{", _objectFieldName, ": \"", value, "\"}")
+					).put(
+						_objectDefinition.getPrimaryKeyColumnName(),
+						String.valueOf(objectEntryId)
 					).build(),
 					new GraphQLField(_objectFieldName))));
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1474,18 +1474,9 @@ public class GraphQLServletExtender {
 
 		builder.name("Input" + objectDefinition.getName());
 
-		GraphQLInputObjectField.Builder inputBuilder =
-			GraphQLInputObjectField.newInputObjectField();
-
-		builder.field(
-			inputBuilder.name(
-				objectDefinition.getPrimaryKeyColumnName()
-			).type(
-				Scalars.GraphQLLong
-			).build());
-
 		for (com.liferay.object.model.ObjectField objectField : objectFields) {
-			inputBuilder = GraphQLInputObjectField.newInputObjectField();
+			GraphQLInputObjectField.Builder inputBuilder =
+				GraphQLInputObjectField.newInputObjectField();
 
 			builder.field(
 				inputBuilder.name(
@@ -1970,7 +1961,10 @@ public class GraphQLServletExtender {
 		mutationBuilder.field(
 			_addField(
 				graphQLObjectType, updateName,
-				_addArgument(graphQLInputType, objectDefinition.getName())));
+				_addArgument(graphQLInputType, objectDefinition.getName()),
+				_addArgument(
+					Scalars.GraphQLLong,
+					objectDefinition.getPrimaryKeyColumnName())));
 
 		schemaBuilder.codeRegistry(
 			graphQLCodeRegistryBuilder.dataFetcher(
@@ -1986,7 +1980,7 @@ public class GraphQLServletExtender {
 						objectDefinition,
 						_objectEntryLocalService.updateObjectEntry(
 							user.getUserId(),
-							(Long)values.get(
+							dataFetchingEnvironment.getArgument(
 								objectDefinition.getPrimaryKeyColumnName()),
 							values, new ServiceContext()));
 				}


### PR DESCRIPTION
… input type. The goal is to be more consistent with Update REST/GraphQL APIs that always have the id as a separate parameter.

I updated the test and also can be tested through /o/api:

<img width="758" alt="Screenshot 2021-05-08 at 01 54 57" src="https://user-images.githubusercontent.com/340653/117518937-f7fbc580-afa1-11eb-9457-53306b963782.png">
