### PR TITLE
LPS-136048 The staging indicator drop-down menu is displayed unstyled in the upper left corner

### DIFF
--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/StagingIndicator.scss
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/StagingIndicator.scss
@@ -1,46 +1,48 @@
-@import 'atlas-variables';
+@import 'cadmin-variables';
 
-.staging-indicator {
-	background-color: $dark-l1;
-	border-bottom: 1px solid lighten($dark-l2, 4.3);
-	font-size: 12px;
-	text-align: center;
+html#{$cadmin-selector} .cadmin {
+	.staging-indicator {
+		background-color: $cadmin-dark-l1;
+		border-bottom: 1px solid lighten($cadmin-dark-l2, 4.3);
+		font-size: 12px;
+		text-align: center;
 
-	.staging-indicator-button {
-		align-items: center;
-		background-color: $dark-l1;
-		border: none;
-		color: $white;
-		display: inline-flex;
-		font-weight: 600;
-		justify-content: center;
-		margin: 2px 2px 1px;
-		padding: 1px 10px;
-		text-decoration: none;
-		vertical-align: middle;
-
-		.staging-indicator-icon-staging {
-			color: $info-l1;
-			margin-right: 6px;
-			margin-top: 0;
-		}
-
-		.staging-indicator-icon-live {
-			color: $success-l1;
-			font-size: 16px;
-			margin-right: 2px;
-			margin-top: 0;
-		}
-
-		.staging-indicator-title {
-			font-size: 12px;
+		.staging-indicator-button {
+			align-items: center;
+			background-color: $cadmin-dark-l1;
+			border: none;
+			color: $cadmin-white;
+			display: inline-flex;
 			font-weight: 600;
-		}
+			justify-content: center;
+			margin: 2px 2px 1px;
+			padding: 1px 10px;
+			text-decoration: none;
+			vertical-align: middle;
 
-		.lexicon-icon-caret-bottom {
-			font-size: 13px;
-			margin-left: 5px;
-			margin-top: 0;
+			.staging-indicator-icon-staging {
+				color: $cadmin-info-l1;
+				margin-right: 6px;
+				margin-top: 0;
+			}
+
+			.staging-indicator-icon-live {
+				color: $cadmin-success-l1;
+				font-size: 16px;
+				margin-right: 2px;
+				margin-top: 0;
+			}
+
+			.staging-indicator-title {
+				font-size: 12px;
+				font-weight: 600;
+			}
+
+			.lexicon-icon-caret-bottom {
+				font-size: 13px;
+				margin-left: 5px;
+				margin-top: 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-136197

**How to reproduce**
1. Add a new Asset Library: Open applications menu > Content > Asset Libraries > [ + ] Add
2. Enable staging for this Asset Library:  Click in the name of new Asset Library > Staging > Select local live
![image](https://user-images.githubusercontent.com/67901/127018543-45da9e81-fa90-41da-8bf3-5d5ca9a6c9b5.png)
3. Assert the staging indicator drop-down menu

---

**Before this PR**
![image](https://user-images.githubusercontent.com/67901/127019112-fbe0c9a8-9f6f-4702-9ee3-660c8c0f9e2c.png)

**After this PR**
![image](https://user-images.githubusercontent.com/67901/127019248-6744274e-ac27-448d-82f0-1fbf9ed2bb95.png)

