### PR TITLE
LPS-136580 Notify tags subscribers when a new Web content, Blog, KB Article, Wiki Page, Message and Document are created

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -2030,6 +2030,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 
 		_unsubscribeHelper.registerHooks(subscriptionSender);
 
+		subscriptionSender.addAssetEntryPersistedSubscribers(
+			BlogsEntry.class.getName(), entry.getEntryId());
+
 		subscriptionSender.addPersistedSubscribers(
 			BlogsEntry.class.getName(), entry.getGroupId());
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
@@ -253,6 +253,9 @@ public class SubscriptionDLAppHelperLocalServiceWrapper
 		subscriptionSender.setScopeGroupId(fileVersion.getGroupId());
 		subscriptionSender.setServiceContext(serviceContext);
 
+		subscriptionSender.addAssetEntryPersistedSubscribers(
+			DLFileEntry.class.getName(), dlFileEntry.getPrimaryKey());
+
 		subscriptionSender.addPersistedSubscribers(
 			DLFolder.class.getName(), fileVersion.getGroupId());
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7962,6 +7962,9 @@ public class JournalArticleLocalServiceImpl
 
 		long liveGroupId = group.getLiveGroupId();
 
+		subscriptionSender.addAssetEntryPersistedSubscribers(
+			JournalArticle.class.getName(), article.getResourcePrimKey());
+
 		if (liveGroupId > 0) {
 			subscriptionSender.addPersistedSubscribers(
 				JournalFolder.class.getName(), liveGroupId, false);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1839,6 +1839,9 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		subscriptionSender.setScopeGroupId(kbArticle.getGroupId());
 		subscriptionSender.setSubject(subject);
 
+		subscriptionSender.addAssetEntryPersistedSubscribers(
+			KBArticle.class.getName(), kbArticle.getResourcePrimKey());
+
 		subscriptionSender.addPersistedSubscribers(
 			KBArticle.class.getName(), kbArticle.getGroupId());
 		subscriptionSender.addPersistedSubscribers(

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -16,7 +16,6 @@ package com.liferay.message.boards.service.impl;
 
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetLinkConstants;
-import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.comment.configuration.CommentGroupServiceConfiguration;
 import com.liferay.comment.constants.CommentConstants;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -2334,13 +2333,8 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			fromName, fromAddress, replyToAddress, emailAddress, fullName,
 			subjectLocalizedValuesMap, bodyLocalizedValuesMap, serviceContext);
 
-		AssetEntry assetEntry = assetEntryLocalService.getEntry(
+		subscriptionSender.addAssetEntryPersistedSubscribers(
 			MBMessage.class.getName(), message.getMessageId());
-
-		for (AssetTag assetTag : assetEntry.getTags()) {
-			subscriptionSender.addPersistedSubscribers(
-				AssetTag.class.getName(), assetTag.getTagId());
-		}
 
 		subscriptionSender.addPersistedSubscribers(
 			MBCategory.class.getName(), message.getGroupId());

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -3129,6 +3129,9 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		subscriptionSender.setScopeGroupId(page.getGroupId());
 		subscriptionSender.setServiceContext(serviceContext);
 
+		subscriptionSender.addAssetEntryPersistedSubscribers(
+			WikiPage.class.getName(), page.getResourcePrimKey());
+
 		subscriptionSender.addPersistedSubscribers(
 			WikiNode.class.getName(), page.getNodeId());
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.kernel.util;
 
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetTag;
+import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.mail.kernel.model.FileAttachment;
 import com.liferay.mail.kernel.model.MailMessage;
 import com.liferay.mail.kernel.model.SMTPAccount;
@@ -79,6 +82,20 @@ import javax.mail.internet.InternetAddress;
  * @author Roberto Díaz
  */
 public class SubscriptionSender implements Serializable {
+
+	public void addAssetEntryPersistedSubscribers(
+		String assetEntryClassName, long assetEntryClassPK) {
+
+		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+			assetEntryClassName, assetEntryClassPK);
+
+		if (assetEntry != null) {
+			for (AssetTag assetTag : assetEntry.getTags()) {
+				addPersistedSubscribers(
+					AssetTag.class.getName(), assetTag.getTagId());
+			}
+		}
+	}
 
 	public void addFileAttachment(File file) {
 		addFileAttachment(file, null);


### PR DESCRIPTION
I've added a new method in the SubscriptionSender to add the persisted subscribers that are related to the given asset entry.

I've tried to add the logic in the initialize method to be automatic and smarter but it was not possible as there are cases where we are using ids that does not correspond with the resource primary key used in the AssetEntry table.

I think this way the logic is in one place and the usage is clean enough