### PR TITLE
LPS-132503 Only try to reload the iframe if have a valid contentWindow

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/progress.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/progress.js
@@ -81,7 +81,9 @@ AUI.add(
 					var instance = this;
 
 					setTimeout(() => {
-						instance._frame.get('contentWindow.location').reload();
+						instance._frame
+							.get('contentWindow')
+							?.location?.reload();
 					}, instance.get(STR_UPDATE_PERIOD));
 				},
 


### PR DESCRIPTION
Hi guys,

The problem is that after a submit when the file is uploaded and the user navigates, we have a pending call trying to reload the iframe, and the `instance._frame.get('contentWindow.location')` throws an error when trying to get the `.location` of null.

**How to reproduce:**

1. Navigate to DM
2. Open browser console
3. Upload document or image


**Before the fix**
Throws an error `Uncaught TypeError: Cannot read property 'location' of null`

**After the fix**
No browser errors 

