### PR TITLE
LPS-132744 Isolate content inside Portlet Topper Look and Feel and Export / Import Modals

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_import.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_import.jsp
@@ -34,50 +34,52 @@ PortletURL portletURL = PortletURLBuilder.createRenderURL(
 ).buildPortletURL();
 %>
 
-<c:choose>
-	<c:when test="<%= !GroupPermissionUtil.contains(permissionChecker, themeDisplay.getScopeGroup(), ActionKeys.MANAGE_STAGING) %>">
-		<div class="alert alert-info">
-			<liferay-ui:message key="you-do-not-have-permission-to-access-the-requested-resource" />
-		</div>
-	</c:when>
-	<c:otherwise>
-		<clay:navigation-bar
-			navigationItems='<%=
-				new JSPNavigationItemList(pageContext) {
-					{
-						portletURL.setParameter("tabs2", "export");
+<div class="cadmin">
+	<c:choose>
+		<c:when test="<%= !GroupPermissionUtil.contains(permissionChecker, themeDisplay.getScopeGroup(), ActionKeys.MANAGE_STAGING) %>">
+			<div class="alert alert-info">
+				<liferay-ui:message key="you-do-not-have-permission-to-access-the-requested-resource" />
+			</div>
+		</c:when>
+		<c:otherwise>
+			<clay:navigation-bar
+				navigationItems='<%=
+					new JSPNavigationItemList(pageContext) {
+						{
+							portletURL.setParameter("tabs2", "export");
 
-						add(
-							navigationItem -> {
-								navigationItem.setActive(tabs2.equals("export"));
-								navigationItem.setHref(portletURL.toString());
-								navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "export"));
-							});
+							add(
+								navigationItem -> {
+									navigationItem.setActive(tabs2.equals("export"));
+									navigationItem.setHref(portletURL.toString());
+									navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "export"));
+								});
 
-						portletURL.setParameter("tabs2", "import");
+							portletURL.setParameter("tabs2", "import");
 
-						add(
-							navigationItem -> {
-								navigationItem.setActive(tabs2.equals("import"));
-								navigationItem.setHref(portletURL.toString());
-								navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "import"));
-							});
+							add(
+								navigationItem -> {
+									navigationItem.setActive(tabs2.equals("import"));
+									navigationItem.setHref(portletURL.toString());
+									navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "import"));
+								});
+						}
 					}
-				}
-			%>'
-		/>
+				%>'
+			/>
 
-		<div class="portlet-export-import-container" id="<portlet:namespace />exportImportPortletContainer">
-			<liferay-util:include page="/export_import_error.jsp" servletContext="<%= application %>" />
+			<div class="portlet-export-import-container" id="<portlet:namespace />exportImportPortletContainer">
+				<liferay-util:include page="/export_import_error.jsp" servletContext="<%= application %>" />
 
