### PR TITLE
LPS-135071 Use company WebId to solve conflict when two object definitions with same name are registered in multiple companies

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryOpenAPIApplication.java
+++ b/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryOpenAPIApplication.java
@@ -15,6 +15,8 @@
 package com.liferay.headless.discovery.internal.jaxrs.application;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
 
@@ -73,6 +75,18 @@ public class HeadlessDiscoveryOpenAPIApplication extends Application {
 		RuntimeDTO runtimeDTO = _jaxrsServiceRuntime.getRuntimeDTO();
 
 		for (ApplicationDTO applicationDTO : runtimeDTO.applicationDTOs) {
+			String name = applicationDTO.name;
+
+			if (StringUtil.startsWith(name, "O_")) {
+				String[] nameChunks = StringUtil.split(name, "_");
+
+				Long companyId = GetterUtil.getLong(nameChunks[1]);
+
+				if (_contextCompany.getCompanyId() != companyId) {
+					continue;
+				}
+			}
+
 			List<String> paths = new ArrayList<>();
 
 			String base = applicationDTO.base;
@@ -120,6 +134,9 @@ public class HeadlessDiscoveryOpenAPIApplication extends Application {
 			}
 		}
 	}
+
+	@Context
+	private Company _contextCompany;
 
 	@Reference
 	private JaxrsServiceRuntime _jaxrsServiceRuntime;

