### PR TITLE
LPS-136502 add overflow to alert messages in editors to avoid overlapping

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/AlloyEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/AlloyEditorConfigContributor.java
@@ -139,13 +139,13 @@ public class AlloyEditorConfigContributor
 				_CKEDITOR_STYLE_INLINE),
 			getStyleFormatJSONObject(
 				LanguageUtil.get(resourceBundle, "info-message"), "div",
-				"portlet-msg-info", _CKEDITOR_STYLE_BLOCK),
+				"overflow-auto portlet-msg-info", _CKEDITOR_STYLE_BLOCK),
 			getStyleFormatJSONObject(
 				LanguageUtil.get(resourceBundle, "alert-message"), "div",
-				"portlet-msg-alert", _CKEDITOR_STYLE_BLOCK),
+				"overflow-auto portlet-msg-alert", _CKEDITOR_STYLE_BLOCK),
 			getStyleFormatJSONObject(
 				LanguageUtil.get(resourceBundle, "error-message"), "div",
-				"portlet-msg-error", _CKEDITOR_STYLE_BLOCK));
+				"overflow-auto portlet-msg-error", _CKEDITOR_STYLE_BLOCK));
 	}
 
 	protected JSONObject getStyleFormatsJSONObject(Locale locale) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -196,13 +196,13 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 				null),
 			getStyleFormatJSONObject(
 				LanguageUtil.get(resourceBundle, "info-message"), "div",
-				"portlet-msg-info"),
+				"overflow-auto portlet-msg-info"),
 			getStyleFormatJSONObject(
 				LanguageUtil.get(resourceBundle, "alert-message"), "div",
-				"portlet-msg-alert"),
+				"overflow-auto portlet-msg-alert"),
 			getStyleFormatJSONObject(
 				LanguageUtil.get(resourceBundle, "error-message"), "div",
-				"portlet-msg-error"));
+				"overflow-auto portlet-msg-error"));
 	}
 
 	protected JSONArray getToolbarSimpleJSONArray(


### PR DESCRIPTION
[Original explanation](https://github.com/antonio-ortega/liferay-portal/pull/159#issue-703731767) from @orsolyaDekany 

> The issue is that when an alert message is inserted below an image in CKEditor and AlloyEditor, and we set the image to float to the right or left (none is the default), the message is going to overlap the image.
> LPS: https://issues.liferay.com/browse/LPS-136502
> 
![image](https://user-images.githubusercontent.com/14979768/128486270-5301038a-4ebd-4cdf-a618-643bda68851c.png)
> Root cause: the image is positioned with the float property, that allows the block element (Clay alert messages) to overlap
> overlap ckeditor
> 
> Fix: add overflow-auto class to the elements in the editors modules. I was a bit hesitating to choose other solutions as changing the display type of the div from block to flexbox give a clear property to Alerts in Clay for instance. I am not sure which would be the better option here.
> overflow
> 
![image](https://user-images.githubusercontent.com/14979768/128486408-9f01d07b-3ad9-40ba-b8b0-88345e47a03a.png)
> Please review it and let me know your opinion.