### PR TITLE
Lps 131285 add batch support to object endpoints

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.rest.internal.jaxrs.application;
 
+import com.liferay.object.rest.internal.jaxrs.container.request.filter.ObjectDefinitionIdContainerRequestFilter;
 import com.liferay.object.rest.internal.jaxrs.context.provider.ObjectDefinitionContextProvider;
 import com.liferay.object.rest.internal.resource.v1_0.OpenAPIResourceImpl;
 import com.liferay.object.rest.resource.v1_0.ObjectEntryResource;
@@ -48,6 +49,8 @@ public class ObjectEntryApplication extends Application {
 			new ObjectDefinitionContextProvider(
 				_objectDefinitionLocalService.fetchObjectDefinition(
 					_objectDefinitionId)));
+		objects.add(
+			new ObjectDefinitionIdContainerRequestFilter(_objectDefinitionId));
 
 		return objects;
 	}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/container/request/filter/ObjectDefinitionIdContainerRequestFilter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/container/request/filter/ObjectDefinitionIdContainerRequestFilter.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.jaxrs.container.request.filter;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author Javier Gamarra
+ */
+@PreMatching
+@Provider
+public class ObjectDefinitionIdContainerRequestFilter
+	implements ContainerRequestFilter {
+
+	public ObjectDefinitionIdContainerRequestFilter(Long objectDefinitionId) {
+		_objectDefinitionId = objectDefinitionId;
+	}
+
+	@Override
+	public void filter(ContainerRequestContext containerRequestContext) {
+		UriInfo uriInfo = containerRequestContext.getUriInfo();
+
+		UriBuilder uriBuilder = uriInfo.getRequestUriBuilder();
+
+		MultivaluedMap<String, String> queryParameters =
+			uriInfo.getQueryParameters();
+
+		queryParameters.add(
+			"objectDefinitionId", String.valueOf(_objectDefinitionId));
+
+		for (Map.Entry<String, List<String>> entry :
+				queryParameters.entrySet()) {
+
+			uriBuilder.queryParam(entry.getKey(), entry.getValue());
+		}
+
+		containerRequestContext.setRequestUri(uriBuilder.build());
+	}
+
+	private final Long _objectDefinitionId;
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.internal.dto.converter.ObjectEntryDTOConverter;
 import com.liferay.object.rest.internal.odata.entity.ObjectEntryEntityModel;
 import com.liferay.object.rest.resource.v1_0.ObjectEntryResource;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
@@ -36,11 +37,15 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
+import java.io.Serializable;
+
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Context;
 
 import org.osgi.service.component.annotations.Component;
@@ -55,6 +60,28 @@ import org.osgi.service.component.annotations.ServiceScope;
 	scope = ServiceScope.PROTOTYPE, service = ObjectEntryResource.class
 )
 public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
+
+	@Override
+	public void create(
+			Collection<ObjectEntry> objectEntries,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		_loadObjectDefinition(parameters);
+
+		super.create(objectEntries, parameters);
+	}
+
+	@Override
+	public void delete(
+			Collection<ObjectEntry> objectEntries,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		_loadObjectDefinition(parameters);
+
+		super.delete(objectEntries, parameters);
+	}
 
 	@Override
 	public void deleteObjectEntry(Long objectEntryId) throws Exception {
@@ -135,6 +162,37 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 				(Map)objectEntry.getProperties(), new ServiceContext()));
 	}
 
+	@Override
+	public void update(
+			Collection<ObjectEntry> objectEntries,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		_loadObjectDefinition(parameters);
+
+		super.update(objectEntries, parameters);
+	}
+
+	private void _loadObjectDefinition(Map<String, Serializable> parameters)
+		throws Exception {
+
+		String parameterString = (String)parameters.get("objectDefinitionId");
+
+		String parameterArray = parameterString.substring(
+			1, parameterString.length() - 1);
+
+		String[] objectDefinitions = parameterArray.split(",");
+
+		if (objectDefinitions.length > 0) {
+			_objectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					GetterUtil.getLong(objectDefinitions[0]));
+		}
+		else {
+			throw new NotFoundException("Missing objectDefinitionId");
+		}
+	}
+
 	private ObjectEntry _toObjectEntry(
 		com.liferay.object.model.ObjectEntry objectEntry) {
 
@@ -152,6 +210,9 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 	@Context
 	private ObjectDefinition _objectDefinition;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
 	private ObjectEntryDTOConverter _objectEntryDTOConverter;


### PR DESCRIPTION
I've sent the PR directly to Brian as he requested: https://github.com/brianchandotcom/liferay-portal/pull/101546. But we can discuss improvements/other architectural approaches here and sent them later.

This adds batch support to `Object` endpoints with and without the rest builder shortcuts. It can be tested by doing a CURL request like:

```
curl -X "POST" "http://localhost:8080/o/YOUR_OBJECT_DEFINITION/v1.0/sites/YOUR_SITE/object-entries/batch" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test' \
     -d $'[
  {
    "YOUR_COLUMN": "hello!"
  }
]'
```

You can add an `ObjectDefinition` either executing the test or changing [this check](https://github.com/liferay/liferay-portal/blob/a52c45ca2dec16d8277eb3288332e9bafa49e9df/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/ObjectDefinitionSampleGenerator.java#L50) to true and redeploying. I prefer the test approach.

This also adds `UPDATE` (PUT to http://localhost:8080/o/YOUR_OBJECT_DEFINITION/v1.0/object-entries/batch) and `DELETE` endpoints (DELETE to http://localhost:8080/o/YOUR_OBJECT_DEFINITION/v1.0/object-entries/batch), passing a list as the POST request + the id of each entity like:

```
[{"id": 63107, "YOUR_COLUMN": "hello!"}, {"id": 63108, "YOUR_COLUMN": "bye!"}...]
```

Content-Type can be `application/json`, xml, jsonl, xls, txt.

There are 2 things I want to note:
* [This](https://github.com/liferay-frontend/liferay-portal/commit/fd17a05ff01d5e19423ee904da853aff3f099db4) is a bit ugly.
* But the main things is what to do with the @Context that do not work in `headless-batch` or `batch-engine` space...

  I do not see a way of filling all the contexts (in fact the Vulcan*Adaptor is not even filling the httpServletRequest/Response). Even if we do reflection and scan all @Context... what do we call? do we ask JAX-RS for all the possible ContextProviders, we try to match them and replicate the JAX-RS logic inside an Adaptor...?

  Another possible way would be changing the current contract and allow passing other types of parameters and propagate them to `batch-engine` and to the runnable and passing them back to the delegate. This is cumbersome but doable... the only thing that stops me from doing it is that we do not have the final say on that contract (it was developed by commerce and changed completely twice, including a change from reflection to interfaces). We may have to do it because as it is right now it's unusable from any developer outside Liferay (current APIs work, but developing batch methods it's very difficult). Commerce have suggestions to improve the interaction after trying to use the process for Liferay Online... so maybe everything changes after that conversation.

  But right now I went the way of using a ContainerRequestFilter to add a query parameter (those are propagated) and read it manually when called asynchronously. Previous code (a draft PR) added the parameter in the resource by implementing `UriInfo`. I think this approach is cleaner.

Open to suggestions :)