### PR TITLE
LPS-127344 Disables the test of running multiple callbacks on deadline

### DIFF
--- a/modules/apps/frontend-js/frontend-js-a11y-web/test/js/A11yChecker.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/test/js/A11yChecker.ts
@@ -61,7 +61,14 @@ describe('A11yChecker', () => {
 			scheduler.scheduleCallback(fn, 'baz');
 		});
 
-		it('execute many callbacks within the 100ms deadline', (done) => {
+		/**
+		 * This test when run on CI is flaky, when the test is run in some
+		 * moments there is a fight for resource causing the instance of
+		 * Node.js to be "frozen" for longer than expected, the test needs
+		 * a high level of accuracy of frame time to know if the task was
+		 * executed within the same deadline.
+		 */
+		it.skip('execute many callbacks within the 100ms deadline', (done) => {
 			const callbacksCalled: Array<{
 				deadline: number;
 				target: string;


### PR DESCRIPTION
I'm submitting this PR as part of ticket LPS-127344, as a follow-up.

Hey guys, I'm disabling the test which is failing in CI execution because it's flaky in build executions. For now, I'm not deleting this test because it's important to test cases like this, I'll still try to figure out better ways to test this, a hypothesis why this is failing is, when the test is run in some moments there is a fight for resource causing the instance of Node.js to be "frozen" for longer than expected (this can probably also be related to the event loop), the test needs a high level of accuracy of frame time to know if the task was executed within the same deadline.