### PR TITLE
LPS-134687 | LPS-134777 Update liferay-ckeditor 4.16.1-liferay.2

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"ckeditor4-react": "1.4.2",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.16.1-liferay.1",
+		"liferay-ckeditor": "4.16.1-liferay.2",
 		"prop-types": "15.7.2"
 	},
 	"main": "index.js",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -9541,10 +9541,10 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
-liferay-ckeditor@4.16.1-liferay.1:
-  version "4.16.1-liferay.1"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.16.1-liferay.1.tgz#f359a29f47b71bd3736a27f0bd5ec8e7c5539da6"
-  integrity sha512-HwK8xdKSjWVP9acsP+qIOzPRlcSQA3Pj7EPTK7AwdMQmPzZBUghimyoQtiiXXyJwOWwe5yiGrE4lmvfhiy/5xw==
+liferay-ckeditor@4.16.1-liferay.2:
+  version "4.16.1-liferay.2"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.16.1-liferay.2.tgz#b3dfbaa2fc8c873393e107fb10c9c451cfefd40e"
+  integrity sha512-hL2JOoUSBphtBn/5rfmE9rCRFfZKWPhZFcDU/t7kA7iDpxxaQ/j/2PIkSicYfRnX/fIZymXK+dIbF5M/HvFszw==
 
 liferay-font-awesome@3.4.0:
   version "3.4.0"


### PR DESCRIPTION
It includes fixes to the following tickets: 

https://issues.liferay.com/browse/LPS-134687
https://issues.liferay.com/browse/LPS-134777

Changelog:

## [v4.16.1-liferay.2](https://github.com/liferay/liferay-ckeditor/tree/v4.16.1-liferay.2) (2021-07-05)

[Full changelog](https://github.com/liferay/liferay-ckeditor/compare/v4.16.1-liferay.1...v4.16.1-liferay.2)

### :wrench: Bug fixes

-   fix: retrieve hspace and vspace values from style ([\#183](https://github.com/liferay/liferay-ckeditor/pull/183))
-   fix: enable browser native menu in codemirror plugin ([\#181](https://github.com/liferay/liferay-ckeditor/pull/181))