--- a/modules/apps/object/object-rest-impl/build.gradle
+++ b/modules/apps/object/object-rest-impl/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly project(":apps:headless:headless-delivery:headless-delivery-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:object:object-rest-api")
+	compileOnly project(":apps:portal-instances:portal-instances-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -60,6 +60,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					HashMapDictionaryBuilder.<String, Object>put(
 						"liferay.jackson", false
 					).put(
+						"liferay.object.definition.company.id",
+						objectDefinition.getCompanyId()
+					).put(
 						"liferay.object.definition.id",
 						objectDefinition.getObjectDefinitionId()
 					).put(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -22,13 +22,10 @@ import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectFie
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
-import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.util.CamelCaseUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOContributor;
 
@@ -59,19 +56,27 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	public List<ServiceRegistration<?>> deploy(
 		ObjectDefinition objectDefinition) {
 
-		String companyName = String.valueOf(objectDefinition.getCompanyId());
+		String namespace = "";
+		String restContextPath = objectDefinition.getRESTContextPath();
 
-		try {
-			Company company = _companyLocalService.getCompany(
-				objectDefinition.getCompanyId());
+		if (_companyLocalService.getCompaniesCount() > 1) {
+			String companyName = "o_" + objectDefinition.getCompanyId();
 
-			companyName = CamelCaseUtil.toCamelCase(
-				company.getName(), CharPool.SPACE);
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception, exception);
+			try {
+				Company company = _companyLocalService.getCompany(
+					objectDefinition.getCompanyId());
+
+				companyName = company.getWebId();
+				companyName = companyName.replaceAll("\\.", "_");
 			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(exception, exception);
+				}
+			}
+
+			namespace = companyName;
+			restContextPath = companyName + "/" + restContextPath;
 		}
 
 		_componentInstancesMap.put(
@@ -90,10 +95,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"liferay.object.definition.name",
 						objectDefinition.getShortName()
 					).put(
-						"osgi.jaxrs.application.base",
-						StringBundler.concat(
-							"/", companyName, "/",
-							objectDefinition.getRESTContextPath())
+						"osgi.jaxrs.application.base", restContextPath
 					).put(
 						"osgi.jaxrs.extension.select",
 						"(osgi.jaxrs.name=Liferay.Vulcan)"
@@ -142,13 +144,12 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					"osgi.jaxrs.extension", "true"
 				).put(
 					"osgi.jaxrs.name",
-					objectDefinition.getRESTContextPath() +
-						"RequiredObjectFieldExceptionMapper"
+					restContextPath + "RequiredObjectFieldExceptionMapper"
 				).build()),
 			_bundleContext.registerService(
 				GraphQLDTOContributor.class,
 				ObjectDefinitionGraphQLDTOContributor.of(
-					companyName, objectDefinition, _objectEntryManager,
+					namespace, objectDefinition, _objectEntryManager,
 					_objectFieldLocalService.getObjectFields(
 						objectDefinition.getObjectDefinitionId())),
 				HashMapDictionaryBuilder.<String, Object>put(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -62,6 +62,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"liferay.object.definition.id",
 						objectDefinition.getObjectDefinitionId()
 					).put(
+						"liferay.object.definition.db.table.name",
+						objectDefinition.getDBTableName()
+					).put(
 						"osgi.jaxrs.application.base",
 						"/" + objectDefinition.getRESTContextPath()
 					).put(
@@ -77,7 +80,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"batch.engine.task.item.delegate", "true"
 					).put(
 						"batch.engine.task.item.delegate.name",
-						objectDefinition.getShortName()
+						objectDefinition.getDBTableName()
 					).put(
 						"osgi.jaxrs.resource", "true"
 					).put(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -22,6 +22,7 @@ import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectFie
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.portal.instances.service.PortalInstancesLocalService;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -59,7 +60,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		String namespace = "";
 		String restContextPath = objectDefinition.getRESTContextPath();
 
-		if (_companyLocalService.getCompaniesCount() > 1) {
+		if ((_companyLocalService.getCompaniesCount() > 1) &&
+			(objectDefinition.getCompanyId() !=
+				_portalInstancesLocalService.getDefaultCompanyId())) {
+
 			String companyName = "o_" + objectDefinition.getCompanyId();
 
 			try {
@@ -201,5 +205,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Reference
+	private PortalInstancesLocalService _portalInstancesLocalService;
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -22,6 +22,7 @@ import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectFie
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOContributor;
 
@@ -62,16 +63,18 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"liferay.object.definition.id",
 						objectDefinition.getObjectDefinitionId()
 					).put(
-						"liferay.object.definition.db.table.name",
-						objectDefinition.getDBTableName()
+						"liferay.object.definition.name",
+						objectDefinition.getShortName()
 					).put(
 						"osgi.jaxrs.application.base",
-						"/" + objectDefinition.getRESTContextPath()
+						StringBundler.concat(
+							"/", objectDefinition.getCompanyId(), "/",
+							objectDefinition.getRESTContextPath())
 					).put(
 						"osgi.jaxrs.extension.select",
 						"(osgi.jaxrs.name=Liferay.Vulcan)"
 					).put(
-						"osgi.jaxrs.name", objectDefinition.getShortName()
+						"osgi.jaxrs.name", objectDefinition.getDBTableName()
 					).build()),
 				_objectEntryResourceComponentFactory.newInstance(
 					HashMapDictionaryBuilder.<String, Object>put(
@@ -85,8 +88,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"osgi.jaxrs.resource", "true"
 					).put(
 						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + objectDefinition.getShortName() +
-							")"
+						"(osgi.jaxrs.name=" +
+							objectDefinition.getDBTableName() + ")"
 					).build())));
 
 		return Arrays.asList(
@@ -95,14 +98,15 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				new ObjectDefinitionContextProvider(objectDefinition),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"osgi.jaxrs.application.select",
-					"(osgi.jaxrs.name=" + objectDefinition.getShortName() + ")"
+					"(osgi.jaxrs.name=" + objectDefinition.getDBTableName() +
+						")"
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
 					"enabled", "false"
 				).put(
 					"osgi.jaxrs.name",
-					objectDefinition.getRESTContextPath() +
+					objectDefinition.getDBTableName() +
 						"ObjectDefinitionContextProvider"
 				).build()),
 			_bundleContext.registerService(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -22,7 +22,13 @@ import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectFie
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.util.CamelCaseUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOContributor;
 
@@ -53,6 +59,21 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	public List<ServiceRegistration<?>> deploy(
 		ObjectDefinition objectDefinition) {
 
+		String companyName = String.valueOf(objectDefinition.getCompanyId());
+
+		try {
+			Company company = _companyLocalService.getCompany(
+				objectDefinition.getCompanyId());
+
+			companyName = CamelCaseUtil.toCamelCase(
+				company.getName(), CharPool.SPACE);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
+		}
+
 		_componentInstancesMap.put(
 			objectDefinition.getObjectDefinitionId(),
 			Arrays.asList(
@@ -71,7 +92,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					).put(
 						"osgi.jaxrs.application.base",
 						StringBundler.concat(
-							"/", objectDefinition.getCompanyId(), "/",
+							"/", companyName, "/",
 							objectDefinition.getRESTContextPath())
 					).put(
 						"osgi.jaxrs.extension.select",
@@ -127,7 +148,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_bundleContext.registerService(
 				GraphQLDTOContributor.class,
 				ObjectDefinitionGraphQLDTOContributor.of(
-					objectDefinition, _objectEntryManager,
+					companyName, objectDefinition, _objectEntryManager,
 					_objectFieldLocalService.getObjectFields(
 						objectDefinition.getObjectDefinitionId())),
 				HashMapDictionaryBuilder.<String, Object>put(
@@ -150,7 +171,14 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_bundleContext = bundleContext;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectDefinitionDeployerImpl.class);
+
 	private BundleContext _bundleContext;
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
 	private final Map<Long, List<ComponentInstance>> _componentInstancesMap =
 		new HashMap<>();
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -22,7 +22,6 @@ import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
@@ -50,7 +49,7 @@ public class ObjectDefinitionGraphQLDTOContributor
 	implements GraphQLDTOContributor<Map<String, Object>, Map<String, Object>> {
 
 	public static ObjectDefinitionGraphQLDTOContributor of(
-		ObjectDefinition objectDefinition,
+		String namespace, ObjectDefinition objectDefinition,
 		ObjectEntryManager objectEntryManager, List<ObjectField> objectFields) {
 
 		List<GraphQLDTOProperty> graphQLDTOProperties = new ArrayList<>();
@@ -68,9 +67,8 @@ public class ObjectDefinitionGraphQLDTOContributor
 		}
 
 		return new ObjectDefinitionGraphQLDTOContributor(
-			String.valueOf(objectDefinition.getCompanyId()),
 			new ObjectEntryEntityModel(objectFields), graphQLDTOProperties,
-			objectDefinition.getPKObjectFieldName(),
+			objectDefinition.getPKObjectFieldName(), namespace,
 			objectDefinition.getObjectDefinitionId(), objectEntryManager,
 			objectDefinition.getShortName());
 	}
@@ -144,7 +142,7 @@ public class ObjectDefinitionGraphQLDTOContributor
 
 	@Override
 	public String getNamespace() {
-		return "Object_" + StringUtil.upperCaseFirstLetter(_companyName);
+		return _namespace;
 	}
 
 	@Override
@@ -165,15 +163,14 @@ public class ObjectDefinitionGraphQLDTOContributor
 	}
 
 	private ObjectDefinitionGraphQLDTOContributor(
-		String companyName, EntityModel entityModel,
-		List<GraphQLDTOProperty> graphQLDTOProperties, String idName,
-		long objectDefinitionId, ObjectEntryManager objectEntryManager,
-		String resourceName) {
+		EntityModel entityModel, List<GraphQLDTOProperty> graphQLDTOProperties,
+		String idName, String namespace, long objectDefinitionId,
+		ObjectEntryManager objectEntryManager, String resourceName) {
 
-		_companyName = companyName;
 		_entityModel = entityModel;
 		_graphQLDTOProperties = graphQLDTOProperties;
 		_idName = idName;
+		_namespace = namespace;
 		_objectDefinitionId = objectDefinitionId;
 		_objectEntryManager = objectEntryManager;
 		_resourceName = resourceName;
@@ -220,10 +217,10 @@ public class ObjectDefinitionGraphQLDTOContributor
 			"String", String.class
 		).build();
 
-	private final String _companyName;
 	private final EntityModel _entityModel;
 	private final List<GraphQLDTOProperty> _graphQLDTOProperties;
 	private final String _idName;
+	private final String _namespace;
 	private final long _objectDefinitionId;
 	private final ObjectEntryManager _objectEntryManager;
 	private final String _resourceName;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -22,6 +22,7 @@ import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
@@ -67,6 +68,7 @@ public class ObjectDefinitionGraphQLDTOContributor
 		}
 
 		return new ObjectDefinitionGraphQLDTOContributor(
+			String.valueOf(objectDefinition.getCompanyId()),
 			new ObjectEntryEntityModel(objectFields), graphQLDTOProperties,
 			objectDefinition.getPKObjectFieldName(),
 			objectDefinition.getObjectDefinitionId(), objectEntryManager,
@@ -141,6 +143,11 @@ public class ObjectDefinitionGraphQLDTOContributor
 	}
 
 	@Override
+	public String getNamespace() {
+		return "Object_" + StringUtil.upperCaseFirstLetter(_companyName);
+	}
+
+	@Override
 	public String getResourceName() {
 		return _resourceName;
 	}
@@ -158,10 +165,12 @@ public class ObjectDefinitionGraphQLDTOContributor
 	}
 
 	private ObjectDefinitionGraphQLDTOContributor(
-		EntityModel entityModel, List<GraphQLDTOProperty> graphQLDTOProperties,
-		String idName, long objectDefinitionId,
-		ObjectEntryManager objectEntryManager, String resourceName) {
+		String companyName, EntityModel entityModel,
+		List<GraphQLDTOProperty> graphQLDTOProperties, String idName,
+		long objectDefinitionId, ObjectEntryManager objectEntryManager,
+		String resourceName) {
 
+		_companyName = companyName;
 		_entityModel = entityModel;
 		_graphQLDTOProperties = graphQLDTOProperties;
 		_idName = idName;
@@ -211,6 +220,7 @@ public class ObjectDefinitionGraphQLDTOContributor
 			"String", String.class
 		).build();
 
+	private final String _companyName;
 	private final EntityModel _entityModel;
 	private final List<GraphQLDTOProperty> _graphQLDTOProperties;
 	private final String _idName;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
@@ -18,6 +18,7 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.internal.jaxrs.container.request.filter.ObjectDefinitionIdContainerRequestFilter;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.OpenAPIResourceImpl;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.vulcan.openapi.DTOProperty;
@@ -55,7 +56,8 @@ public class ObjectEntryApplication extends Application {
 				_applicationName, _objectDefinitionId));
 		objects.add(
 			new OpenAPIResourceImpl(
-				_openAPIResource, _getOpenAPISchemaFilter(),
+				_objectDefinitionCompanyId, _openAPIResource,
+				_getOpenAPISchemaFilter(),
 				new HashSet<Class<?>>() {
 					{
 						add(ObjectEntryResourceImpl.class);
@@ -69,6 +71,9 @@ public class ObjectEntryApplication extends Application {
 	@Activate
 	protected void activate(Map<String, Object> properties) {
 		_applicationName = (String)properties.get("osgi.jaxrs.name");
+
+		_objectDefinitionCompanyId = (Long)properties.get(
+			"liferay.object.definition.company.id");
 
 		_objectDefinitionName = (String)properties.get(
 			"liferay.object.definition.name");
@@ -107,7 +112,12 @@ public class ObjectEntryApplication extends Application {
 	}
 
 	private String _applicationName;
+	private Long _objectDefinitionCompanyId;
 	private Long _objectDefinitionId;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
 	private String _objectDefinitionName;
 
 	@Reference

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
@@ -18,7 +18,6 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.internal.jaxrs.container.request.filter.ObjectDefinitionIdContainerRequestFilter;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.OpenAPIResourceImpl;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.vulcan.openapi.DTOProperty;
@@ -53,7 +52,7 @@ public class ObjectEntryApplication extends Application {
 
 		objects.add(
 			new ObjectDefinitionIdContainerRequestFilter(
-				_objectDefinitionDBTableName, _objectDefinitionId));
+				_applicationName, _objectDefinitionId));
 		objects.add(
 			new OpenAPIResourceImpl(
 				_openAPIResource, _getOpenAPISchemaFilter(),
@@ -71,8 +70,8 @@ public class ObjectEntryApplication extends Application {
 	protected void activate(Map<String, Object> properties) {
 		_applicationName = (String)properties.get("osgi.jaxrs.name");
 
-		_objectDefinitionDBTableName = (String)properties.get(
-			"liferay.object.definition.db.table.name");
+		_objectDefinitionName = (String)properties.get(
+			"liferay.object.definition.name");
 
 		_objectDefinitionId = (Long)properties.get(
 			"liferay.object.definition.id");
@@ -99,20 +98,17 @@ public class ObjectEntryApplication extends Application {
 		openAPISchemaFilter.setDTOProperty(dtoProperty);
 		openAPISchemaFilter.setSchemaMappings(
 			HashMapBuilder.put(
-				"ObjectEntry", _applicationName
+				"ObjectEntry", _objectDefinitionName
 			).put(
-				"PageObjectEntry", "Page" + _applicationName
+				"PageObjectEntry", "Page" + _objectDefinitionName
 			).build());
 
 		return openAPISchemaFilter;
 	}
 
 	private String _applicationName;
-	private String _objectDefinitionDBTableName;
 	private Long _objectDefinitionId;
-
-	@Reference
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private String _objectDefinitionName;
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
@@ -53,7 +53,7 @@ public class ObjectEntryApplication extends Application {
 
 		objects.add(
 			new ObjectDefinitionIdContainerRequestFilter(
-				_applicationName, _objectDefinitionId));
+				_objectDefinitionDBTableName, _objectDefinitionId));
 		objects.add(
 			new OpenAPIResourceImpl(
 				_openAPIResource, _getOpenAPISchemaFilter(),
@@ -70,6 +70,9 @@ public class ObjectEntryApplication extends Application {
 	@Activate
 	protected void activate(Map<String, Object> properties) {
 		_applicationName = (String)properties.get("osgi.jaxrs.name");
+
+		_objectDefinitionDBTableName = (String)properties.get(
+			"liferay.object.definition.db.table.name");
 
 		_objectDefinitionId = (Long)properties.get(
 			"liferay.object.definition.id");
@@ -105,6 +108,7 @@ public class ObjectEntryApplication extends Application {
 	}
 
 	private String _applicationName;
+	private String _objectDefinitionDBTableName;
 	private Long _objectDefinitionId;
 
 	@Reference

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/container/request/filter/ObjectDefinitionIdContainerRequestFilter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/container/request/filter/ObjectDefinitionIdContainerRequestFilter.java
@@ -34,9 +34,9 @@ public class ObjectDefinitionIdContainerRequestFilter
 	implements ContainerRequestFilter {
 
 	public ObjectDefinitionIdContainerRequestFilter(
-		String applicationName, Long objectDefinitionId) {
+		String objectDefinitionDBTableName, Long objectDefinitionId) {
 
-		_applicationName = applicationName;
+		_objectDefinitionDBTableName = objectDefinitionDBTableName;
 		_objectDefinitionId = objectDefinitionId;
 	}
 
@@ -58,12 +58,13 @@ public class ObjectDefinitionIdContainerRequestFilter
 			uriBuilder.queryParam(entry.getKey(), entry.getValue());
 		}
 
-		uriBuilder.queryParam("taskItemDelegateName", _applicationName);
+		uriBuilder.queryParam(
+			"taskItemDelegateName", _objectDefinitionDBTableName);
 
 		containerRequestContext.setRequestUri(uriBuilder.build());
 	}
 
-	private final String _applicationName;
+	private final String _objectDefinitionDBTableName;
 	private final Long _objectDefinitionId;
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.rest.internal.resource.v1_0;
 
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.openapi.OpenAPISchemaFilter;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
@@ -38,10 +39,11 @@ import javax.ws.rs.core.UriInfo;
 public class OpenAPIResourceImpl {
 
 	public OpenAPIResourceImpl(
-		OpenAPIResource openAPIResource,
+		Long objectDefinitionCompanyId, OpenAPIResource openAPIResource,
 		OpenAPISchemaFilter openAPISchemaFilter,
 		Set<Class<?>> resourceClasses) {
 
+		_objectDefinitionCompanyId = objectDefinitionCompanyId;
 		_openAPIResource = openAPIResource;
 		_openAPISchemaFilter = openAPISchemaFilter;
 		_resourceClasses = resourceClasses;
@@ -53,10 +55,20 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_contextCompany.getCompanyId() != _objectDefinitionCompanyId) {
+			return Response.status(
+				404
+			).build();
+		}
+
 		return _openAPIResource.getOpenAPI(
 			_openAPISchemaFilter, _resourceClasses, type, _uriInfo);
 	}
 
+	@Context
+	private Company _contextCompany;
+
+	private final Long _objectDefinitionCompanyId;
 	private final OpenAPIResource _openAPIResource;
 	private final OpenAPISchemaFilter _openAPISchemaFilter;
 	private final Set<Class<?>> _resourceClasses;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
@@ -21,14 +21,11 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
-import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.service.CompanyServiceUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -36,7 +33,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Base64;
-import com.liferay.portal.kernel.util.CamelCaseUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
@@ -73,12 +69,6 @@ public class ObjectDefinitionGraphQLTest {
 
 	@Before
 	public void setUp() throws Exception {
-		Company company = CompanyServiceUtil.getCompanyById(
-			TestPropsValues.getCompanyId());
-
-		_companyNamespace = CamelCaseUtil.toCamelCase(
-			company.getName(), CharPool.SPACE);
-
 		_objectDefinitionName = "A" + RandomTestUtil.randomString(5);
 		_objectFieldName = "a" + RandomTestUtil.randomString(5);
 
@@ -113,18 +103,14 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"mutation",
 						new GraphQLField(
-							_companyNamespace,
-							new GraphQLField(
-								"create" + _objectDefinitionName,
-								HashMapBuilder.<String, Object>put(
-									_objectDefinitionName,
-									StringBundler.concat(
-										"{", _objectFieldName, ": \"", value,
-										"\"}")
-								).build(),
-								new GraphQLField(_objectFieldName))))),
-				"JSONObject/data", "JSONObject/" + _companyNamespace,
-				"JSONObject/create" + _objectDefinitionName,
+							"create" + _objectDefinitionName,
+							HashMapBuilder.<String, Object>put(
+								_objectDefinitionName,
+								StringBundler.concat(
+									"{", _objectFieldName, ": \"", value, "\"}")
+							).build(),
+							new GraphQLField(_objectFieldName)))),
+				"JSONObject/data", "JSONObject/create" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 	}
 
@@ -133,20 +119,17 @@ public class ObjectDefinitionGraphQLTest {
 		GraphQLField graphQLField = new GraphQLField(
 			"mutation",
 			new GraphQLField(
-				_companyNamespace,
-				new GraphQLField(
-					"delete" + _objectDefinitionName,
-					HashMapBuilder.<String, Object>put(
-						_objectDefinition.getPKObjectFieldName(),
-						_objectEntry.getObjectEntryId()
-					).build())));
+				"delete" + _objectDefinitionName,
+				HashMapBuilder.<String, Object>put(
+					_objectDefinition.getPKObjectFieldName(),
+					_objectEntry.getObjectEntryId()
+				).build()));
 
 		JSONObject jsonObject = _invoke(graphQLField);
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
 				jsonObject, "JSONObject/data",
-				"JSONObject/" + _companyNamespace,
 				"Object/delete" + _objectDefinitionName));
 
 		jsonObject = _invoke(graphQLField);
@@ -154,7 +137,6 @@ public class ObjectDefinitionGraphQLTest {
 		Assert.assertFalse(
 			JSONUtil.getValueAsBoolean(
 				jsonObject, "JSONObject/data",
-				"JSONObject/" + _companyNamespace,
 				"Object/delete" + _objectDefinitionName));
 	}
 
@@ -170,20 +152,16 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							_companyNamespace,
+							key,
+							HashMapBuilder.<String, Object>put(
+								"filter",
+								"\"" + _objectFieldName +
+									" eq 'peter@liferay.com'\""
+							).build(),
 							new GraphQLField(
-								key,
-								HashMapBuilder.<String, Object>put(
-									"filter",
-									"\"" + _objectFieldName +
-										" eq 'peter@liferay.com'\""
-								).build(),
-								new GraphQLField(
-									"items",
-									new GraphQLField(_objectFieldName)))))),
-				"JSONObject/data", "JSONObject/" + _companyNamespace,
-				"JSONObject/" + key, "Object/items", "Object/0",
-				"Object/" + _objectFieldName));
+								"items", new GraphQLField(_objectFieldName))))),
+				"JSONObject/data", "JSONObject/" + key, "Object/items",
+				"Object/0", "Object/" + _objectFieldName));
 		Assert.assertEquals(
 			"peter@liferay.com",
 			JSONUtil.getValueAsString(
@@ -191,20 +169,16 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							_companyNamespace,
+							key,
+							HashMapBuilder.<String, Object>put(
+								"filter",
+								"\"contains(" + _objectFieldName +
+									",'peter@liferay.com')\""
+							).build(),
 							new GraphQLField(
-								key,
-								HashMapBuilder.<String, Object>put(
-									"filter",
-									"\"contains(" + _objectFieldName +
-										",'peter@liferay.com')\""
-								).build(),
-								new GraphQLField(
-									"items",
-									new GraphQLField(_objectFieldName)))))),
-				"JSONObject/data", "JSONObject/" + _companyNamespace,
-				"JSONObject/" + key, "Object/items", "Object/0",
-				"Object/" + _objectFieldName));
+								"items", new GraphQLField(_objectFieldName))))),
+				"JSONObject/data", "JSONObject/" + key, "Object/items",
+				"Object/0", "Object/" + _objectFieldName));
 		Assert.assertEquals(
 			"peter@liferay.com",
 			JSONUtil.getValueAsString(
@@ -212,20 +186,16 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							_companyNamespace,
+							key,
+							HashMapBuilder.<String, Object>put(
+								"filter",
+								"\"userId eq " + TestPropsValues.getUserId() +
+									"\""
+							).build(),
 							new GraphQLField(
-								key,
-								HashMapBuilder.<String, Object>put(
-									"filter",
-									"\"userId eq " +
-										TestPropsValues.getUserId() + "\""
-								).build(),
-								new GraphQLField(
-									"items",
-									new GraphQLField(_objectFieldName)))))),
-				"JSONObject/data", "JSONObject/" + _companyNamespace,
-				"JSONObject/" + key, "Object/items", "Object/0",
-				"Object/" + _objectFieldName));
+								"items", new GraphQLField(_objectFieldName))))),
+				"JSONObject/data", "JSONObject/" + key, "Object/items",
+				"Object/0", "Object/" + _objectFieldName));
 	}
 
 	@Test
