### PR TITLE
LPS-129061 Make condition more strict to avoid applying the permission return type transformation to not autogenerated endpoints

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -943,7 +943,9 @@ public class ResourceOpenAPIParser {
 				return void.class.getName();
 			}
 
-			if (path.endsWith("permissions")) {
+			if ((operation instanceof Get || operation instanceof Put) &&
+				path.endsWith("/permissions")) {
+
 				return _getPageClassName(
 					"[L" + Permission.class.getName() + ";");
 			}


### PR DESCRIPTION
I've made the condition more strict to only apply the return type transformation to the endpoints we autogenerate, the ones ending with /permission with method get or put.

The ones you've found in data engine are different and should not be changed as the logic is implemented by the developer.

Hope this fix everything.