### PR TITLE
LPS-130658 | Add sample test for frontend js state

### DIFF
--- a/modules/apps/frontend-js/frontend-js-sample-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-sample-web/.npmbundlerrc
@@ -1,0 +1,9 @@
+{
+	"config": {
+		"imports": {
+			"@liferay/frontend-js-state-web": {
+				"/": ">=1.0.0"
+			}
+		}
+	}
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/bnd.bnd
+++ b/modules/apps/frontend-js/frontend-js-sample-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Frontend JS Sample Web
+Bundle-SymbolicName: com.liferay.frontend.js.sample.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /frontend-js-sample-web

--- a/modules/apps/frontend-js/frontend-js-sample-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-sample-web/build.gradle
@@ -1,0 +1,20 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "jstl", name: "jstl", version: "1.2"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:asset:asset-taglib")
+	compileOnly project(":apps:comment:comment-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-dynamic-section")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-form-navigator")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-util")
+	compileOnly project(":apps:journal:journal-taglib")
+	compileOnly project(":apps:layout:layout-taglib")
+	compileOnly project(":apps:site:site-taglib")
+
+	cssBuilder project(":util:css-builder")
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-sample-web/package.json
@@ -1,0 +1,19 @@
+{
+	"dependencies": {
+		"@clayui/alert": "3.26.0",
+		"@clayui/button": "3.6.0",
+		"@liferay/frontend-js-react-web": "*",
+		"@liferay/frontend-js-state-web": "*",
+		"frontend-js-web": "*",
+		"react": "16.12.0",
+		"react-dom": "16.12.0"
+	},
+	"main": "js/App.es",
+	"name": "@liferay/frontend-js-sample-web",
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "1.0.0"
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/java/com/liferay/frontend/js/sample/web/internal/constants/JavaScriptSamplePortletKeys.java
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/java/com/liferay/frontend/js/sample/web/internal/constants/JavaScriptSamplePortletKeys.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.sample.web.internal.constants;
+
+/**
+ * @author John Co
+ */
+public class JavaScriptSamplePortletKeys {
+
+	public static final String JAVASCRIPTSAMPLE =
+		"com_liferay_frontend_js_sample_web_JavaScriptSamplePortlet";
+
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/java/com/liferay/frontend/js/sample/web/internal/portlet/JavaScriptSamplePortlet.java
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/java/com/liferay/frontend/js/sample/web/internal/portlet/JavaScriptSamplePortlet.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.sample.web.internal.portlet;
+
+import com.liferay.frontend.js.sample.web.internal.constants.JavaScriptSamplePortletKeys;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+
+import javax.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author John Co
+ */
+@Component(
+	immediate = true,
+	property = {
+		"com.liferay.portlet.display-category=category.sample",
+		"com.liferay.portlet.header-portlet-css=/css/main.css",
+		"com.liferay.portlet.instanceable=true",
+		"javax.portlet.display-name=JS Sample",
+		"javax.portlet.init-param.template-path=/META-INF/resources/",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.name=" + JavaScriptSamplePortletKeys.JAVASCRIPTSAMPLE,
+		"javax.portlet.resource-bundle=content.Language",
+		"javax.portlet.security-role-ref=power-user,user"
+	},
+	service = Portlet.class
+)
+public class JavaScriptSamplePortlet extends MVCPortlet {
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,0 +1,3 @@
+.js-sample-class {
+	font-style: italic;
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,24 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/js/App.js
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/js/App.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayCard from '@clayui/card';
+import ClayForm, {ClayInput} from '@clayui/form';
+import {useLiferayState} from '@liferay/frontend-js-react-web';
+import React from 'react';
+
+import {counterAtomReact, userAtom, userSelector} from './sharedState';
+
+import '../css/main.scss';
+
+// Components that access that shared state:
+
+function Name() {
+	const [userNameAndLength] = useLiferayState(userSelector);
+
+	return (
+		<ClayCard>
+			<ClayCard.Body>
+				<ClayCard.Description displayType="title">
+					{Liferay.Language.get('name')}
+				</ClayCard.Description>
+				<ClayCard.Description displayType="text" truncate={false}>
+					{userNameAndLength}
+				</ClayCard.Description>
+			</ClayCard.Body>
+		</ClayCard>
+	);
+}
+
+function NameUpdater(portletId) {
+	const id = `${portletId}_form`;
+	const [user, setUser] = useLiferayState(userAtom);
+
+	return (
+		<ClayForm.Group>
+			<label htmlFor={id}>Name</label>
+			<ClayInput
+				id={id}
+				onChange={(event) => {
+					setUser({
+						...user,
+						name: event.target.value,
+					});
+				}}
+				type="text"
+				value={user.name}
+			/>
+		</ClayForm.Group>
+	);
+}
+
+function ButtonCounter() {
+	const [count] = useLiferayState(counterAtomReact);
+
+	return (
+		<h3>
+			React Counter: <span id="test-counter-react">{count}</span>
+		</h3>
+	);
+}
+
+export default ({portletId}) => {
+	return (
+		<div className="col-md-6">
+			<NameUpdater portletId={portletId} />
+			<Name />
+			<ButtonCounter />
+		</div>
+	);
+};

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/js/sharedState.js
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/js/sharedState.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {State} from '@liferay/frontend-js-state-web';
+
+// Shared state (atoms and selectors);
+
+export const userAtom = State.atom('clay-sample-atom', {
+	name: Liferay.ThemeDisplay.getUserName(),
+});
+
+export const userSelector = State.selector('clay-sample-selector', (get) => {
+	const user = get(userAtom);
+
+	return `${user.name} (${user.name.length})`;
+});
+
+export const counterAtomReact = State.atom('sample-counter', 0);

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,71 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %>
+
+<div class="row">
+	<div class="col">
+		<react:component
+			module="js/App"
+		/>
+	</div>
+
+	<div class="col">
+		<button id="test-button-jsp">Increment jsp</button>
+
+		<h3>JSP Counter: <span id="test-counter-jsp">0</span></h3>
+
+		<h3>Name: <span id="test-name">Initial Name</span></h3>
+
+		<button id="test-button-react">Increment react</button>
+
+		<aui:script require="@liferay/frontend-js-state-web@1.0.3/index as StateModule, @liferay/frontend-js-sample-web@1.0.0/js/sharedState as SharedState">
+			const buttonElementJSP = document.getElementById('test-button-jsp');
+			const buttonElementReact = document.getElementById('test-button-react');
+			const counterElement = document.getElementById('test-counter-jsp');
+			const nameElement = document.getElementById('test-name');
+
+			const State = StateModule.State;
+
+			const counterAtom = State.atom('test-counter-jsp', 0);
+
+			State.subscribe(counterAtom, (newVal) => {
+				counterElement.innerText = newVal;
+			});
+
+			State.subscribe(SharedState.userAtom, (event) => {
+				nameElement.innerText = event.name;
+			});
+
+			if (buttonElementJSP) {
+				buttonElementJSP.addEventListener('click', () => {
+					State.write(counterAtom, State.read(counterAtom) + 1);
+				});
+			}
+
+			if (buttonElementReact) {
+				buttonElementReact.addEventListener('click', () => {
+					State.write(
+						SharedState.counterAtomReact,
+						State.read(SharedState.counterAtomReact) + 1
+					);
+				});
+			}
+		</aui:script>
+	</div>
+</div>

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/content/Language.properties
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/content/Language.properties
@@ -1,0 +1,2 @@
+javascriptsample.caption=Hello from JavaScript Sample!
+javax.portlet.title.com_liferay_frontend_js_sample_web_JavaScriptSamplePortlet=JavaScript Sample


### PR DESCRIPTION
**Description**
Adds a sample portlet to test the acceptance criteria for js global state epic in https://issues.liferay.com/browse/LPS-122065

**Test Plan**
1. Clicking on increment JSP button adds +1 to js state and is instantaneously reflected on JSP Counter
2. Clicking on increment react button adds +1 to js state is instantaneously reflected on the React app counter
3. Typing in the form field will change the card to show the text and string length
4. Typing in the form field will show the same text in JSP (right side) 

https://user-images.githubusercontent.com/35235266/117898116-08998d80-b279-11eb-866b-cf2d6f992e67.mp4


**JIRA Ticket**
https://issues.liferay.com/browse/LPS-130658