@@ -242,17 +212,14 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							_companyNamespace,
-							new GraphQLField(
-								key,
-								HashMapBuilder.<String, Object>put(
-									"filter",
-									"\"" + _objectFieldName +
-										" ne 'peter@liferay.com'\""
-								).build(),
-								new GraphQLField("totalCount"))))),
-				"JSONObject/data", "JSONObject/" + _companyNamespace,
-				"JSONObject/" + key, "Object/totalCount"));
+							key,
+							HashMapBuilder.<String, Object>put(
+								"filter",
+								"\"" + _objectFieldName +
+									" ne 'peter@liferay.com'\""
+							).build(),
+							new GraphQLField("totalCount")))),
+				"JSONObject/data", "JSONObject/" + key, "Object/totalCount"));
 	}
 
 	@Test
@@ -266,16 +233,14 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							_companyNamespace,
-							new GraphQLField(
-								key,
-								HashMapBuilder.<String, Object>put(
-									_objectDefinition.getPKObjectFieldName(),
-									_objectEntry.getObjectEntryId()
-								).build(),
-								new GraphQLField(_objectFieldName))))),
-				"JSONObject/data", "JSONObject/" + _companyNamespace,
-				"JSONObject/" + key, "Object/" + _objectFieldName));
+							key,
+							HashMapBuilder.<String, Object>put(
+								_objectDefinition.getPKObjectFieldName(),
+								_objectEntry.getObjectEntryId()
+							).build(),
+							new GraphQLField(_objectFieldName)))),
+				"JSONObject/data", "JSONObject/" + key,
+				"Object/" + _objectFieldName));
 	}
 
 	@Test
