### PR TITLE
LPS-132060 Always include delta parameter

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -62,7 +62,9 @@ if (end > total) {
 	end = total;
 }
 
-String deltaURL = HttpUtil.removeParameter(url, namespace + deltaParam);
+if (deltaConfigurable) {
+	url = HttpUtil.setParameter(url, namespace + deltaParam, String.valueOf(delta));
+}
 
 NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 %>
@@ -99,11 +101,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 							continue;
 						}
 
-						String curDeltaURL = deltaURL + urlAnchor;
-
-						if (curDelta != delta) {
-							curDeltaURL = HttpUtil.addParameter(deltaURL + urlAnchor, namespace + deltaParam, curDelta);
-						}
+						String curDeltaURL = HttpUtil.setParameter(url + urlAnchor, namespace + deltaParam, curDelta);
 					%>
 
 						<li>

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -76,7 +76,9 @@ else {
 	}
 }
 
-String deltaURL = HttpUtil.removeParameter(url, namespace + deltaParam);
+if (deltaConfigurable) {
+	url = HttpUtil.setParameter(url, namespace + deltaParam, String.valueOf(delta));
+}
 
 NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 %>
@@ -236,11 +238,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 											continue;
 										}
 
-										String curDeltaURL = deltaURL + urlAnchor;
-
-										if (curDelta != delta) {
-											curDeltaURL = deltaURL + "&" + namespace + deltaParam + "=" + curDelta + urlAnchor;
-										}
+										String curDeltaURL = HttpUtil.setParameter(url + urlAnchor, namespace + deltaParam, curDelta);
 									%>
 
 										<liferay-ui:icon


### PR DESCRIPTION
### Steps to reproduce

1. Run server and Login with user Test Test (test@liferay.com / test)
2. Create a commerce Minium site. Control Panel > Sites > New Minium Site
3. Re-index Control Panel > Search > Index Actions > Reindex all search indexes
4. Go to Minium Site > Catalog (default)
5. Ensure Item per page now is 20.
6. Select Items per page = 4
7. Select Items per page = 4 again

**Expected result**: everything stays 4 per page
**Actual result**: everything switches back to the default of 20 per page

8. Select Items per page = 20
9. Select Items per page = 4
10. Select page 2

**Expected result**: Page 2 shows 4 items and subsequent pages show 4 items
**Actual result**: Page 2 shows 20 items (page 3 also does not show 4 items)

### Additional background

In [LPS-98391](https://issues.liferay.com/browse/LPS-98391), we attempt to remove the "delta" parameter when it matches the default in portal properties. However, this caused [LPS-115435](https://issues.liferay.com/browse/LPS-98391), where a portlet can be configured to have a default value that's different from the default value in portal properties.

Both fixes together cause the situation we have now. The proposed fix in this pull request is to abandon the idea of removing the delta parameter and just always have it there, whether it is truly needed or not.