### PR TITLE
LPS-135047 log exception and return more information for Jackson parsing exceptions

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/InvalidFormatExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/InvalidFormatExceptionMapper.java
@@ -18,6 +18,8 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
 
@@ -40,6 +42,10 @@ public class InvalidFormatExceptionMapper
 	protected Problem getProblem(
 		InvalidFormatException invalidFormatException) {
 
+		if (_log.isDebugEnabled()) {
+			_log.debug(invalidFormatException, invalidFormatException);
+		}
+
 		List<JsonMappingException.Reference> references =
 			invalidFormatException.getPath();
 
@@ -58,7 +64,12 @@ public class InvalidFormatExceptionMapper
 			invalidFormatException.getValue(), "\" to class \"",
 			clazz.getSimpleName(), "\"");
 
-		return new Problem(Response.Status.BAD_REQUEST, message);
+		return new Problem(
+			invalidFormatException.getLocalizedMessage(),
+			Response.Status.BAD_REQUEST, message, "InvalidFormat");
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		InvalidFormatExceptionMapper.class);
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/JsonMappingExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/JsonMappingExceptionMapper.java
@@ -16,6 +16,8 @@ package com.liferay.portal.vulcan.internal.jaxrs.exception.mapper;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
 
@@ -36,6 +38,10 @@ public class JsonMappingExceptionMapper
 
 	@Override
 	protected Problem getProblem(JsonMappingException jsonMappingException) {
+		if (_log.isDebugEnabled()) {
+			_log.debug(jsonMappingException, jsonMappingException);
+		}
+
 		List<JsonMappingException.Reference> references =
 			jsonMappingException.getPath();
 
@@ -48,7 +54,12 @@ public class JsonMappingExceptionMapper
 		);
 
 		return new Problem(
-			Response.Status.BAD_REQUEST, "Unable to map JSON path: " + path);
+			jsonMappingException.getLocalizedMessage(),
+			Response.Status.BAD_REQUEST, "Unable to map JSON path: " + path,
+			"JsonMappingException");
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JsonMappingExceptionMapper.class);
 
 }


### PR DESCRIPTION
Add more information to track these 2 internal exceptions because they can be very hard to pinpoint (see https://liferay-community.slack.com/archives/C5H30KZ1A/p1625093482041500 in the community slack).