### PR TITLE
LPS-124114 Fix problems with uniqueness of the external reference code

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/WikiPageDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/WikiPageDTOConverter.java
@@ -95,7 +95,7 @@ public class WikiPageDTOConverter
 				encodingFormat = _getEncodingFormat(wikiPage);
 				externalReferenceCode = wikiPage.getExternalReferenceCode();
 				headline = wikiPage.getTitle();
-				id = wikiPage.getPageId();
+				id = wikiPage.getResourcePrimKey();
 				keywords = ListUtil.toArray(
 					_assetTagLocalService.getTags(
 						BlogsEntry.class.getName(), wikiPage.getPageId()),
@@ -146,7 +146,7 @@ public class WikiPageDTOConverter
 							return null;
 						}
 
-						return parentWikiPage.getPageId();
+						return parentWikiPage.getResourcePrimKey();
 					});
 				wikiNodeId = wikiPage.getNodeId();
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiNodeResourceImpl.java
@@ -37,7 +37,6 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.wiki.constants.WikiConstants;
-import com.liferay.wiki.exception.NoSuchNodeException;
 import com.liferay.wiki.service.WikiNodeLocalService;
 import com.liferay.wiki.service.WikiNodeService;
 
@@ -63,7 +62,8 @@ public class WikiNodeResourceImpl
 		throws Exception {
 
 		com.liferay.wiki.model.WikiNode wikiNode =
-			_getWikiNodeByExternalReferenceCode(siteId, externalReferenceCode);
+			_wikiNodeLocalService.getWikiNodeByExternalReferenceCode(
+				siteId, externalReferenceCode);
 
 		_wikiNodeService.deleteNode(wikiNode.getNodeId());
 	}
@@ -83,10 +83,9 @@ public class WikiNodeResourceImpl
 			Long siteId, String externalReferenceCode)
 		throws Exception {
 
-		com.liferay.wiki.model.WikiNode wikiNode =
-			_getWikiNodeByExternalReferenceCode(siteId, externalReferenceCode);
-
-		return _toWikiNode(wikiNode);
+		return _toWikiNode(
+			_wikiNodeLocalService.getWikiNodeByExternalReferenceCode(
+				siteId, externalReferenceCode));
 	}
 
 	@Override
@@ -197,23 +196,6 @@ public class WikiNodeResourceImpl
 	@Override
 	protected String getPermissionCheckerResourceName(Object id) {
 		return com.liferay.wiki.model.WikiNode.class.getName();
-	}
-
-	private com.liferay.wiki.model.WikiNode _getWikiNodeByExternalReferenceCode(
-			long siteId, String externalReferenceCode)
-		throws Exception {
-
-		com.liferay.wiki.model.WikiNode wikiNode =
-			_wikiNodeLocalService.fetchWikiNodeByExternalReferenceCode(
-				siteId, externalReferenceCode);
-
-		if (wikiNode == null) {
-			throw new NoSuchNodeException(
-				"No wiki node exists with external reference code " +
-					externalReferenceCode);
-		}
-
-		return wikiNode;
 	}
 
 	private WikiNode _toWikiNode(com.liferay.wiki.model.WikiNode wikiNode)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiNodeResourceImpl.java
@@ -209,7 +209,7 @@ public class WikiNodeResourceImpl
 
 		if (wikiNode == null) {
 			throw new NoSuchNodeException(
-				"No wiki node exists with external reference code" +
+				"No wiki node exists with external reference code " +
 					externalReferenceCode);
 		}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
