### PR TITLE
LPS-134266 enable service conditionally to avoid being used in layout…

### DIFF
--- a/modules/apps/questions/questions-web/build.gradle
+++ b/modules/apps/questions/questions-web/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:asset:asset-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/persistence/listener/QuestionsConfigurationModelListener.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/persistence/listener/QuestionsConfigurationModelListener.java
@@ -51,6 +51,8 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
 
 /**
  * @author Javier Gamarra
@@ -80,7 +82,16 @@ public class QuestionsConfigurationModelListener
 			Dictionary<String, Object> configurationProperties =
 				configuration.getProperties();
 
-			if (!Objects.equals("", properties.get("historyRouterBasePath"))) {
+			ComponentDescriptionDTO componentDescriptionDTO =
+				_serviceComponentRuntime.getComponentDescriptionDTO(
+					_bundleContext.getBundle(),
+					QuestionsLayoutSEOLinkManagerImpl.class.getName());
+
+			if (!Objects.equals(
+					GetterUtil.getString(
+						properties.get("historyRouterBasePath")),
+					"")) {
+
 				if (configurationProperties == null) {
 					configurationProperties = new HashMapDictionary<>();
 				}
@@ -90,9 +101,15 @@ public class QuestionsConfigurationModelListener
 					"(component.name=" +
 						QuestionsLayoutSEOLinkManagerImpl.class.getName() +
 							")");
+
+				_serviceComponentRuntime.enableComponent(
+					componentDescriptionDTO);
 			}
 			else if (configurationProperties != null) {
 				configurationProperties.remove("_layoutSEOLinkManager.target");
+
+				_serviceComponentRuntime.disableComponent(
+					componentDescriptionDTO);
 			}
 
 			configuration.update(configurationProperties);
@@ -110,6 +127,21 @@ public class QuestionsConfigurationModelListener
 		_bundleContext = bundleContext;
 
 		_enableAssetRenderer(properties);
+
+		ComponentDescriptionDTO componentDescriptionDTO =
+			_serviceComponentRuntime.getComponentDescriptionDTO(
+				_bundleContext.getBundle(),
+				QuestionsLayoutSEOLinkManagerImpl.class.getName());
+
+		if (!Objects.equals(
+				GetterUtil.getString(properties.get("historyRouterBasePath")),
+				"")) {
+
+			_serviceComponentRuntime.enableComponent(componentDescriptionDTO);
+		}
+		else {
+			_serviceComponentRuntime.disableComponent(componentDescriptionDTO);
+		}
 	}
 
 	@Deactivate
@@ -198,6 +230,9 @@ public class QuestionsConfigurationModelListener
 	)
 	private ModelResourcePermission<MBMessage>
 		_mbMessageModelResourcePermission;
+
+	@Reference
+	private ServiceComponentRuntime _serviceComponentRuntime;
 
 	private List<ServiceRegistration<?>> _serviceRegistrations =
 		new ArrayList<>();

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/layout/seo/QuestionsLayoutSEOLinkManagerImpl.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/layout/seo/QuestionsLayoutSEOLinkManagerImpl.java
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.questions.web.internal.configuration.QuestionsConfiguration",
-	property = "service.ranking:Integer=100",
+	enabled = false, property = "service.ranking:Integer=100",
 	service = LayoutSEOLinkManager.class
 )
 public class QuestionsLayoutSEOLinkManagerImpl implements LayoutSEOLinkManager {


### PR DESCRIPTION
… tests

Our component has to modify the target property to win over `LayoutSEOLinkManagerImpl` (because it has higher priority but the @Reference is not greedy, so wins who gets registered first). But in the layout tests, the module is redeployed so `LayoutSEOLinkManagerImpl` gets registered last and tests fail.

I changed the approach a bit to also enable the component based on the property. I thought of registering the component based on the property but it's very messy because all those @Reference being used inside `QuestionsLayoutSEOLinkManagerImpl`.