### PR TITLE
LPS-136720 Implement options to disable and configure link toolbar

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
@@ -49,16 +49,6 @@
 				title: editor.lang.link.title,
 			});
 
-			editor.ui.addBalloonToolbarButton('LinkRemove', {
-				click() {
-					editor.fire('unlinkTextOrImage', {
-						selection: editor.getSelection(),
-					});
-				},
-				icon: 'unlink',
-				title: editor.lang.link.unlink,
-			});
-
 			editor.ui.addRichCombo('TableHeaders', {
 				init() {
 					const headersPrefix = editor.lang.table.headers;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/config/DefaultBalloonEditorConfiguration.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/config/DefaultBalloonEditorConfiguration.js
@@ -46,6 +46,7 @@ const DEFAULT_BALLOON_EDITOR_CONFIG = {
 	title: false,
 	toolbarImage:
 		'ImageAlignLeft,ImageAlignCenter,ImageAlignRight,LinkAddOrEdit,AltImg',
+	toolbarLink: 'LinkRemove,LinkTarget,LinkInput,LinkConfirm,LinkBrowse',
 	toolbarTable: 'TableHeaders,TableRow,TableColumn,TableCell,TableDelete',
 	toolbarText:
 		'Styles,Bold,Italic,Underline,BulletedList,NumberedList,TextLink,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,LineHeight,BGColor,RemoveFormat',


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-136720

Steps to test:
1. deploy `frontend-editor-ckeditor-sample-web`
2. change `toolbarLink` in `config` to modify or disable link toolbar.

The gif below contains a sample of customization. In it, I added `Bold` button and removed `LinkBrowse` button. To get it, set
```js
toolbarLink: 'Bold,LinkRemoveUnlink,LinkTarget,LinkInput,LinkConfirm',
```

This is in contrast to default
```js
toolbarLink: 'LinkRemove,LinkTarget,LinkInput,LinkConfirm,LinkBrowse',
```

To disable link toolbar, delete `toolbarLink`.

Notes:
- Any standard ckeditor button, like `Bold`, can be added. Some might not work, depending on context.
- Somebody can make a custom plugin with a toolbar item created with `editor.ui.addBalloonToolbarButton`, add it to config, and it will work. There might be some creative hacking needed if they want to interact with other parts of toolbar, like we are doing with default toolbar items. 
- A side-commit to the main bulk of this PR is https://github.com/liferay-frontend/liferay-portal/commit/f21ae4592659e10e309841ad9e94fbcf1466e842, a fix to selection edge case, that popped up during testing.

After PR 
![after](https://user-images.githubusercontent.com/5435511/129233497-6309ae92-7076-4977-8962-86a4a6780eaf.gif)
