### PR TITLE
LPS-132874 Clear cache after mutations to avoid inconsistencies in UI

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/DeleteQuestion.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/DeleteQuestion.es.js
@@ -18,7 +18,7 @@ import {withRouter} from 'react-router-dom';
 
 import {AppContext} from '../AppContext.es';
 import {deleteMessageBoardThreadQuery} from '../utils/client.es';
-import {historyPushWithSlug} from '../utils/utils.es';
+import {deleteCache, historyPushWithSlug} from '../utils/utils.es';
 import Modal from './Modal.es';
 
 export default withRouter(
@@ -41,6 +41,7 @@ export default withRouter(
 									messageBoardThreadId: question.id,
 								},
 							}).then(() => {
+								deleteCache();
 								historyPushParser(
 									`/questions/${
 										context.useTopicNamesInURL

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/SectionSubscription.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/SectionSubscription.es.js
@@ -36,9 +36,7 @@ export default ({
 
 	const onCompleted = () => {
 		setSubscription(!subscription);
-		if (onSubscription) {
-			onSubscription(!subscription);
-		}
+		onSubscription?.();
 	};
 
 	const [subscribeSection] = useMutation(subscribeSectionQuery);

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Subscription.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Subscription.es.js
@@ -19,7 +19,10 @@ import React, {useEffect, useState} from 'react';
 
 import {subscribeQuery, unsubscribeQuery} from '../utils/client.es';
 
-export default ({question: {id: messageBoardThreadId, subscribed}}) => {
+export default ({
+	onSubscription,
+	question: {id: messageBoardThreadId, subscribed},
+}) => {
 	const [subscription, setSubscription] = useState(false);
 
 	useEffect(() => {
@@ -31,9 +34,10 @@ export default ({question: {id: messageBoardThreadId, subscribed}}) => {
 
 	const changeSubscription = () => {
 		const fn = subscription ? unsubscribe : subscribe;
-		fn({variables: {messageBoardThreadId}}).then((_) =>
-			setSubscription(!subscription)
-		);
+		fn({variables: {messageBoardThreadId}}).then((_) => {
+			setSubscription(!subscription);
+			onSubscription?.();
+		});
 	};
 
 	return (

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
@@ -43,12 +43,14 @@ import useQueryParams from '../../hooks/useQueryParams.es';
 import {
 	createAnswerQuery,
 	getMessages,
+	getSubscriptionsQuery,
 	getThread,
 	markAsAnswerMessageBoardMessageQuery,
 } from '../../utils/client.es';
 import lang from '../../utils/lang.es';
 import {
 	dateToBriefInternationalHuman,
+	deleteCacheKey,
 	getContextLink,
 	getFullPath,
 	stripHTML,
@@ -317,6 +319,15 @@ export default withRouter(
 											>
 												{question.actions.subscribe && (
 													<Subscription
+														onSubscription={() =>
+															deleteCacheKey(
+																getSubscriptionsQuery,
+																{
+																	contentType:
+																		'MessageBoardThread',
+																}
+															)
+														}
 														question={question}
 														siteKey={
 															context.siteKey

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
@@ -35,9 +35,11 @@ import {
 	getSectionBySectionTitleQuery,
 	getSectionThreadsQuery,
 	getSectionsQuery,
+	getSubscriptionsQuery,
 	getThreadsQuery,
 } from '../../utils/client.es';
 import {
+	deleteCacheKey,
 	getBasePath,
 	getFullPath,
 	historyPushWithSlug,
@@ -107,6 +109,8 @@ export default withRouter(
 		const [questions, setQuestions] = useState([]);
 		const [search, setSearch] = useState(null);
 		const [section, setSection] = useState({});
+		const [sectionQuery, setSectionQuery] = useState('');
+		const [sectionQueryVariables, setSectionQueryVariables] = useState({});
 		const [totalCount, setTotalCount] = useState(0);
 
 		const queryParams = useQueryParams(location);
@@ -405,19 +409,25 @@ export default withRouter(
 
 		useEffect(() => {
 			if (sectionTitle && sectionTitle !== '0') {
+				const variables = {
+					filter: `title eq '${slugToText(
+						sectionTitle
+					)}' or id eq '${slugToText(sectionTitle)}'`,
+					siteKey: context.siteKey,
+				};
 				getSectionBySectionTitle({
-					variables: {
-						filter: `title eq '${slugToText(
-							sectionTitle
-						)}' or id eq '${slugToText(sectionTitle)}'`,
-						siteKey: context.siteKey,
-					},
-				}).then(({data}) =>
-					setSection(data.messageBoardSections.items[0])
-				);
+					variables,
+				}).then(({data}) => {
+					setSection(data.messageBoardSections.items[0]);
+					setSectionQuery(getSectionBySectionTitleQuery);
+					setSectionQueryVariables(variables);
+				});
 			}
 			else if (sectionTitle === '0') {
-				getSections({variables: {siteKey: context.siteKey}})
+				const variables = {siteKey: context.siteKey};
+				getSections({
+					variables,
+				})
 					.then(({data: {messageBoardSections}}) => ({
 						actions: messageBoardSections.actions,
 						id: 0,
@@ -427,7 +437,11 @@ export default withRouter(
 							messageBoardSections.items &&
 							messageBoardSections.items.length,
 					}))
-					.then(setSection);
+					.then((section) => {
+						setSection(section);
+						setSectionQuery(getSectionsQuery);
+						setSectionQueryVariables(variables);
+					});
 			}
 		}, [
 			sectionTitle,
@@ -547,7 +561,22 @@ export default withRouter(
 							section.actions &&
 							section.actions.subscribe && (
 								<div className="c-ml-3">
-									<SectionSubscription section={section} />
+									<SectionSubscription
+										onSubscription={() => {
+											deleteCacheKey(
+												sectionQuery,
+												sectionQueryVariables
+											);
+											deleteCacheKey(
+												getSubscriptionsQuery,
+												{
+													contentType:
+														'MessageBoardSection',
+												}
+											);
+										}}
+										section={section}
+									/>
 								</div>
 							)}
 					</div>

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/utils/utils.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/utils/utils.es.js
@@ -59,6 +59,17 @@ export function deleteCache() {
 	client.cache.clear();
 }
 
+export function deleteCacheKey(query, variables) {
+	const keyObj = {
+		operation: {
+			query,
+			variables,
+		},
+	};
+	keyObj.fetchOptions = {};
+	client.cache.delete(keyObj);
+}
+
 export function timeDifference(previous, current = new Date()) {
 	const msPerMinute = 60 * 1000;
 	const msPerHour = msPerMinute * 60;


### PR DESCRIPTION
Delete cache after deleting a question.

To fix inconsistencies with Subscription I've tried 3 approaches:

- Delete the cache completely (low performance)
- Use skipCache to by-pass the cache after a subscription operation and always on UserSubscriptions page
- Partially delete the cache to clean queries related to subscriptions
- Maintain state inside the Subscription components and ignore the query results

Another option would be to have a global "dirty" state that we can set when a subscription operation is made and use the skipCache only in the case the state is dirty (but it involves some global state that I was not happy about).

Update: We agreed on partially deleting the ache to clean queries related to subscriptions.