### PR TITLE
LPS-133626 Show structured contents of a content structured without filtering where the content structured is created

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentEntityModel.java
@@ -60,9 +60,11 @@ public class StructuredContentEntityModel implements EntityModel {
 				"datePublished",
 				locale -> Field.getSortableFieldName(Field.DISPLAY_DATE),
 				locale -> Field.DISPLAY_DATE),
+			new IntegerEntityField("assetLibraryId", locale -> Field.GROUP_ID),
 			new IntegerEntityField(
 				"contentStructureId", locale -> Field.CLASS_TYPE_ID),
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),
+			new IntegerEntityField("siteId", locale -> Field.GROUP_ID),
 			new StringEntityField(
 				"friendlyUrlPath",
 				locale -> Field.getSortableFieldName(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -206,8 +206,7 @@ public class StructuredContentResourceImpl
 						contentStructureId.toString()),
 					BooleanClauseOccur.MUST);
 			},
-			ddmStructure.getGroupId(), search, aggregation, filter, pagination,
-			sorts);
+			null, search, aggregation, filter, pagination, sorts);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -481,7 +481,9 @@ public class StructuredContentResourceTest
 
 	@Override
 	protected String[] getIgnoredEntityFieldNames() {
-		return new String[] {"contentStructureId", "creatorId"};
+		return new String[] {
+			"assetLibraryId", "contentStructureId", "creatorId", "siteId"
+		};
 	}
 
 	@Override


### PR DESCRIPTION
Remove the filter of the content structured groupId to allow showing structured contents of content structures that are created in other sites or asset libraries, as Basic Web Content.

Add filter by site and by asset library to Structured Content to be able to filter the content structure structure contents.