### PR TITLE
LPS-138865 - Specify eslint-config version through yarn resolutions

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -10,6 +10,9 @@
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,
+	"resolutions": {
+		"@liferay/eslint-config": "25.0.1"
+	},
 	"scripts": {
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-138865

Note that these changes here don't actually update eslint-config from what we are already using yet. This is just to lock the eslint-config version at the current version provided through npm-scripts. Future eslint-config updates can update it directly here though.

npm-scripts will still contain a dependency of eslint-config, but this way we don't have to always publish npm-scripts since that can often take longer to get merged into dxp.