### PR TITLE
LPS-136065 Make the `paginationBarDeltas` optional in `ClayPaginationBarTag`

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/pagination_bars.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/pagination_bars.jsp
@@ -20,6 +20,8 @@
 	<p>A pagination bar provides navigation through datasets.</p>
 </blockquote>
 
+<h3>Default</h3>
+
 <clay:pagination-bar
 	activePage="<%= 1 %>"
 	disabledPages="<%= Arrays.asList(5, 6, 7) %>"
@@ -27,4 +29,13 @@
 	paginationBarDeltas="<%= Arrays.asList(new PaginationBarDelta(10), new PaginationBarDelta(20), new PaginationBarDelta(30), new PaginationBarDelta(50)) %>"
 	paginationBarLabels='<%= new PaginationBarLabels("Showing {0} - {1} of {2}", "{0} items", "{0} items") %>'
 	totalItems="<%= 100 %>"
+/>
+
+<h3>Without DropDown</h3>
+
+<clay:pagination-bar
+	activePage="<%= 4 %>"
+	ellipsisBuffer="<%= 2 %>"
+	paginationBarLabels='<%= new PaginationBarLabels("Showing {0} - {1} of {2}", "{0} items", "{0} items") %>'
+	totalItems="<%= 80 %>"
 />

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PaginationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PaginationBarTag.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.taglib.util.TagResourceBundleUtil;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -39,6 +40,14 @@ public class PaginationBarTag extends BaseContainerTag {
 	@Override
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		if (getPaginationBarDeltas() == null) {
+			setPaginationBarDeltas(
+				Arrays.asList(
+					new PaginationBarDelta(10), new PaginationBarDelta(20),
+					new PaginationBarDelta(30), new PaginationBarDelta(50)));
+			_showDropDown = false;
+		}
 
 		if (_activeDelta == null) {
 			PaginationBarDelta paginationBarDelta =
@@ -152,6 +161,7 @@ public class PaginationBarTag extends BaseContainerTag {
 		_ellipsisBuffer = null;
 		_paginationBarDeltas = null;
 		_paginationBarLabels = null;
+		_showDropDown = true;
 		_totalItems = null;
 	}
 
@@ -186,25 +196,32 @@ public class PaginationBarTag extends BaseContainerTag {
 
 		JspWriter jspWriter = pageContext.getOut();
 
-		jspWriter.write("<div class=\"dropdown pagination-items-per-page\">");
-		jspWriter.write("<button class=\"dropdown-toggle btn btn-unstyled\"");
-		jspWriter.write(" type=\"button\">");
-		jspWriter.write(_activeDelta.toString());
-		jspWriter.write(StringPool.SPACE);
-
 		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
 			pageContext);
 
-		jspWriter.write(
-			StringUtil.toLowerCase(LanguageUtil.get(resourceBundle, "items")));
+		if (_showDropDown) {
+			jspWriter.write(
+				"<div class=\"dropdown pagination-items-per-page\">");
+			jspWriter.write(
+				"<button class=\"dropdown-toggle btn btn-unstyled\"");
+			jspWriter.write(" type=\"button\">");
+			jspWriter.write(_activeDelta.toString());
+			jspWriter.write(StringPool.SPACE);
 
-		IconTag iconTag = new IconTag();
+			jspWriter.write(
+				StringUtil.toLowerCase(
+					LanguageUtil.get(resourceBundle, "items")));
 
-		iconTag.setSymbol("caret-double-l");
+			IconTag iconTag = new IconTag();
 
-		iconTag.doTag(pageContext);
+			iconTag.setSymbol("caret-double-l");
 
-		jspWriter.write("</button></div><div class=\"pagination-results\">");
+			iconTag.doTag(pageContext);
+
+			jspWriter.write("</button></div>");
+		}
+
+		jspWriter.write("<div class=\"pagination-results\">");
 		jspWriter.write(LanguageUtil.get(resourceBundle, "showing"));
 		jspWriter.write(StringPool.SPACE);
 
@@ -333,6 +350,7 @@ public class PaginationBarTag extends BaseContainerTag {
 	private Integer _ellipsisBuffer;
 	private List<PaginationBarDelta> _paginationBarDeltas;
 	private PaginationBarLabels _paginationBarLabels;
+	private boolean _showDropDown = true;
 	private Integer _totalItems;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -2191,7 +2191,7 @@
 		<attribute>
 			<description></description>
 			<name>paginationBarDeltas</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>


### PR DESCRIPTION
@liferay-echo [asked us](https://github.com/liferay/clay/issues/4175) to mark the `paginationBarDeltas` 
attribute as optional in the `ClayPaginationBarTag`
in order to complete [LPS-123825](https://issues.liferay.com/browse/LPS-123825).

The [fix](https://github.com/liferay/clay/pull/4178) has been sent to the clay repository 
for the React component so here we're 
making the same change in the tag.