### PR TITLE
LPS-137965 Fix tags subscription button out of border

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
@@ -259,8 +259,8 @@ export default withRouter(({history, location}) => {
 								className="col-lg-3 question-tags"
 								key={tag.id}
 							>
-								<div className="card card-interactive card-interactive-primary card-type-template d-flex justify-content-between template-card-horizontal">
-									<div className="col-9 col-lg-8 col-xl-9">
+								<div className="align-items-center card card-interactive card-interactive-primary card-type-template d-flex justify-content-between template-card-horizontal">
+									<div>
 										<Link
 											title={tag.name}
 											to={`/questions/tag/${tag.name}`}
@@ -316,7 +316,7 @@ export default withRouter(({history, location}) => {
 											</div>
 										</Link>
 									</div>
-									<div className="align-items-center col-3 col-lg-4 col-xl-3 d-flex">
+									<div className="c-pr-3">
 										{tag.actions.subscribe && (
 											<div className="autofit-col">
 												<div className="autofit-section">


### PR DESCRIPTION
Related ticket -> [LPS-137965](https://issues.liferay.com/browse/LPS-137965)

**Steps to reproduce:**

- Add a page with a Questions widget on it
- Post questions with tag
- Go to the Tags tab

**Expected Result:**
The subscription icon of the tag display as normal.

**Actual Result:**
The subscription icon of the tag display out of the border.

Before the fix:
![image](https://user-images.githubusercontent.com/17163902/132488263-a620da55-d1a7-4cfa-9957-15003299b64c.png)

After:
![image](https://user-images.githubusercontent.com/17163902/132488479-71635c10-df8d-44ba-91b3-9183b717306c.png)
