### PR TITLE
LPS-136119 We can't open panel elements when the table toolbar is re-rendered

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"ckeditor4-react": "1.4.2",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.16.1-liferay.3",
+		"liferay-ckeditor": "4.16.1-liferay.4",
 		"prop-types": "15.7.2"
 	},
 	"main": "index.js",

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
@@ -383,18 +383,6 @@
 					contextMatched.show(selection);
 				}
 			};
-
-			const originalShowBlockFn = CKEDITOR.ui.panel.prototype.showBlock;
-
-			CKEDITOR.ui.panel.prototype.showBlock = function (name) {
-				if (!this.name) {
-					this.name = name;
-
-					return originalShowBlockFn.call(this, this.name);
-				}
-
-				return originalShowBlockFn.call(this, name);
-			};
 		},
 
 		requires: [


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-136119

See details and steps to reproduce in https://github.com/liferay/liferay-ckeditor/pull/188

We fixed the issue in https://github.com/liferay/liferay-ckeditor/pull/188. Newly released version of ckeditor is 4.16.1-liferay.4, we are updating it in this PR. Along with it, we are removing the code that was inadequate to fix the bug, and prevents the solution in latest ckeditor to work correctly.