### PR TITLE
LPS-132752 clay:label tag should allow for literal values

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_summary/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_summary/page.jsp
@@ -67,6 +67,7 @@ for (AssetVocabulary vocabulary : vocabularies) {
 									displayType="dark"
 									label="<%= HtmlUtil.escape(category.getTitle(themeDisplay.getLocale())) %>"
 									large="<%= true %>"
+									translateLabel="<%= false %>"
 								/>
 
 							<%

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 7.1.14
+Bundle-Version: 7.2.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.data,\
 	com.liferay.frontend.taglib.clay.data.set,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -88,5 +88,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "7.1.14"
+	"version": "7.2.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
@@ -56,6 +56,10 @@ public class LabelTag extends BaseContainerTag {
 		return _large;
 	}
 
+	public boolean getTranslateLabel() {
+		return _translateLabel;
+	}
+
 	public void setDismissible(boolean dismissible) {
 		_dismissible = dismissible;
 	}
@@ -72,6 +76,10 @@ public class LabelTag extends BaseContainerTag {
 		_large = large;
 	}
 
+	public void setTranslateLabel(boolean translateLabel) {
+		_translateLabel = translateLabel;
+	}
+
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
@@ -80,6 +88,7 @@ public class LabelTag extends BaseContainerTag {
 		_displayType = "secondary";
 		_label = null;
 		_large = false;
+		_translateLabel = true;
 	}
 
 	@Override
@@ -107,10 +116,15 @@ public class LabelTag extends BaseContainerTag {
 
 			jspWriter.write("<span class=\"label-item label-item-expand\">");
 
-			jspWriter.write(
-				LanguageUtil.get(
-					TagResourceBundleUtil.getResourceBundle(pageContext),
-					_label));
+			if (_translateLabel) {
+				jspWriter.write(
+					LanguageUtil.get(
+						TagResourceBundleUtil.getResourceBundle(pageContext),
+						_label));
+			}
+			else {
+				jspWriter.write(_label);
+			}
 
 			jspWriter.write("</span>");
 
@@ -141,5 +155,6 @@ public class LabelTag extends BaseContainerTag {
 	private String _displayType = "secondary";
 	private String _label;
 	private boolean _large;
+	private boolean _translateLabel = true;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1441,6 +1441,12 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<description></description>
+			<name>translateLabel</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0


### PR DESCRIPTION
See https://issues.liferay.com/browse/LPS-132752 for reproduction steps.

The issue is that the clay:label tag tries to translate the label as if it was a lang key. This makes it impossible to display a literal value that happens to have a key with the same name.

To keep backwards compatibility, this adds a new attribute to tell the tag that the label should not be translated, but displayed as is.

Thanks!