### PR TITLE
LPS-133035 dynamically register an AssetRenderer to change the URLs in the notifications and how we render the content of MBMessages

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryTracker.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryTracker.java
@@ -128,10 +128,10 @@ public class DepotAssetRendererFactoryTracker {
 					key, serviceReference.getProperty(key));
 			}
 
-			long defaultRanking = Integer.MAX_VALUE - 1000;
-
 			Integer serviceRanking = (Integer)serviceReference.getProperty(
 				"service.ranking:Integer");
+
+			long defaultRanking = Integer.MAX_VALUE - 1000;
 
 			if (serviceRanking != null) {
 				defaultRanking += serviceRanking;

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryTracker.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryTracker.java
@@ -128,8 +128,18 @@ public class DepotAssetRendererFactoryTracker {
 					key, serviceReference.getProperty(key));
 			}
 
+			long defaultRanking = Integer.MAX_VALUE - 1000;
+
+			Integer serviceRanking = (Integer)serviceReference.getProperty(
+				"service.ranking:Integer");
+
+			if (serviceRanking != null) {
+				defaultRanking += serviceRanking;
+			}
+
 			depotAssetRendererFactoryWrapperProperties.put(
-				"service.ranking", Integer.MAX_VALUE);
+				"service.ranking",
+				(int)Math.min(Integer.MAX_VALUE, defaultRanking));
 
 			AssetRendererFactory<?> depotAssetRendererFactoryWrapper =
 				new DepotAssetRendererFactoryWrapper(

--- a/modules/apps/questions/questions-web/build.gradle
+++ b/modules/apps/questions/questions-web/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:petra:petra-portlet-url-builder")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBCategoryAssetRenderer.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBCategoryAssetRenderer.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.questions.web.internal.asset.model;
+
+import com.liferay.asset.kernel.model.BaseJSPAssetRenderer;
+import com.liferay.message.boards.model.MBCategory;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.Locale;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+import javax.portlet.PortletURL;
+import javax.portlet.WindowState;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Javier Gamarra
+ */
+public class MBCategoryAssetRenderer extends BaseJSPAssetRenderer<MBCategory> {
+
+	public MBCategoryAssetRenderer(
+		Company company, String historyRouterBasePath, MBCategory mbCategory,
+		ModelResourcePermission<MBCategory> mbCategoryModelResourcePermission) {
+
+		_company = company;
+		_historyRouterBasePath = historyRouterBasePath;
+		_mbCategory = mbCategory;
+		_mbCategoryModelResourcePermission = mbCategoryModelResourcePermission;
+	}
+
+	@Override
+	public MBCategory getAssetObject() {
+		return _mbCategory;
+	}
+
+	@Override
+	public String getClassName() {
+		return MBCategory.class.getName();
+	}
+
+	@Override
+	public long getClassPK() {
+		return _mbCategory.getCategoryId();
+	}
+
+	@Override
+	public long getGroupId() {
+		return _mbCategory.getGroupId();
+	}
+
+	@Override
+	public String getJspPath(
+		HttpServletRequest httpServletRequest, String template) {
+
+		if (template.equals(TEMPLATE_ABSTRACT) ||
+			template.equals(TEMPLATE_FULL_CONTENT)) {
+
+			return "/message_boards/asset/" + template + ".jsp";
+		}
+
+		return null;
+	}
+
+	@Override
+	public int getStatus() {
+		return _mbCategory.getStatus();
+	}
+
+	@Override
+	public String getSummary(
+		PortletRequest portletRequest, PortletResponse portletResponse) {
+
+		return _mbCategory.getDescription();
+	}
+
+	@Override
+	public String getTitle(Locale locale) {
+		return _mbCategory.getName();
+	}
+
+	@Override
+	public PortletURL getURLEdit(
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		return null;
+	}
+
+	@Override
+	public String getURLView(
+			LiferayPortletResponse liferayPortletResponse,
+			WindowState windowState)
+		throws PortalException {
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_company.getPortalURL(_mbCategory.getGroupId()));
+		sb.append(_historyRouterBasePath);
+		sb.append("/questions/");
+		sb.append(_mbCategory.getCategoryId());
+
+		return sb.toString();
+	}
+
+	@Override
+	public String getURLViewInContext(
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse,
+		String noSuchEntryRedirect) {
+
+		return null;
+	}
+
+	@Override
+	public long getUserId() {
+		return _mbCategory.getUserId();
+	}
+
+	@Override
+	public String getUserName() {
+		return _mbCategory.getUserName();
+	}
+
+	@Override
+	public String getUuid() {
+		return _mbCategory.getUuid();
+	}
+
+	@Override
+	public boolean hasEditPermission(PermissionChecker permissionChecker)
+		throws PortalException {
+
+		return _mbCategoryModelResourcePermission.contains(
+			permissionChecker, _mbCategory, ActionKeys.UPDATE);
+	}
+
+	@Override
+	public boolean hasViewPermission(PermissionChecker permissionChecker)
+		throws PortalException {
+
+		return _mbCategoryModelResourcePermission.contains(
+			permissionChecker, _mbCategory, ActionKeys.VIEW);
+	}
+
+	@Override
+	public boolean include(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String template)
+		throws Exception {
+
+		httpServletRequest.setAttribute(
+			WebKeys.MESSAGE_BOARDS_CATEGORY, _mbCategory);
+
+		return super.include(httpServletRequest, httpServletResponse, template);
+	}
+
+	private final Company _company;
+	private final String _historyRouterBasePath;
+	private final MBCategory _mbCategory;
+	private final ModelResourcePermission<MBCategory>
+		_mbCategoryModelResourcePermission;
+
+}

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBCategoryAssetRendererFactory.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBCategoryAssetRendererFactory.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.questions.web.internal.asset.model;
+
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.BaseAssetRendererFactory;
+import com.liferay.message.boards.constants.MBPortletKeys;
+import com.liferay.message.boards.model.MBCategory;
+import com.liferay.message.boards.service.MBCategoryLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+
+import javax.portlet.PortletURL;
+import javax.portlet.WindowState;
+
+/**
+ * @author Javier Gamarra
+ */
+public class MBCategoryAssetRendererFactory
+	extends BaseAssetRendererFactory<MBCategory> {
+
+	public static final String TYPE = "category";
+
+	public MBCategoryAssetRendererFactory(
+		CompanyLocalService companyLocalService, String historyRouterBasePath,
+		MBCategoryLocalService mbCategoryLocalService,
+		ModelResourcePermission<MBCategory> mbCategoryModelResourcePermission) {
+
+		_companyLocalService = companyLocalService;
+		_historyRouterBasePath = historyRouterBasePath;
+		_mbCategoryLocalService = mbCategoryLocalService;
+		_mbCategoryModelResourcePermission = mbCategoryModelResourcePermission;
+
+		setCategorizable(false);
+		setPortletId(MBPortletKeys.MESSAGE_BOARDS);
+		setSelectable(false);
+	}
+
+	@Override
+	public AssetRenderer<MBCategory> getAssetRenderer(long classPK, int type)
+		throws PortalException {
+
+		MBCategory mbCategory = _mbCategoryLocalService.getMBCategory(classPK);
+
+		Company company = _companyLocalService.getCompany(
+			mbCategory.getCompanyId());
+
+		MBCategoryAssetRenderer mbCategoryAssetRenderer =
+			new MBCategoryAssetRenderer(
+				company, _historyRouterBasePath, mbCategory,
+				_mbCategoryModelResourcePermission);
+
+		mbCategoryAssetRenderer.setAssetRendererType(type);
+
+		return mbCategoryAssetRenderer;
+	}
+
+	@Override
+	public String getClassName() {
+		return MBCategory.class.getName();
+	}
+
+	@Override
+	public String getIconCssClass() {
+		return "comments";
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
+	}
+
+	@Override
+	public PortletURL getURLView(
+		LiferayPortletResponse liferayPortletResponse,
+		WindowState windowState) {
+
+		return null;
+	}
+
+	@Override
+	public boolean hasPermission(
+			PermissionChecker permissionChecker, long classPK, String actionId)
+		throws Exception {
+
+		return _mbCategoryModelResourcePermission.contains(
+			permissionChecker, _mbCategoryLocalService.getMBCategory(classPK),
+			actionId);
+	}
+
+	private final CompanyLocalService _companyLocalService;
+	private final String _historyRouterBasePath;
+	private final MBCategoryLocalService _mbCategoryLocalService;
+	private final ModelResourcePermission<MBCategory>
+		_mbCategoryModelResourcePermission;
+
+}

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBMessageAssetRenderer.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBMessageAssetRenderer.java
@@ -21,6 +21,7 @@ import com.liferay.message.boards.service.permission.MBDiscussionPermission;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -48,17 +49,18 @@ public class MBMessageAssetRenderer
 	extends BaseJSPAssetRenderer<MBMessage> implements TrashRenderer {
 
 	public MBMessageAssetRenderer(
-		String historyRouterPath, MBMessage message,
-		ModelResourcePermission<MBMessage> messageModelResourcePermission) {
+		Company company, String historyRouterPath, MBMessage mbMessage,
+		ModelResourcePermission<MBMessage> mbMessageModelResourcePermission) {
 
+		_company = company;
 		_historyRouterPath = historyRouterPath;
-		_message = message;
-		_messageModelResourcePermission = messageModelResourcePermission;
+		_mbMessage = mbMessage;
+		_mbMessageModelResourcePermission = mbMessageModelResourcePermission;
 	}
 
 	@Override
 	public MBMessage getAssetObject() {
-		return _message;
+		return _mbMessage;
 	}
 
 	@Override
@@ -68,12 +70,12 @@ public class MBMessageAssetRenderer
 
 	@Override
 	public long getClassPK() {
-		return _message.getMessageId();
+		return _mbMessage.getMessageId();
 	}
 
 	@Override
 	public long getGroupId() {
-		return _message.getGroupId();
+		return _mbMessage.getGroupId();
 	}
 
 	@Override
@@ -104,19 +106,19 @@ public class MBMessageAssetRenderer
 
 	@Override
 	public int getStatus() {
-		return _message.getStatus();
+		return _mbMessage.getStatus();
 	}
 
 	@Override
 	public String getSummary(
 		PortletRequest portletRequest, PortletResponse portletResponse) {
 
-		return _message.getBody();
+		return _mbMessage.getBody();
 	}
 
 	@Override
 	public String getTitle(Locale locale) {
-		return _message.getSubject();
+		return _mbMessage.getSubject();
 	}
 
 	@Override
@@ -134,10 +136,11 @@ public class MBMessageAssetRenderer
 
 	@Override
 	public String getURLView(
-		LiferayPortletResponse liferayPortletResponse,
-		WindowState windowState) {
+			LiferayPortletResponse liferayPortletResponse,
+			WindowState windowState)
+		throws PortalException {
 
-		return null;
+		return _getQuestionsURL(_company.getPortalURL(_mbMessage.getGroupId()));
 	}
 
 	@Override
@@ -150,64 +153,57 @@ public class MBMessageAssetRenderer
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		StringBundler sb = new StringBundler(4);
-
-		sb.append(themeDisplay.getPortalURL());
-		sb.append(_historyRouterPath);
-		sb.append("/questions/question/");
-		sb.append(_message.getMessageId());
-
-		return sb.toString();
+		return _getQuestionsURL(themeDisplay.getPortalURL());
 	}
 
 	@Override
 	public long getUserId() {
-		if (_message.isAnonymous()) {
+		if (_mbMessage.isAnonymous()) {
 			return 0;
 		}
 
-		return _message.getUserId();
+		return _mbMessage.getUserId();
 	}
 
 	@Override
 	public String getUserName() {
-		if (_message.isAnonymous()) {
+		if (_mbMessage.isAnonymous()) {
 			return LanguageUtil.get(
 				LocaleThreadLocal.getDefaultLocale(), "anonymous");
 		}
 
-		return _message.getUserName();
+		return _mbMessage.getUserName();
 	}
 
 	@Override
 	public String getUuid() {
-		return _message.getUuid();
+		return _mbMessage.getUuid();
 	}
 
 	@Override
 	public boolean hasEditPermission(PermissionChecker permissionChecker)
 		throws PortalException {
 
-		if (_message.isDiscussion()) {
+		if (_mbMessage.isDiscussion()) {
 			return MBDiscussionPermission.contains(
-				permissionChecker, _message, ActionKeys.UPDATE);
+				permissionChecker, _mbMessage, ActionKeys.UPDATE);
 		}
 
-		return _messageModelResourcePermission.contains(
-			permissionChecker, _message, ActionKeys.UPDATE);
+		return _mbMessageModelResourcePermission.contains(
+			permissionChecker, _mbMessage, ActionKeys.UPDATE);
 	}
 
 	@Override
 	public boolean hasViewPermission(PermissionChecker permissionChecker)
 		throws PortalException {
 
-		if (_message.isDiscussion()) {
+		if (_mbMessage.isDiscussion()) {
 			return MBDiscussionPermission.contains(
-				permissionChecker, _message, ActionKeys.VIEW);
+				permissionChecker, _mbMessage, ActionKeys.VIEW);
 		}
 
-		return _messageModelResourcePermission.contains(
-			permissionChecker, _message, ActionKeys.VIEW);
+		return _mbMessageModelResourcePermission.contains(
+			permissionChecker, _mbMessage, ActionKeys.VIEW);
 	}
 
 	@Override
@@ -217,7 +213,7 @@ public class MBMessageAssetRenderer
 		throws Exception {
 
 		httpServletRequest.setAttribute(
-			WebKeys.MESSAGE_BOARDS_MESSAGE, _message);
+			WebKeys.MESSAGE_BOARDS_MESSAGE, _mbMessage);
 
 		return super.include(httpServletRequest, httpServletResponse, template);
 	}
@@ -227,9 +223,21 @@ public class MBMessageAssetRenderer
 		return true;
 	}
 
