### PR TITLE
LPS-130851 Remove focusing on first node on mouse click

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/NodeList.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/NodeList.js
@@ -22,6 +22,7 @@ export default function NodeList({
 	nodes,
 	onBlur,
 	onFocus,
+	onMouseDown,
 	role = 'group',
 	tabIndex = -1,
 }) {
@@ -45,6 +46,11 @@ export default function NodeList({
 			onFocus={(event) => {
 				if (onFocus) {
 					onFocus(event);
+				}
+			}}
+			onMouseDown={(event) => {
+				if (onMouseDown) {
+					onMouseDown(event);
 				}
 			}}
 			role={role}
@@ -72,5 +78,6 @@ NodeList.propTypes = {
 	).isRequired,
 	onBlur: PropTypes.func,
 	onFocus: PropTypes.func,
+	onMouseDown: PropTypes.func,
 	tabIndex: PropTypes.number,
 };

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.js
@@ -240,8 +240,9 @@ function reducer(state, action) {
 
 	switch (action.type) {
 		case 'ACTIVATE': {
-			const focusedNodeId =
-				state.focusedNodeId || (nodes[0] && nodes[0].id);
+			const focusedNodeId = action.mouseNavigation
+				? state.focusedNodeId
+				: state.focusedNodeId || (nodes[0] && nodes[0].id);
 
 			return {
 				...state,
@@ -778,6 +779,23 @@ function Treeview({
 		}
 	};
 
+	const handleMouseDown = (event) => {
+		cancelTimer();
+
+		setHasFocus((hadFocus) => {
+			if (!hadFocus) {
+				dispatch({
+					mouseNavigation: true,
+					type: 'ACTIVATE',
+				});
+			}
+
+			return true;
+		});
+
+		event.preventDefault();
+	};
+
 	const handleFocus = () => {
 		cancelTimer();
 
@@ -816,6 +834,7 @@ function Treeview({
 				nodes={filteredNodes || nodes}
 				onBlur={handleBlur}
 				onFocus={handleFocus}
+				onMouseDown={handleMouseDown}
 				role="tree"
 				tabIndex={0}
 			/>


### PR DESCRIPTION
LPS-130851 Remove focusing on first node on mouse click, because when using keyboard and state is not initialized with focusedNodeId  is focusing on the first node when using TAB key, so you can start navigating the node list items, this on mouse is not needed, condition added when using keyboard navigation or mouse

For more details and steps to reproduce please check https://issues.liferay.com/browse/PTR-2428