### PR TITLE
[TS] LPS-135628 Allow CKEditor to set an empty text value

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -140,7 +140,7 @@ name = HtmlUtil.escapeJS(name);
 	var windowNode = A.getWin();
 
 	var instanceDataReady = false;
-	var instancePendingData;
+	var instancePendingData = null;
 
 	var getInitialContent = function () {
 		var data;
@@ -625,7 +625,7 @@ name = HtmlUtil.escapeJS(name);
 		});
 
 		ckEditor.on('dataReady', (event) => {
-			if (instancePendingData) {
+			if (instancePendingData !== null) {
 				var pendingData = instancePendingData;
 
 				instancePendingData = null;


### PR DESCRIPTION
[TS] LPS-135628 Allow CKEditor to set an empty text value, init instancePendingData with null and check if different than null to allow set up an empty text value.