@@ -286,30 +251,27 @@ public class ObjectDefinitionGraphQLTest {
 			new GraphQLField(
 				"mutation",
 				new GraphQLField(
-					_companyNamespace,
+					"create" + _objectDefinitionName,
+					HashMapBuilder.<String, Object>put(
+						_objectDefinitionName,
+						StringBundler.concat(
+							"{", _objectFieldName, ": \"", value, "\"}")
+					).build(),
+					new GraphQLField(_objectFieldName),
 					new GraphQLField(
-						"create" + _objectDefinitionName,
-						HashMapBuilder.<String, Object>put(
-							_objectDefinitionName,
-							StringBundler.concat(
-								"{", _objectFieldName, ": \"", value, "\"}")
-						).build(),
-						new GraphQLField(_objectFieldName),
-						new GraphQLField(
-							_objectDefinition.getPKObjectFieldName())))));
+						_objectDefinition.getPKObjectFieldName()))));
 
 		Assert.assertEquals(
 			value,
 			JSONUtil.getValueAsString(
 				jsonObject, "JSONObject/data",
-				"JSONObject/" + _companyNamespace,
 				"JSONObject/create" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 
 		value = RandomTestUtil.randomString();
 
 		Long objectEntryId = JSONUtil.getValueAsLong(
-			jsonObject, "JSONObject/data", "JSONObject/" + _companyNamespace,
+			jsonObject, "JSONObject/data",
 			"JSONObject/create" + _objectDefinitionName,
 			"Object/" + _objectDefinition.getPKObjectFieldName());
 
@@ -320,21 +282,17 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"mutation",
 						new GraphQLField(
-							_companyNamespace,
-							new GraphQLField(
-								"update" + _objectDefinitionName,
-								HashMapBuilder.<String, Object>put(
-									_objectDefinitionName,
-									StringBundler.concat(
-										"{", _objectFieldName, ": \"", value,
-										"\"}")
-								).put(
-									_objectDefinition.getPKObjectFieldName(),
-									String.valueOf(objectEntryId)
-								).build(),
-								new GraphQLField(_objectFieldName))))),
-				"JSONObject/data", "JSONObject/" + _companyNamespace,
-				"JSONObject/update" + _objectDefinitionName,
+							"update" + _objectDefinitionName,
+							HashMapBuilder.<String, Object>put(
+								_objectDefinitionName,
+								StringBundler.concat(
+									"{", _objectFieldName, ": \"", value, "\"}")
+							).put(
+								_objectDefinition.getPKObjectFieldName(),
+								String.valueOf(objectEntryId)
+							).build(),
+							new GraphQLField(_objectFieldName)))),
+				"JSONObject/data", "JSONObject/update" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 	}
 
@@ -370,8 +328,6 @@ public class ObjectDefinitionGraphQLTest {
 
 		return JSONFactoryUtil.createJSONObject(HttpUtil.URLtoString(options));
 	}
-
-	private String _companyNamespace;
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
@@ -103,14 +103,19 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"mutation",
 						new GraphQLField(
-							"create" + _objectDefinitionName,
-							HashMapBuilder.<String, Object>put(
-								_objectDefinitionName,
-								StringBundler.concat(
-									"{", _objectFieldName, ": \"", value, "\"}")
-							).build(),
-							new GraphQLField(_objectFieldName)))),
-				"JSONObject/data", "JSONObject/create" + _objectDefinitionName,
+							"Object_" + _objectDefinition.getCompanyId(),
+							new GraphQLField(
+								"create" + _objectDefinitionName,
+								HashMapBuilder.<String, Object>put(
+									_objectDefinitionName,
+									StringBundler.concat(
+										"{", _objectFieldName, ": \"", value,
+										"\"}")
+								).build(),
+								new GraphQLField(_objectFieldName))))),
+				"JSONObject/data",
+				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/create" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 	}
 
@@ -119,17 +124,20 @@ public class ObjectDefinitionGraphQLTest {
 		GraphQLField graphQLField = new GraphQLField(
 			"mutation",
 			new GraphQLField(
-				"delete" + _objectDefinitionName,
-				HashMapBuilder.<String, Object>put(
-					_objectDefinition.getPKObjectFieldName(),
-					_objectEntry.getObjectEntryId()
-				).build()));
+				"Object_" + _objectDefinition.getCompanyId(),
+				new GraphQLField(
+					"delete" + _objectDefinitionName,
+					HashMapBuilder.<String, Object>put(
+						_objectDefinition.getPKObjectFieldName(),
+						_objectEntry.getObjectEntryId()
+					).build())));
 
 		JSONObject jsonObject = _invoke(graphQLField);
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
 				jsonObject, "JSONObject/data",
+				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
 				"Object/delete" + _objectDefinitionName));
 
 		jsonObject = _invoke(graphQLField);
@@ -137,6 +145,7 @@ public class ObjectDefinitionGraphQLTest {
 		Assert.assertFalse(
 			JSONUtil.getValueAsBoolean(
 				jsonObject, "JSONObject/data",
+				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
 				"Object/delete" + _objectDefinitionName));
 	}
 
@@ -152,16 +161,21 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							key,
-							HashMapBuilder.<String, Object>put(
-								"filter",
-								"\"" + _objectFieldName +
-									" eq 'peter@liferay.com'\""
-							).build(),
+							"Object_" + _objectDefinition.getCompanyId(),
 							new GraphQLField(
-								"items", new GraphQLField(_objectFieldName))))),
-				"JSONObject/data", "JSONObject/" + key, "Object/items",
-				"Object/0", "Object/" + _objectFieldName));
+								key,
+								HashMapBuilder.<String, Object>put(
+									"filter",
+									"\"" + _objectFieldName +
+										" eq 'peter@liferay.com'\""
+								).build(),
+								new GraphQLField(
+									"items",
+									new GraphQLField(_objectFieldName)))))),
+				"JSONObject/data",
+				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/" + key, "Object/items", "Object/0",
+				"Object/" + _objectFieldName));
 		Assert.assertEquals(
 			"peter@liferay.com",
 			JSONUtil.getValueAsString(
@@ -169,16 +183,21 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							key,
-							HashMapBuilder.<String, Object>put(
-								"filter",
-								"\"contains(" + _objectFieldName +
-									",'peter@liferay.com')\""
-							).build(),
+							"Object_" + _objectDefinition.getCompanyId(),
 							new GraphQLField(
-								"items", new GraphQLField(_objectFieldName))))),
-				"JSONObject/data", "JSONObject/" + key, "Object/items",
-				"Object/0", "Object/" + _objectFieldName));
+								key,
+								HashMapBuilder.<String, Object>put(
+									"filter",
+									"\"contains(" + _objectFieldName +
+										",'peter@liferay.com')\""
+								).build(),
+								new GraphQLField(
+									"items",
+									new GraphQLField(_objectFieldName)))))),
+				"JSONObject/data",
+				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/" + key, "Object/items", "Object/0",
+				"Object/" + _objectFieldName));
 		Assert.assertEquals(
 			"peter@liferay.com",
 			JSONUtil.getValueAsString(
@@ -186,16 +205,21 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							key,
-							HashMapBuilder.<String, Object>put(
-								"filter",
-								"\"userId eq " + TestPropsValues.getUserId() +
-									"\""
-							).build(),
+							"Object_" + _objectDefinition.getCompanyId(),
 							new GraphQLField(
-								"items", new GraphQLField(_objectFieldName))))),
-				"JSONObject/data", "JSONObject/" + key, "Object/items",
-				"Object/0", "Object/" + _objectFieldName));
+								key,
+								HashMapBuilder.<String, Object>put(
+									"filter",
+									"\"userId eq " +
+										TestPropsValues.getUserId() + "\""
+								).build(),
+								new GraphQLField(
+									"items",
+									new GraphQLField(_objectFieldName)))))),
+				"JSONObject/data",
+				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/" + key, "Object/items", "Object/0",
+				"Object/" + _objectFieldName));
 	}
 
 	@Test
