### PR TITLE
LPS-137020 |  headless-delivery/v1.0/content-structures/${structureId}/structured-contents fails with 404 if one version of the journalArticle references a missing folder

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -69,6 +69,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Sort;
@@ -1090,6 +1091,9 @@ public class StructuredContentResourceImpl
 		}
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		StructuredContentResourceImpl.class);
+
 	@Reference
 	private Aggregations _aggregations;
 
@@ -1167,9 +1171,6 @@ public class StructuredContentResourceImpl
 
 	@Reference
 	private LayoutPageTemplateEntryService _layoutPageTemplateEntryService;
-
-	@Reference
-	private Log _log;
 
 	@Reference
 	private Portal _portal;


### PR DESCRIPTION
Hello Frontend Team.

**Description of the issue:**

When calling to **headless-delivery/v1.0/content-structures/${structureId}/structured-contents** method below response is shown if there's any exception.

```
status": NOT FOUND, 
"title": "No JournalFolder exist with the primary key XXXX
```
This could be correct if there's a fatal exception, but in case a webcontent references a journalFolder that doesn't exists, same message is shown.

**Steps to reproduce:**

1. Go to global site and create a web content structure (S1)
2. Annotate this structureId, we will need it later (s1-structureId)
3. Create a new s1 web content (g1 with content "this is a global content")
4. Go to Liferay site
5. Create a new folder in webcontent (f1)
6. Create a new folder in webcontent (f2)
7. Create a new s1 web content inside f1 (l1 with content "this is a content in liferay site and folder1")
8. Create a new s1 web content inside f2 (l2 with content "this is a content in liferay site and folder1")
9. Stop Liferay and delete f2 folder from database.
10. Start Liferay
11. with postman make an api call to http://localhost:8080/o/headless-delivery/v1.0/content-structures/${s1-structureId}/structured-contents

Expected result:
contents g1 and l1 are returned

Current result:
404 Error is returned

```
status": NOT FOUND, 
"title": "No JournalFolder exist with the primary key XXXX
```

Things done on this pr:

Add a new catch to avoid propagation of PortalExceptions and rethrow any other exceptions.

Regards,
Jorge
