### PR TITLE
LPS-138665 Don't show dropdown menu if there aren't any options

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -231,7 +231,7 @@
 							</clay:content-col>
 
 							<clay:content-col
-								cssClass="component-action inline-item-after justify-content-end"
+								cssClass="inline-item-after justify-content-end"
 							>
 
 								<%
@@ -239,6 +239,7 @@
 								%>
 
 								<clay:dropdown-actions
+									cssClass="component-action"
 									dropdownItems="<%= assetVocabularyActionDropdownItemsProvider.getActionDropdownItems(vocabulary) %>"
 									propsTransformer="js/VocabularyActionDropdownPropsTransformer"
 								/>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.taglib.clay.servlet.taglib;
 
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownGroupItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.portal.kernel.util.ListUtil;
 
@@ -31,7 +32,7 @@ public class DropdownMenuTag extends ButtonTag {
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
 
-		if (ListUtil.isEmpty(_dropdownItems)) {
+		if (_isEmpty(_dropdownItems)) {
 			return SKIP_BODY;
 		}
 
@@ -56,7 +57,7 @@ public class DropdownMenuTag extends ButtonTag {
 
 	@Override
 	protected String getHydratedModuleName() {
-		if (ListUtil.isEmpty(_dropdownItems)) {
+		if (_isEmpty(_dropdownItems)) {
 			return null;
 		}
 
@@ -68,6 +69,28 @@ public class DropdownMenuTag extends ButtonTag {
 		props.put("items", _dropdownItems);
 
 		return super.prepareProps(props);
+	}
+
+	private boolean _isEmpty(List<DropdownItem> dropdownItems) {
+		if (ListUtil.isEmpty(_dropdownItems)) {
+			return true;
+		}
+
+		for (DropdownItem dropdownItem : dropdownItems) {
+			if (!(dropdownItem instanceof DropdownGroupItem)) {
+				return false;
+			}
+
+			Object items = dropdownItem.get("items");
+
+			if ((items instanceof List) &&
+				ListUtil.isNotEmpty((List<?>)items)) {
+
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:dropdown-menu:";


### PR DESCRIPTION
Related ticket: https://issues.liferay.com/browse/LPS-138665


## Proposed solution

Apart from normal DropdownItems there is also a DropdownGroupItem which may contains other DropdownItems inside. Instead of checking that the dropdownItem list is empty, take into account possible DropdownGroupItems inside and check if those have items

## Steps to reproduce

- Go to Categories
- Display the actions in a private category

### Expected result
Since there isn't any dropdown options the dropdown shouldn't appear

### Actual result
The dropdown appears empty