-			<c:choose>
-				<c:when test='<%= tabs2.equals("export") %>'>
-					<liferay-util:include page="/export_portlet.jsp" servletContext="<%= application %>" />
-				</c:when>
-				<c:when test='<%= tabs2.equals("import") %>'>
-					<liferay-util:include page="/import_portlet.jsp" servletContext="<%= application %>" />
-				</c:when>
-			</c:choose>
-		</div>
-	</c:otherwise>
-</c:choose>
+				<c:choose>
+					<c:when test='<%= tabs2.equals("export") %>'>
+						<liferay-util:include page="/export_portlet.jsp" servletContext="<%= application %>" />
+					</c:when>
+					<c:when test='<%= tabs2.equals("import") %>'>
+						<liferay-util:include page="/import_portlet.jsp" servletContext="<%= application %>" />
+					</c:when>
+				</c:choose>
+			</div>
+		</c:otherwise>
+	</c:choose>
+</div>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet_processes.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet_processes.jsp
@@ -146,6 +146,7 @@ else {
 					</liferay-portlet:actionURL>
 
 					<liferay-ui:icon-menu
+						direction="cadmin"
 						icon="<%= StringPool.BLANK %>"
 						markupView="lexicon"
 						showWhenSingleIcon="<%= true %>"

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_processes.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_processes.jsp
@@ -109,7 +109,7 @@ else {
 					</liferay-portlet:actionURL>
 
 					<liferay-ui:icon-menu
-						direction="left-side"
+						direction="cadmin"
 						icon="<%= StringPool.BLANK %>"
 						markupView="lexicon"
 						showWhenSingleIcon="<%= true %>"

--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -131,10 +131,235 @@ html#{$cadmin-selector} {
 		.user-icon-color-9 {
 			color: $user-icon-color-9;
 		}
+
+		// Lfr Upload Container
+
+		.upload-drop-intent .lfr-upload-container .upload-target {
+			z-index: 100;
+		}
+
+		.upload-drop-active .lfr-upload-container .upload-target {
+			background-color: #ddedde;
+			border-color: #7d7;
+			border-style: dashed;
+		}
+
+		.mobile .lfr-upload-container .upload-target .drop-file-text {
+			display: none;
+		}
+
+		.lfr-upload-container {
+			margin-bottom: 1em;
+
+			.upload-target {
+				border: 3px dashed $cadmin-gray-300;
+				margin-bottom: 1em;
+				min-height: 30px;
+				padding: 30px 0;
+				position: relative;
+				text-align: center;
+
+				h4 span {
+					display: block;
+					margin: 5px 0;
+					text-transform: lowercase;
+				}
+
+				.or-text {
+					font-size: 0.8em;
+				}
+
+				.drop-file-text {
+					font-weight: normal;
+				}
+			}
+
+			.manage-upload-target {
+				padding: 5px 0 0;
+				position: relative;
+
+				.select-files {
+					margin: 0 10px 10px;
+				}
+			}
+
+			.browse-button-container {
+				padding-top: 5px;
+			}
+
+			a {
+				&.browse-button {
+					background-image: url(../images/common/add.png);
+					background-repeat: no-repeat;
+					color: white;
+					font-size: 1.2em;
+					font-weight: bold;
+					text-decoration: none;
+				}
+
+				&.clear-uploads {
+					background-image: url(../images/common/remove.png);
+					background-repeat: no-repeat;
+					float: right;
+					padding-left: 16px;
+				}
+
+				&.cancel-uploads {
+					background-image: url(../images/common/close.png);
+					background-repeat: no-repeat;
+					float: right;
+					margin-right: 0;
+				}
+			}
+
+			.upload-file {
+				&.upload-complete.file-saved {
+					padding-left: 25px;
+				}
+
+				.file-title {
+					display: inline-block;
+					max-width: 95%;
+					overflow: hidden;
+					padding-right: 16px;
+					text-overflow: ellipsis;
+					vertical-align: middle;
+					white-space: nowrap;
+				}
+
+				.icon-file {
+					font-size: 40px;
+				}
+			}
+
+			.upload-list-info {
+				margin: 1em 0 0.5em;
+
+				h4 {
+					font-size: 1.3em;
+				}
+			}
+
+			.cancel-button {
+				color: $cadmin-secondary;
+				margin-top: 1px;
+				position: absolute;
+				right: 5px;
+				top: 50%;
+				white-space: nowrap;
+
+				.cancel-button-text {
+					display: none;
+					margin-left: 5px;
+				}
+
+				&:hover .cancel-button-text {
+					display: inline;
+				}
+
+				.lexicon-icon {
+					height: 12px;
+				}
+			}
+
+			.delete-button {
+				color: $cadmin-secondary;
+			}
+
+			.delete-button-col {
+				padding-right: 10px;
+			}
+
+			.file-added .success-message {
+				float: right;
+				font-weight: normal;
+			}
+
+			.upload-error {
+				opacity: 1;
+				padding-left: 25px;
+			}
+
+			.upload-complete .cancel-button,
+			.delete-button,
+			.upload-complete.file-saved .delete-button,
+			.upload-complete.upload-error .delete-button {
+				display: none;
+			}
+
+			.multiple-files .upload-error {
+				background: #fdd url(../images/messages/error.png) no-repeat 5px
+					5px;
+				border-color: $cadmin-danger-d2;
+				color: $cadmin-danger-d2;
+				font-weight: normal;
+				margin-bottom: 16px;
+				padding: 8px 8px 8px 24px;
+
+				.error-message {
+					display: block;
+				}
+			}
+
+			.single-file .upload-error {
+				list-style: none;
+				margin-top: 1em;
+
+				.upload-error-message {
+					margin-bottom: 0.5em;
+				}
+			}
+
+			.upload-complete {
+				padding-left: 5px;
+
+				.error-message,
+				.success-message {
+					font-weight: bold;
+					margin-left: 1em;
+				}
+
+				.delete-button {
+					display: inline-block;
+				}
+
+				.select-file:disabled + .custom-control-label {
+					display: none;
+				}
+			}
+
+			.progress {
+				display: none;
+				margin-top: 0.5rem;
+			}
+
+			.file-uploading {
+				background-color: #ffc;
+
+				.progress {
+					display: flex;
+				}
+			}
+		}
+
+		input[type='file'] {
+			line-height: 0;
+		}
+
+		.select-files {
+			float: left;
+			line-height: 0;
+			margin-right: 2px;
+			padding: 0 0 0 5px;
+		}
 	}
 
 	.portal-popup {
 		background-color: $cadmin-white;
+
+		.portlet-export-import .portlet-body > .cadmin {
+			height: inherit;
+		}
 
 		.cadmin {
 			.sheet {

--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -132,4 +132,192 @@ html#{$cadmin-selector} {
 			color: $user-icon-color-9;
 		}
 	}
+
+	.portal-popup {
+		background-color: $cadmin-white;
+
+		.cadmin {
+			.sheet {
+				> .lfr-nav {
+					margin-top: -24px;
+				}
+			}
+
+			.contacts-portlet .portlet-configuration-container .form {
+				position: static;
+			}
+
+			.lfr-form-content {
+				padding: 24px 12px;
+			}
+
+			.portlet-body,
+			.portlet-boundary,
+			.portlet-column,
+			.portlet-layout {
+				height: 100%;
+			}
+
+			.portlet-column {
+				position: static;
+			}
+
+			.dialog-body,
+			.export-dialog-tree,
+			.lfr-dynamic-uploader,
+			.lfr-form-content,
+			.portlet-configuration-body-content,
+			.process-list,
+			.roles-selector-body {
+				> .container-fluid-max-xl,
+				.container-view {
+					padding-top: 20px;
+
+					.nav-tabs-underline {
+						margin-left: -$cadmin-grid-gutter-width / 2;
+						margin-right: -$cadmin-grid-gutter-width / 2;
+						margin-top: -20px;
+					}
+				}
+
+				> .lfr-nav + .container-fluid-max-xl {
+					padding-top: 0;
+				}
+			}
+
+			.login-container {
+				padding: $cadmin-modal-inner-padding;
+			}
+
+			.management-bar-default {
+				border-left-width: 0;
+				border-radius: 0;
+				border-right-width: 0;
+				border-top-width: 0;
+				margin-bottom: 0;
+			}
+
+			.navbar ~ .portlet-configuration-setup,
+			.portlet-export-import-container {
+				height: calc(100% - 48px);
+				position: relative;
+			}
+
+			.panel-group .panel {
+				border-left-width: 0;
+				border-radius: 0;
+				border-right-width: 0;
+			}
+
+			.panel-group .panel + .panel {
+				border-top-width: 0;
+				margin-top: 0;
+			}
+
+			.panel-heading {
+				border-top-left-radius: 0;
+				border-top-right-radius: 0;
+			}
+
+			.portlet-configuration-setup {
+				.lfr-nav {
+					margin-left: auto;
+					margin-right: auto;
+					max-width: 1280px;
+					padding-left: 3px;
+					padding-right: 3px;
+
+					@include media-breakpoint-up(sm, $cadmin-grid-breakpoints) {
+						padding-left: 8px;
+						padding-right: 8px;
+					}
+				}
+			}
+
+			.lfr-dynamic-uploader,
+			.process-list {
+				bottom: 0;
+				display: block;
+				left: 0;
+				overflow: auto;
+				position: absolute;
+				right: 0;
+				top: 48px;
+				-webkit-overflow-scrolling: touch;
+			}
+
+			.portlet-export-import-publish-processes {
+				top: 0;
+			}
+
+			.dialog-footer {
+				background-color: $cadmin-white;
+				border-top: $cadmin-modal-footer-border-width solid
+					$cadmin-modal-footer-border-color;
+				bottom: 0;
+				box-shadow: $cadmin-modal-footer-box-shadow;
+				display: flex;
+				flex-direction: row-reverse;
+				left: 0;
+				margin: 0;
+				padding: 10px 24px;
+				width: 100%;
+				z-index: $cadmin-zindex-sticky;
+
+				@include media-breakpoint-up(md) {
+					position: fixed;
+				}
+
+				.btn {
+					margin-left: 16px;
+					margin-right: 0;
+				}
+			}
+
+			.dialog-body,
+			.lfr-dynamic-uploader,
+			.lfr-form-content,
+			.portlet-configuration-body-content,
+			.roles-selector-body {
+				@include media-breakpoint-up(md, $cadmin-grid-breakpoints) {
+					&:not(:last-child) {
+						padding-bottom: 60px;
+					}
+				}
+			}
+
+			.lfr-dynamic-uploader {
+				display: table;
+				table-layout: fixed;
+				width: 100%;
+
+				&.hide-dialog-footer {
+					bottom: 0;
+
+					+ .dialog-footer {
+						display: none;
+					}
+				}
+			}
+
+			.portlet-configuration-edit-permissions {
+				.portlet-configuration-body-content {
+					display: flex;
+					flex-direction: column;
+					overflow: visible;
+
+					> form {
+						flex-grow: 1;
+						max-width: none;
+						overflow: auto;
+					}
+				}
+			}
+
+			.portlet-configuration-edit-templates
+				.portlet-configuration-body-content {
+				bottom: 0;
+			}
+		}
+	}
 }

--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -1,6 +1,7 @@
 @import 'cadmin';
 @import 'sidebar';
 
+$table-responsive-margin-left-md: 375px !default;
 $user-icon-color-0: $cadmin-secondary !default;
 $user-icon-color-1: $cadmin-blue !default;
 $user-icon-color-2: $cadmin-orange !default;
@@ -352,6 +353,82 @@ html#{$cadmin-selector} {
 			margin-right: 2px;
 			padding: 0 0 0 5px;
 		}
