### PR TITLE
LPS-138717 split in empty strings return an element with an empty str…

### DIFF
--- a/modules/apps/custom-elements/custom-elements-service/src/main/java/com/liferay/custom/elements/service/impl/CustomElementsPortletDescriptorLocalServiceImpl.java
+++ b/modules/apps/custom-elements/custom-elements-service/src/main/java/com/liferay/custom/elements/service/impl/CustomElementsPortletDescriptorLocalServiceImpl.java
@@ -148,6 +148,12 @@ public class CustomElementsPortletDescriptorLocalServiceImpl
 
 		String cssURLs = customElementsPortletDescriptor.getCSSURLs();
 
+		String[] cssURLsArray = null;
+
+		if (!cssURLs.isEmpty()) {
+			cssURLsArray = cssURLs.split(StringPool.NEW_LINE);
+		}
+
 		_serviceRegistrations.put(
 			customElementsPortletDescriptor.
 				getCustomElementsPortletDescriptorId(),
@@ -160,8 +166,7 @@ public class CustomElementsPortletDescriptorLocalServiceImpl
 				).put(
 					"com.liferay.portlet.display-category", "category.sample"
 				).put(
-					"com.liferay.portlet.header-portal-css",
-					cssURLs.split(StringPool.NEW_LINE)
+					"com.liferay.portlet.header-portal-css", cssURLsArray
 				).put(
 					"com.liferay.portlet.header-portal-javascript",
 					_getCustomElementsSourceURLs(


### PR DESCRIPTION
…ing that causes an extra CSS request to nothing

cssURLs can not be null, as it's checked internally and always returns an empty string in that case.