### PR TITLE
LPS-136717 Use `justify(left|center|right)` commands to fire float in `img` elements and add `float: left` in the parent element of CKEditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
@@ -22,70 +22,19 @@
 	CKEDITOR.plugins.add(pluginName, {
 		init(editor) {
 			editor.ui.addBalloonToolbarButton('ImageAlignLeft', {
-				click() {
-					const imageWidget = editor.widgets.selected[0];
-
-					if (imageWidget.name !== 'image') {
-						return;
-					}
-
-					imageWidget.focus();
-
-					const alignValue = imageWidget.data.align;
-
-					if (!alignValue || alignValue !== 'left') {
-						imageWidget.setData('align', 'left');
-					}
-					else {
-						imageWidget.setData('align', 'none');
-					}
-				},
+				command: 'justifyleft',
 				icon: 'align-image-left',
 				title: editor.lang.common.alignLeft,
 			});
 
 			editor.ui.addBalloonToolbarButton('ImageAlignCenter', {
-				click() {
-					const imageWidget = editor.widgets.selected[0];
-
-					if (imageWidget.name !== 'image') {
-						return;
-					}
-
-					imageWidget.focus();
-
-					const alignValue = imageWidget.data.align;
-
-					if (!alignValue || alignValue !== 'center') {
-						imageWidget.setData('align', 'center');
-					}
-					else if (alignValue === 'center') {
-						imageWidget.setData('align', 'none');
-					}
-				},
+				command: 'justifycenter',
 				icon: 'align-image-center',
 				title: editor.lang.common.alignCenter,
 			});
 
 			editor.ui.addBalloonToolbarButton('ImageAlignRight', {
-				click() {
-					const imageWidget = editor.widgets.selected[0];
-
-					if (imageWidget.name !== 'image') {
-						return;
-					}
-
-					imageWidget.focus();
-
-					const alignValue = imageWidget.data.align;
-
-					if (!alignValue || alignValue !== 'right') {
-						imageWidget.setData('align', 'right');
-					}
-					else {
-						imageWidget.setData('align', 'none');
-					}
-				},
+				command: 'justifyright',
 				icon: 'align-image-right',
 				title: editor.lang.common.alignRight,
 			});

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -74,6 +74,10 @@
 	width: 24px;
 }
 
+.liferay-editable {
+	overflow: auto;
+}
+
 .cke_toolbar {
 	&.cke_toolbar__a11yhelpbtn {
 		float: right;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -42,6 +42,15 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 		title: false,
 	};
 
+	const imageDirectionShim = editorConfig.toolbarImage.includes(
+		'ImageAlign'
+	) && {
+		style: {
+			float: 'left',
+			width: '100%',
+		},
+	};
+
 	return (
 		<Editor
 			config={editorConfig}
@@ -98,6 +107,7 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 				});
 			}}
 			type="inline"
+			{...imageDirectionShim}
 			{...otherProps}
 		/>
 	);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -70,7 +70,7 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 
 				editor.element.setAttribute('id', `cke_${editor.name}`);
 
-				editable.attachClass('overflow-auto');
+				editable.attachClass('liferay-editable');
 
 				const balloonToolbars = editor.balloonToolbars;
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -42,15 +42,6 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 		title: false,
 	};
 
-	const imageDirectionShim = editorConfig.toolbarImage.includes(
-		'ImageAlign'
-	) && {
-		style: {
-			float: 'left',
-			width: '100%',
-		},
-	};
-
 	return (
 		<Editor
 			config={editorConfig}
@@ -71,12 +62,15 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 			}}
 			onInstanceReady={(event) => {
 				const editor = event.editor;
+				const editable = editor.editable();
 
 				// Workaround to make the "CKEDITOR.ui.richCombo"
 				// plugin work with the CKEditor (React) component
 				// the "id" needs to be "cke_" + "editor.name"
 
 				editor.element.setAttribute('id', `cke_${editor.name}`);
+
+				editable.attachClass('overflow-auto');
 
 				const balloonToolbars = editor.balloonToolbars;
 
@@ -107,7 +101,6 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 				});
 			}}
 			type="inline"
-			{...imageDirectionShim}
 			{...otherProps}
 		/>
 	);


### PR DESCRIPTION
Link to the ticket: https://issues.liferay.com/browse/LPS-136717

I saw in AlloyEditor example, when removing the text below the image and then trying to positioning the image We have the same issue as CKEditor implementation. See:


https://user-images.githubusercontent.com/7663513/128784664-29abfd37-3556-492e-9417-01d270693a72.mov



For fixing it, was needed to place a float: left; in CKEditor's grandparent element and width:100%  in order to fix an issue when having one just image. See:


https://user-images.githubusercontent.com/7663513/128784689-e539a8f9-a13d-41dd-a9b1-aa931423a388.mov


https://user-images.githubusercontent.com/7663513/128784703-97f3636a-2fe2-4f5c-8dfd-9bf44949458d.mov


If you want a reference of the buggy behavior, take a look the attached GIF on https://issues.liferay.com/browse/LPS-136717