### PR TITLE
LPS-138402 Disable isolation from categories selector

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -143,6 +143,7 @@ function AssetVocabulariesCategoriesSelector({
 
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
+			iframeBodyCssClass: '',
 			multiple: true,
 			onSelect: (selectedItems) => {
 				if (selectedItems) {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -340,6 +340,7 @@ const openSelectionModal = ({
 	customSelectEvent = false,
 	height,
 	id,
+	iframeBodyCssClass,
 	multiple = false,
 	onClose,
 	onSelect,
@@ -415,6 +416,7 @@ const openSelectionModal = ({
 		containerProps,
 		height,
 		id: id || selectEventName,
+		iframeBodyCssClass,
 		onClose: () => {
 			eventHandlers.forEach((eventHandler) => {
 				eventHandler.detach();


### PR DESCRIPTION
Sending this here since I've to change Modal.js to propagate `iframeBodyCssClass`


**Steps to reproduce**:

1. Add a vocabulary
2. Add a category
3. Add a web content
4. Expand the Categorization section in sidebar
5. Click the Select button of new vocabulary
6. Select the category

**Expected result**
The category card should have blue background

Treeview styles are not being applied because the css doesn't have into account the cadmin selector. I'm disabling the isolation from the category selection because It is breaking the ui and it is not needed since It is contained in an iframe that will only have the admin theme.

cc/ @pat270 :)