### PR TITLE
LPS-131906 batch bug when registering an extended entity

### DIFF
--- a/modules/apps/account/account-rest-impl/src/main/java/com/liferay/account/rest/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/account/account-rest-impl/src/main/java/com/liferay/account/rest/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -577,7 +577,7 @@ public abstract class BaseAccountResourceImpl
 		for (Account account : accounts) {
 			putAccount(
 				account.getId() != null ? account.getId() :
-					(Long)parameters.get("accountId"),
+					Long.parseLong((String)parameters.get("accountId")),
 				account);
 		}
 	}

--- a/modules/apps/app-builder/app-builder-rest-impl/src/main/java/com/liferay/app/builder/rest/internal/resource/v1_0/BaseAppResourceImpl.java
+++ b/modules/apps/app-builder/app-builder-rest-impl/src/main/java/com/liferay/app/builder/rest/internal/resource/v1_0/BaseAppResourceImpl.java
@@ -405,8 +405,9 @@ public abstract class BaseAppResourceImpl
 		throws Exception {
 
 		return getSiteAppsPage(
-			(Long)parameters.get("siteId"), (String)parameters.get("keywords"),
-			(String)parameters.get("scope"), pagination, sorts);
+			Long.parseLong((String)parameters.get("siteId")),
+			(String)parameters.get("keywords"), (String)parameters.get("scope"),
+			pagination, sorts);
 	}
 
 	@Override
@@ -440,7 +441,7 @@ public abstract class BaseAppResourceImpl
 		for (App app : apps) {
 			putApp(
 				app.getId() != null ? app.getId() :
-					(Long)parameters.get("appId"),
+					Long.parseLong((String)parameters.get("appId")),
 				app);
 		}
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
@@ -611,7 +611,7 @@ public abstract class BaseAccountAddressResourceImpl
 		for (AccountAddress accountAddress : accountAddresses) {
 			putAccountAddress(
 				accountAddress.getId() != null ? accountAddress.getId() :
-					(Long)parameters.get("accountAddressId"),
+					Long.parseLong((String)parameters.get("accountAddressId")),
 				accountAddress);
 		}
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -417,7 +417,7 @@ public abstract class BaseChannelResourceImpl
 		for (Channel channel : channels) {
 			putChannel(
 				channel.getId() != null ? channel.getId() :
-					(Long)parameters.get("channelId"),
+					Long.parseLong((String)parameters.get("channelId")),
 				channel);
 		}
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
@@ -349,7 +349,8 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 			putAvailabilityEstimate(
 				availabilityEstimate.getId() != null ?
 					availabilityEstimate.getId() :
-						(Long)parameters.get("availabilityEstimateId"),
+						Long.parseLong(
+							(String)parameters.get("availabilityEstimateId")),
 				availabilityEstimate);
 		}
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
@@ -345,7 +345,7 @@ public abstract class BaseMeasurementUnitResourceImpl
 		for (MeasurementUnit measurementUnit : measurementUnits) {
 			putMeasurementUnit(
 				measurementUnit.getId() != null ? measurementUnit.getId() :
-					(Long)parameters.get("measurementUnitId"),
+					Long.parseLong((String)parameters.get("measurementUnitId")),
 				measurementUnit);
 		}
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -342,7 +342,7 @@ public abstract class BaseTaxCategoryResourceImpl
 		for (TaxCategory taxCategory : taxCategories) {
 			putTaxCategory(
 				taxCategory.getId() != null ? taxCategory.getId() :
-					(Long)parameters.get("taxCategoryId"),
+					Long.parseLong((String)parameters.get("taxCategoryId")),
 				taxCategory);
 		}
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -344,7 +344,7 @@ public abstract class BaseWarehouseResourceImpl
 		for (Warehouse warehouse : warehouses) {
 			putWarehouse(
 				warehouse.getId() != null ? warehouse.getId() :
-					(Long)parameters.get("warehouseId"),
+					Long.parseLong((String)parameters.get("warehouseId")),
 				warehouse);
 		}
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
@@ -383,7 +383,7 @@ public abstract class BaseCartCommentResourceImpl
 		for (CartComment cartComment : cartComments) {
 			putCartComment(
 				cartComment.getId() != null ? cartComment.getId() :
-					(Long)parameters.get("cartCommentId"),
+					Long.parseLong((String)parameters.get("cartCommentId")),
 				cartComment);
 		}
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
@@ -425,7 +425,7 @@ public abstract class BaseCartItemResourceImpl
 		for (CartItem cartItem : cartItems) {
 			putCartItem(
 				cartItem.getId() != null ? cartItem.getId() :
-					(Long)parameters.get("cartItemId"),
+					Long.parseLong((String)parameters.get("cartItemId")),
 				cartItem);
 		}
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
@@ -504,7 +504,7 @@ public abstract class BaseCartResourceImpl
 		for (Cart cart : carts) {
 			putCart(
 				cart.getId() != null ? cart.getId() :
-					(Long)parameters.get("cartId"),
+					Long.parseLong((String)parameters.get("cartId")),
 				cart);
 		}
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
@@ -130,7 +130,8 @@ public abstract class BasePaymentMethodResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getCartPaymentMethodsPage((Long)parameters.get("cartId"));
+		return getCartPaymentMethodsPage(
+			Long.parseLong((String)parameters.get("cartId")));
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -130,7 +130,8 @@ public abstract class BaseShippingMethodResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getCartShippingMethodsPage((Long)parameters.get("cartId"));
+		return getCartShippingMethodsPage(
+			Long.parseLong((String)parameters.get("cartId")));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -616,7 +616,7 @@ public abstract class BaseDataDefinitionResourceImpl
 		for (DataDefinition dataDefinition : dataDefinitions) {
 			putDataDefinition(
 				dataDefinition.getId() != null ? dataDefinition.getId() :
-					(Long)parameters.get("dataDefinitionId"),
+					Long.parseLong((String)parameters.get("dataDefinitionId")),
 				dataDefinition);
 		}
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
@@ -393,7 +393,8 @@ public abstract class BaseDataLayoutResourceImpl
 
 		for (DataLayout dataLayout : dataLayouts) {
 			postDataDefinitionDataLayout(
-				(Long)parameters.get("dataDefinitionId"), dataLayout);
+				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				dataLayout);
 		}
 	}
 
