### PR TITLE
LPS-132226 Nothing happens when clicking Choose button for Account

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/navigate.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/navigate.es.js
@@ -16,15 +16,21 @@
  * Performs navigation to the given url. If SPA is enabled, it will route the
  * request through the SPA engine. If not, it will simple change the document
  * location.
- * @param {!string} url Destination URL to navigate
+ * @param {string | URL} url Destination URL to navigate
  * @param {?object} listeners Object with key-value pairs with callbacks for
  * specific page lifecycle events
  * @review
  */
 
 export default function (url, listeners) {
-	if (Liferay.SPA && Liferay.SPA.app && Liferay.SPA.app.canNavigate(url)) {
-		Liferay.SPA.app.navigate(url);
+	let urlString = url;
+
+	if (url?.constructor?.name === 'URL') {
+		urlString = String(url);
+	}
+
+	if (Liferay.SPA?.app?.canNavigate(urlString)) {
+		Liferay.SPA.app.navigate(urlString);
 
 		if (listeners) {
 			Object.keys(listeners).forEach((key) => {
@@ -32,8 +38,8 @@ export default function (url, listeners) {
 			});
 		}
 	}
-	else if (isValidURL(url)) {
-		window.location.href = url;
+	else if (isValidURL(urlString)) {
+		window.location.href = urlString;
 	}
 }
 


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-132226

See details and test case in the JIRA ticket.

The root cause of the bug is that `navigate` utility expects `url` param to be a string. In this case, `url` is a `URL` object. We [recently added a validity check for url](https://github.com/brianchandotcom/liferay-portal/pull/101692/commits/1d9f08daf2d9629081c7903fbaf13568891f2d54), and this exposed the issue:
- Before validity check, `Liferay.SPA.app.canNavigate(url)` failed, and the utility defaulted to `window.location.href = url`. This works with a URL object
- After validity check, we are doing `new URL ()` of a `URL` object, and that fails.

In this PR, we are adding a type coercion to string for a URL param. `String()` converts `URL` object, but also anything else that may represent a valid url, like `Liferay.PortletURL`. This solution will work if the object has a `toString` method. Note that we are still checking validity of string as a url after this.

Some alternatives:
- We can be strict in utility and enforce `.toString()` in usages.
- We can allow exclusively string or `URL` object in utility. 

Before:
![before](https://user-images.githubusercontent.com/5435511/118640483-5104fe00-b7d9-11eb-9f7d-898f83e46bb7.gif)

After
![after](https://user-images.githubusercontent.com/5435511/118640470-4e0a0d80-b7d9-11eb-902c-247fcbbee460.gif)

