### PR TITLE
LPS-133007 Fix Page structure tree dnd in page editor

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.js
@@ -779,7 +779,7 @@ function Treeview({
 		}
 	};
 
-	const handleMouseDown = (event) => {
+	const handleMouseDown = () => {
 		cancelTimer();
 
 		setHasFocus((hadFocus) => {
@@ -792,8 +792,6 @@ function Treeview({
 
 			return true;
 		});
-
-		event.preventDefault();
 	};
 
 	const handleFocus = () => {


### PR DESCRIPTION
This pr https://github.com/liferay-frontend/liferay-portal/pull/1063 caused a regression in the page editor. It is not possible to drag and drop element in the page structure tree, which is using this Treeview component

Removing the preventDefault makes fix the regression and also doesn't cause the bug that the previous pr was solving :)
