### PR TITLE
LPS-131904 change how we check if something is an object

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
@@ -190,16 +190,16 @@ public abstract class BaseCartResourceImpl
 			existingCart.setAuthor(cart.getAuthor());
 		}
 
-		if (cart.getBillingAddress() != null) {
-			existingCart.setBillingAddress(cart.getBillingAddress());
-		}
-
 		if (cart.getBillingAddressId() != null) {
 			existingCart.setBillingAddressId(cart.getBillingAddressId());
 		}
 
 		if (cart.getChannelId() != null) {
 			existingCart.setChannelId(cart.getChannelId());
+		}
+
+		if (cart.getCouponCode() != null) {
+			existingCart.setCouponCode(cart.getCouponCode());
 		}
 
 		if (cart.getCreateDate() != null) {
@@ -226,16 +226,12 @@ public abstract class BaseCartResourceImpl
 			existingCart.setModifiedDate(cart.getModifiedDate());
 		}
 
-		if (cart.getNotes() != null) {
-			existingCart.setNotes(cart.getNotes());
-		}
-
-		if (cart.getOrderStatusInfo() != null) {
-			existingCart.setOrderStatusInfo(cart.getOrderStatusInfo());
-		}
-
 		if (cart.getOrderUUID() != null) {
 			existingCart.setOrderUUID(cart.getOrderUUID());
+		}
+
+		if (cart.getPaymentMethod() != null) {
+			existingCart.setPaymentMethod(cart.getPaymentMethod());
 		}
 
 		if (cart.getPaymentMethodLabel() != null) {
@@ -244,10 +240,6 @@ public abstract class BaseCartResourceImpl
 
 		if (cart.getPaymentStatus() != null) {
 			existingCart.setPaymentStatus(cart.getPaymentStatus());
-		}
-
-		if (cart.getPaymentStatusInfo() != null) {
-			existingCart.setPaymentStatusInfo(cart.getPaymentStatusInfo());
 		}
 
 		if (cart.getPaymentStatusLabel() != null) {
@@ -262,12 +254,20 @@ public abstract class BaseCartResourceImpl
 			existingCart.setPurchaseOrderNumber(cart.getPurchaseOrderNumber());
 		}
 
-		if (cart.getShippingAddress() != null) {
-			existingCart.setShippingAddress(cart.getShippingAddress());
-		}
-
 		if (cart.getShippingAddressId() != null) {
 			existingCart.setShippingAddressId(cart.getShippingAddressId());
+		}
+
+		if (cart.getShippingMethod() != null) {
+			existingCart.setShippingMethod(cart.getShippingMethod());
+		}
+
+		if (cart.getShippingOption() != null) {
+			existingCart.setShippingOption(cart.getShippingOption());
+		}
+
+		if (cart.getStatus() != null) {
+			existingCart.setStatus(cart.getStatus());
 		}
 
 		if (cart.getUseAsBilling() != null) {
@@ -276,10 +276,6 @@ public abstract class BaseCartResourceImpl
 
 		if (cart.getValid() != null) {
 			existingCart.setValid(cart.getValid());
-		}
-
-		if (cart.getWorkflowStatusInfo() != null) {
-			existingCart.setWorkflowStatusInfo(cart.getWorkflowStatusInfo());
 		}
 
 		preparePatch(cart, existingCart);

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -283,11 +283,6 @@ public abstract class BaseDataDefinitionResourceImpl
 				dataDefinition.getDateModified());
 		}
 
-		if (dataDefinition.getDefaultDataLayout() != null) {
-			existingDataDefinition.setDefaultDataLayout(
-				dataDefinition.getDefaultDataLayout());
-		}
-
 		if (dataDefinition.getDefaultLanguageId() != null) {
 			existingDataDefinition.setDefaultLanguageId(
 				dataDefinition.getDefaultLanguageId());

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -307,11 +307,6 @@ public abstract class BaseOrganizationResourceImpl
 				organization.getNumberOfOrganizations());
 		}
 
-		if (organization.getParentOrganization() != null) {
-			existingOrganization.setParentOrganization(
-				organization.getParentOrganization());
-		}
-
 		preparePatch(organization, existingOrganization);
 
 		return putOrganization(organizationId, existingOrganization);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -385,6 +385,10 @@ public abstract class BaseUserAccountResourceImpl
 			existingUserAccount.setDateModified(userAccount.getDateModified());
 		}
 
+		if (userAccount.getEmailAddress() != null) {
+			existingUserAccount.setEmailAddress(userAccount.getEmailAddress());
+		}
+
 		if (userAccount.getFamilyName() != null) {
 			existingUserAccount.setFamilyName(userAccount.getFamilyName());
 		}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
@@ -26,6 +26,7 @@ import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Schema;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 /**
@@ -117,26 +118,13 @@ public class DTOOpenAPIParser {
 	public static boolean isSchemaProperty(
 		OpenAPIYAML openAPIYAML, String propertyName, Schema schema) {
 
-		Map<String, Schema> schemas = OpenAPIUtil.getAllSchemas(openAPIYAML);
-
 		Map<String, Schema> propertySchemas = _getPropertySchemas(schema);
 
 		for (Map.Entry<String, Schema> entry : propertySchemas.entrySet()) {
 			String propertySchemaName = entry.getKey();
-			Schema propertySchema = entry.getValue();
 
-			String curPropertyName = _getPropertyName(
-				propertySchema, propertySchemaName);
-
-			if (StringUtil.equalsIgnoreCase(curPropertyName, propertyName)) {
-				String schemaName = StringUtil.upperCaseFirstLetter(
-					propertySchemaName);
-
-				if (propertySchema.getItems() != null) {
-					schemaName = OpenAPIUtil.formatSingular(schemaName);
-				}
-
-				if (schemas.containsKey(schemaName)) {
+			if (propertySchemaName.equals(propertyName)) {
+				if (_isSchema(entry.getValue())) {
 					return true;
 				}
 
@@ -279,6 +267,32 @@ public class DTOOpenAPIParser {
 		}
 
 		return propertyType;
+	}
+
+	private static boolean _isObject(Schema schema, String type) {
+		if (Objects.equals("object", type) &&
+			(schema.getAdditionalPropertySchema() == null)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static boolean _isSchema(Schema schema) {
+		Items items = schema.getItems();
+
+		if (_isObject(schema, schema.getType()) ||
+			(schema.getReference() != null) ||
+			(schema.getAllOfSchemas() != null) ||
+			((items != null) &&
+			 (_isObject(schema, items.getType()) ||
+			  (items.getReference() != null)))) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 }


### PR DESCRIPTION
Instead on relying if a schema with the same name exists (that returns false positives like EmailAddress), use the definition of an object in OpenAPI: type `object` and not a map (`additionalProperties`) or reference or composition (`allOf`) or returns a list of objects (`items` and those conditions again).