### PR TITLE
LPS-134123 Hide ObjectEntry in Object APIs and replace it with the entity name

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
@@ -20,6 +20,7 @@ import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.OpenAPIResourceImpl;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.vulcan.openapi.DTOProperty;
 import com.liferay.portal.vulcan.openapi.OpenAPISchemaFilter;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
@@ -93,6 +94,12 @@ public class ObjectEntryApplication extends Application {
 			));
 
 		openAPISchemaFilter.setDTOProperty(dtoProperty);
+		openAPISchemaFilter.setSchemaMappings(
+			HashMapBuilder.put(
+				"ObjectEntry", _applicationName
+			).put(
+				"PageObjectEntry", "Page" + _applicationName
+			).build());
 
 		return openAPISchemaFilter;
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 8.1.2
+Bundle-Version: 8.2.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/OpenAPISchemaFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/OpenAPISchemaFilter.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.vulcan.openapi;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * @author Javier Gamarra
  */
@@ -23,10 +26,19 @@ public class OpenAPISchemaFilter {
 		return _dtoProperty;
 	}
 
+	public Map<String, String> getSchemaMappings() {
+		return _schemaMappings;
+	}
+
 	public void setDTOProperty(DTOProperty dtoProperty) {
 		_dtoProperty = dtoProperty;
 	}
 
+	public void setSchemaMappings(Map<String, String> schemaMappings) {
+		_schemaMappings = schemaMappings;
+	}
+
 	private DTOProperty _dtoProperty;
+	private Map<String, String> _schemaMappings = new HashMap<>();
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/openapi/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/openapi/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
Renaming all appearances of `ObjectEntry` in the generated OpenAPI. It's not pretty, a lot of code for just hiding an internal concept.

