### PR TITLE
LPS-124114 Fix order in tests parameters

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiNodeResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiNodeResourceTest.java
@@ -59,15 +59,15 @@ public class WikiNodeResourceTest extends BaseWikiNodeResourceTestCase {
 
 		com.liferay.headless.delivery.client.dto.v1_0.WikiNode putWikiNode =
 			wikiNodeResource.putSiteWikiNodeByExternalReferenceCode(
-				randomWikiNode.getExternalReferenceCode(),
-				testGroup.getGroupId(), randomWikiNode);
+				testGroup.getGroupId(),
+				randomWikiNode.getExternalReferenceCode(), randomWikiNode);
 
 		assertEquals(randomWikiNode, putWikiNode);
 		assertValid(putWikiNode);
 
 		com.liferay.headless.delivery.client.dto.v1_0.WikiNode getWikiPage =
 			wikiNodeResource.getSiteWikiNodeByExternalReferenceCode(
-				putWikiNode.getExternalReferenceCode(), testGroup.getGroupId());
+				testGroup.getGroupId(), putWikiNode.getExternalReferenceCode());
 
 		assertEquals(randomWikiNode, getWikiPage);
 		assertValid(getWikiPage);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageResourceTest.java
@@ -74,15 +74,15 @@ public class WikiPageResourceTest extends BaseWikiPageResourceTestCase {
 
 		WikiPage putWikiPage =
 			wikiPageResource.putSiteWikiPageByExternalReferenceCode(
-				randomWikiPage.getExternalReferenceCode(),
-				testGroup.getGroupId(), randomWikiPage);
+				testGroup.getGroupId(),
+				randomWikiPage.getExternalReferenceCode(), randomWikiPage);
 
 		assertEquals(randomWikiPage, putWikiPage);
 		assertValid(putWikiPage);
 
 		WikiPage getWikiPage =
 			wikiPageResource.getSiteWikiPageByExternalReferenceCode(
-				putWikiPage.getExternalReferenceCode(), testGroup.getGroupId());
+				testGroup.getGroupId(), putWikiPage.getExternalReferenceCode());
 
 		assertEquals(randomWikiPage, getWikiPage);
 		assertValid(getWikiPage);
@@ -107,8 +107,9 @@ public class WikiPageResourceTest extends BaseWikiPageResourceTestCase {
 				400,
 				wikiPageResource.
 					putSiteWikiPageByExternalReferenceCodeHttpResponse(
+						testGroup.getGroupId(),
 						randomWikiPage.getExternalReferenceCode(),
-						testGroup.getGroupId(), randomWikiPage));
+						randomWikiPage));
 		}
 	}
 


### PR DESCRIPTION
 Exists a new rule in the SF that orders the parameters of an endpoint in the order that appears on the endpoint. Applying the changes of the rule in [this PR](https://github.com/brianchandotcom/liferay-portal/pull/102009) the endpoints of the ERC for Wiki [was reorder in the `rest-openapi.yaml`](https://github.com/brianchandotcom/liferay-portal/pull/102009/commits/8905659906b6bff9fd23515acc692541c6d9ea90) and [in the implementation](https://github.com/brianchandotcom/liferay-portal/pull/102009/commits/84b2acace95fd4c64fda7761dcc2bcfb3bc41d26). But, the tests were not ordered and now fails. 
This PR is to fix the tests order.