### PR TITLE
Organization Chart 3 - DnD / Multiselect / Path highlighting at mouseover

### DIFF
--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/OrganizationChart.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/OrganizationChart.js
@@ -90,6 +90,7 @@ function OrganizationChartApp({rootOrganizationId, spritemap, templatesURL}) {
 
 			<div className={classnames('org-chart-container', {expanded})}>
 				<svg className="svg-chart" ref={chartSVGRef} />
+
 				<div className="zoom-controls">
 					<ClayButtonWithIcon
 						displayType="secondary"
@@ -97,6 +98,7 @@ function OrganizationChartApp({rootOrganizationId, spritemap, templatesURL}) {
 						small
 						symbol="expand"
 					/>
+
 					<ClayButton.Group className="ml-3">
 						<ClayButtonWithIcon
 							displayType="secondary"
@@ -104,6 +106,7 @@ function OrganizationChartApp({rootOrganizationId, spritemap, templatesURL}) {
 							small
 							symbol="hr"
 						/>
+
 						<ClayButtonWithIcon
 							displayType="secondary"
 							ref={zoomInRef}
@@ -113,11 +116,13 @@ function OrganizationChartApp({rootOrganizationId, spritemap, templatesURL}) {
 					</ClayButton.Group>
 				</div>
 			</div>
+
 			<MenuProvider
 				alignElementRef={clickedMenuButtonRef}
 				data={menuData}
 				parentData={menuParentData}
 			/>
+
 			<ModalProvider
 				active={modalActive}
 				closeModal={() => updateModalActive(false)}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/accounts.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/data/accounts.js
@@ -13,6 +13,7 @@ import {USERS_PROPERTY_NAME_IN_ACCOUNT} from '../utils/constants';
 import {fetchFromHeadless} from '../utils/fetch';
 
 const ACCOUNTS_ROOT_ENDPOINT = '/o/account-rest/v1.0/accounts';
+const ACCOUNTS_MOVING_ENDPOINT = `/o/account-rest/v1.0/organizations/move-accounts`;
 
 export function getAccounts(query) {
 	const url = new URL(ACCOUNTS_ROOT_ENDPOINT, themeDisplay.getPortalURL());
@@ -29,6 +30,18 @@ export function deleteAccount(id) {
 	);
 
 	return fetchFromHeadless(url, {method: 'DELETE'}, null, true);
+}
+
+export function changeOrganizationParent(accountId, source, target) {
+	const url = new URL(
+		`${ACCOUNTS_MOVING_ENDPOINT}/${source}/${target}`,
+		themeDisplay.getPortalURL()
+	);
+
+	return fetchFromHeadless(url, {
+		body: JSON.stringify([accountId]),
+		method: 'PATCH',
+	});
 }
 
 export function getAccount(id) {

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/DndHandler.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/DndHandler.js
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {DRAGGING_THRESHOLD, ZOOM_EXTENT} from './constants';
+
+export function hasPositionChanged(start, end) {
+	if (!end) {
+		return false;
+	}
+
+	const diff = Math.max(Math.abs(start.x - end.x), Math.abs(start.y - end.y));
+
+	return diff > DRAGGING_THRESHOLD;
+}
+
+export default class DndHandler {
+	constructor() {
+		this._mouseStartPositions = null;
+		this._dragging = false;
+		this._chartItems = null;
+		this._dragHandle = null;
+	}
+
+	_handleMouseDown(event) {
+		this._mouseStartPositions = {
+			x: event.offsetX,
+			y: event.offsetY,
+		};
+	}
+
+	_createDragHandle(startingNode, itemsTotal, nodesWrapper) {
+		this._dragHandle = nodesWrapper
+			.append('g')
+			.attr('transform', startingNode.attributes.transform.value)
+			.attr('class', 'dnd-handle');
+
+		const container = this._dragHandle
+			.append('g')
+			.attr('class', 'dnd-handle-content');
+
+		const startingNodeClone = startingNode.cloneNode(true);
+
+		startingNodeClone.classList.remove('highlighted');
+		startingNodeClone.removeAttribute('transform');
+
+		const itemsToBeAppended = Math.min(3, itemsTotal - 1);
+		const rectPlaceholder = startingNodeClone.querySelector('rect');
+
+		for (let i = itemsToBeAppended; i > 0; i--) {
+			container
+				.append(() => rectPlaceholder.cloneNode())
+				.attr('x', i * 3)
+				.attr('y', i * 3);
+		}
+
+		container.append(() => startingNodeClone);
+	}
+
+	_handleMouseMove(
+		event,
+		d,
+		startingNode,
+		selectedNodeIds,
+		nodesGroup,
+		currentScale,
+		svgRef
+	) {
+		if (!this._dragging) {
+			if (
+				hasPositionChanged(this._mouseStartPositions, {
+					x: event.offsetX,
+					y: event.offsetY,
+				})
+			) {
+				this._dragging = true;
+
+				const targetsNotAllowed = new Map();
+
+				/**
+				 * Elements to be disabled while dragging:
+				 * - dragged nodes
+				 * - descendants of dragged nodes
+				 * - all users and accounts nodes
+				 * - all add buttons
+				 * - direct parents
+				 */
+
+				this._chartItems = nodesGroup.selectAll('.chart-item');
+
+				this._chartItems.each((d) => {
+					if (['user', 'account', 'add'].includes(d.data.type)) {
+						targetsNotAllowed.set(d.data.chartNodeId, d);
+					}
+
+					if (selectedNodeIds.has(d.data.chartNodeId)) {
+						targetsNotAllowed.set(d.data.chartNodeId, d);
+
+						if (d.parent) {
+							targetsNotAllowed.set(
+								d.parent.data.chartNodeId,
+								d.parent
+							);
+						}
+
+						const descendants = d.descendants();
+
+						descendants.forEach((descendant) => {
+							targetsNotAllowed.set(
+								descendant.data.chartNodeId,
+								descendant
+							);
+						});
+					}
+				});
+
+				this._createDragHandle(
+					startingNode,
+					selectedNodeIds.size,
+					nodesGroup
+				);
+
+				this._chartItems.each((d, index, nodeInstance) => {
+					if (targetsNotAllowed.has(d.data.chartNodeId)) {
+						nodeInstance[index].classList.add('drop-not-allowed');
+					}
+					else {
+						nodeInstance[index].classList.add('drop-allowed');
+					}
+				});
+
+				svgRef.classList.add('dragging');
+			}
+		}
+
+		if (this._dragHandle) {
+			const handlerPosition = {
+				x:
+					(this._mouseStartPositions.x - event.offsetX) *
+						(ZOOM_EXTENT[1] / currentScale) *
+						-1 +
+					d.y,
+				y:
+					(this._mouseStartPositions.y - event.offsetY) *
+						(ZOOM_EXTENT[1] / currentScale) *
+						-1 +
+					d.x,
+			};
+
+			this._dragHandle
+				.attr(
+					'transform',
+					`translate(${handlerPosition.x}, ${handlerPosition.y})`
+				)
+				.classed('dragging', true);
+		}
+	}
+
+	_handleMouseUp(mouseDownEvent, mouseUpEvent, d, svgRef, resolve) {
+		if (!this._dragging) {
+			return resolve({
+				d,
+				event: mouseDownEvent,
+				type: 'click',
+			});
+		}
+
+		this._mouseStartPositions = null;
+		this._dragging = false;
+		svgRef.classList.remove('dragging');
+
+		const target = mouseUpEvent.target.closest('.drop-allowed');
+
+		this._chartItems.each((_d, index, nodeInstance) => {
+			nodeInstance[index].classList.remove('drop-not-allowed');
+			nodeInstance[index].classList.remove('drop-allowed');
+		});
+
+		this._dragHandle.remove();
+
+		return resolve({
+			d,
+			event: mouseDownEvent,
+			target: target?.__data__,
+			type: 'drop',
+		});
+	}
+
+	handleMouseEvent(
+		initialEvent,
+		d,
+		selectedNodeIds,
+		svgRef,
+		nodesGroup,
+		currentScale
+	) {
+		return new Promise((resolve) => {
+			this._handleMouseDown(initialEvent);
+
+			const nodesToBeDragged = selectedNodeIds.has(d.data.chartNodeId)
+				? selectedNodeIds
+				: new Set([d.data.chartNodeId]);
+			const startingNodeInstance = initialEvent.currentTarget;
+
+			const _handleMouseMove = (event) =>
+				this._handleMouseMove(
+					event,
+					d,
+					startingNodeInstance,
+					nodesToBeDragged,
+					nodesGroup,
+					currentScale,
+					svgRef
+				);
+
+			svgRef.addEventListener('mousemove', _handleMouseMove, this);
+
+			window.addEventListener(
+				'mouseup',
+				(event) => {
+					svgRef.removeEventListener('mousemove', _handleMouseMove);
+
+					this._handleMouseUp(
+						initialEvent,
+						event,
+						d,
+						svgRef,
+						resolve
+					);
+				},
+				{once: true}
+			);
+		});
+	}
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/HighlightHandler.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/HighlightHandler.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+export default class HighlightHandler {
+	constructor() {
+		this._highlightedLinks = null;
+		this._highlightedNodes = null;
+		this._enabled = true;
+	}
+
+	disableHighlight() {
+		this._enabled = false;
+	}
+
+	enableHighlight() {
+		this._enabled = true;
+	}
+
+	highlight(selectedNode, root, nodesGroup, linksGroup) {
+		if (!this._enabled) {
+			return;
+		}
+
+		const nodeInstances = [];
+
+		root.each((d) => {
+			if (d.data.chartNodeId === selectedNode.data.chartNodeId) {
+				nodeInstances.push(d);
+			}
+		});
+
+		const chartIdsToBeHighlighted = nodeInstances.reduce(
+			(chartIdsToBeHighlighted, nodeInstance) => {
+				const ancestorsId = nodeInstance
+					.ancestors()
+					.map((d) => d.data.chartNodeId);
+
+				return chartIdsToBeHighlighted.concat(ancestorsId);
+			},
+			[]
+		);
+
+		this._highlightedNodes = nodesGroup
+			.selectAll('.chart-item')
+			.filter((d) =>
+				chartIdsToBeHighlighted.includes(d.data.chartNodeId)
+			);
+
+		this._highlightedLinks = linksGroup
+			.selectAll('.chart-link')
+			.filter((d) =>
+				chartIdsToBeHighlighted.includes(d.target.data.chartNodeId)
+			);
+
+		this._highlightedLinks.raise();
+
+		this._highlightedLinks.classed('highlighted', true);
+		this._highlightedNodes.classed('highlighted', true);
+	}
+
+	removeHighlight() {
+		if (this._highlightedLinks && this._highlightedNodes) {
+			this._highlightedLinks.classed('highlighted', false);
+			this._highlightedNodes.classed('highlighted', false);
+
+			this._highlightedLinks = null;
+			this._highlightedNodes = null;
+		}
+	}
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/MultiSelectHandler.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/MultiSelectHandler.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {ACCOUNTS_DND_ENABLED} from './flags';
+
+export default class MultiSelectHandler {
+	constructor() {
+		this.items = null;
+	}
+
+	updateSelectableItems(selectedNodes, nodesGroup) {
+		const unselectableItemIds = new Set();
+
+		selectedNodes.forEach((element) => {
+			const descendants = element.descendants();
+
+			descendants.shift();
+
+			const ancestors = element.ancestors();
+
+			ancestors.shift();
+
+			[...ancestors, ...descendants].forEach((descendant) => {
+				unselectableItemIds.add(descendant.data.chartNodeId);
+			});
+		});
+
+		this.items = nodesGroup.selectAll('.chart-item');
+
+		this.items.each((d, index, nodeList) => {
+			if (
+				unselectableItemIds.has(d.data.chartNodeId) ||
+				d.data.type === 'user' ||
+				(d.data.type === 'account' && !ACCOUNTS_DND_ENABLED)
+			) {
+				nodeList[index].classList.add('unselectable');
+
+				d.data.selectable = false;
+			}
+			else {
+				nodeList[index].classList.add('selectable');
+
+				d.data.selectable = true;
+			}
+		});
+	}
+
+	resetSelectableItems() {
+		if (this.items) {
+			this.items.each((d, index, nodeList) => {
+				nodeList[index].classList.remove('unselectable');
+
+				d.data.selectable = undefined;
+			});
+		}
+
+		this.items = null;
+	}
+}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/flags.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/flags.js
@@ -13,4 +13,5 @@ export const USER_INVITATION_ENABLED = false;
 export const USER_ROLES_DEFINITION_ENABLED = false;
 export const ACCOUNTS_ADD_BUTTON_ENABLED = false;
 export const PERMISSION_CHECK_ON_HEADLESS_API_ACTIONS = false;
+export const ACCOUNTS_DND_ENABLED = true;
 export const ACCOUNTS_CREATION_ENABLED = false;

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/index.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/utils/index.js
@@ -11,6 +11,8 @@
 
 import {hierarchy, tree as d3Tree} from 'd3';
 
+import {changeOrganizationParent} from '../data/accounts';
+import {updateOrganization} from '../data/organizations';
 import {
 	ACCOUNTS_PROPERTY_NAME,
 	DX,
@@ -256,4 +258,46 @@ export function getMinWidth(nodes) {
 
 		return maxWidth > width ? maxWidth : width;
 	}, 0);
+}
+
+export function changeNodesParentOrganization(nodes, target) {
+	const movings = [];
+
+	nodes.forEach((node) => {
+		switch (node.data.type) {
+			case 'organization':
+				movings.push(
+					updateOrganization(node.data.id, {
+						parentOrganization: {id: target.data.id},
+					})
+				);
+				break;
+			case 'account':
+				movings.push(
+					changeOrganizationParent(
+						node.data.id,
+						node.parent.data.id,
+						target.data.id
+					)
+				);
+				break;
+			default:
+				throw new Error(`Node type '${node.data.type}' not draggable`);
+		}
+	});
+
+	return Promise.allSettled(movings).then((results) => {
+		const formatted = results.reduce(
+			(formattedNodes, result, i) => ({
+				...formattedNodes,
+				[result.status]: [...formattedNodes[result.status], nodes[i]],
+			}),
+			{
+				fulfilled: [],
+				rejected: [],
+			}
+		);
+
+		return formatted;
+	});
 }

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/style/main.scss
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/style/main.scss
@@ -36,6 +36,10 @@ $btn-size: 28px;
 		fill: none;
 		stroke: $secondary-l2;
 		stroke-width: 1.5;
+
+		&.highlighted {
+			stroke: rgba($primary, 0.4);
+		}
 	}
 
 	.chart-rect {
@@ -60,10 +64,12 @@ $btn-size: 28px;
 		transform: scale(0.8);
 	}
 
-	.selected {
-		.chart-rect {
-			stroke: $primary;
-		}
+	.highlighted .chart-rect {
+		stroke: rgba($primary, 0.6);
+	}
+
+	.selected .chart-rect {
+		stroke: $primary;
 	}
 
 	.chart-data-wrapper {

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required
 root-organization-id=Root Organization ID
 search-account=Search Account
 suborganization=Suborganization
+x-could-not-be-moved={0} could not be moved.
 x-not-found={0} not found.
 x-organizations-were-added-to-x={0} organizations were added to {1}.
 x-will-be-deleted={0} will be deleted.

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ar.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ar.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=معرف المنظمة الجذر
 search-account=Search Account (Automatic Copy)
 suborganization=مؤسسة تابعة
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_bg.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_bg.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Подорганизация (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ca.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ca.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=ID de l'organització arrel
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganització
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_cs.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_cs.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganizace (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_da.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_da.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Underorganisering (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_de.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_de.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Stammorganisation-ID
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganisation
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_el.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_el.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Υποδιοργανοποίηση (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_en.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_en.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required
 root-organization-id=Root Organization ID
 search-account=Search Account
 suborganization=Suborganization
+x-could-not-be-moved={0} could not be moved.
 x-not-found={0} not found.
 x-organizations-were-added-to-x={0} organizations were added to {1}.
 x-will-be-deleted={0} will be deleted.

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_en_AU.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganization (Automatic Copy)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_en_GB.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organisation ID
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganisation
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_es.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_es.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Identificador de organización raíz
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganización
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_et.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_et.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Allorganiseerimine (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_eu.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_eu.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganization (Automatic Copy)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_fa.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_fa.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=زیرمجموعه سازی (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_fi.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_fi.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Pääorganisaation tunnus
 search-account=Search Account (Automatic Copy)
 suborganization=Aliorganisaatio
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_fr.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_fr.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=ID de l'organisation racine
 search-account=Search Account (Automatic Copy)
 suborganization=Sous-organisation
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_fr_CA.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganization (Automatic Copy)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_gl.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_gl.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganization (Automatic Copy)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_hi_IN.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=उपसंचालन (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_hr.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_hr.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganization (Automatic Copy)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_hu.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_hu.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root szervezetazonosító
 search-account=Search Account (Automatic Copy)
 suborganization=Alszervezet
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_in.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_in.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganisasi (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_it.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_it.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Sottoorganizzazione (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_iw.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_iw.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=ארגון משנה (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ja.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ja.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=ルート組織 ID
 search-account=Search Account (Automatic Copy)
 suborganization=下位組織
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_kk.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_kk.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganization (Automatic Copy)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ko.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ko.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=하위 조직 (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_lo.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_lo.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganization (Automatic Copy)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_lt.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_lt.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganizacija (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ms.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ms.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganisasi (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_nb.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_nb.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Underorganisering (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_nl.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_nl.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=ID hoofdorganisatie
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganisatie
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_nl_BE.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganization (Automatic Copy)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_pl.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_pl.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Podorganizacja (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_pt_BR.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=ID da Organização Raiz
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganização
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_pt_PT.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganização (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ro.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ro.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganizare (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ru.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ru.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Суборганизация (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_sk.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_sk.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganizácia (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_sl.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_sl.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Podorganizacija (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_sr_RS.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganization (Automatic Copy)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganization (Automatic Copy)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_sv.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_sv.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Rotorganisations-ID
 search-account=Search Account (Automatic Copy)
 suborganization=Underorganisation
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_ta_IN.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganization (Automatic Copy)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_th.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_th.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=การจัดโครงสร้างย่อย (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_tr.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_tr.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Suborganizasyon (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_uk.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_uk.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Підорганізація (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_vi.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_vi.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=Tổ chức lại (Automatic Translation)
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_zh_CN.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=根组织 ID
 search-account=Search Account (Automatic Copy)
 suborganization=下级组织
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/content/Language_zh_TW.properties
@@ -9,6 +9,7 @@ organization-name-field-required=Organization Name Field Required (Automatic Cop
 root-organization-id=Root Organization ID (Automatic Copy)
 search-account=Search Account (Automatic Copy)
 suborganization=次級組織
+x-could-not-be-moved={0} could not be moved. (Automatic Copy)
 x-not-found={0} not found. (Automatic Copy)
 x-organizations-were-added-to-x={0} organizations were added to {1}. (Automatic Copy)
 x-will-be-deleted={0} will be deleted. (Automatic Copy)

--- a/modules/dxp/apps/commerce/commerce-organization-web/test/D3ChartImplementation.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/test/D3ChartImplementation.js
@@ -17,6 +17,7 @@ import {
 	ORGANIZATIONS_PROPERTY_NAME,
 	USERS_PROPERTY_NAME_IN_ORGANIZATION,
 } from '../src/main/resources/META-INF/resources/js/utils/constants';
+import {USER_INVITATION_ENABLED} from '../src/main/resources/META-INF/resources/js/utils/flags';
 
 jest.mock(
 	'../src/main/resources/META-INF/resources/js/data/organizations',
@@ -67,7 +68,7 @@ jest.mock(
 jest.mock('../src/main/resources/META-INF/resources/js/data/accounts', () => ({
 	getAccount: () =>
 		Promise.resolve({
-			type: 'accountUserAccounts',
+			type: 'account',
 			userAccounts: [
 				{
 					id: '2000',
@@ -387,6 +388,26 @@ describe('D3OrganizationChart implementation', () => {
 
 			expect(lastActionPerformed.name).toBe('modal opened');
 			expect(lastActionPerformed.details.type).toBe('account');
+		});
+
+		it('Must open a invite user modal when a creation button is clicked', async () => {
+			const openActionsWrapper = addButton.querySelector(
+				'.open-actions-wrapper'
+			);
+
+			await d3click(openActionsWrapper);
+
+			const inviteUserButton = addButton.querySelector(
+				'.add-action-wrapper.user'
+			);
+			expect(!!inviteUserButton).toBe(USER_INVITATION_ENABLED);
+
+			if (USER_INVITATION_ENABLED) {
+				await d3click(inviteUserButton);
+
+				expect(lastActionPerformed.name).toBe('modal opened');
+				expect(lastActionPerformed.details.type).toBe('user');
+			}
 		});
 	});
 

--- a/modules/dxp/apps/commerce/commerce-organization-web/test/dev/entry.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/test/dev/entry.js
@@ -18,7 +18,7 @@ import '../../src/main/resources/META-INF/resources/style/main.scss';
 render(
 	OrganizationChart,
 	{
-		rootOrganizationId: 42235,
+		rootOrganizationId: 42616,
 		spritemap: './assets/clay/icons.svg',
 		templatesURL: {
 			accountsDetailsPage: '/account/{id}',


### PR DESCRIPTION
This is the third PR related to the Org Chart refactoring to be reviewed after the [second one](https://github.com/liferay-frontend/liferay-portal/pull/1321) gets merged. I will eventually rebase it on top of the previous PRs corrections (which will come after code reviews)

Here I made chart nodes draggable then I implemented the multi selection. Mouseover on a node also highlights its path to the root.

Requirements for DnD:
- Organizations can be moved under other organizations (except ancestor and descendants)
- Accounts  can be moved in different organizations (except ancestor and descendants)
- Users cannot be moved

**What this PR allows:**

- [x] navigating through organisations, accounts and users in a static environment
- [x] creating new organizations via Modal
- [x] creating or adding accounts within organizations
- [x] inviting users within accounts
- [x] removing / deleting entities via dropdown menu
- [x] update entities connection via drag & drop
- [x] multi selection via shift key
- [x] paths highlighting at mouseover
- [ ] actions available when user has the right permissions
- [x] it works in portal
- [ ] it supports a table view
- [ ] it supports a map view

**Design**

Here's the final expected result: https://www.figma.com/file/Fgh6jD5qPBr8srVZlmxAWc/(m)-commerce-classic-theme-01a-ac?node-id=5037%3A95299. 

Please note: the chart won't work until [this PR](https://github.com/liferay-usm/liferay-portal/pull/189) gets merged

Thanks in advance,
Fabio

cc @nhpatt, @riccardo-alberti