### PR TITLE
LPS-130381 remove domain/tokenized search in object

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -541,9 +541,6 @@ public class ObjectEntryLocalServiceTest {
 
 		// With keywords
 
-		//_assertKeywords("@ liferay.com", 3);
-		//_assertKeywords("@-liferay.com", 0);
-		//_assertKeywords("@liferay.com", 3);
 		_assertKeywords("Peter", 1);
 		_assertKeywords("j0hn", 0);
 		_assertKeywords("john", 1);


### PR DESCRIPTION
This PR removes the assertions commented in [Strange search issue, worked last week...](https://github.com/liferay/liferay-portal/commit/a112a70903522e75f68d06ba25d7dbb84499287a) and that caused [AssertionError for ObjectEntryLocalServiceTest#testSearchObjectEntries](https://issues.liferay.com/browse/LRQA-67015)

These asserts were failing in previous PRs because [Search on emailAddress  field: eliminate wildcard usage and use a different type of query](https://issues.liferay.com/browse/LPS-130381) (fixing a security attack on ** in Elasticsearch). 

I could add a query in the contributor for this specific field but, given that this condition is a dynamic field defined by the user and it would only work if the user decides to call it exactly as `emailAddress`, I do not think it's worth it the extra CPU time in each query. At least now we know why they were failing.