### PR TITLE
LPS-135071 [WIP - Do not forward] Solve Object Definition conflict with multiple companies without using namespaces

### DIFF
--- a/modules/apps/object/object-rest-impl/build.gradle
+++ b/modules/apps/object/object-rest-impl/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.apache.cxf", name: "cxf-core", version: "3.4.4"

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/ObjectDefinitionRESTContextPathRegistry.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/ObjectDefinitionRESTContextPathRegistry.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal;
+
+import com.liferay.object.model.ObjectDefinition;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(service = ObjectDefinitionRESTContextPathRegistry.class)
+public class ObjectDefinitionRESTContextPathRegistry {
+
+	public ObjectDefinition getObjectDefinition(
+		long companyId, String restContextPath) {
+
+		Map<Long, ObjectDefinition> objectDefinitionCompanyMap =
+			_objectDefinitionMap.get(restContextPath);
+
+		if (objectDefinitionCompanyMap != null) {
+			return objectDefinitionCompanyMap.get(companyId);
+		}
+
+		return null;
+	}
+
+	public boolean hasRESTContextPath(String restContextPath) {
+		return _objectDefinitionMap.containsKey(restContextPath);
+	}
+
+	public void register(
+		long companyId, String restContextPath,
+		ObjectDefinition objectDefinition) {
+
+		_objectDefinitionMap.putIfAbsent(restContextPath, new HashMap<>());
+
+		Map<Long, ObjectDefinition> objectDefinitionCompanyMap =
+			_objectDefinitionMap.get(restContextPath);
+
+		objectDefinitionCompanyMap.put(companyId, objectDefinition);
+	}
+
+	private final Map<String, Map<Long, ObjectDefinition>>
+		_objectDefinitionMap = new HashMap<>();
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -16,6 +16,7 @@ package com.liferay.object.rest.internal.deployer;
 
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.internal.ObjectDefinitionRESTContextPathRegistry;
 import com.liferay.object.rest.internal.graphql.dto.v1_0.ObjectDefinitionGraphQLDTOContributor;
 import com.liferay.object.rest.internal.jaxrs.context.provider.ObjectDefinitionContextProvider;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectFieldExceptionMapper;
@@ -23,9 +24,12 @@ import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOContributor;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,77 +56,94 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	public List<ServiceRegistration<?>> deploy(
 		ObjectDefinition objectDefinition) {
 
-		_componentInstancesMap.put(
-			objectDefinition.getObjectDefinitionId(),
-			Arrays.asList(
-				_objectEntryApplicationComponentFactory.newInstance(
+		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
+
+		if (!_objectDefinitionAPIRegistry.hasRESTContextPath(
+				objectDefinition.getRESTContextPath())) {
+
+			_componentInstancesMap.put(
+				objectDefinition.getObjectDefinitionId(),
+				Arrays.asList(
+					_objectEntryApplicationComponentFactory.newInstance(
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferay.jackson", false
+						).put(
+							"liferay.object.definition.id",
+							objectDefinition.getObjectDefinitionId()
+						).put(
+							"osgi.jaxrs.application.base",
+							"/" + objectDefinition.getRESTContextPath()
+						).put(
+							"osgi.jaxrs.extension.select",
+							"(osgi.jaxrs.name=Liferay.Vulcan)"
+						).put(
+							"osgi.jaxrs.name", objectDefinition.getShortName()
+						).build()),
+					_objectEntryResourceComponentFactory.newInstance(
+						HashMapDictionaryBuilder.<String, Object>put(
+							"api.version", "v1.0"
+						).put(
+							"batch.engine.task.item.delegate", "true"
+						).put(
+							"batch.engine.task.item.delegate.name",
+							objectDefinition.getShortName()
+						).put(
+							"osgi.jaxrs.resource", "true"
+						).put(
+							"osgi.jaxrs.application.select",
+							"(osgi.jaxrs.name=" +
+								objectDefinition.getShortName() + ")"
+						).build())));
+
+			Collections.addAll(
+				serviceRegistrations,
+				_bundleContext.registerService(
+					ContextProvider.class,
+					new ObjectDefinitionContextProvider(
+						_objectDefinitionAPIRegistry, _portal),
 					HashMapDictionaryBuilder.<String, Object>put(
-						"liferay.jackson", false
-					).put(
-						"liferay.object.definition.id",
-						objectDefinition.getObjectDefinitionId()
-					).put(
-						"osgi.jaxrs.application.base",
-						"/" + objectDefinition.getRESTContextPath()
-					).put(
-						"osgi.jaxrs.extension.select",
-						"(osgi.jaxrs.name=Liferay.Vulcan)"
-					).put(
-						"osgi.jaxrs.name", objectDefinition.getShortName()
-					).build()),
-				_objectEntryResourceComponentFactory.newInstance(
-					HashMapDictionaryBuilder.<String, Object>put(
-						"api.version", "v1.0"
-					).put(
-						"batch.engine.task.item.delegate", "true"
-					).put(
-						"batch.engine.task.item.delegate.name",
-						objectDefinition.getShortName()
-					).put(
-						"osgi.jaxrs.resource", "true"
-					).put(
 						"osgi.jaxrs.application.select",
 						"(osgi.jaxrs.name=" + objectDefinition.getShortName() +
 							")"
-					).build())));
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"enabled", "false"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getRESTContextPath() +
+							"ObjectDefinitionContextProvider"
+					).build()),
+				_bundleContext.registerService(
+					ExceptionMapper.class,
+					new RequiredObjectFieldExceptionMapper(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"osgi.jaxrs.application.select",
+						"(osgi.jaxrs.name=" + objectDefinition.getShortName() +
+							")"
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getRESTContextPath() +
+							"RequiredObjectFieldExceptionMapper"
+					).build()),
+				_bundleContext.registerService(
+					GraphQLDTOContributor.class,
+					ObjectDefinitionGraphQLDTOContributor.of(
+						objectDefinition, _objectEntryManager,
+						_objectFieldLocalService.getObjectFields(
+							objectDefinition.getObjectDefinitionId())),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"dto.name", objectDefinition.getDBTableName()
+					).build()));
+		}
 