@@ -430,7 +431,7 @@ public abstract class BaseDataLayoutResourceImpl
 		throws Exception {
 
 		return getDataDefinitionDataLayoutsPage(
-			(Long)parameters.get("dataDefinitionId"),
+			Long.parseLong((String)parameters.get("dataDefinitionId")),
 			(String)parameters.get("keywords"), pagination, sorts);
 	}
 
@@ -465,7 +466,7 @@ public abstract class BaseDataLayoutResourceImpl
 		for (DataLayout dataLayout : dataLayouts) {
 			putDataLayout(
 				dataLayout.getId() != null ? dataLayout.getId() :
-					(Long)parameters.get("dataLayoutId"),
+					Long.parseLong((String)parameters.get("dataLayoutId")),
 				dataLayout);
 		}
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
@@ -337,7 +337,8 @@ public abstract class BaseDataListViewResourceImpl
 
 		for (DataListView dataListView : dataListViews) {
 			postDataDefinitionDataListView(
-				(Long)parameters.get("dataDefinitionId"), dataListView);
+				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				dataListView);
 		}
 	}
 
@@ -374,7 +375,7 @@ public abstract class BaseDataListViewResourceImpl
 		throws Exception {
 
 		return getDataDefinitionDataListViewsPage(
-			(Long)parameters.get("dataDefinitionId"),
+			Long.parseLong((String)parameters.get("dataDefinitionId")),
 			(String)parameters.get("keywords"), pagination, sorts);
 	}
 
@@ -409,7 +410,7 @@ public abstract class BaseDataListViewResourceImpl
 		for (DataListView dataListView : dataListViews) {
 			putDataListView(
 				dataListView.getId() != null ? dataListView.getId() :
-					(Long)parameters.get("dataListViewId"),
+					Long.parseLong((String)parameters.get("dataListViewId")),
 				dataListView);
 		}
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -498,7 +498,8 @@ public abstract class BaseDataRecordCollectionResourceImpl
 				dataRecordCollections) {
 
 			postDataDefinitionDataRecordCollection(
-				(Long)parameters.get("dataDefinitionId"), dataRecordCollection);
+				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				dataRecordCollection);
 		}
 	}
 
@@ -537,7 +538,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 		throws Exception {
 
 		return getDataDefinitionDataRecordCollectionsPage(
-			(Long)parameters.get("dataDefinitionId"),
+			Long.parseLong((String)parameters.get("dataDefinitionId")),
 			(String)parameters.get("keywords"), pagination);
 	}
 
@@ -575,7 +576,8 @@ public abstract class BaseDataRecordCollectionResourceImpl
 			putDataRecordCollection(
 				dataRecordCollection.getId() != null ?
 					dataRecordCollection.getId() :
-						(Long)parameters.get("dataRecordCollectionId"),
+						Long.parseLong(
+							(String)parameters.get("dataRecordCollectionId")),
 				dataRecordCollection);
 		}
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
@@ -496,7 +496,8 @@ public abstract class BaseDataRecordResourceImpl
 
 		for (DataRecord dataRecord : dataRecords) {
 			postDataDefinitionDataRecord(
-				(Long)parameters.get("dataDefinitionId"), dataRecord);
+				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				dataRecord);
 		}
 	}
 
@@ -533,8 +534,8 @@ public abstract class BaseDataRecordResourceImpl
 		throws Exception {
 
 		return getDataDefinitionDataRecordsPage(
-			(Long)parameters.get("dataDefinitionId"),
-			(Long)parameters.get("dataListViewId"),
+			Long.parseLong((String)parameters.get("dataDefinitionId")),
+			Long.parseLong((String)parameters.get("dataListViewId")),
 			(String)parameters.get("keywords"), pagination, sorts);
 	}
 
@@ -569,7 +570,7 @@ public abstract class BaseDataRecordResourceImpl
 		for (DataRecord dataRecord : dataRecords) {
 			putDataRecord(
 				dataRecord.getId() != null ? dataRecord.getId() :
-					(Long)parameters.get("dataRecordId"),
+					Long.parseLong((String)parameters.get("dataRecordId")),
 				dataRecord);
 		}
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -659,7 +659,8 @@ public abstract class BaseKeywordResourceImpl
 		throws Exception {
 
 		for (Keyword keyword : keywords) {
-			postSiteKeyword((Long)parameters.get("siteId"), keyword);
+			postSiteKeyword(
+				Long.parseLong((String)parameters.get("siteId")), keyword);
 		}
 	}
 
@@ -696,7 +697,8 @@ public abstract class BaseKeywordResourceImpl
 		throws Exception {
 
 		return getSiteKeywordsPage(
-			(Long)parameters.get("siteId"), search, filter, pagination, sorts);
+			Long.parseLong((String)parameters.get("siteId")), search, filter,
+			pagination, sorts);
 	}
 
 	@Override
@@ -730,7 +732,7 @@ public abstract class BaseKeywordResourceImpl
 		for (Keyword keyword : keywords) {
 			putKeyword(
 				keyword.getId() != null ? keyword.getId() :
-					(Long)parameters.get("keywordId"),
+					Long.parseLong((String)parameters.get("keywordId")),
 				keyword);
 		}
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -606,7 +606,8 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 
 		for (TaxonomyCategory taxonomyCategory : taxonomyCategories) {
 			postTaxonomyVocabularyTaxonomyCategory(
-				(Long)parameters.get("taxonomyVocabularyId"), taxonomyCategory);
+				Long.parseLong((String)parameters.get("taxonomyVocabularyId")),
+				taxonomyCategory);
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -751,7 +751,8 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 
 		for (TaxonomyVocabulary taxonomyVocabulary : taxonomyVocabularies) {
 			postSiteTaxonomyVocabulary(
-				(Long)parameters.get("siteId"), taxonomyVocabulary);
+				Long.parseLong((String)parameters.get("siteId")),
+				taxonomyVocabulary);
 		}
 	}
 
