### PR TITLE
LPS-138028 - Updating Alloy 3.1.x to 3.1.0-deprecated.83

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
@@ -7,7 +7,7 @@ configurations {
 
 task buildAlloyUI(type: Copy)
 
-String alloyUIVersion = "3.1.0-deprecated.82"
+String alloyUIVersion = "3.1.0-deprecated.83"
 
 File jsDestinationDir = file("tmp/META-INF/resources")
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
@@ -15,7 +15,7 @@ task buildLexiconIcons(type: Copy)
 task buildTheme
 task publishNodeModule(type: PublishNodeModuleTask)
 
-String alloyUIVersion = "3.1.0-deprecated.82"
+String alloyUIVersion = "3.1.0-deprecated.83"
 
 String fontAwesomeVersion = "3.2.1"
 


### PR DESCRIPTION
New version that releases these 2 Alloy UI fixes:

* [AUI-3202](https://issues.liferay.com/browse/AUI-3202) Improving accessibility in calendar widget
* [AUI-3201](https://issues.liferay.com/browse/AUI-3201) Tree is built without children nodes when there is not expanded children node (aui-tree-view)

