### PR TITLE
LPS-124110 Add external reference code to BlogsEntry

### DIFF
--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
@@ -176,7 +176,8 @@ public class BaseBatchEngineTaskExecutorTest {
 				blogPosting.getDatePublished());
 
 			_blogsEntryService.addEntry(
-				blogPosting.getHeadline(), blogPosting.getAlternativeHeadline(),
+				null, blogPosting.getHeadline(),
+				blogPosting.getAlternativeHeadline(),
 				blogPosting.getFriendlyUrlPath(), blogPosting.getDescription(),
 				blogPosting.getArticleBody(), localDateTime.getMonthValue() - 1,
 				localDateTime.getDayOfMonth(), localDateTime.getYear(),

--- a/modules/apps/blogs/blogs-api/bnd.bnd
+++ b/modules/apps/blogs/blogs-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Blogs API
 Bundle-SymbolicName: com.liferay.blogs.api
-Bundle-Version: 7.1.2
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.blogs.configuration,\
 	com.liferay.blogs.configuration.definition,\

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/exception/DuplicateEntryExternalReferenceCodeException.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/exception/DuplicateEntryExternalReferenceCodeException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blogs.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DuplicateEntryExternalReferenceCodeException
+	extends PortalException {
+
+	public DuplicateEntryExternalReferenceCodeException() {
+	}
+
+	public DuplicateEntryExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateEntryExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateEntryExternalReferenceCodeException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/model/BlogsEntryModel.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/model/BlogsEntryModel.java
@@ -97,6 +97,21 @@ public interface BlogsEntryModel
 	public void setUuid(String uuid);
 
 	/**
+	 * Returns the external reference code of this blogs entry.
+	 *
+	 * @return the external reference code of this blogs entry
+	 */
+	@AutoEscape
+	public String getExternalReferenceCode();
+
+	/**
+	 * Sets the external reference code of this blogs entry.
+	 *
+	 * @param externalReferenceCode the external reference code of this blogs entry
+	 */
+	public void setExternalReferenceCode(String externalReferenceCode);
+
+	/**
 	 * Returns the entry ID of this blogs entry.
 	 *
 	 * @return the entry ID of this blogs entry

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/model/BlogsEntrySoap.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/model/BlogsEntrySoap.java
@@ -35,6 +35,7 @@ public class BlogsEntrySoap implements Serializable {
 
 		soapModel.setMvccVersion(model.getMvccVersion());
 		soapModel.setUuid(model.getUuid());
+		soapModel.setExternalReferenceCode(model.getExternalReferenceCode());
 		soapModel.setEntryId(model.getEntryId());
 		soapModel.setGroupId(model.getGroupId());
 		soapModel.setCompanyId(model.getCompanyId());
@@ -130,6 +131,14 @@ public class BlogsEntrySoap implements Serializable {
 
 	public void setUuid(String uuid) {
 		_uuid = uuid;
+	}
+
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		_externalReferenceCode = externalReferenceCode;
 	}
 
 	public long getEntryId() {
@@ -370,6 +379,7 @@ public class BlogsEntrySoap implements Serializable {
 
 	private long _mvccVersion;
 	private String _uuid;
+	private String _externalReferenceCode;
 	private long _entryId;
 	private long _groupId;
 	private long _companyId;

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/model/BlogsEntryTable.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/model/BlogsEntryTable.java
@@ -37,6 +37,10 @@ public class BlogsEntryTable extends BaseTable<BlogsEntryTable> {
 		"mvccVersion", Long.class, Types.BIGINT, Column.FLAG_NULLITY);
 	public final Column<BlogsEntryTable, String> uuid = createColumn(
 		"uuid_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<BlogsEntryTable, String> externalReferenceCode =
+		createColumn(
+			"externalReferenceCode", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<BlogsEntryTable, Long> entryId = createColumn(
 		"entryId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<BlogsEntryTable, Long> groupId = createColumn(

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/model/BlogsEntryWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/model/BlogsEntryWrapper.java
@@ -45,6 +45,7 @@ public class BlogsEntryWrapper
 
 		attributes.put("mvccVersion", getMvccVersion());
 		attributes.put("uuid", getUuid());
+		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put("entryId", getEntryId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
@@ -89,6 +90,13 @@ public class BlogsEntryWrapper
 
 		if (uuid != null) {
 			setUuid(uuid);
+		}
+
+		String externalReferenceCode = (String)attributes.get(
+			"externalReferenceCode");
+
+		if (externalReferenceCode != null) {
+			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Long entryId = (Long)attributes.get("entryId");
@@ -385,6 +393,16 @@ public class BlogsEntryWrapper
 	@Override
 	public long getEntryId() {
 		return model.getEntryId();
+	}
+
+	/**
+	 * Returns the external reference code of this blogs entry.
+	 *
+	 * @return the external reference code of this blogs entry
+	 */
+	@Override
+	public String getExternalReferenceCode() {
+		return model.getExternalReferenceCode();
 	}
 
 	/**
@@ -914,6 +932,16 @@ public class BlogsEntryWrapper
 	@Override
 	public void setEntryId(long entryId) {
 		model.setEntryId(entryId);
+	}
+
+	/**
+	 * Sets the external reference code of this blogs entry.
+	 *
+	 * @param externalReferenceCode the external reference code of this blogs entry
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		model.setExternalReferenceCode(externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalService.java
@@ -131,22 +131,23 @@ public interface BlogsEntryLocalService
 
 	@Indexable(type = IndexableType.REINDEX)
 	public BlogsEntry addEntry(
-			long userId, String title, String subtitle, String urlTitle,
-			String description, String content, Date displayDate,
-			boolean allowPingbacks, boolean allowTrackbacks,
-			String[] trackbacks, String coverImageCaption,
-			ImageSelector coverImageImageSelector,
+			String externalReferenceCode, long userId, String title,
+			String subtitle, String urlTitle, String description,
+			String content, Date displayDate, boolean allowPingbacks,
+			boolean allowTrackbacks, String[] trackbacks,
+			String coverImageCaption, ImageSelector coverImageImageSelector,
 			ImageSelector smallImageImageSelector,
 			ServiceContext serviceContext)
 		throws PortalException;
 
 	public BlogsEntry addEntry(
-			long userId, String title, String subtitle, String urlTitle,
-			String description, String content, int displayDateMonth,
-			int displayDateDay, int displayDateYear, int displayDateHour,
-			int displayDateMinute, boolean allowPingbacks,
-			boolean allowTrackbacks, String[] trackbacks,
-			String coverImageCaption, ImageSelector coverImageImageSelector,
+			String externalReferenceCode, long userId, String title,
+			String subtitle, String urlTitle, String description,
+			String content, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			boolean allowPingbacks, boolean allowTrackbacks,
+			String[] trackbacks, String coverImageCaption,
+			ImageSelector coverImageImageSelector,
 			ImageSelector smallImageImageSelector,
 			ServiceContext serviceContext)
 		throws PortalException;
@@ -315,6 +316,25 @@ public interface BlogsEntryLocalService
 	public BlogsEntry fetchBlogsEntry(long entryId);
 
 	/**
+	 * Returns the blogs entry with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the blogs entry's external reference code
+	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BlogsEntry fetchBlogsEntryByExternalReferenceCode(
+		long groupId, String externalReferenceCode);
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBlogsEntryByExternalReferenceCode(long, String)}
+	 */
+	@Deprecated
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BlogsEntry fetchBlogsEntryByReferenceCode(
+		long groupId, String externalReferenceCode);
+
+	/**
 	 * Returns the blogs entry matching the UUID and group.
 	 *
 	 * @param uuid the blogs entry's UUID
@@ -388,6 +408,19 @@ public interface BlogsEntryLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BlogsEntry getBlogsEntry(long entryId) throws PortalException;
+
+	/**
+	 * Returns the blogs entry with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the blogs entry's external reference code
+	 * @return the matching blogs entry
+	 * @throws PortalException if a matching blogs entry could not be found
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BlogsEntry getBlogsEntryByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException;
 
 	/**
 	 * Returns the blogs entry matching the UUID and group.

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceUtil.java
@@ -143,29 +143,9 @@ public class BlogsEntryLocalServiceUtil {
 	}
 
 	public static BlogsEntry addEntry(
-			long userId, String title, String subtitle, String urlTitle,
-			String description, String content, java.util.Date displayDate,
-			boolean allowPingbacks, boolean allowTrackbacks,
-			String[] trackbacks, String coverImageCaption,
-			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
-				coverImageImageSelector,
-			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
-				smallImageImageSelector,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().addEntry(
-			userId, title, subtitle, urlTitle, description, content,
-			displayDate, allowPingbacks, allowTrackbacks, trackbacks,
-			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
-			serviceContext);
-	}
-
-	public static BlogsEntry addEntry(
-			long userId, String title, String subtitle, String urlTitle,
-			String description, String content, int displayDateMonth,
-			int displayDateDay, int displayDateYear, int displayDateHour,
-			int displayDateMinute, boolean allowPingbacks,
+			String externalReferenceCode, long userId, String title,
+			String subtitle, String urlTitle, String description,
+			String content, java.util.Date displayDate, boolean allowPingbacks,
 			boolean allowTrackbacks, String[] trackbacks,
 			String coverImageCaption,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
@@ -176,11 +156,32 @@ public class BlogsEntryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().addEntry(
-			userId, title, subtitle, urlTitle, description, content,
-			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
-			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
-			serviceContext);
+			externalReferenceCode, userId, title, subtitle, urlTitle,
+			description, content, displayDate, allowPingbacks, allowTrackbacks,
+			trackbacks, coverImageCaption, coverImageImageSelector,
+			smallImageImageSelector, serviceContext);
+	}
+
+	public static BlogsEntry addEntry(
+			String externalReferenceCode, long userId, String title,
+			String subtitle, String urlTitle, String description,
+			String content, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			boolean allowPingbacks, boolean allowTrackbacks,
+			String[] trackbacks, String coverImageCaption,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				coverImageImageSelector,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				smallImageImageSelector,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addEntry(
+			externalReferenceCode, userId, title, subtitle, urlTitle,
+			description, content, displayDateMonth, displayDateDay,
+			displayDateYear, displayDateHour, displayDateMinute, allowPingbacks,
+			allowTrackbacks, trackbacks, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
 	public static void addEntryResources(
@@ -413,6 +414,31 @@ public class BlogsEntryLocalServiceUtil {
 	}
 
 	/**
+	 * Returns the blogs entry with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the blogs entry's external reference code
+	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
+	 */
+	public static BlogsEntry fetchBlogsEntryByExternalReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return getService().fetchBlogsEntryByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBlogsEntryByExternalReferenceCode(long, String)}
+	 */
+	@Deprecated
+	public static BlogsEntry fetchBlogsEntryByReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return getService().fetchBlogsEntryByReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
+	/**
 	 * Returns the blogs entry matching the UUID and group.
 	 *
 	 * @param uuid the blogs entry's UUID
@@ -501,6 +527,22 @@ public class BlogsEntryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getBlogsEntry(entryId);
+	}
+
+	/**
+	 * Returns the blogs entry with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the blogs entry's external reference code
+	 * @return the matching blogs entry
+	 * @throws PortalException if a matching blogs entry could not be found
+	 */
+	public static BlogsEntry getBlogsEntryByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getBlogsEntryByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceWrapper.java
@@ -142,30 +142,9 @@ public class BlogsEntryLocalServiceWrapper
 
 	@Override
 	public com.liferay.blogs.model.BlogsEntry addEntry(
-			long userId, String title, String subtitle, String urlTitle,
-			String description, String content, java.util.Date displayDate,
-			boolean allowPingbacks, boolean allowTrackbacks,
-			String[] trackbacks, String coverImageCaption,
-			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
-				coverImageImageSelector,
-			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
-				smallImageImageSelector,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _blogsEntryLocalService.addEntry(
-			userId, title, subtitle, urlTitle, description, content,
-			displayDate, allowPingbacks, allowTrackbacks, trackbacks,
-			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
-			serviceContext);
-	}
-
-	@Override
-	public com.liferay.blogs.model.BlogsEntry addEntry(
-			long userId, String title, String subtitle, String urlTitle,
-			String description, String content, int displayDateMonth,
-			int displayDateDay, int displayDateYear, int displayDateHour,
-			int displayDateMinute, boolean allowPingbacks,
+			String externalReferenceCode, long userId, String title,
+			String subtitle, String urlTitle, String description,
+			String content, java.util.Date displayDate, boolean allowPingbacks,
 			boolean allowTrackbacks, String[] trackbacks,
 			String coverImageCaption,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
@@ -176,11 +155,33 @@ public class BlogsEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _blogsEntryLocalService.addEntry(
-			userId, title, subtitle, urlTitle, description, content,
-			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
-			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
-			serviceContext);
+			externalReferenceCode, userId, title, subtitle, urlTitle,
+			description, content, displayDate, allowPingbacks, allowTrackbacks,
+			trackbacks, coverImageCaption, coverImageImageSelector,
+			smallImageImageSelector, serviceContext);
+	}
+
+	@Override
+	public com.liferay.blogs.model.BlogsEntry addEntry(
+			String externalReferenceCode, long userId, String title,
+			String subtitle, String urlTitle, String description,
+			String content, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			boolean allowPingbacks, boolean allowTrackbacks,
+			String[] trackbacks, String coverImageCaption,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				coverImageImageSelector,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				smallImageImageSelector,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _blogsEntryLocalService.addEntry(
+			externalReferenceCode, userId, title, subtitle, urlTitle,
+			description, content, displayDateMonth, displayDateDay,
+			displayDateYear, displayDateHour, displayDateMinute, allowPingbacks,
+			allowTrackbacks, trackbacks, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
 	@Override
@@ -456,6 +457,34 @@ public class BlogsEntryLocalServiceWrapper
 	}
 
 	/**
+	 * Returns the blogs entry with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the blogs entry's external reference code
+	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
+	 */
+	@Override
+	public com.liferay.blogs.model.BlogsEntry
+		fetchBlogsEntryByExternalReferenceCode(
+			long groupId, String externalReferenceCode) {
+
+		return _blogsEntryLocalService.fetchBlogsEntryByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBlogsEntryByExternalReferenceCode(long, String)}
+	 */
+	@Deprecated
+	@Override
+	public com.liferay.blogs.model.BlogsEntry fetchBlogsEntryByReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return _blogsEntryLocalService.fetchBlogsEntryByReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
+	/**
 	 * Returns the blogs entry matching the UUID and group.
 	 *
 	 * @param uuid the blogs entry's UUID
@@ -560,6 +589,24 @@ public class BlogsEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _blogsEntryLocalService.getBlogsEntry(entryId);
+	}
+
+	/**
+	 * Returns the blogs entry with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the blogs entry's external reference code
+	 * @return the matching blogs entry
+	 * @throws PortalException if a matching blogs entry could not be found
+	 */
+	@Override
+	public com.liferay.blogs.model.BlogsEntry
+			getBlogsEntryByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _blogsEntryLocalService.getBlogsEntryByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
@@ -70,12 +70,12 @@ public interface BlogsEntryService extends BaseService {
 		throws PortalException;
 
 	public BlogsEntry addEntry(
-			String title, String subtitle, String urlTitle, String description,
-			String content, int displayDateMonth, int displayDateDay,
-			int displayDateYear, int displayDateHour, int displayDateMinute,
-			boolean allowPingbacks, boolean allowTrackbacks,
-			String[] trackbacks, String coverImageCaption,
-			ImageSelector coverImageImageSelector,
+			String externalReferenceCode, String title, String subtitle,
+			String urlTitle, String description, String content,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, boolean allowPingbacks,
+			boolean allowTrackbacks, String[] trackbacks,
+			String coverImageCaption, ImageSelector coverImageImageSelector,
 			ImageSelector smallImageImageSelector,
 			ServiceContext serviceContext)
 		throws PortalException;

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
@@ -67,11 +67,12 @@ public class BlogsEntryServiceUtil {
 	}
 
 	public static BlogsEntry addEntry(
-			String title, String subtitle, String urlTitle, String description,
-			String content, int displayDateMonth, int displayDateDay,
-			int displayDateYear, int displayDateHour, int displayDateMinute,
-			boolean allowPingbacks, boolean allowTrackbacks,
-			String[] trackbacks, String coverImageCaption,
+			String externalReferenceCode, String title, String subtitle,
+			String urlTitle, String description, String content,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, boolean allowPingbacks,
+			boolean allowTrackbacks, String[] trackbacks,
+			String coverImageCaption,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
 				coverImageImageSelector,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
@@ -80,10 +81,11 @@ public class BlogsEntryServiceUtil {
 		throws PortalException {
 
 		return getService().addEntry(
-			title, subtitle, urlTitle, description, content, displayDateMonth,
-			displayDateDay, displayDateYear, displayDateHour, displayDateMinute,
-			allowPingbacks, allowTrackbacks, trackbacks, coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
+			externalReferenceCode, title, subtitle, urlTitle, description,
+			content, displayDateMonth, displayDateDay, displayDateYear,
+			displayDateHour, displayDateMinute, allowPingbacks, allowTrackbacks,
+			trackbacks, coverImageCaption, coverImageImageSelector,
+			smallImageImageSelector, serviceContext);
 	}
 
 	public static void deleteEntry(long entryId) throws PortalException {

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
@@ -61,11 +61,12 @@ public class BlogsEntryServiceWrapper
 
 	@Override
 	public com.liferay.blogs.model.BlogsEntry addEntry(
-			String title, String subtitle, String urlTitle, String description,
-			String content, int displayDateMonth, int displayDateDay,
-			int displayDateYear, int displayDateHour, int displayDateMinute,
-			boolean allowPingbacks, boolean allowTrackbacks,
-			String[] trackbacks, String coverImageCaption,
+			String externalReferenceCode, String title, String subtitle,
+			String urlTitle, String description, String content,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, boolean allowPingbacks,
+			boolean allowTrackbacks, String[] trackbacks,
+			String coverImageCaption,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
 				coverImageImageSelector,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
@@ -74,10 +75,11 @@ public class BlogsEntryServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _blogsEntryService.addEntry(
-			title, subtitle, urlTitle, description, content, displayDateMonth,
-			displayDateDay, displayDateYear, displayDateHour, displayDateMinute,
-			allowPingbacks, allowTrackbacks, trackbacks, coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
+			externalReferenceCode, title, subtitle, urlTitle, description,
+			content, displayDateMonth, displayDateDay, displayDateYear,
+			displayDateHour, displayDateMinute, allowPingbacks, allowTrackbacks,
+			trackbacks, coverImageCaption, coverImageImageSelector,
+			smallImageImageSelector, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/persistence/BlogsEntryPersistence.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/persistence/BlogsEntryPersistence.java
@@ -5263,6 +5263,56 @@ public interface BlogsEntryPersistence extends BasePersistence<BlogsEntry> {
 		long groupId, long userId, Date displayDate, int status);
 
 	/**
+	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching blogs entry
+	 * @throws NoSuchEntryException if a matching blogs entry could not be found
+	 */
+	public BlogsEntry findByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
+	 */
+	public BlogsEntry fetchByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
+	 */
+	public BlogsEntry fetchByG_ERC(
+		long groupId, String externalReferenceCode, boolean useFinderCache);
+
+	/**
+	 * Removes the blogs entry where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the blogs entry that was removed
+	 */
+	public BlogsEntry removeByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the number of blogs entries where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching blogs entries
+	 */
+	public int countByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
 	 * Caches the blogs entry in the entity cache if it is enabled.
 	 *
 	 * @param blogsEntry the blogs entry

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/persistence/BlogsEntryUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/persistence/BlogsEntryUtil.java
@@ -6420,6 +6420,74 @@ public class BlogsEntryUtil {
 	}
 
 	/**
+	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching blogs entry
+	 * @throws NoSuchEntryException if a matching blogs entry could not be found
+	 */
+	public static BlogsEntry findByG_ERC(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.blogs.exception.NoSuchEntryException {
+
+		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
+	 */
+	public static BlogsEntry fetchByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().fetchByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
+	 */
+	public static BlogsEntry fetchByG_ERC(
+		long groupId, String externalReferenceCode, boolean useFinderCache) {
+
+		return getPersistence().fetchByG_ERC(
+			groupId, externalReferenceCode, useFinderCache);
+	}
+
+	/**
+	 * Removes the blogs entry where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the blogs entry that was removed
+	 */
+	public static BlogsEntry removeByG_ERC(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.blogs.exception.NoSuchEntryException {
+
+		return getPersistence().removeByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the number of blogs entries where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching blogs entries
+	 */
+	public static int countByG_ERC(long groupId, String externalReferenceCode) {
+		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
 	 * Caches the blogs entry in the entity cache if it is enabled.
 	 *
 	 * @param blogsEntry the blogs entry

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/exception/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.2
+version 1.1.0

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/model/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 3.0.0

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/persistence/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/blogs/blogs-reading-time/src/main/java/com/liferay/blogs/reading/time/internal/service/BlogsReadingTimeEntryLocalServiceWrapper.java
+++ b/modules/apps/blogs/blogs-reading-time/src/main/java/com/liferay/blogs/reading/time/internal/service/BlogsReadingTimeEntryLocalServiceWrapper.java
@@ -47,20 +47,20 @@ public class BlogsReadingTimeEntryLocalServiceWrapper
 
 	@Override
 	public BlogsEntry addEntry(
-			long userId, String title, String subtitle, String urlTitle,
-			String description, String content, Date displayDate,
-			boolean allowPingbacks, boolean allowTrackbacks,
-			String[] trackbacks, String coverImageCaption,
-			ImageSelector coverImageImageSelector,
+			String externalReferenceCode, long userId, String title,
+			String subtitle, String urlTitle, String description,
+			String content, Date displayDate, boolean allowPingbacks,
+			boolean allowTrackbacks, String[] trackbacks,
+			String coverImageCaption, ImageSelector coverImageImageSelector,
 			ImageSelector smallImageImageSelector,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		BlogsEntry blogsEntry = super.addEntry(
-			userId, title, subtitle, urlTitle, description, content,
-			displayDate, allowPingbacks, allowTrackbacks, trackbacks,
-			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
-			serviceContext);
+			externalReferenceCode, userId, title, subtitle, urlTitle,
+			description, content, displayDate, allowPingbacks, allowTrackbacks,
+			trackbacks, coverImageCaption, coverImageImageSelector,
+			smallImageImageSelector, serviceContext);
 
 		_readingTimeEntryLocalService.updateReadingTimeEntry(blogsEntry);
 

--- a/modules/apps/blogs/blogs-service/bnd.bnd
+++ b/modules/apps/blogs/blogs-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Blogs Service
 Bundle-SymbolicName: com.liferay.blogs.service
 Bundle-Version: 5.0.8
-Liferay-Require-SchemaVersion: 2.1.2
+Liferay-Require-SchemaVersion: 2.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/blogs/blogs-service/service.xml
+++ b/modules/apps/blogs/blogs-service/service.xml
@@ -3,7 +3,7 @@
 
 <service-builder auto-import-default-references="false" auto-namespace-tables="false" dependency-injector="ds" mvcc-enabled="true" package-path="com.liferay.blogs">
 	<namespace>Blogs</namespace>
-	<entity local-service="true" name="BlogsEntry" remote-service="true" trash-enabled="true" uuid="true">
+	<entity external-reference-code="group" local-service="true" name="BlogsEntry" remote-service="true" trash-enabled="true" uuid="true">
 
 		<!-- PK fields -->
 

--- a/modules/apps/blogs/blogs-service/service.xml
+++ b/modules/apps/blogs/blogs-service/service.xml
@@ -238,6 +238,7 @@
 		<reference entity="Group" package-path="com.liferay.portal" />
 	</entity>
 	<exceptions>
+		<exception>DuplicateEntryExternalReferenceCode</exception>
 		<exception>EntryContent</exception>
 		<exception>EntryCoverImageCrop</exception>
 		<exception>EntryDescription</exception>

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/exportimport/data/handler/BlogsEntryStagedModelDataHandler.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/exportimport/data/handler/BlogsEntryStagedModelDataHandler.java
@@ -272,7 +272,7 @@ public class BlogsEntryStagedModelDataHandler
 			}
 
 			importedEntry = _blogsEntryLocalService.addEntry(
-				userId, entry.getTitle(), entry.getSubtitle(), urlTitle,
+				null, userId, entry.getTitle(), entry.getSubtitle(), urlTitle,
 				entry.getDescription(), entry.getContent(),
 				entry.getDisplayDate(), entry.isAllowPingbacks(),
 				entry.isAllowTrackbacks(), trackbacks,

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/exportimport/data/handler/BlogsEntryStagedModelDataHandler.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/exportimport/data/handler/BlogsEntryStagedModelDataHandler.java
@@ -272,10 +272,10 @@ public class BlogsEntryStagedModelDataHandler
 			}
 
 			importedEntry = _blogsEntryLocalService.addEntry(
-				null, userId, entry.getTitle(), entry.getSubtitle(), urlTitle,
-				entry.getDescription(), entry.getContent(),
-				entry.getDisplayDate(), entry.isAllowPingbacks(),
-				entry.isAllowTrackbacks(), trackbacks,
+				entry.getExternalReferenceCode(), userId, entry.getTitle(),
+				entry.getSubtitle(), urlTitle, entry.getDescription(),
+				entry.getContent(), entry.getDisplayDate(),
+				entry.isAllowPingbacks(), entry.isAllowTrackbacks(), trackbacks,
 				entry.getCoverImageCaption(), null, null, serviceContext);
 		}
 		else {

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
@@ -18,6 +18,7 @@ import com.liferay.blogs.internal.upgrade.v1_1_0.UpgradeClassNames;
 import com.liferay.blogs.internal.upgrade.v1_1_2.BlogsImagesUpgradeProcess;
 import com.liferay.blogs.internal.upgrade.v2_0_0.util.BlogsEntryTable;
 import com.liferay.blogs.internal.upgrade.v2_0_0.util.BlogsStatsUserTable;
+import com.liferay.blogs.internal.upgrade.v2_2_0.BlogsEntryExternalReferenceCodeUpgradeProcess;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.comment.upgrade.UpgradeDiscussionSubscriptionClassName;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
@@ -103,6 +104,10 @@ public class BlogsServiceUpgrade implements UpgradeStepRegistrator {
 				BlogsEntryUpgradeProcess());
 
 		registry.register("2.1.1", "2.1.2", new DummyUpgradeStep());
+
+		registry.register(
+			"2.1.2", "2.2.0",
+			new BlogsEntryExternalReferenceCodeUpgradeProcess());
 	}
 
 	private UnsafeBiFunction<String, Connection, Boolean, Exception>

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v2_2_0/BlogsEntryExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v2_2_0/BlogsEntryExternalReferenceCodeUpgradeProcess.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blogs.internal.upgrade.v2_2_0;
+
+import com.liferay.blogs.internal.upgrade.v2_2_0.util.BlogsEntryTable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+public class BlogsEntryExternalReferenceCodeUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		if (!hasColumn(BlogsEntryTable.TABLE_NAME, "externalReferenceCode")) {
+			alter(
+				BlogsEntryTable.class,
+				new AlterTableAddColumn(
+					"externalReferenceCode", "VARCHAR(75)"));
+
+			runSQL(
+				StringBundler.concat(
+					"update ", BlogsEntryTable.TABLE_NAME,
+					" set externalReferenceCode = CAST_TEXT(entryId) where ",
+					"externalReferenceCode is null or externalReferenceCode =",
+					"''"));
+		}
+	}
+
+}

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v2_2_0/util/BlogsEntryTable.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v2_2_0/util/BlogsEntryTable.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blogs.internal.upgrade.v2_2_0.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
+public class BlogsEntryTable {
+
+	public static final String TABLE_NAME = "BlogsEntry";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
+		{"externalReferenceCode", Types.VARCHAR}, {"entryId", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"title", Types.VARCHAR}, {"subtitle", Types.VARCHAR},
+		{"urlTitle", Types.VARCHAR}, {"description", Types.VARCHAR},
+		{"content", Types.CLOB}, {"displayDate", Types.TIMESTAMP},
+		{"allowPingbacks", Types.BOOLEAN}, {"allowTrackbacks", Types.BOOLEAN},
+		{"trackbacks", Types.CLOB}, {"coverImageCaption", Types.VARCHAR},
+		{"coverImageFileEntryId", Types.BIGINT},
+		{"coverImageURL", Types.VARCHAR}, {"smallImage", Types.BOOLEAN},
+		{"smallImageFileEntryId", Types.BIGINT}, {"smallImageId", Types.BIGINT},
+		{"smallImageURL", Types.VARCHAR}, {"lastPublishDate", Types.TIMESTAMP},
+		{"status", Types.INTEGER}, {"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR}, {"statusDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
+new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("entryId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("title", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("subtitle", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("urlTitle", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("content", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("displayDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("allowPingbacks", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("allowTrackbacks", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("trackbacks", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("coverImageCaption", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("coverImageFileEntryId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("coverImageURL", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("smallImage", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("smallImageFileEntryId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("smallImageId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("smallImageURL", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE =
+"create table BlogsEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,entryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,title VARCHAR(255) null,subtitle STRING null,urlTitle VARCHAR(255) null,description STRING null,content TEXT null,displayDate DATE null,allowPingbacks BOOLEAN,allowTrackbacks BOOLEAN,trackbacks TEXT null,coverImageCaption STRING null,coverImageFileEntryId LONG,coverImageURL STRING null,smallImage BOOLEAN,smallImageFileEntryId LONG,smallImageId LONG,smallImageURL STRING null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table BlogsEntry";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_BB0C2905 on BlogsEntry (companyId, displayDate, status)",
+		"create index IX_EB2DCE27 on BlogsEntry (companyId, status)",
+		"create index IX_A5F57B61 on BlogsEntry (companyId, userId, status)",
+		"create index IX_2672F77F on BlogsEntry (displayDate, status)",
+		"create index IX_F0E73383 on BlogsEntry (groupId, displayDate, status)",
+		"create index IX_1EFD8EE9 on BlogsEntry (groupId, status)",
+		"create unique index IX_DB780A20 on BlogsEntry (groupId, urlTitle[$COLUMN_LENGTH:255$])",
+		"create index IX_DA04F689 on BlogsEntry (groupId, userId, displayDate, status)",
+		"create index IX_49E15A23 on BlogsEntry (groupId, userId, status)",
+		"create index IX_5E8307BB on BlogsEntry (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_1B1040FD on BlogsEntry (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
+
+}

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/model/impl/BlogsEntryCacheModel.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/model/impl/BlogsEntryCacheModel.java
@@ -77,12 +77,14 @@ public class BlogsEntryCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(61);
+		StringBundler sb = new StringBundler(63);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
 		sb.append(", uuid=");
 		sb.append(uuid);
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
 		sb.append(", entryId=");
 		sb.append(entryId);
 		sb.append(", groupId=");
@@ -155,6 +157,13 @@ public class BlogsEntryCacheModel
 		}
 		else {
 			blogsEntryImpl.setUuid(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			blogsEntryImpl.setExternalReferenceCode("");
+		}
+		else {
+			blogsEntryImpl.setExternalReferenceCode(externalReferenceCode);
 		}
 
 		blogsEntryImpl.setEntryId(entryId);
@@ -297,6 +306,7 @@ public class BlogsEntryCacheModel
 
 		mvccVersion = objectInput.readLong();
 		uuid = objectInput.readUTF();
+		externalReferenceCode = objectInput.readUTF();
 
 		entryId = objectInput.readLong();
 
@@ -348,6 +358,13 @@ public class BlogsEntryCacheModel
 		}
 		else {
 			objectOutput.writeUTF(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(externalReferenceCode);
 		}
 
 		objectOutput.writeLong(entryId);
@@ -463,6 +480,7 @@ public class BlogsEntryCacheModel
 
 	public long mvccVersion;
 	public String uuid;
+	public String externalReferenceCode;
 	public long entryId;
 	public long groupId;
 	public long companyId;

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/model/impl/BlogsEntryModelImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/model/impl/BlogsEntryModelImpl.java
@@ -82,15 +82,15 @@ public class BlogsEntryModelImpl
 
 	public static final Object[][] TABLE_COLUMNS = {
 		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
-		{"entryId", Types.BIGINT}, {"groupId", Types.BIGINT},
-		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
-		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
-		{"modifiedDate", Types.TIMESTAMP}, {"title", Types.VARCHAR},
-		{"subtitle", Types.VARCHAR}, {"urlTitle", Types.VARCHAR},
-		{"description", Types.VARCHAR}, {"content", Types.CLOB},
-		{"displayDate", Types.TIMESTAMP}, {"allowPingbacks", Types.BOOLEAN},
-		{"allowTrackbacks", Types.BOOLEAN}, {"trackbacks", Types.CLOB},
-		{"coverImageCaption", Types.VARCHAR},
+		{"externalReferenceCode", Types.VARCHAR}, {"entryId", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"title", Types.VARCHAR}, {"subtitle", Types.VARCHAR},
+		{"urlTitle", Types.VARCHAR}, {"description", Types.VARCHAR},
+		{"content", Types.CLOB}, {"displayDate", Types.TIMESTAMP},
+		{"allowPingbacks", Types.BOOLEAN}, {"allowTrackbacks", Types.BOOLEAN},
+		{"trackbacks", Types.CLOB}, {"coverImageCaption", Types.VARCHAR},
 		{"coverImageFileEntryId", Types.BIGINT},
 		{"coverImageURL", Types.VARCHAR}, {"smallImage", Types.BOOLEAN},
 		{"smallImageFileEntryId", Types.BIGINT}, {"smallImageId", Types.BIGINT},
@@ -105,6 +105,7 @@ public class BlogsEntryModelImpl
 	static {
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("entryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
@@ -136,7 +137,7 @@ public class BlogsEntryModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table BlogsEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,entryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,title VARCHAR(255) null,subtitle STRING null,urlTitle VARCHAR(255) null,description STRING null,content TEXT null,displayDate DATE null,allowPingbacks BOOLEAN,allowTrackbacks BOOLEAN,trackbacks TEXT null,coverImageCaption STRING null,coverImageFileEntryId LONG,coverImageURL STRING null,smallImage BOOLEAN,smallImageFileEntryId LONG,smallImageId LONG,smallImageURL STRING null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+		"create table BlogsEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,entryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,title VARCHAR(255) null,subtitle STRING null,urlTitle VARCHAR(255) null,description STRING null,content TEXT null,displayDate DATE null,allowPingbacks BOOLEAN,allowTrackbacks BOOLEAN,trackbacks TEXT null,coverImageCaption STRING null,coverImageFileEntryId LONG,coverImageURL STRING null,smallImage BOOLEAN,smallImageFileEntryId LONG,smallImageId LONG,smallImageURL STRING null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table BlogsEntry";
 
@@ -168,38 +169,44 @@ public class BlogsEntryModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 4L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long STATUS_COLUMN_BITMASK = 8L;
+	public static final long GROUPID_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long URLTITLE_COLUMN_BITMASK = 16L;
+	public static final long STATUS_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long USERID_COLUMN_BITMASK = 32L;
+	public static final long URLTITLE_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 64L;
+	public static final long USERID_COLUMN_BITMASK = 64L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long CREATEDATE_COLUMN_BITMASK = 128L;
+	public static final long CREATEDATE_COLUMN_BITMASK = 256L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -232,6 +239,7 @@ public class BlogsEntryModelImpl
 
 		model.setMvccVersion(soapModel.getMvccVersion());
 		model.setUuid(soapModel.getUuid());
+		model.setExternalReferenceCode(soapModel.getExternalReferenceCode());
 		model.setEntryId(soapModel.getEntryId());
 		model.setGroupId(soapModel.getGroupId());
 		model.setCompanyId(soapModel.getCompanyId());
@@ -416,6 +424,12 @@ public class BlogsEntryModelImpl
 		attributeGetterFunctions.put("uuid", BlogsEntry::getUuid);
 		attributeSetterBiConsumers.put(
 			"uuid", (BiConsumer<BlogsEntry, String>)BlogsEntry::setUuid);
+		attributeGetterFunctions.put(
+			"externalReferenceCode", BlogsEntry::getExternalReferenceCode);
+		attributeSetterBiConsumers.put(
+			"externalReferenceCode",
+			(BiConsumer<BlogsEntry, String>)
+				BlogsEntry::setExternalReferenceCode);
 		attributeGetterFunctions.put("entryId", BlogsEntry::getEntryId);
 		attributeSetterBiConsumers.put(
 			"entryId", (BiConsumer<BlogsEntry, Long>)BlogsEntry::setEntryId);
@@ -583,6 +597,35 @@ public class BlogsEntryModelImpl
 	@Deprecated
 	public String getOriginalUuid() {
 		return getColumnOriginalValue("uuid_");
+	}
+
+	@JSON
+	@Override
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCode == null) {
+			return "";
+		}
+		else {
+			return _externalReferenceCode;
+		}
+	}
+
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalExternalReferenceCode() {
+		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -1461,6 +1504,7 @@ public class BlogsEntryModelImpl
 
 		blogsEntryImpl.setMvccVersion(getMvccVersion());
 		blogsEntryImpl.setUuid(getUuid());
+		blogsEntryImpl.setExternalReferenceCode(getExternalReferenceCode());
 		blogsEntryImpl.setEntryId(getEntryId());
 		blogsEntryImpl.setGroupId(getGroupId());
 		blogsEntryImpl.setCompanyId(getCompanyId());
@@ -1585,6 +1629,17 @@ public class BlogsEntryModelImpl
 
 		if ((uuid != null) && (uuid.length() == 0)) {
 			blogsEntryCacheModel.uuid = null;
+		}
+
+		blogsEntryCacheModel.externalReferenceCode = getExternalReferenceCode();
+
+		String externalReferenceCode =
+			blogsEntryCacheModel.externalReferenceCode;
+
+		if ((externalReferenceCode != null) &&
+			(externalReferenceCode.length() == 0)) {
+
+			blogsEntryCacheModel.externalReferenceCode = null;
 		}
 
 		blogsEntryCacheModel.entryId = getEntryId();
@@ -1819,6 +1874,7 @@ public class BlogsEntryModelImpl
 
 	private long _mvccVersion;
 	private String _uuid;
+	private String _externalReferenceCode;
 	private long _entryId;
 	private long _groupId;
 	private long _companyId;
@@ -1880,6 +1936,8 @@ public class BlogsEntryModelImpl
 
 		_columnOriginalValues.put("mvccVersion", _mvccVersion);
 		_columnOriginalValues.put("uuid_", _uuid);
+		_columnOriginalValues.put(
+			"externalReferenceCode", _externalReferenceCode);
 		_columnOriginalValues.put("entryId", _entryId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
@@ -1937,61 +1995,63 @@ public class BlogsEntryModelImpl
 
 		columnBitmasks.put("uuid_", 2L);
 
-		columnBitmasks.put("entryId", 4L);
+		columnBitmasks.put("externalReferenceCode", 4L);
 
-		columnBitmasks.put("groupId", 8L);
+		columnBitmasks.put("entryId", 8L);
 
-		columnBitmasks.put("companyId", 16L);
+		columnBitmasks.put("groupId", 16L);
 
-		columnBitmasks.put("userId", 32L);
+		columnBitmasks.put("companyId", 32L);
 
-		columnBitmasks.put("userName", 64L);
+		columnBitmasks.put("userId", 64L);
 
-		columnBitmasks.put("createDate", 128L);
+		columnBitmasks.put("userName", 128L);
 
-		columnBitmasks.put("modifiedDate", 256L);
+		columnBitmasks.put("createDate", 256L);
 
-		columnBitmasks.put("title", 512L);
+		columnBitmasks.put("modifiedDate", 512L);
 
-		columnBitmasks.put("subtitle", 1024L);
+		columnBitmasks.put("title", 1024L);
 
-		columnBitmasks.put("urlTitle", 2048L);
+		columnBitmasks.put("subtitle", 2048L);
 
-		columnBitmasks.put("description", 4096L);
+		columnBitmasks.put("urlTitle", 4096L);
 
-		columnBitmasks.put("content", 8192L);
+		columnBitmasks.put("description", 8192L);
 
-		columnBitmasks.put("displayDate", 16384L);
+		columnBitmasks.put("content", 16384L);
 
-		columnBitmasks.put("allowPingbacks", 32768L);
+		columnBitmasks.put("displayDate", 32768L);
 
-		columnBitmasks.put("allowTrackbacks", 65536L);
+		columnBitmasks.put("allowPingbacks", 65536L);
 
-		columnBitmasks.put("trackbacks", 131072L);
+		columnBitmasks.put("allowTrackbacks", 131072L);
 
-		columnBitmasks.put("coverImageCaption", 262144L);
+		columnBitmasks.put("trackbacks", 262144L);
 
-		columnBitmasks.put("coverImageFileEntryId", 524288L);
+		columnBitmasks.put("coverImageCaption", 524288L);
 
-		columnBitmasks.put("coverImageURL", 1048576L);
+		columnBitmasks.put("coverImageFileEntryId", 1048576L);
 
-		columnBitmasks.put("smallImage", 2097152L);
+		columnBitmasks.put("coverImageURL", 2097152L);
 
-		columnBitmasks.put("smallImageFileEntryId", 4194304L);
+		columnBitmasks.put("smallImage", 4194304L);
 
-		columnBitmasks.put("smallImageId", 8388608L);
+		columnBitmasks.put("smallImageFileEntryId", 8388608L);
 
-		columnBitmasks.put("smallImageURL", 16777216L);
+		columnBitmasks.put("smallImageId", 16777216L);
 
-		columnBitmasks.put("lastPublishDate", 33554432L);
+		columnBitmasks.put("smallImageURL", 33554432L);
 
-		columnBitmasks.put("status", 67108864L);
+		columnBitmasks.put("lastPublishDate", 67108864L);
 
-		columnBitmasks.put("statusByUserId", 134217728L);
+		columnBitmasks.put("status", 134217728L);
 
-		columnBitmasks.put("statusByUserName", 268435456L);
+		columnBitmasks.put("statusByUserId", 268435456L);
 
-		columnBitmasks.put("statusDate", 536870912L);
+		columnBitmasks.put("statusByUserName", 536870912L);
+
+		columnBitmasks.put("statusDate", 1073741824L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/base/BlogsEntryLocalServiceBaseImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/base/BlogsEntryLocalServiceBaseImpl.java
@@ -273,6 +273,50 @@ public abstract class BlogsEntryLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the blogs entry with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the blogs entry's external reference code
+	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
+	 */
+	@Override
+	public BlogsEntry fetchBlogsEntryByExternalReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return blogsEntryPersistence.fetchByG_ERC(
+			groupId, externalReferenceCode);
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBlogsEntryByExternalReferenceCode(long, String)}
+	 */
+	@Deprecated
+	@Override
+	public BlogsEntry fetchBlogsEntryByReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return fetchBlogsEntryByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the blogs entry with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the blogs entry's external reference code
+	 * @return the matching blogs entry
+	 * @throws PortalException if a matching blogs entry could not be found
+	 */
+	@Override
+	public BlogsEntry getBlogsEntryByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return blogsEntryPersistence.findByG_ERC(
+			groupId, externalReferenceCode);
+	}
+
+	/**
 	 * Returns the blogs entry with the primary key.
 	 *
 	 * @param entryId the primary key of the blogs entry

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
@@ -146,12 +146,12 @@ public class BlogsEntryServiceHttp {
 	}
 
 	public static com.liferay.blogs.model.BlogsEntry addEntry(
-			HttpPrincipal httpPrincipal, String title, String subtitle,
-			String urlTitle, String description, String content,
-			int displayDateMonth, int displayDateDay, int displayDateYear,
-			int displayDateHour, int displayDateMinute, boolean allowPingbacks,
-			boolean allowTrackbacks, String[] trackbacks,
-			String coverImageCaption,
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			String title, String subtitle, String urlTitle, String description,
+			String content, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			boolean allowPingbacks, boolean allowTrackbacks,
+			String[] trackbacks, String coverImageCaption,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
 				coverImageImageSelector,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
@@ -165,10 +165,10 @@ public class BlogsEntryServiceHttp {
 				_addEntryParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, title, subtitle, urlTitle, description, content,
-				displayDateMonth, displayDateDay, displayDateYear,
-				displayDateHour, displayDateMinute, allowPingbacks,
-				allowTrackbacks, trackbacks, coverImageCaption,
+				methodKey, externalReferenceCode, title, subtitle, urlTitle,
+				description, content, displayDateMonth, displayDateDay,
+				displayDateYear, displayDateHour, displayDateMinute,
+				allowPingbacks, allowTrackbacks, trackbacks, coverImageCaption,
 				coverImageImageSelector, smallImageImageSelector,
 				serviceContext);
 
@@ -1265,8 +1265,8 @@ public class BlogsEntryServiceHttp {
 	};
 	private static final Class<?>[] _addEntryParameterTypes2 = new Class[] {
 		String.class, String.class, String.class, String.class, String.class,
-		int.class, int.class, int.class, int.class, int.class, boolean.class,
-		boolean.class, String[].class, String.class,
+		String.class, int.class, int.class, int.class, int.class, int.class,
+		boolean.class, boolean.class, String[].class, String.class,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 		com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
@@ -114,11 +114,12 @@ public class BlogsEntryServiceSoap {
 	}
 
 	public static com.liferay.blogs.model.BlogsEntrySoap addEntry(
-			String title, String subtitle, String urlTitle, String description,
-			String content, int displayDateMonth, int displayDateDay,
-			int displayDateYear, int displayDateHour, int displayDateMinute,
-			boolean allowPingbacks, boolean allowTrackbacks,
-			String[] trackbacks, String coverImageCaption,
+			String externalReferenceCode, String title, String subtitle,
+			String urlTitle, String description, String content,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, boolean allowPingbacks,
+			boolean allowTrackbacks, String[] trackbacks,
+			String coverImageCaption,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
 				coverImageImageSelector,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
@@ -129,12 +130,12 @@ public class BlogsEntryServiceSoap {
 		try {
 			com.liferay.blogs.model.BlogsEntry returnValue =
 				BlogsEntryServiceUtil.addEntry(
-					title, subtitle, urlTitle, description, content,
-					displayDateMonth, displayDateDay, displayDateYear,
-					displayDateHour, displayDateMinute, allowPingbacks,
-					allowTrackbacks, trackbacks, coverImageCaption,
-					coverImageImageSelector, smallImageImageSelector,
-					serviceContext);
+					externalReferenceCode, title, subtitle, urlTitle,
+					description, content, displayDateMonth, displayDateDay,
+					displayDateYear, displayDateHour, displayDateMinute,
+					allowPingbacks, allowTrackbacks, trackbacks,
+					coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
 
 			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(
 				returnValue);

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -270,65 +270,6 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			smallImageImageSelector, serviceContext);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 * #addEntry(String, long, String, String, String, String, String, Date,
-	 * boolean, boolean, String[], String, ImageSelector, ImageSelector,
-	 * ServiceContext)}
-	 */
-	@Deprecated
-	@Indexable(type = IndexableType.REINDEX)
-	@Override
-	public BlogsEntry addEntry(
-			long userId, String title, String subtitle, String urlTitle,
-			String description, String content, Date displayDate,
-			boolean allowPingbacks, boolean allowTrackbacks,
-			String[] trackbacks, String coverImageCaption,
-			ImageSelector coverImageImageSelector,
-			ImageSelector smallImageImageSelector,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		return blogsEntryLocalService.addEntry(
-			null, userId, title, subtitle, urlTitle, description, content,
-			displayDate, allowPingbacks, allowTrackbacks, trackbacks,
-			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
-			serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 * #addEntry(String, long, String, String, String, String, String, int, int,
-	 * int, int, int, boolean, boolean, String[], String, ImageSelector,
-	 * ImageSelector, ServiceContext)}
-	 */
-	@Deprecated
-	@Override
-	public BlogsEntry addEntry(
-			long userId, String title, String subtitle, String urlTitle,
-			String description, String content, int displayDateMonth,
-			int displayDateDay, int displayDateYear, int displayDateHour,
-			int displayDateMinute, boolean allowPingbacks,
-			boolean allowTrackbacks, String[] trackbacks,
-			String coverImageCaption, ImageSelector coverImageImageSelector,
-			ImageSelector smallImageImageSelector,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		User user = userLocalService.getUser(userId);
-
-		Date displayDate = _portal.getDate(
-			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, user.getTimeZone(),
-			EntryDisplayDateException.class);
-
-		return blogsEntryLocalService.addEntry(
-			null, userId, title, subtitle, urlTitle, description, content,
-			displayDate, allowPingbacks, allowTrackbacks, trackbacks,
-			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
-			serviceContext);
-	}
-
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public BlogsEntry addEntry(

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -244,8 +244,8 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 		throws PortalException {
 
 		return blogsEntryLocalService.addEntry(
-			userId, title, subtitle, StringPool.BLANK, description, content,
-			displayDate, allowPingbacks, allowTrackbacks, trackbacks,
+			null, userId, title, subtitle, StringPool.BLANK, description,
+			content, displayDate, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
 			serviceContext);
 	}
@@ -263,13 +263,20 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 		throws PortalException {
 
 		return blogsEntryLocalService.addEntry(
-			userId, title, subtitle, StringPool.BLANK, description, content,
-			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
-			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
-			serviceContext);
+			null, userId, title, subtitle, StringPool.BLANK, description,
+			content, displayDateMonth, displayDateDay, displayDateYear,
+			displayDateHour, displayDateMinute, allowPingbacks, allowTrackbacks,
+			trackbacks, coverImageCaption, coverImageImageSelector,
+			smallImageImageSelector, serviceContext);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 * #addEntry(String, long, String, String, String, String, String, Date,
+	 * boolean, boolean, String[], String, ImageSelector, ImageSelector,
+	 * ServiceContext)}
+	 */
+	@Deprecated
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public BlogsEntry addEntry(
@@ -289,6 +296,13 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			serviceContext);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 * #addEntry(String, long, String, String, String, String, String, int, int,
+	 * int, int, int, boolean, boolean, String[], String, ImageSelector,
+	 * ImageSelector, ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public BlogsEntry addEntry(
 			long userId, String title, String subtitle, String urlTitle,
@@ -309,7 +323,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			EntryDisplayDateException.class);
 
 		return blogsEntryLocalService.addEntry(
-			userId, title, subtitle, urlTitle, description, content,
+			null, userId, title, subtitle, urlTitle, description, content,
 			displayDate, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
 			serviceContext);

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -107,37 +107,6 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			serviceContext);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 * #addEntry(String, String, String, String, String, String, int, int, int,
-	 * int, int, boolean, boolean, String[], String, ImageSelector,
-	 * ImageSelector, ServiceContext)}
-	 */
-	@Deprecated
-	@Override
-	public BlogsEntry addEntry(
-			String title, String subtitle, String urlTitle, String description,
-			String content, int displayDateMonth, int displayDateDay,
-			int displayDateYear, int displayDateHour, int displayDateMinute,
-			boolean allowPingbacks, boolean allowTrackbacks,
-			String[] trackbacks, String coverImageCaption,
-			ImageSelector coverImageImageSelector,
-			ImageSelector smallImageImageSelector,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		_portletResourcePermission.check(
-			getPermissionChecker(), serviceContext.getScopeGroupId(),
-			ActionKeys.ADD_ENTRY);
-
-		return blogsEntryLocalService.addEntry(
-			null, getUserId(), title, subtitle, urlTitle, description, content,
-			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
-			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
-			serviceContext);
-	}
-
 	@Override
 	public BlogsEntry addEntry(
 			String externalReferenceCode, String title, String subtitle,

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -107,6 +107,13 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			serviceContext);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 * #addEntry(String, String, String, String, String, String, int, int, int,
+	 * int, int, boolean, boolean, String[], String, ImageSelector,
+	 * ImageSelector, ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public BlogsEntry addEntry(
 			String title, String subtitle, String urlTitle, String description,
@@ -124,7 +131,7 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			ActionKeys.ADD_ENTRY);
 
 		return blogsEntryLocalService.addEntry(
-			getUserId(), title, subtitle, urlTitle, description, content,
+			null, getUserId(), title, subtitle, urlTitle, description, content,
 			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
 			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector, smallImageImageSelector,

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -132,6 +132,30 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 	}
 
 	@Override
+	public BlogsEntry addEntry(
+			String externalReferenceCode, String title, String subtitle,
+			String urlTitle, String description, String content,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, boolean allowPingbacks,
+			boolean allowTrackbacks, String[] trackbacks,
+			String coverImageCaption, ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_portletResourcePermission.check(
+			getPermissionChecker(), serviceContext.getScopeGroupId(),
+			ActionKeys.ADD_ENTRY);
+
+		return blogsEntryLocalService.addEntry(
+			externalReferenceCode, getUserId(), title, subtitle, urlTitle,
+			description, content, displayDateMonth, displayDateDay,
+			displayDateYear, displayDateHour, displayDateMinute, allowPingbacks,
+			allowTrackbacks, trackbacks, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
+	@Override
 	public void deleteEntry(long entryId) throws PortalException {
 		_blogsEntryModelResourcePermission.check(
 			getPermissionChecker(), entryId, ActionKeys.DELETE);

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/persistence/impl/BlogsEntryPersistenceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/persistence/impl/BlogsEntryPersistenceImpl.java
@@ -64,6 +64,7 @@ import java.lang.reflect.InvocationHandler;
 
 import java.sql.Timestamp;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -20965,6 +20966,272 @@ public class BlogsEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_G_U_LTD_NOTS_STATUS_2 =
 		"blogsEntry.status != ?";
 
+	private FinderPath _finderPathFetchByG_ERC;
+	private FinderPath _finderPathCountByG_ERC;
+
+	/**
+	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching blogs entry
+	 * @throws NoSuchEntryException if a matching blogs entry could not be found
+	 */
+	@Override
+	public BlogsEntry findByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchEntryException {
+
+		BlogsEntry blogsEntry = fetchByG_ERC(groupId, externalReferenceCode);
+
+		if (blogsEntry == null) {
+			StringBundler sb = new StringBundler(6);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("groupId=");
+			sb.append(groupId);
+
+			sb.append(", externalReferenceCode=");
+			sb.append(externalReferenceCode);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchEntryException(sb.toString());
+		}
+
+		return blogsEntry;
+	}
+
+	/**
+	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
+	 */
+	@Override
+	public BlogsEntry fetchByG_ERC(long groupId, String externalReferenceCode) {
+		return fetchByG_ERC(groupId, externalReferenceCode, true);
+	}
+
+	/**
+	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
+	 */
+	@Override
+	public BlogsEntry fetchByG_ERC(
+		long groupId, String externalReferenceCode, boolean useFinderCache) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		Object[] finderArgs = null;
+
+		if (useFinderCache) {
+			finderArgs = new Object[] {groupId, externalReferenceCode};
+		}
+
+		Object result = null;
+
+		if (useFinderCache) {
+			result = finderCache.getResult(_finderPathFetchByG_ERC, finderArgs);
+		}
+
+		if (result instanceof BlogsEntry) {
+			BlogsEntry blogsEntry = (BlogsEntry)result;
+
+			if ((groupId != blogsEntry.getGroupId()) ||
+				!Objects.equals(
+					externalReferenceCode,
+					blogsEntry.getExternalReferenceCode())) {
+
+				result = null;
+			}
+		}
+
+		if (result == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_SELECT_BLOGSENTRY_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				List<BlogsEntry> list = query.list();
+
+				if (list.isEmpty()) {
+					if (useFinderCache) {
+						finderCache.putResult(
+							_finderPathFetchByG_ERC, finderArgs, list);
+					}
+				}
+				else {
+					if (list.size() > 1) {
+						Collections.sort(list, Collections.reverseOrder());
+
+						if (_log.isWarnEnabled()) {
+							if (!useFinderCache) {
+								finderArgs = new Object[] {
+									groupId, externalReferenceCode
+								};
+							}
+
+							_log.warn(
+								"BlogsEntryPersistenceImpl.fetchByG_ERC(long, String, boolean) with parameters (" +
+									StringUtil.merge(finderArgs) +
+										") yields a result set with more than 1 result. This violates the logical unique restriction. There is no order guarantee on which result is returned by this finder.");
+						}
+					}
+
+					BlogsEntry blogsEntry = list.get(0);
+
+					result = blogsEntry;
+
+					cacheResult(blogsEntry);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		if (result instanceof List<?>) {
+			return null;
+		}
+		else {
+			return (BlogsEntry)result;
+		}
+	}
+
+	/**
+	 * Removes the blogs entry where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the blogs entry that was removed
+	 */
+	@Override
+	public BlogsEntry removeByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchEntryException {
+
+		BlogsEntry blogsEntry = findByG_ERC(groupId, externalReferenceCode);
+
+		return remove(blogsEntry);
+	}
+
+	/**
+	 * Returns the number of blogs entries where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching blogs entries
+	 */
+	@Override
+	public int countByG_ERC(long groupId, String externalReferenceCode) {
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		FinderPath finderPath = _finderPathCountByG_ERC;
+
+		Object[] finderArgs = new Object[] {groupId, externalReferenceCode};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(_SQL_COUNT_BLOGSENTRY_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
+		"blogsEntry.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
+		"blogsEntry.externalReferenceCode = ?";
+
+	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
+		"(blogsEntry.externalReferenceCode IS NULL OR blogsEntry.externalReferenceCode = '')";
+
 	public BlogsEntryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -20998,6 +21265,13 @@ public class BlogsEntryPersistenceImpl
 		finderCache.putResult(
 			_finderPathFetchByG_UT,
 			new Object[] {blogsEntry.getGroupId(), blogsEntry.getUrlTitle()},
+			blogsEntry);
+
+		finderCache.putResult(
+			_finderPathFetchByG_ERC,
+			new Object[] {
+				blogsEntry.getGroupId(), blogsEntry.getExternalReferenceCode()
+			},
 			blogsEntry);
 	}
 
@@ -21077,6 +21351,15 @@ public class BlogsEntryPersistenceImpl
 		finderCache.putResult(_finderPathCountByG_UT, args, Long.valueOf(1));
 		finderCache.putResult(
 			_finderPathFetchByG_UT, args, blogsEntryModelImpl);
+
+		args = new Object[] {
+			blogsEntryModelImpl.getGroupId(),
+			blogsEntryModelImpl.getExternalReferenceCode()
+		};
+
+		finderCache.putResult(_finderPathCountByG_ERC, args, Long.valueOf(1));
+		finderCache.putResult(
+			_finderPathFetchByG_ERC, args, blogsEntryModelImpl);
 	}
 
 	/**
@@ -22057,6 +22340,16 @@ public class BlogsEntryPersistenceImpl
 				Date.class.getName(), Integer.class.getName()
 			},
 			new String[] {"groupId", "userId", "displayDate", "status"}, false);
+
+		_finderPathFetchByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, true);
+
+		_finderPathCountByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, false);
 	}
 
 	@Deactivate

--- a/modules/apps/blogs/blogs-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/blogs/blogs-service/src/main/resources/META-INF/module-hbm.xml
@@ -10,6 +10,7 @@
 		</id>
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivatePropertyAccessor" name="mvccVersion" type="long" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />

--- a/modules/apps/blogs/blogs-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/blogs/blogs-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -4,6 +4,7 @@
 	<model name="com.liferay.blogs.model.BlogsEntry">
 		<field name="mvccVersion" type="long" />
 		<field name="uuid" type="String" />
+		<field name="externalReferenceCode" type="String" />
 		<field name="entryId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />

--- a/modules/apps/blogs/blogs-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/blogs/blogs-service/src/main/resources/META-INF/sql/indexes.sql
@@ -3,6 +3,7 @@ create index IX_EB2DCE27 on BlogsEntry (companyId, status);
 create index IX_A5F57B61 on BlogsEntry (companyId, userId, status);
 create index IX_2672F77F on BlogsEntry (displayDate, status);
 create index IX_F0E73383 on BlogsEntry (groupId, displayDate, status);
+create index IX_768836DA on BlogsEntry (groupId, externalReferenceCode[$COLUMN_LENGTH:75$]);
 create index IX_1EFD8EE9 on BlogsEntry (groupId, status);
 create unique index IX_DB780A20 on BlogsEntry (groupId, urlTitle[$COLUMN_LENGTH:255$]);
 create index IX_DA04F689 on BlogsEntry (groupId, userId, displayDate, status);

--- a/modules/apps/blogs/blogs-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/blogs/blogs-service/src/main/resources/META-INF/sql/tables.sql
@@ -1,6 +1,7 @@
 create table BlogsEntry (
 	mvccVersion LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
+	externalReferenceCode VARCHAR(75) null,
 	entryId LONG not null primary key,
 	groupId LONG,
 	companyId LONG,

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/exportimport/data/handler/test/BlogsEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/exportimport/data/handler/test/BlogsEntryStagedModelDataHandlerTest.java
@@ -369,6 +369,9 @@ public class BlogsEntryStagedModelDataHandlerTest
 		BlogsEntry entry = (BlogsEntry)stagedModel;
 		BlogsEntry importedEntry = (BlogsEntry)importedStagedModel;
 
+		Assert.assertEquals(
+			entry.getExternalReferenceCode(),
+			importedEntry.getExternalReferenceCode());
 		Assert.assertEquals(entry.getTitle(), importedEntry.getTitle());
 		Assert.assertEquals(entry.getSubtitle(), importedEntry.getSubtitle());
 		Assert.assertEquals(entry.getUrlTitle(), importedEntry.getUrlTitle());

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/impl/test/BlogsEntryLocalServiceImplTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/impl/test/BlogsEntryLocalServiceImplTest.java
@@ -15,6 +15,7 @@
 package com.liferay.blogs.service.impl.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.blogs.exception.DuplicateEntryExternalReferenceCodeException;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalServiceUtil;
 import com.liferay.portal.kernel.comment.CommentManagerUtil;
@@ -22,6 +23,7 @@ import com.liferay.portal.kernel.service.IdentityServiceContextFunction;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -47,6 +49,59 @@ public class BlogsEntryLocalServiceImplTest {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test(expected = DuplicateEntryExternalReferenceCodeException.class)
+	public void testAddBlogsEntryWithExistingExternalReferenceCode()
+		throws Exception {
+
+		BlogsEntry blogsEntry = BlogsEntryLocalServiceUtil.addEntry(
+			TestPropsValues.getUserId(), StringUtil.randomString(),
+			StringUtil.randomString(), new Date(),
+			ServiceContextTestUtil.getServiceContext());
+
+		BlogsEntryLocalServiceUtil.addEntry(
+			blogsEntry.getExternalReferenceCode(), blogsEntry.getUserId(),
+			blogsEntry.getTitle(), blogsEntry.getSubtitle(),
+			blogsEntry.getUrlTitle(), blogsEntry.getDescription(),
+			blogsEntry.getContent(), blogsEntry.getDisplayDate(),
+			blogsEntry.isAllowPingbacks(), blogsEntry.isAllowTrackbacks(),
+			new String[] {blogsEntry.getTrackbacks()},
+			blogsEntry.getCoverImageCaption(), null, null,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	@Test
+	public void testAddBlogsEntryWithExternalReferenceCode() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		BlogsEntry blogsEntry = BlogsEntryLocalServiceUtil.addEntry(
+			externalReferenceCode, TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.nextDate(), false,
+			false, new String[0], RandomTestUtil.randomString(), null, null,
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			externalReferenceCode, blogsEntry.getExternalReferenceCode());
+	}
+
+	@Test
+	public void testAddBlogsEntryWithoutExternalReferenceCode()
+		throws Exception {
+
+		BlogsEntry blogsEntry = BlogsEntryLocalServiceUtil.addEntry(
+			null, TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.nextDate(), false, false, new String[0],
+			RandomTestUtil.randomString(), null, null,
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			blogsEntry.getExternalReferenceCode(),
+			String.valueOf(blogsEntry.getEntryId()));
+	}
 
 	@Test
 	public void testAddDiscussion() throws Exception {

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
@@ -128,6 +128,8 @@ public class BlogsEntryPersistenceTest {
 
 		newBlogsEntry.setUuid(RandomTestUtil.randomString());
 
+		newBlogsEntry.setExternalReferenceCode(RandomTestUtil.randomString());
+
 		newBlogsEntry.setGroupId(RandomTestUtil.nextLong());
 
 		newBlogsEntry.setCompanyId(RandomTestUtil.nextLong());
@@ -192,6 +194,9 @@ public class BlogsEntryPersistenceTest {
 			newBlogsEntry.getMvccVersion());
 		Assert.assertEquals(
 			existingBlogsEntry.getUuid(), newBlogsEntry.getUuid());
+		Assert.assertEquals(
+			existingBlogsEntry.getExternalReferenceCode(),
+			newBlogsEntry.getExternalReferenceCode());
 		Assert.assertEquals(
 			existingBlogsEntry.getEntryId(), newBlogsEntry.getEntryId());
 		Assert.assertEquals(
@@ -505,6 +510,15 @@ public class BlogsEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_ERC() throws Exception {
+		_persistence.countByG_ERC(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByG_ERC(0L, "null");
+
+		_persistence.countByG_ERC(0L, (String)null);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		BlogsEntry newBlogsEntry = addBlogsEntry();
 
@@ -535,12 +549,13 @@ public class BlogsEntryPersistenceTest {
 
 	protected OrderByComparator<BlogsEntry> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
-			"BlogsEntry", "mvccVersion", true, "uuid", true, "entryId", true,
-			"groupId", true, "companyId", true, "userId", true, "userName",
-			true, "createDate", true, "modifiedDate", true, "title", true,
-			"subtitle", true, "urlTitle", true, "description", true,
-			"displayDate", true, "allowPingbacks", true, "allowTrackbacks",
-			true, "coverImageCaption", true, "coverImageFileEntryId", true,
+			"BlogsEntry", "mvccVersion", true, "uuid", true,
+			"externalReferenceCode", true, "entryId", true, "groupId", true,
+			"companyId", true, "userId", true, "userName", true, "createDate",
+			true, "modifiedDate", true, "title", true, "subtitle", true,
+			"urlTitle", true, "description", true, "displayDate", true,
+			"allowPingbacks", true, "allowTrackbacks", true,
+			"coverImageCaption", true, "coverImageFileEntryId", true,
 			"coverImageURL", true, "smallImage", true, "smallImageFileEntryId",
 			true, "smallImageId", true, "smallImageURL", true,
 			"lastPublishDate", true, "status", true, "statusByUserId", true,
@@ -822,6 +837,17 @@ public class BlogsEntryPersistenceTest {
 			ReflectionTestUtil.invoke(
 				blogsEntry, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "urlTitle"));
+
+		Assert.assertEquals(
+			Long.valueOf(blogsEntry.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				blogsEntry, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
+		Assert.assertEquals(
+			blogsEntry.getExternalReferenceCode(),
+			ReflectionTestUtil.invoke(
+				blogsEntry, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "externalReferenceCode"));
 	}
 
 	protected BlogsEntry addBlogsEntry() throws Exception {
@@ -832,6 +858,8 @@ public class BlogsEntryPersistenceTest {
 		blogsEntry.setMvccVersion(RandomTestUtil.nextLong());
 
 		blogsEntry.setUuid(RandomTestUtil.randomString());
+
+		blogsEntry.setExternalReferenceCode(RandomTestUtil.randomString());
 
 		blogsEntry.setGroupId(RandomTestUtil.nextLong());
 

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -222,18 +222,20 @@ public class BlogsEntryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext(_group, _user.getUserId());
 
 		BlogsEntryLocalServiceUtil.addEntry(
-			_user.getUserId(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), urlTitle,
+			RandomTestUtil.randomString(), _user.getUserId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new Date(), false, false, null, null, null, null, serviceContext);
+			urlTitle, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new Date(), false, false, null, null,
+			null, null, serviceContext);
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
 		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
-			_user.getUserId(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), urlTitle,
+			RandomTestUtil.randomString(), _user.getUserId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new Date(), false, false, null, null, null, null, serviceContext);
+			urlTitle, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new Date(), false, false, null, null,
+			null, null, serviceContext);
 
 		Assert.assertNotEquals(urlTitle, entry.getUrlTitle());
 	}
@@ -364,20 +366,22 @@ public class BlogsEntryLocalServiceTest {
 	@Test(expected = EntryUrlTitleException.class)
 	public void testAddEntryWithInvalidURLTitle() throws Exception {
 		BlogsEntryLocalServiceUtil.addEntry(
-			TestPropsValues.getUserId(), StringUtil.randomString(),
-			StringUtil.randomString(), StringUtil.randomString(256),
-			StringUtil.randomString(), StringUtil.randomString(), new Date(),
-			true, true, new String[0], null, null, null, new ServiceContext());
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(256), StringUtil.randomString(),
+			StringUtil.randomString(), new Date(), true, true, new String[0],
+			null, null, null, new ServiceContext());
 	}
 
 	@Test
 	public void testAddEntryWithNoImages() throws Exception {
 		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
-			TestPropsValues.getUserId(), StringUtil.randomString(),
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 			StringUtil.randomString(), StringUtil.randomString(),
-			StringUtil.randomString(), StringUtil.randomString(), new Date(),
-			true, true, new String[0], null, new ImageSelector(),
-			new ImageSelector(), ServiceContextTestUtil.getServiceContext());
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), new Date(), true, true, new String[0],
+			null, new ImageSelector(), new ImageSelector(),
+			ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(0, entry.getCoverImageFileEntryId());
 		Assert.assertEquals(StringPool.BLANK, entry.getCoverImageURL());
@@ -391,10 +395,11 @@ public class BlogsEntryLocalServiceTest {
 		String urlTitle = StringUtil.toLowerCase(StringUtil.randomString());
 
 		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
-			TestPropsValues.getUserId(), StringUtil.randomString(),
-			StringUtil.randomString(), urlTitle, StringUtil.randomString(),
-			StringUtil.randomString(), new Date(), true, true, new String[0],
-			null, null, null, ServiceContextTestUtil.getServiceContext());
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			StringUtil.randomString(), StringUtil.randomString(), urlTitle,
+			StringUtil.randomString(), StringUtil.randomString(), new Date(),
+			true, true, new String[0], null, null, null,
+			ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(urlTitle, entry.getUrlTitle());
 	}
@@ -999,18 +1004,20 @@ public class BlogsEntryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext(_group, _user.getUserId());
 
 		BlogsEntryLocalServiceUtil.addEntry(
-			_user.getUserId(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), urlTitle,
+			RandomTestUtil.randomString(), _user.getUserId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new Date(), false, false, null, null, null, null, serviceContext);
+			urlTitle, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new Date(), false, false, null, null,
+			null, null, serviceContext);
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
 		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
-			_user.getUserId(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), urlTitle,
+			RandomTestUtil.randomString(), _user.getUserId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new Date(), false, false, null, null, null, null, serviceContext);
+			urlTitle, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new Date(), false, false, null, null,
+			null, null, serviceContext);
 
 		entry = BlogsEntryLocalServiceUtil.updateEntry(
 			_user.getUserId(), entry.getEntryId(), entry.getTitle(),

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryServiceTest.java
@@ -140,9 +140,9 @@ public class BlogsEntryServiceTest {
 			BlogsEntryServiceUtil.addEntry(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), 1, 1, 1990, 1, 1, true, false,
-				new String[0], RandomTestUtil.randomString(), null, null,
-				serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
+				1, 1990, 1, 1, true, false, new String[0],
+				RandomTestUtil.randomString(), null, null, serviceContext);
 		}
 	}
 
@@ -181,9 +181,9 @@ public class BlogsEntryServiceTest {
 			BlogsEntryServiceUtil.addEntry(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), 1, 1, 1990, 1, 1, true, false,
-				new String[0], RandomTestUtil.randomString(), null, null,
-				serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
+				1, 1990, 1, 1, true, false, new String[0],
+				RandomTestUtil.randomString(), null, null, serviceContext);
 		}
 	}
 

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/EditEntryMVCActionCommand.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/EditEntryMVCActionCommand.java
@@ -539,7 +539,7 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 			// Add entry
 
 			entry = _blogsEntryService.addEntry(
-				title, subtitle, urlTitle, description, content,
+				null, title, subtitle, urlTitle, description, content,
 				displayDateMonth, displayDateDay, displayDateYear,
 				displayDateHour, displayDateMinute, allowPingbacks,
 				allowTrackbacks, trackbacks, coverImageCaption,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
@@ -193,7 +193,8 @@ public class BlogPostingResourceImpl
 
 		return _toBlogPosting(
 			_blogsEntryService.addEntry(
-				blogPosting.getHeadline(), blogPosting.getAlternativeHeadline(),
+				null, blogPosting.getHeadline(),
+				blogPosting.getAlternativeHeadline(),
 				blogPosting.getFriendlyUrlPath(), blogPosting.getDescription(),
 				blogPosting.getArticleBody(), localDateTime.getMonthValue() - 1,
 				localDateTime.getDayOfMonth(), localDateTime.getYear(),


### PR DESCRIPTION
This pull is the first part of the feature described in [this ticket](https://issues.liferay.com/browse/LPS-124110)
The external reference code (also called ERC) is a unique id to identify a specific resource. It could be scoped by group or by company.

In the PR, it added support for external reference code in BlogsEntry services to be able to add BlogsEntries with a specific external reference code. In case that the user does not provide the ERC, it will be assigned by default the id of the resource.