@@ -822,7 +823,8 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 			putTaxonomyVocabulary(
 				taxonomyVocabulary.getId() != null ?
 					taxonomyVocabulary.getId() :
-						(Long)parameters.get("taxonomyVocabularyId"),
+						Long.parseLong(
+							(String)parameters.get("taxonomyVocabularyId")),
 				taxonomyVocabulary);
 		}
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -456,8 +456,8 @@ public abstract class BaseOrganizationResourceImpl
 		throws Exception {
 
 		return getOrganizationsPage(
-			(Boolean)parameters.get("flatten"), search, filter, pagination,
-			sorts);
+			Boolean.parseBoolean((String)parameters.get("flatten")), search,
+			filter, pagination, sorts);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
@@ -166,7 +166,8 @@ public abstract class BaseSegmentResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getSiteSegmentsPage((Long)parameters.get("siteId"), pagination);
+		return getSiteSegmentsPage(
+			Long.parseLong((String)parameters.get("siteId")), pagination);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -539,7 +539,8 @@ public abstract class BaseUserAccountResourceImpl
 		throws Exception {
 
 		return getSiteUserAccountsPage(
-			(Long)parameters.get("siteId"), search, filter, pagination, sorts);
+			Long.parseLong((String)parameters.get("siteId")), search, filter,
+			pagination, sorts);
 	}
 
 	@Override
@@ -573,7 +574,7 @@ public abstract class BaseUserAccountResourceImpl
 		for (UserAccount userAccount : userAccounts) {
 			putUserAccount(
 				userAccount.getId() != null ? userAccount.getId() :
-					(Long)parameters.get("userAccountId"),
+					Long.parseLong((String)parameters.get("userAccountId")),
 				userAccount);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -269,7 +269,8 @@ public abstract class BaseBlogPostingImageResourceImpl
 		throws Exception {
 
 		for (BlogPostingImage blogPostingImage : blogPostingImages) {
-			postSiteBlogPostingImage((Long)parameters.get("siteId"), null);
+			postSiteBlogPostingImage(
+				Long.parseLong((String)parameters.get("siteId")), null);
 		}
 	}
 
@@ -306,8 +307,8 @@ public abstract class BaseBlogPostingImageResourceImpl
 		throws Exception {
 
 		return getSiteBlogPostingImagesPage(
-			(Long)parameters.get("siteId"), search, null, filter, pagination,
-			sorts);
+			Long.parseLong((String)parameters.get("siteId")), search, null,
+			filter, pagination, sorts);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -735,7 +735,8 @@ public abstract class BaseBlogPostingResourceImpl
 		throws Exception {
 
 		for (BlogPosting blogPosting : blogPostings) {
-			postSiteBlogPosting((Long)parameters.get("siteId"), blogPosting);
+			postSiteBlogPosting(
+				Long.parseLong((String)parameters.get("siteId")), blogPosting);
 		}
 	}
 
@@ -772,8 +773,8 @@ public abstract class BaseBlogPostingResourceImpl
 		throws Exception {
 
 		return getSiteBlogPostingsPage(
-			(Long)parameters.get("siteId"), search, null, filter, pagination,
-			sorts);
+			Long.parseLong((String)parameters.get("siteId")), search, null,
+			filter, pagination, sorts);
 	}
 
 	@Override
@@ -807,7 +808,7 @@ public abstract class BaseBlogPostingResourceImpl
 		for (BlogPosting blogPosting : blogPostings) {
 			putBlogPosting(
 				blogPosting.getId() != null ? blogPosting.getId() :
-					(Long)parameters.get("blogPostingId"),
+					Long.parseLong((String)parameters.get("blogPostingId")),
 				blogPosting);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -594,7 +594,8 @@ public abstract class BaseCommentResourceImpl
 
 		for (Comment comment : comments) {
 			postBlogPostingComment(
-				(Long)parameters.get("blogPostingId"), comment);
+				Long.parseLong((String)parameters.get("blogPostingId")),
+				comment);
 		}
 	}
 
@@ -631,8 +632,8 @@ public abstract class BaseCommentResourceImpl
 		throws Exception {
 
 		return getBlogPostingCommentsPage(
-			(Long)parameters.get("blogPostingId"), search, null, filter,
-			pagination, sorts);
+			Long.parseLong((String)parameters.get("blogPostingId")), search,
+			null, filter, pagination, sorts);
 	}
 
 	@Override
@@ -666,7 +667,7 @@ public abstract class BaseCommentResourceImpl
 		for (Comment comment : comments) {
 			putComment(
 				comment.getId() != null ? comment.getId() :
-					(Long)parameters.get("commentId"),
+					Long.parseLong((String)parameters.get("commentId")),
 				comment);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
@@ -178,8 +178,8 @@ public abstract class BaseContentElementResourceImpl
 		throws Exception {
 
 		return getSiteContentElementsPage(
-			(Long)parameters.get("siteId"), search, null, filter, pagination,
-			sorts);
+			Long.parseLong((String)parameters.get("siteId")), search, null,
+			filter, pagination, sorts);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -428,8 +428,8 @@ public abstract class BaseContentStructureResourceImpl
 		throws Exception {
 
 		return getSiteContentStructuresPage(
-			(Long)parameters.get("siteId"), search, null, filter, pagination,
-			sorts);
+			Long.parseLong((String)parameters.get("siteId")), search, null,
+			filter, pagination, sorts);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
@@ -203,8 +203,8 @@ public abstract class BaseContentTemplateResourceImpl
 		throws Exception {
 
 		return getSiteContentTemplatesPage(
-			(Long)parameters.get("siteId"), search, null, filter, pagination,
-			sorts);
+			Long.parseLong((String)parameters.get("siteId")), search, null,
+			filter, pagination, sorts);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -848,7 +848,8 @@ public abstract class BaseDocumentFolderResourceImpl
 
 		for (DocumentFolder documentFolder : documentFolders) {
 			postSiteDocumentFolder(
-				(Long)parameters.get("siteId"), documentFolder);
+				Long.parseLong((String)parameters.get("siteId")),
+				documentFolder);
 		}
 	}
 
