### PR TITLE
LPS-135565 Tooltips are erratic in sample balloon editor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -42,6 +42,7 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 		...config,
 		extraAllowedContent: '*',
 		extraPlugins: `${extraPlugins}${defaultExtraPlugins}`,
+		title: false,
 	};
 
 	return (

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -54,7 +54,7 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 
 				setCssClass(CKEDITOR.env.cssClass);
 
-				CKEDITOR.env.cssClass = `${CKEDITOR.env.cssClass} lfr-balloon-editor`;
+				CKEDITOR.env.cssClass = `${CKEDITOR.env.cssClass} lfr-balloon-editor lfr-tooltip-scope`;
 
 				CKEDITOR.getNextZIndex = function () {
 					return CKEDITOR.dialog._.currentZIndex


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-135565

Steps to reproduce:
1. Deploy `frontend-editor-ckeditor-sample-web`
2. See 'before' gif below

Before PR:
![before](https://user-images.githubusercontent.com/5435511/125938281-33e2ac43-7735-4085-99b7-37d9a6ffc2ed.gif)

After PR:
![after](https://user-images.githubusercontent.com/5435511/125938297-67fe57d7-82c8-42d8-a9ac-b13eecad71c9.gif)
