### PR TITLE
LPS-132330 Fix GraphQL conflicts with GraphQL page types

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -473,8 +473,9 @@ public class GraphQLServletExtender {
 
 					for (GraphQLType childGraphQLType2 : childrenGraphQLType2) {
 						if (StringUtil.equals(
-								childGraphQLType2.getName(),
-								childGraphQLType1.getName())) {
+								childGraphQLType1.getName(),
+								childGraphQLType2.getName()) &&
+							_equals(childGraphQLType1, childGraphQLType2)) {
 
 							found = true;
 


### PR DESCRIPTION
The problem was that two GraphQL Pages were considered equals as they have the same field names without taking into account that the field types could be different.

I've taken the field types into consideration to decide whether the GraphQL types are the same, to disambiguate the pages if they refer to different items.