@@ -270,7 +270,7 @@ public class WikiPageResourceImpl
 		throws Exception {
 
 		com.liferay.wiki.model.WikiPage serviceBuilderWikiPage =
-			_wikiPageLocalService.fetchWikiPageByExternalReferenceCode(
+			_wikiPageLocalService.fetchLatestPageByExternalReferenceCode(
 				siteId, externalReferenceCode);
 
 		if (serviceBuilderWikiPage != null) {
@@ -366,7 +366,7 @@ public class WikiPageResourceImpl
 		throws Exception {
 
 		com.liferay.wiki.model.WikiPage wikiPage =
-			_wikiPageLocalService.fetchWikiPageByExternalReferenceCode(
+			_wikiPageLocalService.fetchLatestPageByExternalReferenceCode(
 				siteId, externalReferenceCode);
 
 		if (wikiPage == null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
@@ -55,7 +55,6 @@ import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.wiki.constants.WikiConstants;
 import com.liferay.wiki.constants.WikiPageConstants;
-import com.liferay.wiki.exception.NoSuchPageException;
 import com.liferay.wiki.model.WikiNode;
 import com.liferay.wiki.service.WikiNodeService;
 import com.liferay.wiki.service.WikiPageLocalService;
@@ -88,7 +87,8 @@ public class WikiPageResourceImpl
 		throws Exception {
 
 		com.liferay.wiki.model.WikiPage wikiPage =
-			_getWikiPageByExternalReferenceCode(siteId, externalReferenceCode);
+			_wikiPageService.getLatestPageByExternalReferenceCode(
+				siteId, externalReferenceCode);
 
 		_wikiPageService.deletePage(wikiPage.getNodeId(), wikiPage.getTitle());
 	}
@@ -117,7 +117,8 @@ public class WikiPageResourceImpl
 		throws Exception {
 
 		return _toWikiPage(
-			_getWikiPageByExternalReferenceCode(siteId, externalReferenceCode));
+			_wikiPageService.getLatestPageByExternalReferenceCode(
+				siteId, externalReferenceCode));
 	}
 
 	@Override
@@ -359,23 +360,6 @@ public class WikiPageResourceImpl
 			com.liferay.wiki.model.WikiPage.class.getName(),
 			contextCompany.getCompanyId(), wikiPage.getCustomFields(),
 			contextAcceptLanguage.getPreferredLocale());
-	}
-
-	private com.liferay.wiki.model.WikiPage _getWikiPageByExternalReferenceCode(
-			long siteId, String externalReferenceCode)
-		throws Exception {
-
-		com.liferay.wiki.model.WikiPage wikiPage =
-			_wikiPageLocalService.fetchLatestPageByExternalReferenceCode(
-				siteId, externalReferenceCode);
-
-		if (wikiPage == null) {
-			throw new NoSuchPageException(
-				"No wiki page exists with external reference code " +
-					externalReferenceCode);
-		}
-
-		return wikiPage;
 	}
 
 	private WikiPage _toWikiPage(com.liferay.wiki.model.WikiPage wikiPage)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
@@ -96,7 +96,7 @@ public class WikiPageResourceImpl
 	@Override
 	public void deleteWikiPage(Long wikiPageId) throws Exception {
 		com.liferay.wiki.model.WikiPage wikiPage =
-			_wikiPageLocalService.getPageByPageId(wikiPageId);
+			_wikiPageLocalService.getPage(wikiPageId);
 
 		_wikiPageService.deletePage(wikiPage.getNodeId(), wikiPage.getTitle());
 	}
@@ -172,7 +172,7 @@ public class WikiPageResourceImpl
 	@Override
 	public WikiPage getWikiPage(Long wikiPageId) throws Exception {
 		com.liferay.wiki.model.WikiPage wikiPage =
-			_wikiPageLocalService.getPageByPageId(wikiPageId);
+			_wikiPageLocalService.getPage(wikiPageId);
 
 		_wikiPageModelResourcePermission.check(
 			PermissionThreadLocal.getPermissionChecker(), wikiPage,
@@ -186,7 +186,7 @@ public class WikiPageResourceImpl
 		throws Exception {
 
 		com.liferay.wiki.model.WikiPage wikiPage =
-			_wikiPageLocalService.getPageByPageId(parentWikiPageId);
+			_wikiPageLocalService.getPage(parentWikiPageId);
 
 		_wikiPageModelResourcePermission.check(
 			PermissionThreadLocal.getPermissionChecker(), wikiPage,
@@ -240,7 +240,7 @@ public class WikiPageResourceImpl
 		throws Exception {
 
 		com.liferay.wiki.model.WikiPage parentWikiPage =
-			_wikiPageLocalService.getPageByPageId(parentWikiPageId);
+			_wikiPageLocalService.getPage(parentWikiPageId);
 
 		_wikiNodeModelResourcePermission.check(
 			PermissionThreadLocal.getPermissionChecker(),
@@ -299,7 +299,7 @@ public class WikiPageResourceImpl
 		throws Exception {
 
 		com.liferay.wiki.model.WikiPage serviceBuilderWikiPage =
-			_wikiPageLocalService.getPageByPageId(wikiPageId);
+			_wikiPageLocalService.getPage(wikiPageId);
 
 		_wikiPageModelResourcePermission.check(
 			PermissionThreadLocal.getPermissionChecker(),
@@ -311,7 +311,7 @@ public class WikiPageResourceImpl
 	@Override
 	public void putWikiPageSubscribe(Long wikiPageId) throws Exception {
 		com.liferay.wiki.model.WikiPage wikiPage =
-			_wikiPageLocalService.getPageByPageId(wikiPageId);
+			_wikiPageLocalService.getPage(wikiPageId);
 
 		_wikiPageService.subscribePage(
 			wikiPage.getNodeId(), wikiPage.getTitle());
@@ -320,7 +320,7 @@ public class WikiPageResourceImpl
 	@Override
 	public void putWikiPageUnsubscribe(Long wikiPageId) throws Exception {
 		com.liferay.wiki.model.WikiPage wikiPage =
-			_wikiPageLocalService.getPageByPageId(wikiPageId);
+			_wikiPageLocalService.getPage(wikiPageId);
 
 		_wikiPageService.unsubscribePage(
 			wikiPage.getNodeId(), wikiPage.getTitle());
@@ -329,7 +329,7 @@ public class WikiPageResourceImpl
 	@Override
 	protected Long getPermissionCheckerGroupId(Object id) throws Exception {
 		com.liferay.wiki.model.WikiPage wikiPage =
-			_wikiPageLocalService.getPageByPageId((Long)id);
+			_wikiPageLocalService.getPage((Long)id);
 
 		return wikiPage.getGroupId();
 	}
@@ -342,7 +342,7 @@ public class WikiPageResourceImpl
 	@Override
 	protected Long getPermissionCheckerResourceId(Object id) throws Exception {
 		com.liferay.wiki.model.WikiPage wikiPage =
-			_wikiPageLocalService.getPageByPageId((Long)id);
+			_wikiPageLocalService.getPage((Long)id);
 
 		return wikiPage.getResourcePrimKey();
 	}

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageModel.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageModel.java
@@ -99,21 +99,6 @@ public interface WikiPageModel
 	public void setUuid(String uuid);
 
 	/**
-	 * Returns the external reference code of this wiki page.
-	 *
-	 * @return the external reference code of this wiki page
-	 */
-	@AutoEscape
-	public String getExternalReferenceCode();
-
-	/**
-	 * Sets the external reference code of this wiki page.
-	 *
-	 * @param externalReferenceCode the external reference code of this wiki page
-	 */
-	public void setExternalReferenceCode(String externalReferenceCode);
-
-	/**
 	 * Returns the page ID of this wiki page.
 	 *
 	 * @return the page ID of this wiki page
@@ -258,6 +243,21 @@ public interface WikiPageModel
 	 */
 	@Override
 	public void setModifiedDate(Date modifiedDate);
+
+	/**
+	 * Returns the external reference code of this wiki page.
+	 *
+	 * @return the external reference code of this wiki page
+	 */
+	@AutoEscape
+	public String getExternalReferenceCode();
+
+	/**
+	 * Sets the external reference code of this wiki page.
+	 *
+	 * @param externalReferenceCode the external reference code of this wiki page
+	 */
+	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**
 	 * Returns the node ID of this wiki page.

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageSoap.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageSoap.java
@@ -35,7 +35,6 @@ public class WikiPageSoap implements Serializable {
 
 		soapModel.setMvccVersion(model.getMvccVersion());
 		soapModel.setUuid(model.getUuid());
-		soapModel.setExternalReferenceCode(model.getExternalReferenceCode());
 		soapModel.setPageId(model.getPageId());
 		soapModel.setResourcePrimKey(model.getResourcePrimKey());
 		soapModel.setGroupId(model.getGroupId());
@@ -44,6 +43,7 @@ public class WikiPageSoap implements Serializable {
 		soapModel.setUserName(model.getUserName());
 		soapModel.setCreateDate(model.getCreateDate());
 		soapModel.setModifiedDate(model.getModifiedDate());
+		soapModel.setExternalReferenceCode(model.getExternalReferenceCode());
 		soapModel.setNodeId(model.getNodeId());
 		soapModel.setTitle(model.getTitle());
 		soapModel.setVersion(model.getVersion());
@@ -128,14 +128,6 @@ public class WikiPageSoap implements Serializable {
 		_uuid = uuid;
 	}
 
-	public String getExternalReferenceCode() {
-		return _externalReferenceCode;
-	}
-
-	public void setExternalReferenceCode(String externalReferenceCode) {
-		_externalReferenceCode = externalReferenceCode;
-	}
-
 	public long getPageId() {
 		return _pageId;
 	}
@@ -198,6 +190,14 @@ public class WikiPageSoap implements Serializable {
 
 	public void setModifiedDate(Date modifiedDate) {
 		_modifiedDate = modifiedDate;
+	}
+
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		_externalReferenceCode = externalReferenceCode;
 	}
 
 	public long getNodeId() {
@@ -330,7 +330,6 @@ public class WikiPageSoap implements Serializable {
 
 	private long _mvccVersion;
 	private String _uuid;
-	private String _externalReferenceCode;
 	private long _pageId;
 	private long _resourcePrimKey;
 	private long _groupId;
@@ -339,6 +338,7 @@ public class WikiPageSoap implements Serializable {
 	private String _userName;
 	private Date _createDate;
 	private Date _modifiedDate;
+	private String _externalReferenceCode;
 	private long _nodeId;
 	private String _title;
 	private double _version;

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageTable.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageTable.java
@@ -37,10 +37,6 @@ public class WikiPageTable extends BaseTable<WikiPageTable> {
 		"mvccVersion", Long.class, Types.BIGINT, Column.FLAG_NULLITY);
 	public final Column<WikiPageTable, String> uuid = createColumn(
 		"uuid_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
-	public final Column<WikiPageTable, String> externalReferenceCode =
-		createColumn(
-			"externalReferenceCode", String.class, Types.VARCHAR,
-			Column.FLAG_DEFAULT);
 	public final Column<WikiPageTable, Long> pageId = createColumn(
 		"pageId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<WikiPageTable, Long> resourcePrimKey = createColumn(
@@ -57,6 +53,10 @@ public class WikiPageTable extends BaseTable<WikiPageTable> {
 		"createDate", Date.class, Types.TIMESTAMP, Column.FLAG_DEFAULT);
 	public final Column<WikiPageTable, Date> modifiedDate = createColumn(
 		"modifiedDate", Date.class, Types.TIMESTAMP, Column.FLAG_DEFAULT);
+	public final Column<WikiPageTable, String> externalReferenceCode =
+		createColumn(
+			"externalReferenceCode", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<WikiPageTable, Long> nodeId = createColumn(
 		"nodeId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<WikiPageTable, String> title = createColumn(

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageWrapper.java
@@ -45,7 +45,6 @@ public class WikiPageWrapper
 
 		attributes.put("mvccVersion", getMvccVersion());
 		attributes.put("uuid", getUuid());
-		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put("pageId", getPageId());
 		attributes.put("resourcePrimKey", getResourcePrimKey());
 		attributes.put("groupId", getGroupId());
@@ -54,6 +53,7 @@ public class WikiPageWrapper
 		attributes.put("userName", getUserName());
 		attributes.put("createDate", getCreateDate());
 		attributes.put("modifiedDate", getModifiedDate());
+		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put("nodeId", getNodeId());
 		attributes.put("title", getTitle());
 		attributes.put("version", getVersion());
@@ -85,13 +85,6 @@ public class WikiPageWrapper
 
 		if (uuid != null) {
 			setUuid(uuid);
-		}
-
-		String externalReferenceCode = (String)attributes.get(
-			"externalReferenceCode");
-
-		if (externalReferenceCode != null) {
-			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Long pageId = (Long)attributes.get("pageId");
@@ -140,6 +133,13 @@ public class WikiPageWrapper
 
 		if (modifiedDate != null) {
 			setModifiedDate(modifiedDate);
+		}
+
+		String externalReferenceCode = (String)attributes.get(
+			"externalReferenceCode");
+
+		if (externalReferenceCode != null) {
+			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Long nodeId = (Long)attributes.get("nodeId");

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalService.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalService.java
@@ -320,6 +320,19 @@ public interface WikiPageLocalService
 	public WikiPage fetchLatestPage(
 		long nodeId, String title, int status, boolean preferApproved);
 
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page, or <code>null</code> if no
+	 matching wiki page could be found
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public WikiPage fetchLatestPageByExternalReferenceCode(
+		long groupId, String externalReferenceCode);
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage fetchPage(long resourcePrimKey);
 
@@ -331,25 +344,6 @@ public interface WikiPageLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage fetchWikiPage(long pageId);
-
-	/**
-	 * Returns the wiki page with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page's external reference code
-	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	 */
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public WikiPage fetchWikiPageByExternalReferenceCode(
-		long groupId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchWikiPageByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public WikiPage fetchWikiPageByReferenceCode(
-		long groupId, String externalReferenceCode);
 
 	/**
 	 * Returns the wiki page matching the UUID and group.
@@ -428,6 +422,20 @@ public interface WikiPageLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getLatestPage(
 			long nodeId, String title, int status, boolean preferApproved)
+		throws PortalException;
+
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public WikiPage getLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -614,19 +622,6 @@ public interface WikiPageLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getWikiPage(long pageId) throws PortalException;
-
-	/**
-	 * Returns the wiki page with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page's external reference code
-	 * @return the matching wiki page
-	 * @throws PortalException if a matching wiki page could not be found
-	 */
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public WikiPage getWikiPageByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
-		throws PortalException;
 
 	/**
 	 * Returns the wiki page matching the UUID and group.

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceUtil.java
@@ -397,6 +397,22 @@ public class WikiPageLocalServiceUtil {
 			nodeId, title, status, preferApproved);
 	}
 
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page, or <code>null</code> if no
+	 matching wiki page could be found
+	 */
+	public static WikiPage fetchLatestPageByExternalReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return getService().fetchLatestPageByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
 	public static WikiPage fetchPage(long resourcePrimKey) {
 		return getService().fetchPage(resourcePrimKey);
 	}
@@ -413,31 +429,6 @@ public class WikiPageLocalServiceUtil {
 
 	public static WikiPage fetchWikiPage(long pageId) {
 		return getService().fetchWikiPage(pageId);
-	}
-
-	/**
-	 * Returns the wiki page with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page's external reference code
-	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	 */
-	public static WikiPage fetchWikiPageByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return getService().fetchWikiPageByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchWikiPageByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static WikiPage fetchWikiPageByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return getService().fetchWikiPageByReferenceCode(
-			groupId, externalReferenceCode);
 	}
 
 	/**
@@ -565,6 +556,23 @@ public class WikiPageLocalServiceUtil {
 
 		return getService().getLatestPage(
 			nodeId, title, status, preferApproved);
+	}
+
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static WikiPage getLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getLatestPageByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	public static List<WikiPage> getOrphans(List<WikiPage> pages)
@@ -838,22 +846,6 @@ public class WikiPageLocalServiceUtil {
 	 */
 	public static WikiPage getWikiPage(long pageId) throws PortalException {
 		return getService().getWikiPage(pageId);
-	}
-
-	/**
-	 * Returns the wiki page with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page's external reference code
-	 * @return the matching wiki page
-	 * @throws PortalException if a matching wiki page could not be found
-	 */
-	public static WikiPage getWikiPageByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
-		throws PortalException {
-
-		return getService().getWikiPageByExternalReferenceCode(
-			groupId, externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceWrapper.java
@@ -435,6 +435,24 @@ public class WikiPageLocalServiceWrapper
 			nodeId, title, status, preferApproved);
 	}
 
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page, or <code>null</code> if no
+	 matching wiki page could be found
+	 */
+	@Override
+	public com.liferay.wiki.model.WikiPage
+		fetchLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode) {
+
+		return _wikiPageLocalService.fetchLatestPageByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
 	@Override
 	public com.liferay.wiki.model.WikiPage fetchPage(long resourcePrimKey) {
 		return _wikiPageLocalService.fetchPage(resourcePrimKey);
@@ -457,33 +475,6 @@ public class WikiPageLocalServiceWrapper
 	@Override
 	public com.liferay.wiki.model.WikiPage fetchWikiPage(long pageId) {
 		return _wikiPageLocalService.fetchWikiPage(pageId);
-	}
-
-	/**
-	 * Returns the wiki page with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page's external reference code
-	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	 */
-	@Override
-	public com.liferay.wiki.model.WikiPage fetchWikiPageByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return _wikiPageLocalService.fetchWikiPageByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchWikiPageByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.wiki.model.WikiPage fetchWikiPageByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return _wikiPageLocalService.fetchWikiPageByReferenceCode(
-			groupId, externalReferenceCode);
 	}
 
 	/**
@@ -636,6 +627,24 @@ public class WikiPageLocalServiceWrapper
 
 		return _wikiPageLocalService.getLatestPage(
 			nodeId, title, status, preferApproved);
+	}
+
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public com.liferay.wiki.model.WikiPage getLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _wikiPageLocalService.getLatestPageByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	@Override
@@ -980,23 +989,6 @@ public class WikiPageLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _wikiPageLocalService.getWikiPage(pageId);
-	}
-
-	/**
-	 * Returns the wiki page with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page's external reference code
-	 * @return the matching wiki page
-	 * @throws PortalException if a matching wiki page could not be found
-	 */
-	@Override
-	public com.liferay.wiki.model.WikiPage getWikiPageByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _wikiPageLocalService.getWikiPageByExternalReferenceCode(
-			groupId, externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageService.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageService.java
@@ -132,6 +132,20 @@ public interface WikiPageService extends BaseService {
 	public void discardDraft(long nodeId, String title, double version)
 		throws PortalException;
 
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page, or <code>null</code> if no
+	 matching wiki page could be found
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public WikiPage fetchLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException;
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage fetchPage(long nodeId, String title, double version)
 		throws PortalException;
@@ -143,6 +157,20 @@ public interface WikiPageService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getDraftPage(long nodeId, String title)
+		throws PortalException;
+
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public WikiPage getLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceUtil.java
@@ -178,6 +178,23 @@ public class WikiPageServiceUtil {
 		getService().discardDraft(nodeId, title, version);
 	}
 
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page, or <code>null</code> if no
+	 matching wiki page could be found
+	 */
+	public static WikiPage fetchLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().fetchLatestPageByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
 	public static WikiPage fetchPage(long nodeId, String title, double version)
 		throws PortalException {
 
@@ -195,6 +212,23 @@ public class WikiPageServiceUtil {
 		throws PortalException {
 
 		return getService().getDraftPage(nodeId, title);
+	}
+
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static WikiPage getLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getLatestPageByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	public static List<WikiPage> getNodePages(long nodeId, int max)

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceWrapper.java
@@ -182,6 +182,25 @@ public class WikiPageServiceWrapper
 		_wikiPageService.discardDraft(nodeId, title, version);
 	}
 
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page, or <code>null</code> if no
+	 matching wiki page could be found
+	 */
+	@Override
+	public com.liferay.wiki.model.WikiPage
+			fetchLatestPageByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _wikiPageService.fetchLatestPageByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
 	@Override
 	public com.liferay.wiki.model.WikiPage fetchPage(
 			long nodeId, String title, double version)
@@ -204,6 +223,24 @@ public class WikiPageServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _wikiPageService.getDraftPage(nodeId, title);
+	}
+
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public com.liferay.wiki.model.WikiPage getLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _wikiPageService.getLatestPageByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	@Override

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiPagePersistence.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiPagePersistence.java
@@ -1268,6 +1268,231 @@ public interface WikiPagePersistence extends BasePersistence<WikiPage> {
 	public int countByR_S(long resourcePrimKey, int status);
 
 	/**
+	 * Returns all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching wiki pages
+	 */
+	public java.util.List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns a range of all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @return the range of matching wiki pages
+	 */
+	public java.util.List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching wiki pages
+	 */
+	public java.util.List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<WikiPage>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching wiki pages
+	 */
+	public java.util.List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<WikiPage>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching wiki page
+	 * @throws NoSuchPageException if a matching wiki page could not be found
+	 */
+	public WikiPage findByG_ERC_First(
+			long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<WikiPage>
+				orderByComparator)
+		throws NoSuchPageException;
+
+	/**
+	 * Returns the first wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	public WikiPage fetchByG_ERC_First(
+		long groupId, String externalReferenceCode,
+		com.liferay.portal.kernel.util.OrderByComparator<WikiPage>
+			orderByComparator);
+
+	/**
+	 * Returns the last wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching wiki page
+	 * @throws NoSuchPageException if a matching wiki page could not be found
+	 */
+	public WikiPage findByG_ERC_Last(
+			long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<WikiPage>
+				orderByComparator)
+		throws NoSuchPageException;
+
+	/**
+	 * Returns the last wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	public WikiPage fetchByG_ERC_Last(
+		long groupId, String externalReferenceCode,
+		com.liferay.portal.kernel.util.OrderByComparator<WikiPage>
+			orderByComparator);
+
+	/**
+	 * Returns the wiki pages before and after the current wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param pageId the primary key of the current wiki page
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next wiki page
+	 * @throws NoSuchPageException if a wiki page with the primary key could not be found
+	 */
+	public WikiPage[] findByG_ERC_PrevAndNext(
+			long pageId, long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<WikiPage>
+				orderByComparator)
+		throws NoSuchPageException;
+
+	/**
+	 * Returns all the wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching wiki pages that the user has permission to view
+	 */
+	public java.util.List<WikiPage> filterFindByG_ERC(
+		long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns a range of all the wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @return the range of matching wiki pages that the user has permission to view
+	 */
+	public java.util.List<WikiPage> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the wiki pages that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching wiki pages that the user has permission to view
+	 */
+	public java.util.List<WikiPage> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<WikiPage>
+			orderByComparator);
+
+	/**
+	 * Returns the wiki pages before and after the current wiki page in the ordered set of wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param pageId the primary key of the current wiki page
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next wiki page
+	 * @throws NoSuchPageException if a wiki page with the primary key could not be found
+	 */
+	public WikiPage[] filterFindByG_ERC_PrevAndNext(
+			long pageId, long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<WikiPage>
+				orderByComparator)
+		throws NoSuchPageException;
+
+	/**
+	 * Removes all the wiki pages where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 */
+	public void removeByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns the number of wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching wiki pages
+	 */
+	public int countByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns the number of wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching wiki pages that the user has permission to view
+	 */
+	public int filterCountByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
 	 * Returns all the wiki pages where nodeId = &#63; and title = &#63;.
 	 *
 	 * @param nodeId the node ID
@@ -2428,6 +2653,66 @@ public interface WikiPagePersistence extends BasePersistence<WikiPage> {
 	 * @return the number of matching wiki pages
 	 */
 	public int countByR_N_S(long resourcePrimKey, long nodeId, int status);
+
+	/**
+	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or throws a <code>NoSuchPageException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching wiki page
+	 * @throws NoSuchPageException if a matching wiki page could not be found
+	 */
+	public WikiPage findByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws NoSuchPageException;
+
+	/**
+	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	public WikiPage fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version);
+
+	/**
+	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	public WikiPage fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version,
+		boolean useFinderCache);
+
+	/**
+	 * Removes the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the wiki page that was removed
+	 */
+	public WikiPage removeByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws NoSuchPageException;
+
+	/**
+	 * Returns the number of wiki pages where groupId = &#63; and externalReferenceCode = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the number of matching wiki pages
+	 */
+	public int countByG_ERC_V(
+		long groupId, String externalReferenceCode, double version);
 
 	/**
 	 * Returns all the wiki pages where groupId = &#63; and nodeId = &#63; and head = &#63;.
@@ -5936,56 +6221,6 @@ public interface WikiPagePersistence extends BasePersistence<WikiPage> {
 	public int filterCountByG_N_H_P_S(
 		long groupId, long nodeId, boolean head, String parentTitle,
 		int status);
-
-	/**
-	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchPageException</code> if it could not be found.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the matching wiki page
-	 * @throws NoSuchPageException if a matching wiki page could not be found
-	 */
-	public WikiPage findByG_ERC(long groupId, String externalReferenceCode)
-		throws NoSuchPageException;
-
-	/**
-	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	 */
-	public WikiPage fetchByG_ERC(long groupId, String externalReferenceCode);
-
-	/**
-	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	 */
-	public WikiPage fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache);
-
-	/**
-	 * Removes the wiki page where groupId = &#63; and externalReferenceCode = &#63; from the database.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the wiki page that was removed
-	 */
-	public WikiPage removeByG_ERC(long groupId, String externalReferenceCode)
-		throws NoSuchPageException;
-
-	/**
-	 * Returns the number of wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the number of matching wiki pages
-	 */
-	public int countByG_ERC(long groupId, String externalReferenceCode);
 
 	/**
 	 * Caches the wiki page in the entity cache if it is enabled.

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiPageUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiPageUtil.java
@@ -1562,6 +1562,284 @@ public class WikiPageUtil {
 	}
 
 	/**
+	 * Returns all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching wiki pages
+	 */
+	public static List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns a range of all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @return the range of matching wiki pages
+	 */
+	public static List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return getPersistence().findByG_ERC(
+			groupId, externalReferenceCode, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching wiki pages
+	 */
+	public static List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<WikiPage> orderByComparator) {
+
+		return getPersistence().findByG_ERC(
+			groupId, externalReferenceCode, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching wiki pages
+	 */
+	public static List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<WikiPage> orderByComparator, boolean useFinderCache) {
+
+		return getPersistence().findByG_ERC(
+			groupId, externalReferenceCode, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching wiki page
+	 * @throws NoSuchPageException if a matching wiki page could not be found
+	 */
+	public static WikiPage findByG_ERC_First(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<WikiPage> orderByComparator)
+		throws com.liferay.wiki.exception.NoSuchPageException {
+
+		return getPersistence().findByG_ERC_First(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the first wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	public static WikiPage fetchByG_ERC_First(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<WikiPage> orderByComparator) {
+
+		return getPersistence().fetchByG_ERC_First(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the last wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching wiki page
+	 * @throws NoSuchPageException if a matching wiki page could not be found
+	 */
+	public static WikiPage findByG_ERC_Last(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<WikiPage> orderByComparator)
+		throws com.liferay.wiki.exception.NoSuchPageException {
+
+		return getPersistence().findByG_ERC_Last(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the last wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	public static WikiPage fetchByG_ERC_Last(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<WikiPage> orderByComparator) {
+
+		return getPersistence().fetchByG_ERC_Last(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the wiki pages before and after the current wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param pageId the primary key of the current wiki page
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next wiki page
+	 * @throws NoSuchPageException if a wiki page with the primary key could not be found
+	 */
+	public static WikiPage[] findByG_ERC_PrevAndNext(
+			long pageId, long groupId, String externalReferenceCode,
+			OrderByComparator<WikiPage> orderByComparator)
+		throws com.liferay.wiki.exception.NoSuchPageException {
+
+		return getPersistence().findByG_ERC_PrevAndNext(
+			pageId, groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns all the wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching wiki pages that the user has permission to view
+	 */
+	public static List<WikiPage> filterFindByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().filterFindByG_ERC(
+			groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns a range of all the wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @return the range of matching wiki pages that the user has permission to view
+	 */
+	public static List<WikiPage> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return getPersistence().filterFindByG_ERC(
+			groupId, externalReferenceCode, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the wiki pages that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching wiki pages that the user has permission to view
+	 */
+	public static List<WikiPage> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<WikiPage> orderByComparator) {
+
+		return getPersistence().filterFindByG_ERC(
+			groupId, externalReferenceCode, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the wiki pages before and after the current wiki page in the ordered set of wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param pageId the primary key of the current wiki page
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next wiki page
+	 * @throws NoSuchPageException if a wiki page with the primary key could not be found
+	 */
+	public static WikiPage[] filterFindByG_ERC_PrevAndNext(
+			long pageId, long groupId, String externalReferenceCode,
+			OrderByComparator<WikiPage> orderByComparator)
+		throws com.liferay.wiki.exception.NoSuchPageException {
+
+		return getPersistence().filterFindByG_ERC_PrevAndNext(
+			pageId, groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Removes all the wiki pages where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 */
+	public static void removeByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		getPersistence().removeByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the number of wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching wiki pages
+	 */
+	public static int countByG_ERC(long groupId, String externalReferenceCode) {
+		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the number of wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching wiki pages that the user has permission to view
+	 */
+	public static int filterCountByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().filterCountByG_ERC(
+			groupId, externalReferenceCode);
+	}
+
+	/**
 	 * Returns all the wiki pages where nodeId = &#63; and title = &#63;.
 	 *
 	 * @param nodeId the node ID
@@ -2954,6 +3232,86 @@ public class WikiPageUtil {
 		long resourcePrimKey, long nodeId, int status) {
 
 		return getPersistence().countByR_N_S(resourcePrimKey, nodeId, status);
+	}
+
+	/**
+	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or throws a <code>NoSuchPageException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching wiki page
+	 * @throws NoSuchPageException if a matching wiki page could not be found
+	 */
+	public static WikiPage findByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws com.liferay.wiki.exception.NoSuchPageException {
+
+		return getPersistence().findByG_ERC_V(
+			groupId, externalReferenceCode, version);
+	}
+
+	/**
+	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	public static WikiPage fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version) {
+
+		return getPersistence().fetchByG_ERC_V(
+			groupId, externalReferenceCode, version);
+	}
+
+	/**
+	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	public static WikiPage fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version,
+		boolean useFinderCache) {
+
+		return getPersistence().fetchByG_ERC_V(
+			groupId, externalReferenceCode, version, useFinderCache);
+	}
+
+	/**
+	 * Removes the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the wiki page that was removed
+	 */
+	public static WikiPage removeByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws com.liferay.wiki.exception.NoSuchPageException {
+
+		return getPersistence().removeByG_ERC_V(
+			groupId, externalReferenceCode, version);
+	}
+
+	/**
+	 * Returns the number of wiki pages where groupId = &#63; and externalReferenceCode = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the number of matching wiki pages
+	 */
+	public static int countByG_ERC_V(
+		long groupId, String externalReferenceCode, double version) {
+
+		return getPersistence().countByG_ERC_V(
+			groupId, externalReferenceCode, version);
 	}
 
 	/**
@@ -7152,74 +7510,6 @@ public class WikiPageUtil {
 
 		return getPersistence().filterCountByG_N_H_P_S(
 			groupId, nodeId, head, parentTitle, status);
-	}
-
-	/**
-	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchPageException</code> if it could not be found.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the matching wiki page
-	 * @throws NoSuchPageException if a matching wiki page could not be found
-	 */
-	public static WikiPage findByG_ERC(
-			long groupId, String externalReferenceCode)
-		throws com.liferay.wiki.exception.NoSuchPageException {
-
-		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	 */
-	public static WikiPage fetchByG_ERC(
-		long groupId, String externalReferenceCode) {
-
-		return getPersistence().fetchByG_ERC(groupId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	 */
-	public static WikiPage fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
-
-		return getPersistence().fetchByG_ERC(
-			groupId, externalReferenceCode, useFinderCache);
-	}
-
-	/**
-	 * Removes the wiki page where groupId = &#63; and externalReferenceCode = &#63; from the database.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the wiki page that was removed
-	 */
-	public static WikiPage removeByG_ERC(
-			long groupId, String externalReferenceCode)
-		throws com.liferay.wiki.exception.NoSuchPageException {
-
-		return getPersistence().removeByG_ERC(groupId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the number of wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the number of matching wiki pages
-	 */
-	public static int countByG_ERC(long groupId, String externalReferenceCode) {
-		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/wiki/wiki-service/service.xml
+++ b/modules/apps/wiki/wiki-service/service.xml
@@ -126,10 +126,6 @@
 		<finder name="Format" return-type="Collection">
 			<finder-column name="format" />
 		</finder>
-		<finder name="G_E" return-type="Collection">
-			<finder-column name="groupId" />
-			<finder-column name="externalReferenceCode" />
-		</finder>
 		<finder name="R_N" return-type="Collection">
 			<finder-column name="resourcePrimKey" />
 			<finder-column name="nodeId" />
@@ -137,6 +133,10 @@
 		<finder name="R_S" return-type="Collection">
 			<finder-column name="resourcePrimKey" />
 			<finder-column name="status" />
+		</finder>
+		<finder name="G_ERC" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="externalReferenceCode" />
 		</finder>
 		<finder name="N_T" return-type="Collection">
 			<finder-column name="nodeId" />
@@ -173,7 +173,7 @@
 			<finder-column name="nodeId" />
 			<finder-column name="status" />
 		</finder>
-		<finder name="G_E_V" return-type="WikiPage">
+		<finder name="G_ERC_V" return-type="WikiPage">
 			<finder-column name="groupId" />
 			<finder-column name="externalReferenceCode" />
 			<finder-column name="version" />

--- a/modules/apps/wiki/wiki-service/service.xml
+++ b/modules/apps/wiki/wiki-service/service.xml
@@ -66,7 +66,7 @@
 		<reference entity="User" package-path="com.liferay.portal" />
 		<reference entity="WikiPage" package-path="com.liferay.wiki" />
 	</entity>
-	<entity external-reference-code="group" local-service="true" name="WikiPage" remote-service="true" trash-enabled="true" uuid="true">
+	<entity local-service="true" name="WikiPage" remote-service="true" trash-enabled="true" uuid="true">
 
 		<!-- PK fields -->
 
@@ -90,6 +90,7 @@
 
 		<!-- Other fields -->
 
+		<column name="externalReferenceCode" type="String" />
 		<column name="nodeId" type="long" />
 		<column name="title" type="String" uad-nonanonymizable="true" />
 		<column name="version" type="double" />
@@ -124,6 +125,10 @@
 		</finder>
 		<finder name="Format" return-type="Collection">
 			<finder-column name="format" />
+		</finder>
+		<finder name="G_E" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="externalReferenceCode" />
 		</finder>
 		<finder name="R_N" return-type="Collection">
 			<finder-column name="resourcePrimKey" />
@@ -167,6 +172,11 @@
 			<finder-column name="resourcePrimKey" />
 			<finder-column name="nodeId" />
 			<finder-column name="status" />
+		</finder>
+		<finder name="G_E_V" return-type="WikiPage">
+			<finder-column name="groupId" />
+			<finder-column name="externalReferenceCode" />
+			<finder-column name="version" />
 		</finder>
 		<finder name="G_N_H" return-type="Collection">
 			<finder-column name="groupId" />

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v2_2_0/WikiNodeExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v2_2_0/WikiNodeExternalReferenceCodeUpgradeProcess.java
@@ -14,12 +14,8 @@
 
 package com.liferay.wiki.internal.upgrade.v2_2_0;
 
-import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.wiki.internal.upgrade.v2_2_0.util.WikiNodeTable;
-
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 
 /**
  * @author Luis Miguel Barcos
@@ -34,32 +30,11 @@ public class WikiNodeExternalReferenceCodeUpgradeProcess
 				WikiNodeTable.class,
 				new AlterTableAddColumn(
 					"externalReferenceCode", "VARCHAR(75)"));
-		}
 
-		_populateExternalReferenceCode();
-	}
-
-	private void _populateExternalReferenceCode() throws Exception {
-		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				"select nodeId from WikiNode where externalReferenceCode is " +
-					"null or externalReferenceCode = ''");
-			ResultSet resultSet = preparedStatement1.executeQuery();
-			PreparedStatement preparedStatement2 =
-				AutoBatchPreparedStatementUtil.autoBatch(
-					connection.prepareStatement(
-						"update WikiNode set externalReferenceCode = ? where " +
-							"nodeId = ?"))) {
-
-			while (resultSet.next()) {
-				long nodeId = resultSet.getLong(1);
-
-				preparedStatement2.setString(1, String.valueOf(nodeId));
-				preparedStatement2.setLong(2, nodeId);
-
-				preparedStatement2.addBatch();
-			}
-
-			preparedStatement2.executeBatch();
+			runSQL(
+				"update WikiNode set externalReferenceCode = " +
+					"CAST_TEXT(nodeId) where externalReferenceCode is null " +
+						"or externalReferenceCode = ''");
 		}
 	}
 

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v2_2_0/WikiPageExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v2_2_0/WikiPageExternalReferenceCodeUpgradeProcess.java
@@ -14,12 +14,8 @@
 
 package com.liferay.wiki.internal.upgrade.v2_2_0;
 
-import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.wiki.internal.upgrade.v2_2_0.util.WikiPageTable;
-
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 
 /**
  * @author Luis Miguel Barcos
@@ -34,32 +30,11 @@ public class WikiPageExternalReferenceCodeUpgradeProcess
 				WikiPageTable.class,
 				new AlterTableAddColumn(
 					"externalReferenceCode", "VARCHAR(75)"));
-		}
 
-		_populateExternalReferenceCode();
-	}
-
-	private void _populateExternalReferenceCode() throws Exception {
-		try (PreparedStatement preparedStatement1 = connection.prepareCall(
-				"select pageId from WikiPage where externalReferenceCode is " +
-					"null or externalReferenceCode = ''");
-			ResultSet resultSet = preparedStatement1.executeQuery();
-			PreparedStatement preparedStatement2 =
-				AutoBatchPreparedStatementUtil.autoBatch(
-					connection.prepareStatement(
-						"update WikiPage set externalReferenceCode = ? where " +
-							"pageId = ?"))) {
-
-			while (resultSet.next()) {
-				long pageId = resultSet.getLong(1);
-
-				preparedStatement2.setString(1, String.valueOf(pageId));
-				preparedStatement2.setLong(2, pageId);
-
-				preparedStatement2.addBatch();
-			}
-
-			preparedStatement2.executeBatch();
+			runSQL(
+				"update WikiPage set externalReferenceCode = " +
+					"CAST_TEXT(resourcePrimKey) where externalReferenceCode " +
+						"is null or externalReferenceCode = ''");
 		}
 	}
 

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v2_2_0/util/WikiNodeTable.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v2_2_0/util/WikiNodeTable.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @author	  Luis Miguel Barcos
+ * @author	  Brian Wing Shun Chan
  * @generated
  */
 public class WikiNodeTable {
@@ -87,6 +87,7 @@ TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
 
 	public static final String[] TABLE_SQL_ADD_INDEXES = {
 		"create index IX_B54332D6 on WikiNode (companyId, status)",
+		"create index IX_7FF2268B on WikiNode (groupId, externalReferenceCode[$COLUMN_LENGTH:75$])",
 		"create unique index IX_920CD8B1 on WikiNode (groupId, name[$COLUMN_LENGTH:75$])",
 		"create index IX_23325358 on WikiNode (groupId, status)",
 		"create index IX_E0E6D12C on WikiNode (uuid_[$COLUMN_LENGTH:75$], companyId)",

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v2_2_0/util/WikiPageTable.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v2_2_0/util/WikiPageTable.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @author	  Luis Miguel Barcos
+ * @author	  Brian Wing Shun Chan
  * @generated
  */
 public class WikiPageTable {
@@ -29,11 +29,11 @@ public class WikiPageTable {
 
 	public static final Object[][] TABLE_COLUMNS = {
 		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
-		{"externalReferenceCode", Types.VARCHAR}, {"pageId", Types.BIGINT},
-		{"resourcePrimKey", Types.BIGINT}, {"groupId", Types.BIGINT},
-		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
-		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
-		{"modifiedDate", Types.TIMESTAMP}, {"nodeId", Types.BIGINT},
+		{"pageId", Types.BIGINT}, {"resourcePrimKey", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"externalReferenceCode", Types.VARCHAR}, {"nodeId", Types.BIGINT},
 		{"title", Types.VARCHAR}, {"version", Types.DOUBLE},
 		{"minorEdit", Types.BOOLEAN}, {"content", Types.CLOB},
 		{"summary", Types.VARCHAR}, {"format", Types.VARCHAR},
@@ -51,8 +51,6 @@ TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
 
 TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
 
-TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
-
 TABLE_COLUMNS_MAP.put("pageId", Types.BIGINT);
 
 TABLE_COLUMNS_MAP.put("resourcePrimKey", Types.BIGINT);
@@ -68,6 +66,8 @@ TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
 TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
 
 TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 
 TABLE_COLUMNS_MAP.put("nodeId", Types.BIGINT);
 
@@ -101,7 +101,7 @@ TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
 
 }
 	public static final String TABLE_SQL_CREATE =
-"create table WikiPage (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,pageId LONG not null primary key,resourcePrimKey LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,nodeId LONG,title VARCHAR(255) null,version DOUBLE,minorEdit BOOLEAN,content TEXT null,summary STRING null,format VARCHAR(75) null,head BOOLEAN,parentTitle VARCHAR(255) null,redirectTitle VARCHAR(255) null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+"create table WikiPage (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,pageId LONG not null primary key,resourcePrimKey LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,externalReferenceCode VARCHAR(75) null,nodeId LONG,title VARCHAR(255) null,version DOUBLE,minorEdit BOOLEAN,content TEXT null,summary STRING null,format VARCHAR(75) null,head BOOLEAN,parentTitle VARCHAR(255) null,redirectTitle VARCHAR(255) null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table WikiPage";
 

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/model/impl/WikiPageCacheModel.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/model/impl/WikiPageCacheModel.java
@@ -82,8 +82,6 @@ public class WikiPageCacheModel
 		sb.append(mvccVersion);
 		sb.append(", uuid=");
 		sb.append(uuid);
-		sb.append(", externalReferenceCode=");
-		sb.append(externalReferenceCode);
 		sb.append(", pageId=");
 		sb.append(pageId);
 		sb.append(", resourcePrimKey=");
@@ -100,6 +98,8 @@ public class WikiPageCacheModel
 		sb.append(createDate);
 		sb.append(", modifiedDate=");
 		sb.append(modifiedDate);
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
 		sb.append(", nodeId=");
 		sb.append(nodeId);
 		sb.append(", title=");
@@ -148,13 +148,6 @@ public class WikiPageCacheModel
 			wikiPageImpl.setUuid(uuid);
 		}
 
-		if (externalReferenceCode == null) {
-			wikiPageImpl.setExternalReferenceCode("");
-		}
-		else {
-			wikiPageImpl.setExternalReferenceCode(externalReferenceCode);
-		}
-
 		wikiPageImpl.setPageId(pageId);
 		wikiPageImpl.setResourcePrimKey(resourcePrimKey);
 		wikiPageImpl.setGroupId(groupId);
@@ -180,6 +173,13 @@ public class WikiPageCacheModel
 		}
 		else {
 			wikiPageImpl.setModifiedDate(new Date(modifiedDate));
+		}
+
+		if (externalReferenceCode == null) {
+			wikiPageImpl.setExternalReferenceCode("");
+		}
+		else {
+			wikiPageImpl.setExternalReferenceCode(externalReferenceCode);
 		}
 
 		wikiPageImpl.setNodeId(nodeId);
@@ -266,7 +266,6 @@ public class WikiPageCacheModel
 
 		mvccVersion = objectInput.readLong();
 		uuid = objectInput.readUTF();
-		externalReferenceCode = objectInput.readUTF();
 
 		pageId = objectInput.readLong();
 
@@ -280,6 +279,7 @@ public class WikiPageCacheModel
 		userName = objectInput.readUTF();
 		createDate = objectInput.readLong();
 		modifiedDate = objectInput.readLong();
+		externalReferenceCode = objectInput.readUTF();
 
 		nodeId = objectInput.readLong();
 		title = objectInput.readUTF();
@@ -314,13 +314,6 @@ public class WikiPageCacheModel
 			objectOutput.writeUTF(uuid);
 		}
 
-		if (externalReferenceCode == null) {
-			objectOutput.writeUTF("");
-		}
-		else {
-			objectOutput.writeUTF(externalReferenceCode);
-		}
-
 		objectOutput.writeLong(pageId);
 
 		objectOutput.writeLong(resourcePrimKey);
@@ -340,6 +333,13 @@ public class WikiPageCacheModel
 
 		objectOutput.writeLong(createDate);
 		objectOutput.writeLong(modifiedDate);
+
+		if (externalReferenceCode == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(externalReferenceCode);
+		}
 
 		objectOutput.writeLong(nodeId);
 
@@ -409,7 +409,6 @@ public class WikiPageCacheModel
 
 	public long mvccVersion;
 	public String uuid;
-	public String externalReferenceCode;
 	public long pageId;
 	public long resourcePrimKey;
 	public long groupId;
@@ -418,6 +417,7 @@ public class WikiPageCacheModel
 	public String userName;
 	public long createDate;
 	public long modifiedDate;
+	public String externalReferenceCode;
 	public long nodeId;
 	public String title;
 	public double version;

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/model/impl/WikiPageModelImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/model/impl/WikiPageModelImpl.java
@@ -81,11 +81,11 @@ public class WikiPageModelImpl
 
 	public static final Object[][] TABLE_COLUMNS = {
 		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
-		{"externalReferenceCode", Types.VARCHAR}, {"pageId", Types.BIGINT},
-		{"resourcePrimKey", Types.BIGINT}, {"groupId", Types.BIGINT},
-		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
-		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
-		{"modifiedDate", Types.TIMESTAMP}, {"nodeId", Types.BIGINT},
+		{"pageId", Types.BIGINT}, {"resourcePrimKey", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"externalReferenceCode", Types.VARCHAR}, {"nodeId", Types.BIGINT},
 		{"title", Types.VARCHAR}, {"version", Types.DOUBLE},
 		{"minorEdit", Types.BOOLEAN}, {"content", Types.CLOB},
 		{"summary", Types.VARCHAR}, {"format", Types.VARCHAR},
@@ -101,7 +101,6 @@ public class WikiPageModelImpl
 	static {
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
-		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("pageId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("resourcePrimKey", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
@@ -110,6 +109,7 @@ public class WikiPageModelImpl
 		TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("nodeId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("title", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("version", Types.DOUBLE);
@@ -128,7 +128,7 @@ public class WikiPageModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table WikiPage (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,pageId LONG not null primary key,resourcePrimKey LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,nodeId LONG,title VARCHAR(255) null,version DOUBLE,minorEdit BOOLEAN,content TEXT null,summary STRING null,format VARCHAR(75) null,head BOOLEAN,parentTitle VARCHAR(255) null,redirectTitle VARCHAR(255) null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+		"create table WikiPage (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,pageId LONG not null primary key,resourcePrimKey LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,externalReferenceCode VARCHAR(75) null,nodeId LONG,title VARCHAR(255) null,version DOUBLE,minorEdit BOOLEAN,content TEXT null,summary STRING null,format VARCHAR(75) null,head BOOLEAN,parentTitle VARCHAR(255) null,redirectTitle VARCHAR(255) null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table WikiPage";
 
@@ -259,7 +259,6 @@ public class WikiPageModelImpl
 
 		model.setMvccVersion(soapModel.getMvccVersion());
 		model.setUuid(soapModel.getUuid());
-		model.setExternalReferenceCode(soapModel.getExternalReferenceCode());
 		model.setPageId(soapModel.getPageId());
 		model.setResourcePrimKey(soapModel.getResourcePrimKey());
 		model.setGroupId(soapModel.getGroupId());
@@ -268,6 +267,7 @@ public class WikiPageModelImpl
 		model.setUserName(soapModel.getUserName());
 		model.setCreateDate(soapModel.getCreateDate());
 		model.setModifiedDate(soapModel.getModifiedDate());
+		model.setExternalReferenceCode(soapModel.getExternalReferenceCode());
 		model.setNodeId(soapModel.getNodeId());
 		model.setTitle(soapModel.getTitle());
 		model.setVersion(soapModel.getVersion());
@@ -439,11 +439,6 @@ public class WikiPageModelImpl
 		attributeGetterFunctions.put("uuid", WikiPage::getUuid);
 		attributeSetterBiConsumers.put(
 			"uuid", (BiConsumer<WikiPage, String>)WikiPage::setUuid);
-		attributeGetterFunctions.put(
-			"externalReferenceCode", WikiPage::getExternalReferenceCode);
-		attributeSetterBiConsumers.put(
-			"externalReferenceCode",
-			(BiConsumer<WikiPage, String>)WikiPage::setExternalReferenceCode);
 		attributeGetterFunctions.put("pageId", WikiPage::getPageId);
 		attributeSetterBiConsumers.put(
 			"pageId", (BiConsumer<WikiPage, Long>)WikiPage::setPageId);
@@ -471,6 +466,11 @@ public class WikiPageModelImpl
 		attributeSetterBiConsumers.put(
 			"modifiedDate",
 			(BiConsumer<WikiPage, Date>)WikiPage::setModifiedDate);
+		attributeGetterFunctions.put(
+			"externalReferenceCode", WikiPage::getExternalReferenceCode);
+		attributeSetterBiConsumers.put(
+			"externalReferenceCode",
+			(BiConsumer<WikiPage, String>)WikiPage::setExternalReferenceCode);
 		attributeGetterFunctions.put("nodeId", WikiPage::getNodeId);
 		attributeSetterBiConsumers.put(
 			"nodeId", (BiConsumer<WikiPage, Long>)WikiPage::setNodeId);
@@ -574,35 +574,6 @@ public class WikiPageModelImpl
 	@Deprecated
 	public String getOriginalUuid() {
 		return getColumnOriginalValue("uuid_");
-	}
-
-	@JSON
-	@Override
-	public String getExternalReferenceCode() {
-		if (_externalReferenceCode == null) {
-			return "";
-		}
-		else {
-			return _externalReferenceCode;
-		}
-	}
-
-	@Override
-	public void setExternalReferenceCode(String externalReferenceCode) {
-		if (_columnOriginalValues == Collections.EMPTY_MAP) {
-			_setColumnOriginalValues();
-		}
-
-		_externalReferenceCode = externalReferenceCode;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getColumnOriginalValue(String)}
-	 */
-	@Deprecated
-	public String getOriginalExternalReferenceCode() {
-		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -793,6 +764,35 @@ public class WikiPageModelImpl
 		}
 
 		_modifiedDate = modifiedDate;
+	}
+
+	@JSON
+	@Override
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCode == null) {
+			return "";
+		}
+		else {
+			return _externalReferenceCode;
+		}
+	}
+
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalExternalReferenceCode() {
+		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -1471,7 +1471,6 @@ public class WikiPageModelImpl
 
 		wikiPageImpl.setMvccVersion(getMvccVersion());
 		wikiPageImpl.setUuid(getUuid());
-		wikiPageImpl.setExternalReferenceCode(getExternalReferenceCode());
 		wikiPageImpl.setPageId(getPageId());
 		wikiPageImpl.setResourcePrimKey(getResourcePrimKey());
 		wikiPageImpl.setGroupId(getGroupId());
@@ -1480,6 +1479,7 @@ public class WikiPageModelImpl
 		wikiPageImpl.setUserName(getUserName());
 		wikiPageImpl.setCreateDate(getCreateDate());
 		wikiPageImpl.setModifiedDate(getModifiedDate());
+		wikiPageImpl.setExternalReferenceCode(getExternalReferenceCode());
 		wikiPageImpl.setNodeId(getNodeId());
 		wikiPageImpl.setTitle(getTitle());
 		wikiPageImpl.setVersion(getVersion());
@@ -1612,16 +1612,6 @@ public class WikiPageModelImpl
 			wikiPageCacheModel.uuid = null;
 		}
 
-		wikiPageCacheModel.externalReferenceCode = getExternalReferenceCode();
-
-		String externalReferenceCode = wikiPageCacheModel.externalReferenceCode;
-
-		if ((externalReferenceCode != null) &&
-			(externalReferenceCode.length() == 0)) {
-
-			wikiPageCacheModel.externalReferenceCode = null;
-		}
-
 		wikiPageCacheModel.pageId = getPageId();
 
 		wikiPageCacheModel.resourcePrimKey = getResourcePrimKey();
@@ -1656,6 +1646,16 @@ public class WikiPageModelImpl
 		}
 		else {
 			wikiPageCacheModel.modifiedDate = Long.MIN_VALUE;
+		}
+
+		wikiPageCacheModel.externalReferenceCode = getExternalReferenceCode();
+
+		String externalReferenceCode = wikiPageCacheModel.externalReferenceCode;
+
+		if ((externalReferenceCode != null) &&
+			(externalReferenceCode.length() == 0)) {
+
+			wikiPageCacheModel.externalReferenceCode = null;
 		}
 
 		wikiPageCacheModel.nodeId = getNodeId();
@@ -1819,7 +1819,6 @@ public class WikiPageModelImpl
 
 	private long _mvccVersion;
 	private String _uuid;
-	private String _externalReferenceCode;
 	private long _pageId;
 	private long _resourcePrimKey;
 	private long _groupId;
@@ -1829,6 +1828,7 @@ public class WikiPageModelImpl
 	private Date _createDate;
 	private Date _modifiedDate;
 	private boolean _setModifiedDate;
+	private String _externalReferenceCode;
 	private long _nodeId;
 	private String _title;
 	private double _version;
@@ -1876,8 +1876,6 @@ public class WikiPageModelImpl
 
 		_columnOriginalValues.put("mvccVersion", _mvccVersion);
 		_columnOriginalValues.put("uuid_", _uuid);
-		_columnOriginalValues.put(
-			"externalReferenceCode", _externalReferenceCode);
 		_columnOriginalValues.put("pageId", _pageId);
 		_columnOriginalValues.put("resourcePrimKey", _resourcePrimKey);
 		_columnOriginalValues.put("groupId", _groupId);
@@ -1886,6 +1884,8 @@ public class WikiPageModelImpl
 		_columnOriginalValues.put("userName", _userName);
 		_columnOriginalValues.put("createDate", _createDate);
 		_columnOriginalValues.put("modifiedDate", _modifiedDate);
+		_columnOriginalValues.put(
+			"externalReferenceCode", _externalReferenceCode);
 		_columnOriginalValues.put("nodeId", _nodeId);
 		_columnOriginalValues.put("title", _title);
 		_columnOriginalValues.put("version", _version);
@@ -1928,23 +1928,23 @@ public class WikiPageModelImpl
 
 		columnBitmasks.put("uuid_", 2L);
 
-		columnBitmasks.put("externalReferenceCode", 4L);
+		columnBitmasks.put("pageId", 4L);
 
-		columnBitmasks.put("pageId", 8L);
+		columnBitmasks.put("resourcePrimKey", 8L);
 
-		columnBitmasks.put("resourcePrimKey", 16L);
+		columnBitmasks.put("groupId", 16L);
 
-		columnBitmasks.put("groupId", 32L);
+		columnBitmasks.put("companyId", 32L);
 
-		columnBitmasks.put("companyId", 64L);
+		columnBitmasks.put("userId", 64L);
 
-		columnBitmasks.put("userId", 128L);
+		columnBitmasks.put("userName", 128L);
 
-		columnBitmasks.put("userName", 256L);
+		columnBitmasks.put("createDate", 256L);
 
-		columnBitmasks.put("createDate", 512L);
+		columnBitmasks.put("modifiedDate", 512L);
 
-		columnBitmasks.put("modifiedDate", 1024L);
+		columnBitmasks.put("externalReferenceCode", 1024L);
 
 		columnBitmasks.put("nodeId", 2048L);
 

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/base/WikiPageLocalServiceBaseImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/base/WikiPageLocalServiceBaseImpl.java
@@ -267,48 +267,6 @@ public abstract class WikiPageLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the wiki page with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page's external reference code
-	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	 */
-	@Override
-	public WikiPage fetchWikiPageByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return wikiPagePersistence.fetchByG_ERC(groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchWikiPageByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public WikiPage fetchWikiPageByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return fetchWikiPageByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the wiki page with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page's external reference code
-	 * @return the matching wiki page
-	 * @throws PortalException if a matching wiki page could not be found
-	 */
-	@Override
-	public WikiPage getWikiPageByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
-		throws PortalException {
-
-		return wikiPagePersistence.findByG_ERC(groupId, externalReferenceCode);
-	}
-
-	/**
 	 * Returns the wiki page with the primary key.
 	 *
 	 * @param pageId the primary key of the wiki page

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/http/WikiPageServiceHttp.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/http/WikiPageServiceHttp.java
@@ -653,6 +653,49 @@ public class WikiPageServiceHttp {
 		}
 	}
 
+	public static com.liferay.wiki.model.WikiPage
+			fetchLatestPageByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long groupId,
+				String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				WikiPageServiceUtil.class,
+				"fetchLatestPageByExternalReferenceCode",
+				_fetchLatestPageByExternalReferenceCodeParameterTypes15);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, externalReferenceCode);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.wiki.model.WikiPage)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.wiki.model.WikiPage fetchPage(
 			HttpPrincipal httpPrincipal, long nodeId, String title,
 			double version)
@@ -661,7 +704,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "fetchPage",
-				_fetchPageParameterTypes15);
+				_fetchPageParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, version);
@@ -702,7 +745,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getChildren",
-				_getChildrenParameterTypes16);
+				_getChildrenParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, head, parentTitle);
@@ -742,10 +785,53 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getDraftPage",
-				_getDraftPageParameterTypes17);
+				_getDraftPageParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.wiki.model.WikiPage)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.wiki.model.WikiPage
+			getLatestPageByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long groupId,
+				String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				WikiPageServiceUtil.class,
+				"getLatestPageByExternalReferenceCode",
+				_getLatestPageByExternalReferenceCodeParameterTypes19);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, externalReferenceCode);
 
 			Object returnObj = null;
 
@@ -782,7 +868,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getNodePages",
-				_getNodePagesParameterTypes18);
+				_getNodePagesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, max);
@@ -824,7 +910,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getNodePagesRSS",
-				_getNodePagesRSSParameterTypes19);
+				_getNodePagesRSSParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, max, type, version, displayStyle, feedURL,
@@ -865,7 +951,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getOrphans",
-				_getOrphansParameterTypes20);
+				_getOrphansParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, node);
 
@@ -903,7 +989,7 @@ public class WikiPageServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes21);
+				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, pageId);
 
@@ -942,7 +1028,7 @@ public class WikiPageServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes22);
+				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, title);
@@ -981,7 +1067,7 @@ public class WikiPageServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes23);
+				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -1021,7 +1107,7 @@ public class WikiPageServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes24);
+				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, head);
@@ -1061,7 +1147,7 @@ public class WikiPageServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes25);
+				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, version);
@@ -1104,7 +1190,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPages",
-				_getPagesParameterTypes26);
+				_getPagesParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, head, status, start, end,
@@ -1149,7 +1235,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPages",
-				_getPagesParameterTypes27);
+				_getPagesParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, head, userId, includeOwner, status,
@@ -1191,7 +1277,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPages",
-				_getPagesParameterTypes28);
+				_getPagesParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, nodeId, status, start, end);
@@ -1232,7 +1318,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPagesCount",
-				_getPagesCountParameterTypes29);
+				_getPagesCountParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, head);
@@ -1273,7 +1359,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPagesCount",
-				_getPagesCountParameterTypes30);
+				_getPagesCountParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, head, userId, includeOwner, status);
@@ -1314,7 +1400,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPagesCount",
-				_getPagesCountParameterTypes31);
+				_getPagesCountParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, nodeId, status);
@@ -1357,7 +1443,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPagesRSS",
-				_getPagesRSSParameterTypes32);
+				_getPagesRSSParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, max, type, version, displayStyle,
@@ -1400,7 +1486,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getRecentChanges",
-				_getRecentChangesParameterTypes33);
+				_getRecentChangesParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, start, end);
@@ -1440,7 +1526,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getRecentChangesCount",
-				_getRecentChangesCountParameterTypes34);
+				_getRecentChangesCountParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId);
@@ -1480,7 +1566,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getTempFileNames",
-				_getTempFileNamesParameterTypes35);
+				_getTempFileNamesParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, folderName);
@@ -1522,7 +1608,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "movePageAttachmentToTrash",
-				_movePageAttachmentToTrashParameterTypes36);
+				_movePageAttachmentToTrashParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, fileName);
@@ -1563,7 +1649,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "movePageToTrash",
-				_movePageToTrashParameterTypes37);
+				_movePageToTrashParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -1604,7 +1690,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "movePageToTrash",
-				_movePageToTrashParameterTypes38);
+				_movePageToTrashParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, version);
@@ -1646,7 +1732,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "renamePage",
-				_renamePageParameterTypes39);
+				_renamePageParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, newTitle, serviceContext);
@@ -1683,7 +1769,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "restorePageAttachmentFromTrash",
-				_restorePageAttachmentFromTrashParameterTypes40);
+				_restorePageAttachmentFromTrashParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, fileName);
@@ -1719,7 +1805,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "restorePageFromTrash",
-				_restorePageFromTrashParameterTypes41);
+				_restorePageFromTrashParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey);
@@ -1757,7 +1843,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "revertPage",
-				_revertPageParameterTypes42);
+				_revertPageParameterTypes44);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, version, serviceContext);
@@ -1797,7 +1883,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "subscribePage",
-				_subscribePageParameterTypes43);
+				_subscribePageParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -1833,7 +1919,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "unsubscribePage",
-				_unsubscribePageParameterTypes44);
+				_unsubscribePageParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -1872,7 +1958,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "updatePage",
-				_updatePageParameterTypes45);
+				_updatePageParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, version, content, summary, minorEdit,
@@ -1960,96 +2046,104 @@ public class WikiPageServiceHttp {
 		};
 	private static final Class<?>[] _discardDraftParameterTypes14 =
 		new Class[] {long.class, String.class, double.class};
-	private static final Class<?>[] _fetchPageParameterTypes15 = new Class[] {
+	private static final Class<?>[]
+		_fetchLatestPageByExternalReferenceCodeParameterTypes15 = new Class[] {
+			long.class, String.class
+		};
+	private static final Class<?>[] _fetchPageParameterTypes16 = new Class[] {
 		long.class, String.class, double.class
 	};
-	private static final Class<?>[] _getChildrenParameterTypes16 = new Class[] {
+	private static final Class<?>[] _getChildrenParameterTypes17 = new Class[] {
 		long.class, long.class, boolean.class, String.class
 	};
-	private static final Class<?>[] _getDraftPageParameterTypes17 =
+	private static final Class<?>[] _getDraftPageParameterTypes18 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _getNodePagesParameterTypes18 =
+	private static final Class<?>[]
+		_getLatestPageByExternalReferenceCodeParameterTypes19 = new Class[] {
+			long.class, String.class
+		};
+	private static final Class<?>[] _getNodePagesParameterTypes20 =
 		new Class[] {long.class, int.class};
-	private static final Class<?>[] _getNodePagesRSSParameterTypes19 =
+	private static final Class<?>[] _getNodePagesRSSParameterTypes21 =
 		new Class[] {
 			long.class, int.class, String.class, double.class, String.class,
 			String.class, String.class, String.class
 		};
-	private static final Class<?>[] _getOrphansParameterTypes20 = new Class[] {
+	private static final Class<?>[] _getOrphansParameterTypes22 = new Class[] {
 		com.liferay.wiki.model.WikiNode.class
 	};
-	private static final Class<?>[] _getPageParameterTypes21 = new Class[] {
+	private static final Class<?>[] _getPageParameterTypes23 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getPageParameterTypes22 = new Class[] {
+	private static final Class<?>[] _getPageParameterTypes24 = new Class[] {
 		long.class, long.class, String.class
 	};
-	private static final Class<?>[] _getPageParameterTypes23 = new Class[] {
+	private static final Class<?>[] _getPageParameterTypes25 = new Class[] {
 		long.class, String.class
 	};
-	private static final Class<?>[] _getPageParameterTypes24 = new Class[] {
+	private static final Class<?>[] _getPageParameterTypes26 = new Class[] {
 		long.class, String.class, Boolean.class
 	};
-	private static final Class<?>[] _getPageParameterTypes25 = new Class[] {
+	private static final Class<?>[] _getPageParameterTypes27 = new Class[] {
 		long.class, String.class, double.class
 	};
-	private static final Class<?>[] _getPagesParameterTypes26 = new Class[] {
+	private static final Class<?>[] _getPagesParameterTypes28 = new Class[] {
 		long.class, long.class, boolean.class, int.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _getPagesParameterTypes27 = new Class[] {
+	private static final Class<?>[] _getPagesParameterTypes29 = new Class[] {
 		long.class, long.class, boolean.class, long.class, boolean.class,
 		int.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _getPagesParameterTypes28 = new Class[] {
+	private static final Class<?>[] _getPagesParameterTypes30 = new Class[] {
 		long.class, long.class, long.class, int.class, int.class, int.class
 	};
-	private static final Class<?>[] _getPagesCountParameterTypes29 =
+	private static final Class<?>[] _getPagesCountParameterTypes31 =
 		new Class[] {long.class, long.class, boolean.class};
-	private static final Class<?>[] _getPagesCountParameterTypes30 =
+	private static final Class<?>[] _getPagesCountParameterTypes32 =
 		new Class[] {
 			long.class, long.class, boolean.class, long.class, boolean.class,
 			int.class
 		};
-	private static final Class<?>[] _getPagesCountParameterTypes31 =
+	private static final Class<?>[] _getPagesCountParameterTypes33 =
 		new Class[] {long.class, long.class, long.class, int.class};
-	private static final Class<?>[] _getPagesRSSParameterTypes32 = new Class[] {
+	private static final Class<?>[] _getPagesRSSParameterTypes34 = new Class[] {
 		long.class, String.class, int.class, String.class, double.class,
 		String.class, String.class, String.class, String.class,
 		java.util.Locale.class
 	};
-	private static final Class<?>[] _getRecentChangesParameterTypes33 =
+	private static final Class<?>[] _getRecentChangesParameterTypes35 =
 		new Class[] {long.class, long.class, int.class, int.class};
-	private static final Class<?>[] _getRecentChangesCountParameterTypes34 =
+	private static final Class<?>[] _getRecentChangesCountParameterTypes36 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getTempFileNamesParameterTypes35 =
+	private static final Class<?>[] _getTempFileNamesParameterTypes37 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _movePageAttachmentToTrashParameterTypes36 =
+	private static final Class<?>[] _movePageAttachmentToTrashParameterTypes38 =
 		new Class[] {long.class, String.class, String.class};
-	private static final Class<?>[] _movePageToTrashParameterTypes37 =
+	private static final Class<?>[] _movePageToTrashParameterTypes39 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _movePageToTrashParameterTypes38 =
+	private static final Class<?>[] _movePageToTrashParameterTypes40 =
 		new Class[] {long.class, String.class, double.class};
-	private static final Class<?>[] _renamePageParameterTypes39 = new Class[] {
+	private static final Class<?>[] _renamePageParameterTypes41 = new Class[] {
 		long.class, String.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 	private static final Class<?>[]
-		_restorePageAttachmentFromTrashParameterTypes40 = new Class[] {
+		_restorePageAttachmentFromTrashParameterTypes42 = new Class[] {
 			long.class, String.class, String.class
 		};
-	private static final Class<?>[] _restorePageFromTrashParameterTypes41 =
+	private static final Class<?>[] _restorePageFromTrashParameterTypes43 =
 		new Class[] {long.class};
-	private static final Class<?>[] _revertPageParameterTypes42 = new Class[] {
+	private static final Class<?>[] _revertPageParameterTypes44 = new Class[] {
 		long.class, String.class, double.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _subscribePageParameterTypes43 =
+	private static final Class<?>[] _subscribePageParameterTypes45 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _unsubscribePageParameterTypes44 =
+	private static final Class<?>[] _unsubscribePageParameterTypes46 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _updatePageParameterTypes45 = new Class[] {
+	private static final Class<?>[] _updatePageParameterTypes47 = new Class[] {
 		long.class, String.class, double.class, String.class, String.class,
 		boolean.class, String.class, String.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/http/WikiPageServiceSoap.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/http/WikiPageServiceSoap.java
@@ -271,6 +271,34 @@ public class WikiPageServiceSoap {
 		}
 	}
 
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page, or <code>null</code> if no
+	 matching wiki page could be found
+	 */
+	public static com.liferay.wiki.model.WikiPageSoap
+			fetchLatestPageByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws RemoteException {
+
+		try {
+			com.liferay.wiki.model.WikiPage returnValue =
+				WikiPageServiceUtil.fetchLatestPageByExternalReferenceCode(
+					groupId, externalReferenceCode);
+
+			return com.liferay.wiki.model.WikiPageSoap.toSoapModel(returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
 	public static com.liferay.wiki.model.WikiPageSoap fetchPage(
 			long nodeId, String title, double version)
 		throws RemoteException {
@@ -314,6 +342,34 @@ public class WikiPageServiceSoap {
 		try {
 			com.liferay.wiki.model.WikiPage returnValue =
 				WikiPageServiceUtil.getDraftPage(nodeId, title);
+
+			return com.liferay.wiki.model.WikiPageSoap.toSoapModel(returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static com.liferay.wiki.model.WikiPageSoap
+			getLatestPageByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws RemoteException {
+
+		try {
+			com.liferay.wiki.model.WikiPage returnValue =
+				WikiPageServiceUtil.getLatestPageByExternalReferenceCode(
+					groupId, externalReferenceCode);
 
 			return com.liferay.wiki.model.WikiPageSoap.toSoapModel(returnValue);
 		}

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -3345,6 +3345,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		page.setUserId(user.getUserId());
 		page.setUserName(user.getFullName());
 		page.setCreateDate(oldPage.getCreateDate());
+		page.setExternalReferenceCode(oldPage.getExternalReferenceCode());
 		page.setNodeId(nodeId);
 		page.setTitle(
 			Validator.isNull(newTitle) ? oldPage.getTitle() : newTitle);

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -883,6 +883,23 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			nodeId, title, orderByComparator);
 	}
 
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page, or <code>null</code> if no
+	 *         matching wiki page could be found
+	 */
+	@Override
+	public WikiPage fetchLatestPageByExternalReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return wikiPagePersistence.fetchByG_ERC_First(
+			groupId, externalReferenceCode, new PageVersionComparator());
+	}
+
 	@Override
 	public WikiPage fetchPage(long resourcePrimKey) {
 		WikiPageResource pageResource =
@@ -1117,6 +1134,24 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		sb.append("}");
 
 		throw new NoSuchPageException(sb.toString());
+	}
+
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public WikiPage getLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return wikiPagePersistence.findByG_ERC_First(
+			groupId, externalReferenceCode, new PageVersionComparator());
 	}
 
 	@Override
@@ -3399,7 +3434,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		WikiPage wikiPage = wikiPagePersistence.fetchByG_ERC(
+		WikiPage wikiPage = fetchLatestPageByExternalReferenceCode(
 			groupId, externalReferenceCode);
 
 		if (wikiPage != null) {

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -267,12 +267,12 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		WikiPage page = wikiPagePersistence.create(pageId);
 
 		page.setUuid(serviceContext.getUuid());
-		page.setExternalReferenceCode(externalReferenceCode);
 		page.setResourcePrimKey(resourcePrimKey);
 		page.setGroupId(node.getGroupId());
 		page.setCompanyId(user.getCompanyId());
 		page.setUserId(user.getUserId());
 		page.setUserName(user.getFullName());
+		page.setExternalReferenceCode(externalReferenceCode);
 		page.setNodeId(nodeId);
 		page.setTitle(title);
 		page.setVersion(version);

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageServiceImpl.java
@@ -313,6 +313,32 @@ public class WikiPageServiceImpl extends WikiPageServiceBaseImpl {
 		wikiPagePersistence.remove(page);
 	}
 
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page, or <code>null</code> if no
+	 *         matching wiki page could be found
+	 */
+	@Override
+	public WikiPage fetchLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		WikiPage page =
+			wikiPageLocalService.fetchLatestPageByExternalReferenceCode(
+				groupId, externalReferenceCode);
+
+		if (page != null) {
+			_wikiPageModelResourcePermission.check(
+				getPermissionChecker(), page, ActionKeys.VIEW);
+		}
+
+		return page;
+	}
+
 	@Override
 	public WikiPage fetchPage(long nodeId, String title, double version)
 		throws PortalException {
@@ -350,6 +376,30 @@ public class WikiPageServiceImpl extends WikiPageServiceBaseImpl {
 			getPermissionChecker(), page, ActionKeys.VIEW);
 
 		return page;
+	}
+
+	/**
+	 * Returns the latest wiki page matching the group and the external
+	 * reference code
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the wiki page external reference code
+	 * @return the latest matching wiki page
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public WikiPage getLatestPageByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		WikiPage wikiPage =
+			wikiPageLocalService.getLatestPageByExternalReferenceCode(
+				groupId, externalReferenceCode);
+
+		_wikiPageModelResourcePermission.check(
+			getPermissionChecker(), wikiPage, ActionKeys.VIEW);
+
+		return wikiPage;
 	}
 
 	@Override

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/persistence/impl/WikiPagePersistenceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/persistence/impl/WikiPagePersistenceImpl.java
@@ -4545,6 +4545,1028 @@ public class WikiPagePersistenceImpl
 	private static final String _FINDER_COLUMN_R_S_STATUS_2 =
 		"wikiPage.status = ?";
 
+	private FinderPath _finderPathWithPaginationFindByG_ERC;
+	private FinderPath _finderPathWithoutPaginationFindByG_ERC;
+	private FinderPath _finderPathCountByG_ERC;
+
+	/**
+	 * Returns all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching wiki pages
+	 */
+	@Override
+	public List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return findByG_ERC(
+			groupId, externalReferenceCode, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @return the range of matching wiki pages
+	 */
+	@Override
+	public List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return findByG_ERC(groupId, externalReferenceCode, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching wiki pages
+	 */
+	@Override
+	public List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<WikiPage> orderByComparator) {
+
+		return findByG_ERC(
+			groupId, externalReferenceCode, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching wiki pages
+	 */
+	@Override
+	public List<WikiPage> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<WikiPage> orderByComparator, boolean useFinderCache) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByG_ERC;
+				finderArgs = new Object[] {groupId, externalReferenceCode};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByG_ERC;
+			finderArgs = new Object[] {
+				groupId, externalReferenceCode, start, end, orderByComparator
+			};
+		}
+
+		List<WikiPage> list = null;
+
+		if (useFinderCache) {
+			list = (List<WikiPage>)finderCache.getResult(
+				finderPath, finderArgs);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (WikiPage wikiPage : list) {
+					if ((groupId != wikiPage.getGroupId()) ||
+						!externalReferenceCode.equals(
+							wikiPage.getExternalReferenceCode())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					4 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(4);
+			}
+
+			sb.append(_SQL_SELECT_WIKIPAGE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+			}
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(WikiPageModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				list = (List<WikiPage>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching wiki page
+	 * @throws NoSuchPageException if a matching wiki page could not be found
+	 */
+	@Override
+	public WikiPage findByG_ERC_First(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<WikiPage> orderByComparator)
+		throws NoSuchPageException {
+
+		WikiPage wikiPage = fetchByG_ERC_First(
+			groupId, externalReferenceCode, orderByComparator);
+
+		if (wikiPage != null) {
+			return wikiPage;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
+
+		sb.append("}");
+
+		throw new NoSuchPageException(sb.toString());
+	}
+
+	/**
+	 * Returns the first wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	@Override
+	public WikiPage fetchByG_ERC_First(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<WikiPage> orderByComparator) {
+
+		List<WikiPage> list = findByG_ERC(
+			groupId, externalReferenceCode, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching wiki page
+	 * @throws NoSuchPageException if a matching wiki page could not be found
+	 */
+	@Override
+	public WikiPage findByG_ERC_Last(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<WikiPage> orderByComparator)
+		throws NoSuchPageException {
+
+		WikiPage wikiPage = fetchByG_ERC_Last(
+			groupId, externalReferenceCode, orderByComparator);
+
+		if (wikiPage != null) {
+			return wikiPage;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
+
+		sb.append("}");
+
+		throw new NoSuchPageException(sb.toString());
+	}
+
+	/**
+	 * Returns the last wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	@Override
+	public WikiPage fetchByG_ERC_Last(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<WikiPage> orderByComparator) {
+
+		int count = countByG_ERC(groupId, externalReferenceCode);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<WikiPage> list = findByG_ERC(
+			groupId, externalReferenceCode, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the wiki pages before and after the current wiki page in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param pageId the primary key of the current wiki page
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next wiki page
+	 * @throws NoSuchPageException if a wiki page with the primary key could not be found
+	 */
+	@Override
+	public WikiPage[] findByG_ERC_PrevAndNext(
+			long pageId, long groupId, String externalReferenceCode,
+			OrderByComparator<WikiPage> orderByComparator)
+		throws NoSuchPageException {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		WikiPage wikiPage = findByPrimaryKey(pageId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			WikiPage[] array = new WikiPageImpl[3];
+
+			array[0] = getByG_ERC_PrevAndNext(
+				session, wikiPage, groupId, externalReferenceCode,
+				orderByComparator, true);
+
+			array[1] = wikiPage;
+
+			array[2] = getByG_ERC_PrevAndNext(
+				session, wikiPage, groupId, externalReferenceCode,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected WikiPage getByG_ERC_PrevAndNext(
+		Session session, WikiPage wikiPage, long groupId,
+		String externalReferenceCode,
+		OrderByComparator<WikiPage> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_WIKIPAGE_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(WikiPageModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		if (bindExternalReferenceCode) {
+			queryPos.add(externalReferenceCode);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(wikiPage)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<WikiPage> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching wiki pages that the user has permission to view
+	 */
+	@Override
+	public List<WikiPage> filterFindByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return filterFindByG_ERC(
+			groupId, externalReferenceCode, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @return the range of matching wiki pages that the user has permission to view
+	 */
+	@Override
+	public List<WikiPage> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return filterFindByG_ERC(
+			groupId, externalReferenceCode, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the wiki pages that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>WikiPageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching wiki pages that the user has permission to view
+	 */
+	@Override
+	public List<WikiPage> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<WikiPage> orderByComparator) {
+
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_ERC(
+				groupId, externalReferenceCode, start, end, orderByComparator);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				4 + (orderByComparator.getOrderByFields().length * 2));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_WIKIPAGE_WHERE);
+		}
+		else {
+			sb.append(_FILTER_SQL_SELECT_WIKIPAGE_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+		}
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_WIKIPAGE_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator, true);
+			}
+			else {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_TABLE, orderByComparator, true);
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(WikiPageModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(WikiPageModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), WikiPage.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, WikiPageImpl.class);
+			}
+			else {
+				sqlQuery.addEntity(_FILTER_ENTITY_TABLE, WikiPageImpl.class);
+			}
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(groupId);
+
+			if (bindExternalReferenceCode) {
+				queryPos.add(externalReferenceCode);
+			}
+
+			return (List<WikiPage>)QueryUtil.list(
+				sqlQuery, getDialect(), start, end);
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the wiki pages before and after the current wiki page in the ordered set of wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param pageId the primary key of the current wiki page
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next wiki page
+	 * @throws NoSuchPageException if a wiki page with the primary key could not be found
+	 */
+	@Override
+	public WikiPage[] filterFindByG_ERC_PrevAndNext(
+			long pageId, long groupId, String externalReferenceCode,
+			OrderByComparator<WikiPage> orderByComparator)
+		throws NoSuchPageException {
+
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_ERC_PrevAndNext(
+				pageId, groupId, externalReferenceCode, orderByComparator);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		WikiPage wikiPage = findByPrimaryKey(pageId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			WikiPage[] array = new WikiPageImpl[3];
+
+			array[0] = filterGetByG_ERC_PrevAndNext(
+				session, wikiPage, groupId, externalReferenceCode,
+				orderByComparator, true);
+
+			array[1] = wikiPage;
+
+			array[2] = filterGetByG_ERC_PrevAndNext(
+				session, wikiPage, groupId, externalReferenceCode,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected WikiPage filterGetByG_ERC_PrevAndNext(
+		Session session, WikiPage wikiPage, long groupId,
+		String externalReferenceCode,
+		OrderByComparator<WikiPage> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_WIKIPAGE_WHERE);
+		}
+		else {
+			sb.append(_FILTER_SQL_SELECT_WIKIPAGE_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+		}
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_WIKIPAGE_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByConditionFields[i],
+							true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByConditionFields[i],
+							true));
+				}
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByFields[i], true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByFields[i], true));
+				}
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(WikiPageModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(WikiPageModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), WikiPage.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+		sqlQuery.setFirstResult(0);
+		sqlQuery.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, WikiPageImpl.class);
+		}
+		else {
+			sqlQuery.addEntity(_FILTER_ENTITY_TABLE, WikiPageImpl.class);
+		}
+
+		QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+		queryPos.add(groupId);
+
+		if (bindExternalReferenceCode) {
+			queryPos.add(externalReferenceCode);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(wikiPage)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<WikiPage> list = sqlQuery.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the wiki pages where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 */
+	@Override
+	public void removeByG_ERC(long groupId, String externalReferenceCode) {
+		for (WikiPage wikiPage :
+				findByG_ERC(
+					groupId, externalReferenceCode, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(wikiPage);
+		}
+	}
+
+	/**
+	 * Returns the number of wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching wiki pages
+	 */
+	@Override
+	public int countByG_ERC(long groupId, String externalReferenceCode) {
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		FinderPath finderPath = _finderPathCountByG_ERC;
+
+		Object[] finderArgs = new Object[] {groupId, externalReferenceCode};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(_SQL_COUNT_WIKIPAGE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
+	 * Returns the number of wiki pages that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching wiki pages that the user has permission to view
+	 */
+	@Override
+	public int filterCountByG_ERC(long groupId, String externalReferenceCode) {
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return countByG_ERC(groupId, externalReferenceCode);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(_FILTER_SQL_COUNT_WIKIPAGE_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), WikiPage.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addScalar(
+				COUNT_COLUMN_NAME, com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(groupId);
+
+			if (bindExternalReferenceCode) {
+				queryPos.add(externalReferenceCode);
+			}
+
+			Long count = (Long)sqlQuery.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
+		"wikiPage.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
+		"wikiPage.externalReferenceCode = ?";
+
+	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
+		"(wikiPage.externalReferenceCode IS NULL OR wikiPage.externalReferenceCode = '')";
+
 	private FinderPath _finderPathWithPaginationFindByN_T;
 	private FinderPath _finderPathWithoutPaginationFindByN_T;
 	private FinderPath _finderPathCountByN_T;
@@ -8729,6 +9751,304 @@ public class WikiPagePersistenceImpl
 
 	private static final String _FINDER_COLUMN_R_N_S_STATUS_2 =
 		"wikiPage.status = ?";
+
+	private FinderPath _finderPathFetchByG_ERC_V;
+	private FinderPath _finderPathCountByG_ERC_V;
+
+	/**
+	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or throws a <code>NoSuchPageException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching wiki page
+	 * @throws NoSuchPageException if a matching wiki page could not be found
+	 */
+	@Override
+	public WikiPage findByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws NoSuchPageException {
+
+		WikiPage wikiPage = fetchByG_ERC_V(
+			groupId, externalReferenceCode, version);
+
+		if (wikiPage == null) {
+			StringBundler sb = new StringBundler(8);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("groupId=");
+			sb.append(groupId);
+
+			sb.append(", externalReferenceCode=");
+			sb.append(externalReferenceCode);
+
+			sb.append(", version=");
+			sb.append(version);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchPageException(sb.toString());
+		}
+
+		return wikiPage;
+	}
+
+	/**
+	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	@Override
+	public WikiPage fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version) {
+
+		return fetchByG_ERC_V(groupId, externalReferenceCode, version, true);
+	}
+
+	/**
+	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
+	 */
+	@Override
+	public WikiPage fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version,
+		boolean useFinderCache) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		Object[] finderArgs = null;
+
+		if (useFinderCache) {
+			finderArgs = new Object[] {groupId, externalReferenceCode, version};
+		}
+
+		Object result = null;
+
+		if (useFinderCache) {
+			result = finderCache.getResult(
+				_finderPathFetchByG_ERC_V, finderArgs);
+		}
+
+		if (result instanceof WikiPage) {
+			WikiPage wikiPage = (WikiPage)result;
+
+			if ((groupId != wikiPage.getGroupId()) ||
+				!Objects.equals(
+					externalReferenceCode,
+					wikiPage.getExternalReferenceCode()) ||
+				(version != wikiPage.getVersion())) {
+
+				result = null;
+			}
+		}
+
+		if (result == null) {
+			StringBundler sb = new StringBundler(5);
+
+			sb.append(_SQL_SELECT_WIKIPAGE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_V_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_2);
+			}
+
+			sb.append(_FINDER_COLUMN_G_ERC_V_VERSION_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				queryPos.add(version);
+
+				List<WikiPage> list = query.list();
+
+				if (list.isEmpty()) {
+					if (useFinderCache) {
+						finderCache.putResult(
+							_finderPathFetchByG_ERC_V, finderArgs, list);
+					}
+				}
+				else {
+					if (list.size() > 1) {
+						Collections.sort(list, Collections.reverseOrder());
+
+						if (_log.isWarnEnabled()) {
+							if (!useFinderCache) {
+								finderArgs = new Object[] {
+									groupId, externalReferenceCode, version
+								};
+							}
+
+							_log.warn(
+								"WikiPagePersistenceImpl.fetchByG_ERC_V(long, String, double, boolean) with parameters (" +
+									StringUtil.merge(finderArgs) +
+										") yields a result set with more than 1 result. This violates the logical unique restriction. There is no order guarantee on which result is returned by this finder.");
+						}
+					}
+
+					WikiPage wikiPage = list.get(0);
+
+					result = wikiPage;
+
+					cacheResult(wikiPage);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		if (result instanceof List<?>) {
+			return null;
+		}
+		else {
+			return (WikiPage)result;
+		}
+	}
+
+	/**
+	 * Removes the wiki page where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the wiki page that was removed
+	 */
+	@Override
+	public WikiPage removeByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws NoSuchPageException {
+
+		WikiPage wikiPage = findByG_ERC_V(
+			groupId, externalReferenceCode, version);
+
+		return remove(wikiPage);
+	}
+
+	/**
+	 * Returns the number of wiki pages where groupId = &#63; and externalReferenceCode = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the number of matching wiki pages
+	 */
+	@Override
+	public int countByG_ERC_V(
+		long groupId, String externalReferenceCode, double version) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		FinderPath finderPath = _finderPathCountByG_ERC_V;
+
+		Object[] finderArgs = new Object[] {
+			groupId, externalReferenceCode, version
+		};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_COUNT_WIKIPAGE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_V_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_2);
+			}
+
+			sb.append(_FINDER_COLUMN_G_ERC_V_VERSION_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				queryPos.add(version);
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_ERC_V_GROUPID_2 =
+		"wikiPage.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_2 =
+		"wikiPage.externalReferenceCode = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_3 =
+		"(wikiPage.externalReferenceCode IS NULL OR wikiPage.externalReferenceCode = '') AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_V_VERSION_2 =
+		"wikiPage.version = ?";
 
 	private FinderPath _finderPathWithPaginationFindByG_N_H;
 	private FinderPath _finderPathWithoutPaginationFindByG_N_H;
@@ -22161,272 +23481,6 @@ public class WikiPagePersistenceImpl
 	private static final String _FINDER_COLUMN_G_N_H_P_S_STATUS_2 =
 		"wikiPage.status = ?";
 
-	private FinderPath _finderPathFetchByG_ERC;
-	private FinderPath _finderPathCountByG_ERC;
-
-	/**
-	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchPageException</code> if it could not be found.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the matching wiki page
-	 * @throws NoSuchPageException if a matching wiki page could not be found
-	 */
-	@Override
-	public WikiPage findByG_ERC(long groupId, String externalReferenceCode)
-		throws NoSuchPageException {
-
-		WikiPage wikiPage = fetchByG_ERC(groupId, externalReferenceCode);
-
-		if (wikiPage == null) {
-			StringBundler sb = new StringBundler(6);
-
-			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
-
-			sb.append("groupId=");
-			sb.append(groupId);
-
-			sb.append(", externalReferenceCode=");
-			sb.append(externalReferenceCode);
-
-			sb.append("}");
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(sb.toString());
-			}
-
-			throw new NoSuchPageException(sb.toString());
-		}
-
-		return wikiPage;
-	}
-
-	/**
-	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	 */
-	@Override
-	public WikiPage fetchByG_ERC(long groupId, String externalReferenceCode) {
-		return fetchByG_ERC(groupId, externalReferenceCode, true);
-	}
-
-	/**
-	 * Returns the wiki page where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	 */
-	@Override
-	public WikiPage fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
-
-		externalReferenceCode = Objects.toString(externalReferenceCode, "");
-
-		Object[] finderArgs = null;
-
-		if (useFinderCache) {
-			finderArgs = new Object[] {groupId, externalReferenceCode};
-		}
-
-		Object result = null;
-
-		if (useFinderCache) {
-			result = finderCache.getResult(_finderPathFetchByG_ERC, finderArgs);
-		}
-
-		if (result instanceof WikiPage) {
-			WikiPage wikiPage = (WikiPage)result;
-
-			if ((groupId != wikiPage.getGroupId()) ||
-				!Objects.equals(
-					externalReferenceCode,
-					wikiPage.getExternalReferenceCode())) {
-
-				result = null;
-			}
-		}
-
-		if (result == null) {
-			StringBundler sb = new StringBundler(4);
-
-			sb.append(_SQL_SELECT_WIKIPAGE_WHERE);
-
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
-			boolean bindExternalReferenceCode = false;
-
-			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
-			}
-			else {
-				bindExternalReferenceCode = true;
-
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
-			}
-
-			String sql = sb.toString();
-
-			Session session = null;
-
-			try {
-				session = openSession();
-
-				Query query = session.createQuery(sql);
-
-				QueryPos queryPos = QueryPos.getInstance(query);
-
-				queryPos.add(groupId);
-
-				if (bindExternalReferenceCode) {
-					queryPos.add(externalReferenceCode);
-				}
-
-				List<WikiPage> list = query.list();
-
-				if (list.isEmpty()) {
-					if (useFinderCache) {
-						finderCache.putResult(
-							_finderPathFetchByG_ERC, finderArgs, list);
-					}
-				}
-				else {
-					if (list.size() > 1) {
-						Collections.sort(list, Collections.reverseOrder());
-
-						if (_log.isWarnEnabled()) {
-							if (!useFinderCache) {
-								finderArgs = new Object[] {
-									groupId, externalReferenceCode
-								};
-							}
-
-							_log.warn(
-								"WikiPagePersistenceImpl.fetchByG_ERC(long, String, boolean) with parameters (" +
-									StringUtil.merge(finderArgs) +
-										") yields a result set with more than 1 result. This violates the logical unique restriction. There is no order guarantee on which result is returned by this finder.");
-						}
-					}
-
-					WikiPage wikiPage = list.get(0);
-
-					result = wikiPage;
-
-					cacheResult(wikiPage);
-				}
-			}
-			catch (Exception exception) {
-				throw processException(exception);
-			}
-			finally {
-				closeSession(session);
-			}
-		}
-
-		if (result instanceof List<?>) {
-			return null;
-		}
-		else {
-			return (WikiPage)result;
-		}
-	}
-
-	/**
-	 * Removes the wiki page where groupId = &#63; and externalReferenceCode = &#63; from the database.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the wiki page that was removed
-	 */
-	@Override
-	public WikiPage removeByG_ERC(long groupId, String externalReferenceCode)
-		throws NoSuchPageException {
-
-		WikiPage wikiPage = findByG_ERC(groupId, externalReferenceCode);
-
-		return remove(wikiPage);
-	}
-
-	/**
-	 * Returns the number of wiki pages where groupId = &#63; and externalReferenceCode = &#63;.
-	 *
-	 * @param groupId the group ID
-	 * @param externalReferenceCode the external reference code
-	 * @return the number of matching wiki pages
-	 */
-	@Override
-	public int countByG_ERC(long groupId, String externalReferenceCode) {
-		externalReferenceCode = Objects.toString(externalReferenceCode, "");
-
-		FinderPath finderPath = _finderPathCountByG_ERC;
-
-		Object[] finderArgs = new Object[] {groupId, externalReferenceCode};
-
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
-
-		if (count == null) {
-			StringBundler sb = new StringBundler(3);
-
-			sb.append(_SQL_COUNT_WIKIPAGE_WHERE);
-
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
-			boolean bindExternalReferenceCode = false;
-
-			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
-			}
-			else {
-				bindExternalReferenceCode = true;
-
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
-			}
-
-			String sql = sb.toString();
-
-			Session session = null;
-
-			try {
-				session = openSession();
-
-				Query query = session.createQuery(sql);
-
-				QueryPos queryPos = QueryPos.getInstance(query);
-
-				queryPos.add(groupId);
-
-				if (bindExternalReferenceCode) {
-					queryPos.add(externalReferenceCode);
-				}
-
-				count = (Long)query.uniqueResult();
-
-				finderCache.putResult(finderPath, finderArgs, count);
-			}
-			catch (Exception exception) {
-				throw processException(exception);
-			}
-			finally {
-				closeSession(session);
-			}
-		}
-
-		return count.intValue();
-	}
-
-	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
-		"wikiPage.groupId = ? AND ";
-
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
-		"wikiPage.externalReferenceCode = ?";
-
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
-		"(wikiPage.externalReferenceCode IS NULL OR wikiPage.externalReferenceCode = '')";
-
 	public WikiPagePersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -22465,16 +23519,17 @@ public class WikiPagePersistenceImpl
 			wikiPage);
 
 		finderCache.putResult(
-			_finderPathFetchByN_T_V,
+			_finderPathFetchByG_ERC_V,
 			new Object[] {
-				wikiPage.getNodeId(), wikiPage.getTitle(), wikiPage.getVersion()
+				wikiPage.getGroupId(), wikiPage.getExternalReferenceCode(),
+				wikiPage.getVersion()
 			},
 			wikiPage);
 
 		finderCache.putResult(
-			_finderPathFetchByG_ERC,
+			_finderPathFetchByN_T_V,
 			new Object[] {
-				wikiPage.getGroupId(), wikiPage.getExternalReferenceCode()
+				wikiPage.getNodeId(), wikiPage.getTitle(), wikiPage.getVersion()
 			},
 			wikiPage);
 	}
@@ -22557,20 +23612,22 @@ public class WikiPagePersistenceImpl
 		finderCache.putResult(_finderPathFetchByR_N_V, args, wikiPageModelImpl);
 
 		args = new Object[] {
+			wikiPageModelImpl.getGroupId(),
+			wikiPageModelImpl.getExternalReferenceCode(),
+			wikiPageModelImpl.getVersion()
+		};
+
+		finderCache.putResult(_finderPathCountByG_ERC_V, args, Long.valueOf(1));
+		finderCache.putResult(
+			_finderPathFetchByG_ERC_V, args, wikiPageModelImpl);
+
+		args = new Object[] {
 			wikiPageModelImpl.getNodeId(), wikiPageModelImpl.getTitle(),
 			wikiPageModelImpl.getVersion()
 		};
 
 		finderCache.putResult(_finderPathCountByN_T_V, args, Long.valueOf(1));
 		finderCache.putResult(_finderPathFetchByN_T_V, args, wikiPageModelImpl);
-
-		args = new Object[] {
-			wikiPageModelImpl.getGroupId(),
-			wikiPageModelImpl.getExternalReferenceCode()
-		};
-
-		finderCache.putResult(_finderPathCountByG_ERC, args, Long.valueOf(1));
-		finderCache.putResult(_finderPathFetchByG_ERC, args, wikiPageModelImpl);
 	}
 
 	/**
@@ -23216,6 +24273,25 @@ public class WikiPagePersistenceImpl
 			new String[] {Long.class.getName(), Integer.class.getName()},
 			new String[] {"resourcePrimKey", "status"}, false);
 
+		_finderPathWithPaginationFindByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_ERC",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode"}, true);
+
+		_finderPathWithoutPaginationFindByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_ERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, true);
+
+		_finderPathCountByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, false);
+
 		_finderPathWithPaginationFindByN_T = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByN_T",
 			new String[] {
@@ -23376,6 +24452,23 @@ public class WikiPagePersistenceImpl
 				Integer.class.getName()
 			},
 			new String[] {"resourcePrimKey", "nodeId", "status"}, false);
+
+		_finderPathFetchByG_ERC_V = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC_V",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Double.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode", "version"}, true);
+
+		_finderPathCountByG_ERC_V = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC_V",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Double.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode", "version"},
+			false);
 
 		_finderPathWithPaginationFindByG_N_H = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_N_H",
@@ -23806,16 +24899,6 @@ public class WikiPagePersistenceImpl
 			},
 			new String[] {"groupId", "nodeId", "head", "parentTitle", "status"},
 			false);
-
-		_finderPathFetchByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, true);
-
-		_finderPathCountByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, false);
 	}
 
 	@Deactivate

--- a/modules/apps/wiki/wiki-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/wiki/wiki-service/src/main/resources/META-INF/module-hbm.xml
@@ -33,7 +33,6 @@
 		</id>
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivatePropertyAccessor" name="mvccVersion" type="long" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
-		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="resourcePrimKey" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
@@ -41,6 +40,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="userName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="createDate" type="org.hibernate.type.TimestampType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="modifiedDate" type="org.hibernate.type.TimestampType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="nodeId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="title" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="version" type="com.liferay.portal.dao.orm.hibernate.DoubleType" />

--- a/modules/apps/wiki/wiki-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/wiki/wiki-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -28,7 +28,6 @@
 	<model name="com.liferay.wiki.model.WikiPage">
 		<field name="mvccVersion" type="long" />
 		<field name="uuid" type="String" />
-		<field name="externalReferenceCode" type="String" />
 		<field name="pageId" type="long" />
 		<field name="resourcePrimKey" type="long" />
 		<field name="groupId" type="long" />
@@ -37,6 +36,7 @@
 		<field name="userName" type="String" />
 		<field name="createDate" type="Date" />
 		<field name="modifiedDate" type="Date" />
+		<field name="externalReferenceCode" type="String" />
 		<field name="nodeId" type="long" />
 		<field name="title" type="String">
 			<hint name="max-length">255</hint>

--- a/modules/apps/wiki/wiki-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/wiki/wiki-service/src/main/resources/META-INF/sql/indexes.sql
@@ -7,7 +7,7 @@ create unique index IX_7609B2AE on WikiNode (uuid_[$COLUMN_LENGTH:75$], groupId)
 
 create index IX_B65BBC83 on WikiPage (companyId);
 create index IX_A2001730 on WikiPage (format[$COLUMN_LENGTH:75$]);
-create index IX_8C2777D8 on WikiPage (groupId, externalReferenceCode[$COLUMN_LENGTH:75$]);
+create index IX_18565130 on WikiPage (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], version);
 create index IX_BA72B89A on WikiPage (groupId, nodeId, head, parentTitle[$COLUMN_LENGTH:255$], status);
 create index IX_E0092FF0 on WikiPage (groupId, nodeId, head, status);
 create index IX_941E429C on WikiPage (groupId, nodeId, status);

--- a/modules/apps/wiki/wiki-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/wiki/wiki-service/src/main/resources/META-INF/sql/tables.sql
@@ -22,7 +22,6 @@ create table WikiNode (
 create table WikiPage (
 	mvccVersion LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
-	externalReferenceCode VARCHAR(75) null,
 	pageId LONG not null primary key,
 	resourcePrimKey LONG,
 	groupId LONG,
@@ -31,6 +30,7 @@ create table WikiPage (
 	userName VARCHAR(75) null,
 	createDate DATE null,
 	modifiedDate DATE null,
+	externalReferenceCode VARCHAR(75) null,
 	nodeId LONG,
 	title VARCHAR(255) null,
 	version DOUBLE,

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiPagePersistenceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiPagePersistenceTest.java
@@ -129,8 +129,6 @@ public class WikiPagePersistenceTest {
 
 		newWikiPage.setUuid(RandomTestUtil.randomString());
 
-		newWikiPage.setExternalReferenceCode(RandomTestUtil.randomString());
-
 		newWikiPage.setResourcePrimKey(RandomTestUtil.nextLong());
 
 		newWikiPage.setGroupId(RandomTestUtil.nextLong());
@@ -144,6 +142,8 @@ public class WikiPagePersistenceTest {
 		newWikiPage.setCreateDate(RandomTestUtil.nextDate());
 
 		newWikiPage.setModifiedDate(RandomTestUtil.nextDate());
+
+		newWikiPage.setExternalReferenceCode(RandomTestUtil.randomString());
 
 		newWikiPage.setNodeId(RandomTestUtil.nextLong());
 
@@ -184,9 +184,6 @@ public class WikiPagePersistenceTest {
 			existingWikiPage.getMvccVersion(), newWikiPage.getMvccVersion());
 		Assert.assertEquals(existingWikiPage.getUuid(), newWikiPage.getUuid());
 		Assert.assertEquals(
-			existingWikiPage.getExternalReferenceCode(),
-			newWikiPage.getExternalReferenceCode());
-		Assert.assertEquals(
 			existingWikiPage.getPageId(), newWikiPage.getPageId());
 		Assert.assertEquals(
 			existingWikiPage.getResourcePrimKey(),
@@ -205,6 +202,9 @@ public class WikiPagePersistenceTest {
 		Assert.assertEquals(
 			Time.getShortTimestamp(existingWikiPage.getModifiedDate()),
 			Time.getShortTimestamp(newWikiPage.getModifiedDate()));
+		Assert.assertEquals(
+			existingWikiPage.getExternalReferenceCode(),
+			newWikiPage.getExternalReferenceCode());
 		Assert.assertEquals(
 			existingWikiPage.getNodeId(), newWikiPage.getNodeId());
 		Assert.assertEquals(
@@ -315,6 +315,15 @@ public class WikiPagePersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_ERC() throws Exception {
+		_persistence.countByG_ERC(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByG_ERC(0L, "null");
+
+		_persistence.countByG_ERC(0L, (String)null);
+	}
+
+	@Test
 	public void testCountByN_T() throws Exception {
 		_persistence.countByN_T(RandomTestUtil.nextLong(), "");
 
@@ -382,6 +391,16 @@ public class WikiPagePersistenceTest {
 			RandomTestUtil.nextInt());
 
 		_persistence.countByR_N_S(0L, 0L, 0);
+	}
+
+	@Test
+	public void testCountByG_ERC_V() throws Exception {
+		_persistence.countByG_ERC_V(
+			RandomTestUtil.nextLong(), "", RandomTestUtil.nextDouble());
+
+		_persistence.countByG_ERC_V(0L, "null", 0D);
+
+		_persistence.countByG_ERC_V(0L, (String)null, 0D);
 	}
 
 	@Test
@@ -579,15 +598,6 @@ public class WikiPagePersistenceTest {
 	}
 
 	@Test
-	public void testCountByG_ERC() throws Exception {
-		_persistence.countByG_ERC(RandomTestUtil.nextLong(), "");
-
-		_persistence.countByG_ERC(0L, "null");
-
-		_persistence.countByG_ERC(0L, (String)null);
-	}
-
-	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		WikiPage newWikiPage = addWikiPage();
 
@@ -612,15 +622,14 @@ public class WikiPagePersistenceTest {
 
 	protected OrderByComparator<WikiPage> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
-			"WikiPage", "mvccVersion", true, "uuid", true,
-			"externalReferenceCode", true, "pageId", true, "resourcePrimKey",
-			true, "groupId", true, "companyId", true, "userId", true,
-			"userName", true, "createDate", true, "modifiedDate", true,
-			"nodeId", true, "title", true, "version", true, "minorEdit", true,
-			"summary", true, "format", true, "head", true, "parentTitle", true,
-			"redirectTitle", true, "lastPublishDate", true, "status", true,
-			"statusByUserId", true, "statusByUserName", true, "statusDate",
-			true);
+			"WikiPage", "mvccVersion", true, "uuid", true, "pageId", true,
+			"resourcePrimKey", true, "groupId", true, "companyId", true,
+			"userId", true, "userName", true, "createDate", true,
+			"modifiedDate", true, "externalReferenceCode", true, "nodeId", true,
+			"title", true, "version", true, "minorEdit", true, "summary", true,
+			"format", true, "head", true, "parentTitle", true, "redirectTitle",
+			true, "lastPublishDate", true, "status", true, "statusByUserId",
+			true, "statusByUserName", true, "statusDate", true);
 	}
 
 	@Test
@@ -902,6 +911,22 @@ public class WikiPagePersistenceTest {
 				new Class<?>[] {String.class}, "version"));
 
 		Assert.assertEquals(
+			Long.valueOf(wikiPage.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				wikiPage, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
+		Assert.assertEquals(
+			wikiPage.getExternalReferenceCode(),
+			ReflectionTestUtil.invoke(
+				wikiPage, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "externalReferenceCode"));
+		AssertUtils.assertEquals(
+			wikiPage.getVersion(),
+			ReflectionTestUtil.<Double>invoke(
+				wikiPage, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "version"));
+
+		Assert.assertEquals(
 			Long.valueOf(wikiPage.getNodeId()),
 			ReflectionTestUtil.<Long>invoke(
 				wikiPage, "getColumnOriginalValue",
@@ -916,17 +941,6 @@ public class WikiPagePersistenceTest {
 			ReflectionTestUtil.<Double>invoke(
 				wikiPage, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "version"));
-
-		Assert.assertEquals(
-			Long.valueOf(wikiPage.getGroupId()),
-			ReflectionTestUtil.<Long>invoke(
-				wikiPage, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "groupId"));
-		Assert.assertEquals(
-			wikiPage.getExternalReferenceCode(),
-			ReflectionTestUtil.invoke(
-				wikiPage, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "externalReferenceCode"));
 	}
 
 	protected WikiPage addWikiPage() throws Exception {
@@ -937,8 +951,6 @@ public class WikiPagePersistenceTest {
 		wikiPage.setMvccVersion(RandomTestUtil.nextLong());
 
 		wikiPage.setUuid(RandomTestUtil.randomString());
-
-		wikiPage.setExternalReferenceCode(RandomTestUtil.randomString());
 
 		wikiPage.setResourcePrimKey(RandomTestUtil.nextLong());
 
@@ -953,6 +965,8 @@ public class WikiPagePersistenceTest {
 		wikiPage.setCreateDate(RandomTestUtil.nextDate());
 
 		wikiPage.setModifiedDate(RandomTestUtil.nextDate());
+
+		wikiPage.setExternalReferenceCode(RandomTestUtil.randomString());
 
 		wikiPage.setNodeId(RandomTestUtil.nextLong());
 


### PR DESCRIPTION
We see that exists a problem with the external reference code (ERC) when a resource support versioning. In this case, the resource is WikiPage. Every time that we create a new version of a WikiPage a new file is created in the DB with a new pageId. Because the ERC is a representation of a resource scoped by group, the ERC should be the same for all versions of a resource, but this is not happening.

So, with this PR, we are creating the ERC manually in the DB and adding the filters to search the resource by the groupId and the ERC (called `G_E`) and adding another filter to retrieve a unique resource depending on the group, the ERC and the version (called `G_E_V`)

Also, in the update of the endpoints implementation to use the new methods added to the services, I changed the use of the pageId for the use of the resource primary key as we do in other endpoints and to be consistent with the IDs that we return.