### PR TITLE
LPS-137965 Show tags in 4 columns for Desktops screens and in one column for smaller screens

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
@@ -256,11 +256,11 @@ export default withRouter(({history, location}) => {
 					>
 						{(tag) => (
 							<div
-								className="col-md-3 question-tags"
+								className="col-lg-3 question-tags"
 								key={tag.id}
 							>
 								<div className="card card-interactive card-interactive-primary card-type-template d-flex justify-content-between template-card-horizontal">
-									<div className="col-9">
+									<div className="col-9 col-lg-8 col-xl-9">
 										<Link
 											title={tag.name}
 											to={`/questions/tag/${tag.name}`}
@@ -316,7 +316,7 @@ export default withRouter(({history, location}) => {
 											</div>
 										</Link>
 									</div>
-									<div className="align-items-center col-3 d-flex">
+									<div className="align-items-center col-3 col-lg-4 col-xl-3 d-flex">
 										{tag.actions.subscribe && (
 											<div className="autofit-col">
 												<div className="autofit-section">


### PR DESCRIPTION
Related JIRA ticket [LPS-137965](https://issues.liferay.com/browse/LPS-137965) describing the bug.

**Steps to reproduce:**

- Add a page with a Questions widget on it
- Post questions with tag
- Go to the Tags tab

**Expected Result:**
The subscription icon of the tag display as normal.

**Actual Result:**
The subscription icon of the tag display out of the border.

Before the fix we have this situation in middle screens for tags:
![image](https://user-images.githubusercontent.com/17163902/132252290-1081cb05-231d-49d7-9f5c-34595e5b9158.png)

After seeing this, the decision was to show the tags in 4 columns for desktop screens and in one column for the smaller screens, according to the Bootstrap [documentation](https://getbootstrap.com/docs/4.1/layout/overview/). So, the final result is:

For small screens 
![image](https://user-images.githubusercontent.com/17163902/132252750-23d4fc51-0b4c-4f09-8436-069e314e1c7c.png)

For desktop screens
![image](https://user-images.githubusercontent.com/17163902/132252775-e68913c2-df0e-472a-9c4c-ab4f5456a786.png)
