### PR TITLE
LPS-136716 Adds a mock function for Liferay.Util.sub

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/jest-setup.config.js
+++ b/modules/apps/data-engine/data-engine-taglib/jest-setup.config.js
@@ -43,6 +43,7 @@ window.util = {
 	...window.util,
 	escape: (data) => data,
 	selectEntity: () => {},
+	sub: (data) => data,
 };
 
 const languageMap = {

--- a/modules/apps/data-engine/data-engine-taglib/test/js/data-layout-builder/components/rules/editor/Editor.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/test/js/data-layout-builder/components/rules/editor/Editor.es.js
@@ -28,8 +28,6 @@ import Numeric from 'dynamic-data-mapping-form-field-type/Numeric/Numeric';
 import RichText from 'dynamic-data-mapping-form-field-type/RichText/RichText.es';
 import Select from 'dynamic-data-mapping-form-field-type/Select/Select.es';
 import Text from 'dynamic-data-mapping-form-field-type/Text/Text.es';
-
-import 'frontend-editor-ckeditor-web';
 import React from 'react';
 
 import {Editor} from '../../../../../../src/main/resources/META-INF/resources/data_layout_builder/js/components/rules/editor/Editor.es';


### PR DESCRIPTION
Context: https://liferay.slack.com/archives/CLCD3DQLF/p1629141936032500?thread_ts=1629139360.032200&cid=CLCD3DQLF

Our tests are failing because `data-engine-taglib` doesn't have a mock for `Liferay.Util.sub`.

tagging @miltonmc just to have his bless

I created a [PR](https://github.com/liferay/liferay-frontend-projects/pull/619) in `npm-scripts` to remove those mocks in the future :)