@@ -885,8 +886,9 @@ public abstract class BaseDocumentFolderResourceImpl
 		throws Exception {
 
 		return getSiteDocumentFoldersPage(
-			(Long)parameters.get("siteId"), (Boolean)parameters.get("flatten"),
-			search, null, filter, pagination, sorts);
+			Long.parseLong((String)parameters.get("siteId")),
+			Boolean.parseBoolean((String)parameters.get("flatten")), search,
+			null, filter, pagination, sorts);
 	}
 
 	@Override
@@ -920,7 +922,7 @@ public abstract class BaseDocumentFolderResourceImpl
 		for (DocumentFolder documentFolder : documentFolders) {
 			putDocumentFolder(
 				documentFolder.getId() != null ? documentFolder.getId() :
-					(Long)parameters.get("documentFolderId"),
+					Long.parseLong((String)parameters.get("documentFolderId")),
 				documentFolder);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -914,7 +914,8 @@ public abstract class BaseDocumentResourceImpl
 		throws Exception {
 
 		for (Document document : documents) {
-			postSiteDocument((Long)parameters.get("siteId"), null);
+			postSiteDocument(
+				Long.parseLong((String)parameters.get("siteId")), null);
 		}
 	}
 
@@ -951,8 +952,9 @@ public abstract class BaseDocumentResourceImpl
 		throws Exception {
 
 		return getSiteDocumentsPage(
-			(Long)parameters.get("siteId"), (Boolean)parameters.get("flatten"),
-			search, null, filter, pagination, sorts);
+			Long.parseLong((String)parameters.get("siteId")),
+			Boolean.parseBoolean((String)parameters.get("flatten")), search,
+			null, filter, pagination, sorts);
 	}
 
 	@Override
@@ -986,7 +988,7 @@ public abstract class BaseDocumentResourceImpl
 		for (Document document : documents) {
 			putDocument(
 				document.getId() != null ? document.getId() :
-					(Long)parameters.get("documentId"),
+					Long.parseLong((String)parameters.get("documentId")),
 				null);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -994,7 +994,8 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 				knowledgeBaseArticles) {
 
 			postSiteKnowledgeBaseArticle(
-				(Long)parameters.get("siteId"), knowledgeBaseArticle);
+				Long.parseLong((String)parameters.get("siteId")),
+				knowledgeBaseArticle);
 		}
 	}
 
@@ -1033,8 +1034,9 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 		throws Exception {
 
 		return getSiteKnowledgeBaseArticlesPage(
-			(Long)parameters.get("siteId"), (Boolean)parameters.get("flatten"),
-			search, null, filter, pagination, sorts);
+			Long.parseLong((String)parameters.get("siteId")),
+			Boolean.parseBoolean((String)parameters.get("flatten")), search,
+			null, filter, pagination, sorts);
 	}
 
 	@Override
@@ -1071,7 +1073,8 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			putKnowledgeBaseArticle(
 				knowledgeBaseArticle.getId() != null ?
 					knowledgeBaseArticle.getId() :
-						(Long)parameters.get("knowledgeBaseArticleId"),
+						Long.parseLong(
+							(String)parameters.get("knowledgeBaseArticleId")),
 				knowledgeBaseArticle);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -291,7 +291,9 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 				knowledgeBaseAttachments) {
 
 			postKnowledgeBaseArticleKnowledgeBaseAttachment(
-				(Long)parameters.get("knowledgeBaseArticleId"), null);
+				Long.parseLong(
+					(String)parameters.get("knowledgeBaseArticleId")),
+				null);
 		}
 	}
 
@@ -331,7 +333,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 		throws Exception {
 
 		return getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
-			(Long)parameters.get("knowledgeBaseArticleId"));
+			Long.parseLong((String)parameters.get("knowledgeBaseArticleId")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -639,7 +639,8 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 
 		for (KnowledgeBaseFolder knowledgeBaseFolder : knowledgeBaseFolders) {
 			postSiteKnowledgeBaseFolder(
-				(Long)parameters.get("siteId"), knowledgeBaseFolder);
+				Long.parseLong((String)parameters.get("siteId")),
+				knowledgeBaseFolder);
 		}
 	}
 
@@ -676,7 +677,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		throws Exception {
 
 		return getSiteKnowledgeBaseFoldersPage(
-			(Long)parameters.get("siteId"), pagination);
+			Long.parseLong((String)parameters.get("siteId")), pagination);
 	}
 
 	@Override
@@ -711,7 +712,8 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			putKnowledgeBaseFolder(
 				knowledgeBaseFolder.getId() != null ?
 					knowledgeBaseFolder.getId() :
-						(Long)parameters.get("knowledgeBaseFolderId"),
+						Long.parseLong(
+							(String)parameters.get("knowledgeBaseFolderId")),
 				knowledgeBaseFolder);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
@@ -152,7 +152,8 @@ public abstract class BaseLanguageResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getSiteLanguagesPage((Long)parameters.get("siteId"));
+		return getSiteLanguagesPage(
+			Long.parseLong((String)parameters.get("siteId")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -393,7 +393,8 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 				messageBoardAttachments) {
 
 			postMessageBoardMessageMessageBoardAttachment(
-				(Long)parameters.get("messageBoardMessageId"), null);
+				Long.parseLong((String)parameters.get("messageBoardMessageId")),
+				null);
 		}
 	}
 
