### PR TITLE
LPS-132489 Missing text formating container after double clicking linked blog content 

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/BaseAlloyEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/BaseAlloyEditorConfigContributor.java
@@ -63,8 +63,7 @@ public abstract class BaseAlloyEditorConfigContributor
 		).put(
 			"extraPlugins",
 			"addimages,ae_dragresize,ae_imagealignment,ae_placeholder," +
-				"ae_selectionregion,ae_tableresize,ae_tabletools,ae_uicore," +
-					"autolink"
+				"ae_selectionregion,ae_tableresize,ae_tabletools,ae_uicore"
 		).put(
 			"imageScaleResize", "scale"
 		).put(
@@ -72,8 +71,8 @@ public abstract class BaseAlloyEditorConfigContributor
 			StringUtil.replace(getLanguageId(themeDisplay), "iw_", "he_")
 		).put(
 			"removePlugins",
-			"contextmenu,elementspath,floatingspace,image2,link,liststyle," +
-				"resize,table,tabletools,toolbar"
+			"autolink,contextmenu,elementspath,floatingspace,image2,link," +
+				"liststyle,resize,table,tabletools,toolbar"
 		).put(
 			"skin", "moono-lisa"
 		);


### PR DESCRIPTION
Hello FEI team:

**Description of the issue:**

When you add a link inside the content of a blog and you try to format this content, the text formatting toolbar is not shown.

**Test plan:**
```

1. Start a bundle from master version
2. Go to DM > Add an image
3. Go to blogs > Attempt to add a new blog
4. Type title and content
5. Select all the content > Add a link using added image
6. Double clicking linked blog content
```

**Expected Result:**
Text formating container display. [Expected.mp4](https://issues.liferay.com/secure/attachment/406391/406391_Expected.mp4)

**Current Result:**
Text formating container is missing. [Reproduced.mp4](https://issues.liferay.com/secure/attachment/406392/406392_Reproduced.mp4) 

**Things i've tried:**
Comparing the behavior in other parts of the portal (Message Boards, web content, wiki) but they aren't using alloyeditor by default.
Looking behavior in previous versions without updated ckeditor (7.2)

**Solution:**
After adding autolink to removePlugins the behavior is the same as in previous versions.