### PR TITLE
LPS-132375 | Include all clay testcases in ci relevant coverage of frontend taglib module

### DIFF
--- a/modules/apps/frontend-taglib/test.properties
+++ b/modules/apps/frontend-taglib/test.properties
@@ -14,14 +14,19 @@
     #
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
-        (environment.acceptance == true) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream != quarantine) AND \
         (\
-            (app.server.types == null) OR \
-            (app.server.types ~ "tomcat")\
+            (environment.acceptance == true) OR \
+            (testray.component.names == "Clay")\
         ) AND \
         (\
-            (database.types == null) OR \
-            (database.types ~ "mysql")\
+            (portal.acceptance != quarantine) AND \
+            (portal.upstream != quarantine) AND \
+            (\
+                (app.server.types == null) OR \
+                (app.server.types ~ "tomcat")\
+            ) AND \
+            (\
+                (database.types == null) OR \
+                (database.types ~ "mysql")\
+            )\
         )


### PR DESCRIPTION
**Description**
We need to include clay testcases for ci relevant coverage of frontend taglib clay

**Test Plan**
Verify all clay functional tests are run in `ci:test:relevant` for this PR :heavy_check_mark: 

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-132375