### PR TITLE
LPS-136699 Duplicated keys in DropdownMenu component

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -69,6 +69,7 @@ export default function DropdownMenu({
 						<ClayButtonWithIcon
 							className="component-action quick-action-item"
 							displayType="unstyled"
+							key={data.action}
 							small={true}
 							symbol={icon}
 							{...rest}
@@ -80,6 +81,7 @@ export default function DropdownMenu({
 							<ClayLink
 								className="component-action quick-action-item"
 								href={href}
+								key={href}
 								{...rest}
 							>
 								<ClayIcon symbol={icon} />


### PR DESCRIPTION
[Jira issue](https://issues.liferay.com/browse/LPS-136699)

### Motivation
The DropdownMenu component is throwing a warn due to duplicate ids.
The map over `items` prop is not using a `key` prop for each item.

`modules/apps/frontend-taglib/frontend-taglib-clay/DropdownMenu.js`

**Reproduce**

- Navigate to Product Menu > Content & Data > Web Content and at least 1 web basic contents
- Navigate to Product Menu > Content & Data > Documents and Media and create at least 1 document or media
- Enable FF

`echo "enabled=B\"true\"" > ../bundles/osgi/configs/com.liferay.content.dashboard.web.internal.configuration.FFContentDashboardDocumentConfiguration.config`

- Navigate to Applications Menu > Content Dashboard, open browser console, a warning should appear:

![image](https://user-images.githubusercontent.com/19485114/128153428-ada3d69d-7a86-4fed-9559-dac77c55e334.png)
