### PR TITLE
LPS-134678 DM Management toolbar Clear button doesn't completely clear

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -186,7 +186,8 @@ const SelectionControls = ({
 									href={clearSelectionURL}
 									onClick={(event) => {
 										searchContainerRef.current?.select?.toggleAllRows(
-											false
+											false,
+											true
 										);
 
 										setActive(false);


### PR DESCRIPTION
Hi @liferay-frontend,

This PR fixes a problem with the `Clear` button on the management toolbar of Documents and media.

https://issues.liferay.com/browse/LPS-134678

> When selecting multiple items in documents and media the Clear button produces a bug that in some cases doesn't de-select some of the items.

**How to test it**

1. Go to documents and media
2. Upload multiple documents or images to fill different pages 
3. Select 1 item on the first page using the checkbox in the card
4. Navigate to another page of the documents (page 2 for example)
5. Select some items
6. Click on the "Clear" action
7. Go back to Page 1

**Before this PR:**
The first item that was selected is still selected

https://user-images.githubusercontent.com/67901/124790587-91683900-df4b-11eb-947f-c443e974f9eb.mp4

**After this PR:**
The whole selection should've been cleared

https://user-images.githubusercontent.com/67901/124790808-c6748b80-df4b-11eb-8e4f-8e21c67d6511.mp4

---

I'm assuming when the `Clear` button is rendered, we always want to clear all items in the search container.

Could you please check my PR?