+	private String _getQuestionsURL(String portalURL) {
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(portalURL);
+		sb.append(_historyRouterPath);
+		sb.append("/questions/question/");
+		sb.append(_mbMessage.getMessageId());
+
+		return sb.toString();
+	}
+
+	private final Company _company;
 	private final String _historyRouterPath;
-	private final MBMessage _message;
+	private final MBMessage _mbMessage;
 	private final ModelResourcePermission<MBMessage>
-		_messageModelResourcePermission;
+		_mbMessageModelResourcePermission;
 
 }

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBMessageAssetRenderer.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBMessageAssetRenderer.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.questions.web.internal.asset.model;
+
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.asset.kernel.model.BaseJSPAssetRenderer;
+import com.liferay.message.boards.model.MBMessage;
+import com.liferay.message.boards.service.permission.MBDiscussionPermission;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.trash.TrashRenderer;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.Locale;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+import javax.portlet.PortletURL;
+import javax.portlet.WindowState;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Javier Gamarra
+ */
+public class MBMessageAssetRenderer
+	extends BaseJSPAssetRenderer<MBMessage> implements TrashRenderer {
+
+	public MBMessageAssetRenderer(
+		String historyRouterPath, MBMessage message,
+		ModelResourcePermission<MBMessage> messageModelResourcePermission) {
+
+		_historyRouterPath = historyRouterPath;
+		_message = message;
+		_messageModelResourcePermission = messageModelResourcePermission;
+	}
+
+	@Override
+	public MBMessage getAssetObject() {
+		return _message;
+	}
+
+	@Override
+	public String getClassName() {
+		return MBMessage.class.getName();
+	}
+
+	@Override
+	public long getClassPK() {
+		return _message.getMessageId();
+	}
+
+	@Override
+	public long getGroupId() {
+		return _message.getGroupId();
+	}
+
+	@Override
+	public String getJspPath(
+		HttpServletRequest httpServletRequest, String template) {
+
+		if (template.equals(TEMPLATE_ABSTRACT) ||
+			template.equals(TEMPLATE_FULL_CONTENT)) {
+
+			return "/message_boards/asset/" + template + ".jsp";
+		}
+
+		return null;
+	}
+
+	@Override
+	public String getPortletId() {
+		AssetRendererFactory<MBMessage> assetRendererFactory =
+			getAssetRendererFactory();
+
+		return assetRendererFactory.getPortletId();
+	}
+
+	@Override
+	public String getSearchSummary(Locale locale) {
+		return getSummary(null, null);
+	}
+
+	@Override
+	public int getStatus() {
+		return _message.getStatus();
+	}
+
+	@Override
+	public String getSummary(
+		PortletRequest portletRequest, PortletResponse portletResponse) {
+
+		return _message.getBody();
+	}
+
+	@Override
+	public String getTitle(Locale locale) {
+		return _message.getSubject();
+	}
+
+	@Override
+	public String getType() {
+		return MBMessageAssetRendererFactory.TYPE;
+	}
+
+	@Override
+	public PortletURL getURLEdit(
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		return null;
+	}
+
+	@Override
+	public String getURLView(
+		LiferayPortletResponse liferayPortletResponse,
+		WindowState windowState) {
+
+		return null;
+	}
+
+	@Override
+	public String getURLViewInContext(
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse,
+		String noSuchEntryRedirect) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)liferayPortletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(themeDisplay.getPortalURL());
+		sb.append(_historyRouterPath);
+		sb.append("/questions/question/");
+		sb.append(_message.getMessageId());
+
+		return sb.toString();
+	}
+
+	@Override
+	public long getUserId() {
+		if (_message.isAnonymous()) {
+			return 0;
+		}
+
+		return _message.getUserId();
+	}
+
+	@Override
+	public String getUserName() {
+		if (_message.isAnonymous()) {
+			return LanguageUtil.get(
+				LocaleThreadLocal.getDefaultLocale(), "anonymous");
+		}
+
+		return _message.getUserName();
+	}
+
+	@Override
+	public String getUuid() {
+		return _message.getUuid();
+	}
+
+	@Override
+	public boolean hasEditPermission(PermissionChecker permissionChecker)
+		throws PortalException {
+
+		if (_message.isDiscussion()) {
+			return MBDiscussionPermission.contains(
+				permissionChecker, _message, ActionKeys.UPDATE);
+		}
+
+		return _messageModelResourcePermission.contains(
+			permissionChecker, _message, ActionKeys.UPDATE);
+	}
+
+	@Override
+	public boolean hasViewPermission(PermissionChecker permissionChecker)
+		throws PortalException {
+
+		if (_message.isDiscussion()) {
+			return MBDiscussionPermission.contains(
+				permissionChecker, _message, ActionKeys.VIEW);
+		}
+
+		return _messageModelResourcePermission.contains(
+			permissionChecker, _message, ActionKeys.VIEW);
+	}
+
+	@Override
+	public boolean include(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String template)
+		throws Exception {
+
+		httpServletRequest.setAttribute(
+			WebKeys.MESSAGE_BOARDS_MESSAGE, _message);
+
+		return super.include(httpServletRequest, httpServletResponse, template);
+	}
+
+	@Override
+	public boolean isPrintable() {
+		return true;
+	}
+
+	private final String _historyRouterPath;
+	private final MBMessage _message;
+	private final ModelResourcePermission<MBMessage>
+		_messageModelResourcePermission;
+
+}

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBMessageAssetRendererFactory.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBMessageAssetRendererFactory.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 
 import javax.portlet.PortletURL;
 import javax.portlet.WindowState;
