### PR TITLE
Organization Chart 2 - Modals and Dropdown menus to add/remove entities

### DIFF
--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/D3OrganizationChart.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/D3OrganizationChart.js
@@ -37,7 +37,14 @@ import {
 } from './utils/index';
 import {fillAddButtons, fillEntityNode, getLinkDiagonal} from './utils/paint';
 class D3OrganizationChart {
-	constructor(rootData, refs, spritemap, modalActions, rootVisible = true) {
+	constructor(
+		rootData,
+		refs,
+		spritemap,
+		modalActions,
+		nodeMenuActions,
+		rootVisible = true
+	) {
 		this._spritemap = spritemap;
 		this._refs = refs;
 		this._handleZoomInClick = this._handleZoomInClick.bind(this);
@@ -47,6 +54,7 @@ class D3OrganizationChart {
 		this._handleNodeMouseDown = this._handleNodeMouseDown.bind(this);
 		this._hideChildrenAndUpdate = this._hideChildrenAndUpdate.bind(this);
 		this._currentScale = 1;
+		this._nodeMenuActions = nodeMenuActions;
 		this._modalActions = modalActions;
 		this._selectedNodes = new Map();
 		this._rootVisible = rootVisible;
@@ -297,7 +305,10 @@ class D3OrganizationChart {
 			.scaleExtent(ZOOM_EXTENT)
 			.on('zoom', this._handleZoom);
 
-		this.svg = d3.select(this._refs.svg).call(this._zoom);
+		this.svg = d3
+			.select(this._refs.svg)
+			.on('mousedown', this._nodeMenuActions.close)
+			.call(this._zoom);
 
 		this._zoomHandler = this.svg.append('g');
 
@@ -317,6 +328,7 @@ class D3OrganizationChart {
 
 	_handleNodeMouseDown(d) {
 		d3.event.stopPropagation();
+		this._nodeMenuActions.close();
 
 		if (d.data.type === 'user') {
 			this._createTransition();
@@ -449,7 +461,7 @@ class D3OrganizationChart {
 		const children = nodes.filter((d) => d.data.type !== 'add');
 
 		children.attr('transform', `translate(${source.y0},${source.x0})`);
-		fillEntityNode(children, this._spritemap);
+		fillEntityNode(children, this._spritemap, this._nodeMenuActions.open);
 
 		children.on('mousedown', this._handleNodeMouseDown);
 

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/D3OrganizationChart.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/D3OrganizationChart.js
@@ -30,11 +30,12 @@ import {
 	getEntityId,
 	getMinWidth,
 	hideChildren,
+	insertAddButtons,
 	insertChildrenIntoNode,
 	showChildren,
 	tree,
 } from './utils/index';
-import {fillEntityNode, getLinkDiagonal} from './utils/paint';
+import {fillAddButtons, fillEntityNode, getLinkDiagonal} from './utils/paint';
 class D3OrganizationChart {
 	constructor(rootData, refs, spritemap, modalActions, rootVisible = true) {
 		this._spritemap = spritemap;
@@ -327,6 +328,7 @@ class D3OrganizationChart {
 	}
 
 	_update(source, recenter = true, sourcesMap, showDeleteTransition) {
+		insertAddButtons(this._root, this._selectedNodes);
 		tree(this._root);
 
 		this._root.eachBefore((d) => {
@@ -441,6 +443,8 @@ class D3OrganizationChart {
 			'transform',
 			(d) => `translate(${d.y},${d.x}) scale(0)`
 		);
+
+		fillAddButtons(addButtons, this._spritemap, this._modalActions.open);
 
 		const children = nodes.filter((d) => d.data.type !== 'add');
 

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/D3OrganizationChart.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/D3OrganizationChart.js
@@ -36,13 +36,7 @@ import {
 } from './utils/index';
 import {fillEntityNode, getLinkDiagonal} from './utils/paint';
 class D3OrganizationChart {
-	constructor(
-		rootData,
-		refs,
-		spritemap,
-		modalActions,
-		rootVisible = true
-	) {
+	constructor(rootData, refs, spritemap, modalActions, rootVisible = true) {
 		this._spritemap = spritemap;
 		this._refs = refs;
 		this._handleZoomInClick = this._handleZoomInClick.bind(this);
@@ -302,9 +296,7 @@ class D3OrganizationChart {
 			.scaleExtent(ZOOM_EXTENT)
 			.on('zoom', this._handleZoom);
 
-		this.svg = d3
-			.select(this._refs.svg)
-			.call(this._zoom);
+		this.svg = d3.select(this._refs.svg).call(this._zoom);
 
 		this._zoomHandler = this.svg.append('g');
 
@@ -455,8 +447,7 @@ class D3OrganizationChart {
 		children.attr('transform', `translate(${source.y0},${source.x0})`);
 		fillEntityNode(children, this._spritemap);
 
-		children
-			.on('mousedown', this._handleNodeMouseDown);
+		children.on('mousedown', this._handleNodeMouseDown);
 
 		this._handleTransition(this.bindedNodes.merge(nodes))
 			.attr('opacity', 1)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/D3OrganizationChart.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/D3OrganizationChart.js
@@ -36,7 +36,13 @@ import {
 } from './utils/index';
 import {fillEntityNode, getLinkDiagonal} from './utils/paint';
 class D3OrganizationChart {
-	constructor(rootData, refs, spritemap, modalActions, rootVisible = true) {
+	constructor(
+		rootData,
+		refs,
+		spritemap,
+		modalActions,
+		rootVisible = true
+	) {
 		this._spritemap = spritemap;
 		this._refs = refs;
 		this._handleZoomInClick = this._handleZoomInClick.bind(this);
@@ -296,7 +302,9 @@ class D3OrganizationChart {
 			.scaleExtent(ZOOM_EXTENT)
 			.on('zoom', this._handleZoom);
 
-		this.svg = d3.select(this._refs.svg).call(this._zoom);
+		this.svg = d3
+			.select(this._refs.svg)
+			.call(this._zoom);
 
 		this._zoomHandler = this.svg.append('g');
 
@@ -447,7 +455,8 @@ class D3OrganizationChart {
 		children.attr('transform', `translate(${source.y0},${source.x0})`);
 		fillEntityNode(children, this._spritemap);
 
-		children.on('mousedown', this._handleNodeMouseDown);
+		children
+			.on('mousedown', this._handleNodeMouseDown);
 
 		this._handleTransition(this.bindedNodes.merge(nodes))
 			.attr('opacity', 1)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/OrganizationChart.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/OrganizationChart.js
@@ -18,9 +18,12 @@ import ChartContext from './ChartContext';
 import D3OrganizationChart from './D3OrganizationChart';
 import ManagementBar from './ManagementBar/ManagementBar';
 import {getOrganization} from './data/organizations';
+import ModalProvider from './modals/ModalProvider';
 import {VIEWS} from './utils/constants';
 
 function OrganizationChartApp({rootOrganizationId, spritemap, templatesURL}) {
+	const [modalActive, updateModalActive] = useState(false);
+	const [modalData, updateModalData] = useState(null);
 	const [currentView, updateCurrentView] = useState(VIEWS[0]);
 	const [expanded, updateExpanded] = useState(false);
 	const [rootData, updateRootData] = useState(null);
@@ -42,7 +45,16 @@ function OrganizationChartApp({rootOrganizationId, spritemap, templatesURL}) {
 					zoomIn: zoomInRef.current,
 					zoomOut: zoomOutRef.current,
 				},
-				spritemap
+				spritemap,
+				{
+					open: (parentData, type) => {
+						updateModalData({
+							parentData,
+							type,
+						});
+						updateModalActive(true);
+					},
+				}
 			);
 		}
 
@@ -84,6 +96,12 @@ function OrganizationChartApp({rootOrganizationId, spritemap, templatesURL}) {
 					</ClayButton.Group>
 				</div>
 			</div>
+			<ModalProvider
+				active={modalActive}
+				closeModal={() => updateModalActive(false)}
+				parentData={modalData?.parentData}
+				type={modalData?.type}
+			/>
 		</ChartContext.Provider>
 	);
 }

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/OrganizationChart.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/OrganizationChart.js
@@ -18,6 +18,7 @@ import ChartContext from './ChartContext';
 import D3OrganizationChart from './D3OrganizationChart';
 import ManagementBar from './ManagementBar/ManagementBar';
 import {getOrganization} from './data/organizations';
+import MenuProvider from './menu/MenuProvider';
 import ModalProvider from './modals/ModalProvider';
 import {VIEWS} from './utils/constants';
 
@@ -26,7 +27,10 @@ function OrganizationChartApp({rootOrganizationId, spritemap, templatesURL}) {
 	const [modalData, updateModalData] = useState(null);
 	const [currentView, updateCurrentView] = useState(VIEWS[0]);
 	const [expanded, updateExpanded] = useState(false);
+	const [menuData, updateMenuData] = useState(null);
+	const [menuParentData, updateMenuParentData] = useState(null);
 	const [rootData, updateRootData] = useState(null);
+	const clickedMenuButtonRef = useRef(null);
 	const chartSVGRef = useRef(null);
 	const chartInstanceRef = useRef(null);
 	const zoomOutRef = useRef(null);
@@ -53,6 +57,18 @@ function OrganizationChartApp({rootOrganizationId, spritemap, templatesURL}) {
 							type,
 						});
 						updateModalActive(true);
+					},
+				},
+				{
+					close: () => {
+						clickedMenuButtonRef.current = null;
+						updateMenuData(null);
+						updateMenuParentData(null);
+					},
+					open: (target, data, parentData) => {
+						clickedMenuButtonRef.current = target;
+						updateMenuData(data);
+						updateMenuParentData(parentData);
 					},
 				}
 			);
@@ -96,6 +112,11 @@ function OrganizationChartApp({rootOrganizationId, spritemap, templatesURL}) {
 					</ClayButton.Group>
 				</div>
 			</div>
+			<MenuProvider
+				alignElementRef={clickedMenuButtonRef}
+				data={menuData}
+				parentData={menuParentData}
+			/>
 			<ModalProvider
 				active={modalActive}
 				closeModal={() => updateModalActive(false)}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/OrganizationChart.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/OrganizationChart.js
@@ -87,6 +87,7 @@ function OrganizationChartApp({rootOrganizationId, spritemap, templatesURL}) {
 			}}
 		>
 			<ManagementBar />
+
 			<div className={classnames('org-chart-container', {expanded})}>
 				<svg className="svg-chart" ref={chartSVGRef} />
 				<div className="zoom-controls">

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/accounts.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/accounts.js
@@ -14,6 +14,13 @@ import {fetchFromHeadless} from '../utils/fetch';
 
 const ACCOUNTS_ROOT_ENDPOINT = '/o/account-rest/v1.0/accounts';
 
+export function getAccounts(query) {
+	const url = new URL(ACCOUNTS_ROOT_ENDPOINT, themeDisplay.getPortalURL());
+	url.searchParams.append('search', query);
+
+	return fetchFromHeadless(url);
+}
+
 export function getAccount(id) {
 	const accountUrl = new URL(
 		`${ACCOUNTS_ROOT_ENDPOINT}/${id}`,
@@ -26,4 +33,16 @@ export function getAccount(id) {
 	);
 
 	return fetchFromHeadless(accountUrl);
+}
+
+export function updateAccountDetails(id, details) {
+	const url = new URL(
+		`${ACCOUNTS_ROOT_ENDPOINT}/${id}`,
+		themeDisplay.getPortalURL()
+	);
+
+	return fetchFromHeadless(url, {
+		body: JSON.stringify(details),
+		method: 'PATCH',
+	});
 }

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/accounts.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/accounts.js
@@ -21,6 +21,15 @@ export function getAccounts(query) {
 	return fetchFromHeadless(url);
 }
 
+export function deleteAccount(id) {
+	const url = new URL(
+		`${ACCOUNTS_ROOT_ENDPOINT}/${id}`,
+		themeDisplay.getPortalURL()
+	);
+
+	return fetchFromHeadless(url, {method: 'DELETE'}, null, true);
+}
+
 export function getAccount(id) {
 	const accountUrl = new URL(
 		`${ACCOUNTS_ROOT_ENDPOINT}/${id}`,

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/accounts.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/accounts.js
@@ -16,6 +16,7 @@ const ACCOUNTS_ROOT_ENDPOINT = '/o/account-rest/v1.0/accounts';
 
 export function getAccounts(query) {
 	const url = new URL(ACCOUNTS_ROOT_ENDPOINT, themeDisplay.getPortalURL());
+
 	url.searchParams.append('search', query);
 
 	return fetchFromHeadless(url);

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/organizations.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/organizations.js
@@ -57,6 +57,15 @@ export function getOrganization(id) {
 	return fetchFromHeadless(url);
 }
 
+export function deleteOrganization(id) {
+	const url = new URL(
+		`${ORGANIZATIONS_ROOT_ENDPOINT}/${id}`,
+		themeDisplay.getPortalURL()
+	);
+
+	return fetchFromHeadless(url, {method: 'DELETE'}, null, true);
+}
+
 export function updateOrganization(id, body) {
 	const url = new URL(
 		`${ORGANIZATIONS_ROOT_ENDPOINT}/${id}`,

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/users.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/users.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {fetchFromHeadless} from '../utils/fetch';
+
+export const USERS_ROOT_ENDPOINT = '/o/headless-admin-user/v1.0/user-accounts';
+export const ROLES_ROOT_ENDPOINT = '/o/headless-admin-user/v1.0/roles';
+
+export function getUsersByEmails(emails) {
+	const filterString = emails
+		.map((email) => `emailAddress eq '${email}'`)
+		.join(' or ');
+	const url = new URL(USERS_ROOT_ENDPOINT, themeDisplay.getPortalURL());
+
+	url.searchParams.append('filter', filterString);
+
+	return fetchFromHeadless(url);
+}
+
+export function getUsersRoles(page = 1) {
+	const url = new URL(ROLES_ROOT_ENDPOINT, themeDisplay.getPortalURL());
+
+	url.searchParams.append('page', page);
+	url.searchParams.append('pageSize', 100);
+
+	return fetchFromHeadless(url, {}, null, true);
+}
+
+export function getAllUserRoles() {
+	return getUsersRoles().then((firstResponse) => {
+		if (firstResponse.page === firstResponse.lastPage) {
+			return firstResponse;
+		}
+
+		const requests = [];
+
+		for (
+			let currentPage = 2;
+			currentPage <= firstResponse.lastPage;
+			currentPage++
+		) {
+			requests.push(getUsersRoles(currentPage));
+		}
+
+		return Promise.allSettled(requests).then((results) => {
+			const errors = [];
+			const roles = results.reduce((values, result) => {
+				if (result.status === 'fulfilled') {
+					return [...values, ...result.value.items];
+				}
+				else {
+					errors.push(result.reason);
+
+					return values;
+				}
+			}, []);
+
+			if (errors.length) {
+				throw new Error(errors);
+			}
+
+			return {
+				items: [...firstResponse.items, ...roles],
+			};
+		});
+	});
+}
+
+export function getUsers(query) {
+	const url = new URL(USERS_ROOT_ENDPOINT, themeDisplay.getPortalURL());
+
+	url.searchParams.append('search', query);
+	url.searchParams.append('pageSize', 20);
+
+	return fetchFromHeadless(url);
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/users.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/users.js
@@ -52,6 +52,7 @@ export function getAllUserRoles() {
 
 		return Promise.allSettled(requests).then((results) => {
 			const errors = [];
+
 			const roles = results.reduce((values, result) => {
 				if (result.status === 'fulfilled') {
 					return [...values, ...result.value.items];

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/users.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/users.js
@@ -82,3 +82,12 @@ export function getUsers(query) {
 
 	return fetchFromHeadless(url);
 }
+
+export function deleteUser(id) {
+	const url = new URL(
+		`${USERS_ROOT_ENDPOINT}/${id}`,
+		themeDisplay.getPortalURL()
+	);
+
+	return fetchFromHeadless(url, {method: 'DELETE'}, null, true);
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/AccountMenuContent.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/AccountMenuContent.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import ClayDropDown from '@clayui/drop-down';
+import React, {useContext} from 'react';
+
+import ChartContext from '../ChartContext';
+import {deleteAccount} from '../data/accounts';
+import {PERMISSION_CHECK_ON_HEADLESS_API_ACTIONS} from '../utils/flags';
+
+export default function AccountMenuContent({closeMenu, data, parentData}) {
+	const {chartInstanceRef} = useContext(ChartContext);
+
+	function handleDelete() {
+		if (
+			confirm(
+				Liferay.Util.sub(
+					Liferay.Language.get('x-will-be-deleted'),
+					data.name
+				)
+			)
+		) {
+			deleteAccount(data.id).then(() => {
+				chartInstanceRef.current.deleteNodes([data], true);
+
+				if (parentData) {
+					chartInstanceRef.current.updateNodeContent({
+						...parentData,
+						numberOfAccounts: parentData.numberOfAccounts - 1,
+					});
+				}
+
+				closeMenu();
+			});
+		}
+	}
+
+	const actions = [];
+
+	if (!PERMISSION_CHECK_ON_HEADLESS_API_ACTIONS) {
+		actions.push(
+			<ClayDropDown.Item key="delete" onClick={handleDelete}>
+				{Liferay.Language.get('delete')}
+			</ClayDropDown.Item>
+		);
+	}
+
+	return actions;
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/MenuProvider.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/MenuProvider.js
@@ -16,7 +16,7 @@ import AccountMenuContent from './AccountMenuContent';
 import OrganizationMenuContent from './OrganizationMenuContent';
 import UserMenuContent from './UserMenuContent';
 
-const content = {
+const CONTENT = {
 	account: AccountMenuContent,
 	organization: OrganizationMenuContent,
 	user: UserMenuContent,
@@ -31,9 +31,7 @@ export default function MenuProvider({
 	const [data, updateData] = useState(false);
 	const menuRef = useRef(null);
 
-	/**
-	 * the useEffect below force the component repositioning
-	 */
+	// The useEffect below force the component repositioning
 
 	useEffect(() => {
 		setActive(false);
@@ -46,12 +44,12 @@ export default function MenuProvider({
 		}
 	}, [data]);
 
-	const MenuContent = useMemo(() => data && content[data.type], [data]);
+	const MenuContent = useMemo(() => data && CONTENT[data.type], [data]);
 
-	function closeMenu() {
+	const closeMenu = () => {
 		updateData(null);
 		setActive(false);
-	}
+	};
 
 	return (
 		<ClayDropDown.Menu

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/MenuProvider.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/MenuProvider.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import ClayDropDown from '@clayui/drop-down';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
+
+import AccountMenuContent from './AccountMenuContent';
+import OrganizationMenuContent from './OrganizationMenuContent';
+import UserMenuContent from './UserMenuContent';
+
+const content = {
+	account: AccountMenuContent,
+	organization: OrganizationMenuContent,
+	user: UserMenuContent,
+};
+
+export default function MenuProvider({
+	alignElementRef,
+	data: propData,
+	parentData,
+}) {
+	const [active, setActive] = useState(false);
+	const [data, updateData] = useState(false);
+	const menuRef = useRef(null);
+
+	/**
+	 * the useEffect below force the component repositioning
+	 */
+
+	useEffect(() => {
+		setActive(false);
+		updateData(propData);
+	}, [propData]);
+
+	useEffect(() => {
+		if (data) {
+			setActive(true);
+		}
+	}, [data]);
+
+	const MenuContent = useMemo(() => data && content[data.type], [data]);
+
+	function closeMenu() {
+		updateData(null);
+		setActive(false);
+	}
+
+	return (
+		<ClayDropDown.Menu
+			active={active}
+			alignElementRef={alignElementRef}
+			onSetActive={closeMenu}
+			ref={menuRef}
+		>
+			{MenuContent && (
+				<MenuContent
+					closeMenu={closeMenu}
+					data={data}
+					parentData={parentData}
+				/>
+			)}
+		</ClayDropDown.Menu>
+	);
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/OrganizationMenuContent.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/OrganizationMenuContent.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import ClayDropDown from '@clayui/drop-down';
+import React, {useContext} from 'react';
+
+import ChartContext from '../ChartContext';
+import {deleteOrganization, updateOrganization} from '../data/organizations';
+import {PERMISSION_CHECK_ON_HEADLESS_API_ACTIONS} from '../utils/flags';
+
+export default function OrganizationMenuContent({closeMenu, data, parentData}) {
+	const {chartInstanceRef} = useContext(ChartContext);
+
+	function handleDelete() {
+		if (
+			confirm(
+				Liferay.Util.sub(
+					Liferay.Language.get('x-will-be-deleted'),
+					data.name
+				)
+			)
+		) {
+			deleteOrganization(data.id).then(() => {
+				chartInstanceRef.current.deleteNodes([data], true);
+				chartInstanceRef.current.updateNodeContent({
+					...parentData,
+					numberOfOrganizations: parentData.numberOfOrganizations - 1,
+				});
+
+				closeMenu();
+			});
+		}
+	}
+
+	function handleRemove() {
+		if (
+			confirm(
+				Liferay.Util.sub(
+					Liferay.Language.get(
+						'x-will-be-remove-from-its-parent-organization'
+					),
+					data.name
+				)
+			)
+		) {
+			updateOrganization(data.id, {
+				parentOrganization: {},
+			}).then(() => {
+				chartInstanceRef.current.deleteNodes([data], true);
+
+				if (parentData) {
+					chartInstanceRef.current.updateNodeContent({
+						...parentData,
+						numberOfOrganizations:
+							parentData.numberOfOrganizations - 1,
+					});
+				}
+
+				closeMenu();
+			});
+		}
+	}
+
+	const actions = [];
+
+	if (!PERMISSION_CHECK_ON_HEADLESS_API_ACTIONS) {
+		actions.push(
+			<ClayDropDown.Item key="remove" onClick={handleRemove}>
+				{Liferay.Language.get('remove')}
+			</ClayDropDown.Item>
+		);
+	}
+
+	if (!PERMISSION_CHECK_ON_HEADLESS_API_ACTIONS) {
+		actions.push(
+			<ClayDropDown.Item key="delete" onClick={handleDelete}>
+				{Liferay.Language.get('delete')}
+			</ClayDropDown.Item>
+		);
+	}
+
+	return actions;
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/UserMenuContent.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/UserMenuContent.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import ClayDropDown from '@clayui/drop-down';
+import React, {useContext} from 'react';
+
+import ChartContext from '../ChartContext';
+import {deleteUser} from '../data/users';
+import {PERMISSION_CHECK_ON_HEADLESS_API_ACTIONS} from '../utils/flags';
+
+export default function AccountMenuContent({closeMenu, data, parentData}) {
+	const {chartInstanceRef} = useContext(ChartContext);
+
+	function handleDelete() {
+		if (
+			confirm(
+				Liferay.Util.sub(
+					Liferay.Language.get('x-will-be-deleted'),
+					data.name
+				)
+			)
+		) {
+			deleteUser(data.id).then(() => {
+				chartInstanceRef.current.deleteNodes([data], true);
+
+				if (parentData) {
+					chartInstanceRef.current.updateNodeContent({
+						...parentData,
+						numberOfUsers: parentData.numberOfUsers - 1,
+					});
+				}
+
+				closeMenu();
+			});
+		}
+	}
+
+	const actions = [];
+
+	if (!PERMISSION_CHECK_ON_HEADLESS_API_ACTIONS) {
+		actions.push(
+			<ClayDropDown.Item key="delete" onClick={handleDelete}>
+				{Liferay.Language.get('delete')}
+			</ClayDropDown.Item>
+		);
+	}
+
+	return actions;
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddAccountsModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddAccountsModal.js
@@ -185,8 +185,8 @@ export default function AddOrganizationModal({
 							</label>
 							<ClayInput
 								id="newAccountNameInput"
-								onChange={(e) =>
-									setNewAccountName(e.target.value)
+								onChange={(event) =>
+									setNewAccountName(event.target.value)
 								}
 								value={newAccountName}
 							/>

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddAccountsModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddAccountsModal.js
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import ClayButton from '@clayui/button';
+import ClayForm, {ClayInput, ClayRadio, ClayRadioGroup} from '@clayui/form';
+import ClayModal from '@clayui/modal';
+import ClayMultiSelect from '@clayui/multi-select';
+import {openToast} from 'frontend-js-web';
+import React, {useContext, useEffect, useMemo, useState} from 'react';
+
+import ChartContext from '../ChartContext';
+import {getAccounts, updateAccountDetails} from '../data/accounts';
+import {getUsers} from '../data/users';
+import {ACCOUNTS_CREATION_ENABLED} from '../utils/flags';
+
+function showNotFoundError(name) {
+	openToast({
+		message: Liferay.Util.sub(Liferay.Language.get('x-not-found'), name),
+		type: 'danger',
+	});
+}
+
+export default function AddOrganizationModal({
+	closeModal,
+	observer,
+	parentData,
+}) {
+	const {chartInstanceRef} = useContext(ChartContext);
+
+	const [accountsQuery, setAccountsQuery] = useState('');
+	const [newAccountName, setNewAccountName] = useState('');
+	const [fetchedAccounts, setFetchedAccounts] = useState([]);
+	const [selectedAccounts, setSelectedAccounts] = useState([]);
+
+	const [emailsQuery, setEmailsQuery] = useState('');
+	const [fetchedUsers, setFetchedUsers] = useState([]);
+	const [selectedUsers, setSelectedUsers] = useState([]);
+	const [newAccountMode, updateNewAccountMode] = useState(false);
+
+	useEffect(() => {
+		if (accountsQuery) {
+			getAccounts(accountsQuery).then((response) => {
+				setFetchedAccounts(response.items);
+			});
+		}
+		else {
+			setFetchedAccounts([]);
+		}
+	}, [accountsQuery]);
+
+	useEffect(() => {
+		if (emailsQuery) {
+			getUsers(emailsQuery).then((response) => {
+				setFetchedUsers(response.items);
+			});
+		}
+		else {
+			setFetchedUsers([]);
+		}
+	}, [emailsQuery]);
+
+	const accountOptions = useMemo(() => {
+		const selectedAccountIds = new Set(
+			selectedAccounts.map((account) => account.id)
+		);
+
+		return fetchedAccounts.filter((account) => {
+			const alreadySelected = selectedAccountIds.has(account.id);
+			const alreadyDefinedAsChild = account.organizationIds.some(
+				(organizationId) =>
+					Number(organizationId) === Number(parentData.id)
+			);
+
+			return !alreadySelected && !alreadyDefinedAsChild;
+		});
+	}, [parentData, selectedAccounts, fetchedAccounts]);
+
+	function handleSave() {
+		const errors = [];
+
+		if (newAccountMode) {
+			throw new Error('account-creation-un-handled');
+		}
+		else {
+			if (accountsQuery) {
+				showNotFoundError(accountsQuery);
+			}
+
+			if (selectedAccounts.length) {
+				Promise.allSettled(
+					selectedAccounts.map((account) =>
+						updateAccountDetails(account.id, {
+							organizationIds: [
+								...account.organizationIds,
+								parentData.id,
+							],
+						})
+					)
+				).then((results) => {
+					const nodeChildren = [];
+					results.forEach((result) => {
+						if (result.status === 'fulfilled') {
+							nodeChildren.push(result.value);
+						}
+						else {
+							openToast({
+								message: result.value,
+								type: 'danger',
+							});
+							errors.push(result.value);
+						}
+					});
+
+					chartInstanceRef.current.addNodes(
+						nodeChildren,
+						'account',
+						parentData
+					);
+
+					chartInstanceRef.current.updateNodeContent({
+						...parentData,
+						numberOfAccounts:
+							parentData.numberOfAccounts + nodeChildren.length,
+					});
+
+					if (!errors.length) {
+						closeModal();
+					}
+				});
+			}
+		}
+	}
+
+	function handleItemsChange(items) {
+		const filteredItems = items.filter((item) => {
+			const newItem = item.name === item.id;
+
+			if (newItem) {
+				showNotFoundError(item.name);
+			}
+
+			return !newItem;
+		});
+
+		setSelectedAccounts(filteredItems);
+	}
+
+	return (
+		<ClayModal observer={observer} size="md">
+			<ClayModal.Header>
+				{Liferay.Language.get('add-accounts')}
+			</ClayModal.Header>
+			<ClayModal.Body>
+				{ACCOUNTS_CREATION_ENABLED && (
+					<ClayRadioGroup
+						className="mb-4"
+						onSelectedValueChange={updateNewAccountMode}
+						selectedValue={newAccountMode}
+					>
+						<ClayRadio
+							label={Liferay.Language.get(
+								'select-existing-accounts'
+							)}
+							value={false}
+						/>
+						<ClayRadio
+							label={Liferay.Language.get('create-new-account')}
+							value={true}
+						/>
+					</ClayRadioGroup>
+				)}
+				{newAccountMode ? (
+					<>
+						<ClayForm.Group>
+							<label htmlFor="newAccountNameInput">
+								{Liferay.Language.get('name')}
+							</label>
+							<ClayInput
+								id="newAccountNameInput"
+								onChange={(e) =>
+									setNewAccountName(e.target.value)
+								}
+								value={newAccountName}
+							/>
+						</ClayForm.Group>
+						<ClayForm.Group>
+							<label htmlFor="administratorEmailInput">
+								{Liferay.Language.get('administrators-email')}
+							</label>
+							<ClayMultiSelect
+								id="administratorEmailInput"
+								inputValue={emailsQuery}
+								items={selectedUsers}
+								locator={{label: 'name', value: 'id'}}
+								onChange={setEmailsQuery}
+								onItemsChange={setSelectedUsers}
+								sourceItems={fetchedUsers}
+							/>
+						</ClayForm.Group>
+					</>
+				) : (
+					<ClayForm.Group>
+						<label htmlFor="searchAccountInput">
+							{Liferay.Language.get('search-account')}
+						</label>
+						<ClayMultiSelect
+							id="searchAccountInput"
+							inputValue={accountsQuery}
+							items={selectedAccounts}
+							locator={{label: 'name', value: 'id'}}
+							onChange={setAccountsQuery}
+							onItemsChange={handleItemsChange}
+							sourceItems={accountOptions}
+						/>
+					</ClayForm.Group>
+				)}
+			</ClayModal.Body>
+			<ClayModal.Footer
+				last={
+					<ClayButton.Group spaced>
+						<ClayButton
+							displayType="secondary"
+							onClick={closeModal}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+						<ClayButton displayType="primary" onClick={handleSave}>
+							{Liferay.Language.get('save')}
+						</ClayButton>
+					</ClayButton.Group>
+				}
+			/>
+		</ClayModal>
+	);
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddAccountsModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddAccountsModal.js
@@ -106,6 +106,7 @@ export default function AddOrganizationModal({
 					)
 				).then((results) => {
 					const nodeChildren = [];
+
 					results.forEach((result) => {
 						if (result.status === 'fulfilled') {
 							nodeChildren.push(result.value);
@@ -158,6 +159,7 @@ export default function AddOrganizationModal({
 			<ClayModal.Header>
 				{Liferay.Language.get('add-accounts')}
 			</ClayModal.Header>
+
 			<ClayModal.Body>
 				{ACCOUNTS_CREATION_ENABLED && (
 					<ClayRadioGroup
@@ -171,6 +173,7 @@ export default function AddOrganizationModal({
 							)}
 							value={false}
 						/>
+
 						<ClayRadio
 							label={Liferay.Language.get('create-new-account')}
 							value={true}
@@ -183,6 +186,7 @@ export default function AddOrganizationModal({
 							<label htmlFor="newAccountNameInput">
 								{Liferay.Language.get('name')}
 							</label>
+
 							<ClayInput
 								id="newAccountNameInput"
 								onChange={(event) =>
@@ -191,10 +195,12 @@ export default function AddOrganizationModal({
 								value={newAccountName}
 							/>
 						</ClayForm.Group>
+
 						<ClayForm.Group>
 							<label htmlFor="administratorEmailInput">
 								{Liferay.Language.get('administrators-email')}
 							</label>
+
 							<ClayMultiSelect
 								id="administratorEmailInput"
 								inputValue={emailsQuery}
@@ -211,6 +217,7 @@ export default function AddOrganizationModal({
 						<label htmlFor="searchAccountInput">
 							{Liferay.Language.get('search-account')}
 						</label>
+
 						<ClayMultiSelect
 							id="searchAccountInput"
 							inputValue={accountsQuery}
@@ -223,6 +230,7 @@ export default function AddOrganizationModal({
 					</ClayForm.Group>
 				)}
 			</ClayModal.Body>
+
 			<ClayModal.Footer
 				last={
 					<ClayButton.Group spaced>
@@ -232,6 +240,7 @@ export default function AddOrganizationModal({
 						>
 							{Liferay.Language.get('cancel')}
 						</ClayButton>
+
 						<ClayButton displayType="primary" onClick={handleSave}>
 							{Liferay.Language.get('save')}
 						</ClayButton>

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddOrganizationsModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddOrganizationsModal.js
@@ -35,6 +35,7 @@ export default function AddOrganizationModal({
 		const newOrganizations = query
 			? items.concat({label: query, value: query})
 			: [...items];
+
 		const organizationNames = newOrganizations.map((item) => item.label);
 
 		if (!newOrganizations.length) {
@@ -99,6 +100,7 @@ export default function AddOrganizationModal({
 			<ClayModal.Header>
 				{Liferay.Language.get('add-organizations')}
 			</ClayModal.Header>
+
 			<ClayModal.Body>
 				<ClayForm.Group
 					className={classNames(errors.length && 'has-error')}
@@ -110,6 +112,7 @@ export default function AddOrganizationModal({
 							symbol="asterisk"
 						/>
 					</label>
+
 					<ClayInput.Group>
 						<ClayInput.GroupItem>
 							<ClayMultiSelect
@@ -136,6 +139,7 @@ export default function AddOrganizationModal({
 					</ClayInput.Group>
 				</ClayForm.Group>
 			</ClayModal.Body>
+
 			<ClayModal.Footer
 				last={
 					<ClayButton.Group spaced>
@@ -145,6 +149,7 @@ export default function AddOrganizationModal({
 						>
 							{Liferay.Language.get('cancel')}
 						</ClayButton>
+
 						<ClayButton displayType="primary" onClick={handleSave}>
 							{Liferay.Language.get('save')}
 						</ClayButton>

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddOrganizationsModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddOrganizationsModal.js
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import ClayButton from '@clayui/button';
+import ClayForm, {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import ClayModal from '@clayui/modal';
+import ClayMultiSelect from '@clayui/multi-select';
+import classNames from 'classnames';
+import {openToast} from 'frontend-js-web';
+import React, {useContext, useState} from 'react';
+
+import ChartContext from '../ChartContext';
+import {createOrganizations} from '../data/organizations';
+
+export default function AddOrganizationModal({
+	closeModal,
+	observer,
+	parentData,
+}) {
+	const [query, setQuery] = useState('');
+	const [items, setItems] = useState([]);
+	const [errors, setErrors] = useState([]);
+	const {chartInstanceRef} = useContext(ChartContext);
+
+	function handleSave() {
+		const newOrganizations = query
+			? items.concat({label: query, value: query})
+			: [...items];
+		const organizationNames = newOrganizations.map((item) => item.label);
+
+		if (!newOrganizations.length) {
+			setErrors([
+				Liferay.Language.get('organization-name-field-required'),
+			]);
+
+			return;
+		}
+
+		createOrganizations(organizationNames, parentData).then((results) => {
+			const newOrganizationsDetails = [];
+			const newErrors = new Set();
+			const failedOrganizations = [];
+
+			results.forEach((result, fetchNumber) => {
+				if (result.status === 'rejected') {
+					failedOrganizations.push(newOrganizations[fetchNumber]);
+					newErrors.add(result.reason.title);
+				}
+				else {
+					newOrganizationsDetails.push(result.value);
+				}
+			});
+
+			setItems(failedOrganizations);
+			setErrors(Array.from(newErrors));
+			setQuery('');
+
+			if (newOrganizationsDetails.length) {
+				openToast({
+					message: Liferay.Util.sub(
+						Liferay.Language.get('x-organizations-added-to-x'),
+						newOrganizationsDetails.length,
+						parentData.name
+					),
+					type: 'success',
+				});
+
+				chartInstanceRef.current.addNodes(
+					newOrganizationsDetails,
+					'organization',
+					parentData
+				);
+
+				chartInstanceRef.current.updateNodeContent({
+					...parentData,
+					numberOfOrganizations:
+						parentData.numberOfOrganizations +
+						newOrganizationsDetails.length,
+				});
+			}
+
+			if (!failedOrganizations.length) {
+				closeModal();
+			}
+		});
+	}
+
+	return (
+		<ClayModal center observer={observer} size="md">
+			<ClayModal.Header>
+				{Liferay.Language.get('add-organizations')}
+			</ClayModal.Header>
+			<ClayModal.Body>
+				<ClayForm.Group
+					className={classNames(errors.length && 'has-error')}
+				>
+					<label htmlFor="addNewOrganization">
+						{Liferay.Language.get('name') + ' '}
+						<ClayIcon
+							className="ml-1 reference-mark"
+							symbol="asterisk"
+						/>
+					</label>
+					<ClayInput.Group>
+						<ClayInput.GroupItem>
+							<ClayMultiSelect
+								id="addNewOrganization"
+								inputValue={query}
+								items={items}
+								onChange={setQuery}
+								onItemsChange={setItems}
+								placeholder={Liferay.Language.get(
+									'organization-name'
+								)}
+							/>
+							{!!errors.length && (
+								<ClayForm.FeedbackGroup>
+									{errors.map((error, i) => (
+										<ClayForm.FeedbackItem key={i}>
+											<ClayForm.FeedbackIndicator symbol="info-circle" />
+											{error}
+										</ClayForm.FeedbackItem>
+									))}
+								</ClayForm.FeedbackGroup>
+							)}
+						</ClayInput.GroupItem>
+					</ClayInput.Group>
+				</ClayForm.Group>
+			</ClayModal.Body>
+			<ClayModal.Footer
+				last={
+					<ClayButton.Group spaced>
+						<ClayButton
+							displayType="secondary"
+							onClick={closeModal}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+						<ClayButton displayType="primary" onClick={handleSave}>
+							{Liferay.Language.get('save')}
+						</ClayButton>
+					</ClayButton.Group>
+				}
+			/>
+		</ClayModal>
+	);
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/InviteUsersModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/InviteUsersModal.js
@@ -92,6 +92,7 @@ export default function InviteUserModal({closeModal, observer, parentData}) {
 			<ClayModal.Header>
 				{Liferay.Language.get('invite-users')}
 			</ClayModal.Header>
+
 			<ClayModal.Body>
 				<ClayForm.Group
 					className={classNames(errors.length && 'has-error')}
@@ -103,6 +104,7 @@ export default function InviteUserModal({closeModal, observer, parentData}) {
 							symbol="asterisk"
 						/>
 					</label>
+
 					<ClayInput.Group>
 						<ClayInput.GroupItem>
 							<ClayMultiSelect
@@ -160,6 +162,7 @@ export default function InviteUserModal({closeModal, observer, parentData}) {
 								symbol="asterisk"
 							/>
 						</label>
+
 						<ClaySelectBox
 							id="inviteUsersRoleInput"
 							items={roles.map((role) => ({
@@ -171,6 +174,7 @@ export default function InviteUserModal({closeModal, observer, parentData}) {
 							size={5}
 							value={selectedRoleIds}
 						/>
+
 						<ClayInput.Group>
 							<ClayInput.GroupItem>
 								{!!errors.length && (
@@ -188,6 +192,7 @@ export default function InviteUserModal({closeModal, observer, parentData}) {
 					</ClayForm.Group>
 				)}
 			</ClayModal.Body>
+
 			<ClayModal.Footer
 				last={
 					<ClayButton.Group spaced>
@@ -197,6 +202,7 @@ export default function InviteUserModal({closeModal, observer, parentData}) {
 						>
 							{Liferay.Language.get('cancel')}
 						</ClayButton>
+
 						<ClayButton displayType="primary" onClick={handleSave}>
 							{Liferay.Language.get('save')}
 						</ClayButton>

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/InviteUsersModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/InviteUsersModal.js
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import ClayButton from '@clayui/button';
+import ClayForm, {ClayInput, ClaySelectBox} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import ClayModal from '@clayui/modal';
+import ClayMultiSelect from '@clayui/multi-select';
+import classNames from 'classnames';
+import {openToast} from 'frontend-js-web';
+import React, {useEffect, useState} from 'react';
+
+import {addUsersToOrganization} from '../data/organizations';
+import {getAllUserRoles, getUsersByEmails} from '../data/users';
+import {USER_ROLES_DEFINITION_ENABLED} from '../utils/flags';
+
+export default function InviteUserModal({closeModal, observer, parentData}) {
+	const [emailsQuery, setEmailsQuery] = useState('');
+	const [selectedEmails, setSelectedEmails] = useState([]);
+
+	const [selectedRoleIds, setSelectedRoleIds] = useState([]);
+	const [roles, setRoles] = useState([]);
+	const [errors, setErrors] = useState([]);
+
+	useEffect(() => {
+		if (USER_ROLES_DEFINITION_ENABLED) {
+			getAllUserRoles().then((roles) => {
+				const organizationRoles = roles.items.filter(
+					(role) => role.roleType === 'organization'
+				);
+
+				setRoles(organizationRoles);
+			});
+		}
+	}, [parentData]);
+
+	function handleSave() {
+		const typedEmails = selectedEmails
+			.map((email) => email.emailAddress)
+			.sort();
+
+		getUsersByEmails(typedEmails)
+			.then((response) => {
+				const fetchedUsers = new Map();
+
+				response.items.forEach((user) => {
+					fetchedUsers.set(user.emailAddress, user);
+				});
+
+				const userIds = [];
+				const errorMessages = [];
+
+				typedEmails.forEach((typedEmail) => {
+					if (fetchedUsers.has(typedEmail)) {
+						userIds.push(fetchedUsers.get(typedEmail).id);
+					}
+					else {
+						errorMessages.push(
+							Liferay.Util.sub(
+								Liferay.Language.get('x-not-found'),
+								typedEmail
+							)
+						);
+					}
+				});
+
+				setErrors(errorMessages);
+
+				return userIds;
+			})
+			.then((usersIds) => {
+				if (usersIds.length) {
+					addUsersToOrganization(
+						usersIds,
+						parentData,
+						selectedRoleIds
+					);
+				}
+			});
+	}
+
+	return (
+		<ClayModal center observer={observer} size="md">
+			<ClayModal.Header>
+				{Liferay.Language.get('invite-users')}
+			</ClayModal.Header>
+			<ClayModal.Body>
+				<ClayForm.Group
+					className={classNames(errors.length && 'has-error')}
+				>
+					<label htmlFor="inviteUsersEmailInput">
+						{Liferay.Language.get('email')}
+						<ClayIcon
+							className="ml-1 reference-mark"
+							symbol="asterisk"
+						/>
+					</label>
+					<ClayInput.Group>
+						<ClayInput.GroupItem>
+							<ClayMultiSelect
+								id="inviteUsersEmailInput"
+								inputValue={emailsQuery}
+								items={selectedEmails}
+								locator={{
+									label: 'emailAddress',
+									value: 'emailAddress',
+								}}
+								onChange={setEmailsQuery}
+								onItemsChange={(emails) => {
+									const organizationEmails = new Set(
+										parentData.userAccounts.map(
+											(user) => user.emailAddress
+										)
+									);
+									const filteredEmails = emails.filter(
+										(email) => {
+											if (organizationEmails.has(email)) {
+												openToast({
+													message: Liferay.Util.sub(
+														Liferay.Language.get(
+															'x-is-already-a-user-of-x'
+														),
+														email,
+														parentData.name
+													),
+													type: 'danger',
+												});
+
+												return false;
+											}
+
+											return true;
+										}
+									);
+									setSelectedEmails(filteredEmails);
+								}}
+								placeholder={Liferay.Language.get(
+									'users-emails'
+								)}
+							/>
+						</ClayInput.GroupItem>
+					</ClayInput.Group>
+				</ClayForm.Group>
+				{USER_ROLES_DEFINITION_ENABLED && (
+					<ClayForm.Group
+						className={classNames(errors.length && 'has-error')}
+					>
+						<label htmlFor="inviteUsersRoleInput">
+							{Liferay.Language.get('roles')}
+							<ClayIcon
+								className="ml-1 reference-mark"
+								symbol="asterisk"
+							/>
+						</label>
+						<ClaySelectBox
+							id="inviteUsersRoleInput"
+							items={roles.map((role) => ({
+								label: role.name,
+								value: role.id,
+							}))}
+							multiple
+							onSelectChange={setSelectedRoleIds}
+							size={5}
+							value={selectedRoleIds}
+						/>
+						<ClayInput.Group>
+							<ClayInput.GroupItem>
+								{!!errors.length && (
+									<ClayForm.FeedbackGroup>
+										{errors.map((error, i) => (
+											<ClayForm.FeedbackItem key={i}>
+												<ClayForm.FeedbackIndicator symbol="info-circle" />
+												{error}
+											</ClayForm.FeedbackItem>
+										))}
+									</ClayForm.FeedbackGroup>
+								)}
+							</ClayInput.GroupItem>
+						</ClayInput.Group>
+					</ClayForm.Group>
+				)}
+			</ClayModal.Body>
+			<ClayModal.Footer
+				last={
+					<ClayButton.Group spaced>
+						<ClayButton
+							displayType="secondary"
+							onClick={closeModal}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+						<ClayButton displayType="primary" onClick={handleSave}>
+							{Liferay.Language.get('save')}
+						</ClayButton>
+					</ClayButton.Group>
+				}
+			/>
+		</ClayModal>
+	);
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/ModalProvider.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/ModalProvider.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {useModal} from '@clayui/modal';
+import React, {useMemo} from 'react';
+
+import AddAccountsModal from './AddAccountsModal';
+import AddOrganizationsModal from './AddOrganizationsModal';
+import InviteUsersModal from './InviteUsersModal';
+
+const modals = {
+	account: AddAccountsModal,
+	organization: AddOrganizationsModal,
+	user: InviteUsersModal,
+};
+
+export default function ModalProvider({active, closeModal, parentData, type}) {
+	const {observer, onClose} = useModal({
+		onClose: closeModal,
+	});
+
+	const Modal = useMemo(() => parentData && modals[type], [parentData, type]);
+
+	return (
+		active && (
+			<Modal
+				closeModal={onClose}
+				observer={observer}
+				parentData={parentData}
+			/>
+		)
+	);
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/flags.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/flags.js
@@ -12,4 +12,5 @@
 export const USER_INVITATION_ENABLED = false;
 export const USER_ROLES_DEFINITION_ENABLED = false;
 export const ACCOUNTS_ADD_BUTTON_ENABLED = false;
+export const PERMISSION_CHECK_ON_HEADLESS_API_ACTIONS = false;
 export const ACCOUNTS_CREATION_ENABLED = false;

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/flags.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/flags.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+export const USER_INVITATION_ENABLED = false;
+export const USER_ROLES_DEFINITION_ENABLED = false;
+export const ACCOUNTS_ADD_BUTTON_ENABLED = false;
+export const ACCOUNTS_CREATION_ENABLED = false;

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/index.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/index.js
@@ -121,6 +121,75 @@ export function insertChildrenIntoNode(children, parentNode) {
 	return parentNode;
 }
 
+function removeAddButton(node) {
+	const children = node.children || node._children;
+	const dataChildren = node.data.children || node.data._children;
+
+	if (!children) {
+		return;
+	}
+
+	if (children[0]?.data?.type === 'add') {
+		children.shift();
+		dataChildren.shift();
+	}
+
+	if (Array.isArray(node.children) && !node.children.length) {
+		node.children = null;
+		node.data.children = null;
+	}
+	if (Array.isArray(node._children) && !node._children.length) {
+		node._children = null;
+		node.data._children = null;
+	}
+}
+
+export function insertAddButtons(root, selectedNodesIds) {
+	if (!selectedNodesIds.size) {
+		return;
+	}
+
+	root.each((d) => {
+		if (
+			selectedNodesIds.has(d.data.chartNodeId) &&
+			d.data.type !== 'user' &&
+			d.data.type !== 'account'
+		) {
+			showChildren(d);
+
+			if (!d.children) {
+				d.children = [];
+				d.data.children = [];
+			}
+
+			if (d.children.length && d.children[0].data.type === 'add') {
+				return;
+			}
+
+			const id = Math.random();
+
+			const newNode = hierarchy(
+				{
+					chartNodeId: `add_${id}`,
+					chartNodeNumber: ++chartNodesCounter,
+					id,
+					type: 'add',
+				},
+				(node) => node.children
+			);
+
+			newNode.parent = d;
+			newNode.depth = d.depth + 1;
+
+			d.children.unshift(newNode);
+			d.data.children.unshift(newNode.data);
+		}
+		else {
+			removeAddButton(d);
+		}
+	});
+}
+
 export const tree = d3Tree().nodeSize([DX, DY]);
 
 export const getEntityId = (data) =>

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/paint.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/paint.js
@@ -9,10 +9,12 @@
  * distribution rights of the Software.
  */
 
-import {linkHorizontal} from 'd3';
+import {event as d3event, linkHorizontal} from 'd3';
 
 import {formatItemDescription, formatItemName} from '.';
 import {
+	NODE_BUTTON_WIDTH,
+	NODE_PADDING,
 	RECT_SIZES,
 	SYMBOLS_MAP,
 } from './constants';
@@ -110,7 +112,7 @@ export function fillAddButtons(nodeEnter, spritemap, openModal) {
 	}
 }
 
-export function fillEntityNode(nodeEnter, spritemap) {
+export function fillEntityNode(nodeEnter, spritemap, openMenu) {
 	nodeEnter
 		.append('rect')
 		.attr('width', (d) => RECT_SIZES[d.data.type].width)
@@ -141,4 +143,25 @@ export function fillEntityNode(nodeEnter, spritemap) {
 		.append('text')
 		.attr('class', 'node-description')
 		.text(formatItemDescription);
+
+	const menuWrapper = nodeEnter
+		.append('g')
+		.attr('class', 'node-menu-wrapper')
+		.attr('transform', (d) => {
+			const x =
+				RECT_SIZES[d.data.type].width -
+				NODE_BUTTON_WIDTH -
+				NODE_PADDING;
+
+			return `translate(${x}, -14)`;
+		})
+		.on('mousedown', (d) => {
+			d3event.stopPropagation();
+
+			openMenu(d3event.currentTarget, d.data, d.parent?.data);
+		});
+
+	menuWrapper.append('rect').attr('class', 'node-menu-btn');
+
+	appendIcon(menuWrapper, `${spritemap}#ellipsis-v`, 16, 'node-menu-icon');
 }

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/paint.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/paint.js
@@ -12,7 +12,11 @@
 import {linkHorizontal} from 'd3';
 
 import {formatItemDescription, formatItemName} from '.';
-import {RECT_SIZES, SYMBOLS_MAP} from './constants';
+import {
+	RECT_SIZES,
+	SYMBOLS_MAP,
+} from './constants';
+import {USER_INVITATION_ENABLED} from './flags';
 
 export function appendIcon(node, symbol, size, className) {
 	return node
@@ -56,6 +60,55 @@ export const getLinkDiagonal = linkHorizontal()
 				return [target.y, target.x];
 		}
 	});
+
+export function appendCircle(node, size, className) {
+	return node.append('circle').attr('r', size).attr('class', className);
+}
+
+export function createAddActionButton(wrapper, type, openModal, spritemap) {
+	const newButtonContainer = wrapper
+		.append('g')
+		.attr('class', `add-action-wrapper ${type}`)
+		.on('mousedown', (node) => {
+			openModal(node.parent.data, type);
+		});
+
+	appendCircle(newButtonContainer, 16, 'action-circle');
+	appendIcon(
+		newButtonContainer,
+		`${spritemap}#${SYMBOLS_MAP[type]}`,
+		16,
+		'action-icon'
+	);
+}
+
+export function fillAddButtons(nodeEnter, spritemap, openModal) {
+	const actionsWrapper = nodeEnter
+		.append('g')
+		.attr('class', 'actions-wrapper');
+
+	const openActionsWrapper = actionsWrapper
+		.append('g')
+		.attr('class', 'open-actions-wrapper')
+		.on('mousedown', (node) => {
+			if (node.parent.data.type === 'account') {
+				openModal(node.parent.data, 'user');
+			}
+			else {
+				actionsWrapper.node().classList.toggle('menu-open');
+			}
+		});
+
+	appendCircle(openActionsWrapper, 36, 'action-circle');
+	appendIcon(openActionsWrapper, `${spritemap}#plus`, 18, 'action-icon');
+
+	createAddActionButton(actionsWrapper, 'account', openModal, spritemap);
+	createAddActionButton(actionsWrapper, 'organization', openModal, spritemap);
+
+	if (USER_INVITATION_ENABLED) {
+		createAddActionButton(actionsWrapper, 'user', openModal, spritemap);
+	}
+}
 
 export function fillEntityNode(nodeEnter, spritemap) {
 	nodeEnter

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language.properties
@@ -6,7 +6,7 @@ javax.portlet.title.com_liferay_commerce_organization_web_internal_portlet_Comme
 no-members-found=No members were found for this organization.
 root-organization-id=Root Organization ID
 org=Org.
-organization-name-field-required=Organization name field required
+organization-name-field-required=Organization Name Field Required
 search-account=Search Account
 suborganization=Suborganization
 x-not-found={0} not found.

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language.properties
@@ -6,4 +6,9 @@ javax.portlet.title.com_liferay_commerce_organization_web_internal_portlet_Comme
 no-members-found=No members were found for this organization.
 root-organization-id=Root Organization ID
 org=Org.
+organization-name-field-required=Organization name field required
+search-account=Search Account
 suborganization=Suborganization
+x-not-found={0} not found.
+x-organizations-added-to-x={0} organizations added to {1}
+x-will-be-deleted={0} will be deleted.

--- a/modules/dxp/apps/commerce/commerce-organization-web/test/D3ChartImplementation.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/test/D3ChartImplementation.js
@@ -15,8 +15,14 @@ import D3OrganizationChart from '../src/main/resources/META-INF/resources/js/D3O
 import {
 	ACCOUNTS_PROPERTY_NAME,
 	ORGANIZATIONS_PROPERTY_NAME,
+<<<<<<< HEAD
 	USERS_PROPERTY_NAME_IN_ORGANIZATION,
 } from '../src/main/resources/META-INF/resources/js/utils/constants';
+=======
+	USERS_PROPERTY_NAME,
+} from '../src/main/resources/META-INF/resources/js/utils/constants';
+import {USER_INVITATION_ENABLED} from '../src/main/resources/META-INF/resources/js/utils/flags';
+>>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 
 jest.mock(
 	'../src/main/resources/META-INF/resources/js/data/organizations',
@@ -67,7 +73,12 @@ jest.mock(
 jest.mock('../src/main/resources/META-INF/resources/js/data/accounts', () => ({
 	getAccount: () =>
 		Promise.resolve({
+<<<<<<< HEAD
 			accountUsers: [
+=======
+			type: 'account',
+			userAccounts: [
+>>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 				{
 					id: '2000',
 					name: `User Child 1`,
@@ -81,7 +92,10 @@ jest.mock('../src/main/resources/META-INF/resources/js/data/accounts', () => ({
 					name: `User Child 3`,
 				},
 			],
+<<<<<<< HEAD
 			type: 'account',
+=======
+>>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 		}),
 }));
 
@@ -130,7 +144,11 @@ const INITIAL_DATA = {
 			name: `Spain`,
 		},
 	],
+<<<<<<< HEAD
 	[USERS_PROPERTY_NAME_IN_ORGANIZATION]: [
+=======
+	[USERS_PROPERTY_NAME]: [
+>>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 		{
 			id: '1',
 			name: `Mark`,
@@ -179,6 +197,10 @@ describe('D3OrganizationChart implementation', () => {
 	let zoomOutButton;
 	let defaultParams;
 	const getChartNodes = (...args) => getNodes(chartSVGWrapper, ...args);
+<<<<<<< HEAD
+=======
+	let lastActionPerformed = null;
+>>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 
 	beforeEach(() => {
 		chartSVGWrapper = document.createElement('svg');
@@ -192,15 +214,44 @@ describe('D3OrganizationChart implementation', () => {
 			},
 			'./assets/clay/icons.svg',
 			{
+<<<<<<< HEAD
 				open: () => {},
 			},
 			{
 				close: () => {},
 				open: () => {},
+=======
+				open: (parentData, type) => {
+					lastActionPerformed = {
+						details: {parentData, type},
+						name: 'modal opened',
+					};
+				},
+			},
+			{
+				close: () => {
+					lastActionPerformed = {
+						name: 'menu closed',
+					};
+				},
+				open: (target, data) => {
+					lastActionPerformed = {
+						details: {data, target},
+						name: 'menu opened',
+					};
+				},
+>>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 			},
 		];
 	});
 
+<<<<<<< HEAD
+=======
+	afterEach(() => {
+		lastActionPerformed = null;
+	});
+
+>>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 	it('Must create a chart', async () => {
 		new D3OrganizationChart(INITIAL_DATA, ...defaultParams);
 
@@ -232,7 +283,11 @@ describe('D3OrganizationChart implementation', () => {
 		const chartUsers = chartSVGWrapper.querySelectorAll('.chart-item-user');
 
 		expect(chartUsers.length).toBe(
+<<<<<<< HEAD
 			INITIAL_DATA[USERS_PROPERTY_NAME_IN_ORGANIZATION].length
+=======
+			INITIAL_DATA[USERS_PROPERTY_NAME].length
+>>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 		);
 
 		const chartItems = chartSVGWrapper.querySelectorAll('.chart-item');
@@ -286,4 +341,127 @@ describe('D3OrganizationChart implementation', () => {
 			});
 		});
 	});
+<<<<<<< HEAD
+=======
+
+	describe('Node creation', () => {
+		let addButton = null;
+
+		beforeAll(async () => {
+			new D3OrganizationChart(INITIAL_DATA, ...defaultParams);
+			const clickedNode = getChartNodes('Root', 'name')[0];
+
+			await d3click(clickedNode);
+
+			addButton = getChartNodes('add', 'type')[0];
+		});
+
+		it('Must display an add button when an organization is clicked', () => {
+			expect(addButton).toBeTruthy();
+			expect(addButton.__data__.parent.data.name).toBe('Root');
+		});
+
+		it('Add button must change its state when clicked', async () => {
+			expect(addButton).toBeTruthy();
+
+			const actionsWrapper = addButton.querySelector('.actions-wrapper');
+			const openActionsWrapper = addButton.querySelector(
+				'.open-actions-wrapper'
+			);
+
+			await d3click(openActionsWrapper);
+
+			expect(actionsWrapper.classList).toContain('menu-open');
+		});
+
+		it('Must open a modal when a creation button is clicked', async () => {
+			const openActionsWrapper = addButton.querySelector(
+				'.open-actions-wrapper'
+			);
+
+			await d3click(openActionsWrapper);
+
+			const createOrganizationButton = addButton.querySelector(
+				'.add-action-wrapper.organization'
+			);
+			expect(createOrganizationButton).toBeTruthy();
+
+			await d3click(createOrganizationButton);
+
+			expect(lastActionPerformed.name).toBe('modal opened');
+		});
+
+		it('Must open a create organization modal when a creation button is clicked', async () => {
+			const openActionsWrapper = addButton.querySelector(
+				'.open-actions-wrapper'
+			);
+
+			await d3click(openActionsWrapper);
+
+			const createOrganizationButton = addButton.querySelector(
+				'.add-action-wrapper.organization'
+			);
+			expect(createOrganizationButton).toBeTruthy();
+
+			await d3click(createOrganizationButton);
+
+			expect(lastActionPerformed.name).toBe('modal opened');
+			expect(lastActionPerformed.details.type).toBe('organization');
+		});
+
+		it('Must open a create account modal when a creation button is clicked', async () => {
+			const openActionsWrapper = addButton.querySelector(
+				'.open-actions-wrapper'
+			);
+
+			await d3click(openActionsWrapper);
+
+			const createAccountButton = addButton.querySelector(
+				'.add-action-wrapper.account'
+			);
+			expect(createAccountButton).toBeTruthy();
+
+			await d3click(createAccountButton);
+
+			expect(lastActionPerformed.name).toBe('modal opened');
+			expect(lastActionPerformed.details.type).toBe('account');
+		});
+
+		it('Must open a invite user modal when a creation button is clicked', async () => {
+			const openActionsWrapper = addButton.querySelector(
+				'.open-actions-wrapper'
+			);
+
+			await d3click(openActionsWrapper);
+
+			const inviteUserButton = addButton.querySelector(
+				'.add-action-wrapper.user'
+			);
+			expect(!!inviteUserButton).toBe(USER_INVITATION_ENABLED);
+
+			if (USER_INVITATION_ENABLED) {
+				await d3click(inviteUserButton);
+
+				expect(lastActionPerformed.name).toBe('modal opened');
+				expect(lastActionPerformed.details.type).toBe('user');
+			}
+		});
+	});
+
+	describe('Node actions', () => {
+		it('must open an action menu when a menu button is clicked', async () => {
+			new D3OrganizationChart(INITIAL_DATA, ...defaultParams);
+
+			const rootNode = getChartNodes('Root', 'name')[0];
+			const menuButton = rootNode.querySelector('.node-menu-wrapper');
+
+			expect(menuButton).toBeTruthy();
+
+			await d3click(menuButton);
+
+			expect(lastActionPerformed.name).toBe('menu opened');
+			expect(lastActionPerformed.details.data.name).toBe('Root');
+		});
+	});
+>>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 });

--- a/modules/dxp/apps/commerce/commerce-organization-web/test/D3ChartImplementation.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/test/D3ChartImplementation.js
@@ -15,14 +15,8 @@ import D3OrganizationChart from '../src/main/resources/META-INF/resources/js/D3O
 import {
 	ACCOUNTS_PROPERTY_NAME,
 	ORGANIZATIONS_PROPERTY_NAME,
-<<<<<<< HEAD
 	USERS_PROPERTY_NAME_IN_ORGANIZATION,
 } from '../src/main/resources/META-INF/resources/js/utils/constants';
-=======
-	USERS_PROPERTY_NAME,
-} from '../src/main/resources/META-INF/resources/js/utils/constants';
-import {USER_INVITATION_ENABLED} from '../src/main/resources/META-INF/resources/js/utils/flags';
->>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 
 jest.mock(
 	'../src/main/resources/META-INF/resources/js/data/organizations',
@@ -73,12 +67,8 @@ jest.mock(
 jest.mock('../src/main/resources/META-INF/resources/js/data/accounts', () => ({
 	getAccount: () =>
 		Promise.resolve({
-<<<<<<< HEAD
-			accountUsers: [
-=======
-			type: 'account',
+			type: 'accountUserAccounts',
 			userAccounts: [
->>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 				{
 					id: '2000',
 					name: `User Child 1`,
@@ -92,10 +82,6 @@ jest.mock('../src/main/resources/META-INF/resources/js/data/accounts', () => ({
 					name: `User Child 3`,
 				},
 			],
-<<<<<<< HEAD
-			type: 'account',
-=======
->>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 		}),
 }));
 
@@ -144,11 +130,7 @@ const INITIAL_DATA = {
 			name: `Spain`,
 		},
 	],
-<<<<<<< HEAD
 	[USERS_PROPERTY_NAME_IN_ORGANIZATION]: [
-=======
-	[USERS_PROPERTY_NAME]: [
->>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 		{
 			id: '1',
 			name: `Mark`,
@@ -197,10 +179,7 @@ describe('D3OrganizationChart implementation', () => {
 	let zoomOutButton;
 	let defaultParams;
 	const getChartNodes = (...args) => getNodes(chartSVGWrapper, ...args);
-<<<<<<< HEAD
-=======
 	let lastActionPerformed = null;
->>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 
 	beforeEach(() => {
 		chartSVGWrapper = document.createElement('svg');
@@ -214,13 +193,6 @@ describe('D3OrganizationChart implementation', () => {
 			},
 			'./assets/clay/icons.svg',
 			{
-<<<<<<< HEAD
-				open: () => {},
-			},
-			{
-				close: () => {},
-				open: () => {},
-=======
 				open: (parentData, type) => {
 					lastActionPerformed = {
 						details: {parentData, type},
@@ -240,18 +212,14 @@ describe('D3OrganizationChart implementation', () => {
 						name: 'menu opened',
 					};
 				},
->>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 			},
 		];
 	});
 
-<<<<<<< HEAD
-=======
 	afterEach(() => {
 		lastActionPerformed = null;
 	});
 
->>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 	it('Must create a chart', async () => {
 		new D3OrganizationChart(INITIAL_DATA, ...defaultParams);
 
@@ -283,11 +251,7 @@ describe('D3OrganizationChart implementation', () => {
 		const chartUsers = chartSVGWrapper.querySelectorAll('.chart-item-user');
 
 		expect(chartUsers.length).toBe(
-<<<<<<< HEAD
 			INITIAL_DATA[USERS_PROPERTY_NAME_IN_ORGANIZATION].length
-=======
-			INITIAL_DATA[USERS_PROPERTY_NAME].length
->>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 		);
 
 		const chartItems = chartSVGWrapper.querySelectorAll('.chart-item');
@@ -341,8 +305,6 @@ describe('D3OrganizationChart implementation', () => {
 			});
 		});
 	});
-<<<<<<< HEAD
-=======
 
 	describe('Node creation', () => {
 		let addButton = null;
@@ -426,26 +388,6 @@ describe('D3OrganizationChart implementation', () => {
 			expect(lastActionPerformed.name).toBe('modal opened');
 			expect(lastActionPerformed.details.type).toBe('account');
 		});
-
-		it('Must open a invite user modal when a creation button is clicked', async () => {
-			const openActionsWrapper = addButton.querySelector(
-				'.open-actions-wrapper'
-			);
-
-			await d3click(openActionsWrapper);
-
-			const inviteUserButton = addButton.querySelector(
-				'.add-action-wrapper.user'
-			);
-			expect(!!inviteUserButton).toBe(USER_INVITATION_ENABLED);
-
-			if (USER_INVITATION_ENABLED) {
-				await d3click(inviteUserButton);
-
-				expect(lastActionPerformed.name).toBe('modal opened');
-				expect(lastActionPerformed.details.type).toBe('user');
-			}
-		});
 	});
 
 	describe('Node actions', () => {
@@ -463,5 +405,4 @@ describe('D3OrganizationChart implementation', () => {
 			expect(lastActionPerformed.details.data.name).toBe('Root');
 		});
 	});
->>>>>>> COMMERCE-5674 Organization chart JS component with basic interactions
 });


### PR DESCRIPTION
This is the second PR related to the Org Chart refactoring to be reviewed after the [first one](https://github.com/liferay-frontend/liferay-portal/pull/1311) gets merged.

Here I connected modals and dropdown menu to a d3 chart. in order to let users be able to create and remove connections among organizations, accounts and users.

**What this PR allows:**

- [x] navigating through organisations, accounts and users in a static environment
- [x] creating new organizations via Modal
- [x] creating or adding accounts within organizations
- [x] inviting users within accounts
- [x] removing / deleting entities via dropdown menu
- [ ] update entities connection via drag & drop
- [ ] multi selection via shift key
- [ ] paths highlighting at mouseover
- [ ] actions available when user has the right permissions
- [x] it works in portal
- [ ] it supports a table view
- [ ] it supports a map view

**Design**

Here's the final expected result: https://www.figma.com/file/Fgh6jD5qPBr8srVZlmxAWc/(m)-commerce-classic-theme-01a-ac?node-id=5037%3A95299. 

Please note: the chart won't work until [this PR](https://github.com/liferay-usm/liferay-portal/pull/189) gets merged

Thanks in advance,
Fabio

cc @nhpatt, @riccardo-alberti