### PR TITLE
LPS-137639 Fix redirection when delete a question in top of the topics.

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/DeleteQuestion.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/DeleteQuestion.es.js
@@ -44,9 +44,13 @@ export default withRouter(
 								deleteCache();
 								historyPushParser(
 									`/questions/${
-										context.useTopicNamesInURL
-											? question.messageBoardSection.title
-											: question.messageBoardSection.id
+										question.messageBoardSection
+											? context.useTopicNamesInURL
+												? question.messageBoardSection
+														.title
+												: question.messageBoardSection
+														.id
+											: context.rootTopicId
 									}`
 								);
 							});


### PR DESCRIPTION
Checking that when deleting a question we are providing a section. If there is no section it means that it was created outside of any topic, so we have to redirect to the root.