### PR TITLE
LPS-134354 Add tests for TranslationAdminSelector

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.js
@@ -191,6 +191,7 @@ const TranslationAdminSelector = ({
 						<>
 							<ClayDropDown.Divider />
 							<ClayDropDown.Item
+								data-testid="translation-modal-trigger"
 								onClick={() => setTranslationModalVisible(true)}
 							>
 								<ClayLayout.ContentRow containerElement="span">

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.js
@@ -58,6 +58,9 @@ const TranslationAdminSelector = ({
 	);
 
 	const handleCloseTranslationModal = (activeLanguageIds) => {
+		if (!activeLanguageIds.includes(selectedLanguageId)) {
+			setSelectedLanguageId(defaultLanguageId);
+		}
 		setActiveLanguageIds(activeLanguageIds);
 		setTranslationModalVisible(false);
 	};

--- a/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/TranslationAdminSelector.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/TranslationAdminSelector.js
@@ -1,0 +1,367 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {act, cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import TranslationAdminSelector from '../../src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector';
+
+const activeLanguageIds = ['en_US', 'ca_ES'];
+
+const availableLocales = [
+	{
+		displayName: 'English (United States)',
+		id: 'en_US',
+		label: 'en-US',
+		symbol: 'en-us',
+	},
+	{
+		displayName: 'Arabic (Saudi Arabia)',
+		id: 'ar_SA',
+		label: 'ar-SA',
+		symbol: 'ar-sa',
+	},
+	{
+		displayName: 'Catalan (Spain)',
+		id: 'ca_ES',
+		label: 'ca-ES',
+		symbol: 'ca-es',
+	},
+	{
+		displayName: 'Chinese (China)',
+		id: 'zh_CN',
+		label: 'zh-CN',
+		symbol: 'zh-cn',
+	},
+	{
+		displayName: 'Dutch (Netherlands)',
+		id: 'nl_NL',
+		label: 'nl-NL',
+		symbol: 'nl-nl',
+	},
+	{
+		displayName: 'Finnish (Finland)',
+		id: 'fi_FI',
+		label: 'fi-FI',
+		symbol: 'fi-fi',
+	},
+	{
+		displayName: 'French (France)',
+		id: 'fr_FR',
+		label: 'fr-FR',
+		symbol: 'fr-fr',
+	},
+	{
+		displayName: 'German (Germany)',
+		id: 'de_DE',
+		label: 'de-DE',
+		symbol: 'de-de',
+	},
+	{
+		displayName: 'Hungarian (Hungary)',
+		id: 'hu_HU',
+		label: 'hu-HU',
+		symbol: 'hu-hu',
+	},
+	{
+		displayName: 'Japanese (Japan)',
+		id: 'ja_JP',
+		label: 'ja-JP',
+		symbol: 'ja-jp',
+	},
+	{
+		displayName: 'Portuguese (Brazil)',
+		id: 'pt_BR',
+		label: 'pt-BR',
+		symbol: 'pt-br',
+	},
+	{
+		displayName: 'Spanish (Spain)',
+		id: 'es_ES',
+		label: 'es-ES',
+		symbol: 'es-es',
+	},
+	{
+		displayName: 'Swedish (Sweden)',
+		id: 'sv_SE',
+		label: 'sv-SE',
+		symbol: 'sv-se',
+	},
+];
+
+const defaultLanguageId = 'en_US';
+
+const props = {
+	activeLanguageIds,
+	availableLocales,
+	defaultLanguageId,
+	onActiveLanguageIdsChange: jest.fn(),
+	onSelectedLanguageIdChange: jest.fn(),
+};
+
+jest.mock(
+	'../../src/main/resources/META-INF/resources/translation_manager/TranslationAdminModal',
+	() => {
+		return ({onClose, visible}) => {
+			const handleOnClose = () => {
+				onClose(['ar_SA', 'en_US', 'nl_NL']);
+			};
+
+			return (
+				<>
+					{visible && (
+						<div className="modal">
+							<button className="close" onClick={handleOnClose}>
+								Close
+							</button>
+						</div>
+					)}
+				</>
+			);
+		};
+	}
+);
+
+const TranslationAdminSelectorWithState = () => {
+	const [activeLanguageIds, setActiveLanguageIds] = React.useState(
+		props.activeLanguageIds
+	);
+
+	return (
+		<>
+			<button
+				data-testid="change-state"
+				onClick={() =>
+					setActiveLanguageIds(['ar_SA', 'en_US', 'nl_NL'])
+				}
+			>
+				Change State
+			</button>
+
+			<TranslationAdminSelector
+				{...props}
+				activeLanguageIds={activeLanguageIds}
+			/>
+		</>
+	);
+};
+
+describe('TranslationAdminSelector', () => {
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
+	afterEach(() => {
+		jest.clearAllTimers();
+		jest.restoreAllMocks();
+		cleanup();
+	});
+
+	beforeAll(() => {
+		jest.useFakeTimers();
+	});
+
+	it('renders a dropdown trigger with the selected locale flag icon as content', () => {
+		const {asFragment} = render(<TranslationAdminSelector {...props} />);
+
+		expect(asFragment()).toMatchSnapshot();
+	});
+
+	it('renders an open dropdown with the list of active languages', async () => {
+		const {getByTitle} = render(<TranslationAdminSelector {...props} />);
+
+		const trigger = getByTitle('select-translation-language');
+
+		fireEvent.click(trigger);
+
+		const dropdownMenu = document.querySelector('.dropdown-menu');
+
+		expect(dropdownMenu).toMatchSnapshot();
+	});
+
+	it('renders an open dropdown with the list of active languages and manage translation option', async () => {
+		const {getByTitle} = render(
+			<TranslationAdminSelector adminMode={true} {...props} />
+		);
+
+		const trigger = getByTitle('select-translation-language');
+
+		fireEvent.click(trigger);
+
+		const dropdownMenu = document.querySelector('.dropdown-menu');
+
+		expect(dropdownMenu).toMatchSnapshot();
+	});
+
+	it('renders a modal when click on Manage Translations', async () => {
+		const {getByTitle} = render(
+			<TranslationAdminSelector adminMode={true} {...props} />
+		);
+
+		const trigger = getByTitle('select-translation-language');
+
+		fireEvent.click(trigger);
+
+		const dropdownMenu = document.querySelector('.dropdown-menu');
+
+		const manageTranslationsTrigger = dropdownMenu.querySelector(
+			'[data-testid="translation-modal-trigger"]'
+		);
+
+		fireEvent.click(manageTranslationsTrigger);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		const modal = document.querySelector('.modal');
+
+		expect(modal).toMatchSnapshot();
+	});
+
+	it('renders an open dropdown with updated active locales when added from the Manage Translations Modal', async () => {
+		const {getByTitle} = render(
+			<TranslationAdminSelector adminMode={true} {...props} />
+		);
+
+		const trigger = getByTitle('select-translation-language');
+
+		fireEvent.click(trigger);
+
+		const dropdownMenu = document.querySelector('.dropdown-menu');
+
+		const manageTranslationsTrigger = dropdownMenu.querySelector(
+			'[data-testid="translation-modal-trigger"]'
+		);
+
+		fireEvent.click(manageTranslationsTrigger);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		const modalCloseButton = document.querySelector('.modal .close');
+
+		fireEvent.click(modalCloseButton);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		fireEvent.click(trigger);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(dropdownMenu).toMatchSnapshot();
+		expect(props.onActiveLanguageIdsChange).toHaveBeenLastCalledWith([
+			'ar_SA',
+			'en_US',
+			'nl_NL',
+		]);
+	});
+
+	it('calls onSelectedLocaleChange callback on dropdown locale selection', () => {
+		const {getByTitle} = render(<TranslationAdminSelector {...props} />);
+
+		const trigger = getByTitle('select-translation-language');
+
+		fireEvent.click(trigger);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		const dropdownMenu = document.querySelector('.dropdown-menu');
+
+		const localeElement = dropdownMenu.querySelectorAll(
+			'.dropdown-item'
+		)[1];
+
+		fireEvent.click(localeElement);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(props.onSelectedLanguageIdChange).toHaveBeenLastCalledWith(
+			'ca_ES'
+		);
+	});
+
+	it('is used as a controlled component', () => {
+		const {getByTestId, getByTitle} = render(
+			<TranslationAdminSelectorWithState />
+		);
+
+		const changeStateButton = getByTestId('change-state');
+
+		fireEvent.click(changeStateButton);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		const trigger = getByTitle('select-translation-language');
+
+		fireEvent.click(trigger);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		const dropdownMenu = document.querySelector('.dropdown-menu');
+
+		expect(dropdownMenu).toMatchSnapshot();
+	});
+
+	it('selects the default locale if the current selected one is removed from the active locales list', () => {
+		const {asFragment, getByTitle} = render(
+			<TranslationAdminSelector
+				adminMode={true}
+				selectedLanguageId="ca_ES"
+				{...props}
+			/>
+		);
+
+		const trigger = getByTitle('select-translation-language');
+
+		fireEvent.click(trigger);
+
+		const dropdownMenu = document.querySelector('.dropdown-menu');
+
+		const manageTranslationsTrigger = dropdownMenu.querySelector(
+			'[data-testid="translation-modal-trigger"]'
+		);
+
+		fireEvent.click(manageTranslationsTrigger);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		const modalCloseButton = document.querySelector('.modal .close');
+
+		fireEvent.click(modalCloseButton);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(asFragment()).toMatchSnapshot();
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/__snapshots__/TranslationAdminSelector.js.snap
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/__snapshots__/TranslationAdminSelector.js.snap
@@ -1,0 +1,633 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TranslationAdminSelector is used as a controlled component 1`] = `
+<div
+  class="dropdown-menu show"
+  style="left: -999px; top: -995px;"
+>
+  <ul
+    class="list-unstyled"
+  >
+    <li>
+      <button
+        class="dropdown-item"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-en-us inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#en-us"
+                />
+              </svg>
+              en-US
+            </div>
+          </span>
+          <span
+            class="autofit-col"
+          >
+            <div
+              class="autofit-section"
+            >
+              <span
+                class="label label-info"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  default
+                </span>
+              </span>
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+    <li>
+      <button
+        class="dropdown-item"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-ar-sa inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#ar-sa"
+                />
+              </svg>
+              ar-SA
+            </div>
+          </span>
+          <span
+            class="autofit-col"
+          >
+            <div
+              class="autofit-section"
+            >
+              <span
+                class="label label-warning"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  untranslated
+                </span>
+              </span>
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+    <li>
+      <button
+        class="dropdown-item"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-nl-nl inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#nl-nl"
+                />
+              </svg>
+              nl-NL
+            </div>
+          </span>
+          <span
+            class="autofit-col"
+          >
+            <div
+              class="autofit-section"
+            >
+              <span
+                class="label label-warning"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  untranslated
+                </span>
+              </span>
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`TranslationAdminSelector renders a dropdown trigger with the selected locale flag icon as content 1`] = `
+<DocumentFragment>
+  <div
+    class="dropdown"
+  >
+    <button
+      class="dropdown-toggle btn btn-monospaced btn-secondary"
+      style=""
+      title="select-translation-language"
+      type="button"
+    >
+      <span
+        class="inline-item"
+      >
+        <svg
+          class="lexicon-icon lexicon-icon-en-us"
+          role="presentation"
+        >
+          <use
+            xlink:href="#en-us"
+          />
+        </svg>
+      </span>
+      <span
+        class="btn-section"
+      >
+        en-US
+      </span>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`TranslationAdminSelector renders a modal when click on Manage Translations 1`] = `
+<div
+  class="modal"
+>
+  <button
+    class="close"
+  >
+    Close
+  </button>
+</div>
+`;
+
+exports[`TranslationAdminSelector renders an open dropdown with the list of active languages 1`] = `
+<div
+  class="dropdown-menu show"
+  style="left: -999px; top: -995px;"
+>
+  <ul
+    class="list-unstyled"
+  >
+    <li>
+      <button
+        class="dropdown-item"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-en-us inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#en-us"
+                />
+              </svg>
+              en-US
+            </div>
+          </span>
+          <span
+            class="autofit-col"
+          >
+            <div
+              class="autofit-section"
+            >
+              <span
+                class="label label-info"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  default
+                </span>
+              </span>
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+    <li>
+      <button
+        class="dropdown-item"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-ca-es inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#ca-es"
+                />
+              </svg>
+              ca-ES
+            </div>
+          </span>
+          <span
+            class="autofit-col"
+          >
+            <div
+              class="autofit-section"
+            >
+              <span
+                class="label label-warning"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  untranslated
+                </span>
+              </span>
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`TranslationAdminSelector renders an open dropdown with the list of active languages and manage translation option 1`] = `
+<div
+  class="dropdown-menu show"
+  style="left: -999px; top: -995px;"
+>
+  <ul
+    class="list-unstyled"
+  >
+    <li>
+      <button
+        class="dropdown-item"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-en-us inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#en-us"
+                />
+              </svg>
+              en-US
+            </div>
+          </span>
+          <span
+            class="autofit-col"
+          >
+            <div
+              class="autofit-section"
+            >
+              <span
+                class="label label-info"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  default
+                </span>
+              </span>
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+    <li>
+      <button
+        class="dropdown-item"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-ca-es inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#ca-es"
+                />
+              </svg>
+              ca-ES
+            </div>
+          </span>
+          <span
+            class="autofit-col"
+          >
+            <div
+              class="autofit-section"
+            >
+              <span
+                class="label label-warning"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  untranslated
+                </span>
+              </span>
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+    <li
+      aria-hidden="true"
+      class="dropdown-divider"
+      role="presentation"
+    />
+    <li>
+      <button
+        class="dropdown-item"
+        data-testid="translation-modal-trigger"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-automatic-translate inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#automatic-translate"
+                />
+              </svg>
+              manage-translations
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`TranslationAdminSelector renders an open dropdown with updated active locales when added from the Manage Translations Modal 1`] = `
+<div
+  class="dropdown-menu"
+  style="left: -999px; top: -995px;"
+>
+  <ul
+    class="list-unstyled"
+  >
+    <li>
+      <button
+        class="dropdown-item"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-en-us inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#en-us"
+                />
+              </svg>
+              en-US
+            </div>
+          </span>
+          <span
+            class="autofit-col"
+          >
+            <div
+              class="autofit-section"
+            >
+              <span
+                class="label label-info"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  default
+                </span>
+              </span>
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+    <li>
+      <button
+        class="dropdown-item"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-ar-sa inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#ar-sa"
+                />
+              </svg>
+              ar-SA
+            </div>
+          </span>
+          <span
+            class="autofit-col"
+          >
+            <div
+              class="autofit-section"
+            >
+              <span
+                class="label label-warning"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  untranslated
+                </span>
+              </span>
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+    <li>
+      <button
+        class="dropdown-item"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-nl-nl inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#nl-nl"
+                />
+              </svg>
+              nl-NL
+            </div>
+          </span>
+          <span
+            class="autofit-col"
+          >
+            <div
+              class="autofit-section"
+            >
+              <span
+                class="label label-warning"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  untranslated
+                </span>
+              </span>
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+    <li
+      aria-hidden="true"
+      class="dropdown-divider"
+      role="presentation"
+    />
+    <li>
+      <button
+        class="dropdown-item"
+        data-testid="translation-modal-trigger"
+      >
+        <span
+          class="autofit-row"
+        >
+          <span
+            class="autofit-col autofit-col-expand"
+          >
+            <div
+              class="autofit-section"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-automatic-translate inline-item inline-item-before"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#automatic-translate"
+                />
+              </svg>
+              manage-translations
+            </div>
+          </span>
+        </span>
+      </button>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`TranslationAdminSelector selects the default locale if the current selected one is removed from the active locales list 1`] = `
+<DocumentFragment>
+  <div
+    class="dropdown"
+  >
+    <button
+      class="dropdown-toggle btn btn-monospaced btn-secondary"
+      style=""
+      title="select-translation-language"
+      type="button"
+    >
+      <span
+        class="inline-item"
+      >
+        <svg
+          class="lexicon-icon lexicon-icon-en-us"
+          role="presentation"
+        >
+          <use
+            xlink:href="#en-us"
+          />
+        </svg>
+      </span>
+      <span
+        class="btn-section"
+      >
+        en-US
+      </span>
+    </button>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
Followup on https://github.com/liferay-frontend/liferay-portal/pull/1372

Added tests for Translation Admin Selector

Fixed an issue about current selected locale not being updated to the default one when removed from the list of active locales.

Test plan:

Is not implemented so you'd need to create a component to use it and call it from some jsp. Here's a component sample: https://gist.github.com/carloslancha/6d7b334d73fd154899f67b678046ae62

~Note: Only two last commits are new, waiting for liferay-portal central repo to sync with Brian's latest master.~