### PR TITLE
LPS-134654 Fix CSS selector to work in "older" version of Chrome

### DIFF
--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.tsx
@@ -32,7 +32,7 @@ const SELECTOR_TRIGGER = `
 	.upper-tbar [data-title]:not(.lfr-portal-tooltip),
 	.upper-tbar [title]:not(.lfr-portal-tooltip),
 	.upper-tbar [data-restore-title],
-	.lfr-tooltip-scope [title]:not(iframe,[title=""]),
+	.lfr-tooltip-scope [title]:not(iframe):not([title=""]),
 	.lfr-tooltip-scope [data-title]:not([data-title=""]),
 	.lfr-tooltip-scope [data-restore-title]:not([data-restore-title=""])
 `;


### PR DESCRIPTION
Our CI infrastructure is currently using Chrome 86, which doesn't
support the ["selector list argument of :not()"](https://caniuse.com/css-not-sel-list),
so here we're just making sure it works for that version.

**Test plan**
- Start up tomcat
- Use Google Chrome 86 :warning: 
- Navigate to http://localhost:8080
- Assert no errors are thrown in the console
- Assert that tooltips are working correctly

**Before**

![](https://user-images.githubusercontent.com/5572/123919447-39e32f80-d985-11eb-9b9f-8777078d39b8.png)

**After**

![](https://user-images.githubusercontent.com/5572/123919486-436c9780-d985-11eb-9f86-82d7d1da648f.png)

