### PR TITLE
LPS-130682 Fix style in commerce tables

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
@@ -175,14 +175,17 @@
 .lfr-completion-date-column,
 .lfr-create-date-column,
 .lfr-date-column,
+.lfr-discount-column,
 .lfr-display-date-column,
 .lfr-expiration-date-column,
 .lfr-last-post-date-column,
 .lfr-modified-date-column,
+.lfr-price-column,
 .lfr-removed-date-column,
 .lfr-reply-date-column,
 .lfr-revision-column,
-.lfr-size-column {
+.lfr-size-column,
+.lfr-total-column {
 	white-space: nowrap;
 }
 


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/LPS-130682

The best solution is to upgrade the module adding the class `table-cell-ws-nowrap` to the markup but we don't have the right API [at the moment](https://github.com/liferay/clay/issues/4058)

The proposed solution is a CSS fix where similar code is already present, we have a separated plan (reduce-css-footprint) to upgrade this file so it will be fine in the future

Before
![before](https://user-images.githubusercontent.com/46778114/117851628-cb3bfc80-b286-11eb-841a-3dd79cc31b6d.jpg)

After
![after](https://user-images.githubusercontent.com/46778114/117851655-d131dd80-b286-11eb-95e4-67d670fc88ed.jpg)

---

Edit: about the total price we see in the first screenshots, it seems a different module, so I prefer to exclude it from this fix

![image](https://user-images.githubusercontent.com/46778114/117852473-a4ca9100-b287-11eb-9251-c65226820f13.png)
