### PR TITLE
Commerce 5664 - manage file formats and enable mvp automapping

### DIFF
--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/dev/entry.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/dev/entry.js
@@ -13,12 +13,10 @@ import {render} from '@liferay/frontend-js-react-web';
 
 import Diagram from '../src/main/resources/META-INF/resources/js/Diagram';
 
-import '../src/main/resources/META-INF/resources/css/diagram.scss';
-
 render(
 	Diagram,
 	{
-		imageURL: './assets/lfr_diagram_engine.png',
+		imageURL: './assets/308056.svg',
 		isAdmin: true,
 		namespace: 'portlet_shop_by_diagram_namespace_',
 		spritemap: './assets/clay/icons.svg',

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/css/diagram.scss
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/css/diagram.scss
@@ -1,5 +1,13 @@
 @import 'atlas-variables';
 
+.admin-tooltip {
+	background-color: #fff;
+	height: 300px;
+	position: absolute;
+	width: 400px;
+	z-index: 1; //$zindex-tooltip;
+}
+
 .diagram {
 	.diagram-header {
 		height: 58px;
@@ -115,12 +123,4 @@
 			transform: rotate(180deg);
 		}
 	}
-}
-
-.admin-tooltip {
-	background-color: #fff;
-	height: 300px;
-	position: absolute;
-	width: 400px;
-	z-index: $zindex-tooltip;
 }

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/css/diagram.scss
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/css/diagram.scss
@@ -5,7 +5,7 @@
 	height: 300px;
 	position: absolute;
 	width: 400px;
-	z-index: 1; //$zindex-tooltip;
+	z-index: $zindex-tooltip;
 }
 
 .diagram {

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/diagram_type/diagram.jspf
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/diagram_type/diagram.jspf
@@ -37,7 +37,7 @@
 		).put(
 			"isAdmin", true
 		).put(
-			"pinsEndpoint", "/o/headless-commerce-admin-catalog/v1.0/products/"
+			"pinsEndpoint", "/o/headless-commerce-admin-catalog/v1.0/"
 		).put(
 			"productId", cpDefinition.getCProductId()
 		).put(

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/AdminTooltip.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/AdminTooltip.js
@@ -37,12 +37,14 @@ const AdminTooltip = ({
 	const [quantity, setQuantity] = useState(showTooltip.details.quantity);
 
 	useEffect(() => {
-		searchSkus(sku, linkedValue);
+		if (!sku) {
+			searchSkus(sku, linkedValue);
+		}
 	}, [sku, searchSkus, linkedValue]);
 
 	return (
 		<ClayCard
-			className="admin-tooltip"
+			className="admin-tooltip p-1"
 			style={{
 				left: showTooltip.details.cx,
 				top: showTooltip.details.cy,
@@ -98,7 +100,11 @@ const AdminTooltip = ({
 						<ClayAutocomplete.DropDown active={skus}>
 							<ClayDropDown.ItemList
 								onClick={(event) => {
-									setSku(event.target.innerText);
+									setSku(
+										event.target.innerText.match(
+											/^[\S]*/g
+										)[0]
+									);
 								}}
 							>
 								{skus?.length && (
@@ -113,7 +119,7 @@ const AdminTooltip = ({
 										<ClayAutocomplete.Item
 											key={item.id}
 											match={sku}
-											value={item.sku}
+											value={`${item.sku} - ${item.productName.en_US}`}
 										/>
 									))}
 							</ClayDropDown.ItemList>
@@ -145,9 +151,9 @@ const AdminTooltip = ({
 						onClick={() => {
 							deletePin({
 								id: showTooltip.details.id,
-								number: pinPositionLabel,
 								positionX: showTooltip.details.cx,
 								positionY: showTooltip.details.cy,
+								sequence: pinPositionLabel,
 							});
 							setRemovePinHandler({
 								handler: true,
@@ -199,9 +205,9 @@ const AdminTooltip = ({
 						onClick={() => {
 							updatePin({
 								id: showTooltip.details.id,
-								number: parseInt(pinPositionLabel, 10),
 								positionX: showTooltip.details.cx,
 								positionY: showTooltip.details.cy,
+								sequence: parseInt(pinPositionLabel, 10),
 							});
 							setShowTooltip({
 								details: {

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/Diagram.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/Diagram.js
@@ -40,7 +40,6 @@ const Diagram = ({
 	pinsEndpoint,
 	productId,
 	spritemap,
-	type,
 	zoomController,
 }) => {
 	const [pinImport, setPinImport] = useState([]);
@@ -78,26 +77,29 @@ const Diagram = ({
 		radius: newPinSettings.defaultRadius,
 	});
 
-	const importPinSchema = () => {
+	const importPinSchema = (svg) => {
 		const textDatas = [];
 		const pinDatas = [];
 		const parser = new DOMParser();
-		const xmlImage = parser.parseFromString(svgString, 'image/svg+xml');
+
+		const xmlImage = parser.parseFromString(svg, 'image/svg+xml');
+
 		const rootLevel = xmlImage.getElementById('Livello_Testi');
+
 		if (rootLevel) {
 			const rects = rootLevel.getElementsByTagName('rect');
-			const text = rootLevel.getElementsByTagName('text');
+			const texts = rootLevel.getElementsByTagName('text');
 
-			Array.from(text).map((t) => {
+			Array.from(texts).map((text) => {
 				textDatas.push({
-					label: t.textContent,
+					label: text.textContent,
 				});
 			});
 
-			Array.from(rects).map((r, i) => {
+			Array.from(rects).map((rect, i) => {
 				pinDatas.push({
-					cx: r.attributes.x.value / 2.78,
-					cy: r.attributes.y.value / 2.78,
+					cx: rect.attributes.x.value / 2.78,
+					cy: rect.attributes.y.value / 2.78,
 					id: i,
 					label: textDatas[i].label,
 				});
@@ -106,6 +108,10 @@ const Diagram = ({
 			setPinImport(pinDatas);
 		}
 	};
+
+	useCallback(() => {
+		importPinSchema(svgString);
+	}, [svgString]);
 
 	useEffect(() => {
 		setCpins(pinImport);
@@ -222,14 +228,12 @@ const Diagram = ({
 			<ClayIconSpriteContext.Provider value={spritemap}>
 				<DiagramHeader
 					addNewPinState={addNewPinState}
-					importPinSchema={importPinSchema}
 					isAdmin={isAdmin}
 					namespace={namespace}
 					newPinSettings={newPinSettings}
 					setAddNewPinState={setAddNewPinState}
 					setAddPinHandler={setAddPinHandler}
 					setSelectedOption={setSelectedOption}
-					type={type}
 				/>
 
 				<ImagePins
@@ -300,7 +304,6 @@ const Diagram = ({
 					setZoomOutHandler={setZoomOutHandler}
 				/>
 			</ClayIconSpriteContext.Provider>
-			<div id="culo"></div>
 		</div>
 	) : (
 		<div className="border-0 pt-0 sheet taglib-empty-result-message">
@@ -355,7 +358,6 @@ Diagram.defaultProps = {
 	pins: [],
 	pinsEndpoint:
 		'http://localhost:8080/o/headless-commerce-admin-catalog/v1.0/',
-	productId: 44206,
 	showTooltip: {
 		details: {
 			cx: null,
@@ -442,7 +444,6 @@ Diagram.propTypes = {
 		tooltip: PropTypes.bool,
 	}),
 	spritemap: PropTypes.string,
-	type: PropTypes.oneOf(['diagram.type.svg', 'diagram.type.default']),
 	updatePin: PropTypes.func,
 	zoomController: PropTypes.shape({
 		enable: PropTypes.bool,

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/DiagramHeader.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/DiagramHeader.js
@@ -19,11 +19,13 @@ import React, {useState} from 'react';
 
 const DiagramHeader = ({
 	addNewPinState,
+	importPinSchema,
 	isAdmin,
 	namespace,
 	newPinSettings,
 	setAddNewPinState,
 	setAddPinHandler,
+	type,
 }) => {
 	const RADIUS_CHOICE = [
 		{
@@ -147,6 +149,15 @@ const DiagramHeader = ({
 							</ClayForm>
 						</ClayDropDown.Caption>
 					</ClayDropDown>
+					<ClayButton
+						aria-label={Liferay.Language.get('auto-mapping')}
+						className="ml-3 select-diameter"
+						disabled={type === 'diagram.type.svg' ? false : true}
+						displayType="secondary"
+						onClick={() => importPinSchema()}
+					>
+						{Liferay.Language.get('auto-mapping')}
+					</ClayButton>
 				</div>
 			)}
 		</div>

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/DiagramHeader.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/DiagramHeader.js
@@ -19,13 +19,11 @@ import React, {useState} from 'react';
 
 const DiagramHeader = ({
 	addNewPinState,
-	importPinSchema,
 	isAdmin,
 	namespace,
 	newPinSettings,
 	setAddNewPinState,
 	setAddPinHandler,
-	type,
 }) => {
 	const RADIUS_CHOICE = [
 		{
@@ -149,15 +147,6 @@ const DiagramHeader = ({
 							</ClayForm>
 						</ClayDropDown.Caption>
 					</ClayDropDown>
-					<ClayButton
-						aria-label={Liferay.Language.get('auto-mapping')}
-						className="ml-3 select-diameter"
-						disabled={type === 'diagram.type.svg' ? false : true}
-						displayType="secondary"
-						onClick={() => importPinSchema()}
-					>
-						{Liferay.Language.get('auto-mapping')}
-					</ClayButton>
 				</div>
 			)}
 		</div>

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/ImagePins.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/ImagePins.js
@@ -293,6 +293,7 @@ const ImagePins = ({
 				.attr('id', (attr) => attr.id)
 				.attr('label', (attr) => attr.label)
 				.attr('fill', () => `#${addNewPinState.fill}`)
+				.attr('font-size', 4)
 				.attr('linked_to_sku', (attr) => attr.linked_to_sku)
 				.attr('quantity', (attr) => attr.quantity)
 				.attr('r', () => addNewPinState.radius)
@@ -303,10 +304,10 @@ const ImagePins = ({
 				.call(dragHandler);
 
 			cont.append('circle')
-				.attr('fill', () => '#ffffff')
+				.attr('fill', () => 'transparent')
 				.attr('r', () => addNewPinState.radius)
 				.attr('stroke', () => `#${addNewPinState.fill}`)
-				.attr('stroke-width', 2);
+				.attr('stroke-width', 0.5);
 
 			cont.append('text')
 				.text((attr) => attr.label)
@@ -450,7 +451,7 @@ ImagePins.propTypes = {
 			cy: PropTypes.double,
 			id: PropTypes.number,
 			label: PropTypes.string,
-			linked_to_sku: PropTypes.oneOf(['sku', 'diagram']),
+			linked_to_sku: PropTypes.oneOf(['sku', 'diagram', '']),
 			quantity: PropTypes.number,
 			sku: PropTypes.string,
 		}),

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/webpack.config.dev.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram/commerce-shop-by-diagram-web/webpack.config.dev.js
@@ -61,7 +61,7 @@ module.exports = {
 										done({
 											file: path.resolve(
 												__dirname,
-												'../../../node_modules/@clayui/css/src/scss/atlas-variables.scss'
+												'./../../../../../node_modules/@clayui/css/src/scss/atlas-variables.scss'
 											),
 										});
 									}


### PR DESCRIPTION
As a developer, I want to extend Liferay Commerce to display custom file formats as diagrams in the storefront:
 

Assumption:

To allow a developer to upload different file types a new extension point is needed

Technical assumption:

File type reference is the customer .SVG with all the information already included. This will be read from the SBD component and all information converted into objects (Pins)
This file read will be completed by developing a reg-ex
 

Acceptance criteria:

It is possible to upload all standard img formats + svg
Uploading an svg file, all information contained in that file are added to the SBD as objects (Pins)
On the front store all uploaded objects are visible