-		return Arrays.asList(
-			_bundleContext.registerService(
-				ContextProvider.class,
-				new ObjectDefinitionContextProvider(objectDefinition),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					"(osgi.jaxrs.name=" + objectDefinition.getShortName() + ")"
-				).put(
-					"osgi.jaxrs.extension", "true"
-				).put(
-					"enabled", "false"
-				).put(
-					"osgi.jaxrs.name",
-					objectDefinition.getRESTContextPath() +
-						"ObjectDefinitionContextProvider"
-				).build()),
-			_bundleContext.registerService(
-				ExceptionMapper.class, new RequiredObjectFieldExceptionMapper(),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					"(osgi.jaxrs.name=" + objectDefinition.getShortName() + ")"
-				).put(
-					"osgi.jaxrs.extension", "true"
-				).put(
-					"osgi.jaxrs.name",
-					objectDefinition.getRESTContextPath() +
-						"RequiredObjectFieldExceptionMapper"
-				).build()),
-			_bundleContext.registerService(
-				GraphQLDTOContributor.class,
-				ObjectDefinitionGraphQLDTOContributor.of(
-					objectDefinition, _objectEntryManager,
-					_objectFieldLocalService.getObjectFields(
-						objectDefinition.getObjectDefinitionId())),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"dto.name", objectDefinition.getDBTableName()
-				).build()));
+		_objectDefinitionAPIRegistry.register(
+			objectDefinition.getCompanyId(),
+			objectDefinition.getRESTContextPath(), objectDefinition);
+
+		return serviceRegistrations;
 	}
 
 	@Override
@@ -145,6 +166,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		new HashMap<>();
 
 	@Reference
+	private ObjectDefinitionRESTContextPathRegistry
+		_objectDefinitionAPIRegistry;
+
+	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference(
@@ -162,5 +187,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -127,17 +127,19 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"osgi.jaxrs.name",
 						objectDefinition.getRESTContextPath() +
 							"RequiredObjectFieldExceptionMapper"
-					).build()),
-				_bundleContext.registerService(
-					GraphQLDTOContributor.class,
-					ObjectDefinitionGraphQLDTOContributor.of(
-						objectDefinition, _objectEntryManager,
-						_objectFieldLocalService.getObjectFields(
-							objectDefinition.getObjectDefinitionId())),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"dto.name", objectDefinition.getDBTableName()
 					).build()));
 		}
