### PR TITLE
COMMERCE-6481 interactions between modals and side panels simplified

### DIFF
--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/side_panel_content/SidePanelListenersInitializer.js
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/side_panel_content/SidePanelListenersInitializer.js
@@ -18,21 +18,34 @@ import {
 	OPEN_MODAL_FROM_IFRAME,
 } from 'frontend-taglib-clay/data_set_display/utils/eventsDefinitions';
 
-function initializeSidePanelListeners() {
-	Liferay.on(OPEN_MODAL, (payload) => {
-		window.top.Liferay.fire(OPEN_MODAL_FROM_IFRAME, payload);
-	});
+class SidePanelListenersInitializer {
+	constructor() {
+		Liferay.on(OPEN_MODAL, this.handleOpenModalFromSidePanel);
 
-	document.querySelector('body').classList.remove('open');
+		document.body.classList.remove('open');
 
-	document
-		.querySelectorAll('.side-panel-iframe-close, .btn-cancel')
-		.forEach((trigger) => {
-			trigger.addEventListener('click', (event) => {
-				event.preventDefault();
-				window.parent.Liferay.fire(CLOSE_SIDE_PANEL);
+		document
+			.querySelectorAll('.side-panel-iframe-close, .btn-cancel')
+			.forEach((trigger) => {
+				trigger.addEventListener('click', (event) => {
+					event.preventDefault();
+
+					const parentWindow = Liferay.Util.getOpener();
+
+					parentWindow.Liferay.fire(CLOSE_SIDE_PANEL);
+				});
 			});
-		});
+	}
+
+	dispose() {
+		Liferay.detach(OPEN_MODAL, this.handleOpenModalFromSidePanel);
+	}
+
+	handleOpenModalFromSidePanel(payload) {
+		const topWindow = Liferay.Util.getTop();
+
+		topWindow.Liferay.fire(OPEN_MODAL_FROM_IFRAME, payload);
+	}
 }
 
-export default initializeSidePanelListeners;
+export default SidePanelListenersInitializer;

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/side_panel_content/end.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/side_panel_content/end.jsp
@@ -32,5 +32,5 @@
 </div>
 
 <liferay-frontend:component
-	module="side_panel_content/index"
+	module="side_panel_content/SidePanelListenersInitializer"
 />

--- a/modules/apps/commerce/commerce-tax-engine-fixed-web/src/main/resources/META-INF/resources/address_tax_fixed_rates.jsp
+++ b/modules/apps/commerce/commerce-tax-engine-fixed-web/src/main/resources/META-INF/resources/address_tax_fixed_rates.jsp
@@ -37,22 +37,27 @@ CommerceTaxFixedRateAddressRelsDisplayContext commerceTaxFixedRateAddressRelsDis
 		</aui:select>
 	</commerce-ui:panel>
 
-	<clay:data-set-display
-		contextParams='<%=
-			HashMapBuilder.<String, String>put(
-				"commerceChannelId", String.valueOf(commerceTaxFixedRateAddressRelsDisplayContext.getCommerceChannelId())
-			).put(
-				"commerceTaxMethodId", String.valueOf(commerceTaxFixedRateAddressRelsDisplayContext.getCommerceTaxMethodId())
-			).build()
-		%>'
-		creationMenu="<%= commerceTaxFixedRateAddressRelsDisplayContext.getCreationMenu() %>"
-		dataProviderKey="<%= CommerceTaxRateSettingDataSetConstants.COMMERCE_DATA_SET_KEY_TAX_RATE_SETTING %>"
-		id="<%= commerceTaxFixedRateAddressRelsDisplayContext.getDatasetView() %>"
-		itemsPerPage="<%= 10 %>"
-		namespace="<%= liferayPortletResponse.getNamespace() %>"
-		pageNumber="<%= 1 %>"
-		portletURL="<%= commerceTaxFixedRateAddressRelsDisplayContext.getPortletURL() %>"
-	/>
+	<commerce-ui:panel
+		bodyClasses="p-0"
+	>
+		<clay:data-set-display
+			contextParams='<%=
+				HashMapBuilder.<String, String>put(
+					"commerceChannelId", String.valueOf(commerceTaxFixedRateAddressRelsDisplayContext.getCommerceChannelId())
+				).put(
+					"commerceTaxMethodId", String.valueOf(commerceTaxFixedRateAddressRelsDisplayContext.getCommerceTaxMethodId())
+				).build()
+			%>'
+			creationMenu="<%= commerceTaxFixedRateAddressRelsDisplayContext.getCreationMenu() %>"
+			dataProviderKey="<%= CommerceTaxRateSettingDataSetConstants.COMMERCE_DATA_SET_KEY_TAX_RATE_SETTING %>"
+			id="<%= commerceTaxFixedRateAddressRelsDisplayContext.getDatasetView() %>"
+			itemsPerPage="<%= 10 %>"
+			namespace="<%= liferayPortletResponse.getNamespace() %>"
+			pageNumber="<%= 1 %>"
+			portletURL="<%= commerceTaxFixedRateAddressRelsDisplayContext.getPortletURL() %>"
+			selectedItemsKey="taxRateSettingId"
+		/>
+	</commerce-ui:panel>
 
 	<aui:button-row>
 		<aui:button cssClass="btn-lg" type="submit" />

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/side_panel/SidePanel.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/side_panel/SidePanel.js
@@ -47,7 +47,7 @@ export default class SidePanel extends React.Component {
 			active: null,
 			closeButtonStyle: null,
 			currentURL: props.url || null,
-			iframeHandlerModalId: null,
+			iframeHandlerModalId: subscribeModal(),
 			loading: true,
 			menuCoverTopDistance: 0,
 			moving: false,
@@ -72,7 +72,6 @@ export default class SidePanel extends React.Component {
 		this.updateTop = this.updateTop.bind(this);
 		this.debouncedUpdateTop = debounce(this.updateTop, 250);
 		this.panel = React.createRef();
-		this.modalRef = React.createRef();
 		this.iframeRef = React.createRef();
 	}
 
@@ -107,14 +106,6 @@ export default class SidePanel extends React.Component {
 			url: this.state.currentURL,
 			visible: this.state.visible,
 		}));
-
-		if (!this.state.iframeHandlerModalId && this.modalRef.current) {
-			const modalId = subscribeModal(this.modalRef.current);
-
-			this.setState({
-				iframeHandlerModalId: modalId,
-			});
-		}
 	}
 
 	handlePanelOpenEvent(event) {
@@ -355,10 +346,7 @@ export default class SidePanel extends React.Component {
 
 		const content = (
 			<>
-				<Modal
-					id={this.state.iframeHandlerModalId}
-					ref={this.modalRef}
-				/>
+				<Modal id={this.state.iframeHandlerModalId} />
 				<div
 					className={classNames(
 						'side-panel-nav-cover navigation-bar border-bottom',


### PR DESCRIPTION
I just removed unnecessary code from the side panel component to simplify the communication between modals and iframes. 
I converted a `Map` in a `Set` since there was no need to store the `modalRef`.

The bug was caused by the following code:

```
Liferay.on('endNavigate', () => {
	registeredModals.clear();
});
```

Modals could be registered after some navigation before senna fired the `endNavigate` event. 
This caused an undesired purge of all of them. Replacing `endNavigate` with `beforeNavigate` solved the issue.

This pr also fixes some minor UI issues in `address_tax_fixed_rates.jsp`, the jsp mentioned in the jira ticket:
- a dataset in the side panel with no wrapper looked bad 
- the highlight on the selected element was not working due to missing `selectedItemsKey` property