### PR TITLE
LPS-135421 When styling a JSP, I want to easily refer to external style resources

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -23,6 +23,12 @@ DLAdminManagementToolbarDisplayContext dlAdminManagementToolbarDisplayContext = 
 DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisplayContext, request, renderRequest, renderResponse);
 %>
 
+<liferay-frontend:stylesheet bundle="com.liferay.frontend.taglib" css="example.css" />
+
+<div class="frontend_stylesheet_example">
+	EXAMPLE TEST THAT SHOULD BE RENDERED IN RED
+</div>
+
 <liferay-ui:success key='<%= portletDisplay.getId() + "requestProcessed" %>' message="your-request-completed-successfully" />
 
 <c:choose>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/internal/util/ServicesProvider.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/internal/util/ServicesProvider.java
@@ -17,14 +17,29 @@ package com.liferay.frontend.taglib.internal.util;
 import com.liferay.frontend.js.module.launcher.JSModuleLauncher;
 import com.liferay.frontend.js.module.launcher.JSModuleResolver;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.util.tracker.BundleTracker;
+import org.osgi.util.tracker.BundleTrackerCustomizer;
 
 /**
  * @author Iván Zaera Avellón
  */
 @Component(service = {})
 public class ServicesProvider {
+
+	public static Map<String, Bundle> getBundleMap() {
+		return _bundleConcurrentMap;
+	}
 
 	public static JSModuleLauncher getJSModuleLauncher() {
 		return _jsModuleLauncher;
@@ -44,6 +59,53 @@ public class ServicesProvider {
 		_jsModuleResolver = jsModuleResolver;
 	}
 
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleConcurrentMap = new ConcurrentHashMap<>();
+
+		_bundleTracker = new BundleTracker(
+			bundleContext, Bundle.ACTIVE,
+			new BundleTrackerCustomizer<String>() {
+
+				@Override
+				public String addingBundle(
+					Bundle bundle, BundleEvent bundleEvent) {
+
+					_bundleConcurrentMap.put(bundle.getSymbolicName(), bundle);
+
+					return bundle.getSymbolicName();
+				}
+
+				@Override
+				public void modifiedBundle(
+					Bundle bundle, BundleEvent bundleEvent,
+					String symbolicName) {
+				}
+
+				@Override
+				public void removedBundle(
+					Bundle bundle, BundleEvent bundleEvent,
+					String symbolicName) {
+
+					_bundleConcurrentMap.remove(symbolicName);
+				}
+
+			});
+
+		_bundleTracker.open();
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_bundleTracker.close();
+
+		_bundleTracker = null;
+
+		_bundleConcurrentMap = null;
+	}
+
+	private static ConcurrentMap<String, Bundle> _bundleConcurrentMap;
+	private static BundleTracker<String> _bundleTracker;
 	private static JSModuleLauncher _jsModuleLauncher;
 	private static JSModuleResolver _jsModuleResolver;
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTag.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.servlet.taglib;
+
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolverUtil;
+import com.liferay.frontend.js.module.launcher.JSModuleResolver;
+import com.liferay.frontend.taglib.internal.util.ServicesProvider;
+import com.liferay.taglib.util.AttributesTagSupport;
+
+import java.io.IOException;
+
+import java.util.Map;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+public class StylesheetTag extends AttributesTagSupport {
+
+	@Override
+	public int doEndTag() throws JspException {
+		JspWriter jspWriter = pageContext.getOut();
+
+		try {
+			Map<String, Bundle> bundleMap = ServicesProvider.getBundleMap();
+
+			Bundle bundle = bundleMap.get(_bundle);
+
+			if (bundle == null) {
+				throw new JspException("Unable to find bundle " + _bundle);
+			}
+
+			NPMResolver npmResolver = NPMResolverUtil.getNPMResolver(bundle);
+
+			JSModuleResolver jsModuleResolver =
+				ServicesProvider.getJSModuleResolver();
+
+			String moduleName = jsModuleResolver.resolveModule(bundle, _css);
+
+			String resolvedModuleName = npmResolver.resolveModuleName(
+				moduleName);
+
+			jspWriter.print("<script>Liferay.Loader.require('");
+			jspWriter.print(resolvedModuleName);
+			jspWriter.print("');</script>");
+		}
+		catch (IOException ioException) {
+			throw new JspException(ioException);
+		}
+
+		return EVAL_PAGE;
+	}
+
+	public void setBundle(String bundle) {
+		_bundle = bundle;
+	}
+
+	public void setCss(String css) {
+		_css = css;
+	}
+
+	private String _bundle;
+	private String _css;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -1479,6 +1479,22 @@
 		</attribute>
 	</tag>
 	<tag>
+		<description>Loads a CSS resource using the AMD loader.</description>
+		<name>stylesheet</name>
+		<tag-class>com.liferay.frontend.taglib.servlet.taglib.StylesheetTag</tag-class>
+		<body-content>empty</body-content>
+		<attribute>
+			<name>bundle</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>css</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+	<tag>
 		<description>Creates a UI component for managing translations of associated content.</description>
 		<name>translation-manager</name>
 		<tag-class>com.liferay.frontend.taglib.servlet.taglib.TranslationManagerTag</tag-class>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/example.css
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/example.css
@@ -1,0 +1,4 @@
+.frontend_stylesheet_example {
+	color: red;
+	font-weight: bold;
+}


### PR DESCRIPTION
This is a PoC for LPS-135421. 

It shows how the taglib would be implemented and used. 

Things to determine:

1. Whether to designate the CSS file by bundle name, servlet context name, both, ...
2. Where to put the taglib: I have used `liferay-frontend` but maybe there's a better place for it.
3. How to name the taglib: I named it `stylesheet` and in `<link rel="stylesheet"...`, but there may be better names.
4. What to do when referring to a CSS file that is inside a bundle without `Web-ContextPath` or AMD loader support.