### PR TITLE
LPS-132868 Fix error when the root topic is selected in Questions

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/Home.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/Home.js
@@ -51,8 +51,10 @@ export default withRouter(({history}) => {
 	const [getSectionBySectionTitle] = useManualQuery(
 		getSectionBySectionTitleQuery,
 		{
-			filter: `title eq '${context.rootTopicId}' or id eq '${context.rootTopicId}'`,
-			siteKey: context.siteKey,
+			variables: {
+				filter: `title eq '${context.rootTopicId}' or id eq '${context.rootTopicId}'`,
+				siteKey: context.siteKey,
+			},
 		}
 	);
 
@@ -60,9 +62,10 @@ export default withRouter(({history}) => {
 		const fn =
 			!context.rootTopicId || context.rootTopicId === '0'
 				? getSections()
-				: getSectionBySectionTitle().then(
-						({data}) => data.messageBoardSections.items[0]
-				  );
+				: getSectionBySectionTitle().then((result) => ({
+						...result,
+						data: result.data.messageBoardSections.items[0],
+				  }));
 
 		fn.then((result) => ({
 			...result,
@@ -87,7 +90,7 @@ export default withRouter(({history}) => {
 	]);
 
 	function descriptionTruncate(description) {
-		return description.length > 150
+		return description?.length > 150
 			? description.substring(0, 150) + '...'
 			: description;
 	}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
@@ -84,7 +84,9 @@ export default withRouter(
 			if (question && question.id) {
 				getMessages(question.id, sort, page, pageSize).then(
 					({data: {messageBoardThreadMessageBoardMessages}}) => {
-						if (messageBoardThreadMessageBoardMessages.totalCount) {
+						if (
+							messageBoardThreadMessageBoardMessages?.totalCount
+						) {
 							if (sort !== 'votes') {
 								setAnswers({
 									...messageBoardThreadMessageBoardMessages,


### PR DESCRIPTION
Fix the argument passed to the getSectionBySectionTitle query to be inside the variables property, and make the same transformation of the response we are doing when we make the getSections query to have the same result and have the same behavior in the next chaining transformations.

Also fix some issues when some properties were null.