It can also be done with a [ModelConverter](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Extensions#extending-core-resolver) but those are registered in a singleton and will affect all deployed APIs. The rest of the extension options can not be used in an OSGi world because they require control of instantiation and we can't pass parameters.

Response is now:

```
openapi: 3.0.1
info:
  title: Object
  version: v1.0
servers:
- url: http://localhost:8080/o/sampleobjectdefinitions/
paths:
  /:
    get:
      tags:
      - SampleObjectDefinition
      parameters:
      - name: flatten
        in: query
        schema:
          type: string
      - name: search
        in: query
        schema:
          type: string
      - name: filter
        in: query
        schema:
          type: string
      - name: page
        in: query
        schema:
          type: string
      - name: pageSize
        in: query
        schema:
          type: string
      - name: sort
        in: query
        schema:
          type: string
      responses:
        default:
          description: default response
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/PageSampleObjectDefinition'
            application/xml:
              schema:
                $ref: '#/components/schemas/PageSampleObjectDefinition'
    post:
      tags:
      - SampleObjectDefinition
      parameters: []
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/SampleObjectDefinition'
          application/xml:
            schema:
              $ref: '#/components/schemas/SampleObjectDefinition'
      responses:
        default:
          description: default response
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/SampleObjectDefinition'
            application/xml:
              schema:
                $ref: '#/components/schemas/SampleObjectDefinition'
  /batch:
    put:
      tags:
      - SampleObjectDefinition
      parameters:
      - name: callbackURL
        in: query
        schema:
          type: string
      requestBody:
        content:
          application/json:
            schema:
              type: object
      responses:
        default:
          description: default response
          content:
            application/json: {}
    post:
      tags:
      - SampleObjectDefinition
      parameters:
      - name: callbackURL
        in: query
        schema:
          type: string
      requestBody:
        content:
          application/json:
            schema:
              type: object
      responses:
        default:
          description: default response
          content:
            application/json: {}
    delete:
      tags:
      - SampleObjectDefinition
      parameters:
      - name: callbackURL
        in: query
        schema:
          type: string
      requestBody:
        content:
          application/json:
            schema:
              type: object
      responses:
        default:
          description: default response
          content:
            application/json: {}
  /openapi.{type}:
    get:
      parameters:
      - name: type
        in: path
        required: true
        schema:
          type: string
      responses:
        default:
          description: default response
          content:
            application/json: {}
            application/yaml: {}
  /{sampleObjectDefinitionId}:
    get:
      tags:
      - SampleObjectDefinition
      parameters:
      - name: sampleObjectDefinitionId
        in: path
        required: true
        schema:
          type: string
      responses:
        default:
          description: default response
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/SampleObjectDefinition'
            application/xml:
              schema:
                $ref: '#/components/schemas/SampleObjectDefinition'
    put:
      tags:
      - SampleObjectDefinition
      parameters:
      - name: sampleObjectDefinitionId
        in: path
        required: true
        schema:
          type: string
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/SampleObjectDefinition'
          application/xml:
            schema:
              $ref: '#/components/schemas/SampleObjectDefinition'
      responses:
        default:
          description: default response
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/SampleObjectDefinition'
            application/xml:
              schema:
                $ref: '#/components/schemas/SampleObjectDefinition'
    delete:
      tags:
      - SampleObjectDefinition
      parameters:
      - name: sampleObjectDefinitionId
        in: path
        required: true
        schema:
          type: string
      responses:
        default:
          description: default response
          content:
            application/json: {}
            application/xml: {}
components:
  schemas:
    Creator:
      type: object
      properties:
        additionalName:
          type: string
          description: The author's additional name (e.g., middle name).
          readOnly: true
        contentType:
          type: string
          description: The type of the content.
          readOnly: true
        familyName:
          type: string
          description: The author's surname.
          readOnly: true
        givenName:
          type: string
          description: The author's first name.
          readOnly: true
        id:
          type: integer
          description: The author's ID.
          format: int64
          readOnly: true
        image:
          type: string
          description: A relative URL to the author's profile image.
          readOnly: true
        name:
          type: string
          description: The author's full name.
          readOnly: true
        profileURL:
          type: string
          description: A relative URL to the author's user profile. Optional field,
            can be embedded with nestedFields.
          readOnly: true
        x-class-name:
          type: string
          readOnly: true
          default: com.liferay.headless.delivery.dto.v1_0.Creator
      xml:
        name: Creator
    Facet:
      type: object
      properties:
        facetCriteria:
          type: string
        facetValues:
          type: array
          items:
            $ref: '#/components/schemas/FacetValue'
    FacetValue:
      type: object
      properties:
        numberOfOccurrences:
          type: integer
          format: int32
        term:
          type: string
    PageSampleObjectDefinition:
      type: object
      properties:
        lastPage:
          type: integer
          format: int64
        items:
          type: array
          items:
            $ref: '#/components/schemas/SampleObjectDefinition'
        totalCount:
          type: integer
          format: int64
        pageSize:
          type: integer
          format: int64
        actions:
          type: object
          additionalProperties:
            type: object
            additionalProperties:
              type: string
        page:
          type: integer
          format: int64
        facets:
          type: array
          items:
            $ref: '#/components/schemas/Facet'
    SampleObjectDefinition:
      type: object
      properties:
        actions:
          type: object
          additionalProperties:
            type: object
            additionalProperties:
              type: string
          readOnly: true
        creator:
          $ref: '#/components/schemas/Creator'
        dateCreated:
          type: string
          format: date-time
        dateModified:
          type: string
          format: date-time
        id:
          type: integer
          format: int64
        x-class-name:
          type: string
          readOnly: true
          default: com.liferay.object.rest.dto.v1_0.ObjectEntry
        able:
          type: integer
          format: int64
        baker:
          type: boolean
        dog:
          type: string
          format: date
        easy:
          type: string
        fox:
          type: string
        george:
          type: string
        how:
          type: string
        item:
          type: number
          format: double
        jig:
          type: integer
          format: int32
        king:
          type: object
      xml:
        name: ObjectEntry
```

XML and className are needed for batch/talend