### PR TITLE
LPS-137734 Disable right-click context menu in Balloon Editor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/tabletoolbar/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/tabletoolbar/plugin.js
@@ -1132,6 +1132,7 @@
 			addCmd(
 				{
 					commandName: 'rowDelete',
+					name: 'RowDelete',
 				},
 				createDef({
 					exec(editor) {
@@ -1145,6 +1146,7 @@
 			addCmd(
 				{
 					commandName: 'rowInsertBefore',
+					name: 'RowInsertBefore',
 				},
 				createDef({
 					exec(editor) {
@@ -1157,6 +1159,7 @@
 			addCmd(
 				{
 					commandName: 'rowInsertAfter',
+					name: 'RowInsertAfter',
 				},
 				createDef({
 					exec(editor) {
@@ -1210,6 +1213,7 @@
 			addCmd(
 				{
 					commandName: 'columnDelete',
+					name: 'ColumnDelete',
 				},
 				createDef({
 					exec(editor) {
@@ -1226,6 +1230,7 @@
 			addCmd(
 				{
 					commandName: 'columnInsertBefore',
+					name: 'ColumnInsertBefore',
 				},
 				createDef({
 					exec(editor) {
@@ -1238,6 +1243,7 @@
 			addCmd(
 				{
 					commandName: 'columnInsertAfter',
+					name: 'ColumnInsertAfter',
 				},
 				createDef({
 					exec(editor) {
@@ -1311,6 +1317,7 @@
 			addCmd(
 				{
 					commandName: 'cellDelete',
+					name: 'CellDelete',
 				},
 				createDef({
 					exec(editor) {
@@ -1324,6 +1331,7 @@
 			addCmd(
 				{
 					commandName: 'cellMerge',
+					name: 'CellMerge',
 				},
 				createDef({
 					allowedContent: 'td[colspan,rowspan]',
@@ -1340,6 +1348,7 @@
 			addCmd(
 				{
 					commandName: 'cellMergeRight',
+					name: 'CellMergeRight',
 				},
 				createDef({
 					allowedContent: 'td[colspan]',
@@ -1356,6 +1365,7 @@
 			addCmd(
 				{
 					commandName: 'cellMergeDown',
+					name: 'CellMergeDown',
 				},
 				createDef({
 					allowedContent: 'td[rowspan]',
@@ -1372,6 +1382,7 @@
 			addCmd(
 				{
 					commandName: 'cellVerticalSplit',
+					name: 'CellVerticalSplit',
 				},
 				createDef({
 					allowedContent: 'td[rowspan]',
@@ -1387,6 +1398,7 @@
 			addCmd(
 				{
 					commandName: 'cellHorizontalSplit',
+					name: 'CellHorizontalSplit',
 				},
 				createDef({
 					allowedContent: 'td[colspan]',
@@ -1402,6 +1414,7 @@
 			addCmd(
 				{
 					commandName: 'cellInsertBefore',
+					name: 'CellInsertBefore',
 				},
 				createDef({
 					exec(editor) {
@@ -1415,6 +1428,7 @@
 			addCmd(
 				{
 					commandName: 'cellInsertAfter',
+					name: 'CellInsertAfter',
 				},
 				createDef({
 					exec(editor) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/config/DefaultBalloonEditorConfiguration.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/config/DefaultBalloonEditorConfiguration.js
@@ -17,6 +17,7 @@ const sub = Liferay.Util.sub;
 const DEFAULT_BALLOON_EDITOR_CONFIG = {
 	extraAllowedContent: '*',
 	extraPlugins: 'itemselector,stylescombo,ballooneditor,videoembed',
+	removePlugins: 'contextmenu,liststyle,tabletools',
 	stylesSet: [
 		{
 			element: 'p',


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-137734

Context menu is quite buggy on BE (see gif):
- on link, menu closes immediately after opened
- on image, cut / copy doesn't work, and properties do not load correctly
- on text, the paste option is a bit useless

Alloy Editor does not have this feature, so it is fine to disable it. If we ever want to enable it, we would need to fix all the bugs with it.

Disabling `tabletoolbar` uncovered a problem in out `tabletoolbar` plugin, where we don't set many command names. This used to work because we used commands from `tabletoolbar`. We are fixing this problem in https://github.com/liferay-frontend/liferay-portal/commit/ba2e6c90545f25cd728edb80e8182299d084bb7b. See in 'after' gif below that table toolbar is working correctly.

Before PR:
![before](https://user-images.githubusercontent.com/5435511/130252392-3fe92759-9754-46db-882a-c290a8d204b2.gif)

After PR:
![after](https://user-images.githubusercontent.com/5435511/130252412-a94b3853-442f-4d61-b66a-8046b28af7b2.gif)