+
+		serviceRegistrations.add(
+			_bundleContext.registerService(
+				GraphQLDTOContributor.class,
+				ObjectDefinitionGraphQLDTOContributor.of(
+					objectDefinition, _objectEntryManager,
+					_objectFieldLocalService.getObjectFields(
+						objectDefinition.getObjectDefinitionId())),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"dto.name", objectDefinition.getDBTableName()
+				).build()));
 
 		_objectDefinitionAPIRegistry.register(
 			objectDefinition.getCompanyId(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -67,6 +67,7 @@ public class ObjectDefinitionGraphQLDTOContributor
 		}
 
 		return new ObjectDefinitionGraphQLDTOContributor(
+			objectDefinition.getCompanyId(),
 			new ObjectEntryEntityModel(objectFields), graphQLDTOProperties,
 			objectDefinition.getPKObjectFieldName(),
 			objectDefinition.getObjectDefinitionId(), objectEntryManager,
@@ -89,6 +90,11 @@ public class ObjectDefinitionGraphQLDTOContributor
 		_objectEntryManager.deleteObjectEntry(id);
 
 		return true;
+	}
+
+	@Override
+	public long getCompanyId() {
+		return _companyId;
 	}
 
 	@Override
@@ -158,10 +164,12 @@ public class ObjectDefinitionGraphQLDTOContributor
 	}
 
 	private ObjectDefinitionGraphQLDTOContributor(
-		EntityModel entityModel, List<GraphQLDTOProperty> graphQLDTOProperties,
-		String idName, long objectDefinitionId,
-		ObjectEntryManager objectEntryManager, String resourceName) {
+		long companyId, EntityModel entityModel,
+		List<GraphQLDTOProperty> graphQLDTOProperties, String idName,
+		long objectDefinitionId, ObjectEntryManager objectEntryManager,
+		String resourceName) {
 
+		_companyId = companyId;
 		_entityModel = entityModel;
 		_graphQLDTOProperties = graphQLDTOProperties;
 		_idName = idName;
@@ -211,6 +219,7 @@ public class ObjectDefinitionGraphQLDTOContributor
 			"String", String.class
 		).build();
 
+	private final long _companyId;
 	private final EntityModel _entityModel;
 	private final List<GraphQLDTOProperty> _graphQLDTOProperties;
 	private final String _idName;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
@@ -15,6 +15,11 @@
 package com.liferay.object.rest.internal.jaxrs.context.provider;
 
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.internal.ObjectDefinitionRESTContextPathRegistry;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import javax.servlet.http.HttpServletRequest;
 
 import javax.ws.rs.ext.Provider;
 
@@ -28,15 +33,33 @@ import org.apache.cxf.message.Message;
 public class ObjectDefinitionContextProvider
 	implements ContextProvider<ObjectDefinition> {
 
-	public ObjectDefinitionContextProvider(ObjectDefinition objectDefinition) {
-		_objectDefinition = objectDefinition;
+	public ObjectDefinitionContextProvider(
+		ObjectDefinitionRESTContextPathRegistry
+			objectDefinitionRESTContextPathRegistry,
+		Portal portal) {
+
+		_objectDefinitionRESTContextPathRegistry =
+			objectDefinitionRESTContextPathRegistry;
+		_portal = portal;
 	}
 
 	@Override
 	public ObjectDefinition createContext(Message message) {
-		return _objectDefinition;
+		long companyId = _portal.getCompanyId(
+			(HttpServletRequest)message.getContextualProperty("HTTP.REQUEST"));
+
+		String restContextPath = (String)message.getContextualProperty(
+			"org.apache.cxf.message.Message.BASE_PATH");
+
+		restContextPath = StringUtil.removeSubstring(restContextPath, "/o/");
+		restContextPath = StringUtil.replaceLast(restContextPath, '/', "");
+
+		return _objectDefinitionRESTContextPathRegistry.getObjectDefinition(
+			companyId, restContextPath);
 	}
 
-	private final ObjectDefinition _objectDefinition;
+	private final ObjectDefinitionRESTContextPathRegistry
+		_objectDefinitionRESTContextPathRegistry;
+	private final Portal _portal;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 9.0.1
+Bundle-Version: 10.0.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/dto/GraphQLDTOContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/dto/GraphQLDTOContributor.java
@@ -34,6 +34,8 @@ public interface GraphQLDTOContributor<D, R> {
 
 	public boolean deleteDTO(long id) throws Exception;
 
+	public long getCompanyId();
+
 	public R getDTO(DTOConverterContext dtoConverterContext, long id)
 		throws Exception;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/dto/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/dto/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0


### PR DESCRIPTION
Solve the issue when there were multiple object definitions with the same name in multiple companies.

On the REST side, I've created a registry to keep track of the Object Definitions by company and RESTContextPath. The ObjectDefinitionContextProvider is the one responsible for providing the correct ObjectDefinition to the ObjectDefinitionResourceImpl using the registry.

On the GraphQL side, the only way I found to avoid the conflict without using namespaces or a solution that affects user experience, is creating a GraphQLServlet by company and selecting the right one in each request. I think is a clean solution, my only concern is about performance when there are a lot of companies (like in LOL)