### PR TITLE
LPS-136579 Control if an icon should be displayed in TreeviewCard component

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.scss
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.scss
@@ -28,6 +28,10 @@ $white: #fff;
 
 			.card-body {
 				padding: 0.5rem;
+
+				.card-row {
+					min-height: 2rem;
+				}
 			}
 
 			&.form-check-middle-left .card-horizontal > .card-body {

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewCard.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewCard.js
@@ -47,11 +47,13 @@ export default function TreeviewCard({node}) {
 			<div className="card card-horizontal">
 				<div className="card-body">
 					<ClayCard.Row className="autofit-row-center">
-						<div className="autofit-col">
-							<ClaySticker displayType="secondary" inline>
-								<ClayIcon symbol={node.icon} />
-							</ClaySticker>
-						</div>
+						{node.icon && (
+							<div className="autofit-col">
+								<ClaySticker displayType="secondary" inline>
+									<ClayIcon symbol={node.icon} />
+								</ClaySticker>
+							</div>
+						)}
 
 						<div className="autofit-col autofit-col-expand autofit-col-gutters">
 							<ClayCard.Description displayType="title">

--- a/modules/apps/frontend-js/frontend-js-components-web/test/treeview/Treeview.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/treeview/Treeview.js
@@ -329,4 +329,57 @@ describe('Treeview', () => {
 			expect(queryByText('sandro polo')).not.toBeInTheDocument();
 		});
 	});
+
+	describe('Treeview controls icon visibility in TreeviewCard', () => {
+		it('rendering the icon if present', () => {
+			const nodes = [
+				{
+					icon: 'emoji',
+					id: '1',
+					name: 'Belt',
+				},
+				{
+					icon: 'react',
+					id: '2',
+					name: 'Clara',
+				},
+			];
+
+			const {container} = render(
+				<Treeview NodeComponent={Treeview.Card} nodes={nodes} />
+			);
+
+			expect(
+				container.getElementsByClassName('lexicon-icon').length
+			).toBe(2);
+			expect(
+				container.getElementsByClassName('lexicon-icon-emoji').length
+			).toBe(1);
+			expect(
+				container.getElementsByClassName('lexicon-icon-react').length
+			).toBe(1);
+		});
+
+		it('not rendering icon if not present or falsy', () => {
+			const nodes = [
+				{
+					id: '1',
+					name: 'Belt',
+				},
+				{
+					icon: null,
+					id: '2',
+					name: 'Clara',
+				},
+			];
+
+			const {container} = render(
+				<Treeview NodeComponent={Treeview.Card} nodes={nodes} />
+			);
+
+			expect(
+				container.getElementsByClassName('lexicon-icon').length
+			).toBe(0);
+		});
+	});
 });


### PR DESCRIPTION
[View ticket in Jira](https://issues.liferay.com/browse/LPS-136579)
This task pretends to control the value received via props, and conditionally render the icon only if a value is passed.

Currently, a white box is rendered if no valid string is passed. A valid string should be a string representing one of the available icons in Clay/Lexicon.

<img width="424" alt="Screenshot 2021-08-02 at 16 10 35" src="https://user-images.githubusercontent.com/19485114/127875492-b3395ec6-0756-403d-a9db-d0ff34c5d228.png">

First PR to this repository 😃 
Any feedback super welcome 🙌 

== THIS STEPS WONT WORK ANYMORE AS DEMO COMMITS HAVE BEEN DELETED ==
Steps to reproduce:
1. Activate FF in the portal to use document types for filtering in the Content Dashboard:
`echo "enabled=B\"true\"" > ../bundles/osgi/configs/com.liferay.content.dashboard.web.internal.configuration.FFContentDashboardDocumentConfiguration.config`
2. In Product Menu, under Content & Data > Web Content, create 2 basic web contents
3. In Product Menu, under Content & Data > Documents and media, create 1 External video shortcut, and 1 File Upload, for example.
4. Navigate to Content Dashboard.

You should see something like this, the chart will not show any data if assets are not categorized, does not matter:
![image](https://user-images.githubusercontent.com/19485114/127893502-58317506-0f64-43d8-8ad2-7433c9c08b95.png)

5. Click on Filter and Order
6. Click on Subtype: a modal should pop up with a tree representing [the mocked data from this component](https://github.com/liferay-frontend/liferay-portal/pull/1305/commits/0b2e5d3bbe143f49d5c1740ebdc96caf657aa3b1#diff-c7f23285d54ab0c5952f29d588e7053a53e36c09dbbea8ccc6b91078629c5632R44)
7. See first child "Basic Web Content" with no icon and the rest with icon provided in the mocked data.
8. If changes in this PR are reverted you should see a white rounded square if no icon or invalid string for the icon is provided

I think you can access directly to the tree component without open the modal [here](http://localhost:8080/group/guest/~/control_panel/manage/-/select/contentdashboarditemtype/_com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet_selectedContentDashboardItemTypeItem?_com_liferay_item_selector_web_portlet_ItemSelectorPortlet_0_json=%7B%22desiredItemSelectorReturnTypes%22%3A%22uuid%22%7D&p_p_auth=TPLwsIAL&_null_bodyCssClass=dialog-iframe-popup)

![image](https://user-images.githubusercontent.com/19485114/127894576-37e14a59-945f-4e27-9bc7-a80f5757dfb1.png)
