### PR TITLE
LPS-136017 SPA navigation is not prevented with custom exception selectors

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
@@ -39,7 +39,7 @@ class App extends EventEmitter {
 	/**
 	 * App class that handle routes and screens lifecycle.
 	 */
-	constructor() {
+	constructor(config) {
 		super();
 
 		/**
@@ -102,8 +102,9 @@ class App extends EventEmitter {
 		 * @default form[enctype="multipart/form-data"]:not([data-senna-off])
 		 * @protected
 		 */
-		this.formSelector =
-			'form[enctype="multipart/form-data"]:not([data-senna-off])';
+		this.formSelector = config?.navigationExceptionSelectors
+			? `form${config.navigationExceptionSelectors}`
+			: 'form[enctype="multipart/form-data"]:not([data-senna-off])';
 
 		/**
 		 * When enabled, the route matching ignores query string from the path.
@@ -119,7 +120,9 @@ class App extends EventEmitter {
 		 * @default a:not([data-senna-off])
 		 * @protected
 		 */
-		this.linkSelector = 'a:not([data-senna-off]):not([target="_blank"])';
+		this.linkSelector = config?.navigationExceptionSelectors
+			? `a${config.navigationExceptionSelectors}`
+			: 'a:not([data-senna-off]):not([target="_blank"])';
 
 		/**
 		 * Holds the loading css class.

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/LiferayApp.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/LiferayApp.js
@@ -52,14 +52,12 @@ class LiferayApp extends App {
 		userNotification,
 		validStatusCodes,
 	}) {
-		super();
+		super({navigationExceptionSelectors});
 
 		this._cacheExpirationTime = cacheExpirationTime;
 		this._clearScreensCache = clearScreensCache;
 		this._debugEnabled = debugEnabled;
 
-		this.formSelector = `form${navigationExceptionSelectors}`;
-		this.linkSelector = `a${navigationExceptionSelectors}`;
 		this.portletsBlacklist = portletsBlacklist;
 		this.userNotification = userNotification;
 		this.validStatusCodes = validStatusCodes;


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-136017

**This PR is a bit risky. Even if reviews are green, please wait with forwarding until GA release.**

Steps to reproduce:
1. Deploy `frontend-editor-ckeditor-sample-web`
2. Place it on a page
3. Click on the link in text

Expected result: Nothing happens. CKeditor prevents normal navigation, because of `data-cke-saved-href` attribute.

What actually happens: We try SPA navigation. It fails, with error below in log.
```
LiferayApp.js:164 Uncaught TypeError: Cannot read property 'closest' of null
    at LiferayApp.isInPortletBlacklist (LiferayApp.js:164)
    at LiferayApp.onDocClickDelegate_ (LiferayApp.js:244)
    at HTMLDocument.eventHandler (delegate.es.js:58)
```

The root cause is that we don't set custom navigation exception selectors. We always use default selector 
```
"a:not([data-senna-off]):not([target=\"_blank\"])"
```
This is because [delegation for SPA](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js#L1410-L1416) is defined in App.js constructor, resolving before we get the chance to [set exception selectors](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/LiferayApp.js#L61-L62). Later on, in [delegation callback](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/LiferayApp.js#L245), the selector is updated, and the `closest` breaks on `null`. This callback should not have been executed.  

In this PR, we are extending base class to expect navigation exception selectors, and pass them in before delegation declaration. After this, the selector becomes:
```html
"a:not([target=\"_blank\"]):not([data-senna-off]):not([data-resource-href]):not([data-cke-saved-href]):not([data-cke-saved-href])"
```
`data-resource-href` is used in `roles-admin-web`, so this PR will affect it. 

I would consider this only a temporary quick fix. I think the proper solution would be to merge `App.js` and `LiferayApp.js`, removing all the inheritance complications. The separation to generic API and Liferay-specific API only made sense when `App.js` was a part of standalone Senna. But that's a bigger and much riskier task, outside the scope of this PR.