### PR TITLE
LPS-138379 portal-web: Append namespace to remove the proper parameter

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -349,7 +349,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					namespace: '<%= namespace %>',
 					pages: '<%= pages %>',
 					randomNamespace: '<%= randomNamespace %>',
-					url: '<%= HtmlUtil.escapeJS(HttpUtil.removeParameter(url, curParam)) %>',
+					url: '<%= HtmlUtil.escapeJS(HttpUtil.removeParameter(url, namespace + curParam)) %>',
 					urlAnchor: '<%= urlAnchor %>'
 				}
 			),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-138379

Tests passed at https://github.com/holatuwol/liferay-portal/pull/242#issuecomment-909790958

/cc @ericyanLr

## Steps to reproduce

1. Navigate to Content & Data > Documents and Media
2. Click  \[+] > Multiple Files Upload
3. Add 200 documents ([test.tar.gz](https://issues.liferay.com/secure/attachment/421504/test.tar.gz) - from [LPS-131653](https://issues.liferay.com/browse/LPS-131653))
4. Change the number of Entries per page to 4.
    * Note that now only entries 1 to 4 are shown
5. Select the 2nd page
    * Note that entries 5 to 8 are shown
6. Select the ... symbol and change the page to a much higher number (e.g. 45)

**Expected Results**
 You are taken to page 45 and are shown only 4 entries on that page

**Actual Results**
 You remain on the 2nd page and are still shown only 4 entries on that page

## Solution notes

I made a mistake in my initial solution for [LPS-131653](https://issues.liferay.com/browse/LPS-131653) by copying the logic from `_getHREF` without checking the values that were being passed to it. This update addresses that mistake.