### PR TITLE
LPS-133823 Page Tree missing plus icon when clicking "load more results"

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/tree_view_icons.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/tree_view_icons.js
@@ -43,7 +43,7 @@ AUI.add(
 		A.TreeNode.prototype._syncIconUI = function (args) {
 			originalSyncIconUIFn.call(this, args);
 
-			var hasChildren = this.childrenLength > 0;
+			var hasChildren = !this.get('leaf');
 			var expanded = this.get('expanded');
 			var hitAreaEl = this.get('hitAreaEl');
 			var iconEl = this.get('iconEl');


### PR DESCRIPTION
### Steps to reproduce

1. Use the Page Tree to create 19 top-level pages (enough that the page tree has a “load more results” link)
2. Add a child page to the 1st page you added
3. Add a child page to the 19th page you added
4. Open the page tree and click “load more results”

Expected Result:
A plus icon to expand the tree appears next to the 1st page and the 19th page

Actual Results:
A plus icon to expand the tree appears next to the 1st page, but a blank icon appears next to the 19th page until clicked on

### Solution overview

Issue is that because the node is rendered before we know about any of the children (or even how many there are), the child count is 0, and so it renders the wrong hit area.