### PR TITLE
LPS-135683 Pending messages are not shown in Questions App with default filter

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
@@ -40,6 +40,7 @@ import com.liferay.message.boards.service.MBThreadFlagLocalService;
 import com.liferay.message.boards.service.MBThreadLocalService;
 import com.liferay.message.boards.service.MBThreadService;
 import com.liferay.message.boards.settings.MBGroupServiceSettings;
+import com.liferay.message.boards.util.comparator.ThreadCreateDateComparator;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -190,7 +191,8 @@ public class MessageBoardThreadResourceImpl
 						new QueryDefinition<>(
 							status, contextUser.getUserId(), true,
 							pagination.getStartPosition(),
-							pagination.getEndPosition(), null)),
+							pagination.getEndPosition(),
+							new ThreadCreateDateComparator())),
 					this::_toMessageBoardThread),
 				pagination,
 				_mbThreadService.getThreadsCount(

--- a/modules/apps/message-boards/message-boards-api/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Message Boards API
 Bundle-SymbolicName: com.liferay.message.boards.api
-Bundle-Version: 10.0.5
+Bundle-Version: 10.1.0
 Export-Package:\
 	com.liferay.message.boards.configuration,\
 	com.liferay.message.boards.constants,\

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/util/comparator/ThreadCreateDateComparator.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/util/comparator/ThreadCreateDateComparator.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.util.comparator;
+
+import com.liferay.message.boards.model.MBThread;
+import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.OrderByComparator;
+
+/**
+ * @author Javier de Arcos
+ */
+public class ThreadCreateDateComparator extends OrderByComparator<MBThread> {
+
+	public static final String ORDER_BY_ASC = "MBThread.createDate ASC";
+
+	public static final String[] ORDER_BY_CONDITION_FIELDS = {"createDate"};
+
+	public static final String ORDER_BY_DESC = "MBThread.createDate DESC";
+
+	public static final String[] ORDER_BY_FIELDS = {"createDate"};
+
+	public ThreadCreateDateComparator() {
+		this(false);
+	}
+
+	public ThreadCreateDateComparator(boolean ascending) {
+		_ascending = ascending;
+	}
+
+	@Override
+	public int compare(MBThread thread1, MBThread thread2) {
+		int value = DateUtil.compareTo(
+			thread1.getCreateDate(), thread2.getCreateDate());
+
+		if (_ascending) {
+			return value;
+		}
+
+		return -value;
+	}
+
+	@Override
+	public String getOrderBy() {
+		if (_ascending) {
+			return ORDER_BY_ASC;
+		}
+
+		return ORDER_BY_DESC;
+	}
+
+	@Override
+	public String[] getOrderByFields() {
+		return ORDER_BY_FIELDS;
+	}
+
+	@Override
+	public boolean isAscending() {
+		return _ascending;
+	}
+
+	private final boolean _ascending;
+
+}

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/util/comparator/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/util/comparator/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
@@ -238,7 +238,7 @@ export default withRouter(
 					!search &&
 					!keywords &&
 					!creatorId &&
-					!sort &&
+					(!sort || sort === 'dateCreated:desc') &&
 					!section.messageBoardSections.items.length &&
 					section.id !== 0
 				) {


### PR DESCRIPTION
Adding a default value in the sort getThreadCallback's parameter changes the query we used to get the threads from the backend, using the one that gets all the threads from a site and filters them by the sectionId. This makes the info was handled by elastic search, which doesn't take into account the pending messages.

Change the condition to use the correct query and add the create date ordering as default in the backend. This way the pending messages are returned again.