### PR TITLE
LPS-136721 Check if `toolbar*` buttons were defined before instantiating a new balloonToolbar

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -71,31 +71,42 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 
 				const balloonToolbars = editor.balloonToolbars;
 
-				balloonToolbars.create({
-					buttons: editorConfig.toolbarText,
-					cssSelector: '*',
-				});
+				if (editorConfig.toolbarText) {
+					balloonToolbars.create({
+						buttons: editorConfig.toolbarText,
+						cssSelector: '*',
+					});
+				}
 
-				balloonToolbars.create({
-					buttons: editorConfig.toolbarImage,
-					priority:
-						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
-					widgets: 'image,image2',
-				});
+				if (editorConfig.toolbarImage) {
+					balloonToolbars.create({
+						buttons: editorConfig.toolbarImage,
+						priority:
+							window.CKEDITOR.plugins.balloontoolbar.PRIORITY
+								.HIGH,
+						widgets: 'image,image2',
+					});
+				}
 
-				balloonToolbars.create({
-					buttons: editorConfig.toolbarTable,
-					cssSelector: 'td',
-					priority:
-						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
-				});
+				if (editorConfig.toolbarTable) {
+					balloonToolbars.create({
+						buttons: editorConfig.toolbarTable,
+						cssSelector: 'td',
+						priority:
+							window.CKEDITOR.plugins.balloontoolbar.PRIORITY
+								.HIGH,
+					});
+				}
 
-				balloonToolbars.create({
-					buttons: editorConfig.toolbarVideo,
-					priority:
-						window.CKEDITOR.plugins.balloontoolbar.PRIORITY.HIGH,
-					widgets: 'videoembed',
-				});
+				if (editorConfig.toolbarVideo) {
+					balloonToolbars.create({
+						buttons: editorConfig.toolbarVideo,
+						priority:
+							window.CKEDITOR.plugins.balloontoolbar.PRIORITY
+								.HIGH,
+						widgets: 'videoembed',
+					});
+				}
 			}}
 			type="inline"
 			{...otherProps}


### PR DESCRIPTION
### How to test it:  
  
Go to CKEditorBalloonEditorConfigContributor.java and then remove the value of `toolbarImage` property  
  
Go to BalloonEditor.js in `frontend-js-ckeditor-web` and then comment `toolbarImage` field in `basicToolbars` object. It will temporary remove the buttons of toolbarImage.  
  
You'll notice the toolbar is being rendered but without any button.  
 
### Solution:  
  
For fixing this issue, before creating any toolbar* button, we should check if there are buttons to be rendered. If not, does nothing.  
 
### Side effects:  
  
When solving this issue I noticed there is a bug with toolbarText’s cssSelector because it will render the text sidebar when focusing in an `img` due to a very generic cssSelector(`*`). 
  
In order to solve this issue, I tried:  

`*:not(img)`

`*:not(p span img[data-widget="image”])`  
  
but We still passing the [cssSelector test](https://github.com/ckeditor/ckeditor4/blob/master/plugins/balloontoolbar/plugin.js#L346).  