### PR TITLE
LPS-129637 Fix filter for contentFields

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/search/filter/FilterUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/search/filter/FilterUtil.java
@@ -16,38 +16,201 @@ package com.liferay.headless.delivery.search.filter;
 
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.headless.delivery.dynamic.data.mapping.DDMStructureField;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.BooleanClause;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.QueryTerm;
+import com.liferay.portal.kernel.search.WildcardQuery;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.DateRangeTermFilter;
+import com.liferay.portal.kernel.search.filter.ExistsFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.FilterVisitor;
+import com.liferay.portal.kernel.search.filter.GeoBoundingBoxFilter;
+import com.liferay.portal.kernel.search.filter.GeoDistanceFilter;
+import com.liferay.portal.kernel.search.filter.GeoDistanceRangeFilter;
+import com.liferay.portal.kernel.search.filter.GeoPolygonFilter;
+import com.liferay.portal.kernel.search.filter.MissingFilter;
+import com.liferay.portal.kernel.search.filter.PrefixFilter;
+import com.liferay.portal.kernel.search.filter.QueryFilter;
+import com.liferay.portal.kernel.search.filter.RangeTermFilter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
-import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.NestedQuery;
+import com.liferay.portal.kernel.search.generic.TermQueryImpl;
+import com.liferay.portal.kernel.search.generic.TermRangeQueryImpl;
+import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
+
+import java.util.List;
+import java.util.function.Function;
 
 /**
  * @author Javier de Arcos
  */
 public class FilterUtil {
 
-	public static Filter processFilter(DDMIndexer ddmIndexer, Filter filter)
-		throws Exception {
+	public static Filter processFilter(DDMIndexer ddmIndexer, Filter filter) {
+		if ((filter == null) || ddmIndexer.isLegacyDDMIndexFieldsEnabled()) {
+			return filter;
+		}
 
-		if (ddmIndexer.isLegacyDDMIndexFieldsEnabled() ||
-			!(filter instanceof TermFilter)) {
+		return filter.accept(_ddmFilterVisitor);
+	}
+
+	private static final FilterVisitor<Filter> _ddmFilterVisitor =
+		new DDMFilterVisitor();
+
+	private static class DDMFilterVisitor implements FilterVisitor<Filter> {
+
+		@Override
+		public Filter visit(BooleanFilter booleanFilter) {
+			BooleanFilter filter = new BooleanFilter();
+
+			_addBooleanClauses(
+				booleanFilter.getMustBooleanClauses(), BooleanClauseOccur.MUST,
+				filter);
+			_addBooleanClauses(
+				booleanFilter.getMustNotBooleanClauses(),
+				BooleanClauseOccur.MUST_NOT, filter);
+			_addBooleanClauses(
+				booleanFilter.getShouldBooleanClauses(),
+				BooleanClauseOccur.SHOULD, filter);
 
 			return filter;
 		}
 
-		TermFilter termFilter = (TermFilter)filter;
-
-		String termFilterField = termFilter.getField();
-
-		if (!termFilterField.startsWith(DDMIndexer.DDM_FIELD_PREFIX)) {
-			return filter;
+		@Override
+		public Filter visit(DateRangeTermFilter dateRangeTermFilter) {
+			return dateRangeTermFilter;
 		}
 
-		DDMStructureField ddmStructureField = DDMStructureField.from(
-			termFilterField);
+		@Override
+		public Filter visit(ExistsFilter existsFilter) {
+			return existsFilter;
+		}
 
-		return ddmIndexer.createFieldValueQueryFilter(
-			ddmStructureField.getDDMStructureFieldName(), termFilter.getValue(),
-			LocaleUtil.fromLanguageId(ddmStructureField.getLocale()));
+		@Override
+		public Filter visit(GeoBoundingBoxFilter geoBoundingBoxFilter) {
+			return geoBoundingBoxFilter;
+		}
+
+		@Override
+		public Filter visit(GeoDistanceFilter geoDistanceFilter) {
+			return geoDistanceFilter;
+		}
+
+		@Override
+		public Filter visit(GeoDistanceRangeFilter geoDistanceRangeFilter) {
+			return geoDistanceRangeFilter;
+		}
+
+		@Override
+		public Filter visit(GeoPolygonFilter geoPolygonFilter) {
+			return geoPolygonFilter;
+		}
+
+		@Override
+		public Filter visit(MissingFilter missingFilter) {
+			return missingFilter;
+		}
+
+		@Override
+		public Filter visit(PrefixFilter prefixFilter) {
+			return prefixFilter;
+		}
+
+		@Override
+		public Filter visit(QueryFilter queryFilter) {
+			Query query = queryFilter.getQuery();
+
+			if (query instanceof WildcardQuery) {
+				WildcardQuery wildcardQuery = (WildcardQuery)query;
+
+				QueryTerm queryTerm = wildcardQuery.getQueryTerm();
+
+				return _createNestedQueryFilter(
+					queryTerm.getField(), queryFilter,
+					nestedFieldName -> new WildcardQueryImpl(
+						nestedFieldName, queryTerm.getValue()));
+			}
+
+			return queryFilter;
+		}
+
+		@Override
+		public Filter visit(RangeTermFilter rangeTermFilter) {
+			return _createNestedQueryFilter(
+				rangeTermFilter.getField(), rangeTermFilter,
+				nestedFieldName -> new TermRangeQueryImpl(
+					nestedFieldName, rangeTermFilter.getLowerBound(),
+					rangeTermFilter.getUpperBound(),
+					rangeTermFilter.isIncludesLower(),
+					rangeTermFilter.isIncludesUpper()));
+		}
+
+		@Override
+		public Filter visit(TermFilter termFilter) {
+			return _createNestedQueryFilter(
+				termFilter.getField(), termFilter,
+				nestedFieldName -> new TermQueryImpl(
+					nestedFieldName, termFilter.getValue()));
+		}
+
+		@Override
+		public Filter visit(TermsFilter termsFilter) {
+			return termsFilter;
+		}
+
+		private void _addBooleanClauses(
+			List<BooleanClause<Filter>> booleanClauses,
+			BooleanClauseOccur booleanClauseOccur,
+			BooleanFilter booleanFilter) {
+
+			for (BooleanClause<Filter> booleanClause : booleanClauses) {
+				Filter filter = booleanClause.getClause();
+
+				booleanFilter.add(filter.accept(this), booleanClauseOccur);
+			}
+		}
+
+		private Filter _createNestedQueryFilter(
+			String fieldName, Filter originalQueryFilter,
+			Function<String, Query> queryFunction) {
+
+			if (!fieldName.startsWith(DDMIndexer.DDM_FIELD_PREFIX)) {
+				return originalQueryFilter;
+			}
+
+			try {
+				DDMStructureField ddmStructureField = DDMStructureField.from(
+					fieldName);
+
+				BooleanQuery booleanQuery = new BooleanQueryImpl();
+
+				booleanQuery.addRequiredTerm(
+					StringBundler.concat(
+						DDMIndexer.DDM_FIELD_ARRAY, StringPool.PERIOD,
+						DDMIndexer.DDM_FIELD_NAME),
+					ddmStructureField.getDDMStructureFieldName());
+
+				booleanQuery.add(
+					queryFunction.apply(
+						ddmStructureField.
+							getDDMStructureNestedTypeSortableFieldName()),
+					BooleanClauseOccur.MUST);
+
+				return new QueryFilter(
+					new NestedQuery(DDMIndexer.DDM_FIELD_ARRAY, booleanQuery));
+			}
+			catch (Exception exception) {
+				return originalQueryFilter;
+			}
+		}
+
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
@@ -14,8 +14,8 @@
 
 package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
+import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
-import com.liferay.dynamic.data.mapping.model.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.constants.FieldConstants;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
@@ -81,7 +81,9 @@ public class EntityFieldsProvider {
 			return null;
 		}
 
-		if (Objects.equals(ddmFormField.getType(), DDMFormFieldType.CHECKBOX)) {
+		if (Objects.equals(
+				ddmFormField.getType(), DDMFormFieldTypeConstants.CHECKBOX)) {
+
 			return new BooleanEntityField(
 				ddmFormField.getFieldReference(),
 				locale -> _toFilterableOrSortableFieldName(
@@ -124,9 +126,9 @@ public class EntityFieldsProvider {
 					ddmFormField.getFieldReference(), locale, "Number"));
 		}
 		else if (Objects.equals(
-					ddmFormField.getType(), DDMFormFieldType.RADIO) ||
+					ddmFormField.getType(), DDMFormFieldTypeConstants.RADIO) ||
 				 (Objects.equals(
-					 ddmFormField.getType(), DDMFormFieldType.TEXT) &&
+					 ddmFormField.getType(), DDMFormFieldTypeConstants.TEXT) &&
 				  Objects.equals(ddmFormField.getIndexType(), "keyword"))) {
 
 			return new StringEntityField(


### PR DESCRIPTION
Create specific logic in the FilterUtil instead of using DDMIndexer to use the sortable field name when it is needed without affecting other components in the portal.

I've created a FilterVisitor because like this it is very clean and easy to extend the logic with new cases we may want to consider.

Made tests with 'eq', 'ne', contains, lt, gt ... with text, number, and date fields
