### PR TITLE
LPS-133262 Fix Questions app navigation

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserActivity.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserActivity.es.js
@@ -85,7 +85,7 @@ export default withRouter(
 
 		const hrefConstructor = (page) =>
 			`${
-				context.historyRouterBasePath || '/#'
+				context.historyRouterBasePath || '#'
 			}/questions/activity/${creatorId}?page=${page}&pagesize=${pageSize}`;
 
 		const addSectionToQuestion = (question) => {

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
@@ -370,7 +370,7 @@ export default withRouter(
 		]);
 
 		function buildURL(search, page, pageSize) {
-			let url = (context.historyRouterBasePath || '/#') + '/questions';
+			let url = (context.historyRouterBasePath || '#') + '/questions';
 
 			if (sectionTitle || sectionTitle === '0') {
 				url += `/${sectionTitle}`;

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
@@ -116,7 +116,7 @@ export default withRouter(({history, location}) => {
 	const historyPushParser = historyPushWithSlug(history.push);
 
 	function buildURL(search, page, pageSize) {
-		let url = (context.historyRouterBasePath || '/#') + '/tags?';
+		let url = (context.historyRouterBasePath || '#') + '/tags?';
 
 		if (search) {
 			url += `search=${search}&`;


### PR DESCRIPTION
The href calculated by the buildURL method in Questions.es.js page has a starting "/" that the page don't have (i.e. http://localhost:8080/web/guest/questions-page#/questions/portal). I think this comes from the friendly URL that does not admit URLs ending with slash. Removing the initial slash in the buildUrl method fix the page navigation