### PR TITLE
LPS-132738 Fix unable to add question via tags

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
@@ -479,7 +479,7 @@ export default withRouter(
 							changeDelta={setPageSize}
 							data={questions}
 							emptyState={
-								!search && !filter ? (
+								sectionTitle && !search && !filter ? (
 									<ClayEmptyState
 										description={Liferay.Language.get(
 											'there-are-no-questions-inside-this-topic-be-the-first-to-ask-something'


### PR DESCRIPTION
In this case, it makes no sense to be able to add questions from the tag's page, because the app wouldn't know in which topic you want to create the question.
 
I've hidden the button when there is no sectionTitle in the Questions page (that is when we get there from the Tags page), and show the no results empty state, as it feels more correct for me because we are doing a search by tag