### PR TITLE
LPS-132436 | master

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record_set.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record_set.jsp
@@ -105,10 +105,11 @@ if (ddlDisplayContext.isAdminPortlet()) {
 					<aui:input label="data-definition" name="ddmStructureNameDisplay" required="<%= true %>" type="resource" value="<%= ddmStructureName %>" />
 
 					<liferay-ui:icon
-						cssClass="btn btn-secondary open-record-set-modal"
+						cssClass="open-record-set-modal"
 						label="<%= true %>"
 						linkCssClass="btn btn-secondary"
 						message="select"
+						url="javascript:;"
 					/>
 				</div>
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record_set.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record_set.jsp
@@ -105,10 +105,10 @@ if (ddlDisplayContext.isAdminPortlet()) {
 					<aui:input label="data-definition" name="ddmStructureNameDisplay" required="<%= true %>" type="resource" value="<%= ddmStructureName %>" />
 
 					<liferay-ui:icon
+						cssClass="btn btn-secondary open-record-set-modal"
 						label="<%= true %>"
 						linkCssClass="btn btn-secondary"
 						message="select"
-						url='<%= "javascript:" + liferayPortletResponse.getNamespace() + "openDDMStructureSelector();" %>'
 					/>
 				</div>
 
@@ -165,43 +165,61 @@ if (ddlDisplayContext.isAdminPortlet()) {
 	</aui:form>
 </clay:container-fluid>
 
+<%
+Portlet portlet = PortletLocalServiceUtil.getPortletById(portletDisplay.getId());
+
+String itemSelectorURL = PortletURLBuilder.create(
+	PortletURLFactoryUtil.create(request, PortletProviderUtil.getPortletId(DDMStructure.class.getName(), PortletProvider.Action.VIEW), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE)
+).setMVCPath(
+	"/select_structure.jsp"
+).setParameter(
+	"classNameId", PortalUtil.getClassNameId(DDMStructure.class)
+).setParameter(
+	"classPK", ddmStructureId
+).setParameter(
+	"groupId", groupId
+).setParameter(
+	"navigationStartsOn", DDMNavigationHelper.SELECT_STRUCTURE
+).setParameter(
+	"portletResourceNamespace", liferayPortletResponse.getNamespace()
+).setParameter(
+	"refererPortletName", portlet.getPortletName()
+).setParameter(
+	"refererWebDAVToken", WebDAVUtil.getStorageToken(portlet)
+).setParameter(
+	"showAncestorScopes", true
+).setParameter(
+	"showBackURL", false
+).setParameter(
+	"showHeader", false
+).setParameter(
+	"structureAvailableFields", liferayPortletResponse.getNamespace() + "getAvailableFields"
+).setWindowState(
+	LiferayWindowState.POP_UP
+).buildString();
+%>
+
 <aui:script>
-	var form = document.<portlet:namespace />fm;
-
-	function <portlet:namespace />openDDMStructureSelector() {
-		Liferay.Util.openDDMPortlet(
-			{
-				basePortletURL:
-					'<%= PortletURLFactoryUtil.create(request, PortletProviderUtil.getPortletId(DDMStructure.class.getName(), PortletProvider.Action.VIEW), PortletRequest.RENDER_PHASE) %>',
-				classPK: <%= ddmStructureId %>,
-				dialog: {
-					destroyOnHide: true,
-				},
-				eventName: '<portlet:namespace />selectDDMStructure',
-				groupId: <%= groupId %>,
-				mvcPath: '/select_structure.jsp',
-				navigationStartsOn: '<%= DDMNavigationHelper.SELECT_STRUCTURE %>',
-
-				<%
-				Portlet portlet = PortletLocalServiceUtil.getPortletById(portletDisplay.getId());
-				%>
-
-				refererPortletName: '<%= portlet.getPortletName() %>',
-				refererWebDAVToken: '<%= WebDAVUtil.getStorageToken(portlet) %>',
-				showAncestorScopes: true,
-				title:
-					'<%= UnicodeLanguageUtil.get(request, "data-definitions") %>',
-			},
-			(event) => {
-				Liferay.Util.setFormValues(form, {
-					ddmStructureId: event.ddmstructureid,
-					ddmStructureNameDisplay: Liferay.Util.unescape(event.name),
-				});
-			}
-		);
-	}
+	<liferay-frontend:component
+		context='<%=
+			HashMapBuilder.<String, Object>put(
+				"itemSelectorURL", itemSelectorURL
+			).put(
+				"portletNamespace", liferayPortletResponse.getNamespace()
+			).put(
+				"selectEventName", "<portlet:namespace />selectDDMStructure"
+			).build()
+		%>'
+		module="js/EditRecordSetStructureSelector"
+	/>
 
 	function <portlet:namespace />saveRecordSet() {
+		var form = document.<portlet:namespace />fm;
+
+		if (!form) {
+			return;
+		}
+
 		submitForm(form);
 	}
 </aui:script>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/EditRecordSetStructureSelector.js
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/EditRecordSetStructureSelector.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {openSelectionModal} from 'frontend-js-web';
+
+export default function ({itemSelectorURL, portletNamespace, selectEventName}) {
+	const openRecordSetModalButton = document.querySelector(
+		'.open-record-set-modal'
+	);
+
+	if (openRecordSetModalButton) {
+		openRecordSetModalButton.addEventListener('click', () => {
+			openSelectionModal({
+				onSelect: (selectedItem) => {
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					if (!form) {
+						return;
+					}
+
+					Liferay.Util.setFormValues(form, {
+						ddmStructureId: selectedItem.ddmstructureid,
+						ddmStructureNameDisplay: Liferay.Util.unescape(
+							selectedItem.name
+						),
+					});
+				},
+				selectEventName,
+				title: Liferay.Language.get('data-definitions'),
+				url: itemSelectorURL,
+			});
+		});
+	}
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/EditRecordSetStructureSelector.js
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/EditRecordSetStructureSelector.js
@@ -41,7 +41,6 @@ export default function ({itemSelectorURL, portletNamespace, selectEventName}) {
 				selectEventName,
 				title: Liferay.Language.get('data-definitions'),
 				url: itemSelectorURL,
-				zIndex: 9999,
 			});
 		});
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/EditRecordSetStructureSelector.js
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/EditRecordSetStructureSelector.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import {openSelectionModal} from 'frontend-js-web';
-
 export default function ({itemSelectorURL, portletNamespace, selectEventName}) {
 	const openRecordSetModalButton = document.querySelector(
 		'.open-record-set-modal'
@@ -21,7 +19,9 @@ export default function ({itemSelectorURL, portletNamespace, selectEventName}) {
 
 	if (openRecordSetModalButton) {
 		openRecordSetModalButton.addEventListener('click', () => {
-			openSelectionModal({
+			const openerWindow = Liferay.Util.getOpener();
+
+			openerWindow.Liferay.Util.openSelectionModal({
 				onSelect: (selectedItem) => {
 					const form = document.getElementById(
 						`${portletNamespace}fm`
@@ -41,6 +41,7 @@ export default function ({itemSelectorURL, portletNamespace, selectEventName}) {
 				selectEventName,
 				title: Liferay.Language.get('data-definitions'),
 				url: itemSelectorURL,
+				zIndex: 9999,
 			});
 		});
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_selected_record_set_options.jspf
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_selected_record_set_options.jspf
@@ -40,7 +40,7 @@
 			</liferay-portlet:renderURL>
 
 			<%
-			String taglibAddRecordSetURL = "javascript:Liferay.Util.openWindow({dialog: {destroyOnHide: true}, id: '_" + HtmlUtil.escapeJS(portletDisplay.getId()) + "_editAsset', title: '" + LanguageUtil.get(request, "add-list") + "', uri:'" + HtmlUtil.escapeJS(addRecordSetURL.toString()) + "'});";
+			String taglibAddRecordSetURL = "javascript:Liferay.Util.openModal({dialog: {destroyOnHide: true}, id: '_" + HtmlUtil.escapeJS(portletDisplay.getId()) + "_editAsset', title: '" + LanguageUtil.get(request, "add-list") + "', url:'" + HtmlUtil.escapeJS(addRecordSetURL.toString()) + "'});";
 			%>
 
 			<div class="btn-group-item">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DDLDataDefinition.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DDLDataDefinition.macro
@@ -10,7 +10,9 @@ definition {
 				locator1 = "Portlet#MODAL_TITLE",
 				value1 = "Data Definitions");
 
-			SelectFrame(locator1 = "IFrame#MODAL_BODY");
+			SelectFrame(
+				key_title = "Data Definitions",
+				locator1 = "IFrame#MODAL_ANY");
 		}
 
 		LexiconEntry.gotoAdd();
@@ -27,7 +29,9 @@ definition {
 	}
 
 	macro _select {
-		SelectFrame(locator1 = "IFrame#MODAL_BODY");
+		SelectFrame(
+			key_title = "Data Definitions",
+			locator1 = "IFrame#MODAL_ANY");
 
 		var key_ddlDataDefinitionName = "${ddlDataDefinitionName}";
 


### PR DESCRIPTION
Original post from @kresimir-coko in https://github.com/liferay-data-engine/liferay-portal/pull/456#issue-651206975:

This is a part of an ongoing epic to replace legacy AUI-based modals with Clay/React-based `openSelectionModal`. We have previously migrated DDM modals, but we were not aware of openDDMPortlet utilily. This PR is a first part of the task that migrates openDDMPortlet related to structure, similar to what is being done with template .

I decided to have a granular approach with this task to make both working on it and reviewing easier. The other usages of openDDMPortlet in relation to structure are:

- `select_structure.jsp`
- `edit_structure.jsp`, which I'll start working now. Let me know if you want me to couple that one to this PR or to send a separate PR for that other modal.

# 🧪  Testing
Content & Data > Dynamic Data Lists
Open the Add new List page
Click on Select