### PR TITLE
LPS-135953 uncomment test

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/InvalidObjectDefinitionExceptionMapper.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/InvalidObjectDefinitionExceptionMapper.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Gamarra
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Object.Admin.REST.InvalidObjectDefinitionExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class InvalidObjectDefinitionExceptionMapper
+	extends BaseExceptionMapper<IllegalArgumentException> {
+
+	@Override
+	protected Problem getProblem(
+		IllegalArgumentException illegalArgumentException) {
+
+		return new Problem(
+			Response.Status.NOT_FOUND, "Object Definition does not exist");
+	}
+
+}

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -24,11 +24,12 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.Inject;
 
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -74,10 +75,20 @@ public class ObjectDefinitionResourceTest
 			totalCount + 1, objectDefinitionsPage.getTotalCount());
 	}
 
-	@Ignore
-	@Override
 	@Test
-	public void testGraphQLGetObjectDefinitionNotFound() {
+	public void testGraphQLGetObjectDefinitionNotFound() throws Exception {
+		Assert.assertEquals(
+			"Internal Server Error",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"objectDefinition",
+						HashMapBuilder.<String, Object>put(
+							"objectDefinitionId", RandomTestUtil.randomLong()
+						).build(),
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
 	}
 
 	@Override


### PR DESCRIPTION
Permission Checkers that do not have a group because they are scoped to a company (organization, account...) fail when passing a wrong identifier. Organization passes the check by doing a DB call before the permission check but it's a bit inefficient. Account is not checking that at the moment (pinged Drew).

This could be fixed in the permission side but it can also be supported by the APIs by deploying an `ExceptionMapper` for REST APIs. GraphQL does not support them at the moment but it will in the future so overriding the test for now.

/cc gabrielwas 