### PR TITLE
LPS-134865 Upgrade tinycolor2 to 1.4.2

### DIFF
--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -949,7 +949,7 @@
     "@clayui/icon" "^3.1.0"
     "@clayui/shared" "^3.29.0"
     classnames "^2.2.6"
-    tinycolor2 "^1.4.1"
+    tinycolor2 "^1.4.2"
 
 "@clayui/css@3.30.0":
   version "3.30.0"
@@ -14939,10 +14939,10 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.2.tgz#1dfae771ee1a04396bdfde27a3adcebc6b648b28"
   integrity sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==
 
-tinycolor2@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
-  integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
+tinycolor2@1.4.2, tinycolor2@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
+  integrity sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
jQuery dependency coming from our clayui/color-picker which has a dependency of tinyColor2 (https://github.com/liferay/clay/blob/master/packages/clay-color-picker/package.json#L35), whose @1.4.1 version includes jQuery@1.9.1 (https://github.com/bgrins/TinyColor/blob/1.4.1/demo/jquery-1.9.1.js). Luckily for us, tinycolor2@1.4.2 removed any dependency from jQuery  (https://github.com/bgrins/TinyColor/commit/250a1e2421242b336770d50c2b5e1eae292bc727)

More details: https://issues.liferay.com/browse/PTR-2475

cc @antonio-ortega 