### PR TITLE
LPS-137844 Register DynamicInclude in bottom instead of top head to avoid race condition with SPA

### DIFF
--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/java/com/liferay/frontend/js/a11y/web/internal/servlet/taglib/A11yBottomJSPDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/java/com/liferay/frontend/js/a11y/web/internal/servlet/taglib/A11yBottomJSPDynamicInclude.java
@@ -46,7 +46,7 @@ import org.osgi.service.component.annotations.Reference;
 	configurationPid = "com.liferay.frontend.js.a11y.web.internal.configuration.A11yConfiguration",
 	service = DynamicInclude.class
 )
-public class A11yTopHeadJSPDynamicInclude implements DynamicInclude {
+public class A11yBottomJSPDynamicInclude implements DynamicInclude {
 
 	@Override
 	public void include(
@@ -143,7 +143,7 @@ public class A11yTopHeadJSPDynamicInclude implements DynamicInclude {
 
 		if (FFA11yConfigurationUtil.getEnable()) {
 			dynamicIncludeRegistry.register(
-				"/html/common/themes/top_head.jsp#post");
+				"/html/common/themes/bottom.jsp#post");
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/components/ViolationPopover.tsx
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/components/ViolationPopover.tsx
@@ -43,6 +43,33 @@ type ViolationProps = {
 	violations: Array<string>;
 };
 
+function isVisible(
+	bounds: React.CSSProperties | undefined,
+	node: Element | null
+) {
+	if (!node || !bounds) {
+		return false;
+	}
+
+	// Elements with `sr-only` are considered invisible and a strategy for
+	// dealing with screen reader tools.
+
+	if (node.classList.contains('sr-only')) {
+		return false;
+	}
+
+	if (
+		bounds.height === 0 &&
+		bounds.left === 0 &&
+		bounds.top === 0 &&
+		bounds.width === 0
+	) {
+		return false;
+	}
+
+	return true;
+}
+
 export function ViolationPopover({
 	onClick,
 	rules,
@@ -80,6 +107,10 @@ export function ViolationPopover({
 		),
 		node
 	);
+
+	if (!isVisible(bounds, node)) {
+		return null;
+	}
 
 	return (
 		<ClayPopover

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/index.tsx
@@ -53,10 +53,9 @@ const getDefaultContainer = () => {
 };
 
 export default (props: Omit<A11yCheckerOptions, 'callback' | 'targets'>) => {
-	if (window.themeDisplay.isStatePopUp()) {
-		render(A11yIframe, props, getDefaultContainer());
-	}
-	else {
-		render(A11y, props, getDefaultContainer());
-	}
+	render(
+		window.themeDisplay.isStatePopUp() ? A11yIframe : A11y,
+		props,
+		getDefaultContainer()
+	);
 };

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/ViolationPopover.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/ViolationPopover.d.ts
@@ -27,5 +27,5 @@ export declare function ViolationPopover({
 	rules,
 	target,
 	violations,
-}: ViolationProps): JSX.Element;
+}: ViolationProps): JSX.Element | null;
 export {};


### PR DESCRIPTION
This is a follow-up PR that fixes some known issues and other tweaks I made that were related to the corresponding ticket. The main purpose here is just to avoid problems with the SPA when browsing.

To test this is quite complicated because you have to keep updating the page to check if the A11y container has been moved inside the SPA surface. See https://github.com/liferay-frontend/liferay-portal/commit/d542d45f450cd3231fdd3f1311c24082d89f29ef for more info.

## Test plan

- Fetch this branch
- Run ant all in development environment
- Create a `com.liferay.frontend.js.a11y.web.internal.configuration.FFA11yConfiguration.config` file in `osgi/configs` with the - following content: `enable=B"true"`
- Start tomcat
- The overlay and the Panel will probably show in the page.