### PR TITLE
LPS-133073 Avoid fetching until queryParams are processed

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
@@ -102,10 +102,10 @@ export default withRouter(
 		const [error, setError] = useState({});
 		const [filter, setFilter] = useState();
 		const [loading, setLoading] = useState(true);
-		const [page, setPage] = useState(1);
-		const [pageSize, setPageSize] = useState(20);
+		const [page, setPage] = useState(null);
+		const [pageSize, setPageSize] = useState(null);
 		const [questions, setQuestions] = useState([]);
-		const [search, setSearch] = useState('');
+		const [search, setSearch] = useState(null);
 		const [section, setSection] = useState({});
 		const [totalCount, setTotalCount] = useState(0);
 
@@ -301,6 +301,10 @@ export default withRouter(
 		);
 
 		useEffect(() => {
+			if (!page || !pageSize || search == null) {
+				return;
+			}
+
 			if (section.id == null && !currentTag) {
 				return;
 			}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
@@ -56,9 +56,9 @@ export default withRouter(({history, location}) => {
 	const [searchBoxValue, setSearchBoxValue] = useState('');
 	const [loading, setLoading] = useState(true);
 	const [orderBy, setOrderBy] = useState('number-of-usages');
-	const [page, setPage] = useState(1);
-	const [pageSize, setPageSize] = useState(20);
-	const [search, setSearch] = useState('');
+	const [page, setPage] = useState(null);
+	const [pageSize, setPageSize] = useState(null);
+	const [search, setSearch] = useState(null);
 	const [tags, setTags] = useState([]);
 
 	const [tagsByDate] = useManualQuery(getTagsOrderByDateCreatedQuery, {
@@ -70,6 +70,10 @@ export default withRouter(({history, location}) => {
 	});
 
 	useEffect(() => {
+		if (!page || !pageSize || search == null) {
+			return;
+		}
+
 		const fn =
 			orderBy === 'latest-created'
 				? tagsByDate().then(({data, loading}) => ({


### PR DESCRIPTION
I've tried this strategy to avoid fetching until the queryParams are processed.

I initialized the page, pageSize, and search params to null instead of default values and check for these values before fetching.

In the queryParams hook this parameters will be loaded and then we can fetch the information