@@ -212,14 +236,18 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							key,
-							HashMapBuilder.<String, Object>put(
-								"filter",
-								"\"" + _objectFieldName +
-									" ne 'peter@liferay.com'\""
-							).build(),
-							new GraphQLField("totalCount")))),
-				"JSONObject/data", "JSONObject/" + key, "Object/totalCount"));
+							"Object_" + _objectDefinition.getCompanyId(),
+							new GraphQLField(
+								key,
+								HashMapBuilder.<String, Object>put(
+									"filter",
+									"\"" + _objectFieldName +
+										" ne 'peter@liferay.com'\""
+								).build(),
+								new GraphQLField("totalCount"))))),
+				"JSONObject/data",
+				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/" + key, "Object/totalCount"));
 	}
 
 	@Test
@@ -233,14 +261,17 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							key,
-							HashMapBuilder.<String, Object>put(
-								_objectDefinition.getPKObjectFieldName(),
-								_objectEntry.getObjectEntryId()
-							).build(),
-							new GraphQLField(_objectFieldName)))),
-				"JSONObject/data", "JSONObject/" + key,
-				"Object/" + _objectFieldName));
+							"Object_" + _objectDefinition.getCompanyId(),
+							new GraphQLField(
+								key,
+								HashMapBuilder.<String, Object>put(
+									_objectDefinition.getPKObjectFieldName(),
+									_objectEntry.getObjectEntryId()
+								).build(),
+								new GraphQLField(_objectFieldName))))),
+				"JSONObject/data",
+				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/" + key, "Object/" + _objectFieldName));
 	}
 
 	@Test
@@ -251,20 +282,23 @@ public class ObjectDefinitionGraphQLTest {
 			new GraphQLField(
 				"mutation",
 				new GraphQLField(
-					"create" + _objectDefinitionName,
-					HashMapBuilder.<String, Object>put(
-						_objectDefinitionName,
-						StringBundler.concat(
-							"{", _objectFieldName, ": \"", value, "\"}")
-					).build(),
-					new GraphQLField(_objectFieldName),
+					"Object_" + _objectDefinition.getCompanyId(),
 					new GraphQLField(
-						_objectDefinition.getPKObjectFieldName()))));
+						"create" + _objectDefinitionName,
+						HashMapBuilder.<String, Object>put(
+							_objectDefinitionName,
+							StringBundler.concat(
+								"{", _objectFieldName, ": \"", value, "\"}")
+						).build(),
+						new GraphQLField(_objectFieldName),
+						new GraphQLField(
+							_objectDefinition.getPKObjectFieldName())))));
 
 		Assert.assertEquals(
 			value,
 			JSONUtil.getValueAsString(
 				jsonObject, "JSONObject/data",
+				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
 				"JSONObject/create" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 
@@ -272,6 +306,7 @@ public class ObjectDefinitionGraphQLTest {
 
 		Long objectEntryId = JSONUtil.getValueAsLong(
 			jsonObject, "JSONObject/data",
+			"JSONObject/Object_" + _objectDefinition.getCompanyId(),
 			"JSONObject/create" + _objectDefinitionName,
 			"Object/" + _objectDefinition.getPKObjectFieldName());
 
@@ -282,17 +317,22 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"mutation",
 						new GraphQLField(
-							"update" + _objectDefinitionName,
-							HashMapBuilder.<String, Object>put(
-								_objectDefinitionName,
-								StringBundler.concat(
-									"{", _objectFieldName, ": \"", value, "\"}")
-							).put(
-								_objectDefinition.getPKObjectFieldName(),
-								String.valueOf(objectEntryId)
-							).build(),
-							new GraphQLField(_objectFieldName)))),
-				"JSONObject/data", "JSONObject/update" + _objectDefinitionName,
+							"Object_" + _objectDefinition.getCompanyId(),
+							new GraphQLField(
+								"update" + _objectDefinitionName,
+								HashMapBuilder.<String, Object>put(
+									_objectDefinitionName,
+									StringBundler.concat(
+										"{", _objectFieldName, ": \"", value,
+										"\"}")
+								).put(
+									_objectDefinition.getPKObjectFieldName(),
+									String.valueOf(objectEntryId)
+								).build(),
+								new GraphQLField(_objectFieldName))))),
+				"JSONObject/data",
+				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/update" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
@@ -21,11 +21,14 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyServiceUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -33,6 +36,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.CamelCaseUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
@@ -69,6 +73,12 @@ public class ObjectDefinitionGraphQLTest {
 
 	@Before
 	public void setUp() throws Exception {
+		Company company = CompanyServiceUtil.getCompanyById(
+			TestPropsValues.getCompanyId());
+
+		_companyNamespace = CamelCaseUtil.toCamelCase(
+			company.getName(), CharPool.SPACE);
+
 		_objectDefinitionName = "A" + RandomTestUtil.randomString(5);
 		_objectFieldName = "a" + RandomTestUtil.randomString(5);
 
@@ -103,7 +113,7 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"mutation",
 						new GraphQLField(
-							"Object_" + _objectDefinition.getCompanyId(),
+							_companyNamespace,
 							new GraphQLField(
 								"create" + _objectDefinitionName,
 								HashMapBuilder.<String, Object>put(
@@ -113,8 +123,7 @@ public class ObjectDefinitionGraphQLTest {
 										"\"}")
 								).build(),
 								new GraphQLField(_objectFieldName))))),
-				"JSONObject/data",
-				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/data", "JSONObject/" + _companyNamespace,
 				"JSONObject/create" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 	}
@@ -124,7 +133,7 @@ public class ObjectDefinitionGraphQLTest {
 		GraphQLField graphQLField = new GraphQLField(
 			"mutation",
 			new GraphQLField(
-				"Object_" + _objectDefinition.getCompanyId(),
+				_companyNamespace,
 				new GraphQLField(
 					"delete" + _objectDefinitionName,
 					HashMapBuilder.<String, Object>put(
@@ -137,7 +146,7 @@ public class ObjectDefinitionGraphQLTest {
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
 				jsonObject, "JSONObject/data",
-				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/" + _companyNamespace,
 				"Object/delete" + _objectDefinitionName));
 
 		jsonObject = _invoke(graphQLField);
@@ -145,7 +154,7 @@ public class ObjectDefinitionGraphQLTest {
 		Assert.assertFalse(
 			JSONUtil.getValueAsBoolean(
 				jsonObject, "JSONObject/data",
-				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/" + _companyNamespace,
 				"Object/delete" + _objectDefinitionName));
 	}
 
@@ -161,7 +170,7 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							"Object_" + _objectDefinition.getCompanyId(),
+							_companyNamespace,
 							new GraphQLField(
 								key,
 								HashMapBuilder.<String, Object>put(
@@ -172,8 +181,7 @@ public class ObjectDefinitionGraphQLTest {
 								new GraphQLField(
 									"items",
 									new GraphQLField(_objectFieldName)))))),
-				"JSONObject/data",
-				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/data", "JSONObject/" + _companyNamespace,
 				"JSONObject/" + key, "Object/items", "Object/0",
 				"Object/" + _objectFieldName));
 		Assert.assertEquals(
@@ -183,7 +191,7 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							"Object_" + _objectDefinition.getCompanyId(),
+							_companyNamespace,
 							new GraphQLField(
 								key,
 								HashMapBuilder.<String, Object>put(
@@ -194,8 +202,7 @@ public class ObjectDefinitionGraphQLTest {
 								new GraphQLField(
 									"items",
 									new GraphQLField(_objectFieldName)))))),
-				"JSONObject/data",
-				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/data", "JSONObject/" + _companyNamespace,
 				"JSONObject/" + key, "Object/items", "Object/0",
 				"Object/" + _objectFieldName));
 		Assert.assertEquals(
@@ -205,7 +212,7 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							"Object_" + _objectDefinition.getCompanyId(),
+							_companyNamespace,
 							new GraphQLField(
 								key,
 								HashMapBuilder.<String, Object>put(
@@ -216,8 +223,7 @@ public class ObjectDefinitionGraphQLTest {
 								new GraphQLField(
 									"items",
 									new GraphQLField(_objectFieldName)))))),
