### PR TITLE
LPS-131941 url mapper to avoid rewrite.xml + LPS-130649 support locales in URLs

### DIFF
--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/portlet/QuestionsPortlet.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/portlet/QuestionsPortlet.java
@@ -69,6 +69,7 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",
 		"com.liferay.portlet.scopeable=true",
+		"com.liferay.portlet.single-page-application=false",
 		"javax.portlet.display-name=Questions",
 		"javax.portlet.expiration-cache=0",
 		"javax.portlet.init-param.template-path=/",

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/portlet/route/QuestionsFriendlyURLMapper.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/portlet/route/QuestionsFriendlyURLMapper.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.questions.web.internal.portlet.route;
+
+import com.liferay.portal.kernel.portlet.DefaultFriendlyURLMapper;
+import com.liferay.portal.kernel.portlet.FriendlyURLMapper;
+import com.liferay.questions.web.internal.constants.QuestionsPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Gamarra
+ */
+@Component(
+	property = {
+		"com.liferay.portlet.friendly-url-routes=META-INF/friendly-url-routes/routes.xml",
+		"javax.portlet.name=" + QuestionsPortletKeys.QUESTIONS
+	},
+	service = FriendlyURLMapper.class
+)
+public class QuestionsFriendlyURLMapper extends DefaultFriendlyURLMapper {
+
+	@Override
+	public String getMapping() {
+		return _MAPPING;
+	}
+
+	@Override
+	public boolean isCheckMappingWithPrefix() {
+		return false;
+	}
+
+	private static final String _MAPPING = "questions";
+
+}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/friendly-url-routes/routes.xml
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/friendly-url-routes/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE routes PUBLIC "-//Liferay//DTD Friendly URL Routes 7.4.0//EN" "http://www.liferay.com/dtd/liferay-friendly-url-routes_7_4_0.dtd">
+
+<routes>
+	<route>
+		<pattern></pattern>
+	</route>
+</routes>

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/init.jsp
@@ -34,6 +34,7 @@ page import="com.liferay.portal.kernel.portlet.PortletProvider" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletProviderUtil" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
+page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.questions.web.internal.configuration.QuestionsConfiguration" %><%@
 page import="com.liferay.questions.web.internal.constants.QuestionsWebKeys" %>
 

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/App.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/App.es.js
@@ -75,7 +75,7 @@ export default (props) => {
 										/>
 									)}
 									exact
-									path="/question/:questionId"
+									path="/questions/question/:questionId"
 								/>
 								<Route
 									component={(props) => (
@@ -85,7 +85,7 @@ export default (props) => {
 										/>
 									)}
 									exact
-									path="/activity/:creatorId"
+									path="/questions/activity/:creatorId"
 								/>
 								<Route
 									component={(props) => (
@@ -95,7 +95,7 @@ export default (props) => {
 										/>
 									)}
 									exact
-									path="/subscriptions/:creatorId"
+									path="/questions/subscriptions/:creatorId"
 								/>
 								<Route
 									component={(props) => (

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/App.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/App.es.js
@@ -33,10 +33,16 @@ export default (props) => {
 
 	const packageName = props.npmResolvedPackageName;
 
+	let path = props.historyRouterBasePath;
+
+	if (path && props.i18nPath) {
+		path = props.i18nPath + path;
+	}
+
 	return (
 		<AppContextProvider {...props}>
 			<ClientContext.Provider value={client}>
-				<Router basename={props.historyRouterBasePath}>
+				<Router basename={path}>
 					<ErrorBoundary>
 						<div>
 							<NavigationBar />

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Comment.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Comment.es.js
@@ -50,7 +50,7 @@ export default ({comment, commentChange, editable = true}) => {
 				<div className="c-mb-0">
 					<ArticleBodyRenderer
 						{...comment}
-						signature={comment.creator.name}
+						signature={comment.creator && comment.creator.name}
 					/>
 				</div>
 

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/CreatorRow.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/CreatorRow.es.js
@@ -25,7 +25,7 @@ export default withRouter(
 		match: {
 			params: {sectionTitle},
 		},
-		question: {creator, creatorStatistics, dateCreated},
+		question: {creator = {}, creatorStatistics, dateCreated},
 	}) => (
 		<Link
 			className="align-items-center border-light btn btn-secondary c-ml-md-3 c-mt-3 c-mt-md-0 c-p-3 d-inline-flex justify-content-center position-relative questions-user"

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionRow.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionRow.es.js
@@ -142,20 +142,22 @@ export default ({currentSection, items, question, showSectionLabel}) => {
 
 			<div className="align-items-sm-center align-items-start d-flex flex-column-reverse flex-sm-row justify-content-between">
 				<div className="c-mt-3 c-mt-sm-0 stretched-link-layer">
-					<Link
-						to={`/questions/${sectionTitle}/creator/${question.creator.id}`}
-					>
-						<UserIcon
-							fullName={question.creator.name}
-							portraitURL={question.creator.image}
-							size="sm"
-							userId={String(question.creator.id)}
-						/>
+					{question.creator && (
+						<Link
+							to={`/questions/${sectionTitle}/creator/${question.creator.id}`}
+						>
+							<UserIcon
+								fullName={question.creator.name}
+								portraitURL={question.creator.image}
+								size="sm"
+								userId={String(question.creator.id)}
+							/>
 
-						<strong className="c-ml-2 text-dark">
-							{question.creator.name}
-						</strong>
-					</Link>
+							<strong className="c-ml-2 text-dark">
+								{question.creator.name}
+							</strong>
+						</Link>
+					)}
 
 					<span className="c-ml-2 small">
 						{'- ' + dateToInternationalHuman(question.dateModified)}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/RelatedQuestions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/RelatedQuestions.es.js
@@ -46,11 +46,9 @@ export default withRouter(
 
 		useEffect(() => {
 			setRelatedQuestions(
-				data
-					? data.messageBoardThreads.items.filter(
-							(otherQuestion) => otherQuestion.id !== question.id
-					  )
-					: []
+				data?.messageBoardThreads.items.filter(
+					(otherQuestion) => otherQuestion.id !== question.id
+				) ?? []
 			);
 		}, [data, question.id]);
 
@@ -117,13 +115,13 @@ export default withRouter(
 
 								<div className="c-mt-3 small stretched-link-layer">
 									<UserIcon
-										fullName={relatedQuestion.creator.name}
+										fullName={relatedQuestion.creator?.name}
 										portraitURL={
-											relatedQuestion.creator.image
+											relatedQuestion.creator?.image
 										}
 										size="sm"
 										userId={String(
-											relatedQuestion.creator.id
+											relatedQuestion.creator?.id
 										)}
 									/>
 

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/UserRow.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/UserRow.es.js
@@ -21,7 +21,7 @@ import UserPopover from './UserPopover.es';
 
 export default withRouter(
 	({
-		creator,
+		creator = {},
 		match: {
 			params: {sectionTitle},
 		},

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/NavigationBar.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/NavigationBar.es.js
@@ -34,6 +34,8 @@ export default withRouter(({history, location}) => {
 	const sectionTitle =
 		(match &&
 			match.params &&
+			match.params.sectionTitle !== 'activity' &&
+			match.params.sectionTitle !== 'subscriptions' &&
 			match.params.sectionTitle !== 'tag' &&
 			match.params.sectionTitle) ||
 		queryParams.get('sectiontitle');
@@ -99,7 +101,7 @@ export default withRouter(({history, location}) => {
 
 						<ClayNavigationBar.Item
 							active={isActive(
-								`/subscriptions/${context.userId}`
+								`/questions/subscriptions/${context.userId}`
 							)}
 							className={
 								Liferay.ThemeDisplay.isSignedIn()
@@ -108,7 +110,9 @@ export default withRouter(({history, location}) => {
 							}
 							onClick={() =>
 								historyPushParser(
-									`/subscriptions/${context.userId}${
+									`/questions/subscriptions/${
+										context.userId
+									}${
 										sectionTitle
 											? '?sectionTitle=' + sectionTitle
 											: ''
@@ -125,7 +129,9 @@ export default withRouter(({history, location}) => {
 						</ClayNavigationBar.Item>
 
 						<ClayNavigationBar.Item
-							active={isActive(`/activity/${context.userId}`)}
+							active={isActive(
+								`/questions/activity/${context.userId}`
+							)}
 							className={
 								Liferay.ThemeDisplay.isSignedIn()
 									? ''
@@ -133,7 +139,7 @@ export default withRouter(({history, location}) => {
 							}
 							onClick={() =>
 								historyPushParser(
-									`/activity/${context.userId}${
+									`/questions/activity/${context.userId}${
 										sectionTitle
 											? '?sectionTitle=' + sectionTitle
 											: ''

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
@@ -140,8 +140,8 @@ export default withRouter(
 				  question.messageBoardSection.title;
 
 		useEffect(() => {
-			document.title = questionId;
-		}, [questionId]);
+			document.title = (question && question.title) || questionId;
+		}, [question, questionId]);
 
 		useEffect(() => {
 			fetchMessages();
@@ -524,15 +524,17 @@ export default withRouter(
 					)}
 				</div>
 
-				<Helmet>
-					<title>{questionId}</title>
-					<link
-						href={`${getFullPath('questions')}${
-							context.historyRouterBasePath ? '' : '#/'
-						}questions/${sectionTitle}/${questionId}`}
-						rel="canonical"
-					/>
-				</Helmet>
+				{question && (
+					<Helmet>
+						<title>{question.headline}</title>
+						<link
+							href={`${getFullPath('questions')}${
+								context.historyRouterBasePath ? '' : '#/'
+							}questions/${sectionTitle}/${questionId}`}
+							rel="canonical"
+						/>
+					</Helmet>
+				)}
 			</section>
 		);
 	}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
@@ -525,7 +525,7 @@ export default withRouter(
 				</div>
 
 				<Helmet>
-					<title>${questionId}</title>
+					<title>{questionId}</title>
 					<link
 						href={`${getFullPath('questions')}${
 							context.historyRouterBasePath ? '' : '#/'

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
@@ -705,6 +705,7 @@ export default withRouter(
 							</ClayInput.Group>
 						</div>
 					)}
+
 					{section && (
 						<Helmet>
 							<title>{section.title}</title>

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
@@ -705,15 +705,17 @@ export default withRouter(
 							</ClayInput.Group>
 						</div>
 					)}
-					<Helmet>
-						<title>{sectionTitle}</title>
-						<link
-							href={`${getFullPath('questions')}${
-								context.historyRouterBasePath ? '' : '#/'
-							}questions/${sectionTitle}`}
-							rel="canonical"
-						/>
-					</Helmet>
+					{section && (
+						<Helmet>
+							<title>{section.title}</title>
+							<link
+								href={`${getFullPath('questions')}${
+									context.historyRouterBasePath ? '' : '#/'
+								}questions/${sectionTitle}`}
+								rel="canonical"
+							/>
+						</Helmet>
+					)}
 				</div>
 			);
 		}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
@@ -706,7 +706,7 @@ export default withRouter(
 						</div>
 					)}
 					<Helmet>
-						<title>${sectionTitle}</title>
+						<title>{sectionTitle}</title>
 						<link
 							href={`${getFullPath('questions')}${
 								context.historyRouterBasePath ? '' : '#/'

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/view.jsp
@@ -32,6 +32,8 @@
 			).put(
 				"historyRouterBasePath", questionsConfiguration.historyRouterBasePath()
 			).put(
+				"i18nPath", renderRequest.getAttribute(WebKeys.I18N_PATH)
+			).put(
 				"imageBrowseURL", renderRequest.getAttribute(QuestionsWebKeys.IMAGE_BROWSE_URL)
 			).put(
 				"includeContextPath", renderRequest.getAttribute("javax.servlet.include.context_path")


### PR DESCRIPTION
Add a friendly URL mapper to return the root path and let the history router work without redirections. We are trying to avoid using url-rewrite to change URLs because Liferay Online won't let us customize it (we could hardcode it in the portal, as there are already old forums URLs hardcoded but ugly). The friendly URL mapper logic is very convoluted (and I'm not very smart) so I've tried a lot of approaches. Someone with previous knowledge I'm sure will know of a better solution.

Most promising one and works is: https://github.com/rotty3000/remote-web-component-poc injecting routes (and implementing Route & Router because are inside portal-impl) and setting the base path of the History/Browser router containing the friendly URL (so the basePath would be /ask/-/questions/). This works but means a third change of paths (old forums, questions and this one with the friendly URL. So this could work but I want to avoid it as it means reindexing everything again.

This PR works by cheating. I noticed that tags paths worked as expected (with and without parameters!) and it does not make any sense. What it happens is that they get picked by an obscure logic after the friendly URL mapper/translate part and they get transformed by the AssetTags URL mapper 🤦 , that checks with contains instead of equality, can not do anything with the URL and no parameters so it passes the base path to rendering and everything works.

So, I've done the same. It seems very simple but it isn't.