### PR TITLE
LPS-135533 avoid replacing the categoryIds by the indexer

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
@@ -203,6 +203,18 @@ public class SearchUtil {
 	public static class SearchContext
 		extends com.liferay.portal.kernel.search.SearchContext {
 
+		@Override
+		public void addFacet(
+			com.liferay.portal.kernel.search.facet.Facet facet) {
+
+			Map<String, com.liferay.portal.kernel.search.facet.Facet> facets =
+				getFacets();
+
+			if (!facets.containsKey(facet.getFieldName())) {
+				super.addFacet(facet);
+			}
+		}
+
 		public void addVulcanAggregation(Aggregation aggregation) {
 			if ((aggregation == null) ||
 				(aggregation.getAggregationTerms() == null)) {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.8.0
+version 2.9.0


### PR DESCRIPTION
Category Ids Facets are being replaced by the indexer by a facet that does not return anything (a Multivalue facet, static true). This is clearly being done intentionally by reasons outside my understanding...

But I do not think changing that logic can go anywhere useful, it seems that it makes sense for some use cases. I used our context to avoid replacing the facets we set. Not ideal for sure.