### PR TITLE
LPS-135711 Fix behavior of Balloon Editor link toolbar

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
@@ -72,7 +72,8 @@ public class CKEditorBalloonEditorConfigContributor
 			"stylesSet", getStyleFormatsJSONArray(themeDisplay.getLocale())
 		).put(
 			"toolbarImage",
-			"ImageAlignLeft,ImageAlignCenter,ImageAlignRight,LinkToolbar,AltImg"
+			"ImageAlignLeft,ImageAlignCenter,ImageAlignRight,LinkAddOrEdit," +
+				"AltImg"
 		).put(
 			"toolbarTable",
 			"TableHeaders,TableRow,TableColumn,TableCell,TableDelete"

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
@@ -29,16 +29,16 @@
 			const eventListeners = [];
 
 			editor.on('contentDom', () => {
-				const document = editor.document;
+				const editable = editor.editable();
 
 				eventListeners.push(
-					document.on('keyup', () => {
+					editable.on('keyup', () => {
 						editor.forceNextSelectionCheck();
 					})
 				);
 
 				eventListeners.push(
-					document.on('mouseup', () => {
+					editable.on('mouseup', () => {
 						editor.forceNextSelectionCheck();
 					})
 				);
@@ -121,8 +121,10 @@
 
 				const panelRect = this.parts.panel.getClientRect(true);
 
-				const ranges = elementOrSelection.getRanges();
-				const type = elementOrSelection.getType();
+				const selection = this.editor.getSelection();
+
+				const ranges = selection.getRanges();
+				const type = selection.getType();
 
 				let triangleSide = 'bottom';
 				let x = 0;
@@ -145,9 +147,7 @@
 					let selectionDirection = SELECTION_DIRECTION.TOP_TO_BOTTOM;
 
 					if (firstSelectedRect !== lastSelectedRect) {
-						selectionDirection = getSelectionDirection(
-							this.editor.getSelection()
-						);
+						selectionDirection = getSelectionDirection(selection);
 					}
 
 					if (firstSelectedRect === lastSelectedRect) {
@@ -183,7 +183,7 @@
 					}
 				}
 				else if (type === CKEDITOR.SELECTION_ELEMENT) {
-					let selectedElement = elementOrSelection.getSelectedElement();
+					let selectedElement = selection.getSelectedElement();
 
 					if (!selectedElement) {
 						selectedElement = ranges && ranges[0].startContainer;
@@ -353,9 +353,14 @@
 						}
 					);
 
+					const selectedElement = selection.getSelectedElement();
+
+					const startElement = selection.getStartElement();
+
 					if (
-						!selection.getSelectedElement() &&
-						!selection.getSelectedText()
+						!selectedElement &&
+						(!selection.getSelectedText() ||
+							startElement.getName() === 'a')
 					) {
 						return;
 					}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
@@ -90,16 +90,6 @@
 				title: editor.lang.common.alignRight,
 			});
 
-			editor.ui.addBalloonToolbarButton('LinkToolbar', {
-				click() {
-					editor.fire('showToolbar', {
-						toolbarCommand: 'linkToolbar',
-					});
-				},
-				icon: 'link',
-				title: editor.lang.link.title,
-			});
-
 			editor.ui.addBalloonToolbarButton('LinkAddOrEdit', {
 				click() {
 					editor.fire('showToolbar', {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
@@ -173,9 +173,7 @@
 
 			editor.ui.addBalloonToolbarButton('TextLink', {
 				click() {
-					editor.fire('showToolbar', {
-						toolbarCommand: 'linkToolbar',
-					});
+					editor.execCommand('linkToolbar');
 				},
 				icon: 'link',
 				title: editor.lang.link.title,

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -28,11 +28,10 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 
 	const basicToolbars = {
 		toolbarImage:
-			'ImageAlignLeft,ImageAlignCenter,ImageAlignRight,LinkToolbar,AltImg',
-		toolbarLink: 'LinkAddOrEdit,LinkRemove',
+			'ImageAlignLeft,ImageAlignCenter,ImageAlignRight,LinkAddOrEdit,AltImg',
 		toolbarTable: 'TableHeaders,TableRow,TableColumn,TableCell,TableDelete',
 		toolbarText:
-			'Styles,Bold,Italic,Underline,BulletedList,NumberedList,TextLink' +
+			'Styles,Bold,Italic,Underline,BulletedList,NumberedList,TextLink,' +
 			'JustifyLeft,JustifyCenter,JustifyRight,LineHeight,RemoveFormat',
 		toolbarVideo: 'VideoAlignLeft,VideoAlignCenter,VideoAlignRight',
 	};
@@ -91,13 +90,6 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 					priority:
 						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
 					widgets: 'image,image2',
-				});
-
-				balloonToolbars.create({
-					buttons: editorConfig.toolbarLink,
-					cssSelector: 'a',
-					priority:
-						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
 				});
 
 				balloonToolbars.create({


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-135711

Steps to reproduce:
- Deploy `frontend-editor-ckeditor-sample-web` and place on a page
- Add commits from https://github.com/liferay-frontend/liferay-portal/pull/1274. Without this, click on a newly created link with trigger navigation.
- See gifs on bottom

The bane of my existence for the last few days were [these few lines in CKeditor](https://github.com/ckeditor/ckeditor4/blob/major/core/selection.js#L983-L986). We are updating selection, an consequently opening toolbar, on each `focus` event in editor. This means _anywhere_ in editor, including toolbars. This causes very weird and inconsistent behavior, as selections may or may not change focus. This becomes specially relevant when you have complex case like standard toolbar > opens link toolbar > use input for url  > open selection window. In all of that, focus changes all the time. 

We cannot simply remove this in a patch, as the behavior in needed for other internal mechanisms. Instead, In this PR, I implemented an alternative solution. We don't rely on focus, prevent default behavior on links, and have all handling in the `linktoolbar` plugin.

In addition to the main change above, changes in this PR include:
- Reduce selection events from editor to editable.
- Open link toolbar on click.
- Consistently place 'data-cke-saved-href' attribute, needed to prevent SPA navigation.
- Integrate link selector on toolbar.
- Remove unnecessary async with `showToolbar` event firing. This causes glichy UI.
- Remove unnecessary `cancel` event handling, we don't have an option in UI to explicitely close toolbars.
- Fix multiplication of wrapper link around image.
- Replace `toolbarLink` basic toolbar with `linktoolbar` plugin toolbar.
- Remove `LinkToolbar` button, it is duplicate of `LinkAddOrEdit` button

Before PR:
![before](https://user-images.githubusercontent.com/5435511/127005131-fa1b3bd4-b41d-46ab-a9db-e970fb0e2b49.gif)

After PR:
![after](https://user-images.githubusercontent.com/5435511/127005161-4c58f5b3-0f63-402a-a49a-7534e73e3641.gif)
