### PR TITLE
LPS-138412 Disable isolation from modals created from render_portlet

### DIFF
--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -481,7 +481,8 @@ if (urlConfiguration != null) {
 	StringBundler urlConfigurationJSSB = new StringBundler(PropsValues.PORTLET_CONFIG_SHOW_PORTLET_ID ? 14 : 12);
 
 	urlConfigurationJSSB.append("Liferay.Portlet.openModal({");
-	urlConfigurationJSSB.append("namespace: '");
+	urlConfigurationJSSB.append("iframeBodyCssClass: '");
+	urlConfigurationJSSB.append("', namespace: '");
 	urlConfigurationJSSB.append(portletDisplay.getNamespace());
 	urlConfigurationJSSB.append("', portletSelector: '#p_p_id_");
 	urlConfigurationJSSB.append(portletDisplay.getId());


### PR DESCRIPTION
When using `cadmin` inside modals, it can hide CKEditor portlet view

Steps to reproduce:

1. Go to Wiki/Knowledge Base
2. Click in three-dot button near user avatar button
3. Open "Configuration"
4. Select the tab "Article/Page Added Email" and see there is a missing rich text editor there.

Here is the fixed version:

<img width="500" alt="Screen Shot 2021-09-02 at 17 11 23" src="https://user-images.githubusercontent.com/7663513/131909554-c5bca615-a740-431f-b7b5-608472a0902d.png">
