### PR TITLE
LPS-138139 Add missing key

### DIFF
--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps
 new-remote-app=New Remote App
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ar.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=تطبيقات عن بعد
 new-remote-app=تطبيق عن بعد جديد
 please-enter-a-unique-remote-app-url=الرجاء إدخال عنوان URL فريد للتطبيق عن بعد.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_bg.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Отдалечени приложения (Automatic Translation)
 new-remote-app=Ново дистанционно приложение (Automatic Translation)
 please-enter-a-unique-remote-app-url=Моля, въведете уникален URL адрес на отдалечено приложение. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ca.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Aplicacions remotes
 new-remote-app=Nova aplicació remota
 please-enter-a-unique-remote-app-url=Introduïu un URL únic de l'aplicació remota.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_cs.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Vzdálené aplikace (Automatic Translation)
 new-remote-app=Nová vzdálená aplikace (Automatic Translation)
 please-enter-a-unique-remote-app-url=Zadejte jedinečnou adresu URL vzdálené aplikace. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_da.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Fjernapps (Automatic Translation)
 new-remote-app=Ny fjernapp (Automatic Translation)
 please-enter-a-unique-remote-app-url=Angiv en entydig URL-adresse til en fjernapp. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_de.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote-Apps
 new-remote-app=Neue Remote-App
 please-enter-a-unique-remote-app-url=Bitte geben Sie eine eindeutige Remote-App-URL an.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_el.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Απομακρυσμένες εφαρμογές (Automatic Translation)
 new-remote-app=Νέα απομακρυσμένη εφαρμογή (Automatic Translation)
 please-enter-a-unique-remote-app-url=Πληκτρολογήστε μια μοναδική διεύθυνση URL απομακρυσμένης εφαρμογής. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_en.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps
 new-remote-app=New Remote App
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_en_AU.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps (Automatic Copy)
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_en_GB.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps (Automatic Copy)
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_es.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Aplicaciones remotas
 new-remote-app=Nueva aplicación remota
 please-enter-a-unique-remote-app-url=Escriba una URL de aplicación remota única.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_et.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Kaugrakendused (Automatic Translation)
 new-remote-app=Uus kaugrakendus (Automatic Translation)
 please-enter-a-unique-remote-app-url=Sisestage kordumatu kaugrakenduse URL. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_eu.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps (Automatic Copy)
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_fa.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=برنامه های راه دور (Automatic Translation)
 new-remote-app=برنامه جدید از راه دور (Automatic Translation)
 please-enter-a-unique-remote-app-url=لطفا یک URL برنامه از راه دور منحصر به فرد وارد کنید. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_fi.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Etäsovellukset
 new-remote-app=Uusi Etäsovellus
 please-enter-a-unique-remote-app-url=Anna yksilöllinen etäsovelluksen URL.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_fr.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Applications distantes
 new-remote-app=Nouvelle application distante
 please-enter-a-unique-remote-app-url=Veuillez saisir une URL d'application distante unique.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_fr_CA.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps (Automatic Copy)
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_gl.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Aplicacións remotas
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=रिमोट ऐप्स (Automatic Translation)
 new-remote-app=नया रिमोट ऐप (Automatic Translation)
 please-enter-a-unique-remote-app-url=कृपया एक अद्वितीय रिमोट ऐप यूआरएल दर्ज करें। (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_hr.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps (Automatic Copy)
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_hu.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Távoli alkalmazások
 new-remote-app=Új távoli alkalmazás
 please-enter-a-unique-remote-app-url=Egyedi távoli alkalmazás URL-t adjon meg.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_in.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Aplikasi jarak jauh (Automatic Translation)
 new-remote-app=Aplikasi remote baru (Automatic Translation)
 please-enter-a-unique-remote-app-url=Silakan masukkan URL aplikasi remote yang unik. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_it.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=App remote (Automatic Translation)
 new-remote-app=Nuova app remota (Automatic Translation)
 please-enter-a-unique-remote-app-url=Inserisci un URL univoco dell'app remota. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_iw.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=אפליקציות מרוחקות (Automatic Translation)
 new-remote-app=האפליקציה המרוחקת החדשה (Automatic Translation)
 please-enter-a-unique-remote-app-url=נא הזן כתובת URL ייחודית של יישום מרוחק. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ja.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=リモートアプリケーション
 new-remote-app=新規リモートアプリケーション
 please-enter-a-unique-remote-app-url=重複しないリモートアプリケーションURLを入力してください

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_kk.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps (Automatic Copy)
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ko.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=원격 앱 (Automatic Translation)
 new-remote-app=새로운 원격 앱 (Automatic Translation)
 please-enter-a-unique-remote-app-url=고유한 원격 앱 URL을 입력하십시오. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_lo.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps (Automatic Copy)
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_lt.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Nuotolinės programos (Automatic Translation)
 new-remote-app=Nauja nuotolinė programa (Automatic Translation)
 please-enter-a-unique-remote-app-url=Įveskite unikalų nuotolinės programos URL. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ms.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Aplikasi Jauh (Automatic Translation)
 new-remote-app=Aplikasi Jauh Baru (Automatic Translation)
 please-enter-a-unique-remote-app-url=Sila masukkan URL aplikasi jauh yang unik. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_nb.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Eksterne apper (Automatic Translation)
 new-remote-app=Ny ekstern app (Automatic Translation)
 please-enter-a-unique-remote-app-url=Skriv inn en unik url-adresse for ekstern app. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_nl.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Externe apps
 new-remote-app=Nieuwe externe app
 please-enter-a-unique-remote-app-url=Voer een unieke externe app-URL in.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps (Automatic Copy)
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_pl.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Aplikacje zdalne (Automatic Translation)
 new-remote-app=Nowa aplikacja zdalna (Automatic Translation)
 please-enter-a-unique-remote-app-url=Wprowadź unikatowy adres URL aplikacji zdalnej. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Aplicativos remotos
 new-remote-app=Novo aplicativo remoto
 please-enter-a-unique-remote-app-url=Por favor insira uma URL de aplicativo remoto única.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Aplicativos remotos (Automatic Translation)
 new-remote-app=Novo aplicativo remoto (Automatic Translation)
 please-enter-a-unique-remote-app-url=Por favor, insira uma URL de aplicativo remoto exclusiva. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ro.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Aplicații la distanță (Automatic Translation)
 new-remote-app=Aplicație nouă la distanță (Automatic Translation)
 please-enter-a-unique-remote-app-url=Introduceți un URL unic al aplicației la distanță. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ru.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Удаленные приложения (Automatic Translation)
 new-remote-app=Новое удаленное приложение (Automatic Translation)
 please-enter-a-unique-remote-app-url=Пожалуйста, введите уникальный URL-адрес удаленного приложения. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_sk.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Vzdialené aplikácie (Automatic Translation)
 new-remote-app=Nová vzdialená aplikácia (Automatic Translation)
 please-enter-a-unique-remote-app-url=Zadajte jedinečnú adresu URL vzdialenej aplikácie. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_sl.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Oddaljeni programi (Automatic Translation)
 new-remote-app=Nova oddaljena aplikacija (Automatic Translation)
 please-enter-a-unique-remote-app-url=Vnesite enolični URL oddaljene aplikacije. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps (Automatic Copy)
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps (Automatic Copy)
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_sv.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Fjärrappar
 new-remote-app=Ny fjärrapp
 please-enter-a-unique-remote-app-url=Ange URL för unik fjärrapp.

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_ta_IN.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Remote Apps (Automatic Copy)
 new-remote-app=New Remote App (Automatic Copy)
 please-enter-a-unique-remote-app-url=Please enter a unique remote app URL. (Automatic Copy)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_th.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=แอประยะไกล (Automatic Translation)
 new-remote-app=แอประยะไกลใหม่ (Automatic Translation)
 please-enter-a-unique-remote-app-url=โปรดป้อน URL ของแอประยะไกลที่ไม่ซ้ํากัน (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_tr.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Uzaktan Uygulamalar (Automatic Translation)
 new-remote-app=Yeni Uzaktan Uygulama (Automatic Translation)
 please-enter-a-unique-remote-app-url=Lütfen benzersiz bir uzak uygulama URL'si girin. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_uk.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Віддалені додатки (Automatic Translation)
 new-remote-app=Новий віддалений додаток (Automatic Translation)
 please-enter-a-unique-remote-app-url=Будь ласка, введіть унікальну URL-адресу віддаленої програми. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_vi.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=Ứng dụng từ xa (Automatic Translation)
 new-remote-app=Ứng dụng từ xa mới (Automatic Translation)
 please-enter-a-unique-remote-app-url=Vui lòng nhập URL ứng dụng từ xa duy nhất. (Automatic Translation)

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=远程应用
 new-remote-app=新远程应用
 please-enter-a-unique-remote-app-url=请输入唯一的远程应用 URL。

--- a/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/remote-app/remote-app-admin-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,3 +1,4 @@
+add-remote-web-app=Add Remote Web App (Automatic Copy)
 javax.portlet.title.com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet=遠端應用程式
 new-remote-app=新的遠端應用程式
 please-enter-a-unique-remote-app-url=請輸入唯一的遠端應用程式 URL。


### PR DESCRIPTION
As described in [LPS-138139](https://issues.liferay.com/browse/LPS-138139), 
a language key was missing for the button's tooltip

**Test plan**
Fetch this branch
Deploy the `remote-app-admin-web` OSGi module
Assert that the tooltip renders the correct key

**Before**
![](https://user-images.githubusercontent.com/5572/131321539-b0504290-615f-4749-bc69-0fe4a0abb3a1.png)

**After**
![](https://user-images.githubusercontent.com/5572/131321552-46dca0dc-9a3f-416e-9773-d31a3ae73027.png)

