### PR TITLE
LPS-132334 Using an apostrophe "'" in a page title shows escaped HTML characters in the html's <title> tag

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.ftl
@@ -268,7 +268,7 @@
 </#if>
 
 <#if htmlTitle??>
-	<#assign html_title = htmlUtil.escape(htmlTitle) />
+	<#assign html_title = htmlTitle />
 <#else>
 	<#assign html_title = the_title + " - " + company_name />
 </#if>

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.ftl
@@ -268,8 +268,8 @@
 </#if>
 
 <#if htmlTitle??>
-	<#assign html_title = htmlTitle />
-<#else>
+	<#assign html_title = htmlUtil.escape(htmlTitle) />
+<#else> 
 	<#assign html_title = the_title + " - " + company_name />
 </#if>
 

--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/LayoutSEOLinkManagerImpl.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/LayoutSEOLinkManagerImpl.java
@@ -83,7 +83,7 @@ public class LayoutSEOLinkManagerImpl implements LayoutSEOLinkManager {
 			subtitleListMergeable, locale);
 		String siteAndCompanyName = _getPageTitleSuffix(layout, companyName);
 
-		return _html.escape(_merge(layoutTitle, siteAndCompanyName));
+		return _merge(layoutTitle, siteAndCompanyName);
 	}
 
 	@Override


### PR DESCRIPTION
Hello FEI Team,

**Description of the issue:**

An user reported that page with titles that contains an apostrophe are being shown escaped.

Summary: Using an apostrophe "'" in a page title shows escaped HTML characters like "& #39;" in the html's <title> tag. If we navigate to the page url directly or we refresh the page it shows the wrong characters, however, if we navigate to the page from the Page tree links it shows the right characters.

Image clicking from navigation
![image](https://user-images.githubusercontent.com/48210442/118640397-3468c600-b7d9-11eb-802d-a46757133489.png)
Refreshing page or via url:
![image](https://user-images.githubusercontent.com/48210442/118640446-45193c00-b7d9-11eb-8926-51d947b81821.png)

**Test plan**
```
Create a new page with an apostrophe on the title
Publish the page
Access from navigation menu, check title tag
Refresh page
Check title tag
```
**Solution:**

${html_title} comes from a contributor that already escapes the string, removing htmlUtil.escape made the behavior consistent.

Same contents are shown inside title tag after navigating or refreshing the page.
