### PR TITLE
LPS-128643 Delete actions looks bad in KB

### DIFF
--- a/util-taglib/src/com/liferay/taglib/ui/IconDeleteTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconDeleteTag.java
@@ -91,7 +91,9 @@ public class IconDeleteTag extends IconTag {
 				}
 			}
 
-			setLinkCssClass("component-action");
+			if (!isLabel()) {
+				setLinkCssClass("component-action");
+			}
 		}
 
 		setIcon(icon);


### PR DESCRIPTION
Hi guys, 
I try to avoid the render of `<liferay-ui:icon-delete` with label and icon inside a small button with no space.
I try only adding the `component-action` CSS class when the tag doesn't have a label.

**How to test it:**

1. Go to add a page with the knowledge base display widget
2. Go add a KB article
3. Go to the page to view

**Before the fix**
![image](https://user-images.githubusercontent.com/67901/119969578-093b5f00-bfaf-11eb-8450-c64c0b071482.png)

**After the fix**
![image](https://user-images.githubusercontent.com/67901/119969673-240dd380-bfaf-11eb-8351-64b5eb5c1843.png)
