### PR TITLE
LPS-132761 Active View API: change to path parameters and add java client & test modules

### DIFF
--- a/modules/apps/frontend-view-state/frontend-view-state-rest-api/src/main/java/com/liferay/frontend/view/state/rest/resource/v1_0/ActiveViewResource.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-api/src/main/java/com/liferay/frontend/view/state/rest/resource/v1_0/ActiveViewResource.java
@@ -46,12 +46,13 @@ public interface ActiveViewResource {
 		return FactoryHolder.factory.create();
 	}
 
-	public Object getActiveView(
-			String activeViewId, Long plid, String portletId)
+	public Object getActiveViewPageLayoutPortlet(
+			String activeViewId, Long pageLayoutId, String portletId)
 		throws Exception;
 
-	public Response putActiveView(
-			String activeViewId, Long plid, String portletId, String string)
+	public Response putActiveViewPageLayoutPortlet(
+			String activeViewId, Long pageLayoutId, String portletId,
+			String string)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/bnd.bnd
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Frontend View State REST Client
+Bundle-SymbolicName: com.liferay.frontend.view.state.rest.client
+Bundle-Version: 1.0.0

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/build.gradle
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/build.gradle
@@ -1,0 +1,2 @@
+dependencies {
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/aggregation/Aggregation.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/aggregation/Aggregation.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.client.aggregation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Aggregation {
+
+	public Map<String, String> getAggregationTerms() {
+		return _aggregationTerms;
+	}
+
+	public void setAggregationTerms(Map<String, String> aggregationTerms) {
+		_aggregationTerms = aggregationTerms;
+	}
+
+	private Map<String, String> _aggregationTerms = new HashMap<>();
+
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/aggregation/Facet.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/aggregation/Facet.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.client.aggregation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Facet {
+
+	public Facet() {
+	}
+
+	public Facet(String facetCriteria, List<FacetValue> facetValues) {
+		_facetCriteria = facetCriteria;
+		_facetValues = facetValues;
+	}
+
+	public String getFacetCriteria() {
+		return _facetCriteria;
+	}
+
+	public List<FacetValue> getFacetValues() {
+		return _facetValues;
+	}
+
+	public void setFacetCriteria(String facetCriteria) {
+		_facetCriteria = facetCriteria;
+	}
+
+	public void setFacetValues(List<FacetValue> facetValues) {
+		_facetValues = facetValues;
+	}
+
+	public static class FacetValue {
+
+		public FacetValue() {
+		}
+
+		public FacetValue(Integer numberOfOccurrences, String term) {
+			_numberOfOccurrences = numberOfOccurrences;
+			_term = term;
+		}
+
+		public Integer getNumberOfOccurrences() {
+			return _numberOfOccurrences;
+		}
+
+		public String getTerm() {
+			return _term;
+		}
+
+		private Integer _numberOfOccurrences;
+		private String _term;
+
+	}
+
+	private String _facetCriteria;
+	private List<FacetValue> _facetValues = new ArrayList<>();
+
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/function/UnsafeSupplier.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/function/UnsafeSupplier.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.client.function;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@FunctionalInterface
+@Generated("")
+public interface UnsafeSupplier<T, E extends Throwable> {
+
+	public T get() throws E;
+
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/http/HttpInvoker.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/http/HttpInvoker.java
@@ -1,0 +1,435 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.client.http;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class HttpInvoker {
+
+	public static HttpInvoker newHttpInvoker() {
+		_updateHttpURLConnectionClass();
+
+		return new HttpInvoker();
+	}
+
+	public HttpInvoker body(String body, String contentType) {
+		_body = body;
+		_contentType = contentType;
+
+		return this;
+	}
+
+	public HttpInvoker header(String name, String value) {
+		_headers.put(name, value);
+
+		return this;
+	}
+
+	public HttpInvoker httpMethod(HttpMethod httpMethod) {
+		_httpMethod = httpMethod;
+
+		return this;
+	}
+
+	public HttpResponse invoke() throws IOException {
+		HttpResponse httpResponse = new HttpResponse();
+
+		HttpURLConnection httpURLConnection = _openHttpURLConnection();
+
+		httpResponse.setContent(_readResponse(httpURLConnection));
+		httpResponse.setMessage(httpURLConnection.getResponseMessage());
+		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
+
+		httpURLConnection.disconnect();
+
+		return httpResponse;
+	}
+
+	public HttpInvoker multipart() {
+		_contentType =
+			"multipart/form-data; charset=utf-8; boundary=__MULTIPART_BOUNDARY__";
+		_multipartBoundary = "__MULTIPART_BOUNDARY__";
+
+		return this;
+	}
+
+	public HttpInvoker parameter(String name, String value) {
+		return parameter(name, new String[] {value});
+	}
+
+	public HttpInvoker parameter(String name, String[] values) {
+		String[] oldValues = _parameters.get(name);
+
+		if (oldValues != null) {
+			String[] newValues = new String[oldValues.length + values.length];
+
+			System.arraycopy(oldValues, 0, newValues, 0, oldValues.length);
+			System.arraycopy(
+				values, 0, newValues, oldValues.length, values.length);
+
+			_parameters.put(name, newValues);
+		}
+		else {
+			_parameters.put(name, values);
+		}
+
+		return this;
+	}
+
+	public HttpInvoker part(String name, File file) {
+		_files.put(name, file);
+
+		return this;
+	}
+
+	public HttpInvoker part(String name, String value) {
+		_parts.put(name, value);
+
+		return this;
+	}
+
+	public HttpInvoker path(String path) {
+		_path = path;
+
+		return this;
+	}
+
+	public HttpInvoker path(String name, Object value) {
+		_path = _path.replaceFirst("\\{" + name + "\\}", String.valueOf(value));
+
+		return this;
+	}
+
+	public HttpInvoker userNameAndPassword(String userNameAndPassword)
+		throws IOException {
+
+		Base64.Encoder encoder = Base64.getEncoder();
+
+		_encodedUserNameAndPassword = new String(
+			encoder.encode(userNameAndPassword.getBytes("UTF-8")), "UTF-8");
+
+		return this;
+	}
+
+	public enum HttpMethod {
+
+		DELETE, GET, PATCH, POST, PUT
+
+	}
+
+	public class HttpResponse {
+
+		public String getContent() {
+			return _content;
+		}
+
+		public String getMessage() {
+			return _message;
+		}
+
+		public int getStatusCode() {
+			return _statusCode;
+		}
+
+		public void setContent(String content) {
+			_content = content;
+		}
+
+		public void setMessage(String message) {
+			_message = message;
+		}
+
+		public void setStatusCode(int statusCode) {
+			_statusCode = statusCode;
+		}
+
+		private String _content;
+		private String _message;
+		private int _statusCode;
+
+	}
+
+	private static void _updateHttpURLConnectionClass() {
+		try {
+			Field methodsField = HttpURLConnection.class.getDeclaredField(
+				"methods");
+
+			methodsField.setAccessible(true);
+
+			Field modifiersField = Field.class.getDeclaredField("modifiers");
+
+			modifiersField.setAccessible(true);
+			modifiersField.setInt(
+				methodsField, methodsField.getModifiers() & ~Modifier.FINAL);
+
+			Set<String> methodsFieldValue = new LinkedHashSet<>(
+				Arrays.asList((String[])methodsField.get(null)));
+
+			if (methodsFieldValue.contains("PATCH")) {
+				return;
+			}
+
+			methodsFieldValue.add("PATCH");
+
+			methodsField.set(null, methodsFieldValue.toArray(new String[0]));
+		}
+		catch (IllegalAccessException | NoSuchFieldException e) {
+			_logger.warning("Unable to update HttpURLConnection class");
+		}
+	}
+
+	private HttpInvoker() {
+	}
+
+	private void _appendPart(
+			OutputStream outputStream, PrintWriter printWriter, String key,
+			Object value)
+		throws IOException {
+
+		printWriter.append("\r\n--");
+		printWriter.append(_multipartBoundary);
+		printWriter.append("\r\nContent-Disposition: form-data; name=\"");
+		printWriter.append(key);
+		printWriter.append("\";");
+
+		if (value instanceof File) {
+			File file = (File)value;
+
+			printWriter.append(" filename=\"");
+			printWriter.append(file.getName());
+			printWriter.append("\"\r\nContent-Type: ");
+			printWriter.append(
+				URLConnection.guessContentTypeFromName(file.getName()));
+			printWriter.append("\r\n\r\n");
+
+			printWriter.flush();
+
+			byte[] buffer = new byte[4096];
+			FileInputStream fileInputStream = new FileInputStream(file);
+			int read = -1;
+
+			while ((read = fileInputStream.read(buffer)) != -1) {
+				outputStream.write(buffer, 0, read);
+			}
+
+			outputStream.flush();
+
+			fileInputStream.close();
+		}
+		else {
+			printWriter.append("\r\n\r\n");
+			printWriter.append(value.toString());
+		}
+
+		printWriter.append("\r\n");
+	}
+
+	private String _getQueryString() throws IOException {
+		StringBuilder sb = new StringBuilder();
+
+		Set<Map.Entry<String, String[]>> set = _parameters.entrySet();
+
+		Iterator<Map.Entry<String, String[]>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, String[]> entry = iterator.next();
+
+			String[] values = entry.getValue();
+
+			for (int i = 0; i < values.length; i++) {
+				String name = URLEncoder.encode(entry.getKey(), "UTF-8");
+
+				sb.append(name);
+
+				sb.append("=");
+
+				String value = URLEncoder.encode(values[i], "UTF-8");
+
+				sb.append(value);
+
+				if ((i + 1) < values.length) {
+					sb.append("&");
+				}
+			}
+
+			if (iterator.hasNext()) {
+				sb.append("&");
+			}
+		}
+
+		return sb.toString();
+	}
+
+	private HttpURLConnection _openHttpURLConnection() throws IOException {
+		String urlString = _path;
+
+		String queryString = _getQueryString();
+
+		if (queryString.length() > 0) {
+			if (!urlString.contains("?")) {
+				urlString += "?";
+			}
+
+			urlString += queryString;
+		}
+
+		URL url = new URL(urlString);
+
+		HttpURLConnection httpURLConnection =
+			(HttpURLConnection)url.openConnection();
+
+		httpURLConnection.setRequestMethod(_httpMethod.name());
+
+		if (_encodedUserNameAndPassword != null) {
+			httpURLConnection.setRequestProperty(
+				"Authorization", "Basic " + _encodedUserNameAndPassword);
+		}
+
+		if (_contentType != null) {
+			httpURLConnection.setRequestProperty("Content-Type", _contentType);
+		}
+
+		for (Map.Entry<String, String> header : _headers.entrySet()) {
+			httpURLConnection.setRequestProperty(
+				header.getKey(), header.getValue());
+		}
+
+		_writeBody(httpURLConnection);
+
+		return httpURLConnection;
+	}
+
+	private String _readResponse(HttpURLConnection httpURLConnection)
+		throws IOException {
+
+		StringBuilder sb = new StringBuilder();
+
+		int responseCode = httpURLConnection.getResponseCode();
+
+		InputStream inputStream = null;
+
+		if (responseCode > 299) {
+			inputStream = httpURLConnection.getErrorStream();
+		}
+		else {
+			inputStream = httpURLConnection.getInputStream();
+		}
+
+		BufferedReader bufferedReader = new BufferedReader(
+			new InputStreamReader(inputStream));
+
+		while (true) {
+			String line = bufferedReader.readLine();
+
+			if (line == null) {
+				break;
+			}
+
+			sb.append(line);
+		}
+
+		bufferedReader.close();
+
+		return sb.toString();
+	}
+
+	private void _writeBody(HttpURLConnection httpURLConnection)
+		throws IOException {
+
+		if ((_body == null) && _files.isEmpty() && _parts.isEmpty()) {
+			return;
+		}
+
+		httpURLConnection.setDoOutput(true);
+
+		OutputStream outputStream = httpURLConnection.getOutputStream();
+
+		try (PrintWriter printWriter = new PrintWriter(
+				new OutputStreamWriter(outputStream, "UTF-8"), true)) {
+
+			if (_contentType.startsWith("multipart/form-data")) {
+				for (Map.Entry<String, String> entry : _parts.entrySet()) {
+					_appendPart(
+						outputStream, printWriter, entry.getKey(),
+						entry.getValue());
+				}
+
+				for (Map.Entry<String, File> entry : _files.entrySet()) {
+					_appendPart(
+						outputStream, printWriter, entry.getKey(),
+						entry.getValue());
+				}
+
+				printWriter.append("--" + _multipartBoundary + "--");
+
+				printWriter.flush();
+
+				outputStream.flush();
+			}
+			else {
+				printWriter.append(_body);
+
+				printWriter.flush();
+			}
+		}
+	}
+
+	private static final Logger _logger = Logger.getLogger(
+		HttpInvoker.class.getName());
+
+	private String _body;
+	private String _contentType;
+	private String _encodedUserNameAndPassword;
+	private Map<String, File> _files = new LinkedHashMap<>();
+	private Map<String, String> _headers = new LinkedHashMap<>();
+	private HttpMethod _httpMethod = HttpMethod.GET;
+	private String _multipartBoundary;
+	private Map<String, String[]> _parameters = new LinkedHashMap<>();
+	private Map<String, String> _parts = new LinkedHashMap<>();
+	private String _path;
+
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/json/BaseJSONParser.java
@@ -1,0 +1,635 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.client.json;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public abstract class BaseJSONParser<T> {
+
+	public static final String[][] JSON_ESCAPE_STRINGS = new String[][] {
+		{"\\", "\\\\"}, {"\"", "\\\""}, {"\b", "\\b"}, {"\f", "\\f"},
+		{"\n", "\\n"}, {"\r", "\\r"}, {"\t", "\\t"}
+	};
+
+	public T parseToDTO(String json) {
+		if (json == null) {
+			throw new IllegalArgumentException("JSON is null");
+		}
+
+		_init(json);
+
+		_assertStartsWithAndEndsWith("{", "}");
+
+		T dto = createDTO();
+
+		if (_isEmpty()) {
+			return dto;
+		}
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		_readNextChar();
+
+		if (_isLastChar('}')) {
+			_readWhileLastCharIsWhiteSpace();
+
+			if (!_isEndOfJSON()) {
+				_readNextChar();
+
+				throw new IllegalArgumentException(
+					"Expected end of JSON, but found '" + _lastChar + "'");
+			}
+
+			return dto;
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			String fieldName = _readValueAsString();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			_assertLastChar(':');
+
+			_readNextChar();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			setField(dto, fieldName, _readValue());
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		return dto;
+	}
+
+	public T[] parseToDTOs(String json) {
+		if (json == null) {
+			throw new IllegalArgumentException("JSON is null");
+		}
+
+		_init(json);
+
+		_assertStartsWithAndEndsWith("[", "]");
+
+		if (_isEmpty()) {
+			return createDTOArray(0);
+		}
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar(']')) {
+			_readNextChar();
+
+			return createDTOArray(0);
+		}
+
+		_readWhileLastCharIsWhiteSpace();
+
+		Object[] objects = (Object[])_readValue();
+
+		return Stream.of(
+			objects
+		).map(
+			object -> parseToDTO((String)object)
+		).toArray(
+			size -> createDTOArray(size)
+		);
+	}
+
+	public Map<String, Object> parseToMap(String json) {
+		if (json == null) {
+			throw new IllegalArgumentException("JSON is null");
+		}
+
+		_init(json);
+
+		_assertStartsWithAndEndsWith("{", "}");
+
+		Map<String, Object> map = new TreeMap<>();
+
+		_setCaptureStart();
+
+		_readNextChar();
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar('}')) {
+			return map;
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			String key = _readValueAsString();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			if (!_ifLastCharMatchesThenRead(':')) {
+				throw new IllegalArgumentException("Expected ':'");
+			}
+
+			_readWhileLastCharIsWhiteSpace();
+
+			map.put(key, _readValue(true));
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (!_ifLastCharMatchesThenRead('}')) {
+			throw new IllegalArgumentException(
+				"Expected either ',' or '}', but found '" + _lastChar + "'");
+		}
+
+		return map;
+	}
+
+	protected abstract T createDTO();
+
+	protected abstract T[] createDTOArray(int size);
+
+	protected abstract void setField(
+		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected Date toDate(String string) {
+		try {
+			return _dateFormat.parse(string);
+		}
+		catch (ParseException pe) {
+			throw new IllegalArgumentException(
+				"Unable to parse date from " + string, pe);
+		}
+	}
+
+	protected Date[] toDates(Object[] objects) {
+		return Stream.of(
+			objects
+		).map(
+			object -> toDate((String)object)
+		).toArray(
+			size -> new Date[size]
+		);
+	}
+
+	protected Integer[] toIntegers(Object[] objects) {
+		return Stream.of(
+			objects
+		).map(
+			object -> Integer.valueOf(object.toString())
+		).toArray(
+			size -> new Integer[size]
+		);
+	}
+
+	protected Long[] toLongs(Object[] objects) {
+		return Stream.of(
+			objects
+		).map(
+			object -> Long.valueOf(object.toString())
+		).toArray(
+			size -> new Long[size]
+		);
+	}
+
+	protected String toString(Date date) {
+		return _dateFormat.format(date);
+	}
+
+	protected String[] toStrings(Object[] objects) {
+		return Stream.of(
+			objects
+		).map(
+			String.class::cast
+		).toArray(
+			size -> new String[size]
+		);
+	}
+
+	private void _assertLastChar(char c) {
+		if (_lastChar != c) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Expected last char '%s', but found '%s'", c, _lastChar));
+		}
+	}
+
+	private void _assertStartsWithAndEndsWith(String prefix, String sufix) {
+		if (!_json.startsWith(prefix)) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Expected starts with '%s', but found '%s' in '%s'", prefix,
+					_json.charAt(0), _json));
+		}
+
+		if (!_json.endsWith(sufix)) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Expected ends with '%s', but found '%s' in '%s'", sufix,
+					_json.charAt(_json.length() - 1), _json));
+		}
+	}
+
+	private String _getCapturedJSONSubstring() {
+		return _json.substring(_captureStartStack.pop(), _index - 1);
+	}
+
+	private String _getCapturedSubstring() {
+		return _unescape(_getCapturedJSONSubstring());
+	}
+
+	private boolean _ifLastCharMatchesThenRead(char ch) {
+		if (_lastChar != ch) {
+			return false;
+		}
+
+		_readNextChar();
+
+		return true;
+	}
+
+	private void _init(String json) {
+		_captureStartStack = new Stack<>();
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_index = 0;
+		_json = json.trim();
+		_lastChar = 0;
+	}
+
+	private boolean _isCharEscaped(String string, int index) {
+		int backslashCount = 0;
+
+		while (((index - 1 - backslashCount) >= 0) &&
+			   (string.charAt(index - 1 - backslashCount) == '\\')) {
+
+			backslashCount++;
+		}
+
+		if ((backslashCount % 2) == 0) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private boolean _isEmpty() {
+		String substring = _json.substring(1, _json.length() - 1);
+
+		substring = substring.trim();
+
+		return substring.isEmpty();
+	}
+
+	private boolean _isEndOfJSON() {
+		if (_index == _json.length()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastChar(char c) {
+		if (_lastChar == c) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharDecimalSeparator() {
+		if (_lastChar == '.') {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharDigit() {
+		if ((_lastChar >= '0') && (_lastChar <= '9')) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharNegative() {
+		if (_lastChar == '-') {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharScientificNotation() {
+		if (_lastChar == 'E') {
+			return true;
+		}
+
+		return false;
+	}
+
+	private void _readNextChar() {
+		if (!_isEndOfJSON()) {
+			_lastChar = _json.charAt(_index++);
+		}
+	}
+
+	private Object _readValue() {
+		return _readValue(false);
+	}
+
+	private Object _readValue(boolean parseMaps) {
+		if (_lastChar == '[') {
+			return _readValueAsArray();
+		}
+		else if (_lastChar == 'f') {
+			return _readValueAsBooleanFalse();
+		}
+		else if (_lastChar == 't') {
+			return _readValueAsBooleanTrue();
+		}
+		else if (_lastChar == 'n') {
+			return _readValueAsObjectNull();
+		}
+		else if (_lastChar == '"') {
+			return _readValueAsString();
+		}
+		else if (parseMaps && (_lastChar == '{')) {
+			try {
+				Class<? extends BaseJSONParser> clazz = getClass();
+
+				BaseJSONParser baseJSONParser = clazz.newInstance();
+
+				return baseJSONParser.parseToMap(_readValueAsStringJSON());
+			}
+			catch (Exception e) {
+				throw new IllegalArgumentException(
+					"Expected JSON object or map");
+			}
+		}
+		else if (_lastChar == '{') {
+			return _readValueAsStringJSON();
+		}
+		else if ((_lastChar == '-') || (_lastChar == '0') ||
+				 (_lastChar == '1') || (_lastChar == '2') ||
+				 (_lastChar == '3') || (_lastChar == '4') ||
+				 (_lastChar == '5') || (_lastChar == '6') ||
+				 (_lastChar == '7') || (_lastChar == '8') ||
+				 (_lastChar == '9')) {
+
+			return _readValueAsStringNumber();
+		}
+		else {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	private Object[] _readValueAsArray() {
+		List<Object> objects = new ArrayList<>();
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar(']')) {
+			_readNextChar();
+
+			return objects.toArray();
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			objects.add(_readValue());
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		if (!_isLastChar(']')) {
+			throw new IllegalArgumentException(
+				"Expected ']', but found '" + _lastChar + "'");
+		}
+
+		_readNextChar();
+
+		return objects.toArray();
+	}
+
+	private boolean _readValueAsBooleanFalse() {
+		_readNextChar();
+
+		_assertLastChar('a');
+
+		_readNextChar();
+
+		_assertLastChar('l');
+
+		_readNextChar();
+
+		_assertLastChar('s');
+
+		_readNextChar();
+
+		_assertLastChar('e');
+
+		_readNextChar();
+
+		return false;
+	}
+
+	private boolean _readValueAsBooleanTrue() {
+		_readNextChar();
+
+		_assertLastChar('r');
+
+		_readNextChar();
+
+		_assertLastChar('u');
+
+		_readNextChar();
+
+		_assertLastChar('e');
+
+		_readNextChar();
+
+		return true;
+	}
+
+	private Object _readValueAsObjectNull() {
+		_readNextChar();
+
+		_assertLastChar('u');
+
+		_readNextChar();
+
+		_assertLastChar('l');
+
+		_readNextChar();
+
+		_assertLastChar('l');
+
+		_readNextChar();
+
+		return null;
+	}
+
+	private String _readValueAsString() {
+		_readNextChar();
+
+		_setCaptureStart();
+
+		while ((_lastChar != '"') || _isCharEscaped(_json, _index - 1)) {
+			_readNextChar();
+		}
+
+		String string = _getCapturedSubstring();
+
+		_readNextChar();
+
+		return string;
+	}
+
+	private String _readValueAsStringJSON() {
+		_setCaptureStart();
+
+		_readNextChar();
+
+		if (_isLastChar('}')) {
+			_readNextChar();
+
+			return _getCapturedJSONSubstring();
+		}
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar('}')) {
+			_readNextChar();
+
+			return _getCapturedJSONSubstring();
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			_readValueAsString();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			if (!_ifLastCharMatchesThenRead(':')) {
+				throw new IllegalArgumentException("Expected ':'");
+			}
+
+			_readWhileLastCharIsWhiteSpace();
+
+			_readValue();
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (!_ifLastCharMatchesThenRead('}')) {
+			throw new IllegalArgumentException(
+				"Expected either ',' or '}', but found '" + _lastChar + "'");
+		}
+
+		return _getCapturedJSONSubstring();
+	}
+
+	private String _readValueAsStringNumber() {
+		_setCaptureStart();
+
+		do {
+			_readNextChar();
+		}
+		while (_isLastCharDigit() || _isLastCharDecimalSeparator() ||
+			   _isLastCharNegative() || _isLastCharScientificNotation());
+
+		return _getCapturedSubstring();
+	}
+
+	private void _readWhileLastCharIsWhiteSpace() {
+		while ((_lastChar == ' ') || (_lastChar == '\n') ||
+			   (_lastChar == '\r') || (_lastChar == '\t')) {
+
+			_readNextChar();
+		}
+	}
+
+	private void _setCaptureStart() {
+		_captureStartStack.push(_index - 1);
+	}
+
+	private String _unescape(String string) {
+		for (int i = JSON_ESCAPE_STRINGS.length - 1; i >= 0; i--) {
+			String[] escapeStrings = JSON_ESCAPE_STRINGS[i];
+
+			int index = string.indexOf(escapeStrings[1]);
+
+			while (index != -1) {
+				if (!_isCharEscaped(string, index)) {
+					string =
+						string.substring(0, index) + escapeStrings[0] +
+							string.substring(index + escapeStrings[1].length());
+
+					index = string.indexOf(
+						escapeStrings[1], index + escapeStrings[0].length());
+				}
+				else {
+					index = string.indexOf(
+						escapeStrings[1], index + escapeStrings[1].length());
+				}
+			}
+		}
+
+		return string;
+	}
+
+	private Stack<Integer> _captureStartStack;
+	private DateFormat _dateFormat;
+	private int _index;
+	private String _json;
+	private char _lastChar;
+
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/pagination/Page.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/pagination/Page.java
@@ -1,0 +1,296 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.client.pagination;
+
+import com.liferay.frontend.view.state.rest.client.aggregation.Facet;
+import com.liferay.frontend.view.state.rest.client.json.BaseJSONParser;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Page<T> {
+
+	public static <T> Page<T> of(
+		String json, Function<String, T> toDTOFunction) {
+
+		PageJSONParser pageJSONParser = new PageJSONParser(toDTOFunction);
+
+		return (Page<T>)pageJSONParser.parseToDTO(json);
+	}
+
+	public Map<String, Map> getActions() {
+		return _actions;
+	}
+
+	public List<Facet> getFacets() {
+		return _facets;
+	}
+
+	public Collection<T> getItems() {
+		return _items;
+	}
+
+	public long getLastPage() {
+		if (_totalCount == 0) {
+			return 1;
+		}
+
+		return -Math.floorDiv(-_totalCount, _pageSize);
+	}
+
+	public long getPage() {
+		return _page;
+	}
+
+	public long getPageSize() {
+		return _pageSize;
+	}
+
+	public long getTotalCount() {
+		return _totalCount;
+	}
+
+	public boolean hasNext() {
+		if (getLastPage() > _page) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public boolean hasPrevious() {
+		if (_page > 1) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public void setActions(Map<String, Map> actions) {
+		_actions = actions;
+	}
+
+	public void setFacets(List<Facet> facets) {
+		_facets = facets;
+	}
+
+	public void setItems(Collection<T> items) {
+		_items = items;
+	}
+
+	public void setPage(long page) {
+		_page = page;
+	}
+
+	public void setPageSize(long pageSize) {
+		_pageSize = pageSize;
+	}
+
+	public void setTotalCount(long totalCount) {
+		_totalCount = totalCount;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder("{\"actions\": ");
+
+		sb.append(_toString((Map)_actions));
+		sb.append(", \"items\": [");
+
+		Iterator<T> iterator = _items.iterator();
+
+		while (iterator.hasNext()) {
+			sb.append(iterator.next());
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("], \"page\": ");
+		sb.append(_page);
+		sb.append(", \"pageSize\": ");
+		sb.append(_pageSize);
+		sb.append(", \"totalCount\": ");
+		sb.append(_totalCount);
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static class PageJSONParser<T> extends BaseJSONParser<Page> {
+
+		public PageJSONParser() {
+			_toDTOFunction = null;
+		}
+
+		public PageJSONParser(Function<String, T> toDTOFunction) {
+			_toDTOFunction = toDTOFunction;
+		}
+
+		@Override
+		protected Page createDTO() {
+			return new Page();
+		}
+
+		@Override
+		protected Page[] createDTOArray(int size) {
+			return new Page[size];
+		}
+
+		@Override
+		protected void setField(
+			Page page, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					PageJSONParser pageJSONParser = new PageJSONParser(
+						_toDTOFunction);
+
+					page.setActions(
+						pageJSONParser.parseToMap(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "facets")) {
+				if (jsonParserFieldValue != null) {
+					page.setFacets(
+						Stream.of(
+							toStrings((Object[])jsonParserFieldValue)
+						).map(
+							this::parseToMap
+						).map(
+							facets -> new Facet(
+								(String)facets.get("facetCriteria"),
+								Stream.of(
+									(Object[])facets.get("facetValues")
+								).map(
+									object -> (String)object
+								).map(
+									this::parseToMap
+								).map(
+									facetValues -> new Facet.FacetValue(
+										Integer.valueOf(
+											(String)facetValues.get(
+												"numberOfOccurrences")),
+										(String)facetValues.get("term"))
+								).collect(
+									Collectors.toList()
+								))
+						).collect(
+							Collectors.toList()
+						));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "items")) {
+				if (jsonParserFieldValue != null) {
+					page.setItems(
+						Stream.of(
+							toStrings((Object[])jsonParserFieldValue)
+						).map(
+							string -> _toDTOFunction.apply(string)
+						).collect(
+							Collectors.toList()
+						));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "lastPage")) {
+			}
+			else if (Objects.equals(jsonParserFieldName, "page")) {
+				if (jsonParserFieldValue != null) {
+					page.setPage(Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "pageSize")) {
+				if (jsonParserFieldValue != null) {
+					page.setPageSize(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				if (jsonParserFieldValue != null) {
+					page.setTotalCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+		private final Function<String, T> _toDTOFunction;
+
+	}
+
+	private String _toString(Map<String, Object> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		Set<Map.Entry<String, Object>> entries = map.entrySet();
+
+		Iterator<Map.Entry<String, Object>> iterator = entries.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, Object> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (value instanceof Map) {
+				sb.append(_toString((Map)value));
+			}
+			else {
+				sb.append("\"");
+				sb.append(value);
+				sb.append("\"");
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private Map<String, Map> _actions;
+	private List<Facet> _facets = new ArrayList<>();
+	private Collection<T> _items;
+	private long _page;
+	private long _pageSize;
+	private long _totalCount;
+
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/pagination/Pagination.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/pagination/Pagination.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.client.pagination;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Pagination {
+
+	public static Pagination of(int page, int pageSize) {
+		return new Pagination(page, pageSize);
+	}
+
+	public int getEndPosition() {
+		if ((_page < 0) || (_pageSize < 0)) {
+			return -1;
+		}
+
+		return _page * _pageSize;
+	}
+
+	public int getPage() {
+		return _page;
+	}
+
+	public int getPageSize() {
+		return _pageSize;
+	}
+
+	public int getStartPosition() {
+		if ((_page < 0) || (_pageSize < 0)) {
+			return -1;
+		}
+
+		return (_page - 1) * _pageSize;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder("{\"page\": ");
+
+		sb.append(_page);
+		sb.append(", \"pageSize\": ");
+		sb.append(_pageSize);
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private Pagination(int page, int pageSize) {
+		_page = page;
+		_pageSize = pageSize;
+	}
+
+	private final int _page;
+	private final int _pageSize;
+
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/permission/Permission.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/permission/Permission.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.client.permission;
+
+import com.liferay.frontend.view.state.rest.client.json.BaseJSONParser;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Permission {
+
+	public static Permission toDTO(String json) {
+		PermissionJSONParser<Permission> permissionJSONParser =
+			new PermissionJSONParser();
+
+		return permissionJSONParser.parseToDTO(json);
+	}
+
+	public Object[] getActionIds() {
+		return actionIds;
+	}
+
+	public String getRoleName() {
+		return roleName;
+	}
+
+	public void setActionIds(Object[] actionIds) {
+		this.actionIds = actionIds;
+	}
+
+	public void setRoleName(String roleName) {
+		this.roleName = roleName;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (actionIds != null) {
+			sb.append("\"actionIds\": [");
+
+			for (int i = 0; i < actionIds.length; i++) {
+				sb.append("\"");
+				sb.append(actionIds[i]);
+				sb.append("\"");
+
+				if ((i + 1) < actionIds.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (roleName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"roleName\": \"");
+			sb.append(roleName);
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	protected Object[] actionIds;
+	protected String roleName;
+
+	private static class PermissionJSONParser<T>
+		extends BaseJSONParser<Permission> {
+
+		@Override
+		protected Permission createDTO() {
+			return new Permission();
+		}
+
+		@Override
+		protected Permission[] createDTOArray(int size) {
+			return new Permission[size];
+		}
+
+		@Override
+		protected void setField(
+			Permission permission, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "actionIds")) {
+				if (jsonParserFieldValue != null) {
+					permission.setActionIds((Object[])jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "roleName")) {
+				if (jsonParserFieldValue != null) {
+					permission.setRoleName((String)jsonParserFieldValue);
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+	}
+
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/problem/Problem.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/problem/Problem.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.client.problem;
+
+import com.liferay.frontend.view.state.rest.client.json.BaseJSONParser;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Problem {
+
+	public static Problem toDTO(String json) {
+		ProblemJSONParser<Problem> problemJSONParser = new ProblemJSONParser();
+
+		return problemJSONParser.parseToDTO(json);
+	}
+
+	public static class ProblemException extends Exception {
+
+		private Problem _problem;
+
+		public Problem getProblem() {
+			return _problem;
+		}
+
+		public ProblemException(Problem problem) {
+			super(problem.getTitle());
+
+			_problem = problem;
+		}
+
+	}
+
+	public String getDetail() {
+		return detail;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setDetail(String detail) {
+		this.detail = detail;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (detail != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"detail\": \"");
+			sb.append(detail);
+			sb.append("\"");
+		}
+
+		if (status != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"status\": \"");
+			sb.append(status);
+			sb.append("\"");
+		}
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": \"");
+			sb.append(title);
+			sb.append("\"");
+		}
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": \"");
+			sb.append(type);
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	protected String detail;
+	protected String status;
+	protected String title;
+	protected String type;
+
+	private static class ProblemJSONParser<T> extends BaseJSONParser<Problem> {
+
+		@Override
+		protected Problem createDTO() {
+			return new Problem();
+		}
+
+		@Override
+		protected Problem[] createDTOArray(int size) {
+			return new Problem[size];
+		}
+
+		@Override
+		protected void setField(
+			Problem problem, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "detail")) {
+				if (jsonParserFieldValue != null) {
+					problem.setDetail((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "status")) {
+				if (jsonParserFieldValue != null) {
+					problem.setStatus((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					problem.setTitle((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					problem.setType((String)jsonParserFieldValue);
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+	}
+
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/resource/v1_0/ActiveViewResource.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/resource/v1_0/ActiveViewResource.java
@@ -1,0 +1,304 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.client.resource.v1_0;
+
+import com.liferay.frontend.view.state.rest.client.http.HttpInvoker;
+import com.liferay.frontend.view.state.rest.client.problem.Problem;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public interface ActiveViewResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Object getActiveViewPageLayoutPortlet(
+			String activeViewId, Long pageLayoutId, String portletId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getActiveViewPageLayoutPortletHttpResponse(
+			String activeViewId, Long pageLayoutId, String portletId)
+		throws Exception;
+
+	public void putActiveViewPageLayoutPortlet(
+			String activeViewId, Long pageLayoutId, String portletId,
+			String string)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse putActiveViewPageLayoutPortletHttpResponse(
+			String activeViewId, Long pageLayoutId, String portletId,
+			String string)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public ActiveViewResource build() {
+			return new ActiveViewResourceImpl(this);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login = "";
+		private String _password = "";
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class ActiveViewResourceImpl implements ActiveViewResource {
+
+		public Object getActiveViewPageLayoutPortlet(
+				String activeViewId, Long pageLayoutId, String portletId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getActiveViewPageLayoutPortletHttpResponse(
+					activeViewId, pageLayoutId, portletId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return (Object)content;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getActiveViewPageLayoutPortletHttpResponse(
+					String activeViewId, Long pageLayoutId, String portletId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port +
+						"/o/frontend-view-state/v1.0/active-view/{activeViewId}/page-layout/{pageLayoutId}/portlet/{portletId}");
+
+			httpInvoker.path("activeViewId", activeViewId);
+			httpInvoker.path("pageLayoutId", pageLayoutId);
+			httpInvoker.path("portletId", portletId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void putActiveViewPageLayoutPortlet(
+				String activeViewId, Long pageLayoutId, String portletId,
+				String string)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putActiveViewPageLayoutPortletHttpResponse(
+					activeViewId, pageLayoutId, portletId, string);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putActiveViewPageLayoutPortletHttpResponse(
+					String activeViewId, Long pageLayoutId, String portletId,
+					String string)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(string.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port +
+						"/o/frontend-view-state/v1.0/active-view/{activeViewId}/page-layout/{pageLayoutId}/portlet/{portletId}");
+
+			httpInvoker.path("activeViewId", activeViewId);
+			httpInvoker.path("pageLayoutId", pageLayoutId);
+			httpInvoker.path("portletId", portletId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		private ActiveViewResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			ActiveViewResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-impl/rest-config.yaml
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-impl/rest-config.yaml
@@ -5,5 +5,7 @@ application:
     className: "FrontendViewStateRESTApplication"
     name: "Liferay.Frontend.View.State.REST"
 author: "Javier Gamarra"
+clientDir: "../frontend-view-state-rest-client/src/main/java"
 generateBatch: false
 generateGraphQL: false
+testDir: "../frontend-view-state-rest-test/src/testIntegration/java"

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-impl/rest-openapi.yaml
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-impl/rest-openapi.yaml
@@ -6,7 +6,7 @@ info:
     version: v1.0
 openapi: 3.0.1
 paths:
-    "/active-view/{activeViewId}":
+    "/active-view/{activeViewId}/page-layout/{pageLayoutId}/portlet/{portletId}":
         get:
             parameters:
                 - in: path
@@ -14,12 +14,12 @@ paths:
                   required: true
                   schema:
                       type: string
-                - in: query
-                  name: plid
+                - in: path
+                  name: pageLayoutId
                   schema:
                       format: int64
                       type: integer
-                - in: query
+                - in: path
                   name: portletId
                   schema:
                       type: string
@@ -42,12 +42,12 @@ paths:
                   required: true
                   schema:
                       type: string
-                - in: query
-                  name: plid
+                - in: path
+                  name: pageLayoutId
                   schema:
                       format: int64
                       type: integer
-                - in: query
+                - in: path
                   name: portletId
                   schema:
                       type: string

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-impl/rest-openapi.yaml
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-impl/rest-openapi.yaml
@@ -1,4 +1,7 @@
 info:
+    description:
+        "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
+        'com.liferay.frontend.view.state.rest.client', and version '1.0.0'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/ActiveViewResourceImpl.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/ActiveViewResourceImpl.java
@@ -37,13 +37,13 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class ActiveViewResourceImpl extends BaseActiveViewResourceImpl {
 
 	@Override
-	public Object getActiveView(
-			String activeViewId, Long plid, String portletId)
+	public Object getActiveViewPageLayoutPortlet(
+			String activeViewId, Long pageLayoutId, String portletId)
 		throws Exception {
 
 		FVSActiveEntry fvsActiveEntry =
 			_fvsActiveEntryLocalService.fetchFVSActiveEntry(
-				contextUser.getUserId(), activeViewId, plid, portletId);
+				contextUser.getUserId(), activeViewId, pageLayoutId, portletId);
 
 		if (fvsActiveEntry == null) {
 			throw new NoSuchModelException();
@@ -56,13 +56,14 @@ public class ActiveViewResourceImpl extends BaseActiveViewResourceImpl {
 	}
 
 	@Override
-	public Response putActiveView(
-			String activeViewId, Long plid, String portletId, String string)
+	public Response putActiveViewPageLayoutPortlet(
+			String activeViewId, Long pageLayoutId, String portletId,
+			String string)
 		throws Exception {
 
 		FVSActiveEntry fvsActiveEntry =
 			_fvsActiveEntryLocalService.fetchFVSActiveEntry(
-				contextUser.getUserId(), activeViewId, plid, portletId);
+				contextUser.getUserId(), activeViewId, pageLayoutId, portletId);
 
 		FVSEntry fvsEntry = null;
 
@@ -72,7 +73,7 @@ public class ActiveViewResourceImpl extends BaseActiveViewResourceImpl {
 
 			fvsActiveEntry = _fvsActiveEntryLocalService.addFVSActiveEntry(
 				contextUser.getUserId(), fvsEntry.getFvsEntryId(), activeViewId,
-				plid, portletId);
+				pageLayoutId, portletId);
 		}
 		else {
 			fvsEntry = _fvsEntryLocalService.getFVSEntry(

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/BaseActiveViewResourceImpl.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/BaseActiveViewResourceImpl.java
@@ -48,7 +48,6 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
@@ -63,25 +62,28 @@ public abstract class BaseActiveViewResourceImpl implements ActiveViewResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/frontend-view-state/v1.0/active-view/{activeViewId}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/frontend-view-state/v1.0/active-view/{activeViewId}/page-layout/{pageLayoutId}/portlet/{portletId}'  -u 'test@liferay.com:test'
 	 */
 	@GET
 	@Override
 	@Parameters(
 		value = {
 			@Parameter(in = ParameterIn.PATH, name = "activeViewId"),
-			@Parameter(in = ParameterIn.QUERY, name = "plid"),
-			@Parameter(in = ParameterIn.QUERY, name = "portletId")
+			@Parameter(in = ParameterIn.PATH, name = "pageLayoutId"),
+			@Parameter(in = ParameterIn.PATH, name = "portletId")
 		}
 	)
-	@Path("/active-view/{activeViewId}")
+	@Path(
+		"/active-view/{activeViewId}/page-layout/{pageLayoutId}/portlet/{portletId}"
+	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "ActiveView")})
-	public Object getActiveView(
+	public Object getActiveViewPageLayoutPortlet(
 			@NotNull @Parameter(hidden = true) @PathParam("activeViewId") String
 				activeViewId,
-			@Parameter(hidden = true) @QueryParam("plid") Long plid,
-			@Parameter(hidden = true) @QueryParam("portletId") String portletId)
+			@Parameter(hidden = true) @PathParam("pageLayoutId") Long
+				pageLayoutId,
+			@Parameter(hidden = true) @PathParam("portletId") String portletId)
 		throws Exception {
 
 		return null;
@@ -90,26 +92,29 @@ public abstract class BaseActiveViewResourceImpl implements ActiveViewResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/frontend-view-state/v1.0/active-view/{activeViewId}'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/frontend-view-state/v1.0/active-view/{activeViewId}/page-layout/{pageLayoutId}/portlet/{portletId}'  -u 'test@liferay.com:test'
 	 */
 	@Consumes({"application/json", "application/xml"})
 	@Override
 	@Parameters(
 		value = {
 			@Parameter(in = ParameterIn.PATH, name = "activeViewId"),
-			@Parameter(in = ParameterIn.QUERY, name = "plid"),
-			@Parameter(in = ParameterIn.QUERY, name = "portletId")
+			@Parameter(in = ParameterIn.PATH, name = "pageLayoutId"),
+			@Parameter(in = ParameterIn.PATH, name = "portletId")
 		}
 	)
-	@Path("/active-view/{activeViewId}")
+	@Path(
+		"/active-view/{activeViewId}/page-layout/{pageLayoutId}/portlet/{portletId}"
+	)
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "ActiveView")})
-	public Response putActiveView(
+	public Response putActiveViewPageLayoutPortlet(
 			@NotNull @Parameter(hidden = true) @PathParam("activeViewId") String
 				activeViewId,
-			@Parameter(hidden = true) @QueryParam("plid") Long plid,
-			@Parameter(hidden = true) @QueryParam("portletId") String portletId,
+			@Parameter(hidden = true) @PathParam("pageLayoutId") Long
+				pageLayoutId,
+			@Parameter(hidden = true) @PathParam("portletId") String portletId,
 			String string)
 		throws Exception {
 

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Frontend View State", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.frontend.view.state.rest.client', and version '1.0.0'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Frontend View State", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-test/bnd.bnd
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-test/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Frontend View State REST Test
+Bundle-SymbolicName: com.liferay.frontend.view.state.rest.test
+Bundle-Version: 1.0.0
+-includeresource: com.liferay.frontend.view.state.rest.client.jar=com.liferay.frontend.view.state.rest.client-*.jar;lib:=true

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-test/build.gradle
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-test/build.gradle
@@ -1,0 +1,14 @@
+dependencies {
+	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.10.3"
+	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.10.3"
+	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.10.5.1"
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "commons-beanutils", name: "commons-beanutils", version: "1.9.4"
+	testIntegrationCompile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	testIntegrationCompile project(":apps:frontend-view-state:frontend-view-state-api")
+	testIntegrationCompile project(":apps:frontend-view-state:frontend-view-state-rest-api")
+	testIntegrationCompile project(":apps:frontend-view-state:frontend-view-state-rest-client")
+	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")
+	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")
+	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-test/src/testIntegration/java/com/liferay/frontend/view/state/rest/resource/v1_0/test/ActiveViewResourceTest.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-test/src/testIntegration/java/com/liferay/frontend/view/state/rest/resource/v1_0/test/ActiveViewResourceTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.frontend.view.state.model.FVSActiveEntry;
+import com.liferay.frontend.view.state.model.FVSEntry;
+import com.liferay.frontend.view.state.service.FVSActiveEntryLocalService;
+import com.liferay.frontend.view.state.service.FVSEntryLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Javier Gamarra
+ */
+@RunWith(Arquillian.class)
+public class ActiveViewResourceTest extends BaseActiveViewResourceTestCase {
+
+	@Override
+	@Test
+	public void testGetActiveViewPageLayoutPortlet() throws Exception {
+		String activeViewId = RandomTestUtil.randomString();
+		String string = RandomTestUtil.randomString();
+
+		activeViewResource.putActiveViewPageLayoutPortlet(
+			activeViewId, 0L, "-", string);
+
+		Object activeViewPageLayoutPortlet =
+			activeViewResource.getActiveViewPageLayoutPortlet(
+				activeViewId, 0L, "-");
+
+		Assert.assertEquals(string, activeViewPageLayoutPortlet);
+	}
+
+	@Override
+	@Test
+	public void testPutActiveViewPageLayoutPortlet() throws Exception {
+		String activeViewId = RandomTestUtil.randomString();
+		String string = RandomTestUtil.randomString();
+
+		activeViewResource.putActiveViewPageLayoutPortlet(
+			activeViewId, 0L, "-", string);
+
+		FVSActiveEntry fvsActiveEntry =
+			_fvsActiveEntryLocalService.fetchFVSActiveEntry(
+				TestPropsValues.getUserId(), activeViewId, 0L, "-");
+
+		FVSEntry fvsEntry = _fvsEntryLocalService.getFVSEntry(
+			fvsActiveEntry.getFvsEntryId());
+
+		Assert.assertEquals(string, fvsEntry.getViewState());
+	}
+
+	@Inject
+	private FVSActiveEntryLocalService _fvsActiveEntryLocalService;
+
+	@Inject
+	private FVSEntryLocalService _fvsEntryLocalService;
+
+}

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-test/src/testIntegration/java/com/liferay/frontend/view/state/rest/resource/v1_0/test/BaseActiveViewResourceTestCase.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-test/src/testIntegration/java/com/liferay/frontend/view/state/rest/resource/v1_0/test/BaseActiveViewResourceTestCase.java
@@ -1,0 +1,485 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.view.state.rest.resource.v1_0.test;
+
+import com.liferay.frontend.view.state.rest.client.http.HttpInvoker;
+import com.liferay.frontend.view.state.rest.client.pagination.Page;
+import com.liferay.frontend.view.state.rest.client.resource.v1_0.ActiveViewResource;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+
+import java.text.DateFormat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+
+import org.apache.commons.beanutils.BeanUtilsBean;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public abstract class BaseActiveViewResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_activeViewResource.setContextCompany(testCompany);
+
+		ActiveViewResource.Builder builder = ActiveViewResource.builder();
+
+		activeViewResource = builder.authentication(
+			"test@liferay.com", "test"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testGetActiveViewPageLayoutPortlet() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
+	public void testPutActiveViewPageLayoutPortlet() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(Object activeView1, Object activeView2) {
+		Assert.assertTrue(
+			activeView1 + " does not equal " + activeView2,
+			equals(activeView1, activeView2));
+	}
+
+	protected void assertEquals(
+		List<Object> activeViews1, List<Object> activeViews2) {
+
+		Assert.assertEquals(activeViews1.size(), activeViews2.size());
+
+		for (int i = 0; i < activeViews1.size(); i++) {
+			Object activeView1 = activeViews1.get(i);
+			Object activeView2 = activeViews2.get(i);
+
+			assertEquals(activeView1, activeView2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<Object> activeViews1, List<Object> activeViews2) {
+
+		Assert.assertEquals(activeViews1.size(), activeViews2.size());
+
+		for (Object activeView1 : activeViews1) {
+			boolean contains = false;
+
+			for (Object activeView2 : activeViews2) {
+				if (equals(activeView1, activeView2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				activeViews2 + " does not contain " + activeView1, contains);
+		}
+	}
+
+	protected void assertValid(Object activeView) throws Exception {
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<Object> page) {
+		boolean valid = false;
+
+		java.util.Collection<Object> activeViews = page.getItems();
+
+		int size = activeViews.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(Object activeView1, Object activeView2) {
+		if (activeView1 == activeView2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected Field[] getDeclaredFields(Class clazz) throws Exception {
+		Stream<Field> stream = Stream.of(
+			ReflectionUtil.getDeclaredFields(clazz));
+
+		return stream.filter(
+			field -> !field.isSynthetic()
+		).toArray(
+			Field[]::new
+		);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_activeViewResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_activeViewResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		java.util.Collection<EntityField> entityFields = getEntityFields();
+
+		Stream<EntityField> stream = entityFields.stream();
+
+		return stream.filter(
+			entityField ->
+				Objects.equals(entityField.getType(), type) &&
+				!ArrayUtil.contains(
+					getIgnoredEntityFieldNames(), entityField.getName())
+		).collect(
+			Collectors.toList()
+		);
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator, Object activeView) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path("http://localhost:8080/o/graphql");
+		httpInvoker.userNameAndPassword("test@liferay.com:test");
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected ActiveViewResource activeViewResource;
+	protected Group irrelevantGroup;
+	protected Company testCompany;
+	protected Group testGroup;
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseActiveViewResourceTestCase.class);
+
+	private static BeanUtilsBean _beanUtilsBean = new BeanUtilsBean() {
+
+		@Override
+		public void copyProperty(Object bean, String name, Object value)
+			throws IllegalAccessException, InvocationTargetException {
+
+			if (value != null) {
+				super.copyProperty(bean, name, value);
+			}
+		}
+
+	};
+	private static DateFormat _dateFormat;
+
+	@Inject
+	private
+		com.liferay.frontend.view.state.rest.resource.v1_0.ActiveViewResource
+			_activeViewResource;
+
+}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -395,6 +395,10 @@ public class RESTBuilder {
 
 		String description = info.getDescription();
 
+		if (description == null) {
+			description = "";
+		}
+
 		if (description.contains(clientMessage)) {
 			description = StringUtil.removeSubstring(
 				description,

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -1938,6 +1938,7 @@ public class RESTBuilder {
 		context.put("schemaName", schemaName);
 
 		String javaType = javaDataTypeMap.get(schemaName);
+
 		if (javaType == null) {
 			context.put("schemaJavaType", "Object");
 			context.put("schemaClientJavaType", "Object");
@@ -1947,8 +1948,8 @@ public class RESTBuilder {
 			context.put(
 				"schemaClientJavaType",
 				StringBundler.concat(
-					_configYAML.getApiPackagePath(), ".client.dto.", escapedVersion,
-					".", schemaName));
+					_configYAML.getApiPackagePath(), ".client.dto.",
+					escapedVersion, ".", schemaName));
 		}
 
 		context.put("schemaNames", TextFormatter.formatPlural(schemaName));

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -1,5 +1,7 @@
 package ${configYAML.apiPackagePath}.resource.${escapedVersion}.test;
 
+import ${configYAML.apiPackagePath}.client.resource.${escapedVersion}.${schemaName}Resource;
+
 <#list allExternalSchemas?keys as schemaName>
 	import ${configYAML.apiPackagePath}.client.dto.${escapedVersion}.${schemaName};
 	import ${configYAML.apiPackagePath}.client.resource.${escapedVersion}.${schemaName}Resource;
@@ -157,79 +159,81 @@ public abstract class Base${schemaName}ResourceTestCase {
 		GroupTestUtil.deleteGroup(testGroup);
 	}
 
-	@Test
-	public void testClientSerDesToDTO() throws Exception {
-		ObjectMapper objectMapper = new ObjectMapper() {
-			{
-				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
-				configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
-				enable(SerializationFeature.INDENT_OUTPUT);
-				setDateFormat(new ISO8601DateFormat());
-				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-				setSerializationInclusion(JsonInclude.Include.NON_NULL);
-				setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-				setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-			}
-		};
-
-		${schemaName} ${schemaVarName}1 = random${schemaName}();
-
-		String json = objectMapper.writeValueAsString(${schemaVarName}1);
-
-		${schemaName} ${schemaVarName}2 = ${schemaName}SerDes.toDTO(json);
-
-		Assert.assertTrue(equals(${schemaVarName}1, ${schemaVarName}2));
-	}
-
-	@Test
-	public void testClientSerDesToJSON() throws Exception {
-		ObjectMapper objectMapper = new ObjectMapper() {
-			{
-				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
-				configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
-				setDateFormat(new ISO8601DateFormat());
-				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-				setSerializationInclusion(JsonInclude.Include.NON_NULL);
-				setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-				setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-			}
-		};
-
-		${schemaName} ${schemaVarName} = random${schemaName}();
-
-		String json1 = objectMapper.writeValueAsString(${schemaVarName});
-		String json2 = ${schemaName}SerDes.toJSON(${schemaVarName});
-
-		Assert.assertEquals(
-			objectMapper.readTree(json1), objectMapper.readTree(json2));
-	}
-
 	<#assign properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema) />
 
-	@Test
-	public void testEscapeRegexInStringFields() throws Exception {
-		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+	<#if javaDataTypeMap?keys?seq_contains(schemaName)>
+		@Test
+		public void testClientSerDesToDTO() throws Exception {
+			ObjectMapper objectMapper = new ObjectMapper() {
+				{
+					configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+					configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+					enable(SerializationFeature.INDENT_OUTPUT);
+					setDateFormat(new ISO8601DateFormat());
+					setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+					setSerializationInclusion(JsonInclude.Include.NON_NULL);
+					setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+					setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+				}
+			};
 
-		${schemaName} ${schemaVarName} = random${schemaName}();
+			${schemaName} ${schemaVarName}1 = random${schemaName}();
 
-		<#list properties?keys as propertyName>
-			<#if stringUtil.equals(properties[propertyName], "String")>
-				${schemaVarName}.set${propertyName?cap_first}(regex);
-			</#if>
-		</#list>
+			String json = objectMapper.writeValueAsString(${schemaVarName}1);
 
-		String json = ${schemaName}SerDes.toJSON(${schemaVarName});
+			${schemaName} ${schemaVarName}2 = ${schemaName}SerDes.toDTO(json);
 
-		Assert.assertFalse(json.contains(regex));
+			Assert.assertTrue(equals(${schemaVarName}1, ${schemaVarName}2));
+		}
 
-		${schemaVarName} = ${schemaName}SerDes.toDTO(json);
+		@Test
+		public void testClientSerDesToJSON() throws Exception {
+			ObjectMapper objectMapper = new ObjectMapper() {
+				{
+					configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+					configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+					setDateFormat(new ISO8601DateFormat());
+					setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+					setSerializationInclusion(JsonInclude.Include.NON_NULL);
+					setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+					setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+				}
+			};
 
-		<#list properties?keys as propertyName>
-			<#if stringUtil.equals(properties[propertyName], "String")>
-				Assert.assertEquals(regex, ${schemaVarName}.get${propertyName?cap_first}());
-			</#if>
-		</#list>
-	}
+			${schemaName} ${schemaVarName} = random${schemaName}();
+
+			String json1 = objectMapper.writeValueAsString(${schemaVarName});
+			String json2 = ${schemaName}SerDes.toJSON(${schemaVarName});
+
+			Assert.assertEquals(
+				objectMapper.readTree(json1), objectMapper.readTree(json2));
+		}
+
+		@Test
+		public void testEscapeRegexInStringFields() throws Exception {
+			String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+			${schemaName} ${schemaVarName} = random${schemaName}();
+
+			<#list properties?keys as propertyName>
+				<#if stringUtil.equals(properties[propertyName], "String")>
+					${schemaVarName}.set${propertyName?cap_first}(regex);
+				</#if>
+			</#list>
+
+			String json = ${schemaName}SerDes.toJSON(${schemaVarName});
+
+			Assert.assertFalse(json.contains(regex));
+
+			${schemaVarName} = ${schemaName}SerDes.toDTO(json);
+
+			<#list properties?keys as propertyName>
+				<#if stringUtil.equals(properties[propertyName], "String")>
+					Assert.assertEquals(regex, ${schemaVarName}.get${propertyName?cap_first}());
+				</#if>
+			</#list>
+		}
+	</#if>
 
 	<#assign
 		enumSchemas = freeMarkerTool.getDTOEnumSchemas(openAPIYAML, schema)
@@ -1817,16 +1821,16 @@ public abstract class Base${schemaName}ResourceTestCase {
 		Assert.assertEquals(expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
 	}
 
-	protected void assertEquals(${schemaName} ${schemaVarName}1, ${schemaName} ${schemaVarName}2) {
+	protected void assertEquals(${schemaClientJavaType} ${schemaVarName}1, ${schemaClientJavaType} ${schemaVarName}2) {
 		Assert.assertTrue(${schemaVarName}1 + " does not equal " + ${schemaVarName}2, equals(${schemaVarName}1, ${schemaVarName}2));
 	}
 
-	protected void assertEquals(List<${schemaName}> ${schemaVarNames}1, List<${schemaName}> ${schemaVarNames}2) {
+	protected void assertEquals(List<${schemaClientJavaType}> ${schemaVarNames}1, List<${schemaClientJavaType}> ${schemaVarNames}2) {
 		Assert.assertEquals(${schemaVarNames}1.size(), ${schemaVarNames}2.size());
 
 		for (int i = 0; i < ${schemaVarNames}1.size(); i++) {
-			${schemaName} ${schemaVarName}1 = ${schemaVarNames}1.get(i);
-			${schemaName} ${schemaVarName}2 = ${schemaVarNames}2.get(i);
+			${schemaClientJavaType} ${schemaVarName}1 = ${schemaVarNames}1.get(i);
+			${schemaClientJavaType} ${schemaVarName}2 = ${schemaVarNames}2.get(i);
 
 			assertEquals(${schemaVarName}1, ${schemaVarName}2);
 		}
@@ -1843,13 +1847,13 @@ public abstract class Base${schemaName}ResourceTestCase {
 		}
 	</#list>
 
-	protected void assertEqualsIgnoringOrder(List<${schemaName}> ${schemaVarNames}1, List<${schemaName}> ${schemaVarNames}2) {
+	protected void assertEqualsIgnoringOrder(List<${schemaClientJavaType}> ${schemaVarNames}1, List<${schemaClientJavaType}> ${schemaVarNames}2) {
 		Assert.assertEquals(${schemaVarNames}1.size(), ${schemaVarNames}2.size());
 
-		for (${schemaName} ${schemaVarName}1 : ${schemaVarNames}1) {
+		for (${schemaClientJavaType} ${schemaVarName}1 : ${schemaVarNames}1) {
 			boolean contains = false;
 
-			for (${schemaName} ${schemaVarName}2 : ${schemaVarNames}2) {
+			for (${schemaClientJavaType} ${schemaVarName}2 : ${schemaVarNames}2) {
 				if (equals(${schemaVarName}1, ${schemaVarName}2)) {
 					contains = true;
 
@@ -1861,7 +1865,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 		}
 	}
 
-	protected void assertValid(${configYAML.apiPackagePath}.client.dto.${escapedVersion}.${schemaName} ${schemaVarName}) throws Exception {
+	protected void assertValid(${schemaClientJavaType} ${schemaVarName}) throws Exception {
 		boolean valid = true;
 
 		<#if properties?keys?seq_contains("dateCreated")>
@@ -1928,15 +1932,15 @@ public abstract class Base${schemaName}ResourceTestCase {
 	}
 
 	<#if generateGetMultipartFilesMethod>
-		protected void assertValid(${configYAML.apiPackagePath}.client.dto.${escapedVersion}.${schemaName} ${schemaVarName}, Map<String, File> multipartFiles) throws Exception {
+		protected void assertValid(${schemaClientJavaType} ${schemaVarName}, Map<String, File> multipartFiles) throws Exception {
 			throw new UnsupportedOperationException("This method needs to be implemented");
 		}
 	</#if>
 
-	protected void assertValid(Page<${schemaName}> page) {
+	protected void assertValid(Page<${schemaClientJavaType}> page) {
 		boolean valid = false;
 
-		java.util.Collection<${schemaName}> ${schemaVarNames} = page.getItems();
+		java.util.Collection<${schemaClientJavaType}> ${schemaVarNames} = page.getItems();
 
 		int size = ${schemaVarNames}.size();
 
@@ -2068,7 +2072,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 		return new String[0];
 	}
 
-	protected boolean equals(${schemaName} ${schemaVarName}1, ${schemaName} ${schemaVarName}2) {
+	protected boolean equals(${schemaClientJavaType} ${schemaVarName}1, ${schemaClientJavaType} ${schemaVarName}2) {
 		if (${schemaVarName}1 == ${schemaVarName}2) {
 			return true;
 		}
@@ -2200,7 +2204,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 		);
 	}
 
-	protected String getFilterString(EntityField entityField, String operator, ${schemaName} ${schemaVarName}) {
+	protected String getFilterString(EntityField entityField, String operator, ${schemaClientJavaType} ${schemaVarName}) {
 		StringBundler sb = new StringBundler();
 
 		String entityFieldName = entityField.getName();
@@ -2288,41 +2292,43 @@ public abstract class Base${schemaName}ResourceTestCase {
 		return JSONFactoryUtil.createJSONObject(invoke(queryGraphQLField.toString()));
 	}
 
-	protected ${schemaName} random${schemaName}() throws Exception {
-		return new ${schemaName}() {
-			{
-				<#list properties?keys as propertyName>
-					<#if stringUtil.equals(propertyName, "siteId")>
-						${propertyName} = testGroup.getGroupId();
-					<#elseif stringUtil.equals(properties[propertyName], "Integer")>
-						${propertyName} = RandomTestUtil.randomInt();
-					<#elseif propertyName?contains("email") && stringUtil.equals(properties[propertyName], "String")>
-						${propertyName} = StringUtil.toLowerCase(RandomTestUtil.randomString()) + "@liferay.com";
-					<#elseif stringUtil.equals(properties[propertyName], "String")>
-						${propertyName} = StringUtil.toLowerCase(RandomTestUtil.randomString());
-					<#elseif randomDataTypes?seq_contains(properties[propertyName])>
-						${propertyName} = RandomTestUtil.random${properties[propertyName]}();
-					<#elseif stringUtil.equals(properties[propertyName], "Date")>
-						${propertyName} = RandomTestUtil.nextDate();
-					</#if>
-				</#list>
-			}
-		};
-	}
+	<#if javaDataTypeMap?keys?seq_contains(schemaName)>
+		protected ${schemaName} random${schemaName}() throws Exception {
+			return new ${schemaName}() {
+				{
+					<#list properties?keys as propertyName>
+						<#if stringUtil.equals(propertyName, "siteId")>
+							${propertyName} = testGroup.getGroupId();
+						<#elseif stringUtil.equals(properties[propertyName], "Integer")>
+							${propertyName} = RandomTestUtil.randomInt();
+						<#elseif propertyName?contains("email") && stringUtil.equals(properties[propertyName], "String")>
+							${propertyName} = StringUtil.toLowerCase(RandomTestUtil.randomString()) + "@liferay.com";
+						<#elseif stringUtil.equals(properties[propertyName], "String")>
+							${propertyName} = StringUtil.toLowerCase(RandomTestUtil.randomString());
+						<#elseif randomDataTypes?seq_contains(properties[propertyName])>
+							${propertyName} = RandomTestUtil.random${properties[propertyName]}();
+						<#elseif stringUtil.equals(properties[propertyName], "Date")>
+							${propertyName} = RandomTestUtil.nextDate();
+						</#if>
+					</#list>
+				}
+			};
+		}
 
-	protected ${schemaName} randomIrrelevant${schemaName}() throws Exception {
-		${schemaName} randomIrrelevant${schemaName} = random${schemaName}();
+		protected ${schemaName} randomIrrelevant${schemaName}() throws Exception {
+			${schemaName} randomIrrelevant${schemaName} = random${schemaName}();
 
-		<#if properties?keys?seq_contains("siteId")>
-			randomIrrelevant${schemaName}.setSiteId(irrelevantGroup.getGroupId());
-		</#if>
+			<#if properties?keys?seq_contains("siteId")>
+				randomIrrelevant${schemaName}.setSiteId(irrelevantGroup.getGroupId());
+			</#if>
 
-		return randomIrrelevant${schemaName};
-	}
+			return randomIrrelevant${schemaName};
+		}
 
-	protected ${schemaName} randomPatch${schemaName}() throws Exception {
-		return random${schemaName}();
-	}
+		protected ${schemaName} randomPatch${schemaName}() throws Exception {
+			return random${schemaName}();
+		}
+	</#if>
 
 	<#list relatedSchemaNames as relatedSchemaName>
 		protected ${relatedSchemaName} random${relatedSchemaName}() throws Exception {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_resource.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_resource.ftl
@@ -178,6 +178,8 @@ public interface ${schemaName}Resource {
 							return ${javaMethodSignature.returnType}.valueOf(content);
 						<#elseif stringUtil.equals(javaMethodSignature.returnType, "java.lang.Number")>
 							return Double.valueOf(content);
+						<#elseif stringUtil.equals(javaMethodSignature.returnType, "java.lang.Object")>
+							return (Object)content;
 						<#elseif stringUtil.equals(javaMethodSignature.returnType, "java.math.BigDecimal")>
 							return new java.math.BigDecimal(content);
 						<#elseif stringUtil.equals(javaMethodSignature.returnType, "java.util.Date")>


### PR DESCRIPTION
Change query parameters to path parameters because those values are required.

Add Java client and test modules. Because these are unusual APIs (receive String/Object, return response) it forces me to revamp the test/client generation to support non-schemas, like Object.

/cc @dsanz 