### PR TITLE
LPS-135278 Return language key directly if we cannot translate it

### DIFF
--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/json/JSONLocalizer.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/json/JSONLocalizer.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -107,8 +108,10 @@ public class JSONLocalizer {
 					try {
 						map.put(
 							key,
-							ResourceBundleUtil.getString(
-								resourceBundle, value));
+							GetterUtil.getString(
+								ResourceBundleUtil.getString(
+									resourceBundle, value),
+								value));
 					}
 					catch (MissingResourceException missingResourceException) {
 						if (_log.isWarnEnabled()) {


### PR DESCRIPTION
Return language key directly if we cannot translate it

In order to test this, you can add a new token into [classic theme token definition](https://github.com/liferay/liferay-portal/blob/13ca8965caad5ae1a87d3b3cef751cbbd744e8ac/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json#L21-L24) with an invalid label, e.g. "hola que tal". Without this change the label is not displayed in the stylebook app


