### PR TITLE
LPS-137541 Normalize value to prevent issues when pasting hexcode

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
@@ -21,6 +21,8 @@ const ColorPicker = ({color, label, name}) => {
 	const [colorValue, setColorValue] = useState(color);
 	const [customColors, setCustomColors] = useState([]);
 
+	const noHashColorValue = colorValue.replace('#', '');
+
 	return (
 		<div className="form-group">
 			<input
@@ -29,8 +31,10 @@ const ColorPicker = ({color, label, name}) => {
 				value={
 					colorValue
 						? `${
-								HEX_COLOR_REGEX.test(colorValue) ? '#' : ''
-						  }${colorValue}`
+								HEX_COLOR_REGEX.test(noHashColorValue)
+									? '#'
+									: ''
+						  }${noHashColorValue}`
 						: ''
 				}
 			/>
@@ -44,7 +48,7 @@ const ColorPicker = ({color, label, name}) => {
 				showHex={true}
 				showPredefinedColorsWithCustom
 				title={label}
-				value={colorValue}
+				value={noHashColorValue}
 			/>
 		</div>
 	);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-137541

The issue is pasting a hexcode with `#` in the color picker for a widget, will not register the color change. This happens since the value after the paste will be `##e05929`. The input does not have a validation so it will not display an error.

The way I was able to solve this is to reintroduce `normalizeColor` and have it remove all `#`s. I am using the `colorValue` to create the new value. I tried normalizing the `color`, but I kept seeing the `#` when testing. When I created `normalizeColorValue` I was then able to see the color working correctly.

Let me know if there are any questions or comments about this.
Thank you.