### PR TITLE
LPS-135364 CKEditor cell properties missing options in blogs

### DIFF
--- a/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
+++ b/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
@@ -106,8 +106,10 @@ public class BlogsContentEditorConfigContributor
 	}
 
 	private String _getAllowedContentTable() {
-		return "table[border, cellpadding, cellspacing] {width}; tbody td " +
-			"th[scope]; thead tr[scope];";
+		return StringBundler.concat(
+			"col[span]; colgroup[span]; table[border, cellpadding, ",
+			"cellspacing]{width}; tbody td[colspan, headers, rowspan]{*}; ",
+			"th[abbr, colspan, headers, rowspan, scope, sorted]{*}; thead tr;");
 	}
 
 	private String _getAllowedContentText() {


### PR DESCRIPTION
### Steps to reproduce

1. Set the following in portal-ext.properties to switch the editor to blogs
```properties
editor.wysiwyg.portal-web.docroot.html.portlet.blogs.edit_entry.jsp=ckeditor
```
2. Start up Liferay
3. Navigate to to Blogs
4. Click on + icon to create a new blog
5. See the ckeditor in blog content
6. Add table of any number of rows and columns
7. Click inside of a cell, and right click to load the context menu
8. Select cell -> cell properties

**Expected Behavior**:
The CKeditor still has the cell property functionality that it did in dxp-12-7110 and earlier

**Actual Behavior**:
The CKeditor has very limited cell property functionality.

### Solution overview

This was caused by a CKEditor upgrade, which includes a fix for the following issue:

https://github.com/ckeditor/ckeditor4/issues/1986

Looking at all the git blame for BlogsContentEditorConfigContributor, they were added in order to handle limitations related to alloyeditor, but BlogsContentEditorConfigContributor is used by multiple editor types.