@@ -433,7 +434,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 		throws Exception {
 
 		return getMessageBoardMessageMessageBoardAttachmentsPage(
-			(Long)parameters.get("messageBoardMessageId"));
+			Long.parseLong((String)parameters.get("messageBoardMessageId")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -1031,7 +1031,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 
 		for (MessageBoardMessage messageBoardMessage : messageBoardMessages) {
 			postMessageBoardThreadMessageBoardMessage(
-				(Long)parameters.get("messageBoardThreadId"),
+				Long.parseLong((String)parameters.get("messageBoardThreadId")),
 				messageBoardMessage);
 		}
 	}
@@ -1069,8 +1069,9 @@ public abstract class BaseMessageBoardMessageResourceImpl
 		throws Exception {
 
 		return getSiteMessageBoardMessagesPage(
-			(Long)parameters.get("siteId"), (Boolean)parameters.get("flatten"),
-			search, null, filter, pagination, sorts);
+			Long.parseLong((String)parameters.get("siteId")),
+			Boolean.parseBoolean((String)parameters.get("flatten")), search,
+			null, filter, pagination, sorts);
 	}
 
 	@Override
@@ -1105,7 +1106,8 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			putMessageBoardMessage(
 				messageBoardMessage.getId() != null ?
 					messageBoardMessage.getId() :
-						(Long)parameters.get("messageBoardMessageId"),
+						Long.parseLong(
+							(String)parameters.get("messageBoardMessageId")),
 				messageBoardMessage);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -705,7 +705,8 @@ public abstract class BaseMessageBoardSectionResourceImpl
 
 		for (MessageBoardSection messageBoardSection : messageBoardSections) {
 			postSiteMessageBoardSection(
-				(Long)parameters.get("siteId"), messageBoardSection);
+				Long.parseLong((String)parameters.get("siteId")),
+				messageBoardSection);
 		}
 	}
 
@@ -742,8 +743,9 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		throws Exception {
 
 		return getSiteMessageBoardSectionsPage(
-			(Long)parameters.get("siteId"), (Boolean)parameters.get("flatten"),
-			search, null, filter, pagination, sorts);
+			Long.parseLong((String)parameters.get("siteId")),
+			Boolean.parseBoolean((String)parameters.get("flatten")), search,
+			null, filter, pagination, sorts);
 	}
 
 	@Override
@@ -778,7 +780,8 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			putMessageBoardSection(
 				messageBoardSection.getId() != null ?
 					messageBoardSection.getId() :
-						(Long)parameters.get("messageBoardSectionId"),
+						Long.parseLong(
+							(String)parameters.get("messageBoardSectionId")),
 				messageBoardSection);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -961,7 +961,8 @@ public abstract class BaseMessageBoardThreadResourceImpl
 
 		for (MessageBoardThread messageBoardThread : messageBoardThreads) {
 			postSiteMessageBoardThread(
-				(Long)parameters.get("siteId"), messageBoardThread);
+				Long.parseLong((String)parameters.get("siteId")),
+				messageBoardThread);
 		}
 	}
 
@@ -998,8 +999,9 @@ public abstract class BaseMessageBoardThreadResourceImpl
 		throws Exception {
 
 		return getSiteMessageBoardThreadsPage(
-			(Long)parameters.get("siteId"), (Boolean)parameters.get("flatten"),
-			search, null, filter, pagination, sorts);
+			Long.parseLong((String)parameters.get("siteId")),
+			Boolean.parseBoolean((String)parameters.get("flatten")), search,
+			null, filter, pagination, sorts);
 	}
 
 	@Override
@@ -1034,7 +1036,8 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			putMessageBoardThread(
 				messageBoardThread.getId() != null ?
 					messageBoardThread.getId() :
-						(Long)parameters.get("messageBoardThreadId"),
+						Long.parseLong(
+							(String)parameters.get("messageBoardThreadId")),
 				messageBoardThread);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -473,7 +473,8 @@ public abstract class BaseNavigationMenuResourceImpl
 
 		for (NavigationMenu navigationMenu : navigationMenus) {
 			postSiteNavigationMenu(
-				(Long)parameters.get("siteId"), navigationMenu);
+				Long.parseLong((String)parameters.get("siteId")),
+				navigationMenu);
 		}
 	}
 
@@ -510,7 +511,7 @@ public abstract class BaseNavigationMenuResourceImpl
 		throws Exception {
 
 		return getSiteNavigationMenusPage(
-			(Long)parameters.get("siteId"), pagination);
+			Long.parseLong((String)parameters.get("siteId")), pagination);
 	}
 
 	@Override
@@ -544,7 +545,7 @@ public abstract class BaseNavigationMenuResourceImpl
 		for (NavigationMenu navigationMenu : navigationMenus) {
 			putNavigationMenu(
 				navigationMenu.getId() != null ? navigationMenu.getId() :
-					(Long)parameters.get("navigationMenuId"),
+					Long.parseLong((String)parameters.get("navigationMenuId")),
 				navigationMenu);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -294,8 +294,8 @@ public abstract class BaseSitePageResourceImpl
 		throws Exception {
 
 		return getSiteSitePagesPage(
-			(Long)parameters.get("siteId"), search, null, filter, pagination,
-			sorts);
+			Long.parseLong((String)parameters.get("siteId")), search, null,
+			filter, pagination, sorts);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -913,7 +913,8 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				structuredContentFolders) {
 
 			postSiteStructuredContentFolder(
-				(Long)parameters.get("siteId"), structuredContentFolder);
+				Long.parseLong((String)parameters.get("siteId")),
+				structuredContentFolder);
 		}
 	}
 
@@ -953,8 +954,9 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		throws Exception {
 
 		return getSiteStructuredContentFoldersPage(
-			(Long)parameters.get("siteId"), (Boolean)parameters.get("flatten"),
-			search, null, filter, pagination, sorts);
+			Long.parseLong((String)parameters.get("siteId")),
+			Boolean.parseBoolean((String)parameters.get("flatten")), search,
+			null, filter, pagination, sorts);
 	}
 
 	@Override
@@ -992,7 +994,9 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			putStructuredContentFolder(
 				structuredContentFolder.getId() != null ?
 					structuredContentFolder.getId() :
-						(Long)parameters.get("structuredContentFolderId"),
+						Long.parseLong(
+							(String)parameters.get(
+								"structuredContentFolderId")),
 				structuredContentFolder);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -1217,7 +1217,8 @@ public abstract class BaseStructuredContentResourceImpl
 
 		for (StructuredContent structuredContent : structuredContents) {
 			postSiteStructuredContent(
-				(Long)parameters.get("siteId"), structuredContent);
+				Long.parseLong((String)parameters.get("siteId")),
+				structuredContent);
 		}
 	}
 