+
+		.lfr-search-container-wrapper {
+			&.lfr-search-container-fixed-first-column {
+				position: relative;
+
+				.table-responsive {
+					@include media-breakpoint-up(sm, $cadmin-grid-breakpoints) {
+						margin-left: $table-responsive-margin-left-md;
+						width: auto;
+					}
+
+					.table {
+						position: static;
+
+						.lfr-search-iterator-fixed-header {
+							left: 12px;
+							position: fixed;
+							right: 12px;
+							top: -1px;
+							z-index: $cadmin-zindex-sticky;
+
+							> th {
+								display: block;
+								padding: 0;
+
+								.lfr-search-iterator-fixed-header-inner-wrapper {
+									overflow-x: hidden;
+
+									@include media-breakpoint-up(
+										sm,
+										$cadmin-grid-breakpoints
+									) {
+										margin-left: $table-responsive-margin-left-md;
+									}
+
+									table {
+										border-collapse: collapse;
+										width: 100%;
+
+										th {
+											border-radius: 0;
+										}
+									}
+								}
+							}
+						}
+
+						td,
+						th {
+							width: auto;
+
+							&:first-child {
+								@include media-breakpoint-up(
+									sm,
+									$cadmin-grid-breakpoints
+								) {
+									left: 0;
+									position: absolute;
+									right: 15px;
+								}
+							}
+						}
+
+						th {
+							height: auto;
+						}
+					}
+				}
+
+				.lfr-description-column,
+				.lfr-role-column {
+					max-width: $table-responsive-margin-left-md;
+					min-width: $table-responsive-margin-left-md;
+				}
+			}
+		}
 	}
 
 	.portal-popup {
@@ -525,7 +602,7 @@ html#{$cadmin-selector} {
 				}
 			}
 
