### PR TITLE
LPS-135150 Take into account the history router base path for the canonical URLs

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
@@ -454,9 +454,13 @@ export default withRouter(
 					<Helmet>
 						<title>{question.headline}</title>
 						<link
-							href={`${getFullPath('questions')}${
-								context.historyRouterBasePath ? '' : '#/'
-							}questions/${sectionTitle}/${questionId}`}
+							href={`${getFullPath(
+								context.historyRouterBasePath || 'questions'
+							)}${
+								context.historyRouterBasePath
+									? context.historyRouterBasePath
+									: '#'
+							}/questions/${sectionTitle}/${questionId}`}
 							rel="canonical"
 						/>
 					</Helmet>


### PR DESCRIPTION
Related ticket for the bug -> [LPS-135150](https://issues.liferay.com/browse/LPS-135150)

The ticket describes a bug with the generation of canonical URLs when configuring a history router for the Questions app.

**Steps to reproduce:**

- Add a widget page named Questions Page > place a Questions widget on it
- Set the history router as /questions-page
- Add the policy for guest access question details
- Post a question named Question
- logout
- Navigate to the details of the posted question 

**Expected Result:**
The Canonical URL is
`<link href="http://localhost:8080/web/guest/questions-page/questions/category/question" rel="canonical" data-react-helmet="true"> `

**Actual Result:**
The Canonical URL display as following, it has no page name.
`<link href="http://localhost:8080/web/guest/questions/category/question" rel="canonical" data-react-helmet="true"> `

With the fix, it into account the history router base path specified to get the full path.