### PR TITLE
LPS-132150 Fix error registering GraphQLDTOContributors because Facet GraphQLObjectType was not registered at that moment

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/aggregation/Facet.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/aggregation/Facet.java
@@ -17,16 +17,12 @@ package com.liferay.portal.vulcan.aggregation;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
-import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
-import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
-
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * @author Javier Gamarra
  */
-@GraphQLName("Facet")
 @JacksonXmlRootElement(localName = "Facet")
 public class Facet {
 
@@ -54,7 +50,6 @@ public class Facet {
 		this.facetValues = facetValues;
 	}
 
-	@GraphQLName("FacetValue")
 	@JacksonXmlRootElement(localName = "FacetValue")
 	public static class FacetValue {
 
@@ -74,21 +69,17 @@ public class Facet {
 			return term;
 		}
 
-		@GraphQLField
 		@JsonProperty("numberOfOccurrences")
 		protected Integer numberOfOccurrences;
 
-		@GraphQLField
 		@JsonProperty("term")
 		protected String term;
 
 	}
 
-	@GraphQLField
 	@JsonProperty("facetCriteria")
 	protected String facetCriteria;
 
-	@GraphQLField
 	@JsonProperty("facetValues")
 	protected List<FacetValue> facetValues = new ArrayList<>();
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/aggregation/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/aggregation/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.2.1

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1256,6 +1256,11 @@ public class GraphQLServletExtender {
 			Map<Class<?>, Set<Class<?>>> classesMap =
 				processingElementsContainer.getExtensionsTypeRegistry();
 
+			processingElementsContainer.setTypeRegistry(
+				HashMapBuilder.<String, GraphQLType>put(
+					"Facet", _buildFacetGraphQLType()
+				).build());
+
 			List<ServletData> servletDatas = new ArrayList<>();
 
 			for (ServletData servletData : _servletDataList) {
@@ -1554,10 +1559,6 @@ public class GraphQLServletExtender {
 	private GraphQLObjectType _getPageGraphQLObjectType(
 		GraphQLType facetGraphQLType, GraphQLType objectGraphQLType,
 		String name) {
-
-		if (facetGraphQLType == null) {
-			facetGraphQLType = _buildFacetGraphQLType();
-		}
 
 		GraphQLObjectType.Builder builder = new GraphQLObjectType.Builder();
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -781,6 +781,25 @@ public class GraphQLServletExtender {
 		return builder.build();
 	}
 
+	private GraphQLObjectType _buildFacetGraphQLType() {
+		GraphQLObjectType.Builder builder = new GraphQLObjectType.Builder();
+
+		builder.name("FacetValue");
+		builder.field(_addField(Scalars.GraphQLInt, "numberOfOccurrences"));
+		builder.field(_addField(Scalars.GraphQLString, "term"));
+
+		GraphQLObjectType facetValueGraphQLType = builder.build();
+
+		builder = new GraphQLObjectType.Builder();
+
+		builder.name("Facet");
+		builder.field(_addField(Scalars.GraphQLString, "facetCriteria"));
+		builder.field(
+			_addField(GraphQLList.list(facetValueGraphQLType), "facetValues"));
+
+		return builder.build();
+	}
+
 	private void _collectObjectFields(
 		GraphQLObjectType.Builder builder,
 		Map<String, Configuration> configurations,
@@ -1535,6 +1554,10 @@ public class GraphQLServletExtender {
 	private GraphQLObjectType _getPageGraphQLObjectType(
 		GraphQLType facetGraphQLType, GraphQLType objectGraphQLType,
 		String name) {
+
+		if (facetGraphQLType == null) {
+			facetGraphQLType = _buildFacetGraphQLType();
+		}
 
 		GraphQLObjectType.Builder builder = new GraphQLObjectType.Builder();
 


### PR DESCRIPTION
The bug was caused by a race condition because types coming from annotations are loaded asynchronously and when the type was requested by the GraphQLDTODefinition to be used as part of the Page definition, it was not available yet. To solve it I try to check if the type is available and if not, register it manually.

This solution causes a conflict when the Facet class GraphQL annotations were processed and try to register the type again, so to avoid this conflict I choose to remove the annotations and always register the Facet type at the beginning to be available for GraphQL annotations processor and for the GraphQLDTOContributor registry.

I think it could be a good approach as we mentioned several times that we wanted to remove the GraphQL annotations lib.

I left both commits so you can check the process but we can squash them before sending the PR