### PR TITLE
LPS-135729 Adjust tabletoolbar's panel styles

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/tabletoolbar/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/tabletoolbar/plugin.js
@@ -954,7 +954,9 @@
 
 				let panelBlock;
 
-				panel.className = `${panel.className ?? ''} cke_combopanel`;
+				panel.className = panel.className
+					? `${panel.className} lfr-cke_table_panel`
+					: 'lfr-cke_table_panel';
 
 				editor.ui.add(name, CKEDITOR.UI_PANELBUTTON, {
 					command: commandName,

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/tabletoolbar/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/tabletoolbar/plugin.js
@@ -954,6 +954,8 @@
 
 				let panelBlock;
 
+				panel.className = `${panel.className ?? ''} cke_combopanel`;
+
 				editor.ui.add(name, CKEDITOR.UI_PANELBUTTON, {
 					command: commandName,
 					editorFocus,

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/tabletoolbar/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/tabletoolbar/plugin.js
@@ -954,9 +954,7 @@
 
 				let panelBlock;
 
-				panel.className = panel.className
-					? `${panel.className} lfr-cke_table_panel`
-					: 'lfr-cke_table_panel';
+				panel.className = 'lfr-table-panel';
 
 				editor.ui.add(name, CKEDITOR.UI_PANELBUTTON, {
 					command: commandName,

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -65,7 +65,7 @@
 	}
 }
 
-.lfr-cke_table_panel {
+.lfr-table-panel {
 	min-height: 110px;
 	min-width: 200px;
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -65,7 +65,13 @@
 	}
 }
 
+.lfr-cke_table_panel {
+	min-height: 110px;
+	min-width: 200px;
+}
+
 .lfr-balloon-editor-insert-button {
+	align-items: center;
 	background: white;
 	border: 0.75px solid #0b5fff;
 	border-radius: 2px;


### PR DESCRIPTION
This PR depends on https://github.com/brianchandotcom/liferay-portal/pull/104894

It fixes the truncated text in table toolbar panel.

### Before:

<img width="320" alt="Screen Shot 2021-07-30 at 19 20 16" src="https://user-images.githubusercontent.com/7663513/127717124-388c07a9-6fee-45f3-8ccd-ac6e0694935d.png">


### After:

<img width="320" alt="Screen Shot 2021-07-30 at 18 50 01" src="https://user-images.githubusercontent.com/7663513/127715002-9db9438e-beb1-4d3f-8cba-d094242b82eb.png">

<img width="320" alt="Screen Shot 2021-07-30 at 19 00 23" src="https://user-images.githubusercontent.com/7663513/127715789-9458b694-165b-4a03-b334-c0ae7d91aaae.png">

<img width="320" alt="Screen Shot 2021-07-30 at 19 00 30" src="https://user-images.githubusercontent.com/7663513/127715792-38e40741-c1b5-4f19-a519-b50ae44ff9d1.png">

### AlloyEditor's style:

<img width="320" alt="Screen Shot 2021-07-30 at 19 13 55" src="https://user-images.githubusercontent.com/7663513/127716627-2f6f5547-0a5f-4a55-81e6-d58c330ec186.png">


### There is one issue with this PR:


<img width="514" alt="Screen Shot 2021-07-30 at 20 07 32" src="https://user-images.githubusercontent.com/7663513/127719919-3bed1848-cf7c-4b34-8688-925add22cea0.png">


~~Due to a fixed value of `width`, there is an empty space in the panel depending how many items we have.~~

~~I tried to use `min-height` as alloy-editor does but We still setting a defined height and We might still have some empty spaces there.~~

This issue is also reproduced in combopanel usages, like the format combo:

<img width="589" alt="Screen Shot 2021-07-30 at 20 12 13" src="https://user-images.githubusercontent.com/7663513/127720056-1375730e-984b-473a-a710-0bbcb396bd1c.png">

