### PR TITLE
LPS-134347 Liferay JS Toolkit - Configuration field does not accept single or double quote(s)

### DIFF
--- a/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/internal/portlet/JSPortlet.java
+++ b/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/internal/portlet/JSPortlet.java
@@ -144,6 +144,10 @@ public class JSPortlet extends MVCPortlet implements ManagedService {
 		return StringPool.BLANK;
 	}
 
+	private String _escapeBackslashes(String string) {
+		return string.replaceAll(StringPool.DOUBLE_BACK_SLASH, "\\\\\\\\");
+	}
+
 	private String _getPortletInstanceConfiguration(
 		RenderRequest renderRequest) {
 
@@ -172,11 +176,12 @@ public class JSPortlet extends MVCPortlet implements ManagedService {
 			}
 		}
 
-		return portletPreferencesJSONObject.toJSONString();
+		return _escapeBackslashes(portletPreferencesJSONObject.toJSONString());
 	}
 
 	private String _getSystemConfiguration() {
-		return _jsonFactory.looseSerializeDeep(_configuration.get());
+		return _escapeBackslashes(
+			_jsonFactory.looseSerializeDeep(_configuration.get()));
 	}
 
 	private static final String _TPL_HTML;

--- a/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/internal/portlet/JSPortlet.java
+++ b/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/internal/portlet/JSPortlet.java
@@ -144,8 +144,12 @@ public class JSPortlet extends MVCPortlet implements ManagedService {
 		return StringPool.BLANK;
 	}
 
-	private String _escapeBackslashes(String string) {
-		return string.replaceAll(StringPool.DOUBLE_BACK_SLASH, "\\\\\\\\");
+	private String _escapeJsonString(String string) {
+		string = string.replaceAll(StringPool.DOUBLE_BACK_SLASH, "\\\\\\\\");
+
+		string = string.replaceAll(StringPool.APOSTROPHE, "\\\\'");
+
+		return string;
 	}
 
 	private String _getPortletInstanceConfiguration(
@@ -176,11 +180,11 @@ public class JSPortlet extends MVCPortlet implements ManagedService {
 			}
 		}
 
-		return _escapeBackslashes(portletPreferencesJSONObject.toJSONString());
+		return _escapeJsonString(portletPreferencesJSONObject.toJSONString());
 	}
 
 	private String _getSystemConfiguration() {
-		return _escapeBackslashes(
+		return _escapeJsonString(
 			_jsonFactory.looseSerializeDeep(_configuration.get()));
 	}
 


### PR DESCRIPTION
This is the fix for https://issues.liferay.com/browse/LPS-134347

Tested by deploying a vanilla JS portlet with system configuration, modifying it to accept free strings, and setting the value to a string with double and single quotes:

![image](https://user-images.githubusercontent.com/3273630/122373773-0c988980-cf62-11eb-8273-f6c6284102c4.png)
