### PR TITLE
LPS-132871 ClassicEditor content is missing

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"ckeditor4-react": "1.3.0",
+		"ckeditor4-react": "1.4.2",
 		"frontend-js-web": "*",
 		"liferay-ckeditor": "4.16.0-liferay.2",
 		"prop-types": "15.7.2"

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -123,6 +123,7 @@ const ClassicEditor = React.forwardRef(
 				<Editor
 					className="lfr-editable"
 					config={getConfig()}
+					data={contents}
 					name={name}
 					onBeforeLoad={(CKEDITOR) => {
 						CKEDITOR.disableAutoInline = true;
@@ -153,9 +154,6 @@ const ClassicEditor = React.forwardRef(
 								return editor.pasteFilter.check(name);
 							}
 						}
-					}}
-					onInstanceReady={({editor}) => {
-						editor.setData(contents, {internal: true});
 					}}
 					ref={editorRefsCallback}
 					{...otherProps}

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1671,7 +1671,7 @@
     liferay-npm-bundler-plugin-namespace-packages "2.24.2"
     liferay-npm-bundler-plugin-replace-browser-modules "2.24.2"
     liferay-npm-bundler-plugin-resolve-linked-dependencies "2.24.2"
-    liferay-theme-tasks "10.3.0"
+    liferay-theme-tasks "10.4.0"
     metal-tools-soy "4.3.2"
     mini-css-extract-plugin "0.11.2"
     minimist "^1.2.0"
@@ -3733,12 +3733,19 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ckeditor4-react@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/ckeditor4-react/-/ckeditor4-react-1.3.0.tgz#de0d93380f1b634b896ed41eb9f476cfdfef308a"
-  integrity sha512-73PSba0K0Bx1m9rqCagX2ajPBFq4PDgkUAtqa8o2QrKVzhtPcnpo7uyuY6VYwAN0xLmmolsQu7x5XY4jmEJidg==
+ckeditor4-integrations-common@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ckeditor4-integrations-common/-/ckeditor4-integrations-common-0.2.0.tgz#994a83f94e14161fa8ee15e7f0edc8735b12d8f8"
+  integrity sha512-KkHztF0bkGOnTcifWFd55j5Y9SCR3uk12SGgS6L1mZNnBeIJFCcgTwZWEHtG2aDJF7aZob7cex1CShL+SrNuow==
   dependencies:
     load-script "^1.0.0"
+
+ckeditor4-react@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/ckeditor4-react/-/ckeditor4-react-1.4.2.tgz#6fc9b350c2f0541fd7acf3b102450039f57d91d5"
+  integrity sha512-4H5ZRCLBWoAaOVN+u+3bMXGOaq0n+FlYvHiH7F4FAIbxDXPSyDweQiTdMS74au/neOJffGY8mLtqf2nIP9wr7g==
+  dependencies:
+    ckeditor4-integrations-common "^0.2.0"
     prop-types "^15.6.2"
 
 class-utils@^0.3.5:


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-132871

@boton @julien 

This is a bugfix, but basically a followup on https://github.com/liferay-frontend/liferay-portal/pull/954. The bug was caused by https://github.com/liferay-frontend/liferay-portal/pull/954/commits/84432f7ed93f4c474f22b44f48548f1ba6769dd7, merged as a part of that PR. Looking at the discussion in the PR, I see you wanted to use `data` prop, [expecting](https://github.com/liferay-frontend/liferay-portal/pull/954#issuecomment-839672548) that React component does the updating. But, you were looking at `ckeditor4-react` master and we are using an older version of React component in DXP. If you tried it, we would show unformatted code (see 1.3.0 gif).

In this PR, we are updating `ckeditor4-react` to the latest version and using `data` param to set content.

**Important note** @boton : With this PR, it is likely that we will have regression on  https://issues.liferay.com/browse/LPS-130112. `onChange` is now be triggered internally and we cannot avoid it. I am not sure now to replicate the issue in that ticket, or if it's still valid. We should probably find a different way to work around, because we don't want to be stuck with old version of `ckeditor4-react` forever. Can you please look into this?


Before PR:
![before](https://user-images.githubusercontent.com/5435511/119999603-364d3900-bfd2-11eb-8ccd-3787f3d6cb74.gif)

After using `data` prop, without `ckeditor4-react` update:
![after1](https://user-images.githubusercontent.com/5435511/119998685-3993f500-bfd1-11eb-8686-f249b2e17814.gif)

After this PR:
![after](https://user-images.githubusercontent.com/5435511/119997842-70b5d680-bfd0-11eb-80f5-c7de0e3e7b15.gif)
