### PR TITLE
LPS-135563 Fix placement of Balloon Editor panel

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -22,7 +22,11 @@
 	<h1>Balloon Editor</h1>
 
 	<p>
-		This is a sample portlet with a <a href="https://example.com">link</a>.
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
+	</p>
+
+	<p>
+		This paragraph contains a <a href="https://example.com">link</a>.
 	</p>
 
 	<img src="https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=300" />


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-135563

https://github.com/liferay/liferay-ckeditor/pull/164#issuecomment-825522824 is the most detailed summary of desired behavior for panel positioning I could find, along with discussion of challenges in implementation.

In this PR, we are fixing panel positioning, to reflect most if not all of above requirements:
- Selection in single row, either with double-click, keyboard or mouse drag, positions panel on top, centered on selection.
- Multiple row selection centers on end of selection, top-to-bottom below selection, bottom-to-top on top of selection 
- If horizontal overflow happens, panel is pushed to border of editable area.
- If horizontal overflow happens, and panel is larger than editable area, we are positioning panel to start of editable area. This triggers editor's own mechanisms for overflow (line breaking of toolbars etc).
- There is a minor bug with the multiple-line toolbar, when it first renders. The position is slightly wrong, you can see this in gif. This is because we are first setting position and then ckeditor breaks lines. With second and consequent renders, we are setting position with correct panel height. I think we can ignore this issue. The benefit of letting ckeditor do default overflow is too big. If this becomes a noticeable bug, we can try to find a workaround in a separate task.
- We do not offer option to ignore editable area. We can add this option, if we want to, in a separate task.
- We are displaying triangle, but in a limited capacity. It is only on top or bottom, always on canter of panel. This is the same behavior as Alloy Editor. It looks a bit broken in case of overflow. We could update it to point to selection in a future PR, but there is no direct API to it, so it could be a bit complicated.
- I did some minor SF, notably removing direction constants from global scope.  

@julien @diegonvs @dsanz 

Before PR:
![before](https://user-images.githubusercontent.com/5435511/126197621-703db924-c491-4aa0-a180-bd7139397448.gif)

After PR:
![after](https://user-images.githubusercontent.com/5435511/126197644-0cbfc32f-8b9a-4544-9ec5-ab93241ce054.gif)