### PR TITLE
LPS-134908 Notification message with silent key does not work properly

### DIFF
--- a/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/bnd.bnd
+++ b/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/bnd.bnd
@@ -2,6 +2,8 @@ Bundle-Name: Liferay Push Notifications Sender Apple
 Bundle-SymbolicName: com.liferay.push.notifications.sender.apple
 Bundle-Version: 5.0.5
 Import-Package:\
+	!com.aayushatharva.brotli4j.*,\
+	\
 	!com.barchart.udt.*,\
 	\
 	!com.fasterxml.aalto.*,\
@@ -10,40 +12,41 @@ Import-Package:\
 	\
 	!com.jcraft.jzlib.*,\
 	\
-	!com.ning.*,\
+	!com.ning.compress.*,\
 	\
-	!com.oracle.*,\
+	!com.oracle.svm.core.annotate.*,\
 	\
-	!com.sun.*,\
+	!com.sun.nio.sctp.*,\
 	\
 	!gnu.io.*,\
 	\
 	!io.netty.internal.tcnative.*,\
 	\
-	!jdk.nashorn.*,\
-	\
-	!jdk.net.*,\
-	\
-	!jdk.vm.*,\
-	\
 	!lzma.sdk.*,\
 	\
-	!net.jpountz.*,\
+	!net.jpountz.lz4.*,\
+	!net.jpountz.xxhash.*,\
 	\
 	!org.apache.commons.httpclient.*,\
+	!org.apache.logging.log4j.*,\
 	\
-	!org.bouncycastle.*,\
+	!org.bouncycastle.asn1.x500.*,\
+	!org.bouncycastle.cert.*,\
+	!org.bouncycastle.jce.provider.*,\
+	!org.bouncycastle.operator.*,\
 	\
 	!org.conscrypt.*,\
 	\
-	!org.eclipse.*,\
+	!org.eclipse.jetty.alpn.*,\
+	!org.eclipse.jetty.npn.*,\
 	\
-	!org.graalvm.*,\
-	\
-	!org.jboss.*,\
+	!org.jboss.marshalling.*,\
 	\
 	!reactor.blockhound.*,\
 	\
-	!sun.security.*,\
+	!sun.security.util.*,\
+	!sun.security.x509.*,\
+	\
+	io.netty.channel.socket.nio,\
 	\
 	*

--- a/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/src/main/java/com/liferay/push/notifications/sender/apple/internal/ApplePushNotificationsSender.java
+++ b/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/src/main/java/com/liferay/push/notifications/sender/apple/internal/ApplePushNotificationsSender.java
@@ -278,7 +278,7 @@ public class ApplePushNotificationsSender implements PushNotificationsSender {
 			PushNotificationsConstants.KEY_SILENT);
 
 		if (silent) {
-			simpleApnsPayloadBuilder.setSound(null);
+			simpleApnsPayloadBuilder.setContentAvailable(true);
 		}
 
 		String sound = payloadJSONObject.getString(


### PR DESCRIPTION
The payload sent to Apple services doesn't contain the key `"content-available": 1` in the aps JSON object as we specify in [the documentation](https://github.com/liferay-mobile/liferay-push-ios) of liferay-push-ios when we use the key `"silent": true`.

We notice that push notification was not working on master because some necessary packages were not included in the MANIFEST of the .jar created. I import that package in the bnd.bnd to force the import but I am not sure if this is the best way to do this.

The changes that create this problem were made in [this ticket](https://issues.liferay.com/browse/LPS-133315) to ensure that we are using the same netty version that the portal provides, which makes all sense.