@@ -1254,8 +1255,9 @@ public abstract class BaseStructuredContentResourceImpl
 		throws Exception {
 
 		return getSiteStructuredContentsPage(
-			(Long)parameters.get("siteId"), (Boolean)parameters.get("flatten"),
-			search, null, filter, pagination, sorts);
+			Long.parseLong((String)parameters.get("siteId")),
+			Boolean.parseBoolean((String)parameters.get("flatten")), search,
+			null, filter, pagination, sorts);
 	}
 
 	@Override
@@ -1289,7 +1291,8 @@ public abstract class BaseStructuredContentResourceImpl
 		for (StructuredContent structuredContent : structuredContents) {
 			putStructuredContent(
 				structuredContent.getId() != null ? structuredContent.getId() :
-					(Long)parameters.get("structuredContentId"),
+					Long.parseLong(
+						(String)parameters.get("structuredContentId")),
 				structuredContent);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -608,7 +608,8 @@ public abstract class BaseWikiNodeResourceImpl
 		throws Exception {
 
 		for (WikiNode wikiNode : wikiNodes) {
-			postSiteWikiNode((Long)parameters.get("siteId"), wikiNode);
+			postSiteWikiNode(
+				Long.parseLong((String)parameters.get("siteId")), wikiNode);
 		}
 	}
 
@@ -645,8 +646,8 @@ public abstract class BaseWikiNodeResourceImpl
 		throws Exception {
 
 		return getSiteWikiNodesPage(
-			(Long)parameters.get("siteId"), search, null, filter, pagination,
-			sorts);
+			Long.parseLong((String)parameters.get("siteId")), search, null,
+			filter, pagination, sorts);
 	}
 
 	@Override
@@ -680,7 +681,7 @@ public abstract class BaseWikiNodeResourceImpl
 		for (WikiNode wikiNode : wikiNodes) {
 			putWikiNode(
 				wikiNode.getId() != null ? wikiNode.getId() :
-					(Long)parameters.get("wikiNodeId"),
+					Long.parseLong((String)parameters.get("wikiNodeId")),
 				wikiNode);
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -267,7 +267,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 
 		for (WikiPageAttachment wikiPageAttachment : wikiPageAttachments) {
 			postWikiPageWikiPageAttachment(
-				(Long)parameters.get("wikiPageId"), null);
+				Long.parseLong((String)parameters.get("wikiPageId")), null);
 		}
 	}
 
@@ -304,7 +304,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 		throws Exception {
 
 		return getWikiPageWikiPageAttachmentsPage(
-			(Long)parameters.get("wikiPageId"));
+			Long.parseLong((String)parameters.get("wikiPageId")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -593,7 +593,8 @@ public abstract class BaseWikiPageResourceImpl
 		throws Exception {
 
 		for (WikiPage wikiPage : wikiPages) {
-			postWikiNodeWikiPage((Long)parameters.get("wikiNodeId"), wikiPage);
+			postWikiNodeWikiPage(
+				Long.parseLong((String)parameters.get("wikiNodeId")), wikiPage);
 		}
 	}
 
@@ -630,8 +631,8 @@ public abstract class BaseWikiPageResourceImpl
 		throws Exception {
 
 		return getWikiNodeWikiPagesPage(
-			(Long)parameters.get("wikiNodeId"), search, null, filter,
-			pagination, sorts);
+			Long.parseLong((String)parameters.get("wikiNodeId")), search, null,
+			filter, pagination, sorts);
 	}
 
 	@Override
@@ -665,7 +666,7 @@ public abstract class BaseWikiPageResourceImpl
 		for (WikiPage wikiPage : wikiPages) {
 			putWikiPage(
 				wikiPage.getId() != null ? wikiPage.getId() :
-					(Long)parameters.get("wikiPageId"),
+					Long.parseLong((String)parameters.get("wikiPageId")),
 				wikiPage);
 		}
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -282,7 +282,8 @@ public abstract class BaseFormRecordResourceImpl
 		throws Exception {
 
 		for (FormRecord formRecord : formRecords) {
-			postFormFormRecord((Long)parameters.get("formId"), formRecord);
+			postFormFormRecord(
+				Long.parseLong((String)parameters.get("formId")), formRecord);
 		}
 	}
 
@@ -315,7 +316,7 @@ public abstract class BaseFormRecordResourceImpl
 		throws Exception {
 
 		return getFormFormRecordsPage(
-			(Long)parameters.get("formId"), pagination);
+			Long.parseLong((String)parameters.get("formId")), pagination);
 	}
 
 	@Override
@@ -349,7 +350,7 @@ public abstract class BaseFormRecordResourceImpl
 		for (FormRecord formRecord : formRecords) {
 			putFormRecord(
 				formRecord.getId() != null ? formRecord.getId() :
-					(Long)parameters.get("formRecordId"),
+					Long.parseLong((String)parameters.get("formRecordId")),
 				formRecord);
 		}
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -208,7 +208,8 @@ public abstract class BaseFormResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getSiteFormsPage((Long)parameters.get("siteId"), pagination);
+		return getSiteFormsPage(
+			Long.parseLong((String)parameters.get("siteId")), pagination);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -163,7 +163,7 @@ public abstract class BaseFormStructureResourceImpl
 		throws Exception {
 
 		return getSiteFormStructuresPage(
-			(Long)parameters.get("siteId"), pagination);
+			Long.parseLong((String)parameters.get("siteId")), pagination);
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -276,7 +276,8 @@ public abstract class BaseObjectEntryResourceImpl
 		throws Exception {
 
 		for (ObjectEntry objectEntry : objectEntries) {
-			postSiteObjectEntry((Long)parameters.get("siteId"), objectEntry);
+			postSiteObjectEntry(
+				Long.parseLong((String)parameters.get("siteId")), objectEntry);
 		}
 	}
 