-				"JSONObject/data",
-				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/data", "JSONObject/" + _companyNamespace,
 				"JSONObject/" + key, "Object/items", "Object/0",
 				"Object/" + _objectFieldName));
 	}
@@ -236,7 +242,7 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							"Object_" + _objectDefinition.getCompanyId(),
+							_companyNamespace,
 							new GraphQLField(
 								key,
 								HashMapBuilder.<String, Object>put(
@@ -245,8 +251,7 @@ public class ObjectDefinitionGraphQLTest {
 										" ne 'peter@liferay.com'\""
 								).build(),
 								new GraphQLField("totalCount"))))),
-				"JSONObject/data",
-				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/data", "JSONObject/" + _companyNamespace,
 				"JSONObject/" + key, "Object/totalCount"));
 	}
 
@@ -261,7 +266,7 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							"Object_" + _objectDefinition.getCompanyId(),
+							_companyNamespace,
 							new GraphQLField(
 								key,
 								HashMapBuilder.<String, Object>put(
@@ -269,8 +274,7 @@ public class ObjectDefinitionGraphQLTest {
 									_objectEntry.getObjectEntryId()
 								).build(),
 								new GraphQLField(_objectFieldName))))),
-				"JSONObject/data",
-				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/data", "JSONObject/" + _companyNamespace,
 				"JSONObject/" + key, "Object/" + _objectFieldName));
 	}
 
