### PR TITLE
LPS-134654 Use HtmlUtil.escapeAttribute instead of HtmlUtil.escape

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -938,7 +938,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 
 			if (searchValue != null) {
 				jspWriter.write(" value=\"");
-				jspWriter.write(HtmlUtil.escape(searchValue));
+				jspWriter.write(HtmlUtil.escapeAttribute(searchValue));
 				jspWriter.write("\"");
 			}
 


### PR DESCRIPTION
As noted in [LPS-134654](https://issues.liferay.com/browse/LPS-134654),
we should use `HtmlUtil.escapeAttribute` instead of `HtmlUtil.escape`,
since `searchValue` is being used as an attribute.