### PR TITLE
LPS-135421 Add liferay-frontend:stylesheet tag

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib
 Bundle-SymbolicName: com.liferay.frontend.taglib
-Bundle-Version: 6.1.2
+Bundle-Version: 6.2.0
 Export-Package:\
 	com.liferay.frontend.taglib.servlet.taglib,\
 	com.liferay.frontend.taglib.servlet.taglib.base,\

--- a/modules/apps/frontend-taglib/frontend-taglib/build.gradle
+++ b/modules/apps/frontend-taglib/frontend-taglib/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":apps:petra:petra-portlet-url-builder")
+	compileOnly project(":apps:portal-url-builder:portal-url-builder-api")
 	compileOnly project(":apps:users-admin:users-admin-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib/package.json
@@ -21,5 +21,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "6.1.2"
+	"version": "6.2.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/internal/util/ServicesProvider.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/internal/util/ServicesProvider.java
@@ -16,9 +16,21 @@ package com.liferay.frontend.taglib.internal.util;
 
 import com.liferay.frontend.js.module.launcher.JSModuleLauncher;
 import com.liferay.frontend.js.module.launcher.JSModuleResolver;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.util.tracker.BundleTracker;
+import org.osgi.util.tracker.BundleTrackerCustomizer;
 
 /**
  * @author Iván Zaera Avellón
@@ -26,12 +38,29 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = {})
 public class ServicesProvider {
 
+	public static AbsolutePortalURLBuilderFactory
+		getAbsolutePortalURLBuilderFactory() {
+
+		return _absolutePortalURLBuilderFactory;
+	}
+
+	public static Map<String, Bundle> getBundleMap() {
+		return _bundleConcurrentMap;
+	}
+
 	public static JSModuleLauncher getJSModuleLauncher() {
 		return _jsModuleLauncher;
 	}
 
 	public static JSModuleResolver getJSModuleResolver() {
 		return _jsModuleResolver;
+	}
+
+	@Reference(unbind = "-")
+	public void setAbsolutePortalURLBuilderFactory(
+		AbsolutePortalURLBuilderFactory absolutePortalURLBuilderFactory) {
+
+		_absolutePortalURLBuilderFactory = absolutePortalURLBuilderFactory;
 	}
 
 	@Reference(unbind = "-")
@@ -44,6 +73,55 @@ public class ServicesProvider {
 		_jsModuleResolver = jsModuleResolver;
 	}
 
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleConcurrentMap = new ConcurrentHashMap<>();
+
+		_bundleTracker = new BundleTracker(
+			bundleContext, Bundle.ACTIVE,
+			new BundleTrackerCustomizer<String>() {
+
+				@Override
+				public String addingBundle(
+					Bundle bundle, BundleEvent bundleEvent) {
+
+					_bundleConcurrentMap.put(bundle.getSymbolicName(), bundle);
+
+					return bundle.getSymbolicName();
+				}
+
+				@Override
+				public void modifiedBundle(
+					Bundle bundle, BundleEvent bundleEvent,
+					String symbolicName) {
+				}
+
+				@Override
+				public void removedBundle(
+					Bundle bundle, BundleEvent bundleEvent,
+					String symbolicName) {
+
+					_bundleConcurrentMap.remove(symbolicName);
+				}
+
+			});
+
+		_bundleTracker.open();
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_bundleTracker.close();
+
+		_bundleTracker = null;
+
+		_bundleConcurrentMap = null;
+	}
+
+	private static AbsolutePortalURLBuilderFactory
+		_absolutePortalURLBuilderFactory;
+	private static ConcurrentMap<String, Bundle> _bundleConcurrentMap;
+	private static BundleTracker<String> _bundleTracker;
 	private static JSModuleLauncher _jsModuleLauncher;
 	private static JSModuleResolver _jsModuleResolver;
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTag.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.servlet.taglib;
+
+import com.liferay.frontend.taglib.internal.util.ServicesProvider;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.servlet.taglib.util.OutputData;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+import com.liferay.taglib.util.AttributesTagSupport;
+
+import java.util.Map;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.JspException;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+public class StylesheetTag extends AttributesTagSupport {
+
+	@Override
+	public int doEndTag() throws JspException {
+		Map<String, Bundle> bundleMap = ServicesProvider.getBundleMap();
+
+		Bundle bundle = bundleMap.get(_bundle);
+
+		if (bundle == null) {
+			throw new JspException("Unable to find bundle " + _bundle);
+		}
+
+		AbsolutePortalURLBuilderFactory absolutePortalURLBuilderFactory =
+			ServicesProvider.getAbsolutePortalURLBuilderFactory();
+
+		HttpServletRequest httpServletRequest =
+			(HttpServletRequest)pageContext.getRequest();
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder =
+			absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				httpServletRequest);
+
+		OutputData outputData = _getOutputData(httpServletRequest);
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append("<link rel=\"stylesheet\" type=\"text/css\" href=\"");
+		sb.append(
+			absolutePortalURLBuilder.forModule(
+				bundle, _css
+			).build());
+		sb.append("\"></link>");
+
+		outputData.addDataSB(_getOutputKey(), WebKeys.PAGE_TOP, sb);
+
+		return EVAL_PAGE;
+	}
+
+	public void setBundle(String bundle) {
+		_bundle = bundle;
+	}
+
+	public void setCss(String css) {
+		_css = css;
+	}
+
+	private OutputData _getOutputData(ServletRequest servletRequest) {
+		OutputData outputData = (OutputData)servletRequest.getAttribute(
+			WebKeys.OUTPUT_DATA);
+
+		if (outputData == null) {
+			outputData = new OutputData();
+
+			servletRequest.setAttribute(WebKeys.OUTPUT_DATA, outputData);
+		}
+
+		return outputData;
+	}
+
+	private String _getOutputKey() {
+		return _bundle + StringPool.SLASH + _css;
+	}
+
+	private String _bundle;
+	private String _css;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -1514,6 +1514,22 @@
 		</attribute>
 	</tag>
 	<tag>
+		<description>Loads a CSS resource using the AMD loader.</description>
+		<name>stylesheet</name>
+		<tag-class>com.liferay.frontend.taglib.servlet.taglib.StylesheetTag</tag-class>
+		<body-content>empty</body-content>
+		<attribute>
+			<name>bundle</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>css</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+	<tag>
 		<description>Creates a UI component for managing translations of associated content.</description>
 		<name>translation-manager</name>
 		<tag-class>com.liferay.frontend.taglib.servlet.taglib.TranslationManagerTag</tag-class>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 2.8.0
+version 2.9.0


### PR DESCRIPTION
This is a resend of https://github.com/liferay-frontend/liferay-portal/pull/1245, but it renders the CSS `<link>` in server. Thus, it doesn't need to rely on the AMD loader.

Care has been taken to avoid fetching CSS files twice from the server in case someone requests it from a JSP first, then from a JS module. In that case, the browser cache will avoid a second trip to the server because the CSS will be found in the cache.

This can be tested by invoking the taglib from any portlet, like this:

```
<liferay-frontend:stylesheet bundle="com.liferay.my.test.bundle" css="example.css" />
```