### PR TITLE
LPS-136870 Refactors the A11y Scheduler tests

### DIFF
--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/test/js/A11yChecker.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/test/js/A11yChecker.d.ts
@@ -12,4 +12,14 @@
  * details.
  */
 
+declare global {
+	namespace NodeJS {
+		interface Performance {
+			now: () => number;
+		}
+		interface Global {
+			performance?: Performance;
+		}
+	}
+}
 export {};


### PR DESCRIPTION
Well, the Scheduler tests were failing intermittently, one of the assumptions is that the tests needed frame time accuracy, because internally we were using browser APIs like `requestIdleCallback` and `cancelIdleCallback` and simulating with the `setTimeout` API of  Node.js and also using the `performance.now` API, as this is tied to the Node.js event loop, it could happen that at certain times the CPU could be overloaded or directing resources between other processes in the CI and causing a "frozen", this would probably be breaking the tests and was also unreliable.

This refactoring changes the approach to how we test the Scheduler, we avoid relying on frame time accuracy and avoid simulating when events are called. Instead of using `setTimeout` and `performance.now`, we are mock the APIs that the Scheduler uses to simulate situations and verify behaviors, think of it as a timeline that we have control, like advance time, pause... we take control of the browser APIs and decides when to call them to simulate situations. This is similar to what the React team did with their scheduling system.