### PR TITLE
LPS-134174 add tests & client project in Object APIs, allow posting dates and small cosmetic improvements

### DIFF
--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectField.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectField.java
@@ -28,10 +28,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.io.Serializable;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-
-import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -54,62 +50,6 @@ public class ObjectField implements Serializable {
 	public static ObjectField toDTO(String json) {
 		return ObjectMapperUtil.readValue(ObjectField.class, json);
 	}
-
-	@Schema
-	public Date getDateCreated() {
-		return dateCreated;
-	}
-
-	public void setDateCreated(Date dateCreated) {
-		this.dateCreated = dateCreated;
-	}
-
-	@JsonIgnore
-	public void setDateCreated(
-		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
-
-		try {
-			dateCreated = dateCreatedUnsafeSupplier.get();
-		}
-		catch (RuntimeException re) {
-			throw re;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
-	protected Date dateCreated;
-
-	@Schema
-	public Date getDateModified() {
-		return dateModified;
-	}
-
-	public void setDateModified(Date dateModified) {
-		this.dateModified = dateModified;
-	}
-
-	@JsonIgnore
-	public void setDateModified(
-		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
-
-		try {
-			dateModified = dateModifiedUnsafeSupplier.get();
-		}
-		catch (RuntimeException re) {
-			throw re;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
-	protected Date dateModified;
 
 	@Schema
 	public Long getId() {
@@ -247,7 +187,9 @@ public class ObjectField implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String name;
 
-	@Schema
+	@Schema(
+		description = "The available default types are: BigDecimal, Boolean, Date, Double, Integer, Long and String."
+	)
 	public String getType() {
 		return type;
 	}
@@ -269,7 +211,9 @@ public class ObjectField implements Serializable {
 		}
 	}
 
-	@GraphQLField
+	@GraphQLField(
+		description = "The available default types are: BigDecimal, Boolean, Date, Double, Integer, Long and String."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String type;
 
@@ -299,37 +243,6 @@ public class ObjectField implements Serializable {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
-
-		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
-
-		if (dateCreated != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"dateCreated\": ");
-
-			sb.append("\"");
-
-			sb.append(liferayToJSONDateFormat.format(dateCreated));
-
-			sb.append("\"");
-		}
-
-		if (dateModified != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"dateModified\": ");
-
-			sb.append("\"");
-
-			sb.append(liferayToJSONDateFormat.format(dateModified));
-
-			sb.append("\"");
-		}
 
 		if (id != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/object/object-admin-rest-client/bnd.bnd
+++ b/modules/apps/object/object-admin-rest-client/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Object Admin REST Client
+Bundle-SymbolicName: com.liferay.object.admin.rest.client
+Bundle-Version: 1.0.0

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/aggregation/Aggregation.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/aggregation/Aggregation.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.aggregation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Aggregation {
+
+	public Map<String, String> getAggregationTerms() {
+		return _aggregationTerms;
+	}
+
+	public void setAggregationTerms(Map<String, String> aggregationTerms) {
+		_aggregationTerms = aggregationTerms;
+	}
+
+	private Map<String, String> _aggregationTerms = new HashMap<>();
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/aggregation/Facet.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/aggregation/Facet.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.aggregation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Facet {
+
+	public Facet() {
+	}
+
+	public Facet(String facetCriteria, List<FacetValue> facetValues) {
+		_facetCriteria = facetCriteria;
+		_facetValues = facetValues;
+	}
+
+	public String getFacetCriteria() {
+		return _facetCriteria;
+	}
+
+	public List<FacetValue> getFacetValues() {
+		return _facetValues;
+	}
+
+	public void setFacetCriteria(String facetCriteria) {
+		_facetCriteria = facetCriteria;
+	}
+
+	public void setFacetValues(List<FacetValue> facetValues) {
+		_facetValues = facetValues;
+	}
+
+	public static class FacetValue {
+
+		public FacetValue() {
+		}
+
+		public FacetValue(Integer numberOfOccurrences, String term) {
+			_numberOfOccurrences = numberOfOccurrences;
+			_term = term;
+		}
+
+		public Integer getNumberOfOccurrences() {
+			return _numberOfOccurrences;
+		}
+
+		public String getTerm() {
+			return _term;
+		}
+
+		private Integer _numberOfOccurrences;
+		private String _term;
+
+	}
+
+	private String _facetCriteria;
+	private List<FacetValue> _facetValues = new ArrayList<>();
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/dto/v1_0/ObjectDefinition.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/dto/v1_0/ObjectDefinition.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.dto.v1_0;
+
+import com.liferay.object.admin.rest.client.function.UnsafeSupplier;
+import com.liferay.object.admin.rest.client.serdes.v1_0.ObjectDefinitionSerDes;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class ObjectDefinition implements Cloneable, Serializable {
+
+	public static ObjectDefinition toDTO(String json) {
+		return ObjectDefinitionSerDes.toDTO(json);
+	}
+
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Map<String, String>> actions;
+
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+	}
+
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		try {
+			dateCreated = dateCreatedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateCreated;
+
+	public Date getDateModified() {
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+	}
+
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		try {
+			dateModified = dateModifiedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateModified;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	public ObjectField[] getObjectFields() {
+		return objectFields;
+	}
+
+	public void setObjectFields(ObjectField[] objectFields) {
+		this.objectFields = objectFields;
+	}
+
+	public void setObjectFields(
+		UnsafeSupplier<ObjectField[], Exception> objectFieldsUnsafeSupplier) {
+
+		try {
+			objectFields = objectFieldsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected ObjectField[] objectFields;
+
+	@Override
+	public ObjectDefinition clone() throws CloneNotSupportedException {
+		return (ObjectDefinition)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ObjectDefinition)) {
+			return false;
+		}
+
+		ObjectDefinition objectDefinition = (ObjectDefinition)object;
+
+		return Objects.equals(toString(), objectDefinition.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return ObjectDefinitionSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/dto/v1_0/ObjectField.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/dto/v1_0/ObjectField.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.dto.v1_0;
+
+import com.liferay.object.admin.rest.client.function.UnsafeSupplier;
+import com.liferay.object.admin.rest.client.serdes.v1_0.ObjectFieldSerDes;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class ObjectField implements Cloneable, Serializable {
+
+	public static ObjectField toDTO(String json) {
+		return ObjectFieldSerDes.toDTO(json);
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public Boolean getIndexed() {
+		return indexed;
+	}
+
+	public void setIndexed(Boolean indexed) {
+		this.indexed = indexed;
+	}
+
+	public void setIndexed(
+		UnsafeSupplier<Boolean, Exception> indexedUnsafeSupplier) {
+
+		try {
+			indexed = indexedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean indexed;
+
+	public Boolean getIndexedAsKeyword() {
+		return indexedAsKeyword;
+	}
+
+	public void setIndexedAsKeyword(Boolean indexedAsKeyword) {
+		this.indexedAsKeyword = indexedAsKeyword;
+	}
+
+	public void setIndexedAsKeyword(
+		UnsafeSupplier<Boolean, Exception> indexedAsKeywordUnsafeSupplier) {
+
+		try {
+			indexedAsKeyword = indexedAsKeywordUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean indexedAsKeyword;
+
+	public String getIndexedLanguageId() {
+		return indexedLanguageId;
+	}
+
+	public void setIndexedLanguageId(String indexedLanguageId) {
+		this.indexedLanguageId = indexedLanguageId;
+	}
+
+	public void setIndexedLanguageId(
+		UnsafeSupplier<String, Exception> indexedLanguageIdUnsafeSupplier) {
+
+		try {
+			indexedLanguageId = indexedLanguageIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String indexedLanguageId;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public void setType(UnsafeSupplier<String, Exception> typeUnsafeSupplier) {
+		try {
+			type = typeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String type;
+
+	@Override
+	public ObjectField clone() throws CloneNotSupportedException {
+		return (ObjectField)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ObjectField)) {
+			return false;
+		}
+
+		ObjectField objectField = (ObjectField)object;
+
+		return Objects.equals(toString(), objectField.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return ObjectFieldSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/function/UnsafeSupplier.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/function/UnsafeSupplier.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.function;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@FunctionalInterface
+@Generated("")
+public interface UnsafeSupplier<T, E extends Throwable> {
+
+	public T get() throws E;
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/http/HttpInvoker.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/http/HttpInvoker.java
@@ -1,0 +1,435 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.http;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class HttpInvoker {
+
+	public static HttpInvoker newHttpInvoker() {
+		_updateHttpURLConnectionClass();
+
+		return new HttpInvoker();
+	}
+
+	public HttpInvoker body(String body, String contentType) {
+		_body = body;
+		_contentType = contentType;
+
+		return this;
+	}
+
+	public HttpInvoker header(String name, String value) {
+		_headers.put(name, value);
+
+		return this;
+	}
+
+	public HttpInvoker httpMethod(HttpMethod httpMethod) {
+		_httpMethod = httpMethod;
+
+		return this;
+	}
+
+	public HttpResponse invoke() throws IOException {
+		HttpResponse httpResponse = new HttpResponse();
+
+		HttpURLConnection httpURLConnection = _openHttpURLConnection();
+
+		httpResponse.setContent(_readResponse(httpURLConnection));
+		httpResponse.setMessage(httpURLConnection.getResponseMessage());
+		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
+
+		httpURLConnection.disconnect();
+
+		return httpResponse;
+	}
+
+	public HttpInvoker multipart() {
+		_contentType =
+			"multipart/form-data; charset=utf-8; boundary=__MULTIPART_BOUNDARY__";
+		_multipartBoundary = "__MULTIPART_BOUNDARY__";
+
+		return this;
+	}
+
+	public HttpInvoker parameter(String name, String value) {
+		return parameter(name, new String[] {value});
+	}
+
+	public HttpInvoker parameter(String name, String[] values) {
+		String[] oldValues = _parameters.get(name);
+
+		if (oldValues != null) {
+			String[] newValues = new String[oldValues.length + values.length];
+
+			System.arraycopy(oldValues, 0, newValues, 0, oldValues.length);
+			System.arraycopy(
+				values, 0, newValues, oldValues.length, values.length);
+
+			_parameters.put(name, newValues);
+		}
+		else {
+			_parameters.put(name, values);
+		}
+
+		return this;
+	}
+
+	public HttpInvoker part(String name, File file) {
+		_files.put(name, file);
+
+		return this;
+	}
+
+	public HttpInvoker part(String name, String value) {
+		_parts.put(name, value);
+
+		return this;
+	}
+
+	public HttpInvoker path(String path) {
+		_path = path;
+
+		return this;
+	}
+
+	public HttpInvoker path(String name, Object value) {
+		_path = _path.replaceFirst("\\{" + name + "\\}", String.valueOf(value));
+
+		return this;
+	}
+
+	public HttpInvoker userNameAndPassword(String userNameAndPassword)
+		throws IOException {
+
+		Base64.Encoder encoder = Base64.getEncoder();
+
+		_encodedUserNameAndPassword = new String(
+			encoder.encode(userNameAndPassword.getBytes("UTF-8")), "UTF-8");
+
+		return this;
+	}
+
+	public enum HttpMethod {
+
+		DELETE, GET, PATCH, POST, PUT
+
+	}
+
+	public class HttpResponse {
+
+		public String getContent() {
+			return _content;
+		}
+
+		public String getMessage() {
+			return _message;
+		}
+
+		public int getStatusCode() {
+			return _statusCode;
+		}
+
+		public void setContent(String content) {
+			_content = content;
+		}
+
+		public void setMessage(String message) {
+			_message = message;
+		}
+
+		public void setStatusCode(int statusCode) {
+			_statusCode = statusCode;
+		}
+
+		private String _content;
+		private String _message;
+		private int _statusCode;
+
+	}
+
+	private static void _updateHttpURLConnectionClass() {
+		try {
+			Field methodsField = HttpURLConnection.class.getDeclaredField(
+				"methods");
+
+			methodsField.setAccessible(true);
+
+			Field modifiersField = Field.class.getDeclaredField("modifiers");
+
+			modifiersField.setAccessible(true);
+			modifiersField.setInt(
+				methodsField, methodsField.getModifiers() & ~Modifier.FINAL);
+
+			Set<String> methodsFieldValue = new LinkedHashSet<>(
+				Arrays.asList((String[])methodsField.get(null)));
+
+			if (methodsFieldValue.contains("PATCH")) {
+				return;
+			}
+
+			methodsFieldValue.add("PATCH");
+
+			methodsField.set(null, methodsFieldValue.toArray(new String[0]));
+		}
+		catch (IllegalAccessException | NoSuchFieldException e) {
+			_logger.warning("Unable to update HttpURLConnection class");
+		}
+	}
+
+	private HttpInvoker() {
+	}
+
+	private void _appendPart(
+			OutputStream outputStream, PrintWriter printWriter, String key,
+			Object value)
+		throws IOException {
+
+		printWriter.append("\r\n--");
+		printWriter.append(_multipartBoundary);
+		printWriter.append("\r\nContent-Disposition: form-data; name=\"");
+		printWriter.append(key);
+		printWriter.append("\";");
+
+		if (value instanceof File) {
+			File file = (File)value;
+
+			printWriter.append(" filename=\"");
+			printWriter.append(file.getName());
+			printWriter.append("\"\r\nContent-Type: ");
+			printWriter.append(
+				URLConnection.guessContentTypeFromName(file.getName()));
+			printWriter.append("\r\n\r\n");
+
+			printWriter.flush();
+
+			byte[] buffer = new byte[4096];
+			FileInputStream fileInputStream = new FileInputStream(file);
+			int read = -1;
+
+			while ((read = fileInputStream.read(buffer)) != -1) {
+				outputStream.write(buffer, 0, read);
+			}
+
+			outputStream.flush();
+
+			fileInputStream.close();
+		}
+		else {
+			printWriter.append("\r\n\r\n");
+			printWriter.append(value.toString());
+		}
+
+		printWriter.append("\r\n");
+	}
+
+	private String _getQueryString() throws IOException {
+		StringBuilder sb = new StringBuilder();
+
+		Set<Map.Entry<String, String[]>> set = _parameters.entrySet();
+
+		Iterator<Map.Entry<String, String[]>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, String[]> entry = iterator.next();
+
+			String[] values = entry.getValue();
+
+			for (int i = 0; i < values.length; i++) {
+				String name = URLEncoder.encode(entry.getKey(), "UTF-8");
+
+				sb.append(name);
+
+				sb.append("=");
+
+				String value = URLEncoder.encode(values[i], "UTF-8");
+
+				sb.append(value);
+
+				if ((i + 1) < values.length) {
+					sb.append("&");
+				}
+			}
+
+			if (iterator.hasNext()) {
+				sb.append("&");
+			}
+		}
+
+		return sb.toString();
+	}
+
+	private HttpURLConnection _openHttpURLConnection() throws IOException {
+		String urlString = _path;
+
+		String queryString = _getQueryString();
+
+		if (queryString.length() > 0) {
+			if (!urlString.contains("?")) {
+				urlString += "?";
+			}
+
+			urlString += queryString;
+		}
+
+		URL url = new URL(urlString);
+
+		HttpURLConnection httpURLConnection =
+			(HttpURLConnection)url.openConnection();
+
+		httpURLConnection.setRequestMethod(_httpMethod.name());
+
+		if (_encodedUserNameAndPassword != null) {
+			httpURLConnection.setRequestProperty(
+				"Authorization", "Basic " + _encodedUserNameAndPassword);
+		}
+
+		if (_contentType != null) {
+			httpURLConnection.setRequestProperty("Content-Type", _contentType);
+		}
+
+		for (Map.Entry<String, String> header : _headers.entrySet()) {
+			httpURLConnection.setRequestProperty(
+				header.getKey(), header.getValue());
+		}
+
+		_writeBody(httpURLConnection);
+
+		return httpURLConnection;
+	}
+
+	private String _readResponse(HttpURLConnection httpURLConnection)
+		throws IOException {
+
+		StringBuilder sb = new StringBuilder();
+
+		int responseCode = httpURLConnection.getResponseCode();
+
+		InputStream inputStream = null;
+
+		if (responseCode > 299) {
+			inputStream = httpURLConnection.getErrorStream();
+		}
+		else {
+			inputStream = httpURLConnection.getInputStream();
+		}
+
+		BufferedReader bufferedReader = new BufferedReader(
+			new InputStreamReader(inputStream));
+
+		while (true) {
+			String line = bufferedReader.readLine();
+
+			if (line == null) {
+				break;
+			}
+
+			sb.append(line);
+		}
+
+		bufferedReader.close();
+
+		return sb.toString();
+	}
+
+	private void _writeBody(HttpURLConnection httpURLConnection)
+		throws IOException {
+
+		if ((_body == null) && _files.isEmpty() && _parts.isEmpty()) {
+			return;
+		}
+
+		httpURLConnection.setDoOutput(true);
+
+		OutputStream outputStream = httpURLConnection.getOutputStream();
+
+		try (PrintWriter printWriter = new PrintWriter(
+				new OutputStreamWriter(outputStream, "UTF-8"), true)) {
+
+			if (_contentType.startsWith("multipart/form-data")) {
+				for (Map.Entry<String, String> entry : _parts.entrySet()) {
+					_appendPart(
+						outputStream, printWriter, entry.getKey(),
+						entry.getValue());
+				}
+
+				for (Map.Entry<String, File> entry : _files.entrySet()) {
+					_appendPart(
+						outputStream, printWriter, entry.getKey(),
+						entry.getValue());
+				}
+
+				printWriter.append("--" + _multipartBoundary + "--");
+
+				printWriter.flush();
+
+				outputStream.flush();
+			}
+			else {
+				printWriter.append(_body);
+
+				printWriter.flush();
+			}
+		}
+	}
+
+	private static final Logger _logger = Logger.getLogger(
+		HttpInvoker.class.getName());
+
+	private String _body;
+	private String _contentType;
+	private String _encodedUserNameAndPassword;
+	private Map<String, File> _files = new LinkedHashMap<>();
+	private Map<String, String> _headers = new LinkedHashMap<>();
+	private HttpMethod _httpMethod = HttpMethod.GET;
+	private String _multipartBoundary;
+	private Map<String, String[]> _parameters = new LinkedHashMap<>();
+	private Map<String, String> _parts = new LinkedHashMap<>();
+	private String _path;
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/json/BaseJSONParser.java
@@ -1,0 +1,635 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.json;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public abstract class BaseJSONParser<T> {
+
+	public static final String[][] JSON_ESCAPE_STRINGS = new String[][] {
+		{"\\", "\\\\"}, {"\"", "\\\""}, {"\b", "\\b"}, {"\f", "\\f"},
+		{"\n", "\\n"}, {"\r", "\\r"}, {"\t", "\\t"}
+	};
+
+	public T parseToDTO(String json) {
+		if (json == null) {
+			throw new IllegalArgumentException("JSON is null");
+		}
+
+		_init(json);
+
+		_assertStartsWithAndEndsWith("{", "}");
+
+		T dto = createDTO();
+
+		if (_isEmpty()) {
+			return dto;
+		}
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		_readNextChar();
+
+		if (_isLastChar('}')) {
+			_readWhileLastCharIsWhiteSpace();
+
+			if (!_isEndOfJSON()) {
+				_readNextChar();
+
+				throw new IllegalArgumentException(
+					"Expected end of JSON, but found '" + _lastChar + "'");
+			}
+
+			return dto;
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			String fieldName = _readValueAsString();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			_assertLastChar(':');
+
+			_readNextChar();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			setField(dto, fieldName, _readValue());
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		return dto;
+	}
+
+	public T[] parseToDTOs(String json) {
+		if (json == null) {
+			throw new IllegalArgumentException("JSON is null");
+		}
+
+		_init(json);
+
+		_assertStartsWithAndEndsWith("[", "]");
+
+		if (_isEmpty()) {
+			return createDTOArray(0);
+		}
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar(']')) {
+			_readNextChar();
+
+			return createDTOArray(0);
+		}
+
+		_readWhileLastCharIsWhiteSpace();
+
+		Object[] objects = (Object[])_readValue();
+
+		return Stream.of(
+			objects
+		).map(
+			object -> parseToDTO((String)object)
+		).toArray(
+			size -> createDTOArray(size)
+		);
+	}
+
+	public Map<String, Object> parseToMap(String json) {
+		if (json == null) {
+			throw new IllegalArgumentException("JSON is null");
+		}
+
+		_init(json);
+
+		_assertStartsWithAndEndsWith("{", "}");
+
+		Map<String, Object> map = new TreeMap<>();
+
+		_setCaptureStart();
+
+		_readNextChar();
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar('}')) {
+			return map;
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			String key = _readValueAsString();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			if (!_ifLastCharMatchesThenRead(':')) {
+				throw new IllegalArgumentException("Expected ':'");
+			}
+
+			_readWhileLastCharIsWhiteSpace();
+
+			map.put(key, _readValue(true));
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (!_ifLastCharMatchesThenRead('}')) {
+			throw new IllegalArgumentException(
+				"Expected either ',' or '}', but found '" + _lastChar + "'");
+		}
+
+		return map;
+	}
+
+	protected abstract T createDTO();
+
+	protected abstract T[] createDTOArray(int size);
+
+	protected abstract void setField(
+		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected Date toDate(String string) {
+		try {
+			return _dateFormat.parse(string);
+		}
+		catch (ParseException pe) {
+			throw new IllegalArgumentException(
+				"Unable to parse date from " + string, pe);
+		}
+	}
+
+	protected Date[] toDates(Object[] objects) {
+		return Stream.of(
+			objects
+		).map(
+			object -> toDate((String)object)
+		).toArray(
+			size -> new Date[size]
+		);
+	}
+
+	protected Integer[] toIntegers(Object[] objects) {
+		return Stream.of(
+			objects
+		).map(
+			object -> Integer.valueOf(object.toString())
+		).toArray(
+			size -> new Integer[size]
+		);
+	}
+
+	protected Long[] toLongs(Object[] objects) {
+		return Stream.of(
+			objects
+		).map(
+			object -> Long.valueOf(object.toString())
+		).toArray(
+			size -> new Long[size]
+		);
+	}
+
+	protected String toString(Date date) {
+		return _dateFormat.format(date);
+	}
+
+	protected String[] toStrings(Object[] objects) {
+		return Stream.of(
+			objects
+		).map(
+			String.class::cast
+		).toArray(
+			size -> new String[size]
+		);
+	}
+
+	private void _assertLastChar(char c) {
+		if (_lastChar != c) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Expected last char '%s', but found '%s'", c, _lastChar));
+		}
+	}
+
+	private void _assertStartsWithAndEndsWith(String prefix, String sufix) {
+		if (!_json.startsWith(prefix)) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Expected starts with '%s', but found '%s' in '%s'", prefix,
+					_json.charAt(0), _json));
+		}
+
+		if (!_json.endsWith(sufix)) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Expected ends with '%s', but found '%s' in '%s'", sufix,
+					_json.charAt(_json.length() - 1), _json));
+		}
+	}
+
+	private String _getCapturedJSONSubstring() {
+		return _json.substring(_captureStartStack.pop(), _index - 1);
+	}
+
+	private String _getCapturedSubstring() {
+		return _unescape(_getCapturedJSONSubstring());
+	}
+
+	private boolean _ifLastCharMatchesThenRead(char ch) {
+		if (_lastChar != ch) {
+			return false;
+		}
+
+		_readNextChar();
+
+		return true;
+	}
+
+	private void _init(String json) {
+		_captureStartStack = new Stack<>();
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_index = 0;
+		_json = json.trim();
+		_lastChar = 0;
+	}
+
+	private boolean _isCharEscaped(String string, int index) {
+		int backslashCount = 0;
+
+		while (((index - 1 - backslashCount) >= 0) &&
+			   (string.charAt(index - 1 - backslashCount) == '\\')) {
+
+			backslashCount++;
+		}
+
+		if ((backslashCount % 2) == 0) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private boolean _isEmpty() {
+		String substring = _json.substring(1, _json.length() - 1);
+
+		substring = substring.trim();
+
+		return substring.isEmpty();
+	}
+
+	private boolean _isEndOfJSON() {
+		if (_index == _json.length()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastChar(char c) {
+		if (_lastChar == c) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharDecimalSeparator() {
+		if (_lastChar == '.') {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharDigit() {
+		if ((_lastChar >= '0') && (_lastChar <= '9')) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharNegative() {
+		if (_lastChar == '-') {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharScientificNotation() {
+		if (_lastChar == 'E') {
+			return true;
+		}
+
+		return false;
+	}
+
+	private void _readNextChar() {
+		if (!_isEndOfJSON()) {
+			_lastChar = _json.charAt(_index++);
+		}
+	}
+
+	private Object _readValue() {
+		return _readValue(false);
+	}
+
+	private Object _readValue(boolean parseMaps) {
+		if (_lastChar == '[') {
+			return _readValueAsArray();
+		}
+		else if (_lastChar == 'f') {
+			return _readValueAsBooleanFalse();
+		}
+		else if (_lastChar == 't') {
+			return _readValueAsBooleanTrue();
+		}
+		else if (_lastChar == 'n') {
+			return _readValueAsObjectNull();
+		}
+		else if (_lastChar == '"') {
+			return _readValueAsString();
+		}
+		else if (parseMaps && (_lastChar == '{')) {
+			try {
+				Class<? extends BaseJSONParser> clazz = getClass();
+
+				BaseJSONParser baseJSONParser = clazz.newInstance();
+
+				return baseJSONParser.parseToMap(_readValueAsStringJSON());
+			}
+			catch (Exception e) {
+				throw new IllegalArgumentException(
+					"Expected JSON object or map");
+			}
+		}
+		else if (_lastChar == '{') {
+			return _readValueAsStringJSON();
+		}
+		else if ((_lastChar == '-') || (_lastChar == '0') ||
+				 (_lastChar == '1') || (_lastChar == '2') ||
+				 (_lastChar == '3') || (_lastChar == '4') ||
+				 (_lastChar == '5') || (_lastChar == '6') ||
+				 (_lastChar == '7') || (_lastChar == '8') ||
+				 (_lastChar == '9')) {
+
+			return _readValueAsStringNumber();
+		}
+		else {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	private Object[] _readValueAsArray() {
+		List<Object> objects = new ArrayList<>();
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar(']')) {
+			_readNextChar();
+
+			return objects.toArray();
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			objects.add(_readValue());
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		if (!_isLastChar(']')) {
+			throw new IllegalArgumentException(
+				"Expected ']', but found '" + _lastChar + "'");
+		}
+
+		_readNextChar();
+
+		return objects.toArray();
+	}
+
+	private boolean _readValueAsBooleanFalse() {
+		_readNextChar();
+
+		_assertLastChar('a');
+
+		_readNextChar();
+
+		_assertLastChar('l');
+
+		_readNextChar();
+
+		_assertLastChar('s');
+
+		_readNextChar();
+
+		_assertLastChar('e');
+
+		_readNextChar();
+
+		return false;
+	}
+
+	private boolean _readValueAsBooleanTrue() {
+		_readNextChar();
+
+		_assertLastChar('r');
+
+		_readNextChar();
+
+		_assertLastChar('u');
+
+		_readNextChar();
+
+		_assertLastChar('e');
+
+		_readNextChar();
+
+		return true;
+	}
+
+	private Object _readValueAsObjectNull() {
+		_readNextChar();
+
+		_assertLastChar('u');
+
+		_readNextChar();
+
+		_assertLastChar('l');
+
+		_readNextChar();
+
+		_assertLastChar('l');
+
+		_readNextChar();
+
+		return null;
+	}
+
+	private String _readValueAsString() {
+		_readNextChar();
+
+		_setCaptureStart();
+
+		while ((_lastChar != '"') || _isCharEscaped(_json, _index - 1)) {
+			_readNextChar();
+		}
+
+		String string = _getCapturedSubstring();
+
+		_readNextChar();
+
+		return string;
+	}
+
+	private String _readValueAsStringJSON() {
+		_setCaptureStart();
+
+		_readNextChar();
+
+		if (_isLastChar('}')) {
+			_readNextChar();
+
+			return _getCapturedJSONSubstring();
+		}
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar('}')) {
+			_readNextChar();
+
+			return _getCapturedJSONSubstring();
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			_readValueAsString();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			if (!_ifLastCharMatchesThenRead(':')) {
+				throw new IllegalArgumentException("Expected ':'");
+			}
+
+			_readWhileLastCharIsWhiteSpace();
+
+			_readValue();
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (!_ifLastCharMatchesThenRead('}')) {
+			throw new IllegalArgumentException(
+				"Expected either ',' or '}', but found '" + _lastChar + "'");
+		}
+
+		return _getCapturedJSONSubstring();
+	}
+
+	private String _readValueAsStringNumber() {
+		_setCaptureStart();
+
+		do {
+			_readNextChar();
+		}
+		while (_isLastCharDigit() || _isLastCharDecimalSeparator() ||
+			   _isLastCharNegative() || _isLastCharScientificNotation());
+
+		return _getCapturedSubstring();
+	}
+
+	private void _readWhileLastCharIsWhiteSpace() {
+		while ((_lastChar == ' ') || (_lastChar == '\n') ||
+			   (_lastChar == '\r') || (_lastChar == '\t')) {
+
+			_readNextChar();
+		}
+	}
+
+	private void _setCaptureStart() {
+		_captureStartStack.push(_index - 1);
+	}
+
+	private String _unescape(String string) {
+		for (int i = JSON_ESCAPE_STRINGS.length - 1; i >= 0; i--) {
+			String[] escapeStrings = JSON_ESCAPE_STRINGS[i];
+
+			int index = string.indexOf(escapeStrings[1]);
+
+			while (index != -1) {
+				if (!_isCharEscaped(string, index)) {
+					string =
+						string.substring(0, index) + escapeStrings[0] +
+							string.substring(index + escapeStrings[1].length());
+
+					index = string.indexOf(
+						escapeStrings[1], index + escapeStrings[0].length());
+				}
+				else {
+					index = string.indexOf(
+						escapeStrings[1], index + escapeStrings[1].length());
+				}
+			}
+		}
+
+		return string;
+	}
+
+	private Stack<Integer> _captureStartStack;
+	private DateFormat _dateFormat;
+	private int _index;
+	private String _json;
+	private char _lastChar;
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/pagination/Page.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/pagination/Page.java
@@ -1,0 +1,296 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.pagination;
+
+import com.liferay.object.admin.rest.client.aggregation.Facet;
+import com.liferay.object.admin.rest.client.json.BaseJSONParser;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Page<T> {
+
+	public static <T> Page<T> of(
+		String json, Function<String, T> toDTOFunction) {
+
+		PageJSONParser pageJSONParser = new PageJSONParser(toDTOFunction);
+
+		return (Page<T>)pageJSONParser.parseToDTO(json);
+	}
+
+	public Map<String, Map> getActions() {
+		return _actions;
+	}
+
+	public List<Facet> getFacets() {
+		return _facets;
+	}
+
+	public Collection<T> getItems() {
+		return _items;
+	}
+
+	public long getLastPage() {
+		if (_totalCount == 0) {
+			return 1;
+		}
+
+		return -Math.floorDiv(-_totalCount, _pageSize);
+	}
+
+	public long getPage() {
+		return _page;
+	}
+
+	public long getPageSize() {
+		return _pageSize;
+	}
+
+	public long getTotalCount() {
+		return _totalCount;
+	}
+
+	public boolean hasNext() {
+		if (getLastPage() > _page) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public boolean hasPrevious() {
+		if (_page > 1) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public void setActions(Map<String, Map> actions) {
+		_actions = actions;
+	}
+
+	public void setFacets(List<Facet> facets) {
+		_facets = facets;
+	}
+
+	public void setItems(Collection<T> items) {
+		_items = items;
+	}
+
+	public void setPage(long page) {
+		_page = page;
+	}
+
+	public void setPageSize(long pageSize) {
+		_pageSize = pageSize;
+	}
+
+	public void setTotalCount(long totalCount) {
+		_totalCount = totalCount;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder("{\"actions\": ");
+
+		sb.append(_toString((Map)_actions));
+		sb.append(", \"items\": [");
+
+		Iterator<T> iterator = _items.iterator();
+
+		while (iterator.hasNext()) {
+			sb.append(iterator.next());
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("], \"page\": ");
+		sb.append(_page);
+		sb.append(", \"pageSize\": ");
+		sb.append(_pageSize);
+		sb.append(", \"totalCount\": ");
+		sb.append(_totalCount);
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static class PageJSONParser<T> extends BaseJSONParser<Page> {
+
+		public PageJSONParser() {
+			_toDTOFunction = null;
+		}
+
+		public PageJSONParser(Function<String, T> toDTOFunction) {
+			_toDTOFunction = toDTOFunction;
+		}
+
+		@Override
+		protected Page createDTO() {
+			return new Page();
+		}
+
+		@Override
+		protected Page[] createDTOArray(int size) {
+			return new Page[size];
+		}
+
+		@Override
+		protected void setField(
+			Page page, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					PageJSONParser pageJSONParser = new PageJSONParser(
+						_toDTOFunction);
+
+					page.setActions(
+						pageJSONParser.parseToMap(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "facets")) {
+				if (jsonParserFieldValue != null) {
+					page.setFacets(
+						Stream.of(
+							toStrings((Object[])jsonParserFieldValue)
+						).map(
+							this::parseToMap
+						).map(
+							facets -> new Facet(
+								(String)facets.get("facetCriteria"),
+								Stream.of(
+									(Object[])facets.get("facetValues")
+								).map(
+									object -> (String)object
+								).map(
+									this::parseToMap
+								).map(
+									facetValues -> new Facet.FacetValue(
+										Integer.valueOf(
+											(String)facetValues.get(
+												"numberOfOccurrences")),
+										(String)facetValues.get("term"))
+								).collect(
+									Collectors.toList()
+								))
+						).collect(
+							Collectors.toList()
+						));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "items")) {
+				if (jsonParserFieldValue != null) {
+					page.setItems(
+						Stream.of(
+							toStrings((Object[])jsonParserFieldValue)
+						).map(
+							string -> _toDTOFunction.apply(string)
+						).collect(
+							Collectors.toList()
+						));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "lastPage")) {
+			}
+			else if (Objects.equals(jsonParserFieldName, "page")) {
+				if (jsonParserFieldValue != null) {
+					page.setPage(Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "pageSize")) {
+				if (jsonParserFieldValue != null) {
+					page.setPageSize(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				if (jsonParserFieldValue != null) {
+					page.setTotalCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+		private final Function<String, T> _toDTOFunction;
+
+	}
+
+	private String _toString(Map<String, Object> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		Set<Map.Entry<String, Object>> entries = map.entrySet();
+
+		Iterator<Map.Entry<String, Object>> iterator = entries.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, Object> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (value instanceof Map) {
+				sb.append(_toString((Map)value));
+			}
+			else {
+				sb.append("\"");
+				sb.append(value);
+				sb.append("\"");
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private Map<String, Map> _actions;
+	private List<Facet> _facets = new ArrayList<>();
+	private Collection<T> _items;
+	private long _page;
+	private long _pageSize;
+	private long _totalCount;
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/pagination/Pagination.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/pagination/Pagination.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.pagination;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Pagination {
+
+	public static Pagination of(int page, int pageSize) {
+		return new Pagination(page, pageSize);
+	}
+
+	public int getEndPosition() {
+		if ((_page < 0) || (_pageSize < 0)) {
+			return -1;
+		}
+
+		return _page * _pageSize;
+	}
+
+	public int getPage() {
+		return _page;
+	}
+
+	public int getPageSize() {
+		return _pageSize;
+	}
+
+	public int getStartPosition() {
+		if ((_page < 0) || (_pageSize < 0)) {
+			return -1;
+		}
+
+		return (_page - 1) * _pageSize;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder("{\"page\": ");
+
+		sb.append(_page);
+		sb.append(", \"pageSize\": ");
+		sb.append(_pageSize);
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private Pagination(int page, int pageSize) {
+		_page = page;
+		_pageSize = pageSize;
+	}
+
+	private final int _page;
+	private final int _pageSize;
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/permission/Permission.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/permission/Permission.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.permission;
+
+import com.liferay.object.admin.rest.client.json.BaseJSONParser;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Permission {
+
+	public static Permission toDTO(String json) {
+		PermissionJSONParser<Permission> permissionJSONParser =
+			new PermissionJSONParser();
+
+		return permissionJSONParser.parseToDTO(json);
+	}
+
+	public Object[] getActionIds() {
+		return actionIds;
+	}
+
+	public String getRoleName() {
+		return roleName;
+	}
+
+	public void setActionIds(Object[] actionIds) {
+		this.actionIds = actionIds;
+	}
+
+	public void setRoleName(String roleName) {
+		this.roleName = roleName;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (actionIds != null) {
+			sb.append("\"actionIds\": [");
+
+			for (int i = 0; i < actionIds.length; i++) {
+				sb.append("\"");
+				sb.append(actionIds[i]);
+				sb.append("\"");
+
+				if ((i + 1) < actionIds.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (roleName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"roleName\": \"");
+			sb.append(roleName);
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	protected Object[] actionIds;
+	protected String roleName;
+
+	private static class PermissionJSONParser<T>
+		extends BaseJSONParser<Permission> {
+
+		@Override
+		protected Permission createDTO() {
+			return new Permission();
+		}
+
+		@Override
+		protected Permission[] createDTOArray(int size) {
+			return new Permission[size];
+		}
+
+		@Override
+		protected void setField(
+			Permission permission, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "actionIds")) {
+				if (jsonParserFieldValue != null) {
+					permission.setActionIds((Object[])jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "roleName")) {
+				if (jsonParserFieldValue != null) {
+					permission.setRoleName((String)jsonParserFieldValue);
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/problem/Problem.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/problem/Problem.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.problem;
+
+import com.liferay.object.admin.rest.client.json.BaseJSONParser;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Problem {
+
+	public static Problem toDTO(String json) {
+		ProblemJSONParser<Problem> problemJSONParser = new ProblemJSONParser();
+
+		return problemJSONParser.parseToDTO(json);
+	}
+
+	public static class ProblemException extends Exception {
+
+		private Problem _problem;
+
+		public Problem getProblem() {
+			return _problem;
+		}
+
+		public ProblemException(Problem problem) {
+			super(problem.getTitle());
+
+			_problem = problem;
+		}
+
+	}
+
+	public String getDetail() {
+		return detail;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setDetail(String detail) {
+		this.detail = detail;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (detail != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"detail\": \"");
+			sb.append(detail);
+			sb.append("\"");
+		}
+
+		if (status != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"status\": \"");
+			sb.append(status);
+			sb.append("\"");
+		}
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": \"");
+			sb.append(title);
+			sb.append("\"");
+		}
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": \"");
+			sb.append(type);
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	protected String detail;
+	protected String status;
+	protected String title;
+	protected String type;
+
+	private static class ProblemJSONParser<T> extends BaseJSONParser<Problem> {
+
+		@Override
+		protected Problem createDTO() {
+			return new Problem();
+		}
+
+		@Override
+		protected Problem[] createDTOArray(int size) {
+			return new Problem[size];
+		}
+
+		@Override
+		protected void setField(
+			Problem problem, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "detail")) {
+				if (jsonParserFieldValue != null) {
+					problem.setDetail((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "status")) {
+				if (jsonParserFieldValue != null) {
+					problem.setStatus((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					problem.setTitle((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					problem.setType((String)jsonParserFieldValue);
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectDefinitionResource.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectDefinitionResource.java
@@ -1,0 +1,650 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.resource.v1_0;
+
+import com.liferay.object.admin.rest.client.dto.v1_0.ObjectDefinition;
+import com.liferay.object.admin.rest.client.http.HttpInvoker;
+import com.liferay.object.admin.rest.client.pagination.Page;
+import com.liferay.object.admin.rest.client.pagination.Pagination;
+import com.liferay.object.admin.rest.client.problem.Problem;
+import com.liferay.object.admin.rest.client.serdes.v1_0.ObjectDefinitionSerDes;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public interface ObjectDefinitionResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Page<ObjectDefinition> getObjectDefinitionsPage(
+			Pagination pagination)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getObjectDefinitionsPageHttpResponse(
+			Pagination pagination)
+		throws Exception;
+
+	public ObjectDefinition postObjectDefinition(
+			ObjectDefinition objectDefinition)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postObjectDefinitionHttpResponse(
+			ObjectDefinition objectDefinition)
+		throws Exception;
+
+	public void postObjectDefinitionBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postObjectDefinitionBatchHttpResponse(
+			String callbackURL, Object object)
+		throws Exception;
+
+	public void deleteObjectDefinition(Long objectDefinitionId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse deleteObjectDefinitionHttpResponse(
+			Long objectDefinitionId)
+		throws Exception;
+
+	public void deleteObjectDefinitionBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse deleteObjectDefinitionBatchHttpResponse(
+			String callbackURL, Object object)
+		throws Exception;
+
+	public ObjectDefinition getObjectDefinition(Long objectDefinitionId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getObjectDefinitionHttpResponse(
+			Long objectDefinitionId)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public ObjectDefinitionResource build() {
+			return new ObjectDefinitionResourceImpl(this);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login = "";
+		private String _password = "";
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class ObjectDefinitionResourceImpl
+		implements ObjectDefinitionResource {
+
+		public Page<ObjectDefinition> getObjectDefinitionsPage(
+				Pagination pagination)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getObjectDefinitionsPageHttpResponse(pagination);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, ObjectDefinitionSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getObjectDefinitionsPageHttpResponse(
+				Pagination pagination)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + "/o/object-admin/v1.0/object-definitions");
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public ObjectDefinition postObjectDefinition(
+				ObjectDefinition objectDefinition)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postObjectDefinitionHttpResponse(objectDefinition);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return ObjectDefinitionSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postObjectDefinitionHttpResponse(
+				ObjectDefinition objectDefinition)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(objectDefinition.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + "/o/object-admin/v1.0/object-definitions");
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void postObjectDefinitionBatch(String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postObjectDefinitionBatchHttpResponse(callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postObjectDefinitionBatchHttpResponse(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port +
+						"/o/object-admin/v1.0/object-definitions/batch");
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteObjectDefinition(Long objectDefinitionId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteObjectDefinitionHttpResponse(objectDefinitionId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse deleteObjectDefinitionHttpResponse(
+				Long objectDefinitionId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port +
+						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}");
+
+			httpInvoker.path("objectDefinitionId", objectDefinitionId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteObjectDefinitionBatch(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteObjectDefinitionBatchHttpResponse(callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse deleteObjectDefinitionBatchHttpResponse(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port +
+						"/o/object-admin/v1.0/object-definitions/batch");
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public ObjectDefinition getObjectDefinition(Long objectDefinitionId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getObjectDefinitionHttpResponse(objectDefinitionId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return ObjectDefinitionSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getObjectDefinitionHttpResponse(
+				Long objectDefinitionId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port +
+						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}");
+
+			httpInvoker.path("objectDefinitionId", objectDefinitionId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		private ObjectDefinitionResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			ObjectDefinitionResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectDefinitionSerDes.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectDefinitionSerDes.java
@@ -1,0 +1,363 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.serdes.v1_0;
+
+import com.liferay.object.admin.rest.client.dto.v1_0.ObjectDefinition;
+import com.liferay.object.admin.rest.client.dto.v1_0.ObjectField;
+import com.liferay.object.admin.rest.client.json.BaseJSONParser;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class ObjectDefinitionSerDes {
+
+	public static ObjectDefinition toDTO(String json) {
+		ObjectDefinitionJSONParser objectDefinitionJSONParser =
+			new ObjectDefinitionJSONParser();
+
+		return objectDefinitionJSONParser.parseToDTO(json);
+	}
+
+	public static ObjectDefinition[] toDTOs(String json) {
+		ObjectDefinitionJSONParser objectDefinitionJSONParser =
+			new ObjectDefinitionJSONParser();
+
+		return objectDefinitionJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(ObjectDefinition objectDefinition) {
+		if (objectDefinition == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (objectDefinition.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(objectDefinition.getActions()));
+		}
+
+		if (objectDefinition.getDateCreated() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(
+					objectDefinition.getDateCreated()));
+
+			sb.append("\"");
+		}
+
+		if (objectDefinition.getDateModified() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(
+					objectDefinition.getDateModified()));
+
+			sb.append("\"");
+		}
+
+		if (objectDefinition.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(objectDefinition.getId());
+		}
+
+		if (objectDefinition.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(objectDefinition.getName()));
+
+			sb.append("\"");
+		}
+
+		if (objectDefinition.getObjectFields() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"objectFields\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < objectDefinition.getObjectFields().length;
+				 i++) {
+
+				sb.append(
+					String.valueOf(objectDefinition.getObjectFields()[i]));
+
+				if ((i + 1) < objectDefinition.getObjectFields().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		ObjectDefinitionJSONParser objectDefinitionJSONParser =
+			new ObjectDefinitionJSONParser();
+
+		return objectDefinitionJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(ObjectDefinition objectDefinition) {
+		if (objectDefinition == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (objectDefinition.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put("actions", String.valueOf(objectDefinition.getActions()));
+		}
+
+		if (objectDefinition.getDateCreated() == null) {
+			map.put("dateCreated", null);
+		}
+		else {
+			map.put(
+				"dateCreated",
+				liferayToJSONDateFormat.format(
+					objectDefinition.getDateCreated()));
+		}
+
+		if (objectDefinition.getDateModified() == null) {
+			map.put("dateModified", null);
+		}
+		else {
+			map.put(
+				"dateModified",
+				liferayToJSONDateFormat.format(
+					objectDefinition.getDateModified()));
+		}
+
+		if (objectDefinition.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(objectDefinition.getId()));
+		}
+
+		if (objectDefinition.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(objectDefinition.getName()));
+		}
+
+		if (objectDefinition.getObjectFields() == null) {
+			map.put("objectFields", null);
+		}
+		else {
+			map.put(
+				"objectFields",
+				String.valueOf(objectDefinition.getObjectFields()));
+		}
+
+		return map;
+	}
+
+	public static class ObjectDefinitionJSONParser
+		extends BaseJSONParser<ObjectDefinition> {
+
+		@Override
+		protected ObjectDefinition createDTO() {
+			return new ObjectDefinition();
+		}
+
+		@Override
+		protected ObjectDefinition[] createDTOArray(int size) {
+			return new ObjectDefinition[size];
+		}
+
+		@Override
+		protected void setField(
+			ObjectDefinition objectDefinition, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					objectDefinition.setActions(
+						(Map)ObjectDefinitionSerDes.toMap(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {
+				if (jsonParserFieldValue != null) {
+					objectDefinition.setDateCreated(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				if (jsonParserFieldValue != null) {
+					objectDefinition.setDateModified(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					objectDefinition.setId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					objectDefinition.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "objectFields")) {
+				if (jsonParserFieldValue != null) {
+					objectDefinition.setObjectFields(
+						Stream.of(
+							toStrings((Object[])jsonParserFieldValue)
+						).map(
+							object -> ObjectFieldSerDes.toDTO((String)object)
+						).toArray(
+							size -> new ObjectField[size]
+						));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			Class<?> valueClass = value.getClass();
+
+			if (value instanceof Map) {
+				sb.append(_toJSON((Map)value));
+			}
+			else if (valueClass.isArray()) {
+				Object[] values = (Object[])value;
+
+				sb.append("[");
+
+				for (int i = 0; i < values.length; i++) {
+					sb.append("\"");
+					sb.append(_escape(values[i]));
+					sb.append("\"");
+
+					if ((i + 1) < values.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(entry.getValue()));
+				sb.append("\"");
+			}
+			else {
+				sb.append(String.valueOf(entry.getValue()));
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectFieldSerDes.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectFieldSerDes.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.client.serdes.v1_0;
+
+import com.liferay.object.admin.rest.client.dto.v1_0.ObjectField;
+import com.liferay.object.admin.rest.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class ObjectFieldSerDes {
+
+	public static ObjectField toDTO(String json) {
+		ObjectFieldJSONParser objectFieldJSONParser =
+			new ObjectFieldJSONParser();
+
+		return objectFieldJSONParser.parseToDTO(json);
+	}
+
+	public static ObjectField[] toDTOs(String json) {
+		ObjectFieldJSONParser objectFieldJSONParser =
+			new ObjectFieldJSONParser();
+
+		return objectFieldJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(ObjectField objectField) {
+		if (objectField == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (objectField.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(objectField.getId());
+		}
+
+		if (objectField.getIndexed() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"indexed\": ");
+
+			sb.append(objectField.getIndexed());
+		}
+
+		if (objectField.getIndexedAsKeyword() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"indexedAsKeyword\": ");
+
+			sb.append(objectField.getIndexedAsKeyword());
+		}
+
+		if (objectField.getIndexedLanguageId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"indexedLanguageId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(objectField.getIndexedLanguageId()));
+
+			sb.append("\"");
+		}
+
+		if (objectField.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(objectField.getName()));
+
+			sb.append("\"");
+		}
+
+		if (objectField.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(objectField.getType()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		ObjectFieldJSONParser objectFieldJSONParser =
+			new ObjectFieldJSONParser();
+
+		return objectFieldJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(ObjectField objectField) {
+		if (objectField == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (objectField.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(objectField.getId()));
+		}
+
+		if (objectField.getIndexed() == null) {
+			map.put("indexed", null);
+		}
+		else {
+			map.put("indexed", String.valueOf(objectField.getIndexed()));
+		}
+
+		if (objectField.getIndexedAsKeyword() == null) {
+			map.put("indexedAsKeyword", null);
+		}
+		else {
+			map.put(
+				"indexedAsKeyword",
+				String.valueOf(objectField.getIndexedAsKeyword()));
+		}
+
+		if (objectField.getIndexedLanguageId() == null) {
+			map.put("indexedLanguageId", null);
+		}
+		else {
+			map.put(
+				"indexedLanguageId",
+				String.valueOf(objectField.getIndexedLanguageId()));
+		}
+
+		if (objectField.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(objectField.getName()));
+		}
+
+		if (objectField.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(objectField.getType()));
+		}
+
+		return map;
+	}
+
+	public static class ObjectFieldJSONParser
+		extends BaseJSONParser<ObjectField> {
+
+		@Override
+		protected ObjectField createDTO() {
+			return new ObjectField();
+		}
+
+		@Override
+		protected ObjectField[] createDTOArray(int size) {
+			return new ObjectField[size];
+		}
+
+		@Override
+		protected void setField(
+			ObjectField objectField, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					objectField.setId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "indexed")) {
+				if (jsonParserFieldValue != null) {
+					objectField.setIndexed((Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "indexedAsKeyword")) {
+				if (jsonParserFieldValue != null) {
+					objectField.setIndexedAsKeyword(
+						(Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "indexedLanguageId")) {
+				if (jsonParserFieldValue != null) {
+					objectField.setIndexedLanguageId(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					objectField.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					objectField.setType((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			Class<?> valueClass = value.getClass();
+
+			if (value instanceof Map) {
+				sb.append(_toJSON((Map)value));
+			}
+			else if (valueClass.isArray()) {
+				Object[] values = (Object[])value;
+
+				sb.append("[");
+
+				for (int i = 0; i < values.length; i++) {
+					sb.append("\"");
+					sb.append(_escape(values[i]));
+					sb.append("\"");
+
+					if ((i + 1) < values.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(entry.getValue()));
+				sb.append("\"");
+			}
+			else {
+				sb.append(String.valueOf(entry.getValue()));
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-impl/rest-config.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-config.yaml
@@ -5,3 +5,5 @@ application:
     className: "ObjectAdminRESTApplication"
     name: "Liferay.Object.Admin.REST"
 author: "Javier Gamarra"
+clientDir: "../object-admin-rest-client/src/main/java"
+testDir: "../object-admin-rest-test/src/testIntegration/java"

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -30,14 +30,6 @@ components:
             type: object
         ObjectField:
             properties:
-                dateCreated:
-                    format: date
-                    readOnly: true
-                    type: string
-                dateModified:
-                    format: date
-                    readOnly: true
-                    type: string
                 id:
                     format: int64
                     readOnly: true

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -29,6 +29,7 @@ components:
                     type: array
             type: object
         ObjectField:
+            # @review
             properties:
                 id:
                     format: int64
@@ -43,6 +44,7 @@ components:
                 name:
                     type: string
                 type:
+                    description: "The available default types are: BigDecimal, Boolean, Date, Double, Integer, Long and String."
                     type: string
 info:
     license:

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -44,9 +44,13 @@ components:
                 name:
                     type: string
                 type:
-                    description: "The available default types are: BigDecimal, Boolean, Date, Double, Integer, Long and String."
+                    description:
+                        "The available default types are: BigDecimal, Boolean, Date, Double, Integer, Long and String."
                     type: string
 info:
+    description:
+        "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
+        'com.liferay.object.admin.rest.client', and version '1.0.0'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/DuplicateObjectDefinitionNameExceptionMapper.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/DuplicateObjectDefinitionNameExceptionMapper.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.DuplicateObjectDefinitionException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Gamarra
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Object.Admin.REST.DuplicateObjectDefinitionNameExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class DuplicateObjectDefinitionNameExceptionMapper
+	extends BaseExceptionMapper<DuplicateObjectDefinitionException> {
+
+	@Override
+	protected Problem getProblem(
+		DuplicateObjectDefinitionException duplicateObjectDefinitionException) {
+
+		return new Problem(
+			Response.Status.BAD_REQUEST,
+			duplicateObjectDefinitionException.getMessage());
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/ObjectDefinitionNameExceptionMapper.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/ObjectDefinitionNameExceptionMapper.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.ObjectDefinitionNameException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Gamarra
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Object.Admin.REST.ObjectDefinitionNameExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class ObjectDefinitionNameExceptionMapper
+	extends BaseExceptionMapper<ObjectDefinitionNameException> {
+
+	@Override
+	protected Problem getProblem(
+		ObjectDefinitionNameException objectDefinitionNameException) {
+
+		return new Problem(
+			Response.Status.BAD_REQUEST,
+			objectDefinitionNameException.getMessage());
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/ObjectFieldNameExceptionMapper.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/ObjectFieldNameExceptionMapper.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.ObjectFieldNameException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Gamarra
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Object.Admin.REST.ObjectFieldNameExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class ObjectFieldNameExceptionMapper
+	extends BaseExceptionMapper<ObjectFieldNameException> {
+
+	@Override
+	protected Problem getProblem(
+		ObjectFieldNameException objectFieldNameException) {
+
+		return new Problem(
+			Response.Status.BAD_REQUEST, objectFieldNameException.getMessage());
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -84,8 +84,6 @@ public class ObjectDefinitionResourceImpl
 
 		return new ObjectField() {
 			{
-				dateCreated = objectField.getCreateDate();
-				dateModified = objectField.getModifiedDate();
 				id = objectField.getObjectFieldId();
 				indexed = objectField.getIndexed();
 				indexedAsKeyword = objectField.getIndexedAsKeyword();

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -102,7 +102,7 @@ public class ObjectDefinitionResourceImpl
 				dateCreated = objectDefinition.getCreateDate();
 				dateModified = objectDefinition.getModifiedDate();
 				id = objectDefinition.getObjectDefinitionId();
-				name = objectDefinition.getName();
+				name = objectDefinition.getShortName();
 				objectFields = transformToArray(
 					_objectFieldLocalService.getObjectFields(
 						objectDefinition.getObjectDefinitionId()),

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.0'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/object/object-admin-rest-test/bnd.bnd
+++ b/modules/apps/object/object-admin-rest-test/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Object Admin REST Test
+Bundle-SymbolicName: com.liferay.object.admin.rest.test
+Bundle-Version: 1.0.0
+-includeresource: com.liferay.object.admin.rest.client.jar=com.liferay.object.admin.rest.client-*.jar;lib:=true

--- a/modules/apps/object/object-admin-rest-test/build.gradle
+++ b/modules/apps/object/object-admin-rest-test/build.gradle
@@ -1,0 +1,14 @@
+dependencies {
+	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.10.3"
+	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.10.3"
+	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.10.5.1"
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "commons-beanutils", name: "commons-beanutils", version: "1.9.4"
+	testIntegrationCompile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	testIntegrationCompile project(":apps:object:object-admin-rest-api")
+	testIntegrationCompile project(":apps:object:object-admin-rest-client")
+	testIntegrationCompile project(":apps:object:object-api")
+	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")
+	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")
+	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
@@ -1,0 +1,1000 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.object.admin.rest.client.dto.v1_0.ObjectDefinition;
+import com.liferay.object.admin.rest.client.http.HttpInvoker;
+import com.liferay.object.admin.rest.client.pagination.Page;
+import com.liferay.object.admin.rest.client.resource.v1_0.ObjectDefinitionResource;
+import com.liferay.object.admin.rest.client.serdes.v1_0.ObjectDefinitionSerDes;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+
+import java.text.DateFormat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+
+import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.lang.time.DateUtils;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public abstract class BaseObjectDefinitionResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_objectDefinitionResource.setContextCompany(testCompany);
+
+		ObjectDefinitionResource.Builder builder =
+			ObjectDefinitionResource.builder();
+
+		objectDefinitionResource = builder.authentication(
+			"test@liferay.com", "test"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+
+		ObjectDefinition objectDefinition1 = randomObjectDefinition();
+
+		String json = objectMapper.writeValueAsString(objectDefinition1);
+
+		ObjectDefinition objectDefinition2 = ObjectDefinitionSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(objectDefinition1, objectDefinition2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+
+		ObjectDefinition objectDefinition = randomObjectDefinition();
+
+		String json1 = objectMapper.writeValueAsString(objectDefinition);
+		String json2 = ObjectDefinitionSerDes.toJSON(objectDefinition);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		ObjectDefinition objectDefinition = randomObjectDefinition();
+
+		objectDefinition.setName(regex);
+
+		String json = ObjectDefinitionSerDes.toJSON(objectDefinition);
+
+		Assert.assertFalse(json.contains(regex));
+
+		objectDefinition = ObjectDefinitionSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, objectDefinition.getName());
+	}
+
+	@Test
+	public void testGetObjectDefinitionsPage() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
+	public void testGraphQLGetObjectDefinitionsPage() throws Exception {
+		GraphQLField graphQLField = new GraphQLField(
+			"objectDefinitions",
+			new HashMap<String, Object>() {
+				{
+					put("page", 1);
+					put("pageSize", 2);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
+
+		JSONObject objectDefinitionsJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(graphQLField), "JSONObject/data",
+			"JSONObject/objectDefinitions");
+
+		Assert.assertEquals(0, objectDefinitionsJSONObject.get("totalCount"));
+
+		ObjectDefinition objectDefinition1 =
+			testGraphQLObjectDefinition_addObjectDefinition();
+		ObjectDefinition objectDefinition2 =
+			testGraphQLObjectDefinition_addObjectDefinition();
+
+		objectDefinitionsJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(graphQLField), "JSONObject/data",
+			"JSONObject/objectDefinitions");
+
+		Assert.assertEquals(2, objectDefinitionsJSONObject.get("totalCount"));
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(objectDefinition1, objectDefinition2),
+			Arrays.asList(
+				ObjectDefinitionSerDes.toDTOs(
+					objectDefinitionsJSONObject.getString("items"))));
+	}
+
+	@Test
+	public void testPostObjectDefinition() throws Exception {
+		ObjectDefinition randomObjectDefinition = randomObjectDefinition();
+
+		ObjectDefinition postObjectDefinition =
+			testPostObjectDefinition_addObjectDefinition(
+				randomObjectDefinition);
+
+		assertEquals(randomObjectDefinition, postObjectDefinition);
+		assertValid(postObjectDefinition);
+	}
+
+	protected ObjectDefinition testPostObjectDefinition_addObjectDefinition(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testDeleteObjectDefinition() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ObjectDefinition objectDefinition =
+			testDeleteObjectDefinition_addObjectDefinition();
+
+		assertHttpResponseStatusCode(
+			204,
+			objectDefinitionResource.deleteObjectDefinitionHttpResponse(
+				objectDefinition.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			objectDefinitionResource.getObjectDefinitionHttpResponse(
+				objectDefinition.getId()));
+
+		assertHttpResponseStatusCode(
+			404, objectDefinitionResource.getObjectDefinitionHttpResponse(0L));
+	}
+
+	protected ObjectDefinition testDeleteObjectDefinition_addObjectDefinition()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLDeleteObjectDefinition() throws Exception {
+		ObjectDefinition objectDefinition =
+			testGraphQLObjectDefinition_addObjectDefinition();
+
+		Assert.assertTrue(
+			JSONUtil.getValueAsBoolean(
+				invokeGraphQLMutation(
+					new GraphQLField(
+						"deleteObjectDefinition",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"objectDefinitionId",
+									objectDefinition.getId());
+							}
+						})),
+				"JSONObject/data", "Object/deleteObjectDefinition"));
+
+		JSONArray errorsJSONArray = JSONUtil.getValueAsJSONArray(
+			invokeGraphQLQuery(
+				new GraphQLField(
+					"objectDefinition",
+					new HashMap<String, Object>() {
+						{
+							put("objectDefinitionId", objectDefinition.getId());
+						}
+					},
+					new GraphQLField("id"))),
+			"JSONArray/errors");
+
+		Assert.assertTrue(errorsJSONArray.length() > 0);
+	}
+
+	@Test
+	public void testGetObjectDefinition() throws Exception {
+		ObjectDefinition postObjectDefinition =
+			testGetObjectDefinition_addObjectDefinition();
+
+		ObjectDefinition getObjectDefinition =
+			objectDefinitionResource.getObjectDefinition(
+				postObjectDefinition.getId());
+
+		assertEquals(postObjectDefinition, getObjectDefinition);
+		assertValid(getObjectDefinition);
+	}
+
+	protected ObjectDefinition testGetObjectDefinition_addObjectDefinition()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetObjectDefinition() throws Exception {
+		ObjectDefinition objectDefinition =
+			testGraphQLObjectDefinition_addObjectDefinition();
+
+		Assert.assertTrue(
+			equals(
+				objectDefinition,
+				ObjectDefinitionSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"objectDefinition",
+								new HashMap<String, Object>() {
+									{
+										put(
+											"objectDefinitionId",
+											objectDefinition.getId());
+									}
+								},
+								getGraphQLFields())),
+						"JSONObject/data", "Object/objectDefinition"))));
+	}
+
+	@Test
+	public void testGraphQLGetObjectDefinitionNotFound() throws Exception {
+		Long irrelevantObjectDefinitionId = RandomTestUtil.randomLong();
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"objectDefinition",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"objectDefinitionId",
+									irrelevantObjectDefinitionId);
+							}
+						},
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	protected ObjectDefinition testGraphQLObjectDefinition_addObjectDefinition()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		ObjectDefinition objectDefinition1,
+		ObjectDefinition objectDefinition2) {
+
+		Assert.assertTrue(
+			objectDefinition1 + " does not equal " + objectDefinition2,
+			equals(objectDefinition1, objectDefinition2));
+	}
+
+	protected void assertEquals(
+		List<ObjectDefinition> objectDefinitions1,
+		List<ObjectDefinition> objectDefinitions2) {
+
+		Assert.assertEquals(
+			objectDefinitions1.size(), objectDefinitions2.size());
+
+		for (int i = 0; i < objectDefinitions1.size(); i++) {
+			ObjectDefinition objectDefinition1 = objectDefinitions1.get(i);
+			ObjectDefinition objectDefinition2 = objectDefinitions2.get(i);
+
+			assertEquals(objectDefinition1, objectDefinition2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<ObjectDefinition> objectDefinitions1,
+		List<ObjectDefinition> objectDefinitions2) {
+
+		Assert.assertEquals(
+			objectDefinitions1.size(), objectDefinitions2.size());
+
+		for (ObjectDefinition objectDefinition1 : objectDefinitions1) {
+			boolean contains = false;
+
+			for (ObjectDefinition objectDefinition2 : objectDefinitions2) {
+				if (equals(objectDefinition1, objectDefinition2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				objectDefinitions2 + " does not contain " + objectDefinition1,
+				contains);
+		}
+	}
+
+	protected void assertValid(ObjectDefinition objectDefinition)
+		throws Exception {
+
+		boolean valid = true;
+
+		if (objectDefinition.getDateCreated() == null) {
+			valid = false;
+		}
+
+		if (objectDefinition.getDateModified() == null) {
+			valid = false;
+		}
+
+		if (objectDefinition.getId() == null) {
+			valid = false;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (objectDefinition.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (objectDefinition.getName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("objectFields", additionalAssertFieldName)) {
+				if (objectDefinition.getObjectFields() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<ObjectDefinition> page) {
+		boolean valid = false;
+
+		java.util.Collection<ObjectDefinition> objectDefinitions =
+			page.getItems();
+
+		int size = objectDefinitions.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (Field field :
+				getDeclaredFields(
+					com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition.
+						class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		ObjectDefinition objectDefinition1,
+		ObjectDefinition objectDefinition2) {
+
+		if (objectDefinition1 == objectDefinition2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!equals(
+						(Map)objectDefinition1.getActions(),
+						(Map)objectDefinition2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateCreated", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						objectDefinition1.getDateCreated(),
+						objectDefinition2.getDateCreated())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateModified", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						objectDefinition1.getDateModified(),
+						objectDefinition2.getDateModified())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						objectDefinition1.getId(), objectDefinition2.getId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						objectDefinition1.getName(),
+						objectDefinition2.getName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("objectFields", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						objectDefinition1.getObjectFields(),
+						objectDefinition2.getObjectFields())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected Field[] getDeclaredFields(Class clazz) throws Exception {
+		Stream<Field> stream = Stream.of(
+			ReflectionUtil.getDeclaredFields(clazz));
+
+		return stream.filter(
+			field -> !field.isSynthetic()
+		).toArray(
+			Field[]::new
+		);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_objectDefinitionResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_objectDefinitionResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		java.util.Collection<EntityField> entityFields = getEntityFields();
+
+		Stream<EntityField> stream = entityFields.stream();
+
+		return stream.filter(
+			entityField ->
+				Objects.equals(entityField.getType(), type) &&
+				!ArrayUtil.contains(
+					getIgnoredEntityFieldNames(), entityField.getName())
+		).collect(
+			Collectors.toList()
+		);
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		ObjectDefinition objectDefinition) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("dateCreated")) {
+			if (operator.equals("between")) {
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(
+					_dateFormat.format(
+						DateUtils.addSeconds(
+							objectDefinition.getDateCreated(), -2)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(
+					_dateFormat.format(
+						DateUtils.addSeconds(
+							objectDefinition.getDateCreated(), 2)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(
+					_dateFormat.format(objectDefinition.getDateCreated()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("dateModified")) {
+			if (operator.equals("between")) {
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(
+					_dateFormat.format(
+						DateUtils.addSeconds(
+							objectDefinition.getDateModified(), -2)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(
+					_dateFormat.format(
+						DateUtils.addSeconds(
+							objectDefinition.getDateModified(), 2)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(
+					_dateFormat.format(objectDefinition.getDateModified()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("id")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("name")) {
+			sb.append("'");
+			sb.append(String.valueOf(objectDefinition.getName()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("objectFields")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path("http://localhost:8080/o/graphql");
+		httpInvoker.userNameAndPassword("test@liferay.com:test");
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected ObjectDefinition randomObjectDefinition() throws Exception {
+		return new ObjectDefinition() {
+			{
+				dateCreated = RandomTestUtil.nextDate();
+				dateModified = RandomTestUtil.nextDate();
+				id = RandomTestUtil.randomLong();
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected ObjectDefinition randomIrrelevantObjectDefinition()
+		throws Exception {
+
+		ObjectDefinition randomIrrelevantObjectDefinition =
+			randomObjectDefinition();
+
+		return randomIrrelevantObjectDefinition;
+	}
+
+	protected ObjectDefinition randomPatchObjectDefinition() throws Exception {
+		return randomObjectDefinition();
+	}
+
+	protected ObjectDefinitionResource objectDefinitionResource;
+	protected Group irrelevantGroup;
+	protected Company testCompany;
+	protected Group testGroup;
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseObjectDefinitionResourceTestCase.class);
+
+	private static BeanUtilsBean _beanUtilsBean = new BeanUtilsBean() {
+
+		@Override
+		public void copyProperty(Object bean, String name, Object value)
+			throws IllegalAccessException, InvocationTargetException {
+
+			if (value != null) {
+				super.copyProperty(bean, name, value);
+			}
+		}
+
+	};
+	private static DateFormat _dateFormat;
+
+	@Inject
+	private com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource
+		_objectDefinitionResource;
+
+}

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -20,6 +20,8 @@ import com.liferay.object.admin.rest.client.dto.v1_0.ObjectField;
 import com.liferay.object.admin.rest.client.pagination.Page;
 import com.liferay.object.admin.rest.client.pagination.Pagination;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.test.rule.Inject;
 
 import org.junit.After;
@@ -54,7 +56,7 @@ public class ObjectDefinitionResourceTest
 			objectDefinitionResource.getObjectDefinitionsPage(
 				Pagination.of(1, 10));
 
-		Assert.assertEquals(0, objectDefinitionsPage.getTotalCount());
+		long totalCount = objectDefinitionsPage.getTotalCount();
 
 		_addObjectDefinition(randomObjectDefinition());
 
@@ -62,7 +64,31 @@ public class ObjectDefinitionResourceTest
 			objectDefinitionResource.getObjectDefinitionsPage(
 				Pagination.of(1, 10));
 
-		Assert.assertEquals(1, objectDefinitionsPage.getTotalCount());
+		Assert.assertEquals(
+			totalCount + 1, objectDefinitionsPage.getTotalCount());
+	}
+
+	@Override
+	@Test
+	public void testGraphQLGetObjectDefinitionsPage() throws Exception {
+		GraphQLField graphQLField = new GraphQLField(
+			"objectDefinitions", new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
+
+		JSONObject objectDefinitionsJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(graphQLField), "JSONObject/data",
+			"JSONObject/objectDefinitions");
+
+		int totalCount = (int)objectDefinitionsJSONObject.get("totalCount");
+
+		testGraphQLObjectDefinition_addObjectDefinition();
+
+		objectDefinitionsJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(graphQLField), "JSONObject/data",
+			"JSONObject/objectDefinitions");
+
+		Assert.assertEquals(
+			totalCount + 1, objectDefinitionsJSONObject.get("totalCount"));
 	}
 
 	public ObjectDefinition objectDefinition;

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.admin.rest.client.dto.v1_0.ObjectDefinition;
+import com.liferay.object.admin.rest.client.dto.v1_0.ObjectField;
+import com.liferay.object.admin.rest.client.pagination.Page;
+import com.liferay.object.admin.rest.client.pagination.Pagination;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.portal.test.rule.Inject;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Javier Gamarra
+ */
+@RunWith(Arquillian.class)
+public class ObjectDefinitionResourceTest
+	extends BaseObjectDefinitionResourceTestCase {
+
+	@After
+	@Override
+	public void tearDown() {
+		if (objectDefinition != null) {
+			try {
+				_objectDefinitionLocalService.deleteObjectDefinition(
+					objectDefinition.getId());
+			}
+			catch (Exception exception) {
+			}
+		}
+	}
+
+	@Override
+	@Test
+	public void testGetObjectDefinitionsPage() throws Exception {
+		Page<ObjectDefinition> objectDefinitionsPage =
+			objectDefinitionResource.getObjectDefinitionsPage(
+				Pagination.of(1, 10));
+
+		Assert.assertEquals(0, objectDefinitionsPage.getTotalCount());
+
+		_addObjectDefinition(randomObjectDefinition());
+
+		objectDefinitionsPage =
+			objectDefinitionResource.getObjectDefinitionsPage(
+				Pagination.of(1, 10));
+
+		Assert.assertEquals(1, objectDefinitionsPage.getTotalCount());
+	}
+
+	public ObjectDefinition objectDefinition;
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {"name"};
+	}
+
+	@Override
+	protected ObjectDefinition randomObjectDefinition() throws Exception {
+		ObjectDefinition objectDefinition = super.randomObjectDefinition();
+
+		objectDefinition.setName("A" + objectDefinition.getName());
+
+		ObjectField objectField = new ObjectField();
+
+		objectField.setName("column");
+		objectField.setType("String");
+
+		objectDefinition.setObjectFields(new ObjectField[] {objectField});
+
+		return objectDefinition;
+	}
+
+	@Override
+	protected ObjectDefinition testDeleteObjectDefinition_addObjectDefinition()
+		throws Exception {
+
+		return _addObjectDefinition(randomObjectDefinition());
+	}
+
+	@Override
+	protected ObjectDefinition testGetObjectDefinition_addObjectDefinition()
+		throws Exception {
+
+		return _addObjectDefinition(randomObjectDefinition());
+	}
+
+	@Override
+	protected ObjectDefinition testGraphQLObjectDefinition_addObjectDefinition()
+		throws Exception {
+
+		return _addObjectDefinition(randomObjectDefinition());
+	}
+
+	@Override
+	protected ObjectDefinition testPostObjectDefinition_addObjectDefinition(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		return _addObjectDefinition(objectDefinition);
+	}
+
+	private ObjectDefinition _addObjectDefinition(
+			ObjectDefinition randomObjectDefinition)
+		throws Exception {
+
+		objectDefinition = objectDefinitionResource.postObjectDefinition(
+			randomObjectDefinition);
+
+		return objectDefinition;
+	}
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -16,7 +16,6 @@ package com.liferay.object.rest.internal.resource.v1_0;
 
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
-import com.liferay.object.rest.internal.dto.v1_0.converter.ObjectEntryDTOConverter;
 import com.liferay.object.rest.internal.odata.entity.v1_0.ObjectEntryEntityModel;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.resource.v1_0.ObjectEntryResource;
@@ -181,9 +180,6 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Reference
-	private ObjectEntryDTOConverter _objectEntryDTOConverter;
 
 	@Reference
 	private ObjectEntryManager _objectEntryManager;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
@@ -314,6 +314,10 @@ public class SearchUtil {
 		SearchResponse searchResponse =
 			(SearchResponse)searchContext.getAttribute("search.response");
 
+		if (searchResponse == null) {
+			return new ArrayList<>();
+		}
+
 		Map<String, AggregationResult> aggregationResultsMap =
 			searchResponse.getAggregationResultsMap();
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -389,13 +389,6 @@ public class RESTBuilder {
 			return yamlString;
 		}
 
-		String clientVersion = clientVersionOptional.get();
-
-		String clientMessage = StringBundler.concat(
-			"A Java client JAR is available for use with the group ID '",
-			clientMavenGroupId, "', artifact ID '",
-			_configYAML.getApiPackagePath(), ".client', and version '");
-
 		OpenAPIYAML openAPIYAML = _loadOpenAPIYAML(yamlString);
 
 		Info info = openAPIYAML.getInfo();
@@ -403,8 +396,15 @@ public class RESTBuilder {
 		String description = info.getDescription();
 
 		if (description == null) {
-			description = "";
+			return yamlString;
 		}
+
+		String clientVersion = clientVersionOptional.get();
+
+		String clientMessage = StringBundler.concat(
+			"A Java client JAR is available for use with the group ID '",
+			clientMavenGroupId, "', artifact ID '",
+			_configYAML.getApiPackagePath(), ".client', and version '");
 
 		if (description.contains(clientMessage)) {
 			description = StringUtil.removeSubstring(


### PR DESCRIPTION
Several things in this PR related to Object Admin APIs:

- Remove dates in ObjectFields as they don't provide a lot of information
- Add documentation to reflect the basic types that we can create
- Exception Mappers to return BAD_REQUEST instead of SERVER_ERROR because the User always is the problem
- Client and test project
- Small fix to not crash when description is not set in the OpenAPI profile