### PR TITLE
LPS-133073 Fix different problems with Questions routing

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/App.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/App.es.js
@@ -39,6 +39,10 @@ export default (props) => {
 		path = props.i18nPath + path;
 	}
 
+	if (path && location.pathname.endsWith(path)) {
+		path = location.pathname;
+	}
+
 	return (
 		<AppContextProvider {...props}>
 			<ClientContext.Provider value={client}>

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserActivity.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserActivity.es.js
@@ -23,9 +23,11 @@ import QuestionRow from '../../components/QuestionRow.es';
 import UserIcon from '../../components/UserIcon.es';
 import useQueryParams from '../../hooks/useQueryParams.es';
 import {getUserActivityQuery} from '../../utils/client.es';
+import {historyPushWithSlug} from '../../utils/utils.es';
 
 export default withRouter(
 	({
+		history,
 		location,
 		match: {
 			params: {creatorId},
@@ -99,10 +101,15 @@ export default withRouter(
 			});
 		}, [fetchUserActivity, page, pageSize]);
 
-		const hrefConstructor = (page) =>
-			`${
-				context.historyRouterBasePath || '#'
-			}/questions/activity/${creatorId}?page=${page}&pagesize=${pageSize}`;
+		const historyPushParser = historyPushWithSlug(history.push);
+
+		function buildUrl(page, pageSize) {
+			return `/questions/activity/${creatorId}?page=${page}&pagesize=${pageSize}`;
+		}
+
+		function changePage(page, pageSize) {
+			historyPushParser(buildUrl(page, pageSize));
+		}
 
 		const addSectionToQuestion = (question) => {
 			return {
@@ -155,7 +162,10 @@ export default withRouter(
 						<PaginatedList
 							activeDelta={pageSize}
 							activePage={page}
-							changeDelta={setPageSize}
+							changeDelta={(pageSize) =>
+								changePage(page, pageSize)
+							}
+							changePage={(page) => changePage(page, pageSize)}
 							data={data && data.messageBoardMessages}
 							emptyState={
 								<ClayEmptyState
@@ -165,7 +175,6 @@ export default withRouter(
 									}
 								/>
 							}
-							hrefConstructor={hrefConstructor}
 							loading={loading}
 							totalCount={totalCount}
 						>

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
@@ -120,7 +120,7 @@ export default withRouter(({history, location}) => {
 	const historyPushParser = historyPushWithSlug(history.push);
 
 	function buildURL(search, page, pageSize) {
-		let url = (context.historyRouterBasePath || '#') + '/tags?';
+		let url = '/tags?';
 
 		if (search) {
 			url += `search=${search}&`;
@@ -131,14 +131,16 @@ export default withRouter(({history, location}) => {
 		return url;
 	}
 
+	function changePage(search, page, pageSize) {
+		historyPushParser(buildURL(search, page, pageSize));
+	}
+
 	const orderByOptions = getOrderByOptions();
 
-	const [debounceCallback] = useDebounceCallback((needHashtag, search) => {
-		setLoading(true);
-		historyPushParser(buildURL(search, 1, pageSize));
-	}, 500);
-
-	const hrefConstructor = (page) => buildURL(search, page, pageSize);
+	const [debounceCallback] = useDebounceCallback(
+		(search) => changePage(search, 1, 20),
+		500
+	);
 
 	return (
 		<>
@@ -191,10 +193,7 @@ export default withRouter(({history, location}) => {
 									}
 									onChange={(event) => {
 										setSearchBoxValue(event.target.value);
-										debounceCallback(
-											false,
-											event.target.value
-										);
+										debounceCallback(event.target.value);
 									}}
 									placeholder={Liferay.Language.get('search')}
 									type="text"
@@ -212,7 +211,7 @@ export default withRouter(({history, location}) => {
 											<ClayButtonWithIcon
 												displayType="unstyled"
 												onClick={() => {
-													debounceCallback(false, '');
+													debounceCallback('');
 												}}
 												symbol="times-circle"
 												type="submit"
@@ -234,7 +233,12 @@ export default withRouter(({history, location}) => {
 					<PaginatedList
 						activeDelta={pageSize}
 						activePage={page}
-						changeDelta={setPageSize}
+						changeDelta={(pageSize) =>
+							changePage(search, page, pageSize)
+						}
+						changePage={(page) =>
+							changePage(search, page, pageSize)
+						}
 						data={tags}
 						emptyState={
 							<ClayEmptyState
@@ -244,7 +248,6 @@ export default withRouter(({history, location}) => {
 								)}
 							/>
 						}
-						hrefConstructor={hrefConstructor}
 						loading={loading}
 					>
 						{(tag) => (


### PR DESCRIPTION
This PR fixes the page reload when changing the page with the pagination list. Not sure if it will impact the SEO as we go back to use buttons instead of links in the paginated list.

I've also discovered that we must not consider the historyRouterBasePath or the # when we build the URLs. These URLs should be relative and don't include these path chunks, because if added the constructed URLs are wrong (with two # chars or with repeated path chunks).

The last commit is a possible solution because right now Questions app does not load when the History Router is configured. Right now, when a button is clicked (questions, or tags), the URL is replaced removing the /web/guest chunk, and all start to work fine. With this solution the /web/guest/ is preserved and everything works right from the first moment.