@@ -346,7 +347,7 @@ public abstract class BaseObjectEntryResourceImpl
 		for (ObjectEntry objectEntry : objectEntries) {
 			putObjectEntry(
 				objectEntry.getId() != null ? objectEntry.getId() :
-					(Long)parameters.get("objectEntryId"),
+					Long.parseLong((String)parameters.get("objectEntryId")),
 				objectEntry);
 		}
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateAdaptorFactory.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateAdaptorFactory.java
@@ -17,6 +17,7 @@ package com.liferay.portal.vulcan.internal.batch.engine;
 import com.liferay.batch.engine.BatchEngineTaskItemDelegate;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 
 import org.osgi.framework.BundleContext;
@@ -85,9 +86,14 @@ public class VulcanBatchEngineTaskItemDelegateAdaptorFactory {
 						_depotEntryLocalService, _groupLocalService,
 						vulcanBatchEngineTaskItemDelegate);
 
+			String delegateName = "batch.engine.task.item.delegate.name";
+
 			return _bundleContext.registerService(
 				BatchEngineTaskItemDelegate.class,
-				vulcanBatchEngineTaskItemDelegateAdaptor, null);
+				vulcanBatchEngineTaskItemDelegateAdaptor,
+				HashMapDictionaryBuilder.put(
+					delegateName, serviceReference.getProperty(delegateName)
+				).build());
 		}
 
 		@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
@@ -299,7 +299,8 @@ public abstract class BaseInstanceResourceImpl
 		throws Exception {
 
 		for (Instance instance : instances) {
-			postProcessInstance((Long)parameters.get("processId"), instance);
+			postProcessInstance(
+				Long.parseLong((String)parameters.get("processId")), instance);
 		}
 	}
 
@@ -332,12 +333,12 @@ public abstract class BaseInstanceResourceImpl
 		throws Exception {
 
 		return getProcessInstancesPage(
-			(Long)parameters.get("processId"),
+			Long.parseLong((String)parameters.get("processId")),
 			(Long[])parameters.get("assigneeIds"),
 			(Long[])parameters.get("classPKs"),
-			(Boolean)parameters.get("completed"),
-			(java.util.Date)parameters.get("dateEnd"),
-			(java.util.Date)parameters.get("dateStart"),
+			Boolean.parseBoolean((String)parameters.get("completed")),
+			new java.util.Date((String)parameters.get("dateEnd")),
+			new java.util.Date((String)parameters.get("dateStart")),
 			(String[])parameters.get("slaStatuses"),
 			(String[])parameters.get("taskNames"), pagination);
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
@@ -191,7 +191,8 @@ public abstract class BaseNodeResourceImpl
 		throws Exception {
 
 		for (Node node : nodes) {
-			postProcessNode((Long)parameters.get("processId"), node);
+			postProcessNode(
+				Long.parseLong((String)parameters.get("processId")), node);
 		}
 	}
 
@@ -223,7 +224,8 @@ public abstract class BaseNodeResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getProcessNodesPage((Long)parameters.get("processId"));
+		return getProcessNodesPage(
+			Long.parseLong((String)parameters.get("processId")));
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
@@ -355,7 +355,7 @@ public abstract class BaseProcessResourceImpl
 		for (Process process : processes) {
 			putProcess(
 				process.getId() != null ? process.getId() :
-					(Long)parameters.get("processId"),
+					Long.parseLong((String)parameters.get("processId")),
 				process);
 		}
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -138,8 +138,8 @@ public abstract class BaseRoleResourceImpl
 		throws Exception {
 
 		return getProcessRolesPage(
-			(Long)parameters.get("processId"),
-			(Boolean)parameters.get("completed"));
+			Long.parseLong((String)parameters.get("processId")),
+			Boolean.parseBoolean((String)parameters.get("completed")));
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
@@ -315,7 +315,8 @@ public abstract class BaseSLAResourceImpl
 		throws Exception {
 
 		for (SLA sla : slas) {
-			postProcessSLA((Long)parameters.get("processId"), sla);
+			postProcessSLA(
+				Long.parseLong((String)parameters.get("processId")), sla);
 		}
 	}
 
@@ -352,8 +353,8 @@ public abstract class BaseSLAResourceImpl
 		throws Exception {
 
 		return getProcessSLAsPage(
-			(Long)parameters.get("processId"),
-			(Integer)parameters.get("status"), pagination);
+			Long.parseLong((String)parameters.get("processId")),
+			Integer.parseInt((String)parameters.get("status")), pagination);
 	}
 
 	@Override
@@ -387,7 +388,7 @@ public abstract class BaseSLAResourceImpl
 		for (SLA sla : slas) {
 			putSLA(
 				sla.getId() != null ? sla.getId() :
-					(Long)parameters.get("slaId"),
+					Long.parseLong((String)parameters.get("slaId")),
 				sla);
 		}
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
@@ -293,7 +293,8 @@ public abstract class BaseTaskResourceImpl
 		throws Exception {
 
 		for (Task task : tasks) {
-			postProcessTask((Long)parameters.get("processId"), task);
+			postProcessTask(
+				Long.parseLong((String)parameters.get("processId")), task);
 		}
 	}
 
@@ -325,7 +326,8 @@ public abstract class BaseTaskResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getProcessTasksPage((Long)parameters.get("processId"));
+		return getProcessTasksPage(
+			Long.parseLong((String)parameters.get("processId")));
 	}
 
 	@Override

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -149,7 +149,8 @@ public abstract class BaseStatusResourceImpl
 		throws Exception {
 
 		for (Status status : statuses) {
-			postExperimentStatus((Long)parameters.get("experimentId"), status);
+			postExperimentStatus(
+				Long.parseLong((String)parameters.get("experimentId")), status);
 		}
 	}
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -317,7 +317,10 @@ public abstract class Base${schemaName}ResourceImpl
 							<#if stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
 								${schemaVarName}
 							<#elseif stringUtil.equals(javaMethodParameter.parameterName, postBatchJavaMethodSignature.parentSchemaName!?uncap_first + "Id")>
