### PR TITLE
LPS-131517 Avoid unnecessary renders when typing on Questions Editor

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Comments.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Comments.es.js
@@ -15,14 +15,13 @@
 import ClayButton from '@clayui/button';
 import ClayForm from '@clayui/form';
 import {useMutation} from 'graphql-hooks';
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useRef, useState} from 'react';
 import {withRouter} from 'react-router-dom';
 
 import {createCommentQuery} from '../utils/client.es';
-import {getContextLink, stripHTML} from '../utils/utils.es';
+import {getContextLink} from '../utils/utils.es';
 import Comment from './Comment.es';
-import QuestionsEditor from './QuestionsEditor';
-import TextLengthValidation from './TextLengthValidation.es';
+import DefaultQuestionsEditor from './DefaultQuestionsEditor.es';
 
 export default withRouter(
 	({
@@ -36,7 +35,9 @@ export default withRouter(
 		showNewComment,
 		showNewCommentChange,
 	}) => {
-		const [comment, setComment] = useState('');
+		const editor = useRef('');
+
+		const [isReplyButtonDisable, setIsReplyButtonDisable] = useState(false);
 
 		const [createComment] = useMutation(createCommentQuery);
 
@@ -67,18 +68,15 @@ export default withRouter(
 				{editable && showNewComment && (
 					<>
 						<ClayForm.Group small>
-							<QuestionsEditor
-								contents={comment}
-								onChange={(event) => {
-									setComment(event.editor.getData());
-								}}
+							<DefaultQuestionsEditor
+								label={Liferay.Language.get('your-answer')}
+								onContentLengthValid={setIsReplyButtonDisable}
+								ref={editor}
 							/>
-
-							<TextLengthValidation text={comment} />
 
 							<ClayButton.Group className="c-mt-3" spaced>
 								<ClayButton
-									disabled={stripHTML(comment).length < 15}
+									disabled={isReplyButtonDisable}
 									displayType="primary"
 									onClick={() => {
 										createComment({
@@ -86,11 +84,11 @@ export default withRouter(
 												`${sectionTitle}/${questionId}`
 											),
 											variables: {
-												articleBody: comment,
+												articleBody: editor.current.getContent(),
 												parentMessageBoardMessageId: entityId,
 											},
 										}).then(({data}) => {
-											setComment('');
+											editor.current.clearContent();
 											showNewCommentChange(false);
 											commentsChange([
 												...comments,

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/DefaultQuestionsEditor.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/DefaultQuestionsEditor.es.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayForm from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import React, {forwardRef, useEffect, useState} from 'react';
+
+import {stripHTML} from '../utils/utils.es';
+import QuestionsEditor from './QuestionsEditor';
+import TextLengthValidation from './TextLengthValidation.es';
+
+export default forwardRef(
+	(
+		{
+			additionalInformation,
+			label,
+			onContentLengthValid,
+			question,
+			...otherProps
+		},
+		ref
+	) => {
+		const MIN_CHAR_NUMBER = 15;
+		const [content, setContent] = useState('');
+
+		ref.current = {
+			clearContent: () => setContent(''),
+			getContent: () => content,
+			setContent: (content) => setContent(content),
+		};
+
+		useEffect(() => {
+			onContentLengthValid(stripHTML(content).length < MIN_CHAR_NUMBER);
+		}, [content, onContentLengthValid]);
+
+		return (
+			<>
+				<ClayForm>
+					<ClayForm.Group className="form-group-sm">
+						<label htmlFor="basicInput">
+							{label}
+
+							<span className="c-ml-2 reference-mark">
+								<ClayIcon symbol="asterisk" />
+							</span>
+						</label>
+
+						<div className="c-mt-2">
+							{question && question.locked && (
+								<div className="question-locked-text">
+									<span>
+										<ClayIcon symbol="lock" />
+									</span>
+									{Liferay.Language.get(
+										'this-question-is-closed-new-answers-and-comments-are-disabled'
+									)}
+								</div>
+							)}
+							<QuestionsEditor
+								contents={content}
+								cssClass={
+									question && question.locked
+										? 'question-locked'
+										: ''
+								}
+								editorConfig={{
+									readOnly: question && question.locked,
+								}}
+								onChange={(event) => {
+									setContent(event.editor.getData());
+								}}
+								{...otherProps}
+							/>
+						</div>
+
+						<ClayForm.FeedbackGroup>
+							<ClayForm.FeedbackItem>
+								{additionalInformation && (
+									<span className="small text-secondary">
+										{additionalInformation}
+									</span>
+								)}
+
+								<TextLengthValidation text={content} />
+							</ClayForm.FeedbackItem>
+						</ClayForm.FeedbackGroup>
+					</ClayForm.Group>
+				</ClayForm>
+			</>
+		);
+	}
+);


### PR DESCRIPTION
This PR references [this ticket](https://issues.liferay.com/browse/LPS-131517) where explains that the Highlight library is trying to format the code in each keypress. It is not quite correct, it is true that in each keypress the library is trying to format the code and causes the high use of the CPU, but the reason because is trying to format again and again is that in each keypress we were rendering the whole component again, so we were passing the code to format again and again.

This PR is an approach to solve this encapsulating the Editor and all of its logic in a component to not rendering the parent component and, with this, avoid formatting the code again and again.

Because this could be happening in each component and could be a future source of problems, I changed all the editor to this new Editor to avoid unnecessary rendering in other components that didn't cause performance problems.
The way to connect the editor to the parent component is that the parent component passes a reference of the content to track the content of the editor and be able to do the task necessary with that content.