### PR TITLE
LPS-131654 Intermediate pages in page-iterator do not update when SPA is enabled

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -354,7 +354,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 				}
 			),
 			{
-				portletId: '<%= portletDisplay.getPortletName() %>'
+				portletId: '<%= portletDisplay.getId() %>'
 			}
 		);
 	</aui:script>


### PR DESCRIPTION
## Steps to reproduce

1. Upload the attached 1000 documents to the documents and media portlet
2. Navigate to the home page, and use the search bar portlet to search for "test"
3. Change the pagination to 20 results per page
4. Refresh the page
5. Click on the ... and scroll through the results and confirm that it makes sense
6. Change the pagination to 60 results per page
7. Click on the ... and scroll through the results

Expected behavior is that now that it's 60 results per page, we should see 17 pages. Actual behavior is that we still see 50 pages.

## Solution notes

Originally I fixed it only for documents and media's search, rather than the normal search portlet, and I (incorrectly) assumed that the same fix would work in both places. However, since the search results portlet is instanceable, the solution for the documents and media portlet didn't work for the search results portlet.