### PR TITLE
LPS-132071 Update liferay-ckeditor to v4.16.0-liferay.1

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"ckeditor4-react": "1.3.0",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.14.1-liferay.22",
+		"liferay-ckeditor": "4.16.0-liferay.1",
 		"prop-types": "15.7.2"
 	},
 	"main": "index.js",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -9542,10 +9542,10 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
-liferay-ckeditor@4.14.1-liferay.22:
-  version "4.14.1-liferay.22"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.14.1-liferay.22.tgz#a97063eca746784ccf170bae5bb59afe01db31f7"
-  integrity sha512-fbIwjMqHqoHhJlpMxzk1VSbzI4KZvab7au/430z3xqRwiyj0qq7QNjPy7iF7nLzP8Oiy6Xlu2IzyESuYSXRnFQ==
+liferay-ckeditor@4.16.0-liferay.1:
+  version "4.16.0-liferay.1"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.16.0-liferay.1.tgz#82f563d65fada07300f04d25680015fe9efdaf4f"
+  integrity sha512-Fcc356dXeRkipyj0YDceyrpeaztOMWcLVCP4TLQ/Cn1jLt8U89XESat3erLa9CvW5G9x9kn0XWQmCbrxpviGrQ==
 
 liferay-font-awesome@3.4.0:
   version "3.4.0"


### PR DESCRIPTION
As requested in [LPS-132071](https://issues.liferay.com/browse/LPS-132071),
we've updated ckeditor to the `4.16.0` tag

**Changes in this version**

### :wrench: Bug fixes

-   fix: only download extra plugins during the build ([\#173](https://github.com/liferay/liferay-ckeditor/pull/173))

### :house: Chores

-   chore(deps-dev): bump codemirror from 5.57.0 to 5.58.2 ([\#170](https://github.com/liferay/liferay-ckeditor/pull/170))
-   chore(deps): bump lodash from 4.17.20 to 4.17.21 ([\#169](https://github.com/liferay/liferay-ckeditor/pull/169))

[Full changelog](https://github.com/liferay/liferay-ckeditor/compare/v4.14.1-liferay.22...v4.16.0-liferay.1)