### PR TITLE
LPS-136645 Avoid ArrayIndexOutOfBoundsException in headless api if you sort using a non-localizable DDM field

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dynamic/data/mapping/DDMStructureField.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dynamic/data/mapping/DDMStructureField.java
@@ -64,35 +64,28 @@ public class DDMStructureField {
 		return StringBundler.concat(
 			DDMIndexer.DDM_FIELD_PREFIX, _indexType,
 			DDMIndexer.DDM_FIELD_SEPARATOR, _ddmStructureId,
-			DDMIndexer.DDM_FIELD_SEPARATOR, _fieldReference, getLocaleSuffix());
+			DDMIndexer.DDM_FIELD_SEPARATOR, _fieldReference,
+			_getLocaleSuffix());
 	}
 
 	public String getDDMStructureNestedFieldName() {
 		return StringBundler.concat(
 			DDMIndexer.DDM_FIELD_ARRAY, StringPool.PERIOD,
 			DDMIndexer.DDM_VALUE_FIELD_NAME_PREFIX,
-			StringUtil.upperCaseFirstLetter(_indexType), getLocaleSuffix());
+			StringUtil.upperCaseFirstLetter(_indexType), _getLocaleSuffix());
 	}
 
 	public String getDDMStructureNestedTypeSortableFieldName() {
 		return StringBundler.concat(
 			DDMIndexer.DDM_FIELD_ARRAY, StringPool.PERIOD,
 			DDMIndexer.DDM_VALUE_FIELD_NAME_PREFIX,
-			StringUtil.upperCaseFirstLetter(_indexType), getLocaleSuffix(),
+			StringUtil.upperCaseFirstLetter(_indexType), _getLocaleSuffix(),
 			StringPool.UNDERLINE, _type, StringPool.UNDERLINE,
 			Field.SORTABLE_FIELD_SUFFIX);
 	}
 
 	public String getLocale() {
 		return _locale;
-	}
-
-	public String getLocaleSuffix() {
-		if (_locale == null) {
-			return StringPool.BLANK;
-		}
-
-		return StringPool.UNDERLINE.concat(_locale);
 	}
 
 	private static String _getSuffixLocale(String string) {
@@ -117,6 +110,14 @@ public class DDMStructureField {
 		_indexType = indexType;
 		_locale = locale;
 		_type = type;
+	}
+
+	private String _getLocaleSuffix() {
+		if (_locale == null) {
+			return StringPool.BLANK;
+		}
+
+		return StringPool.UNDERLINE.concat(_locale);
 	}
 
 	private final String _ddmStructureId;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-136645

Change the way we parse the ddmStructureField String:
 - We can have DDM fields without locale. 
 - The locale can also have different number of underscores (en, en_US or sr_RS_latin) so instead of spliting by underscore character, we will do it in a more robust way

This problem has been also addressed in the Custom facet widget, see https://issues.liferay.com/browse/LPS-136137 and https://github.com/liferay-search/liferay-portal/pull/182
