### PR TITLE
LPS-133052 Consider owner permissions in MessageBoardThreadModelResourcePermission

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
@@ -871,9 +871,17 @@ public class MessageBoardThreadResourceImpl
 			PermissionChecker permissionChecker, long primaryKey,
 			String actionId) {
 
-			return permissionChecker.hasPermission(
-				_mbMessage.getGroupId(), _name, _mbMessage.getRootMessageId(),
-				actionId);
+			if (permissionChecker.hasOwnerPermission(
+					_mbMessage.getCompanyId(), _name, _mbMessage.getMessageId(),
+					_mbMessage.getUserId(), actionId) ||
+				permissionChecker.hasPermission(
+					_mbMessage.getGroupId(), _name, _mbMessage.getMessageId(),
+					actionId)) {
+
+				return true;
+			}
+
+			return false;
 		}
 
 		@Override


### PR DESCRIPTION
The owner permissions are not being considered when a custom ModelResourcePermission is passed to the ActionUtil addAction method.

To fix this issue I add the owner consideration inside the MessageBoardThreadModelResourcePermission logic.