### PR TITLE
LPS-130835 Create Balloon Editor Plugins

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -15,7 +15,8 @@
 --%>
 
 <%@ taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <liferay-theme:defineObjects />
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,9 +16,21 @@
 
 <%@ include file="/init.jsp" %>
 
+<liferay-util:buffer
+	var="sampleEditorContents"
+>
+	<h1>Balloon Editor</h1>
+
+	<p>
+		This is a sample portlet with a <a href="https://example.com">link</a>.
+	</p>
+
+	<img src="https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=300" />
+</liferay-util:buffer>
+
 <div>
 	<liferay-editor:editor
-		contents="<h1>Balloon Editor</h1><p>This is a sample portlet with a <a href=\"https://example.com\">link</a>.</p><img src=\"https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=800\">"
+		contents="<%= sampleEditorContents %>"
 		editorName="ballooneditor"
 		name="contentEditor"
 		placeholder="content"

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
@@ -60,10 +60,10 @@ public class CKEditorBalloonEditorConfigContributor
 		String extraPlugins = jsonObject.getString("extraPlugins");
 
 		if (Validator.isNotNull(extraPlugins)) {
-			extraPlugins += ",stylescombo";
+			extraPlugins += ",itemselector,stylescombo";
 		}
 		else {
-			extraPlugins = "stylescombo";
+			extraPlugins = "itemselector,stylescombo";
 		}
 
 		jsonObject.put(
@@ -71,11 +71,15 @@ public class CKEditorBalloonEditorConfigContributor
 		).put(
 			"stylesSet", getStyleFormatsJSONArray(themeDisplay.getLocale())
 		).put(
-			"toolbarImage", "JustifyLeft,JustifyCenter,JustifyRight,Link,Unlink"
+			"toolbarImage",
+			"ImageAlignLeft,ImageAlignCenter,ImageAlignRight,LinkToolbar,AltImg"
+		).put(
+			"toolbarTable",
+			"TableHeaders,TableRow,TableColumn,TableCell,TableDelete"
 		).put(
 			"toolbarText", getToolbarText()
 		).put(
-			"toolbarVideo", "JustifyLeft,JustifyCenter,JustifyRight"
+			"toolbarVideo", "VideoAlignLeft,VideoAlignCenter,VideoAlignRight"
 		);
 	}
 