-								<@castType type=javaMethodParameter.parameterType />parameters.get("${postBatchJavaMethodSignature.parentSchemaName!?uncap_first}Id")
+								<@castParameters
+									type=javaMethodParameter.parameterType
+									value="${postBatchJavaMethodSignature.parentSchemaName!?uncap_first}Id"
+								/>
 							<#else>
 								null
 							</#if>
@@ -363,7 +366,10 @@ public abstract class Base${schemaName}ResourceImpl
 						<#elseif stringUtil.equals(javaMethodParameter.parameterName, "filter") || stringUtil.equals(javaMethodParameter.parameterName, "pagination") || stringUtil.equals(javaMethodParameter.parameterName, "search") || stringUtil.equals(javaMethodParameter.parameterName, "sorts") || stringUtil.equals(javaMethodParameter.parameterName, "user")>
 							${javaMethodParameter.parameterName}
 						<#else>
-							<@castType type=javaMethodParameter.parameterType />parameters.get("${javaMethodParameter.parameterName}")
+							<@castParameters
+								type=javaMethodParameter.parameterType
+								value=javaMethodParameter.parameterName
+							/>
 						</#if>
 						<#sep>, </#sep>
 					</#list>
@@ -414,9 +420,15 @@ public abstract class Base${schemaName}ResourceImpl
 									(${schemaVarName}.get${schemaName}Id() != null) ? ${schemaVarName}.get${schemaName}Id() :
 								</#if>
 
-								<@castType type=javaMethodParameter.parameterType />parameters.get("${schemaVarName}Id")
+								<@castParameters
+									type=javaMethodParameter.parameterType
+									value="${schemaVarName}Id"
+								/>
 							<#elseif putBatchJavaMethodSignature.parentSchemaName?? && stringUtil.equals(javaMethodParameter.parameterName, putBatchJavaMethodSignature.parentSchemaName?uncap_first + "Id")>
-								<@castType type=javaMethodParameter.parameterType />parameters.get("${javaMethodSignature.parentSchemaName?uncap_first}Id")
+								<@castParameters
+									type=javaMethodParameter.parameterType
+									value="${javaMethodSignature.parentSchemaName?uncap_first}Id"
+								/>
 							<#elseif stringUtil.equals(javaMethodParameter.parameterName, "multipartBody")>
 								null
 							<#else>
@@ -557,30 +569,45 @@ public abstract class Base${schemaName}ResourceImpl
 
 }
 
-<#macro castType
+<#macro castParameters
 	type
+	value
 >
-	(
-
-	<#if type?contains("java.lang.Boolean")>
-		Boolean
-	<#elseif type?contains("java.util.Date")>
-		java.util.Date
-	<#elseif type?contains("java.lang.Double")>
-		Double
-	<#elseif type?contains("java.lang.Integer")>
-		Integer
-	<#elseif type?contains("java.lang.Long")>
-		Long
-	<#elseif type?contains("java.lang.String")>
-		String
-	</#if>
-
 	<#if stringUtil.startsWith(type, "[L")>
-		[]
-	</#if>
+		(
+		<#if type?contains("java.lang.Boolean")>
+			Boolean[]
+		<#elseif type?contains("java.util.Date")>
+			java.util.Date[]
+		<#elseif type?contains("java.lang.Double")>
+			Double[]
+		<#elseif type?contains("java.lang.Integer")>
+			Integer[]
+		<#elseif type?contains("java.lang.Long")>
+			Long[]
+		<#else>
+			String[]
+		</#if>
+		)parameters.get("${value}")
+	<#else>
+		<#if type?contains("java.lang.Boolean")>
+			Boolean.parseBoolean(
+		<#elseif type?contains("java.util.Date")>
+			new java.util.Date(
+		<#elseif type?contains("java.lang.Double")>
+			Double.parseDouble(
+		<#elseif type?contains("java.lang.Integer")>
+			Integer.parseInt(
+		<#elseif type?contains("java.lang.Long")>
+			Long.parseLong(
+		</#if>
 
-	)
+		(String)parameters.get("${value}")
+
+		<#if !type?contains("java.lang.String")>
+			)
+		</#if>
+	</#if>
 </#macro>
 
 <#macro updateResourcePermissions


### PR DESCRIPTION
@drewbrokke pinged me because when defining an API that re-uses an existing entity and also has Batch enabled, batch registration fails because it tries to register the same entity twice. So he has `UserAccount` API in `headless-admin-taxonomy` and `AccountUser` API that *reuses `UserAccount`* entity (and uses the extended proccess to add properties) in `account-rest`.

Batch has a completely undocumented way of supporting this use case: `batch.engine.task.item.delegate.name`. If you provide a value to that property it can register the same entity twice but noone is propagating the value to the delegate. Also casting fails for query parameter. This PR fixes both issues.

To be able to set `batch.engine.task.item.delegate.name` you have to add and deploy an OSGI property file that targets the desired resource (`UserAccountResourceImpl` in this case) and fix some wrong `operationId` that were not removed or were hardcoded (`postUserAccount` should be `postAccountUserAccount`).

To test it you can do a CURL request like this:

```
curl -X "POST" "http://localhost:8080/o/headless-batch-engine/v1.0/import-task/com.liferay.headless.admin.user.dto.v1_0.UserAccount?taskItemDelegateName=AccountUser&accountId=63402" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test' \
     -d $'[
  {
    "emailAddress": "1@a.com",
    "givenName": "3",
    "familyName": "2",
    "alternateName": "4"
  }
]'
```

Notice that you have to pass taskItemDelegateName=AccountUser & accountId=63402. First one to identify the entity (DEFAULT is for UserAccount in Headless Admin User) and the second one because path parameters are query parameters in batch.

Then you can query the state in 

```
curl "http://localhost:8080/o/headless-batch-engine/v1.0/import-task/BATCH_ID" \
     -H 'Accept: application/json' \
     -u 'test@liferay.com:test'
```

This PR won't pass until https://github.com/liferay-frontend/liferay-portal/pull/1036 is merged, so ci:stop-ping for now.