@@ -36,12 +37,14 @@ public class MBMessageAssetRendererFactory
 	public static final String TYPE = "message";
 
 	public MBMessageAssetRendererFactory(
-		String historyRouterPath, MBMessageLocalService mbMessageLocalService,
-		ModelResourcePermission<MBMessage> messageModelResourcePermission) {
+		CompanyLocalService companyLocalService, String historyRouterPath,
+		MBMessageLocalService mbMessageLocalService,
+		ModelResourcePermission<MBMessage> mbMessageModelResourcePermission) {
 
+		_companyLocalService = companyLocalService;
 		_historyRouterPath = historyRouterPath;
 		_mbMessageLocalService = mbMessageLocalService;
-		_messageModelResourcePermission = messageModelResourcePermission;
+		_mbMessageModelResourcePermission = mbMessageModelResourcePermission;
 
 		setLinkable(true);
 		setPortletId(MBPortletKeys.MESSAGE_BOARDS);
@@ -52,10 +55,13 @@ public class MBMessageAssetRendererFactory
 	public AssetRenderer<MBMessage> getAssetRenderer(long classPK, int type)
 		throws PortalException {
 
+		MBMessage mbMessage = _mbMessageLocalService.getMessage(classPK);
+
 		MBMessageAssetRenderer mbMessageAssetRenderer =
 			new MBMessageAssetRenderer(
-				_historyRouterPath, _mbMessageLocalService.getMessage(classPK),
-				_messageModelResourcePermission);
+				_companyLocalService.getCompany(mbMessage.getCompanyId()),
+				_historyRouterPath, mbMessage,
+				_mbMessageModelResourcePermission);
 
 		mbMessageAssetRenderer.setAssetRendererType(type);
 
@@ -90,13 +96,14 @@ public class MBMessageAssetRendererFactory
 			PermissionChecker permissionChecker, long classPK, String actionId)
 		throws Exception {
 
-		return _messageModelResourcePermission.contains(
+		return _mbMessageModelResourcePermission.contains(
 			permissionChecker, classPK, actionId);
 	}
 
+	private final CompanyLocalService _companyLocalService;
 	private final String _historyRouterPath;
 	private final MBMessageLocalService _mbMessageLocalService;
 	private final ModelResourcePermission<MBMessage>
-		_messageModelResourcePermission;
+		_mbMessageModelResourcePermission;
 
 }

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBMessageAssetRendererFactory.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBMessageAssetRendererFactory.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.questions.web.internal.asset.model;
+
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.BaseAssetRendererFactory;
+import com.liferay.message.boards.constants.MBPortletKeys;
+import com.liferay.message.boards.model.MBMessage;
+import com.liferay.message.boards.service.MBMessageLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+
+import javax.portlet.PortletURL;
+import javax.portlet.WindowState;
+
+/**
+ * @author Javier Gamarra
+ */
+public class MBMessageAssetRendererFactory
+	extends BaseAssetRendererFactory<MBMessage> {
+
+	public static final String TYPE = "message";
+
+	public MBMessageAssetRendererFactory(
+		String historyRouterPath, MBMessageLocalService mbMessageLocalService,
+		ModelResourcePermission<MBMessage> messageModelResourcePermission) {
+
+		_historyRouterPath = historyRouterPath;
+		_mbMessageLocalService = mbMessageLocalService;
+		_messageModelResourcePermission = messageModelResourcePermission;
+
+		setLinkable(true);
+		setPortletId(MBPortletKeys.MESSAGE_BOARDS);
+		setSearchable(true);
+	}
+
+	@Override
+	public AssetRenderer<MBMessage> getAssetRenderer(long classPK, int type)
+		throws PortalException {
+
+		MBMessageAssetRenderer mbMessageAssetRenderer =
+			new MBMessageAssetRenderer(
+				_historyRouterPath, _mbMessageLocalService.getMessage(classPK),
+				_messageModelResourcePermission);
+
+		mbMessageAssetRenderer.setAssetRendererType(type);
+
+		return mbMessageAssetRenderer;
+	}
+
+	@Override
+	public String getClassName() {
+		return MBMessage.class.getName();
+	}
+
+	@Override
+	public String getIconCssClass() {
+		return "comments";
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
+	}
+
+	@Override
+	public PortletURL getURLView(
+		LiferayPortletResponse liferayPortletResponse,
+		WindowState windowState) {
+
+		return null;
+	}
+
+	@Override
+	public boolean hasPermission(
+			PermissionChecker permissionChecker, long classPK, String actionId)
+		throws Exception {
+
+		return _messageModelResourcePermission.contains(
+			permissionChecker, classPK, actionId);
+	}
+
+	private final String _historyRouterPath;
+	private final MBMessageLocalService _mbMessageLocalService;
+	private final ModelResourcePermission<MBMessage>
+		_messageModelResourcePermission;
+
+}

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/QuestionsConfiguration.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/QuestionsConfiguration.java
@@ -37,6 +37,11 @@ public interface QuestionsConfiguration {
 	public boolean enableRedirectToLogin();
 
 	@Meta.AD(
+		deflt = "false", name = "enable-custom-asset-renderer", required = false
+	)
+	public boolean enableCustomAssetRenderer();
+
+	@Meta.AD(
 		deflt = "true", name = "show-cards-for-topic-navigation",
 		required = false
 	)

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/persistence/listener/QuestionsConfigurationModelListener.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/persistence/listener/QuestionsConfigurationModelListener.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.questions.web.internal.configuration.persistence.listener;
+
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.message.boards.model.MBMessage;
+import com.liferay.message.boards.service.MBMessageLocalService;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.questions.web.internal.asset.model.MBMessageAssetRendererFactory;
+import com.liferay.questions.web.internal.constants.QuestionsPortletKeys;
+
+import java.util.Dictionary;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Javier Gamarra
+ */
+@Component(
+	immediate = true,
+	property = "model.class.name=com.liferay.questions.web.internal.configuration.QuestionsConfiguration",
+	service = ConfigurationModelListener.class
+)
+public class QuestionsConfigurationModelListener
+	implements ConfigurationModelListener {
+
+	@Override
+	public void onAfterSave(String pid, Dictionary<String, Object> properties) {
+		boolean enabled = GetterUtil.getBoolean(
+			properties.get("enableCustomAssetRenderer"));
+
+		if (enabled) {
+			_serviceRegistration =
+				(ServiceRegistration)_bundleContext.registerService(
+					AssetRendererFactory.class,
+					new MBMessageAssetRendererFactory(
+						GetterUtil.getString(
+							properties.get("historyRouterBasePath")),
+						_mbMessageLocalService,
+						_messageModelResourcePermission),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"javax.portlet.name", QuestionsPortletKeys.QUESTIONS
+					).put(
+						"service.ranking:Integer", 100
+					).build());
+		}
+		else if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
+	private BundleContext _bundleContext;
+
+	@Reference
+	private MBMessageLocalService _mbMessageLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.message.boards.model.MBMessage)"
+	)
+	private ModelResourcePermission<MBMessage> _messageModelResourcePermission;
+
+	private ServiceRegistration<AssetRendererFactory<MBMessage>>
+		_serviceRegistration;
+
+}

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer?
 do-you-want-to-delete–this-comment=Do you want to delete this comment?
 do-you-want-to-delete–this-question=Do you want to delete this question?
 edit-answer=Edit Answer
