### PR TITLE
LPS-136018 Upgrade liferay-ui:input-search markup

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/css/management_bar.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/css/management_bar.scss
@@ -157,6 +157,15 @@ $management-bar-default-btn-secondary-active-color: $management-bar-default-btn-
 	.btn-link {
 		color: $nav-link-color;
 	}
+
+	.btn,
+	.dropdown-toggle {
+		.c-inner {
+			display: initial;
+			margin: 0;
+			padding: 0;
+		}
+	}
 }
 
 .management-bar-container {
@@ -266,11 +275,6 @@ $management-bar-default-btn-secondary-active-color: $management-bar-default-btn-
 		.input-group-btn .btn-secondary {
 			background-color: #f1f2f5;
 			border-color: #e7e7ed;
-		}
-
-		.form-control {
-			border-right-color: transparent;
-			width: 100%;
 		}
 	}
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/management_bar_filter/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/management_bar_filter/page.jsp
@@ -25,7 +25,7 @@ String value = (String)request.getAttribute("liferay-frontend:management-bar-fil
 
 <c:if test="<%= !managementBarFilterItems.isEmpty() %>">
 	<li class="dropdown <%= disabled ? "disabled" : StringPool.BLANK %>">
-		<a aria-expanded="true" class="dropdown-toggle" data-qa-id="filter<%= Validator.isNotNull(label) ? label : StringPool.BLANK %>" data-toggle="<%= disabled ? StringPool.BLANK : "dropdown" %>" href="javascript:;">
+		<a aria-expanded="true" class="dropdown-toggle" data-qa-id="filter<%= Validator.isNotNull(label) ? label : StringPool.BLANK %>" data-toggle="<%= disabled ? StringPool.BLANK : "liferay-dropdown" %>" href="javascript:;">
 			<span class="management-bar-item-title">
 				<c:if test="<%= Validator.isNotNull(label) %>">
 					<liferay-ui:message key="<%= label %>" />:

--- a/portal-web/docroot/html/taglib/ui/input_search/lexicon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_search/lexicon/page.jsp
@@ -35,19 +35,17 @@ String value = ParamUtil.getString(request, name);
 %>
 
 <div class="<%= cssClass %> input-group lfr-input-search">
-	<div class="input-group-item input-group-prepend">
-		<label class="hide-accessible" for="<%= namespace + id %>"><%= title %></label>
+	<div class="input-group-item">
+		<input aria-label="<%= title %>" class="form-control <%= showButton ? "input-group-inset input-group-inset-after" : null %> search-query" data-qa-id="searchInput" id="<%= namespace + id %>" name="<%= namespace + name %>" placeholder="<%= placeholder %>" title="<%= title %>" type="text" value="<%= HtmlUtil.escapeAttribute(value) %>" />
 
-		<input class="form-control search-query" data-qa-id="searchInput" id="<%= namespace + id %>" name="<%= namespace + name %>" placeholder="<%= placeholder %>" title="<%= title %>" type="text" value="<%= HtmlUtil.escapeAttribute(value) %>" />
+		<c:if test="<%= showButton %>">
+			<div class="input-group-inset-item input-group-inset-item-after">
+				<button class="btn btn-unstyled" data-qa-id="searchButton" type="submit">
+					<aui:icon image="search" markupView="lexicon" />
+				</button>
+			</div>
+		</c:if>
 	</div>
-
-	<c:if test="<%= showButton %>">
-		<div class="input-group-append input-group-item input-group-item-shrink">
-			<button class="btn btn-monospaced btn-secondary" data-qa-id="searchButton" type="submit">
-				<aui:icon image="search" markupView="lexicon" />
-			</button>
-		</div>
-	</c:if>
 </div>
 
 <c:if test="<%= autoFocus %>">


### PR DESCRIPTION
This PR fixes the `<liferay-frontend:management-bar>` style and upgrades the `<liferay-ui:input-search>` markup to the Clay one.

![1](https://user-images.githubusercontent.com/46778114/128206015-e600caaf-43ae-47d3-94b7-0073e0492349.jpg)

---

**How to test the changes:**

- Open the appllications-menu
- Click on the Control Panel tab
- Click on Account Group under USERS category