### PR TITLE
LPS-137425 LPS-136998 Update liferay-ckeditor to 4.16.2-liferay.1

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"ckeditor4-react": "1.4.2",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.16.1-liferay.4",
+		"liferay-ckeditor": "4.16.2-liferay.1",
 		"prop-types": "15.7.2"
 	},
 	"main": "index.js",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -9560,10 +9560,10 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
-liferay-ckeditor@4.16.1-liferay.3:
-  version "4.16.1-liferay.3"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.16.1-liferay.3.tgz#f72fa055b9be40757dae7ea1215b594ff99b9f11"
-  integrity sha512-fwvFKVr24IcLk9v2VSRUa6ptSegeMqApJ0busLgN2S33xYEMPZiNklUbVpxXDosGanQiTn3F9R5fzZ+eHqYxYw==
+liferay-ckeditor@4.16.2-liferay.1:
+  version "4.16.2-liferay.1"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.16.2-liferay.1.tgz#f78cdb74d3f8802d691acb072e1f026c196a1aa1"
+  integrity sha512-k6M0sNJbx+sWOBDwgTBUcwuROfkopBb5QXvR/tLtZ4aWGTI6prqX/LKAe4gSvGy0p9Q/AyYQU7SMzeb+WlgJzQ==
 
 liferay-font-awesome@3.4.1:
   version "3.4.1"


### PR DESCRIPTION
It includes fixes to the following tickets:

https://issues.liferay.com/browse/LPS-136998
https://issues.liferay.com/browse/LPS-137425

# Changelog:

## [v4.16.2-liferay.1](https://github.com/liferay/liferay-ckeditor/tree/v4.16.2-liferay.1) (2021-08-18)

[Full changelog](https://github.com/liferay/liferay-ckeditor/compare/v4.16.1-liferay.4...v4.16.2-liferay.1)

### :wrench: Bug fixes

-   fix: LPS-137425 Focusing on balloon editor toolbar may open an additional text toolbar ([\#189](https://github.com/liferay/liferay-ckeditor/pull/189))
-   fix: Maximize plugin breaks the UI in Firefox ([\#187](https://github.com/liferay/liferay-ckeditor/pull/187))

/cc @NemethNorbert @markocikos 