### PR TITLE
LPS-136716 Provide balloon editor configuration in JSON files

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
@@ -15,18 +15,11 @@
 package com.liferay.frontend.editor.ckeditor.web.internal.editor.configuration;
 
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
-import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
-import com.liferay.portal.kernel.util.Validator;
 
-import java.util.Locale;
 import java.util.Map;
-import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -49,67 +42,6 @@ public class CKEditorBalloonEditorConfigContributor
 		super.populateConfigJSONObject(
 			jsonObject, inputEditorTaglibAttributes, themeDisplay,
 			requestBackedPortletURLFactory);
-
-		String extraPlugins = jsonObject.getString("extraPlugins");
-
-		if (Validator.isNotNull(extraPlugins)) {
-			extraPlugins += ",itemselector,stylescombo";
-		}
-		else {
-			extraPlugins = "itemselector,stylescombo";
-		}
-
-		jsonObject.put(
-			"extraPlugins", extraPlugins
-		).put(
-			"stylesSet", getStyleFormatsJSONArray(themeDisplay.getLocale())
-		).put(
-			"toolbarImage",
-			"ImageAlignLeft,ImageAlignCenter,ImageAlignRight,LinkAddOrEdit," +
-				"AltImg"
-		).put(
-			"toolbarTable",
-			"TableHeaders,TableRow,TableColumn,TableCell,TableDelete"
-		).put(
-			"toolbarText", getToolbarText()
-		).put(
-			"toolbarVideo", "VideoAlignLeft,VideoAlignCenter,VideoAlignRight"
-		);
-	}
-
-	protected JSONObject getStyleFormatJSONObject(
-		String styleFormatName, String element) {
-
-		return JSONUtil.put(
-			"element", element
-		).put(
-			"name", styleFormatName
-		);
-	}
-
-	protected JSONArray getStyleFormatsJSONArray(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			locale, "com.liferay.frontend.editor.lang");
-
-		return JSONUtil.putAll(
-			getStyleFormatJSONObject(
-				LanguageUtil.get(resourceBundle, "normal"), "p"),
-			getStyleFormatJSONObject(
-				LanguageUtil.format(resourceBundle, "heading-x", "1"), "h1"),
-			getStyleFormatJSONObject(
-				LanguageUtil.format(resourceBundle, "heading-x", "2"), "h2"),
-			getStyleFormatJSONObject(
-				LanguageUtil.get(resourceBundle, "preformatted-text"), "pre"),
-			getStyleFormatJSONObject(
-				LanguageUtil.get(resourceBundle, "cited-work"), "cite"),
-			getStyleFormatJSONObject(
-				LanguageUtil.get(resourceBundle, "computer-code"), "code"));
-	}
-
-	protected String getToolbarText() {
-		return "Styles,Bold,Italic,Underline,BulletedList,NumberedList," +
-			"TextLink,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock," +
-				"LineHeight,BGColor,RemoveFormat";
 	}
 
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -16,30 +16,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {Editor} from './Editor';
+import DEFAULT_BALLOON_EDITOR_CONFIG from './config/DefaultBalloonEditorConfiguration';
 
 import '../css/main.scss';
 
 const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
-	const defaultExtraPlugins = 'ballooneditor,videoembed';
-
-	const extraPlugins = config.extraPlugins ? `${config.extraPlugins},` : '';
-
-	const basicToolbars = {
-		toolbarImage:
-			'ImageAlignLeft,ImageAlignCenter,ImageAlignRight,LinkAddOrEdit,AltImg',
-		toolbarTable: 'TableHeaders,TableRow,TableColumn,TableCell,TableDelete',
-		toolbarText:
-			'Styles,Bold,Italic,Underline,BulletedList,NumberedList,TextLink,' +
-			'JustifyLeft,JustifyCenter,JustifyRight,LineHeight,RemoveFormat',
-		toolbarVideo: 'VideoAlignLeft,VideoAlignCenter,VideoAlignRight',
-	};
-
 	const editorConfig = {
-		...basicToolbars,
+		...DEFAULT_BALLOON_EDITOR_CONFIG,
 		...config,
-		extraAllowedContent: '*',
-		extraPlugins: `${extraPlugins}${defaultExtraPlugins}`,
-		title: false,
 	};
 
 	return (

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/config/DefaultBalloonEditorConfiguration.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/config/DefaultBalloonEditorConfiguration.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const sub = Liferay.Util.sub;
+
+const DEFAULT_BALLOON_EDITOR_CONFIG = {
+	extraAllowedContent: '*',
+	extraPlugins: 'itemselector,stylescombo,ballooneditor,videoembed',
+	stylesSet: [
+		{
+			element: 'p',
+			name: Liferay.Language.get('normal'),
+		},
+		{
+			element: 'h1',
+			name: sub(Liferay.Language.get('heading-x'), 1),
+		},
+		{
+			element: 'h2',
+			name: sub(Liferay.Language.get('heading-x'), 2),
+		},
+		{
+			element: 'pre',
+			name: Liferay.Language.get('preformatted-text'),
+		},
+		{
+			element: 'cite',
+			name: Liferay.Language.get('cited-work'),
+		},
+		{
+			element: 'code',
+			name: Liferay.Language.get('computer-code'),
+		},
+	],
+	title: false,
+	toolbarImage:
+		'ImageAlignLeft,ImageAlignCenter,ImageAlignRight,LinkAddOrEdit,AltImg',
+	toolbarTable: 'TableHeaders,TableRow,TableColumn,TableCell,TableDelete',
+	toolbarText:
+		'Styles,Bold,Italic,Underline,BulletedList,NumberedList,TextLink,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,LineHeight,BGColor,RemoveFormat',
+	toolbarVideo: 'VideoAlignLeft,VideoAlignCenter,VideoAlignRight',
+};
+
+export default DEFAULT_BALLOON_EDITOR_CONFIG;


### PR DESCRIPTION
From: https://issues.liferay.com/browse/LPS-136716

# Context: 

Currently, the default configuration is duplicated, in:

* CKEditorBalloonEditorConfigContributor.java . This is applied if BE is used through `<liferay-editor:editor>` tag. It overrides JS configuration.
* BalloonEditor.js . This is applied if BE is used directly, for example in a React component. In that case, `config` prop will still have priority.
 

Something we might want to consider, as a part of this task, is to remove all configuration from `CKEditorBalloonEditorConfigContributor.java`, just letting it inherit configuration in JS/JSON file.


# How to test it?

1.  Deploy `frontend-js-ckeditor-web` with this change
2.  Deploy `frontend-editor-ckeditor-sample-web`
3. See balloon editor with all panels working :)