### PR TITLE
LPS-133072 propagate history router path

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserActivity.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserActivity.es.js
@@ -85,7 +85,7 @@ export default withRouter(
 
 		const hrefConstructor = (page) =>
 			`${
-				context.historyRouterBasePath ? '' : '/#'
+				context.historyRouterBasePath || '/#'
 			}/questions/activity/${creatorId}?page=${page}&pagesize=${pageSize}`;
 
 		const addSectionToQuestion = (question) => {

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
@@ -370,9 +370,7 @@ export default withRouter(
 		]);
 
 		function buildURL(search, page, pageSize) {
-			let url = !context.historyRouterBasePath
-				? '/#/questions'
-				: '/questions';
+			let url = (context.historyRouterBasePath || '/#') + '/questions';
 
 			if (sectionTitle || sectionTitle === '0') {
 				url += `/${sectionTitle}`;

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
@@ -116,7 +116,7 @@ export default withRouter(({history, location}) => {
 	const historyPushParser = historyPushWithSlug(history.push);
 
 	function buildURL(search, page, pageSize) {
-		let url = `${context.historyRouterBasePath ? '' : '/#'}/tags?`;
+		let url = (context.historyRouterBasePath || '/#') + '/tags?';
 
 		if (search) {
 			url += `search=${search}&`;


### PR DESCRIPTION
Right now we are dropping it from the URL and it works but it's very confusing. 

All these logic has to be refactored to avoid passing a link and doing `history.push` instead.