### PR TITLE
LPS-132150 Fix error registering GraphQLDTOContributors because Facet GraphQLObjectType was not registered at the moment

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -781,6 +781,25 @@ public class GraphQLServletExtender {
 		return builder.build();
 	}
 
+	private GraphQLObjectType _buildFacetGraphQLType() {
+		GraphQLObjectType.Builder builder = new GraphQLObjectType.Builder();
+
+		builder.name("FacetValue");
+		builder.field(_addField(Scalars.GraphQLInt, "numberOfOccurrences"));
+		builder.field(_addField(Scalars.GraphQLString, "term"));
+
+		GraphQLObjectType facetValueGraphQLType = builder.build();
+
+		builder = new GraphQLObjectType.Builder();
+
+		builder.name("Facet");
+		builder.field(_addField(Scalars.GraphQLString, "facetCriteria"));
+		builder.field(
+			_addField(GraphQLList.list(facetValueGraphQLType), "facetValues"));
+
+		return builder.build();
+	}
+
 	private void _collectObjectFields(
 		GraphQLObjectType.Builder builder,
 		Map<String, Configuration> configurations,
@@ -1535,6 +1554,10 @@ public class GraphQLServletExtender {
 	private GraphQLObjectType _getPageGraphQLObjectType(
 		GraphQLType facetGraphQLType, GraphQLType objectGraphQLType,
 		String name) {
+
+		if (facetGraphQLType == null) {
+			facetGraphQLType = _buildFacetGraphQLType();
+		}
 
 		GraphQLObjectType.Builder builder = new GraphQLObjectType.Builder();
 


### PR DESCRIPTION
The bug was caused by a race condition because types coming from annotations are loaded asynchronously and when the type was requested by the GraphQLDTODefinition to be used as part of the Page definition, it was not available yet. To solve it I check if the type is available and if not, register it manually.

Don't know if this solution may cause a problem when the Facet type coming from annotations try to register after making the manual registration... Hope the GraphQL tests catch it if it is the case