### PR TITLE
LPS-135821 required can not be null + LPS-135822 we have to publish after posting (otherwise is left in DRAFT status)

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/ObjectFieldTypeExceptionMapper.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/ObjectFieldTypeExceptionMapper.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.ObjectFieldTypeException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Gamarra
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Object.Admin.REST.ObjectFieldTypeExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class ObjectFieldTypeExceptionMapper
+	extends BaseExceptionMapper<ObjectFieldTypeException> {
+
+	@Override
+	protected Problem getProblem(
+		ObjectFieldTypeException objectFieldTypeException) {
+
+		return new Problem(
+			Response.Status.BAD_REQUEST, objectFieldTypeException.getMessage());
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -72,11 +72,18 @@ public class ObjectDefinitionResourceImpl
 			ObjectDefinition objectDefinition)
 		throws Exception {
 
+		com.liferay.object.model.ObjectDefinition
+			serviceBuilderObjectDefinition =
+				_objectDefinitionLocalService.addCustomObjectDefinition(
+					contextUser.getUserId(), objectDefinition.getName(),
+					transformToList(
+						objectDefinition.getObjectFields(),
+						this::_toObjectField));
+
 		return _toObjectDefinition(
-			_objectDefinitionLocalService.addCustomObjectDefinition(
-				contextUser.getUserId(), objectDefinition.getName(),
-				transformToList(
-					objectDefinition.getObjectFields(), this::_toObjectField)));
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				serviceBuilderObjectDefinition.getUserId(),
+				serviceBuilderObjectDefinition.getObjectDefinitionId()));
 	}
 
 	private static ObjectField _toObjectField(

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -126,7 +126,8 @@ public class ObjectDefinitionResourceImpl
 		serviceBuilderObjectField.setIndexedLanguageId(
 			objectField.getIndexedLanguageId());
 		serviceBuilderObjectField.setName(objectField.getName());
-		serviceBuilderObjectField.setRequired(objectField.getRequired());
+		serviceBuilderObjectField.setRequired(
+			GetterUtil.getBoolean(objectField.getRequired()));
 		serviceBuilderObjectField.setType(objectField.getType());
 
 		return serviceBuilderObjectField;


### PR DESCRIPTION
Simple fixes for the tests (required is boolean in service builder and Boolean in APIs and that is fine because DTOs have to be nullable to allow not passing the values in several cases) + now ObjectDefinition are created in draft mode, have to be published later.