@@ -119,8 +123,9 @@ public class CKEditorBalloonEditorConfigContributor
 	}
 
 	protected String getToolbarText() {
-		return "Styles,Bold,Italic,Underline,BulletedList,NumberedList,Link," +
-			"JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,RemoveFormat";
+		return "Styles,Bold,Italic,Underline,BulletedList,NumberedList," +
+			"TextLink,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock," +
+				"LineHeight,BGColor,RemoveFormat";
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
@@ -1,0 +1,360 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+(function () {
+	const pluginName = 'ballooneditor';
+
+	CKEDITOR.SELECTION_TOP_TO_BOTTOM = 0;
+	CKEDITOR.SELECTION_BOTTOM_TO_TOP = 1;
+
+	if (CKEDITOR.plugins.get(pluginName)) {
+		return;
+	}
+
+	CKEDITOR.plugins.add(pluginName, {
+		init(editor) {
+			const eventListeners = [];
+
+			editor.on('contentDom', () => {
+				const document = editor.document;
+
+				eventListeners.push(
+					document.on('keyup', () => {
+						editor.forceNextSelectionCheck();
+					})
+				);
+
+				eventListeners.push(
+					document.on('mouseup', () => {
+						editor.forceNextSelectionCheck();
+					})
+				);
+			});
+
+			editor.on('destroy', () => {
+				eventListeners.forEach((listener) => {
+					listener.removeListener();
+				});
+			});
+
+			editor.on('hideToolbars', () => {
+				editor.balloonToolbars.hide();
+			});
+
+			editor.on('resize', () => {
+				editor.balloonToolbars.hide();
+			});
+
+			editor.on('showToolbar', (event) => {
+				const toolbarCommand = event.data.toolbarCommand;
+
+				editor.balloonToolbars.hide();
+
+				editor.execCommand(toolbarCommand);
+			});
+		},
+
+		onLoad() {
+			CKEDITOR.ui.balloonPanel.DEFAULT_PANEL_PADDING = 14;
+
+			const getSelectionDirection = (selection) => {
+				let direction = CKEDITOR.SELECTION_TOP_TO_BOTTOM;
+
+				const nativeSelection = selection.getNative();
+
+				if (!nativeSelection) {
+					return CKEDITOR.SELECTION_TOP_TO_BOTTOM;
+				}
+
+				const anchorNode = nativeSelection.anchorNode;
+
+				if (anchorNode?.compareDocumentPosition) {
+					const position = anchorNode.compareDocumentPosition(
+						nativeSelection.focusNode
+					);
+
+					if (
+						(!position &&
+							nativeSelection.anchorOffset >
+								nativeSelection.focusOffset) ||
+						position === Node.DOCUMENT_POSITION_PRECEDING
+					) {
+						direction = CKEDITOR.SELECTION_BOTTOM_TO_TOP;
+					}
+				}
+
+				return direction;
+			};
+
+			CKEDITOR.ui.balloonPanel.prototype.attach = function (
+				elementOrSelection,
+				options
+			) {
+				const padding = CKEDITOR.ui.balloonPanel.DEFAULT_PANEL_PADDING;
+
+				if (options instanceof CKEDITOR.dom.element || !options) {
+					options = {focusElement: options};
+				}
+
+				options = CKEDITOR.tools.extend(options, {
+					show: true,
+				});
+
+				if (options.show === true) {
+					this.show();
+				}
+
+				this.fire('attach');
+
+				const editable = this.editor.editable();
+
+				const editableClientRect = editable.getClientRect(true);
+				const panelClientRect = this.parts.panel.getClientRect(true);
+
+				const ranges = elementOrSelection.getRanges();
+				const type = elementOrSelection.getType();
+
+				let clientRect;
+				let x = 0;
+				let y = 0;
+
+				if (type === CKEDITOR.SELECTION_TEXT) {
+					let rangeClientRects;
+
+					try {
+						rangeClientRects = ranges[0].getClientRects(true);
+					}
+					catch (error) {
+						return;
+					}
+
+					const firstClientRect = rangeClientRects[0];
+					const lastClientRect =
+						rangeClientRects[rangeClientRects.length - 1];
+
+					let direction = CKEDITOR.SELECTION_BOTTOM_TO_TOP;
+
+					if (firstClientRect !== lastClientRect) {
+						direction = getSelectionDirection(
+							this.editor.getSelection()
+						);
+					}
+
+					const rangeHeight =
+						lastClientRect.bottom - firstClientRect.top;
+
+					clientRect = rangeClientRects[0];
+
+					x =
+						clientRect.x +
+						clientRect.width / 2 -
+						panelClientRect.width / 2;
+					y = clientRect.y - panelClientRect.height - padding;
+
+					if (direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) {
+						y = clientRect.y + rangeHeight + padding;
+					}
+				}
+				else if (type === CKEDITOR.SELECTION_ELEMENT) {
+					let selectedElement = elementOrSelection.getSelectedElement();
+
+					if (!selectedElement) {
+						selectedElement = ranges && ranges[0].startContainer;
+					}
+
+					const selectedElementClientRect = selectedElement.getClientRect(
+						true
+					);
+
+					x =
+						selectedElementClientRect.x +
+						selectedElementClientRect.width / 2 -
+						panelClientRect.width / 2;
+					y =
+						selectedElementClientRect.y -
+						panelClientRect.height -
+						padding;
+				}
+
+				if (x < editableClientRect.x) {
+					x = editableClientRect.x + padding;
+				}
+				if (x + panelClientRect.width > editableClientRect.width) {
+					x -= x + panelClientRect.width - editableClientRect.width;
+				}
+
+				if (y < editableClientRect.y) {
+					y = clientRect.bottom + padding;
+				}
+
+				this.move(y, x);
+
+				if (options.focusElement !== false) {
+					(options.focusElement || this.parts.panel).focus();
+				}
+			};
+
+			CKEDITOR.plugins.balloontoolbar.context.prototype._loadButtons = function () {
+				const buttons = this.options.buttons;
+
+				if (!buttons) {
+					return;
+				}
+
+				CKEDITOR.tools.array.forEach(
+					buttons.split(','),
+					(name) => {
+						const newUiItem = this.editor.ui.create(name);
+
+						if (newUiItem) {
+							this.toolbar.addItem(name, newUiItem);
+
+							if (
+								Object.hasOwnProperty.call(
+									newUiItem,
+									'balloonToolbar'
+								)
+							) {
+								newUiItem.balloonToolbar = this.toolbar;
+							}
+						}
+					},
+					this
+				);
+			};
+
+			CKEDITOR.plugins.balloontoolbar.contextManager.prototype.check = function (
+				selection
+			) {
+				if (!selection) {
+					selection = this.editor.getSelection();
+
+					CKEDITOR.tools.array.forEach(
+						selection.getRanges(),
+						(range) => {
+							range.shrink(CKEDITOR.SHRINK_ELEMENT, true);
+						}
+					);
+				}
+
+				if (!selection) {
+					return;
+				}
+
+				const path = selection.getRanges()[0]?.startPath();
+
+				let contextMatched;
+
+				function matchEachContext(
+					contexts,
+					matchingFunction,
+					matchingArg1
+				) {
+					CKEDITOR.tools.array.forEach(contexts, (curContext) => {
+						if (
+							!contextMatched ||
+							contextMatched.options.priority >
+								curContext.options.priority
+						) {
+							const result = matchingFunction(
+								curContext,
+								matchingArg1
+							);
+
+							if (result instanceof CKEDITOR.dom.element) {
+								contextMatched = curContext;
+							}
+						}
+					});
+				}
+
+				function elementsMatcher(curContext, curElement) {
+					return curContext._matchElement(curElement);
+				}
+
+				matchEachContext(this._contexts, (curContext) => {
+					return curContext._matchRefresh(path, selection);
+				});
+
+				matchEachContext(this._contexts, (curContext) => {
+					return curContext._matchWidget();
+				});
+
+				if (path) {
+					const selectedElem = selection.getSelectedElement();
+
+					if (selectedElem && !selectedElem.isReadOnly()) {
+						matchEachContext(
+							this._contexts,
+							elementsMatcher,
+							selectedElem
+						);
+					}
+
+					for (let i = 0; i < path.elements.length; i++) {
+						const curElement = path.elements[i];
+
+						if (!curElement.isReadOnly()) {
+							matchEachContext(
+								this._contexts,
+								elementsMatcher,
+								curElement
+							);
+						}
+					}
+				}
+
+				this.hide();
+
+				if (contextMatched) {
+					CKEDITOR.tools.array.forEach(
+						selection.getRanges(),
+						(range) => {
+							range.shrink(CKEDITOR.SHRINK_ELEMENT, true);
+						}
+					);
+
+					if (
+						!selection.getSelectedElement() &&
+						!selection.getSelectedText()
+					) {
+						return;
+					}
+
+					contextMatched.show(selection);
+				}
+			};
+
+			CKEDITOR.ui.panel.prototype.showBlock = function (name) {
+				if (!this.name) {
+					this.name = name;
+				}
+
+				return CKEDITOR.ui.panel.prototype.showBlock.call(
+					this,
+					this.name
+				);
+			};
+		},
+
+		requires: [
+			'balloonpanel',
+			'balloontoolbar',
+			'imagealt',
+			'insertbutton',
+			'linktoolbar',
+			'toolbarbuttons',
+		],
+	});
+})();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/imagealt/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/imagealt/plugin.js
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+(function () {
+	const pluginName = 'imagealt';
+
+	if (CKEDITOR.plugins.get(pluginName)) {
+		return;
+	}
+
+	CKEDITOR.plugins.add(pluginName, {
+		_createToolbar() {
+			if (this._toolbar) {
+				return this._toolbar;
+			}
+
+			const instance = this;
+
+			this._toolbar = new CKEDITOR.ui.balloonToolbar(this.editor);
+
+			const altInput = new CKEDITOR.ui.balloonToolbarTextInput({
+				placeholder: this.editor.lang.image.alt,
+			});
+
+			altInput.on('cancel', () => {
+				instance._toolbar.hide();
+
+				instance._parentToolbar.show();
+			});
+
+			altInput.on('change', () => {
+				instance.editor.execCommand('imageAlt');
+			});
+
+			this._toolbar.addItem('altInput', altInput);
+
+			const okButton = new CKEDITOR.ui.balloonToolbarButton({
+				command: 'imageAlt',
+				icon: 'check',
+				title: this.editor.lang.common.ok,
+			});
+
+			this._toolbar.addItem('okButton', okButton);
+
+			return this._toolbar;
+		},
+
+		_onSelectionChange() {
+			if (this._toolbar) {
+				this._toolbar.hide();
+			}
+		},
+
+		_parentToolbar: null,
+
+		_toolbar: null,
+
+		init(editor) {
+			const instance = this;
+
+			instance.editor = editor;
+
+			editor.on('selectionChange', this._onSelectionChange.bind(this));
+
+			editor.addCommand('imageAlt', {
+				exec(editor) {
+					const imageWidget =
+						editor.widgets.focused || editor.widgets.selected[0];
+
+					if (!imageWidget || imageWidget.name !== 'image') {
+						return;
+					}
+
+					const altInput = instance._toolbar.getItem('altInput');
+
+					imageWidget.data.alt = altInput.value;
+					imageWidget.element.setAttribute('alt', altInput.value);
+
+					instance._toolbar.hide();
+
+					if (instance._parentToolbar) {
+						instance._parentToolbar.show();
+					}
+				},
+			});
+
+			editor.addCommand('imageAltToolbar', {
+				exec(editor) {
+					const toolbar = instance._createToolbar();
+
+					const imageWidget =
+						editor.widgets.focused || editor.widgets.selected[0];
+
+					if (!imageWidget || imageWidget.name !== 'image') {
+						return;
+					}
+
+					toolbar.getItem('altInput').value = imageWidget.data.alt;
+
+					const selection = editor.getSelection();
+
+					toolbar.attach(selection);
+				},
+			});
+
+			editor.ui.addBalloonToolbarButton('AltImg', {
+				click() {
+					instance._parentToolbar = this.balloonToolbar;
+					editor.execCommand('imageAltToolbar');
+				},
+				icon: 'low-vision',
+				title: editor.lang.image.alt,
+			});
+		},
+		requires: ['uibutton', 'uitextinput'],
+	});
+})();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/insertbutton/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/insertbutton/plugin.js
@@ -1,0 +1,378 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+(function () {
+	const pluginName = 'insertbutton';
+
+	if (CKEDITOR.plugins.get(pluginName)) {
+		return;
+	}
+
+	const template = new CKEDITOR.template(
+		'<button class="lfr-ballon-editor-insert-button">+</button>'
+	);
+
+	CKEDITOR.plugins.add(pluginName, {
+		_createTable() {
+			const editor = this.editor;
+
+			const tableElement = new CKEDITOR.dom.element('table');
+
+			tableElement.setAttributes({
+				border: 1,
+				cellpadding: 1,
+				cellspacing: 1,
+			});
+
+			tableElement.setStyle('width', '500px');
+
+			const tbodyElement = new CKEDITOR.dom.element('tbody');
+
+			tableElement.append(tbodyElement);
+
+			const columns = this._tableData.columns;
+			const rows = this._tableData.rows;
+
+			for (let i = 0; i < rows; i++) {
+				const tableRowElement = new CKEDITOR.dom.element('tr');
+
+				for (let j = 0; j < columns; j++) {
+					const tableCellElement = new CKEDITOR.dom.element('td');
+					const lineBreakElement = new CKEDITOR.dom.element('br');
+
+					tableCellElement.append(lineBreakElement);
+
+					tableRowElement.append(tableCellElement);
+				}
+
+				tbodyElement.append(tableRowElement);
+			}
+
+			editor.insertElement(tableElement);
+
+			this._tableToolbar.destroy();
+			this._tableToolbar = null;
+
+			setTimeout(() => {
+				const range = editor.createRange();
+
+				range.selectNodeContents(tableElement);
+
+				range.select();
+			}, 0);
+		},
+
+		_createTableToolbar() {
+			const instance = this;
+
+			if (instance._tableToolbar) {
+				return instance._tableToolbar;
+			}
+
+			const editor = instance.editor;
+
+			instance._tableToolbar = new CKEDITOR.ui.balloonToolbar(editor);
+
+			const rowsInput = new CKEDITOR.ui.balloonToolbarNumberInput({
+				change(value) {
+					instance._tableData.rows = value;
+				},
+				label: editor.lang.table.rows,
+				min: 1,
+				step: 1,
+				value: this._tableData.rows,
+			});
+
+			instance._tableToolbar.addItem('rowsInput', rowsInput);
+
+			const columnsInput = new CKEDITOR.ui.balloonToolbarNumberInput({
+				change(value) {
+					instance._tableData.columns = value;
+				},
+				label: editor.lang.table.columns,
+				min: 1,
+				step: 1,
+				value: this._tableData.columns,
+			});
+
+			instance._tableToolbar.addItem('columnsInput', columnsInput);
+
+			const okButton = new CKEDITOR.ui.balloonToolbarButton({
+				click: instance._createTable.bind(instance),
+				icon: 'check',
+				title: editor.lang.common.ok,
+			});
+
+			instance._tableToolbar.addItem('okButton', okButton);
+
+			return instance._tableToolbar;
+		},
+
+		_createToolbar() {
+			if (this._toolbar) {
+				return;
+			}
+
+			const instance = this;
+
+			const editor = instance.editor;
+
+			instance._toolbar = new CKEDITOR.ui.balloonToolbar(editor);
+
+			instance._toolbar.addItem(
+				'image',
+				new CKEDITOR.ui.balloonToolbarButton({
+					command: 'imageselector',
+					icon: 'image',
+					title: CKEDITOR.tools.capitalize(
+						editor.lang.image2.pathName
+					),
+				})
+			);
+
+			instance._toolbar.addItem(
+				'video',
+				new CKEDITOR.ui.balloonToolbarButton({
+					command: 'videoselector',
+					icon: 'videoselector',
+					title: 'Video',
+				})
+			);
+
+			instance._toolbar.addItem(
+				'table',
+				new CKEDITOR.ui.balloonToolbarButton({
+					click() {
+						instance._toolbar.hide();
+
+						const tableToolbar = instance._createTableToolbar();
+
+						tableToolbar.attach(editor.getSelection());
+					},
+					icon: 'table',
+					title: editor.lang.table.toolbar,
+				})
+			);
+
+			instance._toolbar.addItem(
+				'horizontalrule',
+				new CKEDITOR.ui.balloonToolbarButton({
+					command: 'horizontalrule',
+					icon: 'horizontalrule',
+					title: editor.lang.horizontalrule.toolbar,
+				})
+			);
+		},
+
+		_eventListeners: [],
+
+		_onAfterCommandExec() {
+			this.hide();
+		},
+
+		_onBlur() {
+			if (!this._toolbarVisible) {
+				this.hide();
+			}
+		},
+
+		_onButtonClick(event) {
+			event.cancel();
+
+			this._createToolbar();
+			this._toolbarVisible = true;
+			this._toolbar.attach(this.editor.getSelection());
+		},
+
+		_onChange() {
+			this.hide();
+		},
+
+		_onContentDom() {
+			this.documentBody = this.editor.document.getBody();
+
+			if (!this.documentBody.contains(this._button)) {
+				this.documentBody.append(this._button);
+			}
+		},
+
+		_onDestroy() {
+			CKEDITOR.tools.array.forEach(this._eventListeners, (listener) => {
+				listener.removeListener();
+			});
+
+			this._eventListeners = [];
+		},
+
+		_onSelectionChange() {
+			const selection = this.editor.getSelection();
+
+			const type = selection.getType();
+
+			if (type === CKEDITOR.SELECTION_ELEMENT || selection.isHidden()) {
+				this.hide();
+
+				return;
+			}
+
+			if (
+				type === CKEDITOR.SELECTION_TEXT &&
+				selection.getSelectedText()
+			) {
+				this.hide();
+
+				return;
+			}
+
+			const ranges = selection.getRanges();
+
+			const rangesNotCollapsed = CKEDITOR.tools.array.some(
+				ranges,
+				(range) => {
+					return !range.collapsed;
+				}
+			);
+
+			if (rangesNotCollapsed) {
+				this.hide();
+
+				return;
+			}
+
+			const range = ranges[ranges.length - 1];
+
+			const startContainer = range.startContainer;
+
+			if (
+				typeof startContainer.getName === 'function' &&
+				startContainer.getName() === 'td'
+			) {
+				this.hide();
+
+				return;
+			}
+
+			const nodeType = startContainer.$.nodeType;
+
+			if (nodeType === CKEDITOR.NODE_ELEMENT) {
+				if (startContainer.getChildCount() !== 1) {
+					this.hide();
+
+					return;
+				}
+				else if (startContainer.getChild(0)) {
+					const child = startContainer.getChild(0);
+
+					if (
+						typeof child.getName === 'function' &&
+						child.getName() !== 'br'
+					) {
+						this.hide();
+
+						return;
+					}
+				}
+			}
+			else if (
+				nodeType === CKEDITOR.NODE_TEXT &&
+				!startContainer.isEmpty()
+			) {
+				this.hide();
+
+				return;
+			}
+
+			const rangeClientRects = range.getClientRects(true);
+
+			const rangeClientRect =
+				rangeClientRects[rangeClientRects.length - 1];
+
+			this._positionButton(rangeClientRect);
+
+			this.show();
+		},
+
+		_positionButton(rangeClientRect) {
+			if (!this._buttonClientRect) {
+				this._buttonClientRect = this._button.getClientRect(true);
+			}
+
+			this._button.setStyles({
+				left:
+					rangeClientRect.x - this._buttonClientRect.width / 2 + 'px',
+				top: rangeClientRect.y + 'px',
+			});
+		},
+
+		_tableData: {
+			columns: 3,
+			rows: 3,
+		},
+
+		_tableToolbar: null,
+
+		_toolbarVisible: false,
+
+		hide() {
+			if (this._button.getStyle('display') !== 'none') {
+				this._button.setStyle('display', 'none');
+			}
+			if (this._toolbar) {
+				this._toolbar.hide();
+			}
+			if (this._tableToolbar) {
+				this._tableToolbar.destroy();
+			}
+		},
+
+		init(editor) {
+			this.editor = editor;
+
+			this._eventListeners.push(
+				this.editor.on(
+					'afterCommandExec',
+					this._onAfterCommandExec.bind(this)
+				),
+				this.editor.on('blur', this._onBlur.bind(this)),
+				this.editor.on('change', this._onChange.bind(this)),
+				this.editor.on('contentDom', this._onContentDom.bind(this)),
+				this.editor.on('destroy', this._onDestroy.bind(this)),
+				this.editor.on('paste', this._onChange.bind(this)),
+				this.editor.on(
+					'selectionChange',
+					this._onSelectionChange.bind(this)
+				)
+			);
+
+			this._button = CKEDITOR.dom.element.createFromHtml(template.source);
+
+			this._button.setStyles({
+				display: 'none',
+				position: 'absolute',
+			});
+
+			this._eventListeners.push(
+				this._button.on('click', this._onButtonClick.bind(this))
+			);
+		},
+
+		requires: ['balloontoolbar', 'uibutton', 'uinumberinput'],
+
+		show() {
+			if (this._button.getStyle('display') !== '') {
+				this._button.setStyle('display', '');
+			}
+		},
+	});
+})();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/linktoolbar/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/linktoolbar/plugin.js
@@ -1,0 +1,337 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+(function () {
+	const pluginName = 'linktoolbar';
+
+	if (CKEDITOR.plugins.get(pluginName)) {
+		return;
+	}
+
+	CKEDITOR.plugins.add(pluginName, {
+		_createToolbar() {
+			if (this._toolbar) {
+				return;
+			}
+
+			const instance = this;
+
+			const editor = instance.editor;
+
+			instance._toolbar = new CKEDITOR.ui.balloonToolbar(editor);
+
+			const unlinkButton = new CKEDITOR.ui.balloonToolbarButton({
+				click: instance._onUnlinkButtonClick.bind(instance),
+				icon: 'unlink',
+				title: editor.lang.undo.undo,
+			});
+
+			instance._toolbar.addItem('unlinkButton', unlinkButton);
+
+			const targetSelect = new CKEDITOR.ui.balloonToolbarSelect({
+				items: [
+					{
+						label: editor.lang.common.optionDefault,
+						value: '',
+					},
+					{
+						label: editor.lang.common.targetSelf,
+						value: '_self',
+					},
+					{
+						label: editor.lang.common.targetNew,
+						value: '_blank',
+					},
+					{
+						label: editor.lang.common.targetParent,
+						value: '_parent',
+					},
+					{
+						label: editor.lang.common.targetTop,
+						value: '_top',
+					},
+				],
+				label: editor.lang.common.target,
+				name: editor.lang.common.target,
+			});
+
+			instance._toolbar.addItem('targetSelect', targetSelect);
+
+			const linkInput = new CKEDITOR.ui.balloonToolbarTextInput({
+				placeholder: editor.lang.link.title,
+			});
+
+			linkInput.on('cancel', () => {
+				instance._toolbar.hide();
+			});
+
+			const changeOrClickHandler = instance._onOkButtonClick.bind(
+				instance
+			);
+
+			linkInput.on('change', () => {
+				changeOrClickHandler();
+			});
+
+			instance._toolbar.addItem('linkInput', linkInput);
+
+			const okButton = new CKEDITOR.ui.balloonToolbarButton({
+				click: changeOrClickHandler,
+				icon: 'check',
+				title: editor.lang.common.ok,
+			});
+
+			instance._toolbar.addItem('okButton', okButton);
+
+			const folderButton = new CKEDITOR.ui.balloonToolbarButton({
+				click() {
+					instance._toolbar.hide();
+
+					const editor = instance.editor;
+
+					const imageWidget = editor.widgets.selected[0];
+
+					if (!imageWidget || imageWidget.name !== 'image') {
+						return;
+					}
+
+					editor.execCommand('imageselector');
+				},
+				icon: 'folder',
+				title: editor.lang.common.browseServer,
+			});
+
+			instance._toolbar.addItem('folderButton', folderButton);
+		},
+
+		_currentSelection: null,
+
+		_onOkButtonClick() {
+			const linkInput = this._toolbar.getItem('linkInput');
+
+			if (!linkInput.value) {
+				this._toolbar.hide();
+
+				return;
+			}
+
+			const targetSelect = this._toolbar.getItem('targetSelect');
+
+			const hasTarget = targetSelect.value !== 'Default';
+
+			if (this.editor.widgets.selected[0]) {
+				const imageWidget = this.editor.widgets.selected[0];
+
+				if (!imageWidget || imageWidget.name !== 'image') {
+					return;
+				}
+
+				const newData = Object.assign(imageWidget.data, {
+					link: {
+						url: linkInput.value,
+					},
+				});
+
+				imageWidget.shiftState({
+					deflate() {},
+					element: imageWidget.element,
+					inflate() {
+						const wrapperElement = imageWidget.wrapper;
+
+						const linkElement = wrapperElement.findOne('a');
+
+						if (linkElement) {
+							linkElement.setAttribute('rel', 'noopener');
+
+							if (hasTarget) {
+								linkElement.setAttribute(
+									'target',
+									targetSelect.value
+								);
+							}
+						}
+					},
+					newData,
+					oldData: imageWidget.oldData,
+					widget: imageWidget,
+				});
+
+				this._toolbar.hide();
+
+				imageWidget.focus();
+				imageWidget.element.focus();
+			}
+			else {
+				let selection = this._currentSelection;
+
+				const startElement = selection.getStartElement();
+
+				let linkElement;
+
+				if (startElement.getName() === 'a') {
+					linkElement = startElement;
+
+					linkElement.setAttributes({
+						'data-cke-saved-href': linkInput.value,
+						href: linkInput.value,
+						rel: 'noopener',
+					});
+
+					if (hasTarget) {
+						linkElement.setAttribute('target', targetSelect.value);
+					}
+
+					linkInput.clear();
+
+					this._toolbar.hide();
+				}
+				else if (selection.getSelectedText()) {
+					selection = this.editor.getSelection();
+
+					const selectedText = selection.getSelectedText();
+
+					const ranges = selection.getRanges();
+
+					const range = ranges[0];
+
+					const bookmark = range.createBookmark();
+
+					linkElement = new CKEDITOR.dom.element('a');
+
+					linkElement.setAttributes({
+						href: linkInput.value,
+						rel: 'noopener',
+					});
+
+					if (hasTarget) {
+						linkElement.setAttribute('target', targetSelect.value);
+					}
+
+					linkElement.setText(selectedText);
+
+					linkElement.insertAfter(bookmark.endNode);
+
+					range.moveToBookmark(bookmark);
+					range.deleteContents();
+
+					linkInput.clear();
+
+					this._toolbar.hide();
+
+					selection = this.editor.getSelection();
+
+					selection.unlock(true);
+				}
+			}
+		},
+
+		_onSelectionChange() {
+			if (this._toolbar) {
+				this._toolbar.hide();
+			}
+		},
+
+		_onUnlinkButtonClick() {
+			const startElement = this._currentSelection.getStartElement();
+			const startElementName = startElement.getName();
+
+			if (startElementName === 'a') {
+				startElement.remove(true);
+			}
+			else if (startElement.findOne('img')) {
+				const imageWidget = this.editor.widgets.selected[0];
+
+				if (!imageWidget || imageWidget.name !== 'image') {
+					return;
+				}
+
+				if (
+					Object.prototype.hasOwnProperty.call(
+						imageWidget.data,
+						'link'
+					)
+				) {
+					imageWidget.setData('link', {url: ''});
+
+					const linkInput = this._toolbar.getItem('linkInput');
+
+					linkInput.clear();
+
+					this._toolbar.hide();
+				}
+			}
+
+			this.editor.fire('hideToolbars');
+		},
+
+		_toolbar: null,
+
+		init(editor) {
+			const instance = this;
+
+			instance.editor = editor;
+
+			editor.on('selectionChange', this._onSelectionChange.bind(this));
+
+			editor.on('unlinkTextOrImage', (event) => {
+				instance._currentSelection = event.data.selection;
+				instance._onUnlinkButtonClick();
+			});
+
+			editor.addCommand('linkToolbar', {
+				exec(editor) {
+					instance._createToolbar();
+
+					if (editor.widgets.selected[0]) {
+						const imageWidget = editor.widgets.selected[0];
+
+						if (!imageWidget || imageWidget.name !== 'image') {
+							return;
+						}
+
+						imageWidget.focus();
+					}
+
+					const selection = editor.getSelection();
+
+					selection.lock();
+
+					instance._currentSelection = selection;
+
+					instance._toolbar.attach(selection);
+
+					const startElement = selection.getStartElement();
+
+					const linkInput = instance._toolbar.getItem('linkInput');
+
+					if (startElement.getName() === 'a') {
+						linkInput.setValue(
+							selection.getStartElement().getAttribute('href')
+						);
+					}
+
+					setTimeout(() => {
+						const linkInputElement = linkInput.getInputElement();
+
+						if (linkInputElement) {
+							linkInputElement.focus();
+						}
+					}, 0);
+				},
+			});
+		},
+
+		requires: ['uibutton', 'uiselect', 'uitextinput'],
+	});
+})();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
@@ -1,0 +1,356 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+(function () {
+	const pluginName = 'toolbarbuttons';
+
+	if (CKEDITOR.plugins.get(pluginName)) {
+		return;
+	}
+
+	CKEDITOR.plugins.add(pluginName, {
+		init(editor) {
+			editor.ui.addBalloonToolbarButton('ImageAlignLeft', {
+				click() {
+					const imageWidget = editor.widgets.selected[0];
+
+					if (imageWidget.name !== 'image') {
+						return;
+					}
+
+					imageWidget.focus();
+
+					const alignValue = imageWidget.data.align;
+
+					if (!alignValue || alignValue !== 'left') {
+						imageWidget.setData('align', 'left');
+					}
+					else {
+						imageWidget.setData('align', 'none');
+					}
+				},
+				icon: 'align-image-left',
+				title: editor.lang.common.alignLeft,
+			});
+
+			editor.ui.addBalloonToolbarButton('ImageAlignCenter', {
+				click() {
+					const imageWidget = editor.widgets.selected[0];
+
+					if (imageWidget.name !== 'image') {
+						return;
+					}
+
+					imageWidget.focus();
+
+					const alignValue = imageWidget.data.align;
+
+					if (!alignValue || alignValue !== 'center') {
+						imageWidget.setData('align', 'center');
+					}
+					else if (alignValue === 'center') {
+						imageWidget.setData('align', 'none');
+					}
+				},
+				icon: 'align-image-center',
+				title: editor.lang.common.alignCenter,
+			});
+
+			editor.ui.addBalloonToolbarButton('ImageAlignRight', {
+				click() {
+					const imageWidget = editor.widgets.selected[0];
+
+					if (imageWidget.name !== 'image') {
+						return;
+					}
+
+					imageWidget.focus();
+
+					const alignValue = imageWidget.data.align;
+
+					if (!alignValue || alignValue !== 'right') {
+						imageWidget.setData('align', 'right');
+					}
+					else {
+						imageWidget.setData('align', 'none');
+					}
+				},
+				icon: 'align-image-right',
+				title: editor.lang.common.alignRight,
+			});
+
+			editor.ui.addBalloonToolbarButton('LinkToolbar', {
+				click() {
+					editor.fire('showToolbar', {
+						toolbarCommand: 'linkToolbar',
+					});
+				},
+				icon: 'link',
+				title: editor.lang.link.title,
+			});
+
+			editor.ui.addBalloonToolbarButton('LinkAddOrEdit', {
+				click() {
+					editor.fire('showToolbar', {
+						toolbarCommand: 'linkToolbar',
+					});
+				},
+				icon: 'link',
+				title: editor.lang.link.title,
+			});
+
+			editor.ui.addBalloonToolbarButton('LinkRemove', {
+				click() {
+					editor.fire('unlinkTextOrImage', {
+						selection: editor.getSelection(),
+					});
+				},
+				icon: 'unlink',
+				title: editor.lang.link.unlink,
+			});
+
+			editor.ui.addRichCombo('TableHeaders', {
+				init() {
+					const headersPrefix = editor.lang.table.headers;
+
+					const headersNone = `${headersPrefix}: ${editor.lang.table.headersNone}`;
+					const headersRow = `${headersPrefix}: ${editor.lang.table.headersRow}`;
+					const headersColumn = `${headersPrefix}: ${editor.lang.table.headersColumn}`;
+					const headersBoth = `${headersPrefix}: ${editor.lang.table.headersBoth}`;
+
+					this.add(headersNone, headersNone, headersNone);
+					this.add(headersRow, headersRow, headersRow);
+					this.add(headersColumn, headersColumn, headersColumn);
+					this.add(headersBoth, headersBoth, headersBoth);
+				},
+
+				label: editor.lang.table.headers,
+
+				panel: {
+					attributes: {'aria-label': editor.lang.table.title},
+					css: [CKEDITOR.skin.getPath('editor')].concat(
+						editor.config.contentsCss
+					),
+					multiSelect: false,
+				},
+
+				title: editor.lang.table.title,
+			});
+
+			editor.ui.addBalloonToolbarButton('TableRow', {
+				icon: 'add-row',
+				title: editor.lang.table.row.menu,
+			});
+
+			editor.ui.addBalloonToolbarButton('TableColumn', {
+				icon: 'add-column',
+				title: editor.lang.table.column.menu,
+			});
+
+			editor.ui.addBalloonToolbarButton('TableCell', {
+				icon: 'add-cell',
+				title: editor.lang.table.cell.menu,
+			});
+
+			editor.ui.addBalloonToolbarButton('TableDelete', {
+				click() {
+					const selection = editor.getSelection();
+
+					const startElement = selection.getStartElement();
+
+					const tableElement = startElement.getAscendant('table');
+
+					if (tableElement) {
+						tableElement.remove();
+
+						editor.fire('hideToolbars');
+					}
+				},
+				icon: 'trash',
+				title: editor.lang.table.deleteTable,
+			});
+
+			editor.ui.addBalloonToolbarButton('TextLink', {
+				click() {
+					editor.fire('showToolbar', {
+						toolbarCommand: 'linkToolbar',
+					});
+				},
+				icon: 'link',
+				title: editor.lang.link.title,
+			});
+
+			editor.ui.addBalloonToolbarSelect('LineHeight', {
+				_applyStyle(className) {
+					const styleConfig = {
+						attributes: {
+							class: className,
+						},
+						element: 'div',
+					};
+
+					const selection = editor.getSelection();
+
+					const startElement = selection.getStartElement();
+
+					const style = new CKEDITOR.style(styleConfig);
+
+					selection.lock();
+
+					style.applyToObject(startElement, this.editor);
+
+					selection.unlock();
+				},
+
+				_checkActive({elementPath, styleConfig}) {
+					let active = true;
+
+					if (elementPath && elementPath.lastElement) {
+						styleConfig.attributes.class
+							.split(' ')
+							.forEach((className) => {
+								active =
+									active &&
+									elementPath.lastElement.hasClass(className);
+							});
+					}
+					else {
+						active = false;
+					}
+
+					return active;
+				},
+
+				_getSelectedIndex(key) {
+					return this.items.findIndex((item) => {
+						return item.value === key;
+					});
+				},
+
+				_stylesFactory: {
+					'1.0x': {
+						style: {attributes: {class: ''}, element: 'div'},
+					},
+					'1.5x': {
+						style: {
+							attributes: {class: 'mt-1 mb-1'},
+							element: 'div',
+						},
+					},
+					'2.0x': {
+						style: {
+							attributes: {class: 'mt-2 mb-2'},
+							element: 'div',
+						},
+					},
+					'3.0x': {
+						style: {
+							attributes: {class: 'mt-3 mb-3'},
+							element: 'div',
+						},
+					},
+					'4.0x': {
+						style: {
+							attributes: {class: 'mt-4 mb-4'},
+							element: 'div',
+						},
+					},
+					'5.0x': {
+						style: {
+							attributes: {class: 'mt-5 mb-5'},
+							element: 'div',
+						},
+					},
+				},
+
+				icon: 'horizontalrule',
+
+				items: [
+					{label: '1.0x', value: '1.0x'},
+					{label: '1.5x', value: '1.5x'},
+					{label: '2.0x', value: '2.0x'},
+					{label: '3.0x', value: '3.0x'},
+					{label: '4.0x', value: '4.0x'},
+					{label: '5.0x', value: '5.0x'},
+				],
+
+				name: Liferay.Language.get('line-height'),
+
+				onChange(key) {
+					this._applyStyle(
+						this._stylesFactory[key].style.attributes.class
+					);
+				},
+
+				onRender() {
+					editor.on(
+						'selectionChange',
+						function (event) {
+							this._editor.focusManager.add(
+								this._editor.document.getById(this._id),
+								1
+							);
+
+							Object.keys(this._stylesFactory).forEach(
+								(spacingKey) => {
+									if (
+										this._checkActive({
+											elementPath: event.data.path,
+											styleConfig: this._stylesFactory[
+												spacingKey
+											].style,
+										})
+									) {
+										const element = document.getElementById(
+											this._id
+										);
+
+										if (element) {
+											element.selectedIndex = this._getSelectedIndex(
+												spacingKey
+											);
+										}
+									}
+								}
+							);
+						},
+						this
+					);
+				},
+
+				title: Liferay.Language.get('line-height'),
+			});
+
+			editor.ui.addBalloonToolbarButton('VideoAlignLeft', {
+				command: 'justifyleft',
+				icon: 'align-image-left',
+				title: editor.lang.common.alignLeft,
+			});
+
+			editor.ui.addBalloonToolbarButton('VideoAlignCenter', {
+				command: 'justifycenter',
+				icon: 'align-image-center',
+				title: editor.lang.common.alignCenter,
+			});
+
+			editor.ui.addBalloonToolbarButton('VideoAlignRight', {
+				command: 'justifyright',
+				icon: 'align-image-right',
+				title: editor.lang.common.alignRight,
+			});
+		},
+
+		requires: ['uibutton', 'uiselect', 'uitextinput'],
+	});
+})();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/uibutton/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/uibutton/plugin.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+(function () {
+	const pluginName = 'uibutton';
+
+	if (CKEDITOR.plugins.get(pluginName)) {
+		return;
+	}
+
+	const templateHTML =
+		'<a' +
+		' class="cke_button cke_button__{name} {cssClass}"' +
+		' hidefocus="true"' +
+		' id="{id}"' +
+		' onclick="CKEDITOR.tools.callFunction({clickFn},event,this);return false;"' +
+		' role="button"' +
+		' tabindex="-1"' +
+		' title="{title}"' +
+		'>' +
+		'<span class="cke_button_icon cke_button__{icon}_icon">&nbsp;</span>' +
+		'</a>';
+
+	const template = CKEDITOR.addTemplate('balloonToolbarButton', templateHTML);
+
+	CKEDITOR.ui.balloonToolbarButton = CKEDITOR.tools.createClass({
+		// eslint-disable-next-line
+		$: function (definition) {
+			CKEDITOR.tools.extend(this, definition, {
+				balloonToolbar: null,
+				click: definition.click,
+				command: definition.command,
+				cssClass: definition.cssClass,
+				icon: definition.icon,
+				modes: {wysiwyg: 1},
+				title: definition.title,
+			});
+		},
+
+		base: CKEDITOR.event,
+
+		proto: {
+			render(editor, output) {
+				const id = CKEDITOR.tools.getNextId();
+
+				this._id = id;
+
+				const button = this;
+
+				this._editor = editor;
+
+				const instance = {
+					button,
+					execute() {
+						if (typeof button.click === 'function') {
+							button.click();
+						}
+						else if (button.command) {
+							editor.execCommand(button.command);
+						}
+					},
+					id,
+				};
+
+				const clickFn = CKEDITOR.tools.addFunction(() => {
+					instance.execute();
+				});
+
+				const params = {
+					clickFn,
+					command: this.command ? this.command : '',
+					cssClass: this.cssClass ? this.cssClass : '',
+					icon: this.icon,
+					id,
+					title: this.title || '',
+				};
+
+				template.output(params, output);
+
+				return instance;
+			},
+		},
+	});
+
+	CKEDITOR.ui.balloonToolbarButton.handler = {
+		create(definition) {
+			return new CKEDITOR.ui.balloonToolbarButton(definition);
+		},
+	};
+
+	CKEDITOR.UI_BALLOON_TOOLBAR_BUTTON = 'balloonToolbarButton';
+
+	CKEDITOR.tools.extend(CKEDITOR.ui.prototype, {
+		addBalloonToolbarButton(name, definition) {
+			this.add(name, CKEDITOR.UI_BALLOON_TOOLBAR_BUTTON, definition);
+		},
+	});
+
+	CKEDITOR.plugins.add(pluginName, {
+		beforeInit(editor) {
+			editor.ui.addHandler(
+				CKEDITOR.UI_BALLOON_TOOLBAR_BUTTON,
+				CKEDITOR.ui.balloonToolbarButton.handler
+			);
+		},
+	});
+})();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/uinumberinput/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/uinumberinput/plugin.js
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+(function () {
+	const pluginName = 'uinumberinput';
+
+	if (CKEDITOR.plugins.get(pluginName)) {
+		return;
+	}
+
+	const template = new CKEDITOR.template((data) => {
+		const output = ['<div class="ui-numberinput">'];
+
+		if (data.label) {
+			output.push('<label for="{id}">{label}</label>');
+		}
+
+		output.push(
+			'<input' +
+				' class="ui-numberinput"' +
+				' id="{id}"' +
+				' min="{min}"' +
+				' max="{max}"' +
+				' onchange="CKEDITOR.tools.callFunction({changeFn},event);return false;" ' +
+				' step="{step}"' +
+				' type="number"' +
+				' value="{value}" />'
+		);
+		output.push('</div>');
+
+		return output.join('');
+	});
+
+	CKEDITOR.ui.balloonToolbarNumberInput = CKEDITOR.tools.createClass({
+		// eslint-disable-next-line
+		$: function (definition) {
+			CKEDITOR.tools.extend(this, definition, {
+				change: definition.change || function () {},
+				label: definition.label || '',
+				max: definition.max,
+				min: definition.min || 0,
+				modes: {wysiwyg: 1},
+				step: definition.step || 1,
+				value: definition.value || 0,
+			});
+		},
+
+		base: CKEDITOR.event,
+
+		proto: {
+			render(editor, output) {
+				const id = CKEDITOR.tools.getNextId();
+
+				this._id = id;
+
+				const input = this;
+
+				this._editor = editor;
+
+				const instance = {
+					input,
+				};
+
+				const changeFn = CKEDITOR.tools.addFunction((event) => {
+					event.preventDefault();
+
+					const value = event.target.valueAsNumber;
+
+					input.value = value;
+
+					input.change(value);
+
+					input.fire(
+						'change',
+						{
+							value,
+						},
+						input._editor
+					);
+				});
+
+				const params = {
+					changeFn,
+					id,
+					label: this.label,
+					max: this.max,
+					min: this.min,
+					step: this.step,
+					value: this.value,
+				};
+
+				template.output(params, output);
+
+				this._element = this._editor.document.findOne(`#${id}`);
+
+				return instance;
+			},
+		},
+	});
+
+	CKEDITOR.ui.balloonToolbarNumberInput.handler = {
+		create(definition) {
+			return new CKEDITOR.ui.balloonToolbarNumberInput(definition);
+		},
+	};
+
+	CKEDITOR.UI_BALLOON_NUMBER_INPUT = 'balloonToolbarNumberInput';
+
+	CKEDITOR.tools.extend(CKEDITOR.ui.prototype, {
+		addBalloonToolbarNumberInput(name, definition) {
+			this.add(name, CKEDITOR.UI_BALLOON_NUMBER_INPUT, definition);
+		},
+	});
+
+	CKEDITOR.plugins.add(pluginName, {
+		init(editor) {
+			editor.ui.addHandler(
+				CKEDITOR.UI_BALLOON_NUMBER_INPUT,
+				CKEDITOR.ui.balloonToolbarNumberInput.handler
+			);
+		},
+	});
+})();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/uiselect/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/uiselect/plugin.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+(function () {
+	const pluginName = 'uiselect';
+
+	if (CKEDITOR.plugins.get(pluginName)) {
+		return;
+	}
+
+	const template = new CKEDITOR.template((data) => {
+		const output = [];
+
+		if (data.icon) {
+			output.push(
+				'<a class="cke_button" tabindex="-1" title="{title}" hidefocus="true" role="button">'
+			);
+			output.push(
+				'<span class="cke_button_icon cke_button__{icon}_icon">&nbsp;</span>'
+			);
+		}
+
+		output.push('<select class="');
+
+		if (data.icon) {
+			output.push('ui-select-wrapper ');
+		}
+
+		output.push(
+			'ui-select" id="{id}" name="{name}" onchange="CKEDITOR.tools.callFunction({changeFn},event,this);return false;">'
+		);
+
+		if (data.items) {
+			data.items.forEach((item) => {
+				const value = item.value
+					? item.value
+					: item.label
+					? item.label
+					: '';
+
+				output.push(
+					`<option value="${String(value)}">${item.label}</option>`
+				);
+			});
+		}
+
+		output.push('</select>');
+
+		if (data.icon) {
+			output.push('</a>');
+		}
+
+		return output.join('');
+	});
+
+	CKEDITOR.ui.balloonToolbarSelect = CKEDITOR.tools.createClass({
+		// eslint-disable-next-line
+		$: function (definition) {
+			const items = Array.isArray(definition.items)
+				? definition.items
+				: [{label: ''}];
+
+			const value = items[0].value
+				? items[0].value
+				: items[0].label
+				? items[0].label
+				: '';
+
+			CKEDITOR.tools.extend(this, definition, {
+				icon: definition.icon,
+				items,
+				modes: {wysiwyg: 1},
+				name: definition.name,
+				title: definition.title,
+				value,
+			});
+		},
+
+		base: CKEDITOR.event,
+
+		proto: {
+			render(editor, output) {
+				const id = CKEDITOR.tools.getNextId();
+
+				this._id = id;
+
+				const select = this;
+
+				this._editor = editor;
+
+				const instance = {
+					execute(value) {
+						this.select.value = value;
+					},
+					id,
+					select,
+				};
+
+				const changeFn = CKEDITOR.tools.addFunction(function (
+					event,
+					element
+				) {
+					event.preventDefault();
+
+					const option = element.options[element.selectedIndex];
+
+					const value = option.value;
+
+					instance.execute(value);
+
+					select.fire(
+						'change',
+						{
+							value,
+						},
+						this._editor
+					);
+
+					if (select.onChange) {
+						select.onChange(value);
+					}
+				});
+
+				instance.changeFn = changeFn;
+
+				const params = {
+					changeFn,
+					icon: this.icon,
+					id,
+					items: this.items,
+					name: this.name,
+					title: this.title,
+				};
+
+				template.output(params, output);
+
+				if (this.onRender) {
+					this.onRender(instance);
+				}
+
+				return instance;
+			},
+		},
+	});
+
+	CKEDITOR.ui.balloonToolbarSelect.handler = {
+		create(definition) {
+			return new CKEDITOR.ui.balloonToolbarSelect(definition);
+		},
+	};
+
+	CKEDITOR.UI_BALLOON_TOOLBAR_SELECT = 'balloonToolbarSelect';
+
+	CKEDITOR.tools.extend(CKEDITOR.ui.prototype, {
+		addBalloonToolbarSelect(name, definition) {
+			this.add(name, CKEDITOR.UI_BALLOON_TOOLBAR_SELECT, definition);
+		},
+	});
+
+	CKEDITOR.plugins.add(pluginName, {
+		init(editor) {
+			editor.ui.addHandler(
+				CKEDITOR.UI_BALLOON_TOOLBAR_SELECT,
+				CKEDITOR.ui.balloonToolbarSelect.handler
+			);
+		},
+	});
+})();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/uitextinput/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/uitextinput/plugin.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+(function () {
+	const pluginName = 'uitextinput';
+
+	if (CKEDITOR.plugins.get(pluginName)) {
+		return;
+	}
+
+	const templateHTML =
+		'<input' +
+		' class="ui-textinput"' +
+		' id="{id}"' +
+		' onchange="CKEDITOR.tools.callFunction({changeFn},this);return false;"' +
+		' onkeyup="CKEDITOR.tools.callFunction({keyupFn},event,this);"' +
+		' placeholder="{placeholder}"' +
+		' type="text"' +
+		' value="{value}"' +
+		'>';
+
+	const template = CKEDITOR.addTemplate(
+		'balloonToolbarTextInput',
+		templateHTML
+	);
+
+	CKEDITOR.ui.balloonToolbarTextInput = CKEDITOR.tools.createClass({
+		// eslint-disable-next-line
+		$: function (definition) {
+			CKEDITOR.tools.extend(this, definition, {
+				modes: {wysiwyg: 1},
+				name: definition.name,
+				placeholder: definition.placeholder,
+				value: definition.value,
+			});
+		},
+
+		base: CKEDITOR.event,
+
+		proto: {
+			clear() {
+				this.value = '';
+
+				const inputElement = this.getInputElement();
+
+				if (inputElement) {
+					inputElement.setAttribute('value', this.value);
+				}
+			},
+
+			getInputElement() {
+				return this._editor.document.getById(this._id);
+			},
+
+			render(editor, output) {
+				const id = CKEDITOR.tools.getNextId();
+
+				this._id = id;
+
+				const input = this;
+
+				this._editor = editor;
+
+				const instance = {
+					input,
+				};
+
+				const changeFn = CKEDITOR.tools.addFunction((element) => {
+					input.value = element.value;
+				});
+
+				instance.changeFn = changeFn;
+
+				const keyupFn = CKEDITOR.tools.addFunction((event, element) => {
+					if (event.keyCode === 13) {
+						input.value = element.value;
+
+						input.fire(
+							'change',
+							{
+								value: element.value,
+							},
+							input._editor
+						);
+					}
+					if (event.keyCode === 27) {
+						input.fire('cancel');
+					}
+				});
+
+				const params = {
+					changeFn,
+					id,
+					keyupFn,
+					name: this.name,
+					placeholder: this.placeholder || '',
+					value: this.value || '',
+				};
+
+				template.output(params, output);
+
+				return instance;
+			},
+
+			setValue(value) {
+				if (value) {
+					this.value = value;
+
+					const inputElement = this.getInputElement();
+
+					if (inputElement) {
+						inputElement.setAttribute('value', value);
+					}
+				}
+			},
+		},
+	});
+
+	CKEDITOR.plugins.add(pluginName, {});
+})();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,3 +1,80 @@
-.lfr-balloon-editor .cke_inner .cke_top {
-	display: none;
+.lfr-balloon-editor {
+	&.cke_balloon.cke_balloontoolbar {
+		z-index: 899;
+	}
+
+	.cke_inner .cke_top {
+		display: none;
+	}
+
+	.ui-numberinput {
+		align-items: center;
+		display: flex;
+		flex-direction: row;
+		float: left;
+		padding: 4px;
+
+		input {
+			background: #f1f2f5;
+			border: 1px solid #e7e7ed;
+			border-radius: 4px;
+			max-width: 32px;
+			padding: 6px 12px;
+		}
+
+		label {
+			padding: 4px;
+		}
+	}
+
+	.ui-select {
+		border: none;
+		color: grey;
+		float: left;
+		line-height: 30px;
+		margin: 2px;
+		min-height: 30px;
+		outline: none;
+		padding: 6px;
+		width: auto;
+
+		option {
+			border: none;
+			color: grey;
+			float: left;
+			line-height: 30px;
+			outline: none;
+			padding: 6px;
+			width: auto;
+		}
+	}
+
+	.ui-select-wrapper {
+		position: relative;
+		top: -9px;
+	}
+
+	.ui-textinput {
+		background: white;
+		border-radius: 4px;
+		float: left;
+		height: 16px;
+		margin: 2px;
+		outline: none;
+		padding: 6px;
+	}
+}
+
+.lfr-ballon-editor-insert-button {
+	align-items: center;
+	background: white;
+	border: 0.75px solid #0b5fff;
+	border-radius: 3px;
+	color: #0b5fff;
+	display: flex;
+	flex-direction: row;
+	font-size: 1.1em;
+	font-weight: bolder;
+	height: 28px;
+	width: 28px;
 }


### PR DESCRIPTION
This pull request provides the Balloon Editor React component,
as well as the required CKEditor plugins.

Here's the list of tasks that have been worked on:

- [x] [LPS-127012](https://issues.liferay.com/browse/LPS-127012) Create balloon editor react component
- [x] [LPS-130608](https://issues.liferay.com/browse/LPS-130608) Create Plus Button plugin
- [x] [LPS-130610](https://issues.liferay.com/browse/LPS-130610) Create Add Toolbars
- [x] [LPS-130612](https://issues.liferay.com/browse/LPS-130612) Create Link Toolbar
- [x] [LPS-130613](https://issues.liferay.com/browse/LPS-130613) Create Image Toolbar
- [x] [LPS-130835](https://issues.liferay.com/browse/LPS-130835) Patch the balloontoolbar and balloonpanel plugins
- [x] [LPS-132043](https://issues.liferay.com/browse/LPS-132043) Create button plugin
- [x] [LPS-132044](https://issues.liferay.com/browse/LPS-132044) Create a text input plugin	
- [x] [LPS-132045](https://issues.liferay.com/browse/LPS-132045) Create a combo/dropdown plugin
- [x] [LPS-132046](https://issues.liferay.com/browse/LPS-132046) Create a number input plugin	
- [x] [LPS-130614](https://issues.liferay.com/browse/LPS-130614) Create Video Toolbar
- [x] [Export missing icons in `liferay-ckeditor`](https://issues.liferay.com/browse/LPS-132051)
- [x] Apply the same toolbar that we use for images when selecting videos
- [x] Make sure all toolbars get "destroyed" when navigating
- [x] [Fix the color button (`BGColor`) plugin](https://issues.liferay.com/browse/LPS-130645)

Instead of using the patch workflow available in [`liferay-ckeditor`](https://github.com/liferay/liferay-ckeditor), a `ballooneditor` plugin has been created to override the default behavior of the `balloonpanel` and `balloontoolbar` plugins: but the end result is the same. Following the advice received [here](https://github.com/liferay/liferay-ckeditor/pull/164) , all plugins have been create directly in DXP (in the `frontend-editor-ckeditor-web` module).

**Screenshots**

Selecting text from top to bottom
![](https://user-images.githubusercontent.com/5572/118636596-24e77e00-b7d5-11eb-86fb-4301e86c16ce.png)

Selecting text from bottom to top
![](https://user-images.githubusercontent.com/5572/118636643-32046d00-b7d5-11eb-8a9f-bfd1986e3ae6.png)

Selecting images
![](https://user-images.githubusercontent.com/5572/118636673-392b7b00-b7d5-11eb-90aa-92d8b8d7bcd3.png)

Adding alternative text to an image
![](https://user-images.githubusercontent.com/5572/118636727-4a748780-b7d5-11eb-9cae-4ecc4e673fe0.png)

Adding a link to an image
![](https://user-images.githubusercontent.com/5572/118636772-57917680-b7d5-11eb-9880-8889c79eda6c.png)

Adding an image from the document library
![](https://user-images.githubusercontent.com/5572/118636856-6e37cd80-b7d5-11eb-9afa-e58a5da62440.png)

The plus button and it's toolbar (which allows adding images, videos, tables, and horizontal rules)
![](https://user-images.githubusercontent.com/5572/118636911-814a9d80-b7d5-11eb-9e43-73d447a82802.png)

Adding a table from the plus button
![](https://user-images.githubusercontent.com/5572/118637190-cf5fa100-b7d5-11eb-9336-1db88458a7bf.png)

Selecting a video 
![](https://user-images.githubusercontent.com/5572/118665388-8ff37d80-b7f2-11eb-8702-27ffdb6661f6.png)


**What's missing**

- [ ] [Create the table toolbar](https://issues.liferay.com/browse/LPS-130616) ([In progress](https://github.com/liferay-frontend/liferay-portal/pull/1070/commits/124b1b5b2af17ffa925c6e0c1b44937f101479d3))
- [ ] [Add a line spacing button to the text toolbar](https://issues.liferay.com/browse/LPS-130638)

**Test plan**
- ~You'll need a local clone of the [`liferay-ckeditor`](https://github.com/liferay/liferay-ckeditor) repository and [these](https://github.com/liferay/liferay-ckeditor/pull/175) changes~ Not anymore, thanks to @markocikos who released a new version of `liferay-ckeditor` .
- Fetch this branch
- Deploy the `frontend-editor-ckeditor-web` module
- Deploy the `frontend-editor-ckeditor-sample-web` module

**Misc**
- Naming is hard: I tried to come up with names that make sense for plugins, but there's always room for improvement

- You'll probably notice that I've added some `eslint` and `prettier` specific comments in some plugins ([here's](https://github.com/julien/liferay-portal/blob/a6c47cf58ffce628cbb966f00f9ad00dc2ec5312/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/uibutton/plugin.js#L39-L55) an example), this will need more investigation, but using the code below (as formatted by prettier) will not work as expected.

    ```js
    CKEDITOR.ui.balloonToolbarButton = CKEDITOR.tools.createClass({
        $(definition) {
             // ...
        }
    });
    // Will throw an error, about a non-existing constructor if you use:
    new CKEDITOR.ui.balloonToolbarButton(...);
    ```
