### PR TITLE
LPS-130190 Implement the Select Custom State operation in DataSet Display

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/AppContext.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/AppContext.js
@@ -14,8 +14,10 @@
 
 import React from 'react';
 
-export const AppContext = React.createContext({
+const AppContext = React.createContext({
 	apiURL: null,
 	appURL: null,
 	portletId: null,
 });
+
+export default AppContext;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -105,7 +105,7 @@ function DataSetDisplay({
 	);
 	const [sorting, updateSorting] = useState(sortingProp);
 	const [total, setTotal] = useState(0);
-	const [{activeView}, dispatch] = useContext(ViewsContext);
+	const [{activeView}, viewsDispatch] = useContext(ViewsContext);
 
 	const {
 		component: CurrentViewComponent,
@@ -266,12 +266,12 @@ function DataSetDisplay({
 		requestComponent().then((component) => {
 			if (isMounted()) {
 				setComponentLoading(false);
-				dispatch(updateViewComponent(activeViewName, component));
+				viewsDispatch(updateViewComponent(activeViewName, component));
 			}
 		});
 	}, [
 		activeViewName,
-		dispatch,
+		viewsDispatch,
 		isMounted,
 		requestComponent,
 		setComponentLoading,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -80,6 +80,7 @@ function DataSetDisplay({
 	style,
 }) {
 	const {apiURL} = useContext(AppContext);
+	const [{activeView}, viewsDispatch] = useContext(ViewsContext);
 
 	const wrapperRef = useRef(null);
 	const [componentLoading, setComponentLoading] = useState(false);
@@ -105,7 +106,6 @@ function DataSetDisplay({
 	);
 	const [sorting, updateSorting] = useState(sortingProp);
 	const [total, setTotal] = useState(0);
-	const [{activeView}, viewsDispatch] = useContext(ViewsContext);
 
 	const {
 		component: CurrentViewComponent,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -28,9 +28,11 @@ import AppContext from './AppContext';
 import DataSetDisplayContext from './DataSetDisplayContext';
 import EmptyResultMessage from './EmptyResultMessage';
 import {updateViewComponent} from './actions/updateViewComponent';
+import StatesContext from './contexts/StatesContext';
 import ManagementBar from './management_bar/ManagementBar';
 import Modal from './modal/Modal';
 import SidePanel from './side_panel/SidePanel';
+import selectActiveDelta from './thunks/selectActiveDelta';
 import {
 	DATASET_ACTION_PERFORMED,
 	DATASET_DISPLAY_UPDATED,
@@ -81,8 +83,15 @@ function DataSetDisplay({
 }) {
 	const {apiURL} = useContext(AppContext);
 	const [{activeView}, viewsDispatch] = useContext(ViewsContext);
+	const [
+		{
+			activeState: {delta},
+		},
+		statesDispatch,
+	] = useContext(StatesContext);
 
 	const wrapperRef = useRef(null);
+
 	const [componentLoading, setComponentLoading] = useState(false);
 	const [dataLoading, setDataLoading] = useState(!!apiURL);
 	const [dataSetDisplaySupportModalId] = useState(
@@ -90,10 +99,6 @@ function DataSetDisplay({
 	);
 	const [dataSetDisplaySupportSidePanelId] = useState(
 		sidePanelId || `support-side-panel-${getRandomId()}`
-	);
-	const [delta, setDelta] = useState(
-		showPagination &&
-			(pagination.initialDelta || pagination.deltas[0].label)
 	);
 	const [filters, updateFilters] = useState(filtersProp);
 	const [highlightedItemsValue, setHighlightedItemsValue] = useState([]);
@@ -384,7 +389,12 @@ function DataSetDisplay({
 					ellipsisBuffer={3}
 					onDeltaChange={(deltaVal) => {
 						setPageNumber(1);
-						setDelta(deltaVal);
+
+						statesDispatch(
+							selectActiveDelta({
+								delta: deltaVal,
+							})
+						);
 					}}
 					onPageChange={setPageNumber}
 					totalItems={total}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -24,7 +24,7 @@ import React, {
 	useState,
 } from 'react';
 
-import {AppContext} from './AppContext';
+import AppContext from './AppContext';
 import DataSetDisplayContext from './DataSetDisplayContext';
 import EmptyResultMessage from './EmptyResultMessage';
 import {updateViewComponent} from './actions/updateViewComponent';

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/actions/updateActiveDelta.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/actions/updateActiveDelta.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export const ACTION_UPDATE_ACTIVE_DELTA = 'ACTION_UPDATE_ACTIVE_DELTA';
+
+export const updateActiveDelta = (delta) => {
+	return {
+		type: ACTION_UPDATE_ACTIVE_DELTA,
+		value: delta,
+	};
+};

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/actions/updateActiveState.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/actions/updateActiveState.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export const ACTION_UPDATE_ACTIVE_STATE = 'ACTION_UPDATE_ACTIVE_STATE';
+
+export const updateActiveState = (activeStateId) => {
+	return {
+		type: ACTION_UPDATE_ACTIVE_STATE,
+		value: activeStateId,
+	};
+};

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/contexts/StatesContext.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/contexts/StatesContext.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React from 'react';
+
+import {ACTION_UPDATE_ACTIVE_STATE} from '../actions/updateActiveState';
+
+const dispatch = () => {};
+
+export const statesReducer = (state, {type, value}) => {
+	const {states} = state;
+
+	if (type === ACTION_UPDATE_ACTIVE_STATE) {
+		return {
+			...state,
+			activeState: states.find(({id}) => id === value),
+		};
+	}
+
+	return state;
+};
+
+const StatesContext = React.createContext([
+	{
+		activeState: null,
+		states: null,
+	},
+	dispatch,
+]);
+
+export default StatesContext;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/contexts/StatesContext.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/contexts/StatesContext.js
@@ -14,17 +14,27 @@
 
 import React from 'react';
 
+import {ACTION_UPDATE_ACTIVE_DELTA} from '../actions/updateActiveDelta';
 import {ACTION_UPDATE_ACTIVE_STATE} from '../actions/updateActiveState';
 
 const dispatch = () => {};
 
 export const statesReducer = (state, {type, value}) => {
-	const {states} = state;
+	const {activeState, states} = state;
 
 	if (type === ACTION_UPDATE_ACTIVE_STATE) {
 		return {
 			...state,
 			activeState: states.find(({id}) => id === value),
+		};
+	}
+	else if (type === ACTION_UPDATE_ACTIVE_DELTA) {
+		return {
+			...state,
+			activeState: {
+				...activeState,
+				delta: value,
+			},
 		};
 	}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/entry.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/entry.js
@@ -16,7 +16,7 @@ import {render, useThunk} from '@liferay/frontend-js-react-web';
 import PropTypes from 'prop-types';
 import React, {useReducer} from 'react';
 
-import {AppContext} from './AppContext';
+import AppContext from './AppContext';
 import DataSetDisplay from './DataSetDisplay';
 import ViewsContext, {viewsReducer} from './views/ViewsContext';
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/entry.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/entry.js
@@ -34,6 +34,7 @@ const App = ({
 	// MOCK
 	states = [
 		{
+			delta: 10,
 			displayType: {
 				name: 'table',
 				settings: {
@@ -47,6 +48,7 @@ const App = ({
 			label: 'Default 1',
 		},
 		{
+			delta: 20,
 			displayType: {
 				name: 'table',
 				settings: {
@@ -60,6 +62,7 @@ const App = ({
 			label: 'Default 2',
 		},
 		{
+			delta: 4,
 			displayType: {
 				name: 'table',
 				settings: {
@@ -112,12 +115,12 @@ const App = ({
 
 App.proptypes = {
 	activeViewSettings: PropTypes.shape({
+		delta: PropTypes.number,
 		displayType: PropTypes.shape({
 			name: PropTypes.string, // id of the display view, must match with a view id
 			settings: PropTypes.object,
 		}),
 		filters: PropTypes.array,
-		itemsPerPage: PropTypes.number,
 		label: PropTypes.string,
 		name: PropTypes.string,
 		visibleFieldNames: PropTypes.array,
@@ -127,12 +130,12 @@ App.proptypes = {
 	portletId: PropTypes.string,
 	states: PropTypes.arrayOf(
 		PropTypes.shape({
+			delta: PropTypes.number,
 			displayType: PropTypes.shape({
 				name: PropTypes.string, // id of the display view, must match with a view id
 				settings: PropTypes.object,
 			}),
 			filters: PropTypes.array,
-			itemsPerPage: PropTypes.number,
 			label: PropTypes.string,
 			name: PropTypes.string,
 		})

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/entry.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/entry.js
@@ -18,46 +18,125 @@ import React, {useReducer} from 'react';
 
 import AppContext from './AppContext';
 import DataSetDisplay from './DataSetDisplay';
+import StatesContext, {statesReducer} from './contexts/StatesContext';
 import ViewsContext, {viewsReducer} from './views/ViewsContext';
 
 const App = ({
-	activeViewSettings,
+	activeViewSettings: activeState,
 	apiURL,
 	appURL,
 	portletId,
+	states,
 	views,
 	...props
 }) => {
-	const activeViewName = activeViewSettings?.name;
+
+	// MOCK
+	states = [
+		{
+			displayType: {
+				name: 'table',
+				settings: {
+					visibleFieldNames: {
+						name: true,
+						url: true,
+					},
+				},
+			},
+			id: 'default-1',
+			label: 'Default 1',
+		},
+		{
+			displayType: {
+				name: 'table',
+				settings: {
+					visibleFieldNames: {
+						name: true,
+						url: false,
+					},
+				},
+			},
+			id: 'default-2',
+			label: 'Default 2',
+		},
+		{
+			displayType: {
+				name: 'table',
+				settings: {
+					visibleFieldNames: {
+						name: false,
+						url: true,
+					},
+				},
+			},
+			id: 'default-3',
+			label: 'Default 3',
+		},
+	];
+
+	activeState = {...states[0]};
+	// END MOCK
+
+	const activeViewName = activeState?.displayType?.name;
 
 	const activeView = activeViewName
 		? views.find(({name}) => name === activeViewName)
 		: views[0];
-	const [state, dispatch] = useThunk(
+
+	const [viewsState, viewsDispatch] = useThunk(
 		useReducer(viewsReducer, {
 			activeView,
 			views,
-			visibleFieldNames: activeViewSettings?.visibleFieldNames || {},
+			visibleFieldNames:
+				activeState?.displayType?.settings?.visibleFieldNames || {},
+		})
+	);
+
+	const [statesState, statesDispatch] = useThunk(
+		useReducer(statesReducer, {
+			activeState,
+			states,
 		})
 	);
 
 	return (
 		<AppContext.Provider value={{apiURL, appURL, portletId}}>
-			<ViewsContext.Provider value={[state, dispatch]}>
-				<DataSetDisplay {...props} />
-			</ViewsContext.Provider>
+			<StatesContext.Provider value={[statesState, statesDispatch]}>
+				<ViewsContext.Provider value={[viewsState, viewsDispatch]}>
+					<DataSetDisplay {...props} />
+				</ViewsContext.Provider>
+			</StatesContext.Provider>
 		</AppContext.Provider>
 	);
 };
 
 App.proptypes = {
 	activeViewSettings: PropTypes.shape({
+		displayType: PropTypes.shape({
+			name: PropTypes.string, // id of the display view, must match with a view id
+			settings: PropTypes.object,
+		}),
+		filters: PropTypes.array,
+		itemsPerPage: PropTypes.number,
+		label: PropTypes.string,
 		name: PropTypes.string,
 		visibleFieldNames: PropTypes.array,
 	}),
 	apiURL: PropTypes.string,
 	appURL: PropTypes.string,
 	portletId: PropTypes.string,
+	states: PropTypes.arrayOf(
+		PropTypes.shape({
+			displayType: PropTypes.shape({
+				name: PropTypes.string, // id of the display view, must match with a view id
+				settings: PropTypes.object,
+			}),
+			filters: PropTypes.array,
+			itemsPerPage: PropTypes.number,
+			label: PropTypes.string,
+			name: PropTypes.string,
+		})
+	),
 	views: PropTypes.arrayOf(
 		PropTypes.shape({
 			component: PropTypes.any,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/ActiveStateSelector.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/ActiveStateSelector.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton from '@clayui/button';
+import ClayDropDown from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
+import React, {useContext, useState} from 'react';
+
+import StatesContext from '../../contexts/StatesContext';
+import selectActiveState from '../../thunks/selectActiveState';
+
+function ActiveStateSelector() {
+	const [{activeState, states}, dispatch] = useContext(StatesContext);
+
+	const [active, setActive] = useState(false);
+
+	return (
+		<ClayDropDown
+			active={active}
+			onActiveChange={setActive}
+			trigger={
+				<ClayButton className="nav-link" displayType="unstyled">
+					{activeState.label}
+
+					<span className="inline-item inline-item-after">
+						<ClayIcon symbol="caret-double-l" />
+					</span>
+				</ClayButton>
+			}
+		>
+			<ClayDropDown.ItemList>
+				{states.map(({id, label}) => (
+					<ClayDropDown.Item
+						key={id}
+						onClick={(event) => {
+							event.preventDefault();
+							setActive(false);
+							dispatch(
+								selectActiveState({
+									activeStateId: id,
+								})
+							);
+						}}
+					>
+						{label}
+					</ClayDropDown.Item>
+				))}
+			</ClayDropDown.ItemList>
+		</ClayDropDown>
+	);
+}
+
+export default ActiveStateSelector;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/ActiveViewSelector.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/ActiveViewSelector.js
@@ -17,16 +17,17 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import React, {useContext, useState} from 'react';
 
-import {AppContext} from '../../AppContext';
+import AppContext from '../../AppContext';
 import DataSetDisplayContext from '../../DataSetDisplayContext';
 import persistActiveView from '../../thunks/persistActiveView';
 import ViewsContext from '../../views/ViewsContext';
 
 function ActiveViewSelector({views}) {
 	const {appURL, portletId} = useContext(AppContext);
-	const [active, setActive] = useState(false);
-	const [{activeView}, dispatch] = useContext(ViewsContext);
 	const {id} = useContext(DataSetDisplayContext);
+	const [{activeView}, dispatch] = useContext(ViewsContext);
+
+	const [active, setActive] = useState(false);
 
 	return (
 		<ClayDropDown

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/NavBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/NavBar.js
@@ -18,7 +18,9 @@ import ClayManagementToolbar from '@clayui/management-toolbar';
 import PropTypes from 'prop-types';
 import React, {useContext, useState} from 'react';
 
+import StatesContext from '../../contexts/StatesContext';
 import ViewsContext from '../../views/ViewsContext';
+import ActiveStateSelector from './ActiveStateSelector';
 import ActiveViewSelector from './ActiveViewSelector';
 import CreationMenu from './CreationMenu';
 import FiltersDropdown from './FiltersDropdown';
@@ -27,6 +29,7 @@ import FiltersContext from './filters/FiltersContext';
 
 function NavBar({creationMenu, showSearch}) {
 	const filtersState = useContext(FiltersContext);
+	const [{states}] = useContext(StatesContext);
 	const [{views}] = useContext(ViewsContext);
 	const [showMobile, setShowMobile] = useState(false);
 
@@ -71,6 +74,13 @@ function NavBar({creationMenu, showSearch}) {
 						<ActiveViewSelector views={views} />
 					</ClayManagementToolbar.Item>
 				)}
+
+				{states?.length && (
+					<ClayManagementToolbar.Item>
+						<ActiveStateSelector />
+					</ClayManagementToolbar.Item>
+				)}
+
 				{creationMenu && (
 					<ClayManagementToolbar.Item>
 						<CreationMenu {...creationMenu} />

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/thunks/selectActiveDelta.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/thunks/selectActiveDelta.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {updateActiveDelta} from '../actions/updateActiveDelta';
+
+export default function selectActiveDelta({delta}) {
+	return (dispatch) => {
+		dispatch(updateActiveDelta(delta));
+	};
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/thunks/selectActiveState.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/thunks/selectActiveState.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {updateActiveState} from '../actions/updateActiveState';
+
+export default function selectActiveState({activeStateId}) {
+	return (dispatch) => {
+		dispatch(updateActiveState(activeStateId));
+	};
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/FieldsSelectorDropdown.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/FieldsSelectorDropdown.js
@@ -18,7 +18,7 @@ import ClayIcon from '@clayui/icon';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useState} from 'react';
 
-import {AppContext} from '../../AppContext';
+import AppContext from '../../AppContext';
 import DataSetDisplayContext from '../../DataSetDisplayContext';
 import persistVisibleFieldNames from '../../thunks/persistVisibleFieldNames';
 import ViewsContext from '../ViewsContext';


### PR DESCRIPTION
First steps to implement custom states.

Here we're creating the selector dropdown and re-rendering the dataset with the selected state options.

Working:
- Pagination update on custom state selection
- Pagination option update on the selected state when pagination changes. (TODO: persist this in the server)

Probably working:
- View update on custom state selection

We need a complete use sample of the dataset display with filters, views and pagination to be able to check everything is working right (and to accomodate the views json to the received one) cc @nhpatt (https://issues.liferay.com/browse/LPS-135322)

The received states are mocked in the js component until we receive it from the Tag