### PR TITLE
LPS-132744 Isolates Portlet Topper Modals

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -23,6 +23,75 @@ html#{$cadmin-selector} {
 			}
 		}
 
+		&.modal.show,
+		.modal.show {
+			display: block;
+		}
+
+		&.modal-dialog,
+		.modal-dialog {
+			&:not(.dialog-iframe-modal):not(.modal-full-screen) {
+				position: relative;
+			}
+
+			&.dialog-iframe-modal {
+				max-width: none;
+			}
+
+			&.modal-dialog-sm {
+				max-width: $cadmin-modal-md;
+			}
+
+			.yui3-resize-handles-wrapper {
+				pointer-events: all;
+
+				.yui3-resize-handle-inner-br {
+					background-position: -30px 0;
+					background-repeat: no-repeat;
+					bottom: 0;
+					display: block;
+					height: 15px;
+					overflow: hidden;
+					right: 0;
+					text-indent: -99999em;
+					width: 15px;
+				}
+			}
+		}
+
+		.modal-body.dialog-iframe-bd {
+			overflow: hidden;
+			padding: 0;
+		}
+
+		.yui3-widget-content-expanded {
+			height: 100%;
+		}
+
+		.loadingmask-message {
+			left: 50%;
+			padding: 2px;
+			position: absolute;
+			top: 50%;
+		}
+
+		.loadingmask-message-content {
+			-webkit-animation: loading-animation 1.2s infinite ease-out;
+			animation: loading-animation 1.2s infinite ease-out;
+			background: transparent;
+			border-radius: 50%;
+			border-width: 0;
+			clear: both;
+			color: transparent;
+			height: 1em;
+			margin: 0;
+			overflow: hidden;
+			padding: 0;
+			position: relative;
+			transform: translateZ(0);
+			width: 1em;
+		}
+
 		.user-icon-color-0 {
 			color: $user-icon-color-0;
 		}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -355,7 +355,12 @@ AUI.add(
 						catch (error) {}
 					};
 
-					modal.get('boundingBox').addClass('dialog-iframe-modal');
+					var boundingBox = modal.get('boundingBox');
+
+					boundingBox.addClass('cadmin');
+					boundingBox.addClass('dialog-iframe-modal');
+					boundingBox.addClass('modal');
+					boundingBox.addClass('show');
 				}
 
 				if (!Lang.isValue(config.title)) {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -27,7 +27,9 @@ import navigate from '../util/navigate.es';
 const Modal = ({
 	bodyHTML,
 	buttons,
-	containerProps = {},
+	containerProps = {
+		className: 'cadmin',
+	},
 	customEvents,
 	headerHTML,
 	height,
@@ -270,6 +272,7 @@ const openModal = (props) => {
 };
 
 const openPortletModal = ({
+	containerProps,
 	iframeBodyCssClass,
 	onClose,
 	portletSelector,
@@ -306,6 +309,7 @@ const openPortletModal = ({
 		}
 
 		openModal({
+			containerProps,
 			headerHTML,
 			iframeBodyCssClass,
 			onClose,
@@ -332,7 +336,7 @@ const openPortletWindow = ({bodyCssClass, portlet, uri, ...otherProps}) => {
 const openSelectionModal = ({
 	buttonAddLabel = Liferay.Language.get('add'),
 	buttonCancelLabel = Liferay.Language.get('cancel'),
-	containerProps = {},
+	containerProps,
 	customSelectEvent = false,
 	height,
 	id,

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/__snapshots__/Modal.js.snap
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/__snapshots__/Modal.js.snap
@@ -5,7 +5,9 @@ exports[`Modal renders markup based on given configuration 1`] = `
   class="modal-open"
 >
   <div />
-  <div>
+  <div
+    class="cadmin"
+  >
     <div
       class="modal-backdrop fade show"
     />

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
@@ -43,6 +43,11 @@
 
 	.yui3-resize-handles-wrapper {
 		pointer-events: all;
+
+		.yui3-resize-handle-inner-br {
+			bottom: 0;
+			right: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-132744

This pr isolates portlet topper modals and simulation menu preview that use the old aui modal plugin and newer  Liferay.Portlet.openModal based on ClayModal. I also fixed the double scrollbars in the modals using the aui version (Look and Feel, Permissions, and Configuration Templates).

Just leaving this part for the future if someone needs to do this. For modals using `Liferay.Portlet.openModal`, you can un-isolate it with:
```
Liferay.Portlet.openModal({
    containerProps: {
        className: '',
    },
});
```

Screenshots:
Look and Feel
![look-and-feel](https://user-images.githubusercontent.com/788266/128752402-e9cb6b2e-2adb-4fa5-970f-394828656bc9.jpg)

Export Import
![export-import](https://user-images.githubusercontent.com/788266/128752464-0f55e4d5-278f-44e4-acfd-0f4016f518dc.jpg)

Configuration
![configuration](https://user-images.githubusercontent.com/788266/128752536-213ad1d7-4750-4a3f-bff7-b864016e384c.jpg)

Permissions
![permissions](https://user-images.githubusercontent.com/788266/128752601-5f052628-04c1-4d10-ab3f-fadb37f99312.jpg)

Configuration Templates
![configuration-templates](https://user-images.githubusercontent.com/788266/128752727-d953d8d5-6373-46d9-aed7-4ff6dd09add8.jpg)
