### PR TITLE
LPS-132211

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/components/_widget.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/components/_widget.scss
@@ -61,6 +61,7 @@
 		margin-bottom: 16px;
 
 		.inline-item-before {
+			flex-shrink: 1;
 			margin-right: 1rem;
 		}
 


### PR DESCRIPTION
Hey @liferay-frontend,

Attached is an update for http://issues.liferay.com/browse/LPS-132211.

When the “Time To Read” option is selected for blogs, the words overflow the card when the blogs widget is placed in the 30 column of a 30/70 page.

**Test Plan:**

1. Create two blog entries
2. Enable Time To Read by navigating to Control Panel > Configuration > System Settings > Content and Data > Blogs > Widget Scope > Blogs > check Enable Reading Time, and save
3. Create a widget page with a 70/30 columns split
4. Put a blogs portlet into the 30 column
5. Navigate to a blog entry and scroll to the card navigation

Please let me know if you have any questions. Thanks!