### PR TITLE
LPS 138264 Mime types filter tree with colored icons

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/selector/ContentDashboardFileExtensionItemSelectorView.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/selector/ContentDashboardFileExtensionItemSelectorView.java
@@ -18,6 +18,7 @@ import com.liferay.content.dashboard.web.internal.display.context.ContentDashboa
 import com.liferay.content.dashboard.web.internal.item.selector.criteria.content.dashboard.file.extension.criterion.ContentDashboardFileExtensionItemSelectorCriterion;
 import com.liferay.content.dashboard.web.internal.searcher.ContentDashboardSearchRequestBuilderFactory;
 import com.liferay.document.library.configuration.DLConfiguration;
+import com.liferay.document.library.display.context.DLMimeTypeDisplayContext;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
@@ -232,6 +233,8 @@ public class ContentDashboardFileExtensionItemSelectorView
 					).put(
 						"icon", fileExtensionGroup.getIcon()
 					).put(
+						"iconCssClass", _getIconCssClass(fileExtensionGroup)
+					).put(
 						"label",
 						LanguageUtil.get(
 							ResourceBundleUtil.getBundle(
@@ -277,6 +280,17 @@ public class ContentDashboardFileExtensionItemSelectorView
 		);
 	}
 
+	private String _getIconCssClass(FileExtensionGroup fileExtensionGroup) {
+		List<String> mimeTypes = fileExtensionGroup.getMimeTypes();
+
+		if (ListUtil.isEmpty(mimeTypes)) {
+			return null;
+		}
+
+		return _dlMimeTypeDisplayContext.getCssClassFileMimeType(
+			mimeTypes.get(0));
+	}
+
 	private static final List<ItemSelectorReturnType>
 		_supportedItemSelectorReturnTypes = Collections.singletonList(
 			new UUIDItemSelectorReturnType());
@@ -289,6 +303,10 @@ public class ContentDashboardFileExtensionItemSelectorView
 		_contentDashboardSearchRequestBuilderFactory;
 
 	private volatile DLConfiguration _dlConfiguration;
+
+	@Reference
+	private DLMimeTypeDisplayContext _dlMimeTypeDisplayContext;
+
 	private volatile Map<String, String> _fileExtensionFileExtensionGroupKeys =
 		new HashMap<>();
 	private volatile List<FileExtensionGroup> _fileExtensionGroups =

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewCard.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewCard.js
@@ -49,7 +49,11 @@ export default function TreeviewCard({node}) {
 					<ClayCard.Row className="autofit-row-center">
 						{node.icon && (
 							<div className="autofit-col">
-								<ClaySticker displayType="secondary" inline>
+								<ClaySticker
+									className={node.iconCssClass}
+									displayType="secondary"
+									inline
+								>
 									<ClayIcon symbol={node.icon} />
 								</ClaySticker>
 							</div>
@@ -72,6 +76,7 @@ export default function TreeviewCard({node}) {
 TreeviewCard.propTypes = {
 	node: PropTypes.shape({
 		icon: PropTypes.string,
+		iconCssClass: PropTypes.string,
 		name: PropTypes.string.isRequired,
 		nodePath: PropTypes.string,
 	}).isRequired,

--- a/modules/apps/frontend-js/frontend-js-components-web/test/treeview/Treeview.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/treeview/Treeview.js
@@ -382,4 +382,58 @@ describe('Treeview', () => {
 			).toBe(0);
 		});
 	});
+
+	describe('Treeview controls icon css class in TreeviewCard', () => {
+		it('rendering the icon with the corresponding class if the class property is present', () => {
+			const nodes = [
+				{
+					icon: 'emoji',
+					iconCssClass: 'emoji-specific-class',
+					id: '1',
+					name: 'Belt',
+				},
+				{
+					icon: 'react',
+					iconCssClass: 'react-specific-class',
+					id: '2',
+					name: 'Clara',
+				},
+			];
+
+			const {container} = render(
+				<Treeview NodeComponent={Treeview.Card} nodes={nodes} />
+			);
+
+			expect(
+				container.getElementsByClassName('emoji-specific-class').length
+			).toBe(1);
+			expect(
+				container.getElementsByClassName('react-specific-class').length
+			).toBe(1);
+		});
+
+		it('rendering the icon if the class is not present or falsy', () => {
+			const nodes = [
+				{
+					icon: 'emoji',
+					iconCssClass: '',
+					id: '1',
+					name: 'Belt',
+				},
+				{
+					icon: 'react',
+					id: '2',
+					name: 'Clara',
+				},
+			];
+
+			const {container} = render(
+				<Treeview NodeComponent={Treeview.Card} nodes={nodes} />
+			);
+
+			expect(
+				container.getElementsByClassName('lexicon-icon').length
+			).toBe(2);
+		});
+	});
 });


### PR DESCRIPTION
Motivation
=======
[Link to story or ticket](https://issues.liferay.com/browse/LPS-138264)

Proposed Solution
========
We changed TreeviewCard component so that nodes accept the property iconCssClass, that will be applied to the icon if both icon and iconCssClass are present for the node.

Change summary:
---------------
* LPS-138264 Adding cssClass prop to add color to the icons
* LPS-138264 Add icon class to TreeviewCard component
* LPS-138264 Add tests for Treeview new iconCssClass prop for nodes

Steps to Verify:
----------------
1. Add some documents and media to your site
1. Go to Content Dashboard
1. Open extension filter modal and check that the icons in the tree have colors
1. Open type filter modal and check that the icons in the tree do NOT have colors

