### PR TITLE
LPS-135636 register a JSONObject serialiser and change object mapper …

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/ObjectMapperContextResolver.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/ObjectMapperContextResolver.java
@@ -18,7 +18,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.vulcan.internal.jaxrs.serializer.JSONArrayStdSerializer;
+import com.liferay.portal.vulcan.internal.jaxrs.serializer.JSONObjectStdSerializer;
 
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
@@ -41,6 +49,25 @@ public class ObjectMapperContextResolver
 			enable(SerializationFeature.INDENT_OUTPUT);
 			setDateFormat(new ISO8601DateFormat());
 			setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+
+			SimpleModule simpleModule = new SimpleModule();
+
+			simpleModule.addSerializer(
+				JSONArray.class, new JSONArrayStdSerializer(JSONArray.class));
+
+			simpleModule.addSerializer(
+				JSONObject.class,
+				new JSONObjectStdSerializer(JSONObject.class));
+
+			registerModule(simpleModule);
+
+			SimpleFilterProvider simpleFilterProvider =
+				new SimpleFilterProvider();
+
+			simpleFilterProvider.addFilter(
+				"Liferay.Vulcan", SimpleBeanPropertyFilter.serializeAll());
+
+			setFilterProvider(simpleFilterProvider);
 		}
 	};
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyWriter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyWriter.java
@@ -15,16 +15,13 @@
 package com.liferay.portal.vulcan.internal.jaxrs.message.body;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.PropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
-import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.vulcan.fields.FieldsQueryParam;
 import com.liferay.portal.vulcan.fields.RestrictFieldsQueryParam;
 import com.liferay.portal.vulcan.internal.jackson.databind.ser.VulcanPropertyFilter;
-import com.liferay.portal.vulcan.internal.jaxrs.serializer.JSONArrayStdSerializer;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -76,13 +73,6 @@ public abstract class BaseMessageBodyWriter
 		throws IOException, WebApplicationException {
 
 		ObjectMapper objectMapper = _getObjectMapper(clazz);
-
-		SimpleModule simpleModule = new SimpleModule();
-
-		simpleModule.addSerializer(
-			JSONArray.class, new JSONArrayStdSerializer(JSONArray.class));
-
-		objectMapper.registerModule(simpleModule);
 
 		objectMapper.writer(
 			_getSimpleFilterProvider()

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/serializer/JSONObjectStdSerializer.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/serializer/JSONObjectStdSerializer.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import com.liferay.portal.kernel.json.JSONObject;
+
+import java.io.IOException;
+
+/**
+ * @author Javier Gamarra
+ */
+public class JSONObjectStdSerializer extends StdSerializer<JSONObject> {
+
+	public JSONObjectStdSerializer(Class<JSONObject> clazz) {
+		super(clazz);
+	}
+
+	@Override
+	public void serialize(
+			JSONObject jsonObject, JsonGenerator jsonGenerator,
+			SerializerProvider serializerProvider)
+		throws IOException {
+
+		jsonGenerator.writeStartObject();
+
+		for (String key : jsonObject.keySet()) {
+			serializerProvider.defaultSerializeField(
+				key, jsonObject.get(key), jsonGenerator);
+		}
+
+		jsonGenerator.writeEndObject();
+	}
+
+}


### PR DESCRIPTION
…to register by default a filter and also the mappers.

Several things here:

- Register a default "Liferay.Vulcan". Oh YES. I should have done this 2 years ago. We override the filter later if users use our body writers. But if they didn't because they registered a custom serializer (as JSONArrayStd/JSONObject) or they used another format that wasn't json/xml... everything would fail. They could not return our entities because they need that filter and they don't know how to provide one.
- Change where we register the modules. I don't know, I don't think it's a good idea to register things after creating the ObjectMapper in the body writers. We get into concurrency problems. I removed some conditional registration some weeks ago and I now move the modules. The JSONArray that I write (I don't remember why, I guess it was because a bug with some ugly API somewhere) was working intermittently. After moving, everything is solved.
- Register a JSONObject serializers:

This has caused me HOURS of sweating until I found the right line: 

> serializerProvider.defaultSerializeField(key, jsonObject.get(key), jsonGenerator);

Everything in the internet or Stack Overflow is a lie, this is only what serializes using existing registered serializers.