### PR TITLE
LPS-132024 Include cadmin.css in Portal

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/bnd.bnd
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Frontend CSS Cadmin Web
+Bundle-SymbolicName: com.liferay.frontend.css.cadmin.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /frontend-css-cadmin-web

--- a/modules/apps/frontend-css/frontend-css-cadmin-web/build.gradle
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/build.gradle
@@ -1,0 +1,25 @@
+buildCSS {
+	imports = [
+		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
+	]
+}
+
+dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:portal-url-builder:portal-url-builder-api")
+	compileOnly project(":apps:static:osgi:osgi-util")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-sql-dsl-api")
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/frontend-css/frontend-css-cadmin-web/build.gradle
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/build.gradle
@@ -17,9 +17,4 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:portal-url-builder:portal-url-builder-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
-	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
-	compileOnly project(":core:osgi-service-tracker-collections")
-	compileOnly project(":core:petra:petra-lang")
-	compileOnly project(":core:petra:petra-sql-dsl-api")
-	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/java/com/liferay/frontend/css/cadmin/web/internal/servlet/taglib/CadminTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/java/com/liferay/frontend/css/cadmin/web/internal/servlet/taglib/CadminTopHeadDynamicInclude.java
@@ -65,8 +65,7 @@ public class CadminTopHeadDynamicInclude extends BaseDynamicInclude {
 				_bundleContext.getBundle(), _FILE_NAME
 			).build());
 
-		printWriter.println(
-			"\" id=\"liferayCadminCSS\" rel=\"stylesheet\"");
+		printWriter.println("\" id=\"liferayCadminCSS\" rel=\"stylesheet\"");
 		printWriter.println(" type=\"text/css\" />");
 	}
 
@@ -101,6 +100,6 @@ public class CadminTopHeadDynamicInclude extends BaseDynamicInclude {
 	@Reference
 	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
 
-	private BundleContext _bundleContext;
+	private volatile BundleContext _bundleContext;
 
 }

--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/java/com/liferay/frontend/css/cadmin/web/internal/servlet/taglib/CadminTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/java/com/liferay/frontend/css/cadmin/web/internal/servlet/taglib/CadminTopHeadDynamicInclude.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.css.cadmin.web.internal.servlet.taglib;
+
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Patrick Yeo
+ */
+@Component(immediate = true, service = DynamicInclude.class)
+public class CadminTopHeadDynamicInclude extends BaseDynamicInclude {
+
+	@Override
+	public void include(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String key)
+		throws IOException {
+
+		if (!isSignedIn()) {
+			return;
+		}
+
+		PrintWriter printWriter = httpServletResponse.getWriter();
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder =
+			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				httpServletRequest);
+
+		printWriter.print("<link data-senna-track=\"temporary\" href=\"");
+
+		printWriter.print(
+			absolutePortalURLBuilder.forModule(
+				_bundleContext.getBundle(), _FILE_NAME
+			).build());
+
+		printWriter.println(
+			"\" id=\"liferayCadminCSS\" rel=\"stylesheet\"");
+		printWriter.println(" type=\"text/css\" />");
+	}
+
+	@Override
+	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
+		dynamicIncludeRegistry.register("/html/common/themes/top_head.jsp#pre");
+	}
+
+	@Activate
+	@Modified
+	protected void activate(
+			BundleContext bundleContext, ComponentContext componentContext,
+			Map<String, Object> properties)
+		throws Exception {
+
+		_bundleContext = bundleContext;
+	}
+
+	protected boolean isSignedIn() {
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if ((permissionChecker == null) || !permissionChecker.isSignedIn()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private static final String _FILE_NAME = "main.css";
+
+	@Reference
+	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
+
+	private BundleContext _bundleContext;
+
+}

--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/main.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/main.scss
@@ -1,0 +1,1 @@
+@import 'cadmin';


### PR DESCRIPTION
After jbalsas mentioned:

> We shouldn't couple cadmin with other modules that don't belong to us and that could make the isolation system go down if anything unexpected happens outside of our control.

> The mechanism to add css to any page given some conditions that are checked in Java is simple, generic and used extensively, so there should be no strong motivation to avoid having our own.

~and some discussion with @marcoscv-work @edalgrin, it was decided this should live in `frontend-css-web` or its own module in the parent directory. I'm not sure how to load css based on some Java conditions, but it sounds interesting. It may or may not be beneficial to load `cadmin` based on user permissions. If anyone has ideas / suggestions please help.~

Edit: I created a new module `frontend-css-cadmin-web` and it works, but I don't know if I did this right.