### PR TITLE
LPS-136282 Add missing translation to frontend-theme-classic-style-guide-sample-web

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/META-INF/resources/css/main.scss
@@ -86,3 +86,7 @@
 		margin-right: 0.5rem;
 	}
 }
+
+.token-group-buttons .token-sample {
+	border: none;
+}

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/META-INF/resources/js/App.js
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/META-INF/resources/js/App.js
@@ -100,6 +100,14 @@ const THEME_COLORS = [
 	'dark',
 ];
 
+const BUTTONS = [
+	'primary',
+	'secondary',
+	'outline-primary',
+	'outline-secondary',
+	'link',
+];
+
 const TokenGroup = ({children, group, medium, title}) => {
 	return (
 		<ClayLayout.Col
@@ -319,6 +327,19 @@ export default function App() {
 						<TokenItem label="separator">
 							<hr />
 						</TokenItem>
+					</TokenGroup>
+
+					<TokenGroup
+						group="buttons"
+						title={Liferay.Language.get('buttons')}
+					>
+						{BUTTONS.map((item) => (
+							<TokenItem key={item} sample={item}>
+								<button className={'btn btn-' + item}>
+									Button
+								</button>
+							</TokenItem>
+						))}
 					</TokenGroup>
 				</ClayLayout.Row>
 			</ClayLayout.ContainerFluid>

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/META-INF/resources/js/App.js
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/META-INF/resources/js/App.js
@@ -311,7 +311,7 @@ export default function App() {
 						title={Liferay.Language.get('others')}
 					>
 						<TokenItem sample="lead">{SAMPLE_TEXT}</TokenItem>
-						<TokenItem sample="muted">{SAMPLE_TEXT}</TokenItem>
+						<TokenItem sample="text-muted">{SAMPLE_TEXT}</TokenItem>
 						<TokenItem label="blockquote">
 							<span className="blockquote">{SAMPLE_TEXT}</span>
 							<span className="blockquote-footer">Liferay</span>

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios
 borders=Borders
 box-shadow=Box Shadow
+buttons=Buttons
 displays=Displays
 font-families=Font Families
 font-weights=Font Weights

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ar.properties
@@ -1,6 +1,7 @@
 aspect-ratios=نسب الأبعاد
 borders=الحدود
 box-shadow=ظل المربع
+buttons=Buttons (Automatic Copy)
 displays=شاشات العرض
 font-families=مجموعات الخطوط
 font-weights=أوزان الخطوط

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_bg.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Пропорции на пропорциите (Automatic Translation)
 borders=Граници (Automatic Translation)
 box-shadow=Сянка на поле (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Показва (Automatic Translation)
 font-families=Семейство шрифтове (Automatic Translation)
 font-weights=Теглине на шрифта (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ca.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Relacions d'aspecte
 borders=Vores
 box-shadow=Ombra de la caixa
+buttons=Buttons (Automatic Copy)
 displays=Visualitzacions
 font-families=Famílies de tipus de lletra
 font-weights=Gruixos de tipus de lletra

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_cs.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Poměry stran (Automatic Translation)
 borders=hranice (Automatic Translation)
 box-shadow=Stín pole (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=zobrazuje (Automatic Translation)
 font-families=Rodiny písem (Automatic Translation)
 font-weights=Hmotnosti písma (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_da.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Højde-bredde-forhold (Automatic Translation)
 borders=Grænser (Automatic Translation)
 box-shadow=Skygge af boks (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Viser (Automatic Translation)
 font-families=Skrifttypefamilier (Automatic Translation)
 font-weights=Skrifttykkelser (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_de.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Seitenverhältnisse
 borders=Rahmen
 box-shadow=Kastenschattierung
+buttons=Buttons (Automatic Copy)
 displays=Anzeigen
 font-families=Schriftfamilien
 font-weights=Schriftstärken

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_el.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Αναλογίες διαστάσεων (Automatic Translation)
 borders=σύνορο (Automatic Translation)
 box-shadow=Σκιά κουτιού (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Εμφανίζει (Automatic Translation)
 font-families=Οικογένειες γραμματοσειρών (Automatic Translation)
 font-weights=Βάρη γραμματοσειράς (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_en.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios
 borders=Borders
 box-shadow=Box Shadow
+buttons=Buttons
 displays=Displays
 font-families=Font Families
 font-weights=Font Weights

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_en_AU.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios (Automatic Copy)
 borders=Borders (Automatic Copy)
 box-shadow=Box Shadow (Automatic Copy)
+buttons=Buttons (Automatic Copy)
 displays=Displays (Automatic Copy)
 font-families=Font Families (Automatic Copy)
 font-weights=Font Weights (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_en_GB.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios (Automatic Copy)
 borders=Borders (Automatic Copy)
 box-shadow=Box Shadow (Automatic Copy)
+buttons=Buttons (Automatic Copy)
 displays=Displays (Automatic Copy)
 font-families=Font Families (Automatic Copy)
 font-weights=Font Weights (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_es.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Relaciones de aspecto
 borders=Bordes
 box-shadow=Sombra del cuadro
+buttons=Buttons (Automatic Copy)
 displays=Visualizaciones
 font-families=Familias de fuentes
 font-weights=Grosores de fuente

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_et.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Proportsioonid (Automatic Translation)
 borders=Piire (Automatic Translation)
 box-shadow=Kasti vari (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Kuvab (Automatic Translation)
 font-families=Fondi pered (Automatic Translation)
 font-weights=Fondi kaalud (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_eu.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios (Automatic Copy)
 borders=Borders (Automatic Copy)
 box-shadow=Box Shadow (Automatic Copy)
+buttons=Buttons (Automatic Copy)
 displays=Displays (Automatic Copy)
 font-families=Font Families (Automatic Copy)
 font-weights=Font Weights (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_fa.properties
@@ -1,6 +1,7 @@
 aspect-ratios=نسبت های جنبه (Automatic Translation)
 borders=مرزهای (Automatic Translation)
 box-shadow=سایه جعبه (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=نمایش (Automatic Translation)
 font-families=خانواده های فونت (Automatic Translation)
 font-weights=وزن فونت (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_fi.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Kuvasuhteet
 borders=Reunukset
 box-shadow=Laatikon Varjo
+buttons=Buttons (Automatic Copy)
 displays=Näytöt
 font-families=Kirjasinperheet
 font-weights=Kirjasimen Vahvuudet

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_fr.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Formats
 borders=Bordures
 box-shadow=Ombre de boîte
+buttons=Buttons (Automatic Copy)
 displays=Affichages
 font-families=Familles de polices
 font-weights=Poids de police

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_fr_CA.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios (Automatic Copy)
 borders=Borders (Automatic Copy)
 box-shadow=Box Shadow (Automatic Copy)
+buttons=Buttons (Automatic Copy)
 displays=Displays (Automatic Copy)
 font-families=Font Families (Automatic Copy)
 font-weights=Font Weights (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_gl.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Proporcións de aspecto
 borders=Bordos
 box-shadow=Sombra de caixa
+buttons=Buttons (Automatic Copy)
 displays=Visualizacións
 font-families=Familias de tipo de letra
 font-weights=Grosores de tipo de letra

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,6 +1,7 @@
 aspect-ratios=आस्पेक्ट रेशियो (Automatic Translation)
 borders=बॉर्डर्स (Automatic Translation)
 box-shadow=बॉक्स छाया (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=प्रदर्शित (Automatic Translation)
 font-families=फ़ॉन्ट परिवार (Automatic Translation)
 font-weights=फ़ॉन्ट वजन (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_hr.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios (Automatic Copy)
 borders=Borders (Automatic Copy)
 box-shadow=Box Shadow (Automatic Copy)
+buttons=Buttons (Automatic Copy)
 displays=Displays (Automatic Copy)
 font-families=Font Families (Automatic Copy)
 font-weights=Font Weights (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_hu.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Képarányok
 borders=Keretek
 box-shadow=Doboz árnyéka
+buttons=Buttons (Automatic Copy)
 displays=Megjelenítések
 font-families=Betűtípuscsalád
 font-weights=Betűvastagság

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_in.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Rasio Aspek (Automatic Translation)
 borders=Perbatasan (Automatic Translation)
 box-shadow=Bayangan Kotak (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Menampilkan (Automatic Translation)
 font-families=Keluarga Fonta (Automatic Translation)
 font-weights=Ketebotan Font (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_it.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Proporzioni (Automatic Translation)
 borders=borders (Automatic Translation)
 box-shadow=Ombra scatola (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Visualizza (Automatic Translation)
 font-families=Famiglie di caratteri (Automatic Translation)
 font-weights=Pesi carattere (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_iw.properties
@@ -1,6 +1,7 @@
 aspect-ratios=יחסי גובה-רוחב (Automatic Translation)
 borders=גבולות (Automatic Translation)
 box-shadow=צל תיבה (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=מציג (Automatic Translation)
 font-families=משפחות גופנים (Automatic Translation)
 font-weights=עובי גופן (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ja.properties
@@ -1,6 +1,7 @@
 aspect-ratios=アスペクト比
 borders=枠線
 box-shadow=ボックスの影
+buttons=Buttons (Automatic Copy)
 displays=表示設定
 font-families=フォントファミリー
 font-weights=フォントの太さ

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_kk.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios (Automatic Copy)
 borders=Borders (Automatic Copy)
 box-shadow=Box Shadow (Automatic Copy)
+buttons=Buttons (Automatic Copy)
 displays=Displays (Automatic Copy)
 font-families=Font Families (Automatic Copy)
 font-weights=Font Weights (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ko.properties
@@ -1,6 +1,7 @@
 aspect-ratios=종횡비 (Automatic Translation)
 borders=테두리 (Automatic Translation)
 box-shadow=박스 섀도우 (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=표시 (Automatic Translation)
 font-families=글꼴 패밀리 (Automatic Translation)
 font-weights=글꼴 가중치 (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_lo.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios (Automatic Copy)
 borders=Borders (Automatic Copy)
 box-shadow=Box Shadow (Automatic Copy)
+buttons=Buttons (Automatic Copy)
 displays=Displays (Automatic Copy)
 font-families=Font Families (Automatic Copy)
 font-weights=Font Weights (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_lt.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Vaizdo formatai (Automatic Translation)
 borders=Sienų (Automatic Translation)
 box-shadow=Lauko šešėlis (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Rodo (Automatic Translation)
 font-families=Šriftų šeimos (Automatic Translation)
 font-weights=Šrifto storis (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ms.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Nisbah Aspek (Automatic Translation)
 borders=Sempadan (Automatic Translation)
 box-shadow=Bayang-bayang Kotak (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Memaparkan (Automatic Translation)
 font-families=Keluarga Fon (Automatic Translation)
 font-weights=Berat Fon (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_nb.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Størrelsesforhold (Automatic Translation)
 borders=Kantlinjer (Automatic Translation)
 box-shadow=Skygge for boks (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Viser (Automatic Translation)
 font-families=Skriftfamilier (Automatic Translation)
 font-weights=Skrifttykkelser (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_nl.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Beeldverhoudingen
 borders=Randen
 box-shadow=Vakschaduw
+buttons=Buttons (Automatic Copy)
 displays=Weergaven
 font-families=Lettertypegroepen
 font-weights=Tekendikten

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios (Automatic Copy)
 borders=Borders (Automatic Copy)
 box-shadow=Box Shadow (Automatic Copy)
+buttons=Buttons (Automatic Copy)
 displays=Displays (Automatic Copy)
 font-families=Font Families (Automatic Copy)
 font-weights=Font Weights (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_pl.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Proporcje (Automatic Translation)
 borders=Granic (Automatic Translation)
 box-shadow=Cień pola (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Wyświetla (Automatic Translation)
 font-families=Rodziny czcionek (Automatic Translation)
 font-weights=Wagi czcionek (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Taxas de proporção
 borders=Bordas
 box-shadow=Sombra de caixa
+buttons=Buttons (Automatic Copy)
 displays=Exibições
 font-families=Famílias de fonte
 font-weights=Pesos de fonte

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Proporções de aspectos (Automatic Translation)
 borders=Fronteiras (Automatic Translation)
 box-shadow=Sombra da caixa (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Exibe (Automatic Translation)
 font-families=Famílias de Fontes (Automatic Translation)
 font-weights=Pesos de Fonte (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ro.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Raporturi de aspect (Automatic Translation)
 borders=Frontierele (Automatic Translation)
 box-shadow=Umbră casetă (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Afişează (Automatic Translation)
 font-families=Familii de fonturi (Automatic Translation)
 font-weights=Greutăți font (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ru.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Пропорции (Automatic Translation)
 borders=Границы (Automatic Translation)
 box-shadow=Коробка Тень (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Отображает (Automatic Translation)
 font-families=Семьи шрифтов (Automatic Translation)
 font-weights=Вес шрифта (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_sk.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Pomery strán (Automatic Translation)
 borders=Hraníc (Automatic Translation)
 box-shadow=Tieň poľa (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Zobrazí (Automatic Translation)
 font-families=Rodiny písiem (Automatic Translation)
 font-weights=Závažia písma (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_sl.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Razmerja širine in širine (Automatic Translation)
 borders=Meja (Automatic Translation)
 box-shadow=Senca polja (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Prikaže (Automatic Translation)
 font-families=Družine pisav (Automatic Translation)
 font-weights=Uteži pisave (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios (Automatic Copy)
 borders=Borders (Automatic Copy)
 box-shadow=Box Shadow (Automatic Copy)
+buttons=Buttons (Automatic Copy)
 displays=Displays (Automatic Copy)
 font-families=Font Families (Automatic Copy)
 font-weights=Font Weights (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios (Automatic Copy)
 borders=Borders (Automatic Copy)
 box-shadow=Box Shadow (Automatic Copy)
+buttons=Buttons (Automatic Copy)
 displays=Displays (Automatic Copy)
 font-families=Font Families (Automatic Copy)
 font-weights=Font Weights (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_sv.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Bredd–höjd-förhållanden
 borders=Kanter
 box-shadow=Rutskugga
+buttons=Buttons (Automatic Copy)
 displays=Skärmar
 font-families=Teckensnittsfamiljer
 font-weights=Teckengrovlekar

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_ta_IN.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Aspect Ratios (Automatic Copy)
 borders=Borders (Automatic Copy)
 box-shadow=Box Shadow (Automatic Copy)
+buttons=Buttons (Automatic Copy)
 displays=Displays (Automatic Copy)
 font-families=Font Families (Automatic Copy)
 font-weights=Font Weights (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_th.properties
@@ -1,6 +1,7 @@
 aspect-ratios=อัตราส่วนกว้างยาว (Automatic Translation)
 borders=เส้น ขอบ (Automatic Translation)
 box-shadow=เงาของกล่อง (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=แสดง (Automatic Translation)
 font-families=ตระกูลแบบอักษร (Automatic Translation)
 font-weights=น้ําหนักแบบอักษร (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_tr.properties
@@ -1,6 +1,7 @@
 aspect-ratios=En Boy Oranları (Automatic Translation)
 borders=Sınır -ları (Automatic Translation)
 box-shadow=Kutu Gölgesi (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Görüntü -ler (Automatic Translation)
 font-families=Yazı Tipi Aileleri (Automatic Translation)
 font-weights=Yazı Tipi Ağırlıkları (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_uk.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Пропорції (Automatic Translation)
 borders=Кордонів (Automatic Translation)
 box-shadow=Тінь рамки (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Відображає (Automatic Translation)
 font-families=Сім'ї шрифтів (Automatic Translation)
 font-weights=Товщина шрифту (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_vi.properties
@@ -1,6 +1,7 @@
 aspect-ratios=Tỷ lệ khung hình (Automatic Translation)
 borders=Giáp (Automatic Translation)
 box-shadow=Bóng Hộp (Automatic Translation)
+buttons=Buttons (Automatic Copy)
 displays=Hiển thị (Automatic Translation)
 font-families=Gia đình Phông (Automatic Translation)
 font-weights=Trọng lượng phông chữ (Automatic Translation)

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,6 +1,7 @@
 aspect-ratios=纵横比
 borders=边框
 box-shadow=框阴影
+buttons=Buttons (Automatic Copy)
 displays=显示
 font-families=字体系列
 font-weights=字体粗细

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,6 +1,7 @@
 aspect-ratios=縱橫比
 borders=邊框
 box-shadow=框陰影
+buttons=Buttons (Automatic Copy)
 displays=顯示
 font-families=字型
 font-weights=字體粗細


### PR DESCRIPTION
This PR fixes a minor visual bug on the text-muted of the frontend-theme-classic-style-guide-sample-web widget and adds the buttons sample

![image](https://user-images.githubusercontent.com/46778114/127016076-d776fa0d-9a34-497f-97b3-797f278e5602.png)