### PR TITLE
LPS-132367 Fixed the regression of the sourceItems filter

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/share-form/Email.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/share-form/Email.es.js
@@ -114,7 +114,8 @@ const Email = ({
 									sourceItems={
 										resource
 											? formatAutocompleteUsersFromRequest(
-													resource
+													resource,
+													multiSelectValue
 											  )
 											: []
 									}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Multiselect.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Multiselect.js
@@ -38,7 +38,7 @@ export default function Multiselect({
 	sourceItems,
 	...otherProps
 }) {
-	const [inputValue, setInputValue] = useState(_inputValue);
+	const [inputValue, setInputValue] = useState(_inputValue ?? '');
 
 	const [selectedItems, setSelectedItems] = useState(_selectedItems);
 
@@ -67,7 +67,8 @@ export default function Multiselect({
 							onItemsChange={setSelectedItems}
 							sourceItems={itemLabelFilter(
 								sourceItems,
-								inputValue
+								inputValue,
+								multiselectLocator?.label ?? 'label'
 							)}
 							{...otherProps}
 						/>


### PR DESCRIPTION
Ticket: https://issues.liferay.com/browse/LPS-132367

The taglib component for MultiSelect, needs to ensure that the value of the input is not `null` or `undefined`, we add an empty `string` instead. We do this just to avoid making a conditional on `sourceItems`, also `null` is not desired for the input value, React throws a warning on the console.

### Steps to reproduce

1. Add Clay sample portlet
2. Navigate to Form Elements tab
3. Scroll down to MultiSelect
4. Interact with MultiSelect