-			.portlet-configuration-edit-permissions {
+			&.portlet-configuration-edit-permissions {
 				.portlet-configuration-body-content {
 					display: flex;
 					flex-direction: column;
@@ -539,7 +616,7 @@ html#{$cadmin-selector} {
 				}
 			}
 
-			.portlet-configuration-edit-templates
+			&.portlet-configuration-edit-templates
 				.portlet-configuration-body-content {
 				bottom: 0;
 			}

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
@@ -41,6 +41,9 @@ const ColorPicker = ({color, label, name}) => {
 
 			<ClayColorPicker
 				colors={customColors}
+				dropDownContainerProps={{
+					className: 'cadmin',
+				}}
 				label={label}
 				name={`${name}ColorPicker`}
 				onColorsChange={setCustomColors}

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
@@ -24,6 +24,7 @@
 
 		<liferay-frontend:edit-form
 			action="<%= updateLookAndFeelURL %>"
+			cssClass="cadmin"
 			method="post"
 			name="fm"
 		>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
@@ -25,7 +25,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 	<portlet:param name="portletConfiguration" value="<%= Boolean.TRUE.toString() %>" />
 </portlet:actionURL>
 
-<div class="portlet-configuration-add-template">
+<div class="cadmin portlet-configuration-add-template">
 	<aui:form action="<%= updateArchivedSetupURL %>" cssClass="form" id="fm" method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 		<aui:input name="portletResource" type="hidden" value="<%= portletResource %>" />

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration_templates.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration_templates.jsp
@@ -20,7 +20,7 @@
 PortletConfigurationTemplatesDisplayContext portletConfigurationTemplatesDisplayContext = new PortletConfigurationTemplatesDisplayContext(request, renderRequest, renderResponse);
 %>
 
-<div class="portlet-configuration-edit-templates">
+<div class="cadmin portlet-configuration-edit-templates">
 	<portlet:actionURL name="deleteArchivedSetups" var="deleteArchivedSetupsURL">
 		<portlet:param name="mvcPath" value="/edit_configuration_templates.jsp" />
 		<portlet:param name="redirect" value="<%= currentURL %>" />

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -30,7 +30,7 @@ if (Validator.isNotNull(portletConfigurationPermissionsDisplayContext.getModelRe
 }
 %>
 
-<div class="edit-permissions portlet-configuration-edit-permissions">
+<div class="cadmin edit-permissions portlet-configuration-edit-permissions">
 	<div class="portlet-configuration-body-content">
 		<clay:management-toolbar
 			clearResultsURL="<%= portletConfigurationPermissionsDisplayContext.getClearResultsURL() %>"

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -141,6 +141,9 @@
 
 					Liferay.Util.openModal({
 						bodyHTML: html ? html : '<span class="loading-animation">',
+						containerProps: {
+							className: '',
+						},
 						height: '400px',
 						onClose: function () {
 							loading = false;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-132744

Portlet Topper Modal content are rendered inside iframes isolating the outer modal doesn't isolate the content inside. This pr isolates the Look and Feel content and Export / Import content.

Screenshots:
![look-feel](https://user-images.githubusercontent.com/788266/130153354-f641f462-fc0e-46db-a72e-37e1fc1360a0.jpg)

![export-import](https://user-images.githubusercontent.com/788266/130153370-307cf21a-8754-4a89-bea6-88fb74d5b660.jpg)
