### PR TITLE
LPS-135071 Avoid possible sync problems adding synchronized to ObjectDefinitionDeployerImpl deploy and undeploy methods

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -52,7 +52,7 @@ import org.osgi.service.component.annotations.Reference;
 public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Override
-	public List<ServiceRegistration<?>> deploy(
+	public synchronized List<ServiceRegistration<?>> deploy(
 		ObjectDefinition objectDefinition) {
 
 		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
@@ -169,7 +169,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	}
 
 	@Override
-	public void undeploy(ObjectDefinition objectDefinition) {
+	public synchronized void undeploy(ObjectDefinition objectDefinition) {
 		Map<Long, ObjectDefinition> objectDefinitions =
 			_objectDefinitionsMap.get(objectDefinition.getRESTContextPath());
 


### PR DESCRIPTION
Brian told me to take care of possible synchronization issues when deploying and undeploying Object Definitions (I thought about it but I thought it would be very rare cases and then I forgot...) and send the PR directly to him.

I want to share the solution with you anyway because concurrency is not one of my strengths.

In this case, as the map is heavily used in the deploy and undeploy methods, I think it is better to synchronize the methods.

I doubt about synchronizing the getObjectDefinition method but I think it is better to synchronize it also to avoid returning an ObjectDefinition that was already undeployed.

I think it is very improbable to fall into these concurrency problems but it may be worth the performance penalty to be safer in the DeployerImpl functionality.

Once we agreed on the solution we can close the PR request and send it directly to Brian to solve this issue quick as he demanded.