### PR TITLE
LPS-130366 Migrate selection modals to openSelectionModal in commerce-product-type-grouped-web

### DIFF
--- a/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/view_cp_definition_grouped_entries.jsp
+++ b/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/view_cp_definition_grouped_entries.jsp
@@ -190,7 +190,11 @@ renderResponse.setTitle(cpDefinition.getName(themeDisplay.getLanguageId()));
 				'<liferay-ui:message key="are-you-sure-you-want-to-delete-the-selected-entries" />'
 			)
 		) {
-			var form = window.document['<portlet:namespace />fm'];
+			const form = document.getElementById('<portlet:namespace />fm');
+
+			if (!form) {
+				return;
+			}
 
 			form.setAttribute('method', 'post');
 			form['<portlet:namespace /><%= Constants.CMD %>'].value =
@@ -210,39 +214,40 @@ renderResponse.setTitle(cpDefinition.getName(themeDisplay.getLanguageId()));
 	}
 </aui:script>
 
-<aui:script use="liferay-item-selector-dialog">
-	window.document
-		.querySelector('#<portlet:namespace />addDefinitionGroupedEntry')
-		.addEventListener('click', (event) => {
+<aui:script sandbox="<%= true %>">
+	const addDefinitionGroupedEntryButton = document.getElementById('<portlet:namespace />addDefinitionGroupedEntry');
+
+	if (addDefinitionGroupedEntryButton) {
+		addDefinitionGroupedEntryButton.addEventListener('click', (event) => {
 			event.preventDefault();
 
-			var itemSelectorDialog = new A.LiferayItemSelectorDialog({
-				eventName: 'productDefinitionsSelectItem',
-				on: {
-					selectedItemChange: function (event) {
-						var <portlet:namespace />addCPDefinitionIds = [];
+			Liferay.Util.openSelectionModal({
+				multiple: true,
+				onSelect: function (selectedItems) {
+					if (selectedItems?.length) {
+						const entryCPDefinitionIds = document.getElementById(
+							'<portlet:namespace />entryCPDefinitionIds'
+						);
 
-						var selectedItems = event.newVal;
+						if (entryCPDefinitionIds) {
+							entryCPDefinitionIds.value = selectedItems.map(item => item.value);
+						}
 
-						if (selectedItems) {
-							window.document.querySelector(
-								'#<portlet:namespace />entryCPDefinitionIds'
-							).value = selectedItems;
+						const addCPDefinitionGroupedEntryFm = document.getElementById(
+							'<portlet:namespace />addCPDefinitionGroupedEntryFm'
+						);
 
-							var addCPDefinitionGroupedEntryFm = window.document.querySelector(
-								'#<portlet:namespace />addCPDefinitionGroupedEntryFm'
-							);
-
+						if (addCPDefinitionGroupedEntryFm) {
 							submitForm(addCPDefinitionGroupedEntryFm);
 						}
-					},
+					}
 				},
+				selectEventName: 'productDefinitionsSelectItem',
 				title:
 					'<liferay-ui:message arguments="<%= cpDefinition.getName(themeDisplay.getLanguageId()) %>" key="add-new-grouped-entry-to-x" />',
 				url:
 					'<%= cpDefinitionGroupedEntriesDisplayContext.getItemSelectorUrl() %>',
 			});
-
-			itemSelectorDialog.open();
 		});
+	}
 </aui:script>


### PR DESCRIPTION
Opening this to get some feedback from @markocikos and @jonmak08.

# 🧪 Testing
1. Product menu > Commerce > Products
2. Add new `Grouped` product
3. Go to `Grouped` tab and click on `+`

My main concern is that migrating to these new changes is causing the following errors, no console errors are present on clean master:
![image](https://user-images.githubusercontent.com/24564752/117824397-bf444080-b26e-11eb-9cc1-49dca42e1713.png)

The functionality is preserved, but I didn't manage to figure out the errors today, will take a look tomorrow but if you boys have experience with them feel free to point me in the right direction