### PR TITLE
Filter javascript from url navigation

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/navigate.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/navigate.es.js
@@ -32,7 +32,25 @@ export default function (url, listeners) {
 			});
 		}
 	}
-	else {
+	else if (isValidURL(url)) {
 		window.location.href = url;
 	}
+}
+
+function isValidURL(url) {
+	let urlObject;
+
+	try {
+		if (url.startsWith('/')) {
+			urlObject = new URL(url, window.location.origin);
+		}
+		else {
+			urlObject = new URL(url);
+		}
+	}
+	catch (error) {
+		return false;
+	}
+
+	return urlObject.protocol === 'http:' || urlObject.protocol === 'https:';
 }


### PR DESCRIPTION
Hello @markocikos,

I created a new PR for this issue. Please review my changes!

I debugged this further and the [Liferay.SPA.app.canNavigate(url)](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js#L350-L381), is working as expected and gives back false. So we are running into this [else statement](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/navigate.es.js#L36) where is no URL validity check. I moved my validation here then.

Thank you!