### PR TITLE
LPS-138903 enum creation fails in Object APIs, use create to use the …

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
@@ -41,7 +41,7 @@ public class ObjectFieldUtil {
 					serviceBuilderObjectField.getListTypeDefinitionId();
 				name = serviceBuilderObjectField.getName();
 				required = serviceBuilderObjectField.isRequired();
-				type = ObjectField.Type.valueOf(
+				type = ObjectField.Type.create(
 					serviceBuilderObjectField.getType());
 			}
 		};

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -128,7 +128,7 @@ public class ObjectDefinitionResourceTest
 					{
 						setLabel(Collections.singletonMap("en_US", "Column"));
 						setName("column");
-						setType(ObjectField.Type.valueOf("String"));
+						setType(ObjectField.Type.create("String"));
 					}
 				}
 			});

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFieldResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFieldResourceTest.java
@@ -81,7 +81,7 @@ public class ObjectFieldResourceTest extends BaseObjectFieldResourceTestCase {
 		objectField.setLabel(
 			Collections.singletonMap("en-US", "a" + objectField.getName()));
 		objectField.setName("a" + objectField.getName());
-		objectField.setType(ObjectField.Type.valueOf("String"));
+		objectField.setType(ObjectField.Type.create("String"));
 
 		return objectField;
 	}


### PR DESCRIPTION
…lowercased string instead of the full enum string representation in upper case