### PR TITLE
LPS-124112 Add external reference code to KBArticle and KBFolder

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base API
 Bundle-SymbolicName: com.liferay.knowledge.base.api
-Bundle-Version: 8.0.2
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.knowledge.base.configuration,\
 	com.liferay.knowledge.base.constants,\

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBArticleExternalReferenceCodeException.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBArticleExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DuplicateKBArticleExternalReferenceCodeException
+	extends PortalException {
+
+	public DuplicateKBArticleExternalReferenceCodeException() {
+	}
+
+	public DuplicateKBArticleExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateKBArticleExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateKBArticleExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBFolderExternalReferenceCodeException.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBFolderExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DuplicateKBFolderExternalReferenceCodeException
+	extends PortalException {
+
+	public DuplicateKBFolderExternalReferenceCodeException() {
+	}
+
+	public DuplicateKBFolderExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateKBFolderExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateKBFolderExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleModel.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleModel.java
@@ -256,6 +256,21 @@ public interface KBArticleModel
 	public void setRootResourcePrimKey(long rootResourcePrimKey);
 
 	/**
+	 * Returns the external reference code of this kb article.
+	 *
+	 * @return the external reference code of this kb article
+	 */
+	@AutoEscape
+	public String getExternalReferenceCode();
+
+	/**
+	 * Sets the external reference code of this kb article.
+	 *
+	 * @param externalReferenceCode the external reference code of this kb article
+	 */
+	public void setExternalReferenceCode(String externalReferenceCode);
+
+	/**
 	 * Returns the parent resource class name ID of this kb article.
 	 *
 	 * @return the parent resource class name ID of this kb article

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleSoap.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleSoap.java
@@ -44,6 +44,7 @@ public class KBArticleSoap implements Serializable {
 		soapModel.setCreateDate(model.getCreateDate());
 		soapModel.setModifiedDate(model.getModifiedDate());
 		soapModel.setRootResourcePrimKey(model.getRootResourcePrimKey());
+		soapModel.setExternalReferenceCode(model.getExternalReferenceCode());
 		soapModel.setParentResourceClassNameId(
 			model.getParentResourceClassNameId());
 		soapModel.setParentResourcePrimKey(model.getParentResourcePrimKey());
@@ -202,6 +203,14 @@ public class KBArticleSoap implements Serializable {
 
 	public void setRootResourcePrimKey(long rootResourcePrimKey) {
 		_rootResourcePrimKey = rootResourcePrimKey;
+	}
+
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		_externalReferenceCode = externalReferenceCode;
 	}
 
 	public long getParentResourceClassNameId() {
@@ -367,6 +376,7 @@ public class KBArticleSoap implements Serializable {
 	private Date _createDate;
 	private Date _modifiedDate;
 	private long _rootResourcePrimKey;
+	private String _externalReferenceCode;
 	private long _parentResourceClassNameId;
 	private long _parentResourcePrimKey;
 	private long _kbFolderId;

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleTable.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleTable.java
@@ -57,6 +57,10 @@ public class KBArticleTable extends BaseTable<KBArticleTable> {
 		createColumn(
 			"rootResourcePrimKey", Long.class, Types.BIGINT,
 			Column.FLAG_DEFAULT);
+	public final Column<KBArticleTable, String> externalReferenceCode =
+		createColumn(
+			"externalReferenceCode", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<KBArticleTable, Long> parentResourceClassNameId =
 		createColumn(
 			"parentResourceClassNameId", Long.class, Types.BIGINT,

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleWrapper.java
@@ -54,6 +54,7 @@ public class KBArticleWrapper
 		attributes.put("createDate", getCreateDate());
 		attributes.put("modifiedDate", getModifiedDate());
 		attributes.put("rootResourcePrimKey", getRootResourcePrimKey());
+		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put(
 			"parentResourceClassNameId", getParentResourceClassNameId());
 		attributes.put("parentResourcePrimKey", getParentResourcePrimKey());
@@ -143,6 +144,13 @@ public class KBArticleWrapper
 
 		if (rootResourcePrimKey != null) {
 			setRootResourcePrimKey(rootResourcePrimKey);
+		}
+
+		String externalReferenceCode = (String)attributes.get(
+			"externalReferenceCode");
+
+		if (externalReferenceCode != null) {
+			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Long parentResourceClassNameId = (Long)attributes.get(
@@ -336,6 +344,16 @@ public class KBArticleWrapper
 	@Override
 	public String getDescription() {
 		return model.getDescription();
+	}
+
+	/**
+	 * Returns the external reference code of this kb article.
+	 *
+	 * @return the external reference code of this kb article
+	 */
+	@Override
+	public String getExternalReferenceCode() {
+		return model.getExternalReferenceCode();
 	}
 
 	/**
@@ -795,6 +813,16 @@ public class KBArticleWrapper
 	@Override
 	public void setDescription(String description) {
 		model.setDescription(description);
+	}
+
+	/**
+	 * Sets the external reference code of this kb article.
+	 *
+	 * @param externalReferenceCode the external reference code of this kb article
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		model.setExternalReferenceCode(externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBFolderModel.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBFolderModel.java
@@ -93,6 +93,21 @@ public interface KBFolderModel
 	public void setUuid(String uuid);
 
 	/**
+	 * Returns the external reference code of this kb folder.
+	 *
+	 * @return the external reference code of this kb folder
+	 */
+	@AutoEscape
+	public String getExternalReferenceCode();
+
+	/**
+	 * Sets the external reference code of this kb folder.
+	 *
+	 * @param externalReferenceCode the external reference code of this kb folder
+	 */
+	public void setExternalReferenceCode(String externalReferenceCode);
+
+	/**
 	 * Returns the kb folder ID of this kb folder.
 	 *
 	 * @return the kb folder ID of this kb folder

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBFolderSoap.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBFolderSoap.java
@@ -35,6 +35,7 @@ public class KBFolderSoap implements Serializable {
 
 		soapModel.setMvccVersion(model.getMvccVersion());
 		soapModel.setUuid(model.getUuid());
+		soapModel.setExternalReferenceCode(model.getExternalReferenceCode());
 		soapModel.setKbFolderId(model.getKbFolderId());
 		soapModel.setGroupId(model.getGroupId());
 		soapModel.setCompanyId(model.getCompanyId());
@@ -114,6 +115,14 @@ public class KBFolderSoap implements Serializable {
 
 	public void setUuid(String uuid) {
 		_uuid = uuid;
+	}
+
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		_externalReferenceCode = externalReferenceCode;
 	}
 
 	public long getKbFolderId() {
@@ -214,6 +223,7 @@ public class KBFolderSoap implements Serializable {
 
 	private long _mvccVersion;
 	private String _uuid;
+	private String _externalReferenceCode;
 	private long _kbFolderId;
 	private long _groupId;
 	private long _companyId;

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBFolderTable.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBFolderTable.java
@@ -36,6 +36,10 @@ public class KBFolderTable extends BaseTable<KBFolderTable> {
 		"mvccVersion", Long.class, Types.BIGINT, Column.FLAG_NULLITY);
 	public final Column<KBFolderTable, String> uuid = createColumn(
 		"uuid_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<KBFolderTable, String> externalReferenceCode =
+		createColumn(
+			"externalReferenceCode", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<KBFolderTable, Long> kbFolderId = createColumn(
 		"kbFolderId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<KBFolderTable, Long> groupId = createColumn(

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBFolderWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBFolderWrapper.java
@@ -45,6 +45,7 @@ public class KBFolderWrapper
 
 		attributes.put("mvccVersion", getMvccVersion());
 		attributes.put("uuid", getUuid());
+		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put("kbFolderId", getKbFolderId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
@@ -73,6 +74,13 @@ public class KBFolderWrapper
 
 		if (uuid != null) {
 			setUuid(uuid);
+		}
+
+		String externalReferenceCode = (String)attributes.get(
+			"externalReferenceCode");
+
+		if (externalReferenceCode != null) {
+			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Long kbFolderId = (Long)attributes.get("kbFolderId");
@@ -188,6 +196,16 @@ public class KBFolderWrapper
 	@Override
 	public String getDescription() {
 		return model.getDescription();
+	}
+
+	/**
+	 * Returns the external reference code of this kb folder.
+	 *
+	 * @return the external reference code of this kb folder
+	 */
+	@Override
+	public String getExternalReferenceCode() {
+		return model.getExternalReferenceCode();
 	}
 
 	/**
@@ -379,6 +397,16 @@ public class KBFolderWrapper
 	@Override
 	public void setDescription(String description) {
 		model.setDescription(description);
+	}
+
+	/**
+	 * Sets the external reference code of this kb folder.
+	 *
+	 * @param externalReferenceCode the external reference code of this kb folder
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		model.setExternalReferenceCode(externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
@@ -91,11 +91,25 @@ public interface KBArticleLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public KBArticle addKBArticle(KBArticle kbArticle);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBArticle(String, long, long, long, String, String, String, String,
+	 String, String[], String[], ServiceContext)}
+	 */
+	@Deprecated
 	public KBArticle addKBArticle(
 			long userId, long parentResourceClassNameId,
 			long parentResourcePrimKey, String title, String urlTitle,
 			String content, String description, String sourceURL,
 			String[] sections, String[] selectedFileNames,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public KBArticle addKBArticle(
+			String externalReferenceCode, long userId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String title, String urlTitle, String content, String description,
+			String sourceURL, String[] sections, String[] selectedFileNames,
 			ServiceContext serviceContext)
 		throws PortalException;
 
@@ -295,6 +309,19 @@ public interface KBArticleLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle fetchLatestKBArticle(long resourcePrimKey, long groupId);
 
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article, or <code>null</code> if no
+	 matching kb article could be found
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBArticle fetchLatestKBArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode);
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle fetchLatestKBArticleByUrlTitle(
 		long groupId, long kbFolderId, String urlTitle, int status);
@@ -450,6 +477,20 @@ public interface KBArticleLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle getLatestKBArticle(long resourcePrimKey, int status)
+		throws PortalException;
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBArticle getLatestKBArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
@@ -70,6 +70,12 @@ public class KBArticleLocalServiceUtil {
 		return getService().addKBArticle(kbArticle);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBArticle(String, long, long, long, String, String, String, String,
+	 String, String[], String[], ServiceContext)}
+	 */
+	@Deprecated
 	public static KBArticle addKBArticle(
 			long userId, long parentResourceClassNameId,
 			long parentResourcePrimKey, String title, String urlTitle,
@@ -82,6 +88,20 @@ public class KBArticleLocalServiceUtil {
 			userId, parentResourceClassNameId, parentResourcePrimKey, title,
 			urlTitle, content, description, sourceURL, sections,
 			selectedFileNames, serviceContext);
+	}
+
+	public static KBArticle addKBArticle(
+			String externalReferenceCode, long userId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String title, String urlTitle, String content, String description,
+			String sourceURL, String[] sections, String[] selectedFileNames,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addKBArticle(
+			externalReferenceCode, userId, parentResourceClassNameId,
+			parentResourcePrimKey, title, urlTitle, content, description,
+			sourceURL, sections, selectedFileNames, serviceContext);
 	}
 
 	public static void addKBArticleResources(
@@ -359,6 +379,22 @@ public class KBArticleLocalServiceUtil {
 		return getService().fetchLatestKBArticle(resourcePrimKey, groupId);
 	}
 
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article, or <code>null</code> if no
+	 matching kb article could be found
+	 */
+	public static KBArticle fetchLatestKBArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return getService().fetchLatestKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
 	public static KBArticle fetchLatestKBArticleByUrlTitle(
 		long groupId, long kbFolderId, String urlTitle, int status) {
 
@@ -587,6 +623,23 @@ public class KBArticleLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getLatestKBArticle(resourcePrimKey, status);
+	}
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static KBArticle getLatestKBArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getLatestKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	public static KBArticle getLatestKBArticleByUrlTitle(

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
@@ -59,6 +59,12 @@ public class KBArticleLocalServiceWrapper
 		return _kbArticleLocalService.addKBArticle(kbArticle);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBArticle(String, long, long, long, String, String, String, String,
+	 String, String[], String[], ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.knowledge.base.model.KBArticle addKBArticle(
 			long userId, long parentResourceClassNameId,
@@ -72,6 +78,21 @@ public class KBArticleLocalServiceWrapper
 			userId, parentResourceClassNameId, parentResourcePrimKey, title,
 			urlTitle, content, description, sourceURL, sections,
 			selectedFileNames, serviceContext);
+	}
+
+	@Override
+	public com.liferay.knowledge.base.model.KBArticle addKBArticle(
+			String externalReferenceCode, long userId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String title, String urlTitle, String content, String description,
+			String sourceURL, String[] sections, String[] selectedFileNames,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbArticleLocalService.addKBArticle(
+			externalReferenceCode, userId, parentResourceClassNameId,
+			parentResourcePrimKey, title, urlTitle, content, description,
+			sourceURL, sections, selectedFileNames, serviceContext);
 	}
 
 	@Override
@@ -396,6 +417,25 @@ public class KBArticleLocalServiceWrapper
 			resourcePrimKey, groupId);
 	}
 
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article, or <code>null</code> if no
+	 matching kb article could be found
+	 */
+	@Override
+	public com.liferay.knowledge.base.model.KBArticle
+		fetchLatestKBArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode) {
+
+		return _kbArticleLocalService.
+			fetchLatestKBArticleByExternalReferenceCode(
+				groupId, externalReferenceCode);
+	}
+
 	@Override
 	public com.liferay.knowledge.base.model.KBArticle
 		fetchLatestKBArticleByUrlTitle(
@@ -686,6 +726,25 @@ public class KBArticleLocalServiceWrapper
 
 		return _kbArticleLocalService.getLatestKBArticle(
 			resourcePrimKey, status);
+	}
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public com.liferay.knowledge.base.model.KBArticle
+			getLatestKBArticleByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbArticleLocalService.getLatestKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
@@ -59,11 +59,26 @@ public interface KBArticleService extends BaseService {
 	 *
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.knowledge.base.service.impl.KBArticleServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the kb article remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link KBArticleServiceUtil} if injection and service tracking are not available.
 	 */
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBArticle(String, String, long, long, String, String, String, String,
+	 String, String[], String[], ServiceContext)}
+	 */
+	@Deprecated
 	public KBArticle addKBArticle(
 			String portletId, long parentResourceClassNameId,
 			long parentResourcePrimKey, String title, String urlTitle,
 			String content, String description, String sourceURL,
 			String[] sections, String[] selectedFileNames,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public KBArticle addKBArticle(
+			String externalReferenceCode, String portletId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String title, String urlTitle, String content, String description,
+			String sourceURL, String[] sections, String[] selectedFileNames,
 			ServiceContext serviceContext)
 		throws PortalException;
 
@@ -104,6 +119,21 @@ public interface KBArticleService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle fetchLatestKBArticle(long resourcePrimKey, int status)
+		throws PortalException;
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article, or <code>null</code> if no
+	 matching kb article could be found
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBArticle fetchLatestKBArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -189,6 +219,20 @@ public interface KBArticleService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle getLatestKBArticle(long resourcePrimKey, int status)
+		throws PortalException;
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBArticle getLatestKBArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
@@ -42,6 +42,13 @@ public class KBArticleServiceUtil {
 	 *
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.knowledge.base.service.impl.KBArticleServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBArticle(String, String, long, long, String, String, String, String,
+	 String, String[], String[], ServiceContext)}
+	 */
+	@Deprecated
 	public static KBArticle addKBArticle(
 			String portletId, long parentResourceClassNameId,
 			long parentResourcePrimKey, String title, String urlTitle,
@@ -54,6 +61,20 @@ public class KBArticleServiceUtil {
 			portletId, parentResourceClassNameId, parentResourcePrimKey, title,
 			urlTitle, content, description, sourceURL, sections,
 			selectedFileNames, serviceContext);
+	}
+
+	public static KBArticle addKBArticle(
+			String externalReferenceCode, String portletId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String title, String urlTitle, String content, String description,
+			String sourceURL, String[] sections, String[] selectedFileNames,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addKBArticle(
+			externalReferenceCode, portletId, parentResourceClassNameId,
+			parentResourcePrimKey, title, urlTitle, content, description,
+			sourceURL, sections, selectedFileNames, serviceContext);
 	}
 
 	public static int addKBArticlesMarkdown(
@@ -125,6 +146,24 @@ public class KBArticleServiceUtil {
 		throws PortalException {
 
 		return getService().fetchLatestKBArticle(resourcePrimKey, status);
+	}
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article, or <code>null</code> if no
+	 matching kb article could be found
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static KBArticle fetchLatestKBArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().fetchLatestKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	public static KBArticle fetchLatestKBArticleByUrlTitle(
@@ -262,6 +301,23 @@ public class KBArticleServiceUtil {
 		throws PortalException {
 
 		return getService().getLatestKBArticle(resourcePrimKey, status);
+	}
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static KBArticle getLatestKBArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getLatestKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
@@ -30,6 +30,12 @@ public class KBArticleServiceWrapper
 		_kbArticleService = kbArticleService;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBArticle(String, String, long, long, String, String, String, String,
+	 String, String[], String[], ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.knowledge.base.model.KBArticle addKBArticle(
 			String portletId, long parentResourceClassNameId,
@@ -43,6 +49,21 @@ public class KBArticleServiceWrapper
 			portletId, parentResourceClassNameId, parentResourcePrimKey, title,
 			urlTitle, content, description, sourceURL, sections,
 			selectedFileNames, serviceContext);
+	}
+
+	@Override
+	public com.liferay.knowledge.base.model.KBArticle addKBArticle(
+			String externalReferenceCode, String portletId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String title, String urlTitle, String content, String description,
+			String sourceURL, String[] sections, String[] selectedFileNames,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbArticleService.addKBArticle(
+			externalReferenceCode, portletId, parentResourceClassNameId,
+			parentResourcePrimKey, title, urlTitle, content, description,
+			sourceURL, sections, selectedFileNames, serviceContext);
 	}
 
 	@Override
@@ -126,6 +147,26 @@ public class KBArticleServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kbArticleService.fetchLatestKBArticle(resourcePrimKey, status);
+	}
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article, or <code>null</code> if no
+	 matching kb article could be found
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public com.liferay.knowledge.base.model.KBArticle
+			fetchLatestKBArticleByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbArticleService.fetchLatestKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	@Override
@@ -308,6 +349,25 @@ public class KBArticleServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kbArticleService.getLatestKBArticle(resourcePrimKey, status);
+	}
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public com.liferay.knowledge.base.model.KBArticle
+			getLatestKBArticleByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbArticleService.getLatestKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalService.java
@@ -78,10 +78,21 @@ public interface KBFolderLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public KBFolder addKBFolder(KBFolder kbFolder);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBFolder(String, long, long, long, long, String, String, ServiceContext)}
+	 */
+	@Deprecated
 	public KBFolder addKBFolder(
 			long userId, long groupId, long parentResourceClassNameId,
 			long parentResourcePrimKey, String name, String description,
 			ServiceContext serviceContext)
+		throws PortalException;
+
+	public KBFolder addKBFolder(
+			String externalReferenceCode, long userId, long groupId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String name, String description, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -220,6 +231,25 @@ public interface KBFolderLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBFolder fetchKBFolder(String uuid, long groupId);
 
+	/**
+	 * Returns the kb folder with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb folder's external reference code
+	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBFolder fetchKBFolderByExternalReferenceCode(
+		long groupId, String externalReferenceCode);
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchKBFolderByExternalReferenceCode(long, String)}
+	 */
+	@Deprecated
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBFolder fetchKBFolderByReferenceCode(
+		long groupId, String externalReferenceCode);
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBFolder fetchKBFolderByUrlTitle(
 			long groupId, long parentKbFolderId, String urlTitle)
@@ -254,6 +284,19 @@ public interface KBFolderLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBFolder getKBFolder(long kbFolderId) throws PortalException;
+
+	/**
+	 * Returns the kb folder with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb folder's external reference code
+	 * @return the matching kb folder
+	 * @throws PortalException if a matching kb folder could not be found
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBFolder getKBFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBFolder getKBFolderByUrlTitle(

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalServiceUtil.java
@@ -59,6 +59,11 @@ public class KBFolderLocalServiceUtil {
 		return getService().addKBFolder(kbFolder);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBFolder(String, long, long, long, long, String, String, ServiceContext)}
+	 */
+	@Deprecated
 	public static KBFolder addKBFolder(
 			long userId, long groupId, long parentResourceClassNameId,
 			long parentResourcePrimKey, String name, String description,
@@ -68,6 +73,18 @@ public class KBFolderLocalServiceUtil {
 		return getService().addKBFolder(
 			userId, groupId, parentResourceClassNameId, parentResourcePrimKey,
 			name, description, serviceContext);
+	}
+
+	public static KBFolder addKBFolder(
+			String externalReferenceCode, long userId, long groupId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String name, String description,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addKBFolder(
+			externalReferenceCode, userId, groupId, parentResourceClassNameId,
+			parentResourcePrimKey, name, description, serviceContext);
 	}
 
 	/**
@@ -240,6 +257,31 @@ public class KBFolderLocalServiceUtil {
 		return getService().fetchKBFolder(uuid, groupId);
 	}
 
+	/**
+	 * Returns the kb folder with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb folder's external reference code
+	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
+	 */
+	public static KBFolder fetchKBFolderByExternalReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return getService().fetchKBFolderByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchKBFolderByExternalReferenceCode(long, String)}
+	 */
+	@Deprecated
+	public static KBFolder fetchKBFolderByReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return getService().fetchKBFolderByReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
 	public static KBFolder fetchKBFolderByUrlTitle(
 			long groupId, long parentKbFolderId, String urlTitle)
 		throws PortalException {
@@ -291,6 +333,22 @@ public class KBFolderLocalServiceUtil {
 	 */
 	public static KBFolder getKBFolder(long kbFolderId) throws PortalException {
 		return getService().getKBFolder(kbFolderId);
+	}
+
+	/**
+	 * Returns the kb folder with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb folder's external reference code
+	 * @return the matching kb folder
+	 * @throws PortalException if a matching kb folder could not be found
+	 */
+	public static KBFolder getKBFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getKBFolderByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	public static KBFolder getKBFolderByUrlTitle(

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalServiceWrapper.java
@@ -49,6 +49,11 @@ public class KBFolderLocalServiceWrapper
 		return _kbFolderLocalService.addKBFolder(kbFolder);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBFolder(String, long, long, long, long, String, String, ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.knowledge.base.model.KBFolder addKBFolder(
 			long userId, long groupId, long parentResourceClassNameId,
@@ -59,6 +64,19 @@ public class KBFolderLocalServiceWrapper
 		return _kbFolderLocalService.addKBFolder(
 			userId, groupId, parentResourceClassNameId, parentResourcePrimKey,
 			name, description, serviceContext);
+	}
+
+	@Override
+	public com.liferay.knowledge.base.model.KBFolder addKBFolder(
+			String externalReferenceCode, long userId, long groupId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String name, String description,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbFolderLocalService.addKBFolder(
+			externalReferenceCode, userId, groupId, parentResourceClassNameId,
+			parentResourcePrimKey, name, description, serviceContext);
 	}
 
 	/**
@@ -268,6 +286,35 @@ public class KBFolderLocalServiceWrapper
 		return _kbFolderLocalService.fetchKBFolder(uuid, groupId);
 	}
 
+	/**
+	 * Returns the kb folder with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb folder's external reference code
+	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
+	 */
+	@Override
+	public com.liferay.knowledge.base.model.KBFolder
+		fetchKBFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode) {
+
+		return _kbFolderLocalService.fetchKBFolderByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchKBFolderByExternalReferenceCode(long, String)}
+	 */
+	@Deprecated
+	@Override
+	public com.liferay.knowledge.base.model.KBFolder
+		fetchKBFolderByReferenceCode(
+			long groupId, String externalReferenceCode) {
+
+		return _kbFolderLocalService.fetchKBFolderByReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
 	@Override
 	public com.liferay.knowledge.base.model.KBFolder fetchKBFolderByUrlTitle(
 			long groupId, long parentKbFolderId, String urlTitle)
@@ -329,6 +376,24 @@ public class KBFolderLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kbFolderLocalService.getKBFolder(kbFolderId);
+	}
+
+	/**
+	 * Returns the kb folder with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb folder's external reference code
+	 * @return the matching kb folder
+	 * @throws PortalException if a matching kb folder could not be found
+	 */
+	@Override
+	public com.liferay.knowledge.base.model.KBFolder
+			getKBFolderByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbFolderLocalService.getKBFolderByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderService.java
@@ -53,10 +53,22 @@ public interface KBFolderService extends BaseService {
 	 *
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.knowledge.base.service.impl.KBFolderServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the kb folder remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link KBFolderServiceUtil} if injection and service tracking are not available.
 	 */
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBFolder(String, long, long, long, String, String, ServiceContext)}
+	 */
+	@Deprecated
 	public KBFolder addKBFolder(
 			long groupId, long parentResourceClassNameId,
 			long parentResourcePrimKey, String name, String description,
 			ServiceContext serviceContext)
+		throws PortalException;
+
+	public KBFolder addKBFolder(
+			String externalReferenceCode, long groupId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String name, String description, ServiceContext serviceContext)
 		throws PortalException;
 
 	public KBFolder deleteKBFolder(long kbFolderId) throws PortalException;

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceUtil.java
@@ -39,6 +39,12 @@ public class KBFolderServiceUtil {
 	 *
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.knowledge.base.service.impl.KBFolderServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBFolder(String, long, long, long, String, String, ServiceContext)}
+	 */
+	@Deprecated
 	public static KBFolder addKBFolder(
 			long groupId, long parentResourceClassNameId,
 			long parentResourcePrimKey, String name, String description,
@@ -48,6 +54,18 @@ public class KBFolderServiceUtil {
 		return getService().addKBFolder(
 			groupId, parentResourceClassNameId, parentResourcePrimKey, name,
 			description, serviceContext);
+	}
+
+	public static KBFolder addKBFolder(
+			String externalReferenceCode, long groupId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String name, String description,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addKBFolder(
+			externalReferenceCode, groupId, parentResourceClassNameId,
+			parentResourcePrimKey, name, description, serviceContext);
 	}
 
 	public static KBFolder deleteKBFolder(long kbFolderId)

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceWrapper.java
@@ -30,6 +30,11 @@ public class KBFolderServiceWrapper
 		_kbFolderService = kbFolderService;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBFolder(String, long, long, long, String, String, ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.knowledge.base.model.KBFolder addKBFolder(
 			long groupId, long parentResourceClassNameId,
@@ -40,6 +45,19 @@ public class KBFolderServiceWrapper
 		return _kbFolderService.addKBFolder(
 			groupId, parentResourceClassNameId, parentResourcePrimKey, name,
 			description, serviceContext);
+	}
+
+	@Override
+	public com.liferay.knowledge.base.model.KBFolder addKBFolder(
+			String externalReferenceCode, long groupId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String name, String description,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbFolderService.addKBFolder(
+			externalReferenceCode, groupId, parentResourceClassNameId,
+			parentResourcePrimKey, name, description, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticlePersistence.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticlePersistence.java
@@ -1509,6 +1509,231 @@ public interface KBArticlePersistence extends BasePersistence<KBArticle> {
 	public int countByR_S(long[] resourcePrimKeys, int status);
 
 	/**
+	 * Returns all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb articles
+	 */
+	public java.util.List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns a range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles
+	 */
+	public java.util.List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles
+	 */
+	public java.util.List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching kb articles
+	 */
+	public java.util.List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	public KBArticle findByG_E_First(
+			long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public KBArticle fetchByG_E_First(
+		long groupId, String externalReferenceCode,
+		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+			orderByComparator);
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	public KBArticle findByG_E_Last(
+			long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public KBArticle fetchByG_E_Last(
+		long groupId, String externalReferenceCode,
+		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+			orderByComparator);
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	public KBArticle[] findByG_E_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb articles that the user has permission to view
+	 */
+	public java.util.List<KBArticle> filterFindByG_E(
+		long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns a range of all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles that the user has permission to view
+	 */
+	public java.util.List<KBArticle> filterFindByG_E(
+		long groupId, String externalReferenceCode, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the kb articles that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles that the user has permission to view
+	 */
+	public java.util.List<KBArticle> filterFindByG_E(
+		long groupId, String externalReferenceCode, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+			orderByComparator);
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	public KBArticle[] filterFindByG_E_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Removes all the kb articles where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 */
+	public void removeByG_E(long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns the number of kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching kb articles
+	 */
+	public int countByG_E(long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns the number of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching kb articles that the user has permission to view
+	 */
+	public int filterCountByG_E(long groupId, String externalReferenceCode);
+
+	/**
 	 * Returns all the kb articles where groupId = &#63; and latest = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -4568,6 +4793,66 @@ public interface KBArticlePersistence extends BasePersistence<KBArticle> {
 	 */
 	public int filterCountByR_G_S(
 		long[] resourcePrimKeys, long groupId, int status);
+
+	/**
+	 * Returns the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or throws a <code>NoSuchArticleException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	public KBArticle findByG_E_V(
+			long groupId, String externalReferenceCode, int version)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public KBArticle fetchByG_E_V(
+		long groupId, String externalReferenceCode, int version);
+
+	/**
+	 * Returns the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public KBArticle fetchByG_E_V(
+		long groupId, String externalReferenceCode, int version,
+		boolean useFinderCache);
+
+	/**
+	 * Removes the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the kb article that was removed
+	 */
+	public KBArticle removeByG_E_V(
+			long groupId, String externalReferenceCode, int version)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns the number of kb articles where groupId = &#63; and externalReferenceCode = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the number of matching kb articles
+	 */
+	public int countByG_E_V(
+		long groupId, String externalReferenceCode, int version);
 
 	/**
 	 * Returns all the kb articles where groupId = &#63; and parentResourcePrimKey = &#63; and latest = &#63;.

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticleUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticleUtil.java
@@ -1882,6 +1882,282 @@ public class KBArticleUtil {
 	}
 
 	/**
+	 * Returns all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb articles
+	 */
+	public static List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().findByG_E(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns a range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles
+	 */
+	public static List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return getPersistence().findByG_E(
+			groupId, externalReferenceCode, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles
+	 */
+	public static List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		return getPersistence().findByG_E(
+			groupId, externalReferenceCode, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching kb articles
+	 */
+	public static List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<KBArticle> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_E(
+			groupId, externalReferenceCode, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	public static KBArticle findByG_E_First(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
+
+		return getPersistence().findByG_E_First(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public static KBArticle fetchByG_E_First(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		return getPersistence().fetchByG_E_First(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	public static KBArticle findByG_E_Last(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
+
+		return getPersistence().findByG_E_Last(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public static KBArticle fetchByG_E_Last(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		return getPersistence().fetchByG_E_Last(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	public static KBArticle[] findByG_E_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
+
+		return getPersistence().findByG_E_PrevAndNext(
+			kbArticleId, groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb articles that the user has permission to view
+	 */
+	public static List<KBArticle> filterFindByG_E(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().filterFindByG_E(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns a range of all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles that the user has permission to view
+	 */
+	public static List<KBArticle> filterFindByG_E(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return getPersistence().filterFindByG_E(
+			groupId, externalReferenceCode, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles that the user has permission to view
+	 */
+	public static List<KBArticle> filterFindByG_E(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		return getPersistence().filterFindByG_E(
+			groupId, externalReferenceCode, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	public static KBArticle[] filterFindByG_E_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
+
+		return getPersistence().filterFindByG_E_PrevAndNext(
+			kbArticleId, groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Removes all the kb articles where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 */
+	public static void removeByG_E(long groupId, String externalReferenceCode) {
+		getPersistence().removeByG_E(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the number of kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching kb articles
+	 */
+	public static int countByG_E(long groupId, String externalReferenceCode) {
+		return getPersistence().countByG_E(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the number of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching kb articles that the user has permission to view
+	 */
+	public static int filterCountByG_E(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().filterCountByG_E(
+			groupId, externalReferenceCode);
+	}
+
+	/**
 	 * Returns all the kb articles where groupId = &#63; and latest = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -5584,6 +5860,86 @@ public class KBArticleUtil {
 
 		return getPersistence().filterCountByR_G_S(
 			resourcePrimKeys, groupId, status);
+	}
+
+	/**
+	 * Returns the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or throws a <code>NoSuchArticleException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	public static KBArticle findByG_E_V(
+			long groupId, String externalReferenceCode, int version)
+		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
+
+		return getPersistence().findByG_E_V(
+			groupId, externalReferenceCode, version);
+	}
+
+	/**
+	 * Returns the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public static KBArticle fetchByG_E_V(
+		long groupId, String externalReferenceCode, int version) {
+
+		return getPersistence().fetchByG_E_V(
+			groupId, externalReferenceCode, version);
+	}
+
+	/**
+	 * Returns the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public static KBArticle fetchByG_E_V(
+		long groupId, String externalReferenceCode, int version,
+		boolean useFinderCache) {
+
+		return getPersistence().fetchByG_E_V(
+			groupId, externalReferenceCode, version, useFinderCache);
+	}
+
+	/**
+	 * Removes the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the kb article that was removed
+	 */
+	public static KBArticle removeByG_E_V(
+			long groupId, String externalReferenceCode, int version)
+		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
+
+		return getPersistence().removeByG_E_V(
+			groupId, externalReferenceCode, version);
+	}
+
+	/**
+	 * Returns the number of kb articles where groupId = &#63; and externalReferenceCode = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the number of matching kb articles
+	 */
+	public static int countByG_E_V(
+		long groupId, String externalReferenceCode, int version) {
+
+		return getPersistence().countByG_E_V(
+			groupId, externalReferenceCode, version);
 	}
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBFolderPersistence.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBFolderPersistence.java
@@ -874,6 +874,56 @@ public interface KBFolderPersistence extends BasePersistence<KBFolder> {
 		long groupId, long parentKBFolderId, String urlTitle);
 
 	/**
+	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb folder
+	 * @throws NoSuchFolderException if a matching kb folder could not be found
+	 */
+	public KBFolder findByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchFolderException;
+
+	/**
+	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
+	 */
+	public KBFolder fetchByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
+	 */
+	public KBFolder fetchByG_ERC(
+		long groupId, String externalReferenceCode, boolean useFinderCache);
+
+	/**
+	 * Removes the kb folder where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the kb folder that was removed
+	 */
+	public KBFolder removeByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchFolderException;
+
+	/**
+	 * Returns the number of kb folders where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching kb folders
+	 */
+	public int countByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
 	 * Caches the kb folder in the entity cache if it is enabled.
 	 *
 	 * @param kbFolder the kb folder

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBFolderUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBFolderUtil.java
@@ -1127,6 +1127,74 @@ public class KBFolderUtil {
 	}
 
 	/**
+	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb folder
+	 * @throws NoSuchFolderException if a matching kb folder could not be found
+	 */
+	public static KBFolder findByG_ERC(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.knowledge.base.exception.NoSuchFolderException {
+
+		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
+	 */
+	public static KBFolder fetchByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().fetchByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
+	 */
+	public static KBFolder fetchByG_ERC(
+		long groupId, String externalReferenceCode, boolean useFinderCache) {
+
+		return getPersistence().fetchByG_ERC(
+			groupId, externalReferenceCode, useFinderCache);
+	}
+
+	/**
+	 * Removes the kb folder where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the kb folder that was removed
+	 */
+	public static KBFolder removeByG_ERC(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.knowledge.base.exception.NoSuchFolderException {
+
+		return getPersistence().removeByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the number of kb folders where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching kb folders
+	 */
+	public static int countByG_ERC(long groupId, String externalReferenceCode) {
+		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
 	 * Caches the kb folder in the entity cache if it is enabled.
 	 *
 	 * @param kbFolder the kb folder

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/exception/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.1
+version 1.4.0

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/model/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/persistence/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/knowledge-base/knowledge-base-service/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base Service
 Bundle-SymbolicName: com.liferay.knowledge.base.service
 Bundle-Version: 5.0.5
-Liferay-Require-SchemaVersion: 4.0.0
+Liferay-Require-SchemaVersion: 4.1.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/knowledge-base/knowledge-base-service/service.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/service.xml
@@ -369,6 +369,8 @@
 		<reference entity="SocialActivity" package-path="com.liferay.portlet.social" />
 	</entity>
 	<exceptions>
+		<exception>DuplicateKBArticleExternalReferenceCode</exception>
+		<exception>DuplicateKBFolderExternalReferenceCode</exception>
 		<exception>DuplicateKBFolderName</exception>
 		<exception>InvalidKBFolderName</exception>
 		<exception>KBArticleContent</exception>

--- a/modules/apps/knowledge-base/knowledge-base-service/service.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/service.xml
@@ -28,6 +28,7 @@
 		<!-- Other fields -->
 
 		<column filter-primary="true" name="rootResourcePrimKey" type="long" />
+		<column name="externalReferenceCode" type="String" />
 		<column name="parentResourceClassNameId" type="long" />
 		<column name="parentResourcePrimKey" type="long" />
 		<column name="kbFolderId" type="long" />
@@ -74,6 +75,10 @@
 		<finder name="R_S" return-type="Collection">
 			<finder-column arrayable-operator="OR" name="resourcePrimKey" />
 			<finder-column name="status" />
+		</finder>
+		<finder name="G_E" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="externalReferenceCode" />
 		</finder>
 		<finder name="G_L" return-type="Collection">
 			<finder-column name="groupId" />
@@ -130,6 +135,11 @@
 			<finder-column arrayable-operator="OR" name="resourcePrimKey" />
 			<finder-column name="groupId" />
 			<finder-column name="status" />
+		</finder>
+		<finder name="G_E_V" return-type="KBArticle">
+			<finder-column name="groupId" />
+			<finder-column name="externalReferenceCode" />
+			<finder-column name="version" />
 		</finder>
 		<finder name="G_P_L" return-type="Collection">
 			<finder-column name="groupId" />
@@ -267,7 +277,7 @@
 		<reference entity="RatingsEntry" package-path="com.liferay.portlet.ratings" />
 		<reference entity="SocialActivity" package-path="com.liferay.portlet.social" />
 	</entity>
-	<entity local-service="true" name="KBFolder" remote-service="true" uuid="true">
+	<entity external-reference-code="group" local-service="true" name="KBFolder" remote-service="true" uuid="true">
 
 		<!-- PK fields -->
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -395,7 +395,8 @@ public class KBArticleStagedModelDataHandler
 		throws Exception {
 
 		KBArticle importedKBArticle = _kbArticleLocalService.addKBArticle(
-			userId, parentResourceClassNameId, parentResourcePrimKey,
+			kbArticle.getExternalReferenceCode(), userId,
+			parentResourceClassNameId, parentResourcePrimKey,
 			kbArticle.getTitle(), kbArticle.getUrlTitle(),
 			kbArticle.getContent(), kbArticle.getDescription(),
 			kbArticle.getSourceURL(), sections, null, serviceContext);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBFolderStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBFolderStagedModelDataHandler.java
@@ -122,7 +122,8 @@ public class KBFolderStagedModelDataHandler
 				serviceContext.setUuid(kbFolder.getUuid());
 
 				importedKBFolder = _kbFolderLocalService.addKBFolder(
-					userId, portletDataContext.getScopeGroupId(),
+					kbFolder.getExternalReferenceCode(), userId,
+					portletDataContext.getScopeGroupId(),
 					kbFolder.getClassNameId(), parentFolderId,
 					kbFolder.getName(), kbFolder.getDescription(),
 					serviceContext);
@@ -136,9 +137,10 @@ public class KBFolderStagedModelDataHandler
 		}
 		else {
 			importedKBFolder = _kbFolderLocalService.addKBFolder(
-				userId, portletDataContext.getScopeGroupId(),
-				kbFolder.getClassNameId(), parentFolderId, kbFolder.getName(),
-				kbFolder.getDescription(), serviceContext);
+				kbFolder.getExternalReferenceCode(), userId,
+				portletDataContext.getScopeGroupId(), kbFolder.getClassNameId(),
+				parentFolderId, kbFolder.getName(), kbFolder.getDescription(),
+				serviceContext);
 		}
 
 		portletDataContext.importClassedModel(kbFolder, importedKBFolder);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/KnowledgeBaseServiceUpgrade.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/KnowledgeBaseServiceUpgrade.java
@@ -19,6 +19,8 @@ import com.liferay.knowledge.base.internal.upgrade.v3_0_0.util.KBArticleTable;
 import com.liferay.knowledge.base.internal.upgrade.v3_0_0.util.KBCommentTable;
 import com.liferay.knowledge.base.internal.upgrade.v3_0_0.util.KBFolderTable;
 import com.liferay.knowledge.base.internal.upgrade.v3_0_0.util.KBTemplateTable;
+import com.liferay.knowledge.base.internal.upgrade.v4_1_0.KBArticleExternalReferenceCodeUpgradeProcess;
+import com.liferay.knowledge.base.internal.upgrade.v4_1_0.KBFolderExternalReferenceCodeUpgradeProcess;
 import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -158,6 +160,11 @@ public class KnowledgeBaseServiceUpgrade implements UpgradeStepRegistrator {
 			"3.1.0", "4.0.0",
 			new ViewCountUpgradeProcess(
 				"KBArticle", KBArticle.class, "kbArticleId", "viewCount"));
+
+		registry.register(
+			"4.0.0", "4.1.0",
+			new KBArticleExternalReferenceCodeUpgradeProcess(),
+			new KBFolderExternalReferenceCodeUpgradeProcess());
 	}
 
 	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED, unbind = "-")

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v4_1_0/KBArticleExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v4_1_0/KBArticleExternalReferenceCodeUpgradeProcess.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.internal.upgrade.v4_1_0;
+
+import com.liferay.knowledge.base.internal.upgrade.v4_1_0.util.KBArticleTable;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+public class KBArticleExternalReferenceCodeUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		if (!hasColumn(KBArticleTable.TABLE_NAME, "externalReferenceCode")) {
+			alter(
+				KBArticleTable.class,
+				new AlterTableAddColumn(
+					"externalReferenceCode", "VARCHAR(75)"));
+
+			runSQL(
+				"update KBArticle set externalReferenceCode = " +
+					"CAST_TEXT(resourcePrimKey) where externalReferenceCode " +
+						"is null or externalReferenceCode = ''");
+		}
+	}
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v4_1_0/KBFolderExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v4_1_0/KBFolderExternalReferenceCodeUpgradeProcess.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.internal.upgrade.v4_1_0;
+
+import com.liferay.knowledge.base.internal.upgrade.v4_1_0.util.KBFolderTable;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ *@author Luis Miguel Barcos
+ */
+public class KBFolderExternalReferenceCodeUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		if (!hasColumn(KBFolderTable.TABLE_NAME, "externalReferenceCode")) {
+			alter(
+				KBFolderTable.class,
+				new AlterTableAddColumn(
+					"externalReferenceCode", "VARCHAR(75)"));
+
+			runSQL(
+				"update KBFolder set externalReferenceCode = " +
+					"CAST_TEXT(kbFolderId) where externalReferenceCode is " +
+						"null or externalReferenceCode = ''");
+		}
+	}
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v4_1_0/util/KBArticleTable.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v4_1_0/util/KBArticleTable.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.internal.upgrade.v4_1_0.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
+public class KBArticleTable {
+
+	public static final String TABLE_NAME = "KBArticle";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
+		{"kbArticleId", Types.BIGINT}, {"resourcePrimKey", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"rootResourcePrimKey", Types.BIGINT},
+		{"externalReferenceCode", Types.VARCHAR},
+		{"parentResourceClassNameId", Types.BIGINT},
+		{"parentResourcePrimKey", Types.BIGINT}, {"kbFolderId", Types.BIGINT},
+		{"version", Types.INTEGER}, {"title", Types.VARCHAR},
+		{"urlTitle", Types.VARCHAR}, {"content", Types.CLOB},
+		{"description", Types.VARCHAR}, {"priority", Types.DOUBLE},
+		{"sections", Types.VARCHAR}, {"latest", Types.BOOLEAN},
+		{"main", Types.BOOLEAN}, {"sourceURL", Types.VARCHAR},
+		{"lastPublishDate", Types.TIMESTAMP}, {"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT}, {"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
+new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("kbArticleId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("resourcePrimKey", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("rootResourcePrimKey", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("parentResourceClassNameId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("parentResourcePrimKey", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kbFolderId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("version", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("title", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("urlTitle", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("content", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("priority", Types.DOUBLE);
+
+TABLE_COLUMNS_MAP.put("sections", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("latest", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("main", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("sourceURL", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE =
+"create table KBArticle (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,kbArticleId LONG not null primary key,resourcePrimKey LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,rootResourcePrimKey LONG,externalReferenceCode VARCHAR(75) null,parentResourceClassNameId LONG,parentResourcePrimKey LONG,kbFolderId LONG,version INTEGER,title STRING null,urlTitle VARCHAR(75) null,content TEXT null,description STRING null,priority DOUBLE,sections STRING null,latest BOOLEAN,main BOOLEAN,sourceURL STRING null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KBArticle";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_571C019E on KBArticle (companyId, latest)",
+		"create index IX_5A381890 on KBArticle (companyId, main)",
+		"create index IX_FBC2D349 on KBArticle (companyId, status)",
+		"create index IX_2B11F674 on KBArticle (groupId, kbFolderId, latest)",
+		"create index IX_CFB8C81F on KBArticle (groupId, kbFolderId, status)",
+		"create index IX_379FD6BC on KBArticle (groupId, kbFolderId, urlTitle[$COLUMN_LENGTH:75$], status)",
+		"create index IX_694EA2E0 on KBArticle (groupId, latest)",
+		"create index IX_97C62252 on KBArticle (groupId, main)",
+		"create index IX_994AC32D on KBArticle (groupId, parentResourcePrimKey, latest, status)",
+		"create index IX_D91D2879 on KBArticle (groupId, parentResourcePrimKey, main)",
+		"create index IX_55A38CF2 on KBArticle (groupId, parentResourcePrimKey, status)",
+		"create index IX_DF5748B on KBArticle (groupId, status)",
+		"create index IX_86BA3247 on KBArticle (parentResourcePrimKey, latest)",
+		"create index IX_1DCC5F79 on KBArticle (parentResourcePrimKey, main)",
+		"create index IX_2B6103F2 on KBArticle (parentResourcePrimKey, status)",
+		"create index IX_5FEF5F4F on KBArticle (resourcePrimKey, groupId, latest)",
+		"create index IX_8EF92E81 on KBArticle (resourcePrimKey, groupId, main)",
+		"create index IX_49630FA on KBArticle (resourcePrimKey, groupId, status)",
+		"create index IX_A9E2C691 on KBArticle (resourcePrimKey, latest)",
+		"create index IX_69C17E43 on KBArticle (resourcePrimKey, main)",
+		"create index IX_4E89983C on KBArticle (resourcePrimKey, status)",
+		"create unique index IX_AA304772 on KBArticle (resourcePrimKey, version)",
+		"create index IX_4E87D659 on KBArticle (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_5C941F1B on KBArticle (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v4_1_0/util/KBFolderTable.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v4_1_0/util/KBFolderTable.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.internal.upgrade.v4_1_0.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
+public class KBFolderTable {
+
+	public static final String TABLE_NAME = "KBFolder";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
+		{"externalReferenceCode", Types.VARCHAR}, {"kbFolderId", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"parentKBFolderId", Types.BIGINT}, {"name", Types.VARCHAR},
+		{"urlTitle", Types.VARCHAR}, {"description", Types.VARCHAR},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
+new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("kbFolderId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("parentKBFolderId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("urlTitle", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE =
+"create table KBFolder (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,kbFolderId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,parentKBFolderId LONG,name VARCHAR(75) null,urlTitle VARCHAR(75) null,description STRING null,lastPublishDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KBFolder";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_F32A081D on KBFolder (companyId)",
+		"create index IX_3FA4415C on KBFolder (groupId, parentKBFolderId, name[$COLUMN_LENGTH:75$])",
+		"create index IX_729A89FA on KBFolder (groupId, parentKBFolderId, urlTitle[$COLUMN_LENGTH:75$])",
+		"create index IX_32D1105F on KBFolder (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_1FD022A1 on KBFolder (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleCacheModel.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleCacheModel.java
@@ -76,7 +76,7 @@ public class KBArticleCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(59);
+		StringBundler sb = new StringBundler(61);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -100,6 +100,8 @@ public class KBArticleCacheModel
 		sb.append(modifiedDate);
 		sb.append(", rootResourcePrimKey=");
 		sb.append(rootResourcePrimKey);
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
 		sb.append(", parentResourceClassNameId=");
 		sb.append(parentResourceClassNameId);
 		sb.append(", parentResourcePrimKey=");
@@ -182,6 +184,14 @@ public class KBArticleCacheModel
 		}
 
 		kbArticleImpl.setRootResourcePrimKey(rootResourcePrimKey);
+
+		if (externalReferenceCode == null) {
+			kbArticleImpl.setExternalReferenceCode("");
+		}
+		else {
+			kbArticleImpl.setExternalReferenceCode(externalReferenceCode);
+		}
+
 		kbArticleImpl.setParentResourceClassNameId(parentResourceClassNameId);
 		kbArticleImpl.setParentResourcePrimKey(parentResourcePrimKey);
 		kbArticleImpl.setKbFolderId(kbFolderId);
@@ -284,6 +294,7 @@ public class KBArticleCacheModel
 		modifiedDate = objectInput.readLong();
 
 		rootResourcePrimKey = objectInput.readLong();
+		externalReferenceCode = objectInput.readUTF();
 
 		parentResourceClassNameId = objectInput.readLong();
 
@@ -345,6 +356,13 @@ public class KBArticleCacheModel
 		objectOutput.writeLong(modifiedDate);
 
 		objectOutput.writeLong(rootResourcePrimKey);
+
+		if (externalReferenceCode == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(externalReferenceCode);
+		}
 
 		objectOutput.writeLong(parentResourceClassNameId);
 
@@ -429,6 +447,7 @@ public class KBArticleCacheModel
 	public long createDate;
 	public long modifiedDate;
 	public long rootResourcePrimKey;
+	public String externalReferenceCode;
 	public long parentResourceClassNameId;
 	public long parentResourcePrimKey;
 	public long kbFolderId;

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleModelImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleModelImpl.java
@@ -83,6 +83,7 @@ public class KBArticleModelImpl
 		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
 		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
 		{"rootResourcePrimKey", Types.BIGINT},
+		{"externalReferenceCode", Types.VARCHAR},
 		{"parentResourceClassNameId", Types.BIGINT},
 		{"parentResourcePrimKey", Types.BIGINT}, {"kbFolderId", Types.BIGINT},
 		{"version", Types.INTEGER}, {"title", Types.VARCHAR},
@@ -110,6 +111,7 @@ public class KBArticleModelImpl
 		TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("rootResourcePrimKey", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("parentResourceClassNameId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("parentResourcePrimKey", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("kbFolderId", Types.BIGINT);
@@ -131,7 +133,7 @@ public class KBArticleModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table KBArticle (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,kbArticleId LONG not null primary key,resourcePrimKey LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,rootResourcePrimKey LONG,parentResourceClassNameId LONG,parentResourcePrimKey LONG,kbFolderId LONG,version INTEGER,title STRING null,urlTitle VARCHAR(75) null,content TEXT null,description STRING null,priority DOUBLE,sections STRING null,latest BOOLEAN,main BOOLEAN,sourceURL STRING null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+		"create table KBArticle (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,kbArticleId LONG not null primary key,resourcePrimKey LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,rootResourcePrimKey LONG,externalReferenceCode VARCHAR(75) null,parentResourceClassNameId LONG,parentResourcePrimKey LONG,kbFolderId LONG,version INTEGER,title STRING null,urlTitle VARCHAR(75) null,content TEXT null,description STRING null,priority DOUBLE,sections STRING null,latest BOOLEAN,main BOOLEAN,sourceURL STRING null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table KBArticle";
 
@@ -157,74 +159,80 @@ public class KBArticleModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 2L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long KBFOLDERID_COLUMN_BITMASK = 4L;
+	public static final long GROUPID_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long LATEST_COLUMN_BITMASK = 8L;
+	public static final long KBFOLDERID_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long MAIN_COLUMN_BITMASK = 16L;
+	public static final long LATEST_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long PARENTRESOURCEPRIMKEY_COLUMN_BITMASK = 32L;
+	public static final long MAIN_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long RESOURCEPRIMKEY_COLUMN_BITMASK = 64L;
+	public static final long PARENTRESOURCEPRIMKEY_COLUMN_BITMASK = 64L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long SECTIONS_COLUMN_BITMASK = 128L;
+	public static final long RESOURCEPRIMKEY_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long STATUS_COLUMN_BITMASK = 256L;
+	public static final long SECTIONS_COLUMN_BITMASK = 256L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long URLTITLE_COLUMN_BITMASK = 512L;
+	public static final long STATUS_COLUMN_BITMASK = 512L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 1024L;
+	public static final long URLTITLE_COLUMN_BITMASK = 1024L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long VERSION_COLUMN_BITMASK = 2048L;
+	public static final long UUID_COLUMN_BITMASK = 2048L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long VERSION_COLUMN_BITMASK = 4096L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long MODIFIEDDATE_COLUMN_BITMASK = 4096L;
+	public static final long MODIFIEDDATE_COLUMN_BITMASK = 8192L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -266,6 +274,7 @@ public class KBArticleModelImpl
 		model.setCreateDate(soapModel.getCreateDate());
 		model.setModifiedDate(soapModel.getModifiedDate());
 		model.setRootResourcePrimKey(soapModel.getRootResourcePrimKey());
+		model.setExternalReferenceCode(soapModel.getExternalReferenceCode());
 		model.setParentResourceClassNameId(
 			soapModel.getParentResourceClassNameId());
 		model.setParentResourcePrimKey(soapModel.getParentResourcePrimKey());
@@ -476,6 +485,11 @@ public class KBArticleModelImpl
 		attributeSetterBiConsumers.put(
 			"rootResourcePrimKey",
 			(BiConsumer<KBArticle, Long>)KBArticle::setRootResourcePrimKey);
+		attributeGetterFunctions.put(
+			"externalReferenceCode", KBArticle::getExternalReferenceCode);
+		attributeSetterBiConsumers.put(
+			"externalReferenceCode",
+			(BiConsumer<KBArticle, String>)KBArticle::setExternalReferenceCode);
 		attributeGetterFunctions.put(
 			"parentResourceClassNameId",
 			KBArticle::getParentResourceClassNameId);
@@ -791,6 +805,35 @@ public class KBArticleModelImpl
 		}
 
 		_rootResourcePrimKey = rootResourcePrimKey;
+	}
+
+	@JSON
+	@Override
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCode == null) {
+			return "";
+		}
+		else {
+			return _externalReferenceCode;
+		}
+	}
+
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalExternalReferenceCode() {
+		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -1357,6 +1400,7 @@ public class KBArticleModelImpl
 		kbArticleImpl.setCreateDate(getCreateDate());
 		kbArticleImpl.setModifiedDate(getModifiedDate());
 		kbArticleImpl.setRootResourcePrimKey(getRootResourcePrimKey());
+		kbArticleImpl.setExternalReferenceCode(getExternalReferenceCode());
 		kbArticleImpl.setParentResourceClassNameId(
 			getParentResourceClassNameId());
 		kbArticleImpl.setParentResourcePrimKey(getParentResourcePrimKey());
@@ -1503,6 +1547,17 @@ public class KBArticleModelImpl
 		}
 
 		kbArticleCacheModel.rootResourcePrimKey = getRootResourcePrimKey();
+
+		kbArticleCacheModel.externalReferenceCode = getExternalReferenceCode();
+
+		String externalReferenceCode =
+			kbArticleCacheModel.externalReferenceCode;
+
+		if ((externalReferenceCode != null) &&
+			(externalReferenceCode.length() == 0)) {
+
+			kbArticleCacheModel.externalReferenceCode = null;
+		}
 
 		kbArticleCacheModel.parentResourceClassNameId =
 			getParentResourceClassNameId();
@@ -1682,6 +1737,7 @@ public class KBArticleModelImpl
 	private Date _modifiedDate;
 	private boolean _setModifiedDate;
 	private long _rootResourcePrimKey;
+	private String _externalReferenceCode;
 	private long _parentResourceClassNameId;
 	private long _parentResourcePrimKey;
 	private long _kbFolderId;
@@ -1741,6 +1797,8 @@ public class KBArticleModelImpl
 		_columnOriginalValues.put("createDate", _createDate);
 		_columnOriginalValues.put("modifiedDate", _modifiedDate);
 		_columnOriginalValues.put("rootResourcePrimKey", _rootResourcePrimKey);
+		_columnOriginalValues.put(
+			"externalReferenceCode", _externalReferenceCode);
 		_columnOriginalValues.put(
 			"parentResourceClassNameId", _parentResourceClassNameId);
 		_columnOriginalValues.put(
@@ -1806,41 +1864,43 @@ public class KBArticleModelImpl
 
 		columnBitmasks.put("rootResourcePrimKey", 1024L);
 
-		columnBitmasks.put("parentResourceClassNameId", 2048L);
+		columnBitmasks.put("externalReferenceCode", 2048L);
 
-		columnBitmasks.put("parentResourcePrimKey", 4096L);
+		columnBitmasks.put("parentResourceClassNameId", 4096L);
 
-		columnBitmasks.put("kbFolderId", 8192L);
+		columnBitmasks.put("parentResourcePrimKey", 8192L);
 
-		columnBitmasks.put("version", 16384L);
+		columnBitmasks.put("kbFolderId", 16384L);
 
-		columnBitmasks.put("title", 32768L);
+		columnBitmasks.put("version", 32768L);
 
-		columnBitmasks.put("urlTitle", 65536L);
+		columnBitmasks.put("title", 65536L);
 
-		columnBitmasks.put("content", 131072L);
+		columnBitmasks.put("urlTitle", 131072L);
 
-		columnBitmasks.put("description", 262144L);
+		columnBitmasks.put("content", 262144L);
 
-		columnBitmasks.put("priority", 524288L);
+		columnBitmasks.put("description", 524288L);
 
-		columnBitmasks.put("sections", 1048576L);
+		columnBitmasks.put("priority", 1048576L);
 
-		columnBitmasks.put("latest", 2097152L);
+		columnBitmasks.put("sections", 2097152L);
 
-		columnBitmasks.put("main", 4194304L);
+		columnBitmasks.put("latest", 4194304L);
 
-		columnBitmasks.put("sourceURL", 8388608L);
+		columnBitmasks.put("main", 8388608L);
 
-		columnBitmasks.put("lastPublishDate", 16777216L);
+		columnBitmasks.put("sourceURL", 16777216L);
 
-		columnBitmasks.put("status", 33554432L);
+		columnBitmasks.put("lastPublishDate", 33554432L);
 
-		columnBitmasks.put("statusByUserId", 67108864L);
+		columnBitmasks.put("status", 67108864L);
 
-		columnBitmasks.put("statusByUserName", 134217728L);
+		columnBitmasks.put("statusByUserId", 134217728L);
 
-		columnBitmasks.put("statusDate", 268435456L);
+		columnBitmasks.put("statusByUserName", 268435456L);
+
+		columnBitmasks.put("statusDate", 536870912L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBFolderCacheModel.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBFolderCacheModel.java
@@ -76,12 +76,14 @@ public class KBFolderCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(29);
+		StringBundler sb = new StringBundler(31);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
 		sb.append(", uuid=");
 		sb.append(uuid);
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
 		sb.append(", kbFolderId=");
 		sb.append(kbFolderId);
 		sb.append(", groupId=");
@@ -122,6 +124,13 @@ public class KBFolderCacheModel
 		}
 		else {
 			kbFolderImpl.setUuid(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			kbFolderImpl.setExternalReferenceCode("");
+		}
+		else {
+			kbFolderImpl.setExternalReferenceCode(externalReferenceCode);
 		}
 
 		kbFolderImpl.setKbFolderId(kbFolderId);
@@ -189,6 +198,7 @@ public class KBFolderCacheModel
 	public void readExternal(ObjectInput objectInput) throws IOException {
 		mvccVersion = objectInput.readLong();
 		uuid = objectInput.readUTF();
+		externalReferenceCode = objectInput.readUTF();
 
 		kbFolderId = objectInput.readLong();
 
@@ -217,6 +227,13 @@ public class KBFolderCacheModel
 		}
 		else {
 			objectOutput.writeUTF(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(externalReferenceCode);
 		}
 
 		objectOutput.writeLong(kbFolderId);
@@ -265,6 +282,7 @@ public class KBFolderCacheModel
 
 	public long mvccVersion;
 	public String uuid;
+	public String externalReferenceCode;
 	public long kbFolderId;
 	public long groupId;
 	public long companyId;

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBFolderModelImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBFolderModelImpl.java
@@ -76,12 +76,13 @@ public class KBFolderModelImpl
 
 	public static final Object[][] TABLE_COLUMNS = {
 		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
-		{"kbFolderId", Types.BIGINT}, {"groupId", Types.BIGINT},
-		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
-		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
-		{"modifiedDate", Types.TIMESTAMP}, {"parentKBFolderId", Types.BIGINT},
-		{"name", Types.VARCHAR}, {"urlTitle", Types.VARCHAR},
-		{"description", Types.VARCHAR}, {"lastPublishDate", Types.TIMESTAMP}
+		{"externalReferenceCode", Types.VARCHAR}, {"kbFolderId", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"parentKBFolderId", Types.BIGINT}, {"name", Types.VARCHAR},
+		{"urlTitle", Types.VARCHAR}, {"description", Types.VARCHAR},
+		{"lastPublishDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -90,6 +91,7 @@ public class KBFolderModelImpl
 	static {
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("kbFolderId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
@@ -105,7 +107,7 @@ public class KBFolderModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table KBFolder (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,kbFolderId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,parentKBFolderId LONG,name VARCHAR(75) null,urlTitle VARCHAR(75) null,description STRING null,lastPublishDate DATE null)";
+		"create table KBFolder (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,kbFolderId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,parentKBFolderId LONG,name VARCHAR(75) null,urlTitle VARCHAR(75) null,description STRING null,lastPublishDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table KBFolder";
 
@@ -131,38 +133,44 @@ public class KBFolderModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 2L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long NAME_COLUMN_BITMASK = 4L;
+	public static final long GROUPID_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long PARENTKBFOLDERID_COLUMN_BITMASK = 8L;
+	public static final long NAME_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long URLTITLE_COLUMN_BITMASK = 16L;
+	public static final long PARENTKBFOLDERID_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 32L;
+	public static final long URLTITLE_COLUMN_BITMASK = 32L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 64L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long KBFOLDERID_COLUMN_BITMASK = 64L;
+	public static final long KBFOLDERID_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -195,6 +203,7 @@ public class KBFolderModelImpl
 
 		model.setMvccVersion(soapModel.getMvccVersion());
 		model.setUuid(soapModel.getUuid());
+		model.setExternalReferenceCode(soapModel.getExternalReferenceCode());
 		model.setKbFolderId(soapModel.getKbFolderId());
 		model.setGroupId(soapModel.getGroupId());
 		model.setCompanyId(soapModel.getCompanyId());
@@ -363,6 +372,11 @@ public class KBFolderModelImpl
 		attributeGetterFunctions.put("uuid", KBFolder::getUuid);
 		attributeSetterBiConsumers.put(
 			"uuid", (BiConsumer<KBFolder, String>)KBFolder::setUuid);
+		attributeGetterFunctions.put(
+			"externalReferenceCode", KBFolder::getExternalReferenceCode);
+		attributeSetterBiConsumers.put(
+			"externalReferenceCode",
+			(BiConsumer<KBFolder, String>)KBFolder::setExternalReferenceCode);
 		attributeGetterFunctions.put("kbFolderId", KBFolder::getKbFolderId);
 		attributeSetterBiConsumers.put(
 			"kbFolderId", (BiConsumer<KBFolder, Long>)KBFolder::setKbFolderId);
@@ -454,6 +468,35 @@ public class KBFolderModelImpl
 	@Deprecated
 	public String getOriginalUuid() {
 		return getColumnOriginalValue("uuid_");
+	}
+
+	@JSON
+	@Override
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCode == null) {
+			return "";
+		}
+		else {
+			return _externalReferenceCode;
+		}
+	}
+
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalExternalReferenceCode() {
+		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -789,6 +832,7 @@ public class KBFolderModelImpl
 
 		kbFolderImpl.setMvccVersion(getMvccVersion());
 		kbFolderImpl.setUuid(getUuid());
+		kbFolderImpl.setExternalReferenceCode(getExternalReferenceCode());
 		kbFolderImpl.setKbFolderId(getKbFolderId());
 		kbFolderImpl.setGroupId(getGroupId());
 		kbFolderImpl.setCompanyId(getCompanyId());
@@ -888,6 +932,16 @@ public class KBFolderModelImpl
 
 		if ((uuid != null) && (uuid.length() == 0)) {
 			kbFolderCacheModel.uuid = null;
+		}
+
+		kbFolderCacheModel.externalReferenceCode = getExternalReferenceCode();
+
+		String externalReferenceCode = kbFolderCacheModel.externalReferenceCode;
+
+		if ((externalReferenceCode != null) &&
+			(externalReferenceCode.length() == 0)) {
+
+			kbFolderCacheModel.externalReferenceCode = null;
 		}
 
 		kbFolderCacheModel.kbFolderId = getKbFolderId();
@@ -1034,6 +1088,7 @@ public class KBFolderModelImpl
 
 	private long _mvccVersion;
 	private String _uuid;
+	private String _externalReferenceCode;
 	private long _kbFolderId;
 	private long _groupId;
 	private long _companyId;
@@ -1079,6 +1134,8 @@ public class KBFolderModelImpl
 
 		_columnOriginalValues.put("mvccVersion", _mvccVersion);
 		_columnOriginalValues.put("uuid_", _uuid);
+		_columnOriginalValues.put(
+			"externalReferenceCode", _externalReferenceCode);
 		_columnOriginalValues.put("kbFolderId", _kbFolderId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
@@ -1118,29 +1175,31 @@ public class KBFolderModelImpl
 
 		columnBitmasks.put("uuid_", 2L);
 
-		columnBitmasks.put("kbFolderId", 4L);
+		columnBitmasks.put("externalReferenceCode", 4L);
 
-		columnBitmasks.put("groupId", 8L);
+		columnBitmasks.put("kbFolderId", 8L);
 
-		columnBitmasks.put("companyId", 16L);
+		columnBitmasks.put("groupId", 16L);
 
-		columnBitmasks.put("userId", 32L);
+		columnBitmasks.put("companyId", 32L);
 
-		columnBitmasks.put("userName", 64L);
+		columnBitmasks.put("userId", 64L);
 
-		columnBitmasks.put("createDate", 128L);
+		columnBitmasks.put("userName", 128L);
 
-		columnBitmasks.put("modifiedDate", 256L);
+		columnBitmasks.put("createDate", 256L);
 
-		columnBitmasks.put("parentKBFolderId", 512L);
+		columnBitmasks.put("modifiedDate", 512L);
 
-		columnBitmasks.put("name", 1024L);
+		columnBitmasks.put("parentKBFolderId", 1024L);
 
-		columnBitmasks.put("urlTitle", 2048L);
+		columnBitmasks.put("name", 2048L);
 
-		columnBitmasks.put("description", 4096L);
+		columnBitmasks.put("urlTitle", 4096L);
 
-		columnBitmasks.put("lastPublishDate", 8192L);
+		columnBitmasks.put("description", 8192L);
+
+		columnBitmasks.put("lastPublishDate", 16384L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/base/KBFolderLocalServiceBaseImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/base/KBFolderLocalServiceBaseImpl.java
@@ -259,6 +259,48 @@ public abstract class KBFolderLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the kb folder with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb folder's external reference code
+	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
+	 */
+	@Override
+	public KBFolder fetchKBFolderByExternalReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return kbFolderPersistence.fetchByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchKBFolderByExternalReferenceCode(long, String)}
+	 */
+	@Deprecated
+	@Override
+	public KBFolder fetchKBFolderByReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return fetchKBFolderByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the kb folder with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb folder's external reference code
+	 * @return the matching kb folder
+	 * @throws PortalException if a matching kb folder could not be found
+	 */
+	@Override
+	public KBFolder getKBFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return kbFolderPersistence.findByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
 	 * Returns the kb folder with the primary key.
 	 *
 	 * @param kbFolderId the primary key of the kb folder

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceHttp.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceHttp.java
@@ -97,6 +97,54 @@ public class KBArticleServiceHttp {
 		}
 	}
 
+	public static com.liferay.knowledge.base.model.KBArticle addKBArticle(
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			String portletId, long parentResourceClassNameId,
+			long parentResourcePrimKey, String title, String urlTitle,
+			String content, String description, String sourceURL,
+			String[] sections, String[] selectedFileNames,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				KBArticleServiceUtil.class, "addKBArticle",
+				_addKBArticleParameterTypes1);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, portletId,
+				parentResourceClassNameId, parentResourcePrimKey, title,
+				urlTitle, content, description, sourceURL, sections,
+				selectedFileNames, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.knowledge.base.model.KBArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static int addKBArticlesMarkdown(
 			HttpPrincipal httpPrincipal, long groupId, long parentKBFolderId,
 			String fileName, boolean prioritizeByNumericalPrefix,
@@ -107,7 +155,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "addKBArticlesMarkdown",
-				_addKBArticlesMarkdownParameterTypes1);
+				_addKBArticlesMarkdownParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentKBFolderId, fileName,
@@ -150,7 +198,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "addTempAttachment",
-				_addTempAttachmentParameterTypes2);
+				_addTempAttachmentParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey, fileName, tempFolderName,
@@ -187,7 +235,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "deleteKBArticle",
-				_deleteKBArticleParameterTypes3);
+				_deleteKBArticleParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey);
@@ -227,7 +275,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "deleteKBArticles",
-				_deleteKBArticlesParameterTypes4);
+				_deleteKBArticlesParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKeys);
@@ -264,7 +312,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "deleteTempAttachment",
-				_deleteTempAttachmentParameterTypes5);
+				_deleteTempAttachmentParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey, fileName, tempFolderName);
@@ -301,7 +349,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "fetchFirstChildKBArticle",
-				_fetchFirstChildKBArticleParameterTypes6);
+				_fetchFirstChildKBArticleParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey);
@@ -335,7 +383,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "fetchFirstChildKBArticle",
-				_fetchFirstChildKBArticleParameterTypes7);
+				_fetchFirstChildKBArticleParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey, status);
@@ -370,7 +418,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "fetchKBArticleByUrlTitle",
-				_fetchKBArticleByUrlTitleParameterTypes8);
+				_fetchKBArticleByUrlTitleParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, kbFolderId, urlTitle);
@@ -411,10 +459,53 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "fetchLatestKBArticle",
-				_fetchLatestKBArticleParameterTypes9);
+				_fetchLatestKBArticleParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, status);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.knowledge.base.model.KBArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.knowledge.base.model.KBArticle
+			fetchLatestKBArticleByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long groupId,
+				String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				KBArticleServiceUtil.class,
+				"fetchLatestKBArticleByExternalReferenceCode",
+				_fetchLatestKBArticleByExternalReferenceCodeParameterTypes11);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, externalReferenceCode);
 
 			Object returnObj = null;
 
@@ -453,7 +544,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "fetchLatestKBArticleByUrlTitle",
-				_fetchLatestKBArticleByUrlTitleParameterTypes10);
+				_fetchLatestKBArticleByUrlTitleParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, kbFolderId, urlTitle, status);
@@ -498,7 +589,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getAllDescendantKBArticles",
-				_getAllDescendantKBArticlesParameterTypes11);
+				_getAllDescendantKBArticlesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey, status, orderByComparator);
@@ -543,7 +634,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getGroupKBArticles",
-				_getGroupKBArticlesParameterTypes12);
+				_getGroupKBArticlesParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, start, end, orderByComparator);
@@ -576,7 +667,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getGroupKBArticlesCount",
-				_getGroupKBArticlesCountParameterTypes13);
+				_getGroupKBArticlesCountParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status);
@@ -611,7 +702,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getGroupKBArticlesRSS",
-				_getGroupKBArticlesRSSParameterTypes14);
+				_getGroupKBArticlesRSSParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, status, rssDelta, rssDisplayStyle, rssFormat,
@@ -652,7 +743,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticle",
-				_getKBArticleParameterTypes15);
+				_getKBArticleParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, version);
@@ -697,7 +788,7 @@ public class KBArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class,
 				"getKBArticleAndAllDescendantKBArticles",
-				_getKBArticleAndAllDescendantKBArticlesParameterTypes16);
+				_getKBArticleAndAllDescendantKBArticlesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, status, orderByComparator);
@@ -740,7 +831,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticleRSS",
-				_getKBArticleRSSParameterTypes17);
+				_getKBArticleRSSParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, status, rssDelta, rssDisplayStyle,
@@ -785,7 +876,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticles",
-				_getKBArticlesParameterTypes18);
+				_getKBArticlesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey, status, start, end,
@@ -824,7 +915,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticles",
-				_getKBArticlesParameterTypes19);
+				_getKBArticlesParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKeys, status, start, end,
@@ -863,7 +954,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticles",
-				_getKBArticlesParameterTypes20);
+				_getKBArticlesParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKeys, status,
@@ -898,7 +989,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticlesCount",
-				_getKBArticlesCountParameterTypes21);
+				_getKBArticlesCountParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey, status);
@@ -931,7 +1022,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticlesCount",
-				_getKBArticlesCountParameterTypes22);
+				_getKBArticlesCountParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKeys, status);
@@ -971,7 +1062,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticleSearchDisplay",
-				_getKBArticleSearchDisplayParameterTypes23);
+				_getKBArticleSearchDisplayParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, title, content, status, startDate, endDate,
@@ -1017,7 +1108,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticleVersions",
-				_getKBArticleVersionsParameterTypes24);
+				_getKBArticleVersionsParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey, status, start, end,
@@ -1052,7 +1143,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticleVersionsCount",
-				_getKBArticleVersionsCountParameterTypes25);
+				_getKBArticleVersionsCountParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey, status);
@@ -1085,10 +1176,53 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getLatestKBArticle",
-				_getLatestKBArticleParameterTypes26);
+				_getLatestKBArticleParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, status);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.knowledge.base.model.KBArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.knowledge.base.model.KBArticle
+			getLatestKBArticleByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long groupId,
+				String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				KBArticleServiceUtil.class,
+				"getLatestKBArticleByExternalReferenceCode",
+				_getLatestKBArticleByExternalReferenceCodeParameterTypes29);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, externalReferenceCode);
 
 			Object returnObj = null;
 
@@ -1126,7 +1260,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getPreviousAndNextKBArticles",
-				_getPreviousAndNextKBArticlesParameterTypes27);
+				_getPreviousAndNextKBArticlesParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, kbArticleId);
@@ -1170,7 +1304,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getSectionsKBArticles",
-				_getSectionsKBArticlesParameterTypes28);
+				_getSectionsKBArticlesParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, sections, status, start, end,
@@ -1205,7 +1339,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getSectionsKBArticlesCount",
-				_getSectionsKBArticlesCountParameterTypes29);
+				_getSectionsKBArticlesCountParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, sections, status);
@@ -1238,7 +1372,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getTempAttachmentNames",
-				_getTempAttachmentNamesParameterTypes30);
+				_getTempAttachmentNamesParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, tempFolderName);
@@ -1280,7 +1414,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "moveKBArticle",
-				_moveKBArticleParameterTypes31);
+				_moveKBArticleParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, parentResourceClassNameId,
@@ -1318,7 +1452,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "revertKBArticle",
-				_revertKBArticleParameterTypes32);
+				_revertKBArticleParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, version, serviceContext);
@@ -1358,7 +1492,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "subscribeGroupKBArticles",
-				_subscribeGroupKBArticlesParameterTypes33);
+				_subscribeGroupKBArticlesParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, portletId);
@@ -1394,7 +1528,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "subscribeKBArticle",
-				_subscribeKBArticleParameterTypes34);
+				_subscribeKBArticleParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey);
@@ -1430,7 +1564,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "unsubscribeGroupKBArticles",
-				_unsubscribeGroupKBArticlesParameterTypes35);
+				_unsubscribeGroupKBArticlesParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, portletId);
@@ -1466,7 +1600,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "unsubscribeKBArticle",
-				_unsubscribeKBArticleParameterTypes36);
+				_unsubscribeKBArticleParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey);
@@ -1506,7 +1640,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "updateKBArticle",
-				_updateKBArticleParameterTypes37);
+				_updateKBArticleParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, title, content, description,
@@ -1549,7 +1683,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "updateKBArticlesPriorities",
-				_updateKBArticlesPrioritiesParameterTypes38);
+				_updateKBArticlesPrioritiesParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKeyToPriorityMap);
@@ -1585,139 +1719,150 @@ public class KBArticleServiceHttp {
 		String.class, String.class, String.class, String[].class,
 		String[].class, com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _addKBArticlesMarkdownParameterTypes1 =
+	private static final Class<?>[] _addKBArticleParameterTypes1 = new Class[] {
+		String.class, String.class, long.class, long.class, String.class,
+		String.class, String.class, String.class, String.class, String[].class,
+		String[].class, com.liferay.portal.kernel.service.ServiceContext.class
+	};
+	private static final Class<?>[] _addKBArticlesMarkdownParameterTypes2 =
 		new Class[] {
 			long.class, long.class, String.class, boolean.class,
 			java.io.InputStream.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _addTempAttachmentParameterTypes2 =
+	private static final Class<?>[] _addTempAttachmentParameterTypes3 =
 		new Class[] {
 			long.class, long.class, String.class, String.class,
 			java.io.InputStream.class, String.class
 		};
-	private static final Class<?>[] _deleteKBArticleParameterTypes3 =
+	private static final Class<?>[] _deleteKBArticleParameterTypes4 =
 		new Class[] {long.class};
-	private static final Class<?>[] _deleteKBArticlesParameterTypes4 =
+	private static final Class<?>[] _deleteKBArticlesParameterTypes5 =
 		new Class[] {long.class, long[].class};
-	private static final Class<?>[] _deleteTempAttachmentParameterTypes5 =
+	private static final Class<?>[] _deleteTempAttachmentParameterTypes6 =
 		new Class[] {long.class, long.class, String.class, String.class};
-	private static final Class<?>[] _fetchFirstChildKBArticleParameterTypes6 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _fetchFirstChildKBArticleParameterTypes7 =
+		new Class[] {long.class, long.class};
+	private static final Class<?>[] _fetchFirstChildKBArticleParameterTypes8 =
 		new Class[] {long.class, long.class, int.class};
-	private static final Class<?>[] _fetchKBArticleByUrlTitleParameterTypes8 =
+	private static final Class<?>[] _fetchKBArticleByUrlTitleParameterTypes9 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _fetchLatestKBArticleParameterTypes9 =
+	private static final Class<?>[] _fetchLatestKBArticleParameterTypes10 =
 		new Class[] {long.class, int.class};
 	private static final Class<?>[]
-		_fetchLatestKBArticleByUrlTitleParameterTypes10 = new Class[] {
+		_fetchLatestKBArticleByExternalReferenceCodeParameterTypes11 =
+			new Class[] {long.class, String.class};
+	private static final Class<?>[]
+		_fetchLatestKBArticleByUrlTitleParameterTypes12 = new Class[] {
 			long.class, long.class, String.class, int.class
 		};
 	private static final Class<?>[]
-		_getAllDescendantKBArticlesParameterTypes11 = new Class[] {
+		_getAllDescendantKBArticlesParameterTypes13 = new Class[] {
 			long.class, long.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupKBArticlesParameterTypes12 =
+	private static final Class<?>[] _getGroupKBArticlesParameterTypes14 =
 		new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupKBArticlesCountParameterTypes13 =
+	private static final Class<?>[] _getGroupKBArticlesCountParameterTypes15 =
 		new Class[] {long.class, int.class};
-	private static final Class<?>[] _getGroupKBArticlesRSSParameterTypes14 =
+	private static final Class<?>[] _getGroupKBArticlesRSSParameterTypes16 =
 		new Class[] {
 			int.class, int.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getKBArticleParameterTypes15 =
+	private static final Class<?>[] _getKBArticleParameterTypes17 =
 		new Class[] {long.class, int.class};
 	private static final Class<?>[]
-		_getKBArticleAndAllDescendantKBArticlesParameterTypes16 = new Class[] {
+		_getKBArticleAndAllDescendantKBArticlesParameterTypes18 = new Class[] {
 			long.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticleRSSParameterTypes17 =
+	private static final Class<?>[] _getKBArticleRSSParameterTypes19 =
 		new Class[] {
 			long.class, int.class, int.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getKBArticlesParameterTypes18 =
+	private static final Class<?>[] _getKBArticlesParameterTypes20 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticlesParameterTypes19 =
+	private static final Class<?>[] _getKBArticlesParameterTypes21 =
 		new Class[] {
 			long.class, long[].class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticlesParameterTypes20 =
+	private static final Class<?>[] _getKBArticlesParameterTypes22 =
 		new Class[] {
 			long.class, long[].class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticlesCountParameterTypes21 =
+	private static final Class<?>[] _getKBArticlesCountParameterTypes23 =
 		new Class[] {long.class, long.class, int.class};
-	private static final Class<?>[] _getKBArticlesCountParameterTypes22 =
+	private static final Class<?>[] _getKBArticlesCountParameterTypes24 =
 		new Class[] {long.class, long[].class, int.class};
-	private static final Class<?>[] _getKBArticleSearchDisplayParameterTypes23 =
+	private static final Class<?>[] _getKBArticleSearchDisplayParameterTypes25 =
 		new Class[] {
 			long.class, String.class, String.class, int.class,
 			java.util.Date.class, java.util.Date.class, boolean.class,
 			int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticleVersionsParameterTypes24 =
+	private static final Class<?>[] _getKBArticleVersionsParameterTypes26 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticleVersionsCountParameterTypes25 =
+	private static final Class<?>[] _getKBArticleVersionsCountParameterTypes27 =
 		new Class[] {long.class, long.class, int.class};
-	private static final Class<?>[] _getLatestKBArticleParameterTypes26 =
+	private static final Class<?>[] _getLatestKBArticleParameterTypes28 =
 		new Class[] {long.class, int.class};
 	private static final Class<?>[]
-		_getPreviousAndNextKBArticlesParameterTypes27 = new Class[] {
+		_getLatestKBArticleByExternalReferenceCodeParameterTypes29 =
+			new Class[] {long.class, String.class};
+	private static final Class<?>[]
+		_getPreviousAndNextKBArticlesParameterTypes30 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getSectionsKBArticlesParameterTypes28 =
+	private static final Class<?>[] _getSectionsKBArticlesParameterTypes31 =
 		new Class[] {
 			long.class, String[].class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getSectionsKBArticlesCountParameterTypes29 = new Class[] {
+		_getSectionsKBArticlesCountParameterTypes32 = new Class[] {
 			long.class, String[].class, int.class
 		};
-	private static final Class<?>[] _getTempAttachmentNamesParameterTypes30 =
+	private static final Class<?>[] _getTempAttachmentNamesParameterTypes33 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _moveKBArticleParameterTypes31 =
+	private static final Class<?>[] _moveKBArticleParameterTypes34 =
 		new Class[] {long.class, long.class, long.class, double.class};
-	private static final Class<?>[] _revertKBArticleParameterTypes32 =
+	private static final Class<?>[] _revertKBArticleParameterTypes35 =
 		new Class[] {
 			long.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _subscribeGroupKBArticlesParameterTypes33 =
+	private static final Class<?>[] _subscribeGroupKBArticlesParameterTypes36 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _subscribeKBArticleParameterTypes34 =
+	private static final Class<?>[] _subscribeKBArticleParameterTypes37 =
 		new Class[] {long.class, long.class};
 	private static final Class<?>[]
-		_unsubscribeGroupKBArticlesParameterTypes35 = new Class[] {
+		_unsubscribeGroupKBArticlesParameterTypes38 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _unsubscribeKBArticleParameterTypes36 =
+	private static final Class<?>[] _unsubscribeKBArticleParameterTypes39 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateKBArticleParameterTypes37 =
+	private static final Class<?>[] _updateKBArticleParameterTypes40 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String[].class, String[].class, long[].class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_updateKBArticlesPrioritiesParameterTypes38 = new Class[] {
+		_updateKBArticlesPrioritiesParameterTypes41 = new Class[] {
 			long.class, java.util.Map.class
 		};
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceSoap.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceSoap.java
@@ -63,6 +63,12 @@ import java.rmi.RemoteException;
 @Deprecated
 public class KBArticleServiceSoap {
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBArticle(String, String, long, long, String, String, String, String,
+	 String, String[], String[], ServiceContext)}
+	 */
+	@Deprecated
 	public static com.liferay.knowledge.base.model.KBArticleSoap addKBArticle(
 			String portletId, long parentResourceClassNameId,
 			long parentResourcePrimKey, String title, String urlTitle,
@@ -77,6 +83,32 @@ public class KBArticleServiceSoap {
 					portletId, parentResourceClassNameId, parentResourcePrimKey,
 					title, urlTitle, content, description, sourceURL, sections,
 					selectedFileNames, serviceContext);
+
+			return com.liferay.knowledge.base.model.KBArticleSoap.toSoapModel(
+				returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
+	public static com.liferay.knowledge.base.model.KBArticleSoap addKBArticle(
+			String externalReferenceCode, String portletId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String title, String urlTitle, String content, String description,
+			String sourceURL, String[] sections, String[] selectedFileNames,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws RemoteException {
+
+		try {
+			com.liferay.knowledge.base.model.KBArticle returnValue =
+				KBArticleServiceUtil.addKBArticle(
+					externalReferenceCode, portletId, parentResourceClassNameId,
+					parentResourcePrimKey, title, urlTitle, content,
+					description, sourceURL, sections, selectedFileNames,
+					serviceContext);
 
 			return com.liferay.knowledge.base.model.KBArticleSoap.toSoapModel(
 				returnValue);
@@ -202,6 +234,37 @@ public class KBArticleServiceSoap {
 			com.liferay.knowledge.base.model.KBArticle returnValue =
 				KBArticleServiceUtil.fetchLatestKBArticle(
 					resourcePrimKey, status);
+
+			return com.liferay.knowledge.base.model.KBArticleSoap.toSoapModel(
+				returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article, or <code>null</code> if no
+	 matching kb article could be found
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static com.liferay.knowledge.base.model.KBArticleSoap
+			fetchLatestKBArticleByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws RemoteException {
+
+		try {
+			com.liferay.knowledge.base.model.KBArticle returnValue =
+				KBArticleServiceUtil.
+					fetchLatestKBArticleByExternalReferenceCode(
+						groupId, externalReferenceCode);
 
 			return com.liferay.knowledge.base.model.KBArticleSoap.toSoapModel(
 				returnValue);
@@ -519,6 +582,35 @@ public class KBArticleServiceSoap {
 			com.liferay.knowledge.base.model.KBArticle returnValue =
 				KBArticleServiceUtil.getLatestKBArticle(
 					resourcePrimKey, status);
+
+			return com.liferay.knowledge.base.model.KBArticleSoap.toSoapModel(
+				returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static com.liferay.knowledge.base.model.KBArticleSoap
+			getLatestKBArticleByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws RemoteException {
+
+		try {
+			com.liferay.knowledge.base.model.KBArticle returnValue =
+				KBArticleServiceUtil.getLatestKBArticleByExternalReferenceCode(
+					groupId, externalReferenceCode);
 
 			return com.liferay.knowledge.base.model.KBArticleSoap.toSoapModel(
 				returnValue);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBFolderServiceHttp.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBFolderServiceHttp.java
@@ -95,6 +95,51 @@ public class KBFolderServiceHttp {
 		}
 	}
 
+	public static com.liferay.knowledge.base.model.KBFolder addKBFolder(
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long groupId, long parentResourceClassNameId,
+			long parentResourcePrimKey, String name, String description,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				KBFolderServiceUtil.class, "addKBFolder",
+				_addKBFolderParameterTypes1);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId,
+				parentResourceClassNameId, parentResourcePrimKey, name,
+				description, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.knowledge.base.model.KBFolder)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.knowledge.base.model.KBFolder deleteKBFolder(
 			HttpPrincipal httpPrincipal, long kbFolderId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -102,7 +147,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "deleteKBFolder",
-				_deleteKBFolderParameterTypes1);
+				_deleteKBFolderParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, kbFolderId);
@@ -143,7 +188,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "fetchFirstChildKBFolder",
-				_fetchFirstChildKBFolderParameterTypes2);
+				_fetchFirstChildKBFolderParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, kbFolderId);
@@ -187,7 +232,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "fetchFirstChildKBFolder",
-				_fetchFirstChildKBFolderParameterTypes3);
+				_fetchFirstChildKBFolderParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, kbFolderId, orderByComparator);
@@ -227,7 +272,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "fetchKBFolder",
-				_fetchKBFolderParameterTypes4);
+				_fetchKBFolderParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, kbFolderId);
@@ -269,7 +314,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "fetchKBFolderByUrlTitle",
-				_fetchKBFolderByUrlTitleParameterTypes5);
+				_fetchKBFolderByUrlTitleParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentKbFolderId, urlTitle);
@@ -309,7 +354,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "getKBFolder",
-				_getKBFolderParameterTypes6);
+				_getKBFolderParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, kbFolderId);
@@ -351,7 +396,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "getKBFolderByUrlTitle",
-				_getKBFolderByUrlTitleParameterTypes7);
+				_getKBFolderByUrlTitleParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentKbFolderId, urlTitle);
@@ -393,7 +438,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "getKBFolders",
-				_getKBFoldersParameterTypes8);
+				_getKBFoldersParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentKBFolderId, start, end);
@@ -435,7 +480,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "getKBFoldersAndKBArticles",
-				_getKBFoldersAndKBArticlesParameterTypes9);
+				_getKBFoldersAndKBArticlesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey, status, start, end,
@@ -469,7 +514,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "getKBFoldersAndKBArticlesCount",
-				_getKBFoldersAndKBArticlesCountParameterTypes10);
+				_getKBFoldersAndKBArticlesCountParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey, status);
@@ -502,7 +547,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "getKBFoldersCount",
-				_getKBFoldersCountParameterTypes11);
+				_getKBFoldersCountParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentKBFolderId);
@@ -542,7 +587,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "moveKBFolder",
-				_moveKBFolderParameterTypes12);
+				_moveKBFolderParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, kbFolderId, parentKBFolderId);
@@ -581,7 +626,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "updateKBFolder",
-				_updateKBFolderParameterTypes13);
+				_updateKBFolderParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, parentResourceClassNameId, parentResourcePrimKey,
@@ -621,41 +666,45 @@ public class KBFolderServiceHttp {
 		long.class, long.class, long.class, String.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _deleteKBFolderParameterTypes1 =
+	private static final Class<?>[] _addKBFolderParameterTypes1 = new Class[] {
+		String.class, long.class, long.class, long.class, String.class,
+		String.class, com.liferay.portal.kernel.service.ServiceContext.class
+	};
+	private static final Class<?>[] _deleteKBFolderParameterTypes2 =
 		new Class[] {long.class};
-	private static final Class<?>[] _fetchFirstChildKBFolderParameterTypes2 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _fetchFirstChildKBFolderParameterTypes3 =
+		new Class[] {long.class, long.class};
+	private static final Class<?>[] _fetchFirstChildKBFolderParameterTypes4 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _fetchKBFolderParameterTypes4 =
+	private static final Class<?>[] _fetchKBFolderParameterTypes5 =
 		new Class[] {long.class};
-	private static final Class<?>[] _fetchKBFolderByUrlTitleParameterTypes5 =
+	private static final Class<?>[] _fetchKBFolderByUrlTitleParameterTypes6 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _getKBFolderParameterTypes6 = new Class[] {
+	private static final Class<?>[] _getKBFolderParameterTypes7 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getKBFolderByUrlTitleParameterTypes7 =
+	private static final Class<?>[] _getKBFolderByUrlTitleParameterTypes8 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _getKBFoldersParameterTypes8 = new Class[] {
+	private static final Class<?>[] _getKBFoldersParameterTypes9 = new Class[] {
 		long.class, long.class, int.class, int.class
 	};
-	private static final Class<?>[] _getKBFoldersAndKBArticlesParameterTypes9 =
+	private static final Class<?>[] _getKBFoldersAndKBArticlesParameterTypes10 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getKBFoldersAndKBArticlesCountParameterTypes10 = new Class[] {
+		_getKBFoldersAndKBArticlesCountParameterTypes11 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getKBFoldersCountParameterTypes11 =
+	private static final Class<?>[] _getKBFoldersCountParameterTypes12 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _moveKBFolderParameterTypes12 =
+	private static final Class<?>[] _moveKBFolderParameterTypes13 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _updateKBFolderParameterTypes13 =
+	private static final Class<?>[] _updateKBFolderParameterTypes14 =
 		new Class[] {
 			long.class, long.class, long.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBFolderServiceSoap.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBFolderServiceSoap.java
@@ -63,6 +63,11 @@ import java.rmi.RemoteException;
 @Deprecated
 public class KBFolderServiceSoap {
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addKBFolder(String, long, long, long, String, String, ServiceContext)}
+	 */
+	@Deprecated
 	public static com.liferay.knowledge.base.model.KBFolderSoap addKBFolder(
 			long groupId, long parentResourceClassNameId,
 			long parentResourcePrimKey, String name, String description,
@@ -74,6 +79,29 @@ public class KBFolderServiceSoap {
 				KBFolderServiceUtil.addKBFolder(
 					groupId, parentResourceClassNameId, parentResourcePrimKey,
 					name, description, serviceContext);
+
+			return com.liferay.knowledge.base.model.KBFolderSoap.toSoapModel(
+				returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
+	public static com.liferay.knowledge.base.model.KBFolderSoap addKBFolder(
+			String externalReferenceCode, long groupId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String name, String description,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws RemoteException {
+
+		try {
+			com.liferay.knowledge.base.model.KBFolder returnValue =
+				KBFolderServiceUtil.addKBFolder(
+					externalReferenceCode, groupId, parentResourceClassNameId,
+					parentResourcePrimKey, name, description, serviceContext);
 
 			return com.liferay.knowledge.base.model.KBFolderSoap.toSoapModel(
 				returnValue);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1182,6 +1182,8 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			kbArticle.setCreateDate(oldKBArticle.getCreateDate());
 			kbArticle.setRootResourcePrimKey(
 				oldKBArticle.getRootResourcePrimKey());
+			kbArticle.setExternalReferenceCode(
+				oldKBArticle.getExternalReferenceCode());
 			kbArticle.setParentResourceClassNameId(
 				oldKBArticle.getParentResourceClassNameId());
 			kbArticle.setParentResourcePrimKey(

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -144,6 +144,12 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			false);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 * #addKBArticle(String, long, long, long, String, String, String, String,
+	 * String, String[], String[], ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public KBArticle addKBArticle(
 			long userId, long parentResourceClassNameId,

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -208,13 +208,13 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		KBArticle kbArticle = kbArticlePersistence.create(kbArticleId);
 
 		kbArticle.setUuid(serviceContext.getUuid());
-		kbArticle.setExternalReferenceCode(externalReferenceCode);
 		kbArticle.setResourcePrimKey(resourcePrimKey);
 		kbArticle.setGroupId(groupId);
 		kbArticle.setCompanyId(user.getCompanyId());
 		kbArticle.setUserId(user.getUserId());
 		kbArticle.setUserName(user.getFullName());
 		kbArticle.setRootResourcePrimKey(rootResourcePrimKey);
+		kbArticle.setExternalReferenceCode(externalReferenceCode);
 		kbArticle.setParentResourceClassNameId(parentResourceClassNameId);
 		kbArticle.setParentResourcePrimKey(parentResourcePrimKey);
 		kbArticle.setKbFolderId(kbFolderId);
@@ -553,6 +553,23 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			resourcePrimKey, groupId, true, null);
 	}
 
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article, or <code>null</code> if no
+	 *         matching kb article could be found
+	 */
+	@Override
+	public KBArticle fetchLatestKBArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return kbArticlePersistence.fetchByG_E_Last(
+			groupId, externalReferenceCode, new KBArticleVersionComparator());
+	}
+
 	@Override
 	public KBArticle fetchLatestKBArticleByUrlTitle(
 		long groupId, long kbFolderId, String urlTitle, int status) {
@@ -837,6 +854,24 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		return kbArticlePersistence.findByR_S_First(
 			resourcePrimKey, status, new KBArticleVersionComparator());
+	}
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public KBArticle getLatestKBArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return kbArticlePersistence.findByG_E_First(
+			groupId, externalReferenceCode, new KBArticleVersionComparator());
 	}
 
 	@Override
@@ -2052,7 +2087,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		KBArticle kbArticle = kbArticlePersistence.fetchByG_ERC(
+		KBArticle kbArticle = fetchLatestKBArticleByExternalReferenceCode(
 			groupId, externalReferenceCode);
 
 		if (kbArticle != null) {

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
@@ -91,21 +91,29 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		if (portletId.equals(KBPortletKeys.KNOWLEDGE_BASE_ADMIN)) {
-			_adminPortletResourcePermission.check(
-				getPermissionChecker(), serviceContext.getScopeGroupId(),
-				KBActionKeys.ADD_KB_ARTICLE);
-		}
-		else if (portletId.equals(KBPortletKeys.KNOWLEDGE_BASE_DISPLAY)) {
-			_displayPortletResourcePermission.check(
-				getPermissionChecker(), serviceContext.getScopeGroupId(),
-				KBActionKeys.ADD_KB_ARTICLE);
-		}
+		_checkKBArticlePermissions(portletId, serviceContext);
 
 		return kbArticleLocalService.addKBArticle(
 			getUserId(), parentResourceClassNameId, parentResourcePrimKey,
 			title, urlTitle, content, description, sourceURL, sections,
 			selectedFileNames, serviceContext);
+	}
+
+	@Override
+	public KBArticle addKBArticle(
+			String externalReferenceCode, String portletId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String title, String urlTitle, String content, String description,
+			String sourceURL, String[] sections, String[] selectedFileNames,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_checkKBArticlePermissions(portletId, serviceContext);
+
+		return kbArticleLocalService.addKBArticle(
+			externalReferenceCode, getUserId(), parentResourceClassNameId,
+			parentResourcePrimKey, title, urlTitle, content, description,
+			sourceURL, sections, selectedFileNames, serviceContext);
 	}
 
 	@Override
@@ -953,6 +961,22 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 		else {
 			_kbArticleModelResourcePermission.check(
 				getPermissionChecker(), resourcePrimKey, KBActionKeys.UPDATE);
+		}
+	}
+
+	private void _checkKBArticlePermissions(
+			String portletId, ServiceContext serviceContext)
+		throws PortalException {
+
+		if (portletId.equals(KBPortletKeys.KNOWLEDGE_BASE_ADMIN)) {
+			_adminPortletResourcePermission.check(
+				getPermissionChecker(), serviceContext.getScopeGroupId(),
+				KBActionKeys.ADD_KB_ARTICLE);
+		}
+		else if (portletId.equals(KBPortletKeys.KNOWLEDGE_BASE_DISPLAY)) {
+			_displayPortletResourcePermission.check(
+				getPermissionChecker(), serviceContext.getScopeGroupId(),
+				KBActionKeys.ADD_KB_ARTICLE);
 		}
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
@@ -82,6 +82,12 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 * #addKBArticle(String, String, long, long, String, String, String, String,
+	 * String, String[], String[], ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public KBArticle addKBArticle(
 			String portletId, long parentResourceClassNameId,

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
@@ -250,6 +250,35 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 		return null;
 	}
 
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article, or <code>null</code> if no
+	 *         matching kb article could be found
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public KBArticle fetchLatestKBArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		KBArticle kbArticle =
+			kbArticleLocalService.fetchLatestKBArticleByExternalReferenceCode(
+				groupId, externalReferenceCode);
+
+		if ((kbArticle != null) &&
+			_kbArticleModelResourcePermission.contains(
+				getPermissionChecker(), kbArticle, ActionKeys.VIEW)) {
+
+			return kbArticle;
+		}
+
+		return null;
+	}
+
 	@Override
 	public KBArticle fetchLatestKBArticleByUrlTitle(
 			long groupId, long kbFolderId, String urlTitle, int status)
@@ -605,6 +634,30 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 
 		return kbArticleLocalService.getLatestKBArticle(
 			resourcePrimKey, status);
+	}
+
+	/**
+	 * Returns the latest kb article matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the kb article external reference code
+	 * @return the latest matching kb article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public KBArticle getLatestKBArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		KBArticle kbArticle =
+			kbArticleLocalService.getLatestKBArticleByExternalReferenceCode(
+				groupId, externalReferenceCode);
+
+		_kbArticleModelResourcePermission.check(
+			getPermissionChecker(), kbArticle, KBActionKeys.VIEW);
+
+		return kbArticle;
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderLocalServiceImpl.java
@@ -55,6 +55,11 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class KBFolderLocalServiceImpl extends KBFolderLocalServiceBaseImpl {
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 * #addKBFolder(String, long, long, long, long, String, String, ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public KBFolder addKBFolder(
 			long userId, long groupId, long parentResourceClassNameId,

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
@@ -42,6 +42,11 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class KBFolderServiceImpl extends KBFolderServiceBaseImpl {
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 * #addKBFolder(String, long, long, long, String, String, ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public KBFolder addKBFolder(
 			long groupId, long parentResourceClassNameId,

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
@@ -59,6 +59,23 @@ public class KBFolderServiceImpl extends KBFolderServiceBaseImpl {
 	}
 
 	@Override
+	public KBFolder addKBFolder(
+			String externalReferenceCode, long groupId,
+			long parentResourceClassNameId, long parentResourcePrimKey,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
+		ModelResourcePermissionUtil.check(
+			_kbFolderModelResourcePermission, getPermissionChecker(), groupId,
+			parentResourcePrimKey, KBActionKeys.ADD_KB_FOLDER);
+
+		return kbFolderLocalService.addKBFolder(
+			externalReferenceCode, getUserId(), groupId,
+			parentResourceClassNameId, parentResourcePrimKey, name, description,
+			serviceContext);
+	}
+
+	@Override
 	public KBFolder deleteKBFolder(long kbFolderId) throws PortalException {
 		_kbFolderModelResourcePermission.check(
 			getPermissionChecker(), kbFolderId, KBActionKeys.DELETE);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
@@ -62,6 +62,7 @@ import java.io.Serializable;
 
 import java.lang.reflect.InvocationHandler;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -5568,6 +5569,1029 @@ public class KBArticlePersistenceImpl
 
 	private static final String _FINDER_COLUMN_R_S_STATUS_2 =
 		"kbArticle.status = ?";
+
+	private FinderPath _finderPathWithPaginationFindByG_E;
+	private FinderPath _finderPathWithoutPaginationFindByG_E;
+	private FinderPath _finderPathCountByG_E;
+
+	/**
+	 * Returns all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb articles
+	 */
+	@Override
+	public List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode) {
+
+		return findByG_E(
+			groupId, externalReferenceCode, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles
+	 */
+	@Override
+	public List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return findByG_E(groupId, externalReferenceCode, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles
+	 */
+	@Override
+	public List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		return findByG_E(
+			groupId, externalReferenceCode, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching kb articles
+	 */
+	@Override
+	public List<KBArticle> findByG_E(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<KBArticle> orderByComparator,
+		boolean useFinderCache) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByG_E;
+				finderArgs = new Object[] {groupId, externalReferenceCode};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByG_E;
+			finderArgs = new Object[] {
+				groupId, externalReferenceCode, start, end, orderByComparator
+			};
+		}
+
+		List<KBArticle> list = null;
+
+		if (useFinderCache) {
+			list = (List<KBArticle>)finderCache.getResult(
+				finderPath, finderArgs);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (KBArticle kbArticle : list) {
+					if ((groupId != kbArticle.getGroupId()) ||
+						!externalReferenceCode.equals(
+							kbArticle.getExternalReferenceCode())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					4 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(4);
+			}
+
+			sb.append(_SQL_SELECT_KBARTICLE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_E_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_2);
+			}
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(KBArticleModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				list = (List<KBArticle>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	@Override
+	public KBArticle findByG_E_First(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		KBArticle kbArticle = fetchByG_E_First(
+			groupId, externalReferenceCode, orderByComparator);
+
+		if (kbArticle != null) {
+			return kbArticle;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
+
+		sb.append("}");
+
+		throw new NoSuchArticleException(sb.toString());
+	}
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	@Override
+	public KBArticle fetchByG_E_First(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		List<KBArticle> list = findByG_E(
+			groupId, externalReferenceCode, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	@Override
+	public KBArticle findByG_E_Last(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		KBArticle kbArticle = fetchByG_E_Last(
+			groupId, externalReferenceCode, orderByComparator);
+
+		if (kbArticle != null) {
+			return kbArticle;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
+
+		sb.append("}");
+
+		throw new NoSuchArticleException(sb.toString());
+	}
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	@Override
+	public KBArticle fetchByG_E_Last(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		int count = countByG_E(groupId, externalReferenceCode);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<KBArticle> list = findByG_E(
+			groupId, externalReferenceCode, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	@Override
+	public KBArticle[] findByG_E_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		KBArticle kbArticle = findByPrimaryKey(kbArticleId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			KBArticle[] array = new KBArticleImpl[3];
+
+			array[0] = getByG_E_PrevAndNext(
+				session, kbArticle, groupId, externalReferenceCode,
+				orderByComparator, true);
+
+			array[1] = kbArticle;
+
+			array[2] = getByG_E_PrevAndNext(
+				session, kbArticle, groupId, externalReferenceCode,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected KBArticle getByG_E_PrevAndNext(
+		Session session, KBArticle kbArticle, long groupId,
+		String externalReferenceCode,
+		OrderByComparator<KBArticle> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_KBARTICLE_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_E_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(KBArticleModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		if (bindExternalReferenceCode) {
+			queryPos.add(externalReferenceCode);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(kbArticle)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<KBArticle> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb articles that the user has permission to view
+	 */
+	@Override
+	public List<KBArticle> filterFindByG_E(
+		long groupId, String externalReferenceCode) {
+
+		return filterFindByG_E(
+			groupId, externalReferenceCode, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles that the user has permission to view
+	 */
+	@Override
+	public List<KBArticle> filterFindByG_E(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return filterFindByG_E(
+			groupId, externalReferenceCode, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles that the user has permission to view
+	 */
+	@Override
+	public List<KBArticle> filterFindByG_E(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_E(
+				groupId, externalReferenceCode, start, end, orderByComparator);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				4 + (orderByComparator.getOrderByFields().length * 2));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_WHERE);
+		}
+		else {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_G_E_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_2);
+		}
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator, true);
+			}
+			else {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_TABLE, orderByComparator, true);
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(KBArticleModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(KBArticleModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), KBArticle.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, KBArticleImpl.class);
+			}
+			else {
+				sqlQuery.addEntity(_FILTER_ENTITY_TABLE, KBArticleImpl.class);
+			}
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(groupId);
+
+			if (bindExternalReferenceCode) {
+				queryPos.add(externalReferenceCode);
+			}
+
+			return (List<KBArticle>)QueryUtil.list(
+				sqlQuery, getDialect(), start, end);
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	@Override
+	public KBArticle[] filterFindByG_E_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_E_PrevAndNext(
+				kbArticleId, groupId, externalReferenceCode, orderByComparator);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		KBArticle kbArticle = findByPrimaryKey(kbArticleId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			KBArticle[] array = new KBArticleImpl[3];
+
+			array[0] = filterGetByG_E_PrevAndNext(
+				session, kbArticle, groupId, externalReferenceCode,
+				orderByComparator, true);
+
+			array[1] = kbArticle;
+
+			array[2] = filterGetByG_E_PrevAndNext(
+				session, kbArticle, groupId, externalReferenceCode,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected KBArticle filterGetByG_E_PrevAndNext(
+		Session session, KBArticle kbArticle, long groupId,
+		String externalReferenceCode,
+		OrderByComparator<KBArticle> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_WHERE);
+		}
+		else {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_G_E_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_2);
+		}
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByConditionFields[i],
+							true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByConditionFields[i],
+							true));
+				}
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByFields[i], true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByFields[i], true));
+				}
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(KBArticleModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(KBArticleModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), KBArticle.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+		sqlQuery.setFirstResult(0);
+		sqlQuery.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, KBArticleImpl.class);
+		}
+		else {
+			sqlQuery.addEntity(_FILTER_ENTITY_TABLE, KBArticleImpl.class);
+		}
+
+		QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+		queryPos.add(groupId);
+
+		if (bindExternalReferenceCode) {
+			queryPos.add(externalReferenceCode);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(kbArticle)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<KBArticle> list = sqlQuery.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the kb articles where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 */
+	@Override
+	public void removeByG_E(long groupId, String externalReferenceCode) {
+		for (KBArticle kbArticle :
+				findByG_E(
+					groupId, externalReferenceCode, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(kbArticle);
+		}
+	}
+
+	/**
+	 * Returns the number of kb articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching kb articles
+	 */
+	@Override
+	public int countByG_E(long groupId, String externalReferenceCode) {
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		FinderPath finderPath = _finderPathCountByG_E;
+
+		Object[] finderArgs = new Object[] {groupId, externalReferenceCode};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(_SQL_COUNT_KBARTICLE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_E_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
+	 * Returns the number of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching kb articles that the user has permission to view
+	 */
+	@Override
+	public int filterCountByG_E(long groupId, String externalReferenceCode) {
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return countByG_E(groupId, externalReferenceCode);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(_FILTER_SQL_COUNT_KBARTICLE_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_E_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_2);
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), KBArticle.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addScalar(
+				COUNT_COLUMN_NAME, com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(groupId);
+
+			if (bindExternalReferenceCode) {
+				queryPos.add(externalReferenceCode);
+			}
+
+			Long count = (Long)sqlQuery.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	private static final String _FINDER_COLUMN_G_E_GROUPID_2 =
+		"kbArticle.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_2 =
+		"kbArticle.externalReferenceCode = ?";
+
+	private static final String _FINDER_COLUMN_G_E_EXTERNALREFERENCECODE_3 =
+		"(kbArticle.externalReferenceCode IS NULL OR kbArticle.externalReferenceCode = '')";
 
 	private FinderPath _finderPathWithPaginationFindByG_L;
 	private FinderPath _finderPathWithoutPaginationFindByG_L;
@@ -17275,6 +18299,303 @@ public class KBArticlePersistenceImpl
 
 	private static final String _FINDER_COLUMN_R_G_S_STATUS_2 =
 		"kbArticle.status = ?";
+
+	private FinderPath _finderPathFetchByG_E_V;
+	private FinderPath _finderPathCountByG_E_V;
+
+	/**
+	 * Returns the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or throws a <code>NoSuchArticleException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	@Override
+	public KBArticle findByG_E_V(
+			long groupId, String externalReferenceCode, int version)
+		throws NoSuchArticleException {
+
+		KBArticle kbArticle = fetchByG_E_V(
+			groupId, externalReferenceCode, version);
+
+		if (kbArticle == null) {
+			StringBundler sb = new StringBundler(8);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("groupId=");
+			sb.append(groupId);
+
+			sb.append(", externalReferenceCode=");
+			sb.append(externalReferenceCode);
+
+			sb.append(", version=");
+			sb.append(version);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchArticleException(sb.toString());
+		}
+
+		return kbArticle;
+	}
+
+	/**
+	 * Returns the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	@Override
+	public KBArticle fetchByG_E_V(
+		long groupId, String externalReferenceCode, int version) {
+
+		return fetchByG_E_V(groupId, externalReferenceCode, version, true);
+	}
+
+	/**
+	 * Returns the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	@Override
+	public KBArticle fetchByG_E_V(
+		long groupId, String externalReferenceCode, int version,
+		boolean useFinderCache) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		Object[] finderArgs = null;
+
+		if (useFinderCache) {
+			finderArgs = new Object[] {groupId, externalReferenceCode, version};
+		}
+
+		Object result = null;
+
+		if (useFinderCache) {
+			result = finderCache.getResult(_finderPathFetchByG_E_V, finderArgs);
+		}
+
+		if (result instanceof KBArticle) {
+			KBArticle kbArticle = (KBArticle)result;
+
+			if ((groupId != kbArticle.getGroupId()) ||
+				!Objects.equals(
+					externalReferenceCode,
+					kbArticle.getExternalReferenceCode()) ||
+				(version != kbArticle.getVersion())) {
+
+				result = null;
+			}
+		}
+
+		if (result == null) {
+			StringBundler sb = new StringBundler(5);
+
+			sb.append(_SQL_SELECT_KBARTICLE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_E_V_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_E_V_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_E_V_EXTERNALREFERENCECODE_2);
+			}
+
+			sb.append(_FINDER_COLUMN_G_E_V_VERSION_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				queryPos.add(version);
+
+				List<KBArticle> list = query.list();
+
+				if (list.isEmpty()) {
+					if (useFinderCache) {
+						finderCache.putResult(
+							_finderPathFetchByG_E_V, finderArgs, list);
+					}
+				}
+				else {
+					if (list.size() > 1) {
+						Collections.sort(list, Collections.reverseOrder());
+
+						if (_log.isWarnEnabled()) {
+							if (!useFinderCache) {
+								finderArgs = new Object[] {
+									groupId, externalReferenceCode, version
+								};
+							}
+
+							_log.warn(
+								"KBArticlePersistenceImpl.fetchByG_E_V(long, String, int, boolean) with parameters (" +
+									StringUtil.merge(finderArgs) +
+										") yields a result set with more than 1 result. This violates the logical unique restriction. There is no order guarantee on which result is returned by this finder.");
+						}
+					}
+
+					KBArticle kbArticle = list.get(0);
+
+					result = kbArticle;
+
+					cacheResult(kbArticle);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		if (result instanceof List<?>) {
+			return null;
+		}
+		else {
+			return (KBArticle)result;
+		}
+	}
+
+	/**
+	 * Removes the kb article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the kb article that was removed
+	 */
+	@Override
+	public KBArticle removeByG_E_V(
+			long groupId, String externalReferenceCode, int version)
+		throws NoSuchArticleException {
+
+		KBArticle kbArticle = findByG_E_V(
+			groupId, externalReferenceCode, version);
+
+		return remove(kbArticle);
+	}
+
+	/**
+	 * Returns the number of kb articles where groupId = &#63; and externalReferenceCode = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the number of matching kb articles
+	 */
+	@Override
+	public int countByG_E_V(
+		long groupId, String externalReferenceCode, int version) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		FinderPath finderPath = _finderPathCountByG_E_V;
+
+		Object[] finderArgs = new Object[] {
+			groupId, externalReferenceCode, version
+		};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_COUNT_KBARTICLE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_E_V_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_E_V_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_E_V_EXTERNALREFERENCECODE_2);
+			}
+
+			sb.append(_FINDER_COLUMN_G_E_V_VERSION_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				queryPos.add(version);
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_E_V_GROUPID_2 =
+		"kbArticle.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_E_V_EXTERNALREFERENCECODE_2 =
+		"kbArticle.externalReferenceCode = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_E_V_EXTERNALREFERENCECODE_3 =
+		"(kbArticle.externalReferenceCode IS NULL OR kbArticle.externalReferenceCode = '') AND ";
+
+	private static final String _FINDER_COLUMN_G_E_V_VERSION_2 =
+		"kbArticle.version = ?";
 
 	private FinderPath _finderPathWithPaginationFindByG_P_L;
 	private FinderPath _finderPathWithoutPaginationFindByG_P_L;
@@ -33446,6 +34767,14 @@ public class KBArticlePersistenceImpl
 				kbArticle.getVersion()
 			},
 			kbArticle);
+
+		finderCache.putResult(
+			_finderPathFetchByG_E_V,
+			new Object[] {
+				kbArticle.getGroupId(), kbArticle.getExternalReferenceCode(),
+				kbArticle.getVersion()
+			},
+			kbArticle);
 	}
 
 	/**
@@ -33533,6 +34862,16 @@ public class KBArticlePersistenceImpl
 		finderCache.putResult(_finderPathCountByR_G_V, args, Long.valueOf(1));
 		finderCache.putResult(
 			_finderPathFetchByR_G_V, args, kbArticleModelImpl);
+
+		args = new Object[] {
+			kbArticleModelImpl.getGroupId(),
+			kbArticleModelImpl.getExternalReferenceCode(),
+			kbArticleModelImpl.getVersion()
+		};
+
+		finderCache.putResult(_finderPathCountByG_E_V, args, Long.valueOf(1));
+		finderCache.putResult(
+			_finderPathFetchByG_E_V, args, kbArticleModelImpl);
 	}
 
 	/**
@@ -34192,6 +35531,25 @@ public class KBArticlePersistenceImpl
 			new String[] {Long.class.getName(), Integer.class.getName()},
 			new String[] {"resourcePrimKey", "status"}, false);
 
+		_finderPathWithPaginationFindByG_E = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_E",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode"}, true);
+
+		_finderPathWithoutPaginationFindByG_E = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_E",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, true);
+
+		_finderPathCountByG_E = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_E",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, false);
+
 		_finderPathWithPaginationFindByG_L = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_L",
 			new String[] {
@@ -34492,6 +35850,23 @@ public class KBArticlePersistenceImpl
 				Integer.class.getName()
 			},
 			new String[] {"resourcePrimKey", "groupId", "status"}, false);
+
+		_finderPathFetchByG_E_V = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_E_V",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode", "version"}, true);
+
+		_finderPathCountByG_E_V = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_E_V",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode", "version"},
+			false);
 
 		_finderPathWithPaginationFindByG_P_L = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_L",

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBFolderPersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBFolderPersistenceImpl.java
@@ -3462,6 +3462,272 @@ public class KBFolderPersistenceImpl
 	private static final String _FINDER_COLUMN_G_P_UT_URLTITLE_3 =
 		"(kbFolder.urlTitle IS NULL OR kbFolder.urlTitle = '')";
 
+	private FinderPath _finderPathFetchByG_ERC;
+	private FinderPath _finderPathCountByG_ERC;
+
+	/**
+	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb folder
+	 * @throws NoSuchFolderException if a matching kb folder could not be found
+	 */
+	@Override
+	public KBFolder findByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchFolderException {
+
+		KBFolder kbFolder = fetchByG_ERC(groupId, externalReferenceCode);
+
+		if (kbFolder == null) {
+			StringBundler sb = new StringBundler(6);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("groupId=");
+			sb.append(groupId);
+
+			sb.append(", externalReferenceCode=");
+			sb.append(externalReferenceCode);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchFolderException(sb.toString());
+		}
+
+		return kbFolder;
+	}
+
+	/**
+	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
+	 */
+	@Override
+	public KBFolder fetchByG_ERC(long groupId, String externalReferenceCode) {
+		return fetchByG_ERC(groupId, externalReferenceCode, true);
+	}
+
+	/**
+	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
+	 */
+	@Override
+	public KBFolder fetchByG_ERC(
+		long groupId, String externalReferenceCode, boolean useFinderCache) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		Object[] finderArgs = null;
+
+		if (useFinderCache) {
+			finderArgs = new Object[] {groupId, externalReferenceCode};
+		}
+
+		Object result = null;
+
+		if (useFinderCache) {
+			result = finderCache.getResult(_finderPathFetchByG_ERC, finderArgs);
+		}
+
+		if (result instanceof KBFolder) {
+			KBFolder kbFolder = (KBFolder)result;
+
+			if ((groupId != kbFolder.getGroupId()) ||
+				!Objects.equals(
+					externalReferenceCode,
+					kbFolder.getExternalReferenceCode())) {
+
+				result = null;
+			}
+		}
+
+		if (result == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_SELECT_KBFOLDER_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				List<KBFolder> list = query.list();
+
+				if (list.isEmpty()) {
+					if (useFinderCache) {
+						finderCache.putResult(
+							_finderPathFetchByG_ERC, finderArgs, list);
+					}
+				}
+				else {
+					if (list.size() > 1) {
+						Collections.sort(list, Collections.reverseOrder());
+
+						if (_log.isWarnEnabled()) {
+							if (!useFinderCache) {
+								finderArgs = new Object[] {
+									groupId, externalReferenceCode
+								};
+							}
+
+							_log.warn(
+								"KBFolderPersistenceImpl.fetchByG_ERC(long, String, boolean) with parameters (" +
+									StringUtil.merge(finderArgs) +
+										") yields a result set with more than 1 result. This violates the logical unique restriction. There is no order guarantee on which result is returned by this finder.");
+						}
+					}
+
+					KBFolder kbFolder = list.get(0);
+
+					result = kbFolder;
+
+					cacheResult(kbFolder);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		if (result instanceof List<?>) {
+			return null;
+		}
+		else {
+			return (KBFolder)result;
+		}
+	}
+
+	/**
+	 * Removes the kb folder where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the kb folder that was removed
+	 */
+	@Override
+	public KBFolder removeByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchFolderException {
+
+		KBFolder kbFolder = findByG_ERC(groupId, externalReferenceCode);
+
+		return remove(kbFolder);
+	}
+
+	/**
+	 * Returns the number of kb folders where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching kb folders
+	 */
+	@Override
+	public int countByG_ERC(long groupId, String externalReferenceCode) {
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		FinderPath finderPath = _finderPathCountByG_ERC;
+
+		Object[] finderArgs = new Object[] {groupId, externalReferenceCode};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(_SQL_COUNT_KBFOLDER_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
+		"kbFolder.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
+		"kbFolder.externalReferenceCode = ?";
+
+	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
+		"(kbFolder.externalReferenceCode IS NULL OR kbFolder.externalReferenceCode = '')";
+
 	public KBFolderPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -3504,6 +3770,13 @@ public class KBFolderPersistenceImpl
 			new Object[] {
 				kbFolder.getGroupId(), kbFolder.getParentKBFolderId(),
 				kbFolder.getUrlTitle()
+			},
+			kbFolder);
+
+		finderCache.putResult(
+			_finderPathFetchByG_ERC,
+			new Object[] {
+				kbFolder.getGroupId(), kbFolder.getExternalReferenceCode()
 			},
 			kbFolder);
 	}
@@ -3594,6 +3867,14 @@ public class KBFolderPersistenceImpl
 		finderCache.putResult(_finderPathCountByG_P_UT, args, Long.valueOf(1));
 		finderCache.putResult(
 			_finderPathFetchByG_P_UT, args, kbFolderModelImpl);
+
+		args = new Object[] {
+			kbFolderModelImpl.getGroupId(),
+			kbFolderModelImpl.getExternalReferenceCode()
+		};
+
+		finderCache.putResult(_finderPathCountByG_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathFetchByG_ERC, args, kbFolderModelImpl);
 	}
 
 	/**
@@ -4177,6 +4458,16 @@ public class KBFolderPersistenceImpl
 				String.class.getName()
 			},
 			new String[] {"groupId", "parentKBFolderId", "urlTitle"}, false);
+
+		_finderPathFetchByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, true);
+
+		_finderPathCountByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, false);
 	}
 
 	@Deactivate

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/module-hbm.xml
@@ -20,6 +20,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="createDate" type="org.hibernate.type.TimestampType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="modifiedDate" type="org.hibernate.type.TimestampType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="rootResourcePrimKey" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="parentResourceClassNameId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="parentResourcePrimKey" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="kbFolderId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
@@ -64,6 +65,7 @@
 		</id>
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivatePropertyAccessor" name="mvccVersion" type="long" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -13,6 +13,7 @@
 		<field name="createDate" type="Date" />
 		<field name="modifiedDate" type="Date" />
 		<field name="rootResourcePrimKey" type="long" />
+		<field name="externalReferenceCode" type="String" />
 		<field name="parentResourceClassNameId" type="long" />
 		<field name="parentResourcePrimKey" type="long" />
 		<field name="kbFolderId" type="long" />
@@ -65,6 +66,7 @@
 	<model name="com.liferay.knowledge.base.model.KBFolder">
 		<field name="mvccVersion" type="long" />
 		<field name="uuid" type="String" />
+		<field name="externalReferenceCode" type="String" />
 		<field name="kbFolderId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,6 +1,7 @@
 create index IX_571C019E on KBArticle (companyId, latest);
 create index IX_5A381890 on KBArticle (companyId, main);
 create index IX_FBC2D349 on KBArticle (companyId, status);
+create index IX_A358F410 on KBArticle (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], version);
 create index IX_2B11F674 on KBArticle (groupId, kbFolderId, latest);
 create index IX_CFB8C81F on KBArticle (groupId, kbFolderId, status);
 create index IX_379FD6BC on KBArticle (groupId, kbFolderId, urlTitle[$COLUMN_LENGTH:75$], status);
@@ -31,6 +32,7 @@ create index IX_6CB72942 on KBComment (uuid_[$COLUMN_LENGTH:75$], companyId);
 create unique index IX_791D1844 on KBComment (uuid_[$COLUMN_LENGTH:75$], groupId);
 
 create index IX_F32A081D on KBFolder (companyId);
+create index IX_1638507E on KBFolder (groupId, externalReferenceCode[$COLUMN_LENGTH:75$]);
 create index IX_3FA4415C on KBFolder (groupId, parentKBFolderId, name[$COLUMN_LENGTH:75$]);
 create index IX_729A89FA on KBFolder (groupId, parentKBFolderId, urlTitle[$COLUMN_LENGTH:75$]);
 create index IX_32D1105F on KBFolder (uuid_[$COLUMN_LENGTH:75$], companyId);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/sql/tables.sql
@@ -10,6 +10,7 @@ create table KBArticle (
 	createDate DATE null,
 	modifiedDate DATE null,
 	rootResourcePrimKey LONG,
+	externalReferenceCode VARCHAR(75) null,
 	parentResourceClassNameId LONG,
 	parentResourcePrimKey LONG,
 	kbFolderId LONG,
@@ -51,6 +52,7 @@ create table KBComment (
 create table KBFolder (
 	mvccVersion LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
+	externalReferenceCode VARCHAR(75) null,
 	kbFolderId LONG not null primary key,
 	groupId LONG,
 	companyId LONG,

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/exportimport/data/handler/test/KBArticleStagedModelDataHandlerTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/exportimport/data/handler/test/KBArticleStagedModelDataHandlerTest.java
@@ -102,6 +102,10 @@ public class KBArticleStagedModelDataHandlerTest
 			kbArticle.getUuid(), liveGroup);
 
 		Assert.assertEquals(
+			kbArticle.getExternalReferenceCode(),
+			importedKBArticle.getExternalReferenceCode());
+
+		Assert.assertEquals(
 			ClassNameLocalServiceUtil.getClassNameId(
 				KBFolderConstants.getClassName()),
 			importedKBArticle.getParentResourceClassNameId());

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
@@ -145,6 +145,8 @@ public class KBArticlePersistenceTest {
 
 		newKBArticle.setRootResourcePrimKey(RandomTestUtil.nextLong());
 
+		newKBArticle.setExternalReferenceCode(RandomTestUtil.randomString());
+
 		newKBArticle.setParentResourceClassNameId(RandomTestUtil.nextLong());
 
 		newKBArticle.setParentResourcePrimKey(RandomTestUtil.nextLong());
@@ -212,6 +214,9 @@ public class KBArticlePersistenceTest {
 		Assert.assertEquals(
 			existingKBArticle.getRootResourcePrimKey(),
 			newKBArticle.getRootResourcePrimKey());
+		Assert.assertEquals(
+			existingKBArticle.getExternalReferenceCode(),
+			newKBArticle.getExternalReferenceCode());
 		Assert.assertEquals(
 			existingKBArticle.getParentResourceClassNameId(),
 			newKBArticle.getParentResourceClassNameId());
@@ -348,6 +353,15 @@ public class KBArticlePersistenceTest {
 		_persistence.countByR_S(
 			new long[] {RandomTestUtil.nextLong(), 0L},
 			RandomTestUtil.nextInt());
+	}
+
+	@Test
+	public void testCountByG_E() throws Exception {
+		_persistence.countByG_E(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByG_E(0L, "null");
+
+		_persistence.countByG_E(0L, (String)null);
 	}
 
 	@Test
@@ -498,6 +512,16 @@ public class KBArticlePersistenceTest {
 		_persistence.countByR_G_S(
 			new long[] {RandomTestUtil.nextLong(), 0L},
 			RandomTestUtil.nextLong(), RandomTestUtil.nextInt());
+	}
+
+	@Test
+	public void testCountByG_E_V() throws Exception {
+		_persistence.countByG_E_V(
+			RandomTestUtil.nextLong(), "", RandomTestUtil.nextInt());
+
+		_persistence.countByG_E_V(0L, "null", 0);
+
+		_persistence.countByG_E_V(0L, (String)null, 0);
 	}
 
 	@Test
@@ -706,12 +730,12 @@ public class KBArticlePersistenceTest {
 			"resourcePrimKey", true, "groupId", true, "companyId", true,
 			"userId", true, "userName", true, "createDate", true,
 			"modifiedDate", true, "rootResourcePrimKey", true,
-			"parentResourceClassNameId", true, "parentResourcePrimKey", true,
-			"kbFolderId", true, "version", true, "title", true, "urlTitle",
-			true, "description", true, "priority", true, "sections", true,
-			"latest", true, "main", true, "sourceURL", true, "lastPublishDate",
-			true, "status", true, "statusByUserId", true, "statusByUserName",
-			true, "statusDate", true);
+			"externalReferenceCode", true, "parentResourceClassNameId", true,
+			"parentResourcePrimKey", true, "kbFolderId", true, "version", true,
+			"title", true, "urlTitle", true, "description", true, "priority",
+			true, "sections", true, "latest", true, "main", true, "sourceURL",
+			true, "lastPublishDate", true, "status", true, "statusByUserId",
+			true, "statusByUserName", true, "statusDate", true);
 	}
 
 	@Test
@@ -1011,6 +1035,22 @@ public class KBArticlePersistenceTest {
 			ReflectionTestUtil.<Integer>invoke(
 				kbArticle, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "version"));
+
+		Assert.assertEquals(
+			Long.valueOf(kbArticle.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				kbArticle, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
+		Assert.assertEquals(
+			kbArticle.getExternalReferenceCode(),
+			ReflectionTestUtil.invoke(
+				kbArticle, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Integer.valueOf(kbArticle.getVersion()),
+			ReflectionTestUtil.<Integer>invoke(
+				kbArticle, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "version"));
 	}
 
 	protected KBArticle addKBArticle() throws Exception {
@@ -1037,6 +1077,8 @@ public class KBArticlePersistenceTest {
 		kbArticle.setModifiedDate(RandomTestUtil.nextDate());
 
 		kbArticle.setRootResourcePrimKey(RandomTestUtil.nextLong());
+
+		kbArticle.setExternalReferenceCode(RandomTestUtil.randomString());
 
 		kbArticle.setParentResourceClassNameId(RandomTestUtil.nextLong());
 

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBFolderPersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBFolderPersistenceTest.java
@@ -128,6 +128,8 @@ public class KBFolderPersistenceTest {
 
 		newKBFolder.setUuid(RandomTestUtil.randomString());
 
+		newKBFolder.setExternalReferenceCode(RandomTestUtil.randomString());
+
 		newKBFolder.setGroupId(RandomTestUtil.nextLong());
 
 		newKBFolder.setCompanyId(RandomTestUtil.nextLong());
@@ -158,6 +160,9 @@ public class KBFolderPersistenceTest {
 		Assert.assertEquals(
 			existingKBFolder.getMvccVersion(), newKBFolder.getMvccVersion());
 		Assert.assertEquals(existingKBFolder.getUuid(), newKBFolder.getUuid());
+		Assert.assertEquals(
+			existingKBFolder.getExternalReferenceCode(),
+			newKBFolder.getExternalReferenceCode());
 		Assert.assertEquals(
 			existingKBFolder.getKbFolderId(), newKBFolder.getKbFolderId());
 		Assert.assertEquals(
@@ -250,6 +255,15 @@ public class KBFolderPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_ERC() throws Exception {
+		_persistence.countByG_ERC(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByG_ERC(0L, "null");
+
+		_persistence.countByG_ERC(0L, (String)null);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		KBFolder newKBFolder = addKBFolder();
 
@@ -274,11 +288,11 @@ public class KBFolderPersistenceTest {
 
 	protected OrderByComparator<KBFolder> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
-			"KBFolder", "mvccVersion", true, "uuid", true, "kbFolderId", true,
-			"groupId", true, "companyId", true, "userId", true, "userName",
-			true, "createDate", true, "modifiedDate", true, "parentKBFolderId",
-			true, "name", true, "urlTitle", true, "description", true,
-			"lastPublishDate", true);
+			"KBFolder", "mvccVersion", true, "uuid", true,
+			"externalReferenceCode", true, "kbFolderId", true, "groupId", true,
+			"companyId", true, "userId", true, "userName", true, "createDate",
+			true, "modifiedDate", true, "parentKBFolderId", true, "name", true,
+			"urlTitle", true, "description", true, "lastPublishDate", true);
 	}
 
 	@Test
@@ -580,6 +594,17 @@ public class KBFolderPersistenceTest {
 			ReflectionTestUtil.invoke(
 				kbFolder, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "urlTitle"));
+
+		Assert.assertEquals(
+			Long.valueOf(kbFolder.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				kbFolder, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
+		Assert.assertEquals(
+			kbFolder.getExternalReferenceCode(),
+			ReflectionTestUtil.invoke(
+				kbFolder, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "externalReferenceCode"));
 	}
 
 	protected KBFolder addKBFolder() throws Exception {
@@ -590,6 +615,8 @@ public class KBFolderPersistenceTest {
 		kbFolder.setMvccVersion(RandomTestUtil.nextLong());
 
 		kbFolder.setUuid(RandomTestUtil.randomString());
+
+		kbFolder.setExternalReferenceCode(RandomTestUtil.randomString());
 
 		kbFolder.setGroupId(RandomTestUtil.nextLong());
 

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -18,6 +18,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.knowledge.base.constants.KBArticleConstants;
 import com.liferay.knowledge.base.constants.KBFolderConstants;
+import com.liferay.knowledge.base.exception.DuplicateKBArticleExternalReferenceCodeException;
 import com.liferay.knowledge.base.exception.KBArticleContentException;
 import com.liferay.knowledge.base.exception.KBArticleParentException;
 import com.liferay.knowledge.base.exception.KBArticleSourceURLException;
@@ -315,6 +316,40 @@ public class KBArticleLocalServiceTest {
 			StringUtil.randomString(), null, null, null, _serviceContext);
 	}
 
+	@Test(expected = DuplicateKBArticleExternalReferenceCodeException.class)
+	public void testAddKBArticleWithExistingExternalReferenceCode()
+		throws Exception {
+
+		KBArticle kbArticle = KBArticleLocalServiceUtil.addKBArticle(
+			RandomTestUtil.randomString(), _user.getUserId(),
+			_kbFolderClassNameId, KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringPool.BLANK, null, null, _serviceContext);
+
+		KBArticleLocalServiceUtil.addKBArticle(
+			kbArticle.getExternalReferenceCode(), _user.getUserId(),
+			_kbFolderClassNameId, KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringPool.BLANK, null, null, _serviceContext);
+	}
+
+	@Test
+	public void testAddKBArticleWithExternalReferenceCode() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		KBArticle kbArticle = KBArticleLocalServiceUtil.addKBArticle(
+			externalReferenceCode, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringPool.BLANK, null, null, _serviceContext);
+
+		Assert.assertEquals(
+			externalReferenceCode, kbArticle.getExternalReferenceCode());
+	}
+
 	@Test(expected = KBArticleParentException.class)
 	public void testAddKBArticleWithInvalidParentClassNameId()
 		throws Exception {
@@ -416,6 +451,22 @@ public class KBArticleLocalServiceTest {
 			StringUtil.randomString(), null, null, null, _serviceContext);
 
 		Assert.assertTrue(Validator.isNotNull(kbArticle.getUrlTitle()));
+	}
+
+	@Test
+	public void testAddKBArticleWithoutExternalReferenceCode()
+		throws Exception {
+
+		KBArticle kbArticle = KBArticleLocalServiceUtil.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringPool.BLANK, null, null, _serviceContext);
+
+		Assert.assertEquals(
+			kbArticle.getExternalReferenceCode(),
+			String.valueOf(kbArticle.getKbArticleId()));
 	}
 
 	@Test

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBFolderLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBFolderLocalServiceTest.java
@@ -17,6 +17,7 @@ package com.liferay.knowledge.base.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.knowledge.base.constants.KBArticleConstants;
 import com.liferay.knowledge.base.constants.KBFolderConstants;
+import com.liferay.knowledge.base.exception.DuplicateKBFolderExternalReferenceCodeException;
 import com.liferay.knowledge.base.exception.InvalidKBFolderNameException;
 import com.liferay.knowledge.base.exception.KBFolderParentException;
 import com.liferay.knowledge.base.exception.NoSuchFolderException;
@@ -72,6 +73,54 @@ public class KBFolderLocalServiceTest {
 		_user = TestPropsValues.getUser();
 
 		_kbFolder = addKBFolder(KBFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+	}
+
+	@Test(expected = DuplicateKBFolderExternalReferenceCodeException.class)
+	public void testAddKBFolderWithExistingExternalReferenceCode()
+		throws Exception {
+
+		KBFolder kbFolder = addKBFolder(
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		KBFolderLocalServiceUtil.addKBFolder(
+			kbFolder.getExternalReferenceCode(), _user.getUserId(),
+			_group.getGroupId(),
+			PortalUtil.getClassNameId(KBFolderConstants.getClassName()),
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				_group, _user.getUserId()));
+	}
+
+	@Test
+	public void testAddKBFolderWithExternalReferenceCode() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		KBFolder kbFolder = KBFolderLocalServiceUtil.addKBFolder(
+			externalReferenceCode, _user.getUserId(), _group.getGroupId(),
+			PortalUtil.getClassNameId(KBFolderConstants.getClassName()),
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				_group, _user.getUserId()));
+
+		Assert.assertEquals(
+			externalReferenceCode, kbFolder.getExternalReferenceCode());
+	}
+
+	@Test
+	public void testAddKBFolderWithoutExternalReferenceCode() throws Exception {
+		KBFolder kbFolder = KBFolderLocalServiceUtil.addKBFolder(
+			null, _user.getUserId(), _group.getGroupId(),
+			PortalUtil.getClassNameId(KBFolderConstants.getClassName()),
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				_group, _user.getUserId()));
+
+		Assert.assertEquals(
+			kbFolder.getExternalReferenceCode(),
+			String.valueOf(kbFolder.getKbFolderId()));
 	}
 
 	@Test


### PR DESCRIPTION
This pull is the first part of the feature described in [this ticket](https://issues.liferay.com/browse/LPS-124112)
The external reference code (also called ERC) is a unique id to identify a specific resource. It could be scoped by group or by company.

In the PR, it added support for external reference code in KBArticle and KBFolder services to be able to add KBArticles and KBFolders with a specific external reference code. In case that the user does not provide the ERC, it will be assigned by default the id of the resource.

We see that exists a problem with the external reference code when a resource support versioning. In this case, the resource is KBArticle. Every time that we create a new version of a KBArticle a new file is created in the DB with a new kbArticleId. Because the ERC is a representation of a resource scoped by group, the ERC should be the same for all versions of a resource.

To avoid the problem described above, we've created the ERC for KBArticle in the DB manually and add the filters to search the resource by groupId and ERC and by groupId, ERC, and version.

The next pull will be the addition of endpoints in the headless APIs to do upsert for Knowledge Base using ERC