@@ -282,7 +286,7 @@ public class ObjectDefinitionGraphQLTest {
 			new GraphQLField(
 				"mutation",
 				new GraphQLField(
-					"Object_" + _objectDefinition.getCompanyId(),
+					_companyNamespace,
 					new GraphQLField(
 						"create" + _objectDefinitionName,
 						HashMapBuilder.<String, Object>put(
@@ -298,15 +302,14 @@ public class ObjectDefinitionGraphQLTest {
 			value,
 			JSONUtil.getValueAsString(
 				jsonObject, "JSONObject/data",
-				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/" + _companyNamespace,
 				"JSONObject/create" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 
 		value = RandomTestUtil.randomString();
 
 		Long objectEntryId = JSONUtil.getValueAsLong(
-			jsonObject, "JSONObject/data",
-			"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+			jsonObject, "JSONObject/data", "JSONObject/" + _companyNamespace,
 			"JSONObject/create" + _objectDefinitionName,
 			"Object/" + _objectDefinition.getPKObjectFieldName());
 
@@ -317,7 +320,7 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"mutation",
 						new GraphQLField(
-							"Object_" + _objectDefinition.getCompanyId(),
+							_companyNamespace,
 							new GraphQLField(
 								"update" + _objectDefinitionName,
 								HashMapBuilder.<String, Object>put(
@@ -330,8 +333,7 @@ public class ObjectDefinitionGraphQLTest {
 									String.valueOf(objectEntryId)
 								).build(),
 								new GraphQLField(_objectFieldName))))),
-				"JSONObject/data",
-				"JSONObject/Object_" + _objectDefinition.getCompanyId(),
+				"JSONObject/data", "JSONObject/" + _companyNamespace,
 				"JSONObject/update" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 	}
@@ -368,6 +370,8 @@ public class ObjectDefinitionGraphQLTest {
 
 		return JSONFactoryUtil.createJSONObject(HttpUtil.URLtoString(options));
 	}
+
+	private String _companyNamespace;
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition;

--- a/modules/apps/object/object-web/build.gradle
+++ b/modules/apps/object/object-web/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:petra:petra-portlet-url-builder")
+	compileOnly project(":apps:portal-instances:portal-instances-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -24,6 +24,10 @@ import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.web.internal.application.list.ObjectDefinitionPanelApp;
 import com.liferay.object.web.internal.frontend.taglib.clay.data.set.view.table.ObjectDefinitionTableClayDataSetDisplayView;
 import com.liferay.object.web.internal.portlet.ObjectDefinitionPortlet;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -48,6 +52,27 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	public List<ServiceRegistration<?>> deploy(
 		ObjectDefinition objectDefinition) {
 
+		String restContextPath = objectDefinition.getRESTContextPath();
+
+		if (_companyLocalService.getCompaniesCount() > 1) {
+			String companyName = "o_" + objectDefinition.getCompanyId();
+
+			try {
+				Company company = _companyLocalService.getCompany(
+					objectDefinition.getCompanyId());
+
+				companyName = company.getWebId();
+				companyName = companyName.replaceAll("\\.", "_");
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(exception, exception);
+				}
+			}
+
+			restContextPath = companyName + "/" + restContextPath;
+		}
+
 		return Arrays.asList(
 			_bundleContext.registerService(
 				ClayDataSetDisplayView.class,
@@ -68,8 +93,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				).build()),
 			_bundleContext.registerService(
 				Portlet.class,
-				new ObjectDefinitionPortlet(
-					_portal, objectDefinition.getRESTContextPath()),
+				new ObjectDefinitionPortlet(_portal, restContextPath),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"com.liferay.portlet.display-category", "category.hidden"
 				).put(
@@ -87,10 +111,16 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_bundleContext = bundleContext;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectDefinitionDeployerImpl.class);
+
 	private BundleContext _bundleContext;
 
 	@Reference
 	private ClayTableSchemaBuilderFactory _clayTableSchemaBuilderFactory;
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -24,6 +24,7 @@ import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.web.internal.application.list.ObjectDefinitionPanelApp;
 import com.liferay.object.web.internal.frontend.taglib.clay.data.set.view.table.ObjectDefinitionTableClayDataSetDisplayView;
 import com.liferay.object.web.internal.portlet.ObjectDefinitionPortlet;
+import com.liferay.portal.instances.service.PortalInstancesLocalService;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -54,7 +55,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		String restContextPath = objectDefinition.getRESTContextPath();
 
-		if (_companyLocalService.getCompaniesCount() > 1) {
+		if ((_companyLocalService.getCompaniesCount() > 1) &&
+			(objectDefinition.getCompanyId() !=
+				_portalInstancesLocalService.getDefaultCompanyId())) {
+
 			String companyName = "o_" + objectDefinition.getCompanyId();
 
 			try {
@@ -127,5 +131,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private PortalInstancesLocalService _portalInstancesLocalService;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 8.3.2
+Bundle-Version: 8.4.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/dto/GraphQLDTOContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/dto/GraphQLDTOContributor.java
@@ -48,6 +48,10 @@ public interface GraphQLDTOContributor<D, R> {
 
 	public String getIdName();
 
+	public default String getNamespace() {
+		return "";
+	}
+
 	public String getResourceName();
 
 	public R updateDTO(D dto, DTOConverterContext dtoConverterContext, long id)

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/dto/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/dto/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
@@ -828,6 +829,17 @@ public class GraphQLServletExtender {
 		}
 	}
 
+	private GraphQLObjectType.Builder _createGraphQLObjectTypeBuilder(
+		String graphQLObjectTypeName, String namespaceName,
+		Map<String, GraphQLObjectType.Builder> namespaceBuilderMap) {
+
+		namespaceBuilderMap.putIfAbsent(
+			namespaceName,
+			new GraphQLObjectType.Builder().name(graphQLObjectTypeName));
+
+		return namespaceBuilderMap.get(namespaceName);
+	}
+
 	private Message _createMessage(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
@@ -1566,7 +1578,9 @@ public class GraphQLServletExtender {
 		GraphQLInputObjectType.Builder builder =
 			new GraphQLInputObjectType.Builder();
 
-		builder.name("Input" + graphQLDTOContributor.getResourceName());
+		builder.name(
+			graphQLDTOContributor.getNamespace() + "_Input" +
+				graphQLDTOContributor.getResourceName());
 
 		for (GraphQLDTOProperty graphQLDTOProperty :
 				graphQLDTOContributor.getGraphQLDTOProperties()) {
@@ -1590,7 +1604,9 @@ public class GraphQLServletExtender {
 
 		GraphQLObjectType.Builder builder = new GraphQLObjectType.Builder();
 
-		builder.name(graphQLDTOContributor.getResourceName());
+		builder.name(
+			graphQLDTOContributor.getNamespace() + "_" +
+				graphQLDTOContributor.getResourceName());
 
 		for (GraphQLDTOProperty graphQLDTOProperty :
 				graphQLDTOContributor.getGraphQLDTOProperties()) {
@@ -1729,7 +1745,34 @@ public class GraphQLServletExtender {
 		GraphQLObjectType.Builder mutationBuilder,
 		ProcessingElementsContainer processingElementsContainer,
 		GraphQLObjectType.Builder queryBuilder,
-		GraphQLSchema.Builder schemaBuilder) {
+		GraphQLSchema.Builder schemaBuilder,
+		Map<String, GraphQLObjectType.Builder> queryNamespaceBuilderMap,
+		Map<String, GraphQLObjectType.Builder> mutationNamespaceBuilderMap) {
+
+		GraphQLObjectType.Builder queryGraphQLObjectTypeBuilder = queryBuilder;
+		String queryParentType = "query";
+		GraphQLObjectType.Builder mutationGraphQLObjectTypeBuilder =
+			mutationBuilder;
+		String mutationParentType = "mutation";
+
+		if (Validator.isNotNull(graphQLDTOContributor.getNamespace())) {
+			queryGraphQLObjectTypeBuilder = _createGraphQLObjectTypeBuilder(
+				graphQLDTOContributor.getNamespace(),
+				graphQLDTOContributor.getNamespace(), queryNamespaceBuilderMap);
+
+			queryParentType = graphQLDTOContributor.getNamespace();
+
+			mutationGraphQLObjectTypeBuilder = _createGraphQLObjectTypeBuilder(
+				"Mutation" + graphQLDTOContributor.getNamespace(),
+				graphQLDTOContributor.getNamespace(),
+				mutationNamespaceBuilderMap);
+
+			mutationParentType =
+				"Mutation" + graphQLDTOContributor.getNamespace();
+		}
+
+		GraphQLCodeRegistry.Builder graphQLCodeRegistryBuilder =
+			processingElementsContainer.getCodeRegistryBuilder();
 
 		// Create
 
@@ -1743,17 +1786,14 @@ public class GraphQLServletExtender {
 		GraphQLInputObjectType graphQLInputType = _getGraphQLInputObjectType(
 			graphQLDTOContributor);
 
-		mutationBuilder.field(
+		mutationGraphQLObjectTypeBuilder.field(
 			_addField(
 				graphQLObjectType, createName,
 				_addArgument(graphQLInputType, resourceName)));
 
-		GraphQLCodeRegistry.Builder graphQLCodeRegistryBuilder =
-			processingElementsContainer.getCodeRegistryBuilder();
-
 		schemaBuilder.codeRegistry(
 			graphQLCodeRegistryBuilder.dataFetcher(
-				FieldCoordinates.coordinates("mutation", createName),
+				FieldCoordinates.coordinates(mutationParentType, createName),
 				(DataFetcher<Object>)
 					dataFetchingEnvironment -> graphQLDTOContributor.createDTO(
 						dataFetchingEnvironment.getArgument(resourceName),
@@ -1766,14 +1806,14 @@ public class GraphQLServletExtender {
 
 		String idName = graphQLDTOContributor.getIdName();
 
-		mutationBuilder.field(
+		mutationGraphQLObjectTypeBuilder.field(
 			_addField(
 				Scalars.GraphQLBoolean, deleteName,
 				_addArgument(Scalars.GraphQLLong, idName)));
 
 		schemaBuilder.codeRegistry(
 			graphQLCodeRegistryBuilder.dataFetcher(
-				FieldCoordinates.coordinates("mutation", deleteName),
+				FieldCoordinates.coordinates(mutationParentType, deleteName),
 				(DataFetcher<Object>)
 					dataFetchingEnvironment -> graphQLDTOContributor.deleteDTO(
 						dataFetchingEnvironment.<Long>getArgument(idName))
@@ -1783,13 +1823,13 @@ public class GraphQLServletExtender {
 
 		String getName = StringUtil.lowerCaseFirstLetter(resourceName);
 
-		queryBuilder.field(
+		queryGraphQLObjectTypeBuilder.field(
 			_addField(
 				graphQLObjectType, getName,
 				_addArgument(Scalars.GraphQLLong, idName)));
 		schemaBuilder.codeRegistry(
 			graphQLCodeRegistryBuilder.dataFetcher(
-				FieldCoordinates.coordinates("query", getName),
+				FieldCoordinates.coordinates(queryParentType, getName),
 				(DataFetcher<Object>)
 					dataFetchingEnvironment -> graphQLDTOContributor.getDTO(
 						_getDTOConverterContext(dataFetchingEnvironment, null),
@@ -1803,10 +1843,11 @@ public class GraphQLServletExtender {
 		String listName = StringUtil.lowerCaseFirstLetter(
 			TextFormatter.formatPlural(resourceName));
 
-		queryBuilder.field(
+		queryGraphQLObjectTypeBuilder.field(
 			_addField(
 				_getPageGraphQLObjectType(
-					graphQLTypes.get("Facet"), graphQLObjectType, resourceName),
+					graphQLTypes.get("Facet"), graphQLObjectType,
+					graphQLDTOContributor.getNamespace() + "_" + resourceName),
 				listName,
 				_addArgument(
 					GraphQLList.list(Scalars.GraphQLString), "aggregation"),
@@ -1818,7 +1859,7 @@ public class GraphQLServletExtender {
 
 		schemaBuilder.codeRegistry(
 			graphQLCodeRegistryBuilder.dataFetcher(
-				FieldCoordinates.coordinates("query", listName),
+				FieldCoordinates.coordinates(queryParentType, listName),
 				(DataFetcher<Object>)dataFetchingEnvironment -> {
 					GraphQLContext graphQLContext =
 						dataFetchingEnvironment.getLocalContext();
@@ -1868,7 +1909,7 @@ public class GraphQLServletExtender {
 
 		String updateName = "update" + resourceName;
 
-		mutationBuilder.field(
+		mutationGraphQLObjectTypeBuilder.field(
 			_addField(
 				graphQLObjectType, updateName,
 				_addArgument(graphQLInputType, resourceName),
@@ -1876,7 +1917,7 @@ public class GraphQLServletExtender {
 
 		schemaBuilder.codeRegistry(
 			graphQLCodeRegistryBuilder.dataFetcher(
-				FieldCoordinates.coordinates("mutation", updateName),
+				FieldCoordinates.coordinates(mutationParentType, updateName),
 				(DataFetcher<Object>)
 					dataFetchingEnvironment -> graphQLDTOContributor.updateDTO(
 						dataFetchingEnvironment.
@@ -1893,12 +1934,54 @@ public class GraphQLServletExtender {
 		GraphQLObjectType.Builder queryBuilder,
 		GraphQLSchema.Builder schemaBuilder) {
 
+		Map<String, GraphQLObjectType.Builder> queryNamespaceBuilderMap =
+			new HashMap<>();
+		Map<String, GraphQLObjectType.Builder> mutationNamespaceBuilderMap =
+			new HashMap<>();
+
 		for (GraphQLDTOContributor graphQLDTOContributor :
 				_graphQLDTOContributorServiceTrackerMap.values()) {
 
 			_registerGraphQLDTOContributor(
 				graphQLDTOContributor, mutationBuilder,
-				processingElementsContainer, queryBuilder, schemaBuilder);
+				processingElementsContainer, queryBuilder, schemaBuilder,
+				queryNamespaceBuilderMap, mutationNamespaceBuilderMap);
+		}
+
+		GraphQLCodeRegistry.Builder graphQLCodeRegistryBuilder =
+			processingElementsContainer.getCodeRegistryBuilder();
+
+		// Register GraphQLDTOContributor namespaces
+
+		for (Map.Entry<String, GraphQLObjectType.Builder> entry :
+				queryNamespaceBuilderMap.entrySet()) {
+
+			GraphQLObjectType.Builder queryNamespaceBuilder = entry.getValue();
+
+			queryBuilder.field(
+				_addField(queryNamespaceBuilder.build(), entry.getKey()));
+
+			schemaBuilder.codeRegistry(
+				graphQLCodeRegistryBuilder.dataFetcher(
+					FieldCoordinates.coordinates("query", entry.getKey()),
+					(DataFetcher<Object>)dataFetchingEnvironment -> new Object()
+				).build());
+		}
+
+		for (Map.Entry<String, GraphQLObjectType.Builder> entry :
+				mutationNamespaceBuilderMap.entrySet()) {
+
+			GraphQLObjectType.Builder mutationNamespaceBuilder =
+				entry.getValue();
+
+			mutationBuilder.field(
+				_addField(mutationNamespaceBuilder.build(), entry.getKey()));
+
+			schemaBuilder.codeRegistry(
+				graphQLCodeRegistryBuilder.dataFetcher(
+					FieldCoordinates.coordinates("mutation", entry.getKey()),
+					(DataFetcher<Object>)dataFetchingEnvironment -> new Object()
+				).build());
 		}
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1485,8 +1485,7 @@ public class GraphQLServletExtender {
 			Map<String, Serializable> attributes)
 		throws PortalException {
 
-		GraphQLContext graphQLContext =
-			dataFetchingEnvironment.getLocalContext();
+		GraphQLContext graphQLContext = dataFetchingEnvironment.getContext();
 
 		Optional<HttpServletRequest> httpServletRequestOptional =
 			graphQLContext.getHttpServletRequest();
@@ -1862,7 +1861,7 @@ public class GraphQLServletExtender {
 				FieldCoordinates.coordinates(queryParentType, listName),
 				(DataFetcher<Object>)dataFetchingEnvironment -> {
 					GraphQLContext graphQLContext =
-						dataFetchingEnvironment.getLocalContext();
+						dataFetchingEnvironment.getContext();
 
 					Optional<HttpServletRequest> httpServletRequestOptional =
 						graphQLContext.getHttpServletRequest();

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1572,18 +1572,14 @@ public class GraphQLServletExtender {
 	}
 
 	private GraphQLInputObjectType _getGraphQLInputObjectType(
-		GraphQLDTOContributor<?, ?> graphQLDTOContributor) {
+		String name, List<GraphQLDTOProperty> properties) {
 
 		GraphQLInputObjectType.Builder builder =
 			new GraphQLInputObjectType.Builder();
 
-		builder.name(
-			graphQLDTOContributor.getNamespace() + "_Input" +
-				graphQLDTOContributor.getResourceName());
+		builder.name(name);
 
-		for (GraphQLDTOProperty graphQLDTOProperty :
-				graphQLDTOContributor.getGraphQLDTOProperties()) {
-
+		for (GraphQLDTOProperty graphQLDTOProperty : properties) {
 			GraphQLInputObjectField.Builder graphQLInputObjectFieldBuilder =
 				GraphQLInputObjectField.newInputObjectField();
 
@@ -1599,17 +1595,13 @@ public class GraphQLServletExtender {
 	}
 
 	private GraphQLObjectType _getGraphQLObjectType(
-		GraphQLDTOContributor<?, ?> graphQLDTOContributor) {
+		String name, List<GraphQLDTOProperty> properties) {
 
 		GraphQLObjectType.Builder builder = new GraphQLObjectType.Builder();
 
-		builder.name(
-			graphQLDTOContributor.getNamespace() + "_" +
-				graphQLDTOContributor.getResourceName());
+		builder.name(name);
 
-		for (GraphQLDTOProperty graphQLDTOProperty :
-				graphQLDTOContributor.getGraphQLDTOProperties()) {
-
+		for (GraphQLDTOProperty graphQLDTOProperty : properties) {
 			builder.field(
 				_addField(
 					_toGraphQLScalarType(graphQLDTOProperty.getTypeClass()),
@@ -1748,26 +1740,30 @@ public class GraphQLServletExtender {
 		Map<String, GraphQLObjectType.Builder> queryNamespaceBuilderMap,
 		Map<String, GraphQLObjectType.Builder> mutationNamespaceBuilderMap) {
 
-		GraphQLObjectType.Builder queryGraphQLObjectTypeBuilder = queryBuilder;
-		String queryParentType = "query";
+		String namespace = Optional.ofNullable(
+			graphQLDTOContributor.getNamespace()
+		).orElse(
+			""
+		);
+
 		GraphQLObjectType.Builder mutationGraphQLObjectTypeBuilder =
 			mutationBuilder;
 		String mutationParentType = "mutation";
+		GraphQLObjectType.Builder queryGraphQLObjectTypeBuilder = queryBuilder;
+		String queryParentType = "query";
 
-		if (Validator.isNotNull(graphQLDTOContributor.getNamespace())) {
-			queryGraphQLObjectTypeBuilder = _createGraphQLObjectTypeBuilder(
-				graphQLDTOContributor.getNamespace(),
-				graphQLDTOContributor.getNamespace(), queryNamespaceBuilderMap);
-
-			queryParentType = graphQLDTOContributor.getNamespace();
-
+		if (Validator.isNotNull(namespace)) {
 			mutationGraphQLObjectTypeBuilder = _createGraphQLObjectTypeBuilder(
-				"Mutation" + graphQLDTOContributor.getNamespace(),
-				graphQLDTOContributor.getNamespace(),
-				mutationNamespaceBuilderMap);
+				"Mutation" + StringUtil.upperCaseFirstLetter(namespace),
+				namespace, mutationNamespaceBuilderMap);
 
 			mutationParentType =
-				"Mutation" + graphQLDTOContributor.getNamespace();
+				"Mutation" + StringUtil.upperCaseFirstLetter(namespace);
+
+			queryGraphQLObjectTypeBuilder = _createGraphQLObjectTypeBuilder(
+				namespace, namespace, queryNamespaceBuilderMap);
+
+			queryParentType = namespace;
 		}
 
 		GraphQLCodeRegistry.Builder graphQLCodeRegistryBuilder =
@@ -1775,15 +1771,17 @@ public class GraphQLServletExtender {
 
 		// Create
 
-		GraphQLObjectType graphQLObjectType = _getGraphQLObjectType(
-			graphQLDTOContributor);
-
 		String resourceName = graphQLDTOContributor.getResourceName();
+
+		GraphQLObjectType graphQLObjectType = _getGraphQLObjectType(
+			namespace + resourceName,
+			graphQLDTOContributor.getGraphQLDTOProperties());
 
 		String createName = "create" + resourceName;
 
 		GraphQLInputObjectType graphQLInputType = _getGraphQLInputObjectType(
-			graphQLDTOContributor);
+			"Input" + namespace + resourceName,
+			graphQLDTOContributor.getGraphQLDTOProperties());
 
 		mutationGraphQLObjectTypeBuilder.field(
 			_addField(
@@ -1846,7 +1844,7 @@ public class GraphQLServletExtender {
 			_addField(
 				_getPageGraphQLObjectType(
 					graphQLTypes.get("Facet"), graphQLObjectType,
-					graphQLDTOContributor.getNamespace() + "_" + resourceName),
+					namespace + resourceName),
 				listName,
 				_addArgument(
 					GraphQLList.list(Scalars.GraphQLString), "aggregation"),
@@ -1950,38 +1948,12 @@ public class GraphQLServletExtender {
 		GraphQLCodeRegistry.Builder graphQLCodeRegistryBuilder =
 			processingElementsContainer.getCodeRegistryBuilder();
 
-		// Register GraphQLDTOContributor namespaces
-
-		for (Map.Entry<String, GraphQLObjectType.Builder> entry :
-				queryNamespaceBuilderMap.entrySet()) {
-
-			GraphQLObjectType.Builder queryNamespaceBuilder = entry.getValue();
-
-			queryBuilder.field(
-				_addField(queryNamespaceBuilder.build(), entry.getKey()));
-
-			schemaBuilder.codeRegistry(
-				graphQLCodeRegistryBuilder.dataFetcher(
-					FieldCoordinates.coordinates("query", entry.getKey()),
-					(DataFetcher<Object>)dataFetchingEnvironment -> new Object()
-				).build());
-		}
-
-		for (Map.Entry<String, GraphQLObjectType.Builder> entry :
-				mutationNamespaceBuilderMap.entrySet()) {
-
-			GraphQLObjectType.Builder mutationNamespaceBuilder =
-				entry.getValue();
-
-			mutationBuilder.field(
-				_addField(mutationNamespaceBuilder.build(), entry.getKey()));
-
-			schemaBuilder.codeRegistry(
-				graphQLCodeRegistryBuilder.dataFetcher(
-					FieldCoordinates.coordinates("mutation", entry.getKey()),
-					(DataFetcher<Object>)dataFetchingEnvironment -> new Object()
-				).build());
-		}
+		_registerNamespaceBuilderFields(
+			graphQLCodeRegistryBuilder, queryNamespaceBuilderMap, queryBuilder,
+			"query", schemaBuilder);
+		_registerNamespaceBuilderFields(
+			graphQLCodeRegistryBuilder, mutationNamespaceBuilderMap,
+			mutationBuilder, "mutation", schemaBuilder);
 	}
 
 	private void _registerInterfaces(
@@ -2112,6 +2084,29 @@ public class GraphQLServletExtender {
 			graphQLSchemaBuilder.codeRegistry(
 				graphQLCodeRegistryBuilder.dataFetcher(
 					FieldCoordinates.coordinates(parentField, graphQLNamespace),
+					(DataFetcher<Object>)dataFetchingEnvironment -> new Object()
+				).build());
+		}
+	}
+
+	private void _registerNamespaceBuilderFields(
+		GraphQLCodeRegistry.Builder graphQLCodeRegistryBuilder,
+		Map<String, GraphQLObjectType.Builder> namespaceBuilderMap,
+		GraphQLObjectType.Builder parentBuilder, String parentName,
+		GraphQLSchema.Builder schemaBuilder) {
+
+		for (Map.Entry<String, GraphQLObjectType.Builder> entry :
+				namespaceBuilderMap.entrySet()) {
+
+			String namespaceName = entry.getKey();
+			GraphQLObjectType.Builder namespaceBuilder = entry.getValue();
+
+			parentBuilder.field(
+				_addField(namespaceBuilder.build(), namespaceName));
+
+			schemaBuilder.codeRegistry(
+				graphQLCodeRegistryBuilder.dataFetcher(
+					FieldCoordinates.coordinates(parentName, namespaceName),
 					(DataFetcher<Object>)dataFetchingEnvironment -> new Object()
 				).build());
 		}


### PR DESCRIPTION
Using the webId that is unique and a string property, much better to use as a path chunk or namespace in REST and GraphQL.

The namespace is only used when more than one company exists. This way is easier to use for the clients with only one company.