### PR TITLE
LPS-133324 handle empty body

### DIFF
--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
@@ -120,9 +120,11 @@ public class JSResolveModulesServlet
 			body = URLDecoder.decode(
 				body, httpServletRequest.getCharacterEncoding());
 
-			body = body.substring(8);
+			if (!body.isEmpty()) {
+				body = body.substring(8);
 
-			moduleNames = body.split(StringPool.COMMA);
+				moduleNames = body.split(StringPool.COMMA);
+			}
 		}
 
 		if (moduleNames != null) {


### PR DESCRIPTION
From @NemethNorbert

> Hello,
> LPS-133324,
> 
> In case we our request doesn't have a body, like with an OPTION request, the hardcoded substring to get the body throws an StringIndexOutOfBoundsException. This is fairly harmless, but can quickly fill up the log. To resolve this issue, I added a simple empty check on the body.
> 
> Please review my change,
> 
> Thanks!

Regards.