### PR TITLE
LPS-137633 Handle error when creating a tag with invalid characters

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/NewQuestion.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/NewQuestion.es.js
@@ -127,6 +127,9 @@ export default withRouter(
 			setError(error);
 		};
 
+		const processResponse = (error) =>
+			error ? processError(error.graphQLErrors[0]) : debounceCallback();
+
 		const createQuestion = () => {
 			deleteCache();
 			if (
@@ -142,7 +145,7 @@ export default withRouter(
 						siteKey: context.siteKey,
 					},
 				})
-					.then(debounceCallback)
+					.then(({error}) => processResponse(error))
 					.catch(processError);
 			}
 			else {
@@ -155,7 +158,7 @@ export default withRouter(
 						messageBoardSectionId: sectionId,
 					},
 				})
-					.then(debounceCallback)
+					.then(({error}) => processResponse(error))
 					.catch(processError);
 			}
 		};


### PR DESCRIPTION
Handling this error we provide feedback (and avoid redirection) to the user who is adding a tag with invalid characters