### PR TITLE
LPS-135308 Adds a version resolution for d3-color library

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -14,6 +14,9 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
+	"resolutions": {
+		"d3-color": "3.0.0"
+	},
 	"workspaces": {
 		"packages": [
 			"apps/*/*",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -4912,10 +4912,10 @@ d3-collection@1:
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
 
-d3-color@1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.3.tgz#6c67bb2af6df3cc8d79efcc4d3a3e83e28c8048f"
-  integrity sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw==
+d3-color@1, d3-color@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.0.0.tgz#34235bff4f7cef9cb26661a627df78a08da6993e"
+  integrity sha512-FzEzJGJPTstWe+YNZ7F1WU12WxIQkeYO+SiBfw4a8Ln6JP8YTWxm6ZVr+I2M9MRbtQNYJCs1dtgsAJtaRzCdCA==
 
 d3-contour@1:
   version "1.3.2"


### PR DESCRIPTION
This novel comes from: https://issues.liferay.com/browse/LPS-135308

## What it does

There is an existing vulnerability with `d3-color` package which is a dependency for `recharts` and the paliative way to fix it is creating a resolution for fixing the current usages to @3.0.0 where the vulnerability is already fixed.

See https://github.com/recharts/recharts/issues/2590 for more details

## `yarn why`, after creating the resolution

**d3-color:**

```log
modules ❯ yarn why d3-color                                                    0.06s [LPS-135308●] ~/workspace/liferay-portal/modules
yarn why v1.22.4
[1/4] 🤔  Why do we have the module "d3-color"...?
[2/4] 🚚  Initialising dependency graph...
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "d3-color@3.0.0"
info Reasons this module exists
   - "_project_#d3" depends on it
   - Hoisted from "_project_#d3#d3-color"
   - Hoisted from "_project_#commerce-organization-web#d3#d3-color"
   - Hoisted from "_project_#d3#d3-transition#d3-color"
   - Hoisted from "_project_#d3#d3-scale-chromatic#d3-color"
   - Hoisted from "_project_#d3#d3-interpolate#d3-color"
   - Hoisted from "_project_#frontend-taglib-chart#clay-charts#d3#d3-color"
info Disk size without dependencies: "96KB"
info Disk size with unique dependencies: "96KB"
info Disk size with transitive dependencies: "96KB"
info Number of shared dependencies: 0
✨  Done in 1.72s.
```

**recharts:**

```log
modules ❯ yarn why recharts                                                    2.23s [LPS-135308●] ~/workspace/liferay-portal/modules
yarn why v1.22.4
[1/4] 🤔  Why do we have the module "recharts"...?
[2/4] 🚚  Initialising dependency graph...
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "recharts@1.8.5"
info Reasons this module exists
   - "_project_#portal-workflow-metrics-web" depends on it
   - Hoisted from "_project_#portal-workflow-metrics-web#recharts"
   - Hoisted from "_project_#frontend-js-recharts#recharts"
   - Hoisted from "_project_#content-dashboard-web#recharts"
   - Hoisted from "_project_#dynamic-data-mapping-form-report-web#recharts"
   - Hoisted from "_project_#analytics-reports-web#recharts"
info Disk size without dependencies: "6.83MB"
info Disk size with unique dependencies: "21.74MB"
info Disk size with transitive dependencies: "28.77MB"
info Number of shared dependencies: 32
✨  Done in 2.20s.
```

> `warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"`

This is intriguing me because when running `yarn why d3-color@1`, 


```
modules ❯ yarn why d3-color@1                                                  0.05s [LPS-135308●] ~/workspace/liferay-portal/modules
yarn why v1.22.4
[1/4] 🤔  Why do we have the module "d3-color@1"...?
[2/4] 🚚  Initialising dependency graph...
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
warning Resolution field "d3-color@3.0.0" is incompatible with requested version "d3-color@1"
[3/4] 🔍  Finding dependency...
error We couldn't find a match!
✨  Done in 1.37s.
```

Looks like d3-color@1 is not installed anymore and seeing the yarn.lock when having this dep, yarn will point to d3-color@3 directly.

## Test Case

Considering this library(recharts) is currently being used in:

* portal-workflow-metrics-web
* frontend-js-recharts
* content-dashboard-web
* dynamic-data-mapping-form-report-web
* analytics-reports-web

I decided to test in ddm-form-report-web because I'm more familiar, here is the reproduction steps:

1. Create a form containing these field types:

* Grid
* Multiple Selection
* Single Selection

2. Hit "Publish" button

3. Click on "Share" button and then copy the Form URL

4. Open the Form URL in another tab and then start filling some entries in those fields

5. Once you filled the entries, go to Forms admin again

6. Click in "Entries" button with the console from DevTools opened

See that any errors are thrown and everything looks okay.

### Still to be fixed:

When running `yarn test` in `ddm-form-report-web`, an error is thrown:

```
 FAIL  test/js/components/chart/pie/PieChart.es.js
  ● Test suite failed to run

    Jest encountered an unexpected token

    This usually means that you are trying to import a file which Jest cannot parse, e.g. it's not plain JavaScript.

    By default, if Jest sees a Babel config, it will use that to transform your files, ignoring "node_modules".

    Here's what you can do:
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/en/configuration.html

    Details:

    /Users/diego/workspace/liferay-portal/modules/node_modules/d3-color/src/index.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){export {default as color, rgb, hsl} from "./color.js";
                                                                                             ^^^^^^

    SyntaxError: Unexpected token export

      at Runtime.createScriptFromCode (../../../node_modules/jest-runtime/build/index.js:1059:14)
      at ../../../node_modules/d3-interpolate/dist/d3-interpolate.js:3:81
      at Object.<anonymous> (../../../node_modules/d3-interpolate/dist/d3-interpolate.js:6:2)
```