### PR TITLE
LRQA-68607 Use select function instead of click

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClaySelect.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClaySelect.testcase
@@ -80,14 +80,10 @@ definition {
 			key_label = "Regular Select Element",
 			locator1 = "ClaySamplePortlet#SELECTOR");
 
-		Click(
+		Select(
 			key_label = "Regular Select Element",
-			key_option = "Sample 1",
-			locator1 = "ClaySamplePortlet#SELECTOR_OPTION");
-
-		Click(
-			key_label = "Regular Select Element",
-			locator1 = "ClaySamplePortlet#SELECTOR");
+			locator1 = "ClaySamplePortlet#SELECTOR",
+			value1 = "Sample 1");
 
 		takeScreenshot();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-68607

Fix the Javascript error in test ClaySelect#SmokeRegularSelect:

`javascript error: Failed to execute 'elementsFromPoint' on 'Document': The provided double value is non-finite.
  (Session info: chrome=86.0.4240.111)
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
System info: host: 'cloud-10-0-13-74.lax.liferay.com', ip: '127.0.0.1', os.name: 'Linux', os.arch: 'amd64', os.version: '4.14.138-rancher', java.version: '1.8.0_121'
Driver info: org.openqa.selenium.chrome.ChromeDriver
Capabilities {acceptInsecureCerts: false, browserName: chrome, browserVersion: 86.0.4240.111, chrome: {chromedriverVersion: 86.0.4240.22 (398b0743353ff..., userDataDir: /tmp/.com.google.Chrome.xnp8tv}, goog:chromeOptions: {debuggerAddress: localhost:41137}, javascriptEnabled: true, networkConnectionEnabled: false, pageLoadStrategy: normal, platform: LINUX, platformName: LINUX, proxy: Proxy(), setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: ignore, webauthn:virtualAuthenticators: true}
Session ID: 5e360df69e432136c1b910feec172981`

This is for master only!