+enable-custom-asset-renderer=Enable Custom Assset Renderer
 enable-redirect-to-login=Enable Redirect To Login
 enter-at-least-x-characters=Enter at least {0} characters.
 filter-by=Filter By

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_ar.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=هل تريد حذف هذه الإجابة؟
 do-you-want-to-delete–this-comment=هل تريد حذف هذا التعليق؟
 do-you-want-to-delete–this-question=هل تريد حذف هذا السؤال؟
 edit-answer=تحرير الإجابة
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=تمكين إعادة التوجيه إلى تسجيل الدخول
 enter-at-least-x-characters=أدخل على الأقل {0} من الأحرف.
 filter-by=تصفية حسب

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_bg.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Искате ли да изтриете този въпрос? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_ca.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Voleu suprimir aquesta resposta?
 do-you-want-to-delete–this-comment=Voleu suprimir aquest comentari?
 do-you-want-to-delete–this-question=Voleu suprimir aquesta pregunta?
 edit-answer=Editeu la resposta
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Habilita el redireccionament per iniciar la sessió
 enter-at-least-x-characters=Introduïu almenys {0} caràcters.
 filter-by=Filtra per

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_cs.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Chcete tuto otázku odstranit? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_da.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_de.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Möchten Sie diese Antwort löschen?
 do-you-want-to-delete–this-comment=Möchten Sie diesen Kommentar löschen?
 do-you-want-to-delete–this-question=Möchten Sie diese Frage löschen?
 edit-answer=Antwort bearbeiten
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Weiterleitung zur Anmeldung aktivieren
 enter-at-least-x-characters=Bitte geben Sie mindestens {0} Zeichen ein.
 filter-by=Filtern nach

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_el.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Θέλετε να διαγράψετε αυτήν την ερώτηση; (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_en.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer?
 do-you-want-to-delete–this-comment=Do you want to delete this comment?
 do-you-want-to-delete–this-question=Do you want to delete this question?
 edit-answer=Edit Answer
+enable-custom-asset-renderer=Enable Custom Assset Renderer
 enable-redirect-to-login=Enable Redirect To Login
 enter-at-least-x-characters=Enter at least {0} characters.
 filter-by=Filter By

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_en_AU.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_en_GB.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_es.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=¿Quiere eliminar esta respuesta?
 do-you-want-to-delete–this-comment=¿Quiere eliminar este comentario?
 do-you-want-to-delete–this-question=¿Quiere eliminar esta pregunta?
 edit-answer=Editar respuesta
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Habilite el redireccionamiento para iniciar la sesión
 enter-at-least-x-characters=Escriba como mínimo {0} caracteres.
 filter-by=Filtrar por

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_et.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Kas soovite selle küsimuse kustutada? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_eu.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_fa.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=آیا می خواهید این سوال را حذف کنید؟ (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_fi.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Haluatko poistaa vastauksen?
 do-you-want-to-delete–this-comment=Haluatko poistaa tämän kommentin?
 do-you-want-to-delete–this-question=Haluatko poistaa tämän kysymyksen?
 edit-answer=Muokkaa Vastausta
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Ota Käyttöön Uudelleenohjaus Kirjautumista Varten
 enter-at-least-x-characters=Syötä vähintään {0} merkkiä.
 filter-by=Suodata

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_fr.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Voulez-vous supprimer cette réponse ?
 do-you-want-to-delete–this-comment=Voulez-vous supprimer ce commentaire ?
 do-you-want-to-delete–this-question=Voulez-vous supprimer cette question ?
 edit-answer=Modifier la réponse
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Activer la redirection lors de la connexion
 enter-at-least-x-characters=Saisissez au moins {0} caractères.
 filter-by=Filtrer par

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_fr_CA.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_gl.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Editar resposta
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filtrar por

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_hi_IN.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=क्या आप इस प्रश्न को हटाना चाहते हैं? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_hr.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_hu.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Kívánja törölni ezt a választ?
 do-you-want-to-delete–this-comment=Kívánja törölni ezt a hozzászólást?
 do-you-want-to-delete–this-question=Szeretné törölni ezt a kérdést?
 edit-answer=Válasz szerkesztése
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Bejelentkezésre való átirányítás engedélyezése
 enter-at-least-x-characters=Írjon be legalább {0} karaktert.
 filter-by=Szűrés kulcsa

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_in.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Apakah Anda ingin menghapus pertanyaan ini? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_it.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Vuoi eliminare questa domanda? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_iw.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=האם ברצונך למחוק שאלה זו? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_ja.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=この回答を削除してもよろしい�
 do-you-want-to-delete–this-comment=このコメントを削除してもよろしいですか？
 do-you-want-to-delete–this-question=この質問を削除しますか？
 edit-answer=回答を編集
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=ログインへのリダイレクトを有効にする
 enter-at-least-x-characters={0}文字以上を入力してください。
 filter-by=次の項目で絞り込む

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_kk.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_ko.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=이 질문을 삭제하시겠습니까? (Automatic Translation)
 edit-answer=답변 편집
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=필터링 기준

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_lo.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_lt.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Ar norite panaikinti šį klausimą? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_ms.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Adakah anda mahu menghapuskan soalan ini? (Automatic Translation)
 edit-answer=Edit Jawapan (Automatic Translation)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Dayakan Penglencongan Untuk Log Masuk (Automatic Translation)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Tapis Mengikut (Automatic Translation)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_nb.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Vil du slette dette spørsmålet? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_nl.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Wilt u dit antwoord verwijderen?
 do-you-want-to-delete–this-comment=Wilt u deze opmerking verwijderen?
 do-you-want-to-delete–this-question=Wilt u deze vraag verwijderen?
 edit-answer=Antwoord bewerken
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Omleiden naar login inschakelen
 enter-at-least-x-characters=Voer minstens {0} tekens in.
 filter-by=Filteren volgens

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_nl_BE.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_pl.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Czy chcesz usunąć tę odpowiedź? (Automat
 do-you-want-to-delete–this-comment=Czy chcesz usunąć ten komentarz? (Automatic Translation)
 do-you-want-to-delete–this-question=Czy chcesz usunąć to pytanie? (Automatic Translation)
 edit-answer=Edytuj odpowiedź (Automatic Translation)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Włącz przekierowanie do logowania (Automatic Translation)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filtruj według (Automatic Translation)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_pt_BR.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Deseja excluir esta resposta?
 do-you-want-to-delete–this-comment=Deseja excluir este comentário?
 do-you-want-to-delete–this-question=Deseja excluir esta pergunta?
 edit-answer=Editar Resposta
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Habilitar redirecionar para login
 enter-at-least-x-characters=Insira pelo menos {0} caracteres.
 filter-by=Filtrado por

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_pt_PT.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_ro.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Ștergeți această întrebare? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_ru.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Вы хотите удалить этот вопрос? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_sk.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Chcete odstrániť túto otázku? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_sl.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Ali želite izbrisati to vprašanje? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_sr_RS.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_sv.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Vill du ta bort det här svaret?
 do-you-want-to-delete–this-comment=Vill du ta bort den här kommentaren?
 do-you-want-to-delete–this-question=Vill du ta bort den här frågan?
 edit-answer=Redigera svaret
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Aktivera omdirigering för att logga in
 enter-at-least-x-characters=Ange minst {0} tecken.
 filter-by=Filtrera efter

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_ta_IN.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Do you want to delete this question? (Automatic Copy)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_th.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=คุณต้องการลบคําถามนี้หรือไม่ (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_tr.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Bu soruyu silmek istiyor musunuz? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_uk.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Видалити це питання? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_vi.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=Do you want to delete this answer? (Automati
 do-you-want-to-delete–this-comment=Do you want to delete this comment? (Automatic Copy)
 do-you-want-to-delete–this-question=Bạn có muốn xóa câu hỏi này không? (Automatic Translation)
 edit-answer=Edit Answer (Automatic Copy)
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=Enable Redirect To Login (Automatic Copy)
 enter-at-least-x-characters=Enter at least {0} characters. (Automatic Copy)
 filter-by=Filter By (Automatic Copy)

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_zh_CN.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=要删除此回答吗？
 do-you-want-to-delete–this-comment=要删除此注释吗？
 do-you-want-to-delete–this-question=是否想要删除此问题？
 edit-answer=编辑答案
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=启用重定向至登录
 enter-at-least-x-characters=输入至少 {0} 个字符。
 filter-by=筛选依据

--- a/modules/apps/questions/questions-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/questions/questions-web/src/main/resources/content/Language_zh_TW.properties
@@ -21,6 +21,7 @@ do-you-want-to-delete–this-answer=確定要刪除此回答？
 do-you-want-to-delete–this-comment=確定要刪除此評論？
 do-you-want-to-delete–this-question=確定要刪除此問題？
 edit-answer=編輯答案
+enable-custom-asset-renderer=Enable Custom Assset Renderer (Automatic Copy)
 enable-redirect-to-login=啟用重導向登入
 enter-at-least-x-characters=請輸入至少 {0} 字元。
 filter-by=篩選依據


### PR DESCRIPTION
So this allows to register an AssetRenderer based on a configuration flag that takes control of the AssetRenderer for MBMessages to return `questions` URLs. This can break other places where the AssetRenderer is being used.

I had to touch Lima code (the depot stuff) because the `AssetRendererFactories` are wrapped to add depot features and, when wrapping, the new service is created with a MAX_INT priority. When our module, that is loaded later, tries to register the wrapper it is ignored because it also has a MAX_INT priority and in the case of a draw the lower id wins.

I don't know how urgent is this and if I should send it to be merged on sunday or we can wait until monday.