### PR TITLE
LRQA-66397 | Deploy clay sample portlet for clay poshi tests

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -7631,6 +7631,7 @@ virtualHostname="localhost"
 				<pathconvert pathsep="," property="osgi.modules.paths">
 					<dirset
 						dir="modules"
+						excludes="**/node_modules/**"
 						includes="${osgi.modules.includes.pattern}"
 					>
 						<or>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
@@ -1,6 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
+	property osgi.modules.includes = "frontend-taglib-clay-sample-web";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.component.names = "Clay";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayMultiselect.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayMultiselect.testcase
@@ -1,6 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
+	property osgi.modules.includes = "frontend-taglib-clay-sample-web";
 	property portal.release = "true";
 	property portal.upstream = "quarantine";
 	property testray.component.names = "Clay";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClaySelect.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClaySelect.testcase
@@ -1,6 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
+	property osgi.modules.includes = "frontend-taglib-clay-sample-web";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.component.names = "Clay";


### PR DESCRIPTION
**Description**
The clay sample portlet is not packaged in a release bundle but is required for Clay CI poshi tests. We need a way to deploy the sample portlet when the tests are run. This adds a property to the clay tests to deploy the clay sample web module during ci testing.

**Test Plan**
- [x]  Check that the clay sample module is deployed before poshi test in CI: https://github.com/john-co/liferay-portal/pull/409#issuecomment-846318005
- [x] Locally make sure clay sample web is not included in bundle, run poshi test, and validate clay sample web is deployed before poshi test executes login

**JIRA Ticket**
https://issues.liferay.com/browse/LRQA-66397