### PR TITLE
Lps 134200

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container.js
@@ -101,7 +101,9 @@ AUI.add(
 						var template = instance._table.one('.' + CSS_TEMPLATE);
 
 						if (template) {
-							row = template.clone();
+							row = template.previous()
+								? template.previous().clone()
+								: template.clone();
 
 							var cells = row.all('> td');
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container.js
@@ -92,7 +92,7 @@ AUI.add(
 					instance._parentContainer[action]();
 				},
 
-				addRow(array, id) {
+				addRow(array, id, columnsCssClasses) {
 					var instance = this;
 
 					var row;
@@ -114,6 +114,12 @@ AUI.add(
 
 								if (cell) {
 									cell.html(item);
+									if (
+										columnsCssClasses &&
+										columnsCssClasses[index]
+									) {
+										cell.addClass(columnsCssClasses[index]);
+									}
 								}
 							});
 


### PR DESCRIPTION
This has already been discussed with @antonio-ortega.

The situation is that the customer has noticed that when adding a new row in searchContainer, using addRow, the new cells on that row don't have the same CSS classes that the rest of the table has.

In order to solve this behavior what @antonio-ortega proposed was instead of cloning the template row, clone the previows row existing in the container (if it exists). But this had a limitation and if the table has no previous rows when we add the first one with the addRow this row will not have the CSS classes that would have a row generated by the jsp.

In order to solve this problem I tried to replicate something similar of what was done on LPS-130722 capturing the CSS class when processing the taglib on the doStartTag method of  SearchContainerColumnTag (LPS-130722 is on the same method of SearchContainerRowTag). But since when the table has no rows the tags of the columns are not processed it wouldn't have solved the problem.

Finally to overcome this limitation I have added a new param on the addRow method so now we can specify the CSS classes of  the cells of the new row and doing so we can add rows to a empty container, and those cells will have the desired style.