### PR TITLE
LPS-132570 Duplicate error messages show up when resetting password

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/MultiSessionErrors.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/MultiSessionErrors.java
@@ -15,6 +15,8 @@
 package com.liferay.portal.kernel.servlet;
 
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
+import com.liferay.portal.kernel.exception.UserPasswordException;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 import javax.portlet.PortletRequest;
@@ -92,8 +94,11 @@ public class MultiSessionErrors {
 		return false;
 	}
 
-	private static final Class<?>[] _HIDE_DEFAULT_ERROR_MESSAGE_CLASSES = {
-		NoSuchLayoutException.class
-	};
+	private static final Class<?>[] _HIDE_DEFAULT_ERROR_MESSAGE_CLASSES =
+		ArrayUtil.append(
+			new Class<?>[] {
+				NoSuchLayoutException.class, UserPasswordException.class
+			},
+			UserPasswordException.class.getDeclaredClasses());
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/MultiSessionErrors.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/MultiSessionErrors.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.servlet;
 
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 import javax.portlet.PortletRequest;
@@ -63,6 +64,26 @@ public class MultiSessionErrors {
 		return false;
 	}
 
+	public static boolean isHideDefaultErrorMessage(
+		PortletRequest portletRequest, String portletId) {
+
+		if (MultiSessionMessages.contains(
+				portletRequest,
+				portletId +
+					SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE)) {
+
+			return true;
+		}
+
+		for (Class<?> clazz : _HIDE_DEFAULT_ERROR_MESSAGE_CLASSES) {
+			if (contains(portletRequest, clazz.getName())) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private static boolean _isEmpty(HttpServletRequest httpServletRequest) {
 		if (SessionErrors.isEmpty(httpServletRequest)) {
 			return true;
@@ -70,5 +91,9 @@ public class MultiSessionErrors {
 
 		return false;
 	}
+
+	private static final Class<?>[] _HIDE_DEFAULT_ERROR_MESSAGE_CLASSES = {
+		NoSuchLayoutException.class
+	};
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/packageinfo
@@ -1,1 +1,1 @@
-version 8.5.0
+version 8.6.0

--- a/portal-web/docroot/html/taglib/theme/portlet_messages/page.jsp
+++ b/portal-web/docroot/html/taglib/theme/portlet_messages/page.jsp
@@ -97,6 +97,6 @@ else if (group.isStagingGroup()) {
 <liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_CONFIGURATION %>" message="you-have-successfully-updated-the-setup" />
 <liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_PREFERENCES %>" message="you-have-successfully-updated-your-preferences" />
 
-<c:if test="<%= !MultiSessionErrors.contains(renderRequest, NoSuchLayoutException.class.getName()) && !MultiSessionMessages.contains(renderRequest, portlet.getPortletId() + SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE) %>">
+<c:if test="<%= !MultiSessionErrors.isHideDefaultErrorMessage(renderRequest, portlet.getPortletId()) %>">
 	<liferay-ui:error embed="<%= false %>" />
 </c:if>


### PR DESCRIPTION
## Steps to reproduce

1. Set up an SMTP server to listen to email requests, such as http://nilhcem.com/FakeSMTP/ 
2. Navigate to Control Panel > Instance Settings > search for "mail" and select Mail Sender
3. Update the email address to something not on the blacklist (I chose jb@liferay.com)
4. Navigate to Control Panel > Server Administration > Mail and set the SMTP server info to match the SMTP server you setup in step 1
5. Create a new user, and set their password to something you know
6. Open a new web browser, and click on sign in > forgot password, enter in the email address of the user you created, and request a password reset email
7. Enter the same password as the password you set it to in the earlier step.

**Expected**: The "Your request failed to complete" toast error message should only show once. Not multiple times.

**Actual**: You will get an error "your password cannot be the same as the old password", and two "Your request failed to complete" toast error messages show up at the bottom left corner.

## Initial analysis

This appears to have been caused by there being two portlets (site navigation menu and search bar) on this placeholder page, each one running the `liferay-theme:portlet-messages` tag library, which in turn invokes the `liferay-ui:error` with no key, causing the toast message Javascript to appear in the page multiple times.

Adding code to remember if it's already shown at least once resolves the issue, but if there's a different way that you suspect may resolve the issue, or if there's something you'd like me to investigate, please let me know.