### PR TITLE
LPS-137550 Add translations to empty state in User Activity

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserActivity.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserActivity.es.js
@@ -169,10 +169,16 @@ export default withRouter(
 							data={data && data.messageBoardMessages}
 							emptyState={
 								<ClayEmptyState
+									description={Liferay.Language.get(
+										'sorry-there-are-no-results-found'
+									)}
 									imgSrc={
 										context.includeContextPath +
 										'/assets/empty_questions_list.png'
 									}
+									title={Liferay.Language.get(
+										'there-are-no-results'
+									)}
 								/>
 							}
 							loading={loading}


### PR DESCRIPTION
As described in [LPS-137550](https://issues.liferay.com/browse/LPS-137550)
the translation of the empty state in the user activity is lost.
**Test plan**
- Fetch this branch
- Deploy the questions module (path `modules/apps/questions/questions-web`)
- Assert that the title and the description of the empty state in "My activity" page change when the portal changes the language

**Before**
![image](https://user-images.githubusercontent.com/17163902/131883280-5d492c1f-6ddb-4488-92fb-6457473dbe91.png)

**After**
![image](https://user-images.githubusercontent.com/17163902/131883681-2b089dbf-9bec-44d0-96cd-afd89541a35c.png)

**Steps to reproduce:**
Add a widget page > Place a Questions widget on it
Attempt to access the bundle using other languages like via `localhost:8080/ja`
Go to My Activity of Questions widget

**Expected Result:**
 "表示するデータが見つかりません。" display.
**Actual Result:**
 "No results found." display.

