### PR TITLE
LPS-136065 Adds the `showDeltasDropDown` attribute to `ClayPaginationBarTag`

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/pagination_bars.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/pagination_bars.jsp
@@ -20,6 +20,8 @@
 	<p>A pagination bar provides navigation through datasets.</p>
 </blockquote>
 
+<h3>Default</h3>
+
 <clay:pagination-bar
 	activePage="<%= 1 %>"
 	disabledPages="<%= Arrays.asList(5, 6, 7) %>"
@@ -27,4 +29,14 @@
 	paginationBarDeltas="<%= Arrays.asList(new PaginationBarDelta(10), new PaginationBarDelta(20), new PaginationBarDelta(30), new PaginationBarDelta(50)) %>"
 	paginationBarLabels='<%= new PaginationBarLabels("Showing {0} - {1} of {2}", "{0} items", "{0} items") %>'
 	totalItems="<%= 100 %>"
+/>
+
+<h3>Without DropDown</h3>
+
+<clay:pagination-bar
+	activePage="<%= 4 %>"
+	ellipsisBuffer="<%= 2 %>"
+	paginationBarLabels='<%= new PaginationBarLabels("Showing {0} - {1} of {2}", "{0} items", "{0} items") %>'
+	showDeltasDropDown="<%= false %>"
+	totalItems="<%= 80 %>"
 />

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 7.3.5
+Bundle-Version: 7.4.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.data,\
 	com.liferay.frontend.taglib.clay.data.set,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -88,5 +88,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "7.3.5"
+	"version": "7.4.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PaginationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PaginationBarTag.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.taglib.util.TagResourceBundleUtil;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -39,6 +40,13 @@ public class PaginationBarTag extends BaseContainerTag {
 	@Override
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		if (getPaginationBarDeltas() == null) {
+			setPaginationBarDeltas(
+				Arrays.asList(
+					new PaginationBarDelta(10), new PaginationBarDelta(20),
+					new PaginationBarDelta(30), new PaginationBarDelta(50)));
+		}
 
 		if (_activeDelta == null) {
 			PaginationBarDelta paginationBarDelta =
@@ -106,6 +114,10 @@ public class PaginationBarTag extends BaseContainerTag {
 		return _paginationBarLabels;
 	}
 
+	public boolean getShowDeltasDropDown() {
+		return _showDeltasDropDown;
+	}
+
 	public Integer getTotalItems() {
 		return _totalItems;
 	}
@@ -138,6 +150,10 @@ public class PaginationBarTag extends BaseContainerTag {
 		_paginationBarLabels = paginationBarLabels;
 	}
 
+	public void setShowDeltasDropDown(boolean showDeltasDropDown) {
+		_showDeltasDropDown = false;
+	}
+
 	public void setTotalItems(Integer totalItems) {
 		_totalItems = totalItems;
 	}
@@ -152,6 +168,7 @@ public class PaginationBarTag extends BaseContainerTag {
 		_ellipsisBuffer = null;
 		_paginationBarDeltas = null;
 		_paginationBarLabels = null;
+		_showDeltasDropDown = true;
 		_totalItems = null;
 	}
 
@@ -168,6 +185,7 @@ public class PaginationBarTag extends BaseContainerTag {
 		props.put("disabledPages", _disabledPages);
 		props.put("ellipsisBuffer", _ellipsisBuffer);
 		props.put("labels", _paginationBarLabels);
+		props.put("showDeltasDropDown", _showDeltasDropDown);
 		props.put("totalItems", _totalItems);
 
 		return super.prepareProps(props);
@@ -186,25 +204,32 @@ public class PaginationBarTag extends BaseContainerTag {
 
 		JspWriter jspWriter = pageContext.getOut();
 
-		jspWriter.write("<div class=\"dropdown pagination-items-per-page\">");
-		jspWriter.write("<button class=\"dropdown-toggle btn btn-unstyled\"");
-		jspWriter.write(" type=\"button\">");
-		jspWriter.write(_activeDelta.toString());
-		jspWriter.write(StringPool.SPACE);
-
 		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
 			pageContext);
 
-		jspWriter.write(
-			StringUtil.toLowerCase(LanguageUtil.get(resourceBundle, "items")));
+		if (_showDeltasDropDown) {
+			jspWriter.write(
+				"<div class=\"dropdown pagination-items-per-page\">");
+			jspWriter.write(
+				"<button class=\"dropdown-toggle btn btn-unstyled\"");
+			jspWriter.write(" type=\"button\">");
+			jspWriter.write(_activeDelta.toString());
+			jspWriter.write(StringPool.SPACE);
 
-		IconTag iconTag = new IconTag();
+			jspWriter.write(
+				StringUtil.toLowerCase(
+					LanguageUtil.get(resourceBundle, "items")));
 
-		iconTag.setSymbol("caret-double-l");
+			IconTag iconTag = new IconTag();
 
-		iconTag.doTag(pageContext);
+			iconTag.setSymbol("caret-double-l");
 
-		jspWriter.write("</button></div><div class=\"pagination-results\">");
+			iconTag.doTag(pageContext);
+
+			jspWriter.write("</button></div>");
+		}
+
+		jspWriter.write("<div class=\"pagination-results\">");
 		jspWriter.write(LanguageUtil.get(resourceBundle, "showing"));
 		jspWriter.write(StringPool.SPACE);
 
@@ -333,6 +358,7 @@ public class PaginationBarTag extends BaseContainerTag {
 	private Integer _ellipsisBuffer;
 	private List<PaginationBarDelta> _paginationBarDeltas;
 	private PaginationBarLabels _paginationBarLabels;
+	private boolean _showDeltasDropDown = true;
 	private Integer _totalItems;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -2191,7 +2191,7 @@
 		<attribute>
 			<description></description>
 			<name>paginationBarDeltas</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
@@ -2209,6 +2209,12 @@
 		<attribute>
 			<description></description>
 			<name>propsTransformerServletContext</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>showDeltasDropDown</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/PaginationBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/PaginationBar.js
@@ -26,6 +26,7 @@ export default function PaginationBar({
 	locale: _locale,
 	portletId: _portletId,
 	portletNamespace: _portletNamespace,
+	showDeltasDropDown,
 	totalItems,
 	...otherProps
 }) {
@@ -46,6 +47,7 @@ export default function PaginationBar({
 			ellipsisBuffer={initialEllipsisBuffer}
 			onDeltaChange={setInitialActiveDelta}
 			onPageChange={setInitialActivePage}
+			showDeltasDropDown={showDeltasDropDown}
 			totalItems={totalItems}
 			{...otherProps}
 		/>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0


### PR DESCRIPTION
@liferay-echo [asked us](https://github.com/liferay/clay/issues/4175) to mark
the `paginationBarDeltas` attribute as optional in the `ClayPaginationBarTag`
in order to complete [LPS-123825](https://issues.liferay.com/browse/LPS-123825).

After discusing this in https://github.com/liferay/clay/pull/4178 and https://github.com/liferay-frontend/liferay-portal/pull/1276, we decided
that it would be better to add a new `showDeltasDropDown` prop in order
to avoid breaking changes.

The [fix](https://github.com/liferay/clay/pull/4178) has been sent to the clay repository for the React component 
so here we're making the same change in the tag, we might want to wait 
for the change in Clay to be in dxp before merging this one, although 
there's no real risk of breaking anything since no one  is using this tag yet.