### PR TITLE
LPS-137766 add empty build.gradle that is needed for compilation

### DIFF
--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/build.gradle
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/build.gradle
@@ -1,0 +1,2 @@
+dependencies {
+}


### PR DESCRIPTION
Several headless builds are failing because this package that has been moved recently has lost his build.gradle. I'm with a poor connection to be able to check root cause but at least ninja fixing it for now.