### PR TITLE
LPS-138464 Create a common pattern when using ManagementBarSortTag so that the chosen order column/type can be saved in the user preferences

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -82,8 +82,14 @@ public class AssetBrowserDisplayContext {
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			httpServletRequest, AssetBrowserPortletKeys.ASSET_BROWSER);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, AssetBrowserPortletKeys.ASSET_BROWSER
+			).defaultOrderByCol(
+				"modified-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 	}
 
 	public AssetBrowserSearch getAssetBrowserSearch()
@@ -453,11 +459,11 @@ public class AssetBrowserDisplayContext {
 	}
 
 	protected String getOrderByCol() {
-		return _managementBarOrderByHandler.getOrderByCol("modified-date");
+		return _managementBarOrderByHandler.getOrderByCol();
 	}
 
 	protected String getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByType("asc");
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	private long[] _getClassNameIds() {

--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -25,6 +25,7 @@ import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.asset.util.AssetHelper;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryServiceUtil;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.item.selector.constants.ItemSelectorPortletKeys;
 import com.liferay.item.selector.criteria.constants.ItemSelectorCriteriaConstants;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
@@ -35,8 +36,6 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.SearchDisplayStyleUtil;
 import com.liferay.portal.kernel.search.Field;
@@ -83,8 +82,8 @@ public class AssetBrowserDisplayContext {
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 
-		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
-			_httpServletRequest);
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			httpServletRequest, AssetBrowserPortletKeys.ASSET_BROWSER);
 	}
 
 	public AssetBrowserSearch getAssetBrowserSearch()
@@ -454,50 +453,11 @@ public class AssetBrowserDisplayContext {
 	}
 
 	protected String getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		String orderByCol = ParamUtil.getString(
-			_httpServletRequest, "orderByCol");
-
-		if (Validator.isNotNull(orderByCol)) {
-			_portalPreferences.setValue(
-				AssetBrowserPortletKeys.ASSET_BROWSER, "order-by-col",
-				orderByCol);
-		}
-		else {
-			orderByCol = _portalPreferences.getValue(
-				AssetBrowserPortletKeys.ASSET_BROWSER, "order-by-col",
-				"modified-date");
-		}
-
-		_orderByCol = orderByCol;
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol("modified-date");
 	}
 
 	protected String getOrderByType() {
-		if (_orderByType != null) {
-			return _orderByType;
-		}
-
-		String orderByType = ParamUtil.getString(
-			_httpServletRequest, "orderByType");
-
-		if (Validator.isNotNull(orderByType)) {
-			_portalPreferences.setValue(
-				AssetBrowserPortletKeys.ASSET_BROWSER, "order-by-type",
-				orderByType);
-		}
-		else {
-			orderByType = _portalPreferences.getValue(
-				AssetBrowserPortletKeys.ASSET_BROWSER, "order-by-type", "asc");
-		}
-
-		_orderByType = orderByType;
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType("asc");
 	}
 
 	private long[] _getClassNameIds() {
@@ -647,10 +607,8 @@ public class AssetBrowserDisplayContext {
 	private Long _groupId;
 	private final HttpServletRequest _httpServletRequest;
 	private String _keywords;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private Boolean _multipleSelection;
-	private String _orderByCol;
-	private String _orderByType;
-	private final PortalPreferences _portalPreferences;
 	private final PortletURL _portletURL;
 	private Long _refererAssetEntryId;
 	private final RenderRequest _renderRequest;

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
@@ -284,51 +284,27 @@ public class AssetListDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		_orderByCol = ParamUtil.getString(_httpServletRequest, "orderByCol");
-
-		if (Validator.isNull(_orderByCol)) {
-			_orderByCol = _portalPreferences.getValue(
-				AssetListPortletKeys.ASSET_LIST, "order-by-col", "create-date");
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				_httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				_portalPreferences.setValue(
-					AssetListPortletKeys.ASSET_LIST, "order-by-col",
-					_orderByCol);
-			}
-		}
-
-		return _orderByCol;
+		return _getOrderByCol();
 	}
 
 	public String getOrderByType() {
-		if (_orderByType != null) {
+		if (Validator.isNotNull(_orderByType)) {
 			return _orderByType;
 		}
 
-		_orderByType = ParamUtil.getString(_httpServletRequest, "orderByType");
+		String orderByType = ParamUtil.getString(
+			_httpServletRequest, "orderByType");
 
-		if (Validator.isNull(_orderByType)) {
-			_orderByType = _portalPreferences.getValue(
-				AssetListPortletKeys.ASSET_LIST, "order-by-type", "asc");
+		if (Validator.isNotNull(orderByType)) {
+			_portalPreferences.setValue(
+				AssetListPortletKeys.ASSET_LIST, "order-by-type", orderByType);
 		}
 		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				_httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				_portalPreferences.setValue(
-					AssetListPortletKeys.ASSET_LIST, "order-by-type",
-					_orderByType);
-			}
+			orderByType = _portalPreferences.getValue(
+				AssetListPortletKeys.ASSET_LIST, "order-by-type", "asc");
 		}
+
+		_orderByType = orderByType;
 
 		return _orderByType;
 	}
@@ -435,8 +411,19 @@ public class AssetListDisplayContext {
 			return _orderByCol;
 		}
 
-		_orderByCol = ParamUtil.getString(
-			_httpServletRequest, "orderByCol", "create-date");
+		String orderByCol = ParamUtil.getString(
+			_httpServletRequest, "orderByCol");
+
+		if (Validator.isNotNull(orderByCol)) {
+			_portalPreferences.setValue(
+				AssetListPortletKeys.ASSET_LIST, "order-by-col", orderByCol);
+		}
+		else {
+			orderByCol = _portalPreferences.getValue(
+				AssetListPortletKeys.ASSET_LIST, "order-by-col", "create-date");
+		}
+
+		_orderByCol = orderByCol;
 
 		return _orderByCol;
 	}

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
@@ -74,8 +74,14 @@ public class AssetListDisplayContext {
 
 		_httpServletRequest = PortalUtil.getHttpServletRequest(renderRequest);
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			_httpServletRequest, AssetListPortletKeys.ASSET_LIST);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				_httpServletRequest, AssetListPortletKeys.ASSET_LIST
+			).defaultOrderByCol(
+				"create-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 
 		_themeDisplay = (ThemeDisplay)_httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -284,11 +290,11 @@ public class AssetListDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		return _managementBarOrderByHandler.getOrderByCol("create-date");
+		return _managementBarOrderByHandler.getOrderByCol();
 	}
 
 	public String getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByType("asc");
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	public PortletURL getPortletURL() {

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
@@ -30,6 +30,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringPool;
@@ -40,8 +41,6 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -75,8 +74,9 @@ public class AssetListDisplayContext {
 
 		_httpServletRequest = PortalUtil.getHttpServletRequest(renderRequest);
 
-		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
-			_httpServletRequest);
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			_httpServletRequest, AssetListPortletKeys.ASSET_LIST);
+
 		_themeDisplay = (ThemeDisplay)_httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 	}
@@ -122,9 +122,9 @@ public class AssetListDisplayContext {
 
 		OrderByComparator<AssetListEntry> orderByComparator =
 			AssetListPortletUtil.getAssetListEntryOrderByComparator(
-				_getOrderByCol(), getOrderByType());
+				getOrderByCol(), getOrderByType());
 
-		assetListEntriesSearchContainer.setOrderByCol(_getOrderByCol());
+		assetListEntriesSearchContainer.setOrderByCol(getOrderByCol());
 		assetListEntriesSearchContainer.setOrderByComparator(orderByComparator);
 		assetListEntriesSearchContainer.setOrderByType(getOrderByType());
 
@@ -284,29 +284,11 @@ public class AssetListDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		return _getOrderByCol();
+		return _managementBarOrderByHandler.getOrderByCol("create-date");
 	}
 
 	public String getOrderByType() {
-		if (Validator.isNotNull(_orderByType)) {
-			return _orderByType;
-		}
-
-		String orderByType = ParamUtil.getString(
-			_httpServletRequest, "orderByType");
-
-		if (Validator.isNotNull(orderByType)) {
-			_portalPreferences.setValue(
-				AssetListPortletKeys.ASSET_LIST, "order-by-type", orderByType);
-		}
-		else {
-			orderByType = _portalPreferences.getValue(
-				AssetListPortletKeys.ASSET_LIST, "order-by-type", "asc");
-		}
-
-		_orderByType = orderByType;
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType("asc");
 	}
 
 	public PortletURL getPortletURL() {
@@ -406,28 +388,6 @@ public class AssetListDisplayContext {
 		return _keywords;
 	}
 
-	private String _getOrderByCol() {
-		if (Validator.isNotNull(_orderByCol)) {
-			return _orderByCol;
-		}
-
-		String orderByCol = ParamUtil.getString(
-			_httpServletRequest, "orderByCol");
-
-		if (Validator.isNotNull(orderByCol)) {
-			_portalPreferences.setValue(
-				AssetListPortletKeys.ASSET_LIST, "order-by-col", orderByCol);
-		}
-		else {
-			orderByCol = _portalPreferences.getValue(
-				AssetListPortletKeys.ASSET_LIST, "order-by-col", "create-date");
-		}
-
-		_orderByCol = orderByCol;
-
-		return _orderByCol;
-	}
-
 	private boolean _isSearch() {
 		if (Validator.isNotNull(_getKeywords())) {
 			return true;
@@ -448,9 +408,7 @@ public class AssetListDisplayContext {
 		_assetRendererFactoryClassProvider;
 	private final HttpServletRequest _httpServletRequest;
 	private String _keywords;
-	private String _orderByCol;
-	private String _orderByType;
-	private final PortalPreferences _portalPreferences;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
 	private Long _segmentsEntryId;

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/BasePublicationsDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/BasePublicationsDisplayContext.java
@@ -15,7 +15,7 @@
 package com.liferay.change.tracking.web.internal.display.context;
 
 import com.liferay.change.tracking.constants.CTPortletKeys;
-import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
@@ -36,6 +36,9 @@ public abstract class BasePublicationsDisplayContext {
 		HttpServletRequest httpServletRequest) {
 
 		_httpServletRequest = httpServletRequest;
+
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			_httpServletRequest, CTPortletKeys.PUBLICATIONS);
 
 		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
 			httpServletRequest);
@@ -76,68 +79,14 @@ public abstract class BasePublicationsDisplayContext {
 	protected abstract String getDefaultOrderByCol();
 
 	protected String getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		String orderByCol = ParamUtil.getString(
-			_httpServletRequest, SearchContainer.DEFAULT_ORDER_BY_COL_PARAM);
-
-		if (Validator.isNull(orderByCol)) {
-			orderByCol = _portalPreferences.getValue(
-				CTPortletKeys.PUBLICATIONS,
-				getPortalPreferencesPrefix() + "-order-by-col",
-				getDefaultOrderByCol());
-		}
-
-		try {
-			_portalPreferences.setValue(
-				CTPortletKeys.PUBLICATIONS,
-				getPortalPreferencesPrefix() + "-order-by-col", orderByCol);
-		}
-		catch (ConcurrentModificationException
-					concurrentModificationException) {
-
-			log.error(
-				concurrentModificationException,
-				concurrentModificationException);
-		}
-
-		_orderByCol = orderByCol;
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol(
+			getPortalPreferencesPrefix() + "-order-by-col",
+			getDefaultOrderByCol());
 	}
 
 	protected String getOrderByType() {
-		if (_orderByType != null) {
-			return _orderByType;
-		}
-
-		String orderByType = ParamUtil.getString(
-			_httpServletRequest, SearchContainer.DEFAULT_ORDER_BY_TYPE_PARAM);
-
-		if (Validator.isNull(orderByType)) {
-			orderByType = _portalPreferences.getValue(
-				CTPortletKeys.PUBLICATIONS,
-				getPortalPreferencesPrefix() + "-order-by-type", "desc");
-		}
-
-		try {
-			_portalPreferences.setValue(
-				CTPortletKeys.PUBLICATIONS,
-				getPortalPreferencesPrefix() + "-order-by-type", orderByType);
-		}
-		catch (ConcurrentModificationException
-					concurrentModificationException) {
-
-			log.error(
-				concurrentModificationException,
-				concurrentModificationException);
-		}
-
-		_orderByType = orderByType;
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType(
+			getPortalPreferencesPrefix() + "-order-by-type", "desc");
 	}
 
 	protected abstract String getPortalPreferencesPrefix();
@@ -147,8 +96,7 @@ public abstract class BasePublicationsDisplayContext {
 
 	private String _displayStyle;
 	private final HttpServletRequest _httpServletRequest;
-	private String _orderByCol;
-	private String _orderByType;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final PortalPreferences _portalPreferences;
 
 }

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/BasePublicationsDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/BasePublicationsDisplayContext.java
@@ -37,8 +37,14 @@ public abstract class BasePublicationsDisplayContext {
 
 		_httpServletRequest = httpServletRequest;
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			_httpServletRequest, CTPortletKeys.PUBLICATIONS);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, CTPortletKeys.PUBLICATIONS
+			).defaultOrderByCol(
+				getDefaultOrderByCol()
+			).defaultOrderByType(
+				"desc"
+			).build();
 
 		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
 			httpServletRequest);
@@ -80,13 +86,12 @@ public abstract class BasePublicationsDisplayContext {
 
 	protected String getOrderByCol() {
 		return _managementBarOrderByHandler.getOrderByCol(
-			getPortalPreferencesPrefix() + "-order-by-col",
-			getDefaultOrderByCol());
+			getPortalPreferencesPrefix() + "-order-by-col");
 	}
 
 	protected String getOrderByType() {
 		return _managementBarOrderByHandler.getOrderByType(
-			getPortalPreferencesPrefix() + "-order-by-type", "desc");
+			getPortalPreferencesPrefix() + "-order-by-type");
 	}
 
 	protected abstract String getPortalPreferencesPrefix();

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/display/context/BaseCPDefinitionsSearchContainerDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/display/context/BaseCPDefinitionsSearchContainerDisplayContext.java
@@ -50,13 +50,19 @@ public abstract class BaseCPDefinitionsSearchContainerDisplayContext<T>
 
 		super(actionHelper, httpServletRequest);
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			httpServletRequest, portalPreferenceNamespace);
-
 		_portalPreferenceNamespace = portalPreferenceNamespace;
 
 		_defaultOrderByCol = "modified-date";
 		_defaultOrderByType = "asc";
+
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, portalPreferenceNamespace
+			).defaultOrderByCol(
+				_defaultOrderByCol
+			).defaultOrderByType(
+				_defaultOrderByType
+			).build();
 	}
 
 	public String getDisplayStyle() {
@@ -94,11 +100,11 @@ public abstract class BaseCPDefinitionsSearchContainerDisplayContext<T>
 	}
 
 	public String getOrderByCol() {
-		return _managementBarOrderByHandler.getOrderByCol(_defaultOrderByCol);
+		return _managementBarOrderByHandler.getOrderByCol();
 	}
 
 	public String getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByType(_defaultOrderByType);
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	@Override
@@ -193,10 +199,28 @@ public abstract class BaseCPDefinitionsSearchContainerDisplayContext<T>
 
 	public void setDefaultOrderByCol(String defaultOrderByCol) {
 		_defaultOrderByCol = defaultOrderByCol;
+
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, _portalPreferenceNamespace
+			).defaultOrderByCol(
+				_defaultOrderByCol
+			).defaultOrderByType(
+				_defaultOrderByType
+			).build();
 	}
 
 	public void setDefaultOrderByType(String defaultOrderByType) {
 		_defaultOrderByType = defaultOrderByType;
+
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, _portalPreferenceNamespace
+			).defaultOrderByCol(
+				_defaultOrderByCol
+			).defaultOrderByType(
+				_defaultOrderByType
+			).build();
 	}
 
 	protected String getDisplayStyle(
@@ -245,7 +269,7 @@ public abstract class BaseCPDefinitionsSearchContainerDisplayContext<T>
 	private String _defaultOrderByType;
 	private String _displayStyle;
 	private String _keywords;
-	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
+	private ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final String _portalPreferenceNamespace;
 	private RowChecker _rowChecker;
 	private Integer _status;

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/display/context/BaseCPDefinitionsSearchContainerDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/display/context/BaseCPDefinitionsSearchContainerDisplayContext.java
@@ -16,6 +16,7 @@ package com.liferay.commerce.product.display.context;
 
 import com.liferay.commerce.product.portlet.action.ActionHelper;
 import com.liferay.frontend.taglib.servlet.taglib.ManagementBarFilterItem;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.RowChecker;
@@ -48,6 +49,9 @@ public abstract class BaseCPDefinitionsSearchContainerDisplayContext<T>
 		String portalPreferenceNamespace) {
 
 		super(actionHelper, httpServletRequest);
+
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			httpServletRequest, portalPreferenceNamespace);
 
 		_portalPreferenceNamespace = portalPreferenceNamespace;
 
@@ -90,52 +94,11 @@ public abstract class BaseCPDefinitionsSearchContainerDisplayContext<T>
 	}
 
 	public String getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		_orderByCol = ParamUtil.getString(httpServletRequest, "orderByCol");
-
-		if (Validator.isNull(_orderByCol)) {
-			_orderByCol = portalPreferences.getValue(
-				_portalPreferenceNamespace, "order-by-col", _defaultOrderByCol);
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				portalPreferences.setValue(
-					_portalPreferenceNamespace, "order-by-col", _orderByCol);
-			}
-		}
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol(_defaultOrderByCol);
 	}
 
 	public String getOrderByType() {
-		if (_orderByType != null) {
-			return _orderByType;
-		}
-
-		_orderByType = ParamUtil.getString(httpServletRequest, "orderByType");
-
-		if (Validator.isNull(_orderByType)) {
-			_orderByType = portalPreferences.getValue(
-				_portalPreferenceNamespace, "order-by-type",
-				_defaultOrderByType);
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				portalPreferences.setValue(
-					_portalPreferenceNamespace, "order-by-type", _orderByType);
-			}
-		}
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType(_defaultOrderByType);
 	}
 
 	@Override
@@ -282,8 +245,7 @@ public abstract class BaseCPDefinitionsSearchContainerDisplayContext<T>
 	private String _defaultOrderByType;
 	private String _displayStyle;
 	private String _keywords;
-	private String _orderByCol;
-	private String _orderByType;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final String _portalPreferenceNamespace;
 	private RowChecker _rowChecker;
 	private Integer _status;

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/BaseCPItemSelectorViewDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/BaseCPItemSelectorViewDisplayContext.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.product.item.selector.web.internal.display.context;
 
 import com.liferay.commerce.product.display.context.util.CPRequestHelper;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -44,6 +45,9 @@ public abstract class BaseCPItemSelectorViewDisplayContext<T> {
 		_portletURL = portletURL;
 		_itemSelectedEventName = itemSelectedEventName;
 		_portalPreferenceNamespace = portalPreferenceNamespace;
+
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			httpServletRequest, portalPreferenceNamespace);
 
 		portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
 			this.httpServletRequest);
@@ -81,52 +85,11 @@ public abstract class BaseCPItemSelectorViewDisplayContext<T> {
 	}
 
 	public String getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		_orderByCol = ParamUtil.getString(httpServletRequest, "orderByCol");
-
-		if (Validator.isNull(_orderByCol)) {
-			_orderByCol = portalPreferences.getValue(
-				_portalPreferenceNamespace, "order-by-col", _defaultOrderByCol);
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				portalPreferences.setValue(
-					_portalPreferenceNamespace, "order-by-col", _orderByCol);
-			}
-		}
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol(_defaultOrderByCol);
 	}
 
 	public String getOrderByType() {
-		if (_orderByType != null) {
-			return _orderByType;
-		}
-
-		_orderByType = ParamUtil.getString(httpServletRequest, "orderByType");
-
-		if (Validator.isNull(_orderByType)) {
-			_orderByType = portalPreferences.getValue(
-				_portalPreferenceNamespace, "order-by-type",
-				_defaultOrderByType);
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				portalPreferences.setValue(
-					_portalPreferenceNamespace, "order-by-type", _orderByType);
-			}
-		}
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType(_defaultOrderByType);
 	}
 
 	public PortletURL getPortletURL() {
@@ -206,8 +169,7 @@ public abstract class BaseCPItemSelectorViewDisplayContext<T> {
 	private String _displayStyle;
 	private final String _itemSelectedEventName;
 	private String _keywords;
-	private String _orderByCol;
-	private String _orderByType;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final String _portalPreferenceNamespace;
 	private final PortletURL _portletURL;
 	private RowChecker _rowChecker;

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/BaseCPItemSelectorViewDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/BaseCPItemSelectorViewDisplayContext.java
@@ -46,9 +46,6 @@ public abstract class BaseCPItemSelectorViewDisplayContext<T> {
 		_itemSelectedEventName = itemSelectedEventName;
 		_portalPreferenceNamespace = portalPreferenceNamespace;
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			httpServletRequest, portalPreferenceNamespace);
-
 		portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
 			this.httpServletRequest);
 
@@ -59,6 +56,15 @@ public abstract class BaseCPItemSelectorViewDisplayContext<T> {
 
 		_defaultOrderByCol = "title";
 		_defaultOrderByType = "asc";
+
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, portalPreferenceNamespace
+			).defaultOrderByCol(
+				_defaultOrderByCol
+			).defaultOrderByType(
+				_defaultOrderByType
+			).build();
 	}
 
 	public String getDisplayStyle() {
@@ -85,11 +91,11 @@ public abstract class BaseCPItemSelectorViewDisplayContext<T> {
 	}
 
 	public String getOrderByCol() {
-		return _managementBarOrderByHandler.getOrderByCol(_defaultOrderByCol);
+		return _managementBarOrderByHandler.getOrderByCol();
 	}
 
 	public String getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByType(_defaultOrderByType);
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	public PortletURL getPortletURL() {
@@ -121,10 +127,28 @@ public abstract class BaseCPItemSelectorViewDisplayContext<T> {
 
 	public void setDefaultOrderByCol(String defaultOrderByCol) {
 		_defaultOrderByCol = defaultOrderByCol;
+
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, _portalPreferenceNamespace
+			).defaultOrderByCol(
+				_defaultOrderByCol
+			).defaultOrderByType(
+				_defaultOrderByType
+			).build();
 	}
 
 	public void setDefaultOrderByType(String defaultOrderByType) {
 		_defaultOrderByType = defaultOrderByType;
+
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, _portalPreferenceNamespace
+			).defaultOrderByCol(
+				_defaultOrderByCol
+			).defaultOrderByType(
+				_defaultOrderByType
+			).build();
 	}
 
 	protected String getDisplayStyle(
@@ -169,7 +193,7 @@ public abstract class BaseCPItemSelectorViewDisplayContext<T> {
 	private String _displayStyle;
 	private final String _itemSelectedEventName;
 	private String _keywords;
-	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
+	private ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final String _portalPreferenceNamespace;
 	private final PortletURL _portletURL;
 	private RowChecker _rowChecker;

--- a/modules/apps/commerce/commerce-product-options-web/src/main/java/com/liferay/commerce/product/options/web/internal/display/context/BaseCPOptionsDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/java/com/liferay/commerce/product/options/web/internal/display/context/BaseCPOptionsDisplayContext.java
@@ -50,9 +50,6 @@ public abstract class BaseCPOptionsDisplayContext<T> {
 		_portalPreferenceNamespace = portalPreferenceNamespace;
 		_portletResourcePermission = portletResourcePermission;
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			httpServletRequest, portalPreferenceNamespace);
-
 		portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
 			this.httpServletRequest);
 
@@ -63,6 +60,15 @@ public abstract class BaseCPOptionsDisplayContext<T> {
 
 		_defaultOrderByCol = "title";
 		_defaultOrderByType = "asc";
+
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, _portalPreferenceNamespace
+			).defaultOrderByCol(
+				_defaultOrderByCol
+			).defaultOrderByType(
+				_defaultOrderByType
+			).build();
 	}
 
 	public String getDisplayStyle() {
@@ -75,11 +81,11 @@ public abstract class BaseCPOptionsDisplayContext<T> {
 	}
 
 	public String getOrderByCol() {
-		return _managementBarOrderByHandler.getOrderByCol(_defaultOrderByCol);
+		return _managementBarOrderByHandler.getOrderByCol();
 	}
 
 	public String getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByType(_defaultOrderByType);
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	public PortletURL getPortletURL() throws PortalException {
@@ -198,10 +204,28 @@ public abstract class BaseCPOptionsDisplayContext<T> {
 
 	protected void setDefaultOrderByCol(String defaultOrderByCol) {
 		_defaultOrderByCol = defaultOrderByCol;
+
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, _portalPreferenceNamespace
+			).defaultOrderByCol(
+				_defaultOrderByCol
+			).defaultOrderByType(
+				_defaultOrderByType
+			).build();
 	}
 
 	protected void setDefaultOrderByType(String defaultOrderByType) {
 		_defaultOrderByType = defaultOrderByType;
+
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, _portalPreferenceNamespace
+			).defaultOrderByCol(
+				_defaultOrderByCol
+			).defaultOrderByType(
+				_defaultOrderByType
+			).build();
 	}
 
 	protected final ActionHelper actionHelper;
@@ -216,7 +240,7 @@ public abstract class BaseCPOptionsDisplayContext<T> {
 	private String _defaultOrderByType;
 	private String _displayStyle;
 	private String _keywords;
-	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
+	private ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final String _portalPreferenceNamespace;
 	private final PortletResourcePermission _portletResourcePermission;
 	private RowChecker _rowChecker;

--- a/modules/apps/commerce/commerce-product-options-web/src/main/java/com/liferay/commerce/product/options/web/internal/display/context/BaseCPOptionsDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/java/com/liferay/commerce/product/options/web/internal/display/context/BaseCPOptionsDisplayContext.java
@@ -16,6 +16,7 @@ package com.liferay.commerce.product.options.web.internal.display.context;
 
 import com.liferay.commerce.product.display.context.util.CPRequestHelper;
 import com.liferay.commerce.product.options.web.internal.portlet.action.ActionHelper;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -49,6 +50,9 @@ public abstract class BaseCPOptionsDisplayContext<T> {
 		_portalPreferenceNamespace = portalPreferenceNamespace;
 		_portletResourcePermission = portletResourcePermission;
 
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			httpServletRequest, portalPreferenceNamespace);
+
 		portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
 			this.httpServletRequest);
 
@@ -71,52 +75,11 @@ public abstract class BaseCPOptionsDisplayContext<T> {
 	}
 
 	public String getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		_orderByCol = ParamUtil.getString(httpServletRequest, "orderByCol");
-
-		if (Validator.isNull(_orderByCol)) {
-			_orderByCol = portalPreferences.getValue(
-				_portalPreferenceNamespace, "order-by-col", _defaultOrderByCol);
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				portalPreferences.setValue(
-					_portalPreferenceNamespace, "order-by-col", _orderByCol);
-			}
-		}
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol(_defaultOrderByCol);
 	}
 
 	public String getOrderByType() {
-		if (_orderByType != null) {
-			return _orderByType;
-		}
-
-		_orderByType = ParamUtil.getString(httpServletRequest, "orderByType");
-
-		if (Validator.isNull(_orderByType)) {
-			_orderByType = portalPreferences.getValue(
-				_portalPreferenceNamespace, "order-by-type",
-				_defaultOrderByType);
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				portalPreferences.setValue(
-					_portalPreferenceNamespace, "order-by-type", _orderByType);
-			}
-		}
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType(_defaultOrderByType);
 	}
 
 	public PortletURL getPortletURL() throws PortalException {
@@ -253,8 +216,7 @@ public abstract class BaseCPOptionsDisplayContext<T> {
 	private String _defaultOrderByType;
 	private String _displayStyle;
 	private String _keywords;
-	private String _orderByCol;
-	private String _orderByType;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final String _portalPreferenceNamespace;
 	private final PortletResourcePermission _portletResourcePermission;
 	private RowChecker _rowChecker;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -34,6 +34,7 @@ import com.liferay.document.library.kernel.versioning.VersioningStrategy;
 import com.liferay.document.library.web.internal.display.context.logic.DLPortletInstanceSettingsHelper;
 import com.liferay.document.library.web.internal.display.context.util.DLRequestHelper;
 import com.liferay.document.library.web.internal.settings.DLPortletInstanceSettings;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -111,6 +112,15 @@ public class DLAdminDisplayContext {
 		_dlPortletInstanceSettingsHelper = new DLPortletInstanceSettingsHelper(
 			_dlRequestHelper);
 
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, DLPortletKeys.DOCUMENT_LIBRARY
+			).defaultOrderByCol(
+				"modifiedDate"
+			).defaultOrderByType(
+				"desc"
+			).build();
+
 		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
 			httpServletRequest);
 
@@ -177,10 +187,6 @@ public class DLAdminDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
 		String orderByCol = ParamUtil.getString(
 			_httpServletRequest, "orderByCol");
 
@@ -191,40 +197,12 @@ public class DLAdminDisplayContext {
 			orderByCol = "modifiedDate";
 		}
 
-		if (Validator.isNotNull(orderByCol)) {
-			_portalPreferences.setValue(
-				DLPortletKeys.DOCUMENT_LIBRARY, "order-by-col", orderByCol);
-		}
-		else {
-			orderByCol = _portalPreferences.getValue(
-				DLPortletKeys.DOCUMENT_LIBRARY, "order-by-col", "modifiedDate");
-		}
-
-		_orderByCol = orderByCol;
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol(
+			"order-by-col", orderByCol);
 	}
 
 	public String getOrderByType() {
-		if (_orderByType != null) {
-			return _orderByType;
-		}
-
-		String orderByType = ParamUtil.getString(
-			_httpServletRequest, "orderByType");
-
-		if (Validator.isNotNull(orderByType)) {
-			_portalPreferences.setValue(
-				DLPortletKeys.DOCUMENT_LIBRARY, "order-by-type", orderByType);
-		}
-		else {
-			orderByType = _portalPreferences.getValue(
-				DLPortletKeys.DOCUMENT_LIBRARY, "order-by-type", "desc");
-		}
-
-		_orderByType = orderByType;
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	public String getRememberCheckBoxStateURLRegex() {
@@ -787,9 +765,8 @@ public class DLAdminDisplayContext {
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private String _navigation;
-	private String _orderByCol;
-	private String _orderByType;
 	private final PermissionChecker _permissionChecker;
 	private final PortalPreferences _portalPreferences;
 	private Long _repositoryId;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryMetadataSetsDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryMetadataSetsDisplayContext.java
@@ -25,14 +25,13 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLinkLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureService;
 import com.liferay.dynamic.data.mapping.util.DDMUtil;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -48,6 +47,8 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionURL;
 import javax.portlet.PortletURL;
 import javax.portlet.RenderURL;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Rafael Praxedes
@@ -67,8 +68,13 @@ public class DLViewFileEntryMetadataSetsDisplayContext {
 
 		_portal = portal;
 
-		_dlRequestHelper = new DLRequestHelper(
-			_portal.getHttpServletRequest(liferayPortletRequest));
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			liferayPortletRequest);
+
+		_dlRequestHelper = new DLRequestHelper(httpServletRequest);
+
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			httpServletRequest, DDMPortletKeys.DYNAMIC_DATA_MAPPING);
 	}
 
 	public PortletURL getCopyDDMStructurePortletURL(DDMStructure ddmStructure) {
@@ -115,47 +121,13 @@ public class DLViewFileEntryMetadataSetsDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		PortalPreferences portalPreferences =
-			PortletPreferencesFactoryUtil.getPortalPreferences(
-				_liferayPortletRequest);
-
-		String orderByCol = ParamUtil.getString(
-			_liferayPortletRequest, "orderByCol");
-
-		if (Validator.isNull(orderByCol)) {
-			orderByCol = portalPreferences.getValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING, "entries-order-by-col",
-				"modified-date");
-		}
-		else {
-			portalPreferences.setValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING, "entries-order-by-col",
-				orderByCol);
-		}
-
-		return orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol(
+			"entries-order-by-col", "modified-date");
 	}
 
 	public String getOrderByType() {
-		PortalPreferences portalPreferences =
-			PortletPreferencesFactoryUtil.getPortalPreferences(
-				_liferayPortletRequest);
-
-		String orderByType = ParamUtil.getString(
-			_liferayPortletRequest, "orderByType");
-
-		if (Validator.isNull(orderByType)) {
-			orderByType = portalPreferences.getValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING, "entries-order-by-type",
-				"asc");
-		}
-		else {
-			portalPreferences.setValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING, "entries-order-by-type",
-				orderByType);
-		}
-
-		return orderByType;
+		return _managementBarOrderByHandler.getOrderByCol(
+			"entries-order-by-type");
 	}
 
 	public SearchContainer<DDMStructure> getStructureSearch() throws Exception {
@@ -426,6 +398,7 @@ public class DLViewFileEntryMetadataSetsDisplayContext {
 	private String _keywords;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final Portal _portal;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryMetadataSetsDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryMetadataSetsDisplayContext.java
@@ -73,8 +73,14 @@ public class DLViewFileEntryMetadataSetsDisplayContext {
 
 		_dlRequestHelper = new DLRequestHelper(httpServletRequest);
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			httpServletRequest, DDMPortletKeys.DYNAMIC_DATA_MAPPING);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, DDMPortletKeys.DYNAMIC_DATA_MAPPING
+			).defaultOrderByCol(
+				"modified-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 	}
 
 	public PortletURL getCopyDDMStructurePortletURL(DDMStructure ddmStructure) {
@@ -122,11 +128,11 @@ public class DLViewFileEntryMetadataSetsDisplayContext {
 
 	public String getOrderByCol() {
 		return _managementBarOrderByHandler.getOrderByCol(
-			"entries-order-by-col", "modified-date");
+			"entries-order-by-col");
 	}
 
 	public String getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByCol(
+		return _managementBarOrderByHandler.getOrderByType(
 			"entries-order-by-type");
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordsDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordsDisplayContext.java
@@ -36,14 +36,13 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.search.Field;
@@ -97,6 +96,10 @@ public class DDMFormViewFormInstanceRecordsDisplayContext {
 		_ddmFormInstance = ddmFormInstance;
 		_ddmFormInstanceRecordLocalService = ddmFormInstanceRecordLocalService;
 		_ddmFormFieldTypeServicesTracker = ddmFormFieldTypeServicesTracker;
+
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			PortalUtil.getHttpServletRequest(renderRequest),
+			DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_ADMIN);
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -292,43 +295,13 @@ public class DDMFormViewFormInstanceRecordsDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		PortalPreferences portalPreferences =
-			PortletPreferencesFactoryUtil.getPortalPreferences(_renderRequest);
-
-		String orderByCol = ParamUtil.getString(_renderRequest, "orderByCol");
-
-		if (Validator.isNull(orderByCol)) {
-			orderByCol = portalPreferences.getValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_ADMIN,
-				"view-entries-order-by-col", "modified-date");
-		}
-		else {
-			portalPreferences.setValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_ADMIN,
-				"view-entries-order-by-col", orderByCol);
-		}
-
-		return orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol(
+			"view-entries-order-by-col", "modified-date");
 	}
 
 	public String getOrderByType() {
-		PortalPreferences portalPreferences =
-			PortletPreferencesFactoryUtil.getPortalPreferences(_renderRequest);
-
-		String orderByType = ParamUtil.getString(_renderRequest, "orderByType");
-
-		if (Validator.isNull(orderByType)) {
-			orderByType = portalPreferences.getValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_ADMIN,
-				"view-entries-order-by-type", "asc");
-		}
-		else {
-			portalPreferences.setValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_ADMIN,
-				"view-entries-order-by-type", orderByType);
-		}
-
-		return orderByType;
+		return _managementBarOrderByHandler.getOrderByType(
+			"view-entries-order-by-type", "asc");
 	}
 
 	public PortletURL getPortletURL() {
@@ -714,6 +687,7 @@ public class DDMFormViewFormInstanceRecordsDisplayContext {
 	private final DDMFormInstance _ddmFormInstance;
 	private final DDMFormInstanceRecordLocalService
 		_ddmFormInstanceRecordLocalService;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordsDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordsDisplayContext.java
@@ -97,9 +97,15 @@ public class DDMFormViewFormInstanceRecordsDisplayContext {
 		_ddmFormInstanceRecordLocalService = ddmFormInstanceRecordLocalService;
 		_ddmFormFieldTypeServicesTracker = ddmFormFieldTypeServicesTracker;
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			PortalUtil.getHttpServletRequest(renderRequest),
-			DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_ADMIN);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				PortalUtil.getHttpServletRequest(renderRequest),
+				DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_ADMIN
+			).defaultOrderByCol(
+				"modified-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -296,12 +302,12 @@ public class DDMFormViewFormInstanceRecordsDisplayContext {
 
 	public String getOrderByCol() {
 		return _managementBarOrderByHandler.getOrderByCol(
-			"view-entries-order-by-col", "modified-date");
+			"view-entries-order-by-col");
 	}
 
 	public String getOrderByType() {
 		return _managementBarOrderByHandler.getOrderByType(
-			"view-entries-order-by-type", "asc");
+			"view-entries-order-by-type");
 	}
 
 	public PortletURL getPortletURL() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordsDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordsDisplayContextTest.java
@@ -29,6 +29,8 @@ import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -39,6 +41,7 @@ import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsImpl;
+import com.liferay.portlet.PortletPreferencesImpl;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -77,6 +80,8 @@ public class DDMFormViewFormInstanceRecordsDisplayContextTest
 	@Before
 	public void setUp() throws PortalException {
 		_setUpPortalUtil();
+
+		_setUpPortletPreferencesFactoryUtil();
 
 		_setUpDDMFormViewFormInstanceRecordsDisplayContext();
 	}
@@ -300,6 +305,24 @@ public class DDMFormViewFormInstanceRecordsDisplayContextTest
 		);
 
 		portalUtil.setPortal(portal);
+	}
+
+	private void _setUpPortletPreferencesFactoryUtil() {
+		PortletPreferencesFactoryUtil portletPreferencesFactoryUtil =
+			new PortletPreferencesFactoryUtil();
+
+		PortletPreferencesFactory portletPreferencesFactory = mock(
+			PortletPreferencesFactory.class);
+
+		when(
+			portletPreferencesFactory.getPreferences(
+				Mockito.any(HttpServletRequest.class))
+		).thenReturn(
+			new PortletPreferencesImpl()
+		);
+
+		portletPreferencesFactoryUtil.setPortletPreferencesFactory(
+			portletPreferencesFactory);
 	}
 
 	private DDMFormViewFormInstanceRecordsDisplayContext

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
@@ -45,6 +45,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuil
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemList;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringPool;
@@ -55,8 +56,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
@@ -112,8 +111,13 @@ public class DDMDisplayContext {
 		_ddmWebConfiguration = ddmWebConfiguration;
 		_storageAdapterRegistry = storageAdapterRegistry;
 
-		_ddmWebRequestHelper = new DDMWebRequestHelper(
-			PortalUtil.getHttpServletRequest(renderRequest));
+		HttpServletRequest httpServletRequest =
+			PortalUtil.getHttpServletRequest(renderRequest);
+
+		_ddmWebRequestHelper = new DDMWebRequestHelper(httpServletRequest);
+
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			httpServletRequest, DDMPortletKeys.DYNAMIC_DATA_MAPPING);
 	}
 
 	public boolean autogenerateStructureKey() {
@@ -263,43 +267,13 @@ public class DDMDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		PortalPreferences portalPreferences =
-			PortletPreferencesFactoryUtil.getPortalPreferences(_renderRequest);
-
-		String orderByCol = ParamUtil.getString(_renderRequest, "orderByCol");
-
-		if (Validator.isNull(orderByCol)) {
-			orderByCol = portalPreferences.getValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING, "entries-order-by-col",
-				"modified-date");
-		}
-		else {
-			portalPreferences.setValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING, "entries-order-by-col",
-				orderByCol);
-		}
-
-		return orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol(
+			"entries-order-by-col", "modified-date");
 	}
 
 	public String getOrderByType() {
-		PortalPreferences portalPreferences =
-			PortletPreferencesFactoryUtil.getPortalPreferences(_renderRequest);
-
-		String orderByType = ParamUtil.getString(_renderRequest, "orderByType");
-
-		if (Validator.isNull(orderByType)) {
-			orderByType = portalPreferences.getValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING, "entries-order-by-type",
-				"asc");
-		}
-		else {
-			portalPreferences.setValue(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING, "entries-order-by-type",
-				orderByType);
-		}
-
-		return orderByType;
+		return _managementBarOrderByHandler.getOrderByType(
+			"entries-order-by-type", "asc");
 	}
 
 	public String getRefererPortletName() {
@@ -1145,6 +1119,7 @@ public class DDMDisplayContext {
 	private final DDMTemplateService _ddmTemplateService;
 	private final DDMWebConfiguration _ddmWebConfiguration;
 	private final DDMWebRequestHelper _ddmWebRequestHelper;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
 	private final StorageAdapterRegistry _storageAdapterRegistry;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
@@ -116,8 +116,14 @@ public class DDMDisplayContext {
 
 		_ddmWebRequestHelper = new DDMWebRequestHelper(httpServletRequest);
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			httpServletRequest, DDMPortletKeys.DYNAMIC_DATA_MAPPING);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, DDMPortletKeys.DYNAMIC_DATA_MAPPING
+			).defaultOrderByCol(
+				"modified-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 	}
 
 	public boolean autogenerateStructureKey() {
@@ -268,12 +274,12 @@ public class DDMDisplayContext {
 
 	public String getOrderByCol() {
 		return _managementBarOrderByHandler.getOrderByCol(
-			"entries-order-by-col", "modified-date");
+			"entries-order-by-col");
 	}
 
 	public String getOrderByType() {
 		return _managementBarOrderByHandler.getOrderByType(
-			"entries-order-by-type", "asc");
+			"entries-order-by-type");
 	}
 
 	public String getRefererPortletName() {

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentCollectionsDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentCollectionsDisplayContext.java
@@ -53,8 +53,14 @@ public class FragmentCollectionsDisplayContext {
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			_httpServletRequest, FragmentPortletKeys.FRAGMENT);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				_httpServletRequest, FragmentPortletKeys.FRAGMENT
+			).defaultOrderByCol(
+				"create-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 	}
 
 	public String getEventName() {
@@ -70,7 +76,7 @@ public class FragmentCollectionsDisplayContext {
 	}
 
 	public String getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByType("asc");
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	public SearchContainer<FragmentCollection> getSearchContainer() {
@@ -160,7 +166,7 @@ public class FragmentCollectionsDisplayContext {
 	}
 
 	private String _getOrderByCol() {
-		return _managementBarOrderByHandler.getOrderByCol("create-date");
+		return _managementBarOrderByHandler.getOrderByCol();
 	}
 
 	private PortletURL _getPortletURL() {

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentCollectionsDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentCollectionsDisplayContext.java
@@ -18,13 +18,12 @@ import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionServiceUtil;
 import com.liferay.fragment.web.internal.util.FragmentPortletUtil;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -54,8 +53,8 @@ public class FragmentCollectionsDisplayContext {
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 
-		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
-			_httpServletRequest);
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			_httpServletRequest, FragmentPortletKeys.FRAGMENT);
 	}
 
 	public String getEventName() {
@@ -71,25 +70,7 @@ public class FragmentCollectionsDisplayContext {
 	}
 
 	public String getOrderByType() {
-		if (Validator.isNotNull(_orderByType)) {
-			return _orderByType;
-		}
-
-		String orderByType = ParamUtil.getString(
-			_httpServletRequest, "orderByType");
-
-		if (Validator.isNotNull(orderByType)) {
-			_portalPreferences.setValue(
-				FragmentPortletKeys.FRAGMENT, "order-by-type", orderByType);
-		}
-		else {
-			orderByType = _portalPreferences.getValue(
-				FragmentPortletKeys.FRAGMENT, "order-by-type", "asc");
-		}
-
-		_orderByType = orderByType;
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType("asc");
 	}
 
 	public SearchContainer<FragmentCollection> getSearchContainer() {
@@ -179,25 +160,7 @@ public class FragmentCollectionsDisplayContext {
 	}
 
 	private String _getOrderByCol() {
-		if (Validator.isNotNull(_orderByCol)) {
-			return _orderByCol;
-		}
-
-		String orderByCol = ParamUtil.getString(
-			_httpServletRequest, "orderByCol");
-
-		if (Validator.isNotNull(orderByCol)) {
-			_portalPreferences.setValue(
-				FragmentPortletKeys.FRAGMENT, "order-by-col", orderByCol);
-		}
-		else {
-			orderByCol = _portalPreferences.getValue(
-				FragmentPortletKeys.FRAGMENT, "order-by-col", "create-date");
-		}
-
-		_orderByCol = orderByCol;
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol("create-date");
 	}
 
 	private PortletURL _getPortletURL() {
@@ -268,9 +231,7 @@ public class FragmentCollectionsDisplayContext {
 	private final HttpServletRequest _httpServletRequest;
 	private Boolean _includeGlobalFragmentCollections;
 	private String _keywords;
-	private String _orderByCol;
-	private String _orderByType;
-	private final PortalPreferences _portalPreferences;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
 	private SearchContainer<FragmentCollection> _searchContainer;

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentCollectionsDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentCollectionsDisplayContext.java
@@ -14,6 +14,7 @@
 
 package com.liferay.fragment.web.internal.display.context;
 
+import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionServiceUtil;
 import com.liferay.fragment.web.internal.util.FragmentPortletUtil;
@@ -22,6 +23,8 @@ import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -50,6 +53,9 @@ public class FragmentCollectionsDisplayContext {
 		_httpServletRequest = httpServletRequest;
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
+
+		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
+			_httpServletRequest);
 	}
 
 	public String getEventName() {
@@ -69,8 +75,19 @@ public class FragmentCollectionsDisplayContext {
 			return _orderByType;
 		}
 
-		_orderByType = ParamUtil.getString(
-			_httpServletRequest, "orderByType", "asc");
+		String orderByType = ParamUtil.getString(
+			_httpServletRequest, "orderByType");
+
+		if (Validator.isNotNull(orderByType)) {
+			_portalPreferences.setValue(
+				FragmentPortletKeys.FRAGMENT, "order-by-type", orderByType);
+		}
+		else {
+			orderByType = _portalPreferences.getValue(
+				FragmentPortletKeys.FRAGMENT, "order-by-type", "asc");
+		}
+
+		_orderByType = orderByType;
 
 		return _orderByType;
 	}
@@ -166,8 +183,19 @@ public class FragmentCollectionsDisplayContext {
 			return _orderByCol;
 		}
 
-		_orderByCol = ParamUtil.getString(
-			_httpServletRequest, "orderByCol", "create-date");
+		String orderByCol = ParamUtil.getString(
+			_httpServletRequest, "orderByCol");
+
+		if (Validator.isNotNull(orderByCol)) {
+			_portalPreferences.setValue(
+				FragmentPortletKeys.FRAGMENT, "order-by-col", orderByCol);
+		}
+		else {
+			orderByCol = _portalPreferences.getValue(
+				FragmentPortletKeys.FRAGMENT, "order-by-col", "create-date");
+		}
+
+		_orderByCol = orderByCol;
 
 		return _orderByCol;
 	}
@@ -242,6 +270,7 @@ public class FragmentCollectionsDisplayContext {
 	private String _keywords;
 	private String _orderByCol;
 	private String _orderByType;
+	private final PortalPreferences _portalPreferences;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
 	private SearchContainer<FragmentCollection> _searchContainer;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/util/ManagementBarOrderByHandler.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/util/ManagementBarOrderByHandler.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.servlet.taglib.util;
+
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Mariano Álvaro Sáiz
+ */
+public class ManagementBarOrderByHandler {
+
+	public ManagementBarOrderByHandler(
+		HttpServletRequest httpServletRequest, String namespace) {
+
+		_httpServletRequest = httpServletRequest;
+		_namespace = namespace;
+
+		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
+			httpServletRequest);
+	}
+
+	public String getOrderByCol(String defaultOrderByCol) {
+		if (Validator.isNotNull(_orderByCol)) {
+			return _orderByCol;
+		}
+
+		String orderByCol = ParamUtil.getString(
+			_httpServletRequest, "orderByCol");
+
+		if (Validator.isNotNull(orderByCol)) {
+			_portalPreferences.setValue(_namespace, "order-by-col", orderByCol);
+		}
+		else {
+			orderByCol = _portalPreferences.getValue(
+				_namespace, "order-by-col", defaultOrderByCol);
+		}
+
+		_orderByCol = orderByCol;
+
+		return _orderByCol;
+	}
+
+	public String getOrderByType(String defaultOrderByType) {
+		if (Validator.isNotNull(_orderByType)) {
+			return _orderByType;
+		}
+
+		String orderByType = ParamUtil.getString(
+			_httpServletRequest, "orderByType");
+
+		if (Validator.isNotNull(orderByType)) {
+			_portalPreferences.setValue(
+				_namespace, "order-by-type", orderByType);
+		}
+		else {
+			orderByType = _portalPreferences.getValue(
+				_namespace, "order-by-type", defaultOrderByType);
+		}
+
+		_orderByType = orderByType;
+
+		return _orderByType;
+	}
+
+	private final HttpServletRequest _httpServletRequest;
+	private final String _namespace;
+	private String _orderByCol;
+	private String _orderByType;
+	private final PortalPreferences _portalPreferences;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/util/ManagementBarOrderByHandler.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/util/ManagementBarOrderByHandler.java
@@ -37,6 +37,12 @@ public class ManagementBarOrderByHandler {
 	}
 
 	public String getOrderByCol(String defaultOrderByCol) {
+		return getOrderByCol("order-by-col", defaultOrderByCol);
+	}
+
+	public String getOrderByCol(
+		String orderByColName, String defaultOrderByCol) {
+
 		if (Validator.isNotNull(_orderByCol)) {
 			return _orderByCol;
 		}
@@ -45,11 +51,11 @@ public class ManagementBarOrderByHandler {
 			_httpServletRequest, "orderByCol");
 
 		if (Validator.isNotNull(orderByCol)) {
-			_portalPreferences.setValue(_namespace, "order-by-col", orderByCol);
+			_portalPreferences.setValue(_namespace, orderByColName, orderByCol);
 		}
 		else {
 			orderByCol = _portalPreferences.getValue(
-				_namespace, "order-by-col", defaultOrderByCol);
+				_namespace, orderByColName, defaultOrderByCol);
 		}
 
 		_orderByCol = orderByCol;
@@ -58,6 +64,12 @@ public class ManagementBarOrderByHandler {
 	}
 
 	public String getOrderByType(String defaultOrderByType) {
+		return getOrderByType("order-by-type", defaultOrderByType);
+	}
+
+	public String getOrderByType(
+		String orderByTypeName, String defaultOrderByType) {
+
 		if (Validator.isNotNull(_orderByType)) {
 			return _orderByType;
 		}
@@ -67,11 +79,11 @@ public class ManagementBarOrderByHandler {
 
 		if (Validator.isNotNull(orderByType)) {
 			_portalPreferences.setValue(
-				_namespace, "order-by-type", orderByType);
+				_namespace, orderByTypeName, orderByType);
 		}
 		else {
 			orderByType = _portalPreferences.getValue(
-				_namespace, "order-by-type", defaultOrderByType);
+				_namespace, orderByTypeName, defaultOrderByType);
 		}
 
 		_orderByType = orderByType;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/util/ManagementBarOrderByHandler.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/util/ManagementBarOrderByHandler.java
@@ -26,36 +26,29 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class ManagementBarOrderByHandler {
 
-	public ManagementBarOrderByHandler(
-		HttpServletRequest httpServletRequest, String namespace) {
-
-		_httpServletRequest = httpServletRequest;
-		_namespace = namespace;
-
-		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
-			httpServletRequest);
+	public String getOrderByCol() {
+		return getOrderByCol("order-by-col");
 	}
 
-	public String getOrderByCol(String defaultOrderByCol) {
-		return getOrderByCol("order-by-col", defaultOrderByCol);
+	public String getOrderByCol(String orderByColName) {
+		return getOrderByCol(
+			orderByColName,
+			ParamUtil.getString(_httpServletRequest, "orderByCol"));
 	}
 
-	public String getOrderByCol(
-		String orderByColName, String defaultOrderByCol) {
-
+	public String getOrderByCol(String orderByColName, String orderByColValue) {
 		if (Validator.isNotNull(_orderByCol)) {
 			return _orderByCol;
 		}
 
-		String orderByCol = ParamUtil.getString(
-			_httpServletRequest, "orderByCol");
+		String orderByCol = orderByColValue;
 
 		if (Validator.isNotNull(orderByCol)) {
 			_portalPreferences.setValue(_namespace, orderByColName, orderByCol);
 		}
 		else {
 			orderByCol = _portalPreferences.getValue(
-				_namespace, orderByColName, defaultOrderByCol);
+				_namespace, orderByColName, _defaultOrderByCol);
 		}
 
 		_orderByCol = orderByCol;
@@ -63,13 +56,11 @@ public class ManagementBarOrderByHandler {
 		return _orderByCol;
 	}
 
-	public String getOrderByType(String defaultOrderByType) {
-		return getOrderByType("order-by-type", defaultOrderByType);
+	public String getOrderByType() {
+		return getOrderByType("order-by-type");
 	}
 
-	public String getOrderByType(
-		String orderByTypeName, String defaultOrderByType) {
-
+	public String getOrderByType(String orderByTypeName) {
 		if (Validator.isNotNull(_orderByType)) {
 			return _orderByType;
 		}
@@ -83,7 +74,7 @@ public class ManagementBarOrderByHandler {
 		}
 		else {
 			orderByType = _portalPreferences.getValue(
-				_namespace, orderByTypeName, defaultOrderByType);
+				_namespace, orderByTypeName, _defaultOrderByType);
 		}
 
 		_orderByType = orderByType;
@@ -91,6 +82,62 @@ public class ManagementBarOrderByHandler {
 		return _orderByType;
 	}
 
+	public static class ManagementBarOrderByHandlerBuilder {
+
+		public ManagementBarOrderByHandlerBuilder(
+			HttpServletRequest httpServletRequest, String namespace) {
+
+			_httpServletRequest = httpServletRequest;
+			_namespace = namespace;
+		}
+
+		public ManagementBarOrderByHandler build() {
+			ManagementBarOrderByHandler managementBarOrderByHandler =
+				new ManagementBarOrderByHandler(
+					_httpServletRequest, _namespace);
+
+			managementBarOrderByHandler._defaultOrderByCol = _defaultOrderByCol;
+			managementBarOrderByHandler._defaultOrderByType =
+				_defaultOrderByType;
+
+			return managementBarOrderByHandler;
+		}
+
+		public ManagementBarOrderByHandlerBuilder defaultOrderByCol(
+			String defaultOrderByCol) {
+
+			_defaultOrderByCol = defaultOrderByCol;
+
+			return this;
+		}
+
+		public ManagementBarOrderByHandlerBuilder defaultOrderByType(
+			String defaultOrderByType) {
+
+			_defaultOrderByType = defaultOrderByType;
+
+			return this;
+		}
+
+		private String _defaultOrderByCol;
+		private String _defaultOrderByType;
+		private HttpServletRequest _httpServletRequest;
+		private String _namespace;
+
+	}
+
+	private ManagementBarOrderByHandler(
+		HttpServletRequest httpServletRequest, String namespace) {
+
+		_httpServletRequest = httpServletRequest;
+		_namespace = namespace;
+
+		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
+			httpServletRequest);
+	}
+
+	private String _defaultOrderByCol;
+	private String _defaultOrderByType;
 	private final HttpServletRequest _httpServletRequest;
 	private final String _namespace;
 	private String _orderByCol;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/util/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutCollectionDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutCollectionDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.asset.list.service.AssetListEntryServiceUtil;
 import com.liferay.asset.list.util.AssetListPortletUtil;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.info.collection.provider.InfoCollectionProvider;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFormProvider;
@@ -31,8 +32,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -74,8 +73,8 @@ public class SelectLayoutCollectionDisplayContext {
 		_groupDisplayContextHelper = new GroupDisplayContextHelper(
 			_httpServletRequest);
 
-		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
-			_httpServletRequest);
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			_httpServletRequest, LayoutAdminPortletKeys.GROUP_PAGES);
 	}
 
 	public SearchContainer<InfoCollectionProvider<?>>
@@ -306,49 +305,11 @@ public class SelectLayoutCollectionDisplayContext {
 	}
 
 	private String _getOrderByCol() {
-		if (Validator.isNotNull(_orderByCol)) {
-			return _orderByCol;
-		}
-
-		String orderByCol = ParamUtil.getString(
-			_httpServletRequest, "orderByCol");
-
-		if (Validator.isNotNull(orderByCol)) {
-			_portalPreferences.setValue(
-				LayoutAdminPortletKeys.GROUP_PAGES, "order-by-col", orderByCol);
-		}
-		else {
-			orderByCol = _portalPreferences.getValue(
-				LayoutAdminPortletKeys.GROUP_PAGES, "order-by-col",
-				"create-date");
-		}
-
-		_orderByCol = orderByCol;
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol("create-date");
 	}
 
 	private String _getOrderByType() {
-		if (Validator.isNotNull(_orderByType)) {
-			return _orderByType;
-		}
-
-		String orderByType = ParamUtil.getString(
-			_httpServletRequest, "orderByType");
-
-		if (Validator.isNotNull(orderByType)) {
-			_portalPreferences.setValue(
-				LayoutAdminPortletKeys.GROUP_PAGES, "order-by-type",
-				orderByType);
-		}
-		else {
-			orderByType = _portalPreferences.getValue(
-				LayoutAdminPortletKeys.GROUP_PAGES, "order-by-type", "asc");
-		}
-
-		_orderByType = orderByType;
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType("asc");
 	}
 
 	private boolean _isSearch() {
@@ -368,9 +329,7 @@ public class SelectLayoutCollectionDisplayContext {
 	private String _keywords;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
-	private String _orderByCol;
-	private String _orderByType;
-	private final PortalPreferences _portalPreferences;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private String _redirect;
 	private String _selectedTab;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutCollectionDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutCollectionDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.info.collection.provider.InfoCollectionProvider;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFormProvider;
+import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -30,6 +31,8 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -69,6 +72,9 @@ public class SelectLayoutCollectionDisplayContext {
 			WebKeys.THEME_DISPLAY);
 
 		_groupDisplayContextHelper = new GroupDisplayContextHelper(
+			_httpServletRequest);
+
+		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
 			_httpServletRequest);
 	}
 
@@ -304,8 +310,20 @@ public class SelectLayoutCollectionDisplayContext {
 			return _orderByCol;
 		}
 
-		_orderByCol = ParamUtil.getString(
-			_httpServletRequest, "orderByCol", "create-date");
+		String orderByCol = ParamUtil.getString(
+			_httpServletRequest, "orderByCol");
+
+		if (Validator.isNotNull(orderByCol)) {
+			_portalPreferences.setValue(
+				LayoutAdminPortletKeys.GROUP_PAGES, "order-by-col", orderByCol);
+		}
+		else {
+			orderByCol = _portalPreferences.getValue(
+				LayoutAdminPortletKeys.GROUP_PAGES, "order-by-col",
+				"create-date");
+		}
+
+		_orderByCol = orderByCol;
 
 		return _orderByCol;
 	}
@@ -315,8 +333,20 @@ public class SelectLayoutCollectionDisplayContext {
 			return _orderByType;
 		}
 
-		_orderByType = ParamUtil.getString(
-			_httpServletRequest, "orderByType", "asc");
+		String orderByType = ParamUtil.getString(
+			_httpServletRequest, "orderByType");
+
+		if (Validator.isNotNull(orderByType)) {
+			_portalPreferences.setValue(
+				LayoutAdminPortletKeys.GROUP_PAGES, "order-by-type",
+				orderByType);
+		}
+		else {
+			orderByType = _portalPreferences.getValue(
+				LayoutAdminPortletKeys.GROUP_PAGES, "order-by-type", "asc");
+		}
+
+		_orderByType = orderByType;
 
 		return _orderByType;
 	}
@@ -340,6 +370,7 @@ public class SelectLayoutCollectionDisplayContext {
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private String _orderByCol;
 	private String _orderByType;
+	private final PortalPreferences _portalPreferences;
 	private String _redirect;
 	private String _selectedTab;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutCollectionDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutCollectionDisplayContext.java
@@ -73,8 +73,14 @@ public class SelectLayoutCollectionDisplayContext {
 		_groupDisplayContextHelper = new GroupDisplayContextHelper(
 			_httpServletRequest);
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			_httpServletRequest, LayoutAdminPortletKeys.GROUP_PAGES);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				_httpServletRequest, LayoutAdminPortletKeys.GROUP_PAGES
+			).defaultOrderByCol(
+				"create-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 	}
 
 	public SearchContainer<InfoCollectionProvider<?>>
@@ -305,11 +311,11 @@ public class SelectLayoutCollectionDisplayContext {
 	}
 
 	private String _getOrderByCol() {
-		return _managementBarOrderByHandler.getOrderByCol("create-date");
+		return _managementBarOrderByHandler.getOrderByCol();
 	}
 
 	private String _getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByType("asc");
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	private boolean _isSearch() {

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBEntriesManagementToolbarDisplayContext.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBEntriesManagementToolbarDisplayContext.java
@@ -78,8 +78,14 @@ public class MBEntriesManagementToolbarDisplayContext {
 		_currentURLObj = currentURLObj;
 		_trashHelper = trashHelper;
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			httpServletRequest, MBPortletKeys.MESSAGE_BOARDS_ADMIN);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, MBPortletKeys.MESSAGE_BOARDS_ADMIN
+			).defaultOrderByCol(
+				"modified-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -308,11 +314,11 @@ public class MBEntriesManagementToolbarDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		return _managementBarOrderByHandler.getOrderByCol("modified-date");
+		return _managementBarOrderByHandler.getOrderByCol();
 	}
 
 	public String getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByType("asc");
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	public PortletURL getPortletURL() {

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBEntriesManagementToolbarDisplayContext.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBEntriesManagementToolbarDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.constants.MBPortletKeys;
 import com.liferay.message.boards.model.MBCategory;
@@ -38,8 +39,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -79,9 +78,10 @@ public class MBEntriesManagementToolbarDisplayContext {
 		_currentURLObj = currentURLObj;
 		_trashHelper = trashHelper;
 
-		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
-			liferayPortletRequest);
-		_themeDisplay = (ThemeDisplay)_httpServletRequest.getAttribute(
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			httpServletRequest, MBPortletKeys.MESSAGE_BOARDS_ADMIN);
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 	}
 
@@ -308,49 +308,11 @@ public class MBEntriesManagementToolbarDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		String orderByCol = ParamUtil.getString(
-			_httpServletRequest, "orderByCol");
-
-		if (Validator.isNotNull(orderByCol)) {
-			_portalPreferences.setValue(
-				MBPortletKeys.MESSAGE_BOARDS_ADMIN, "order-by-col", orderByCol);
-		}
-		else {
-			orderByCol = _portalPreferences.getValue(
-				MBPortletKeys.MESSAGE_BOARDS_ADMIN, "order-by-col",
-				"modified-date");
-		}
-
-		_orderByCol = orderByCol;
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol("modified-date");
 	}
 
 	public String getOrderByType() {
-		if (_orderByType != null) {
-			return _orderByType;
-		}
-
-		String orderByType = ParamUtil.getString(
-			_httpServletRequest, "orderByType");
-
-		if (Validator.isNotNull(orderByType)) {
-			_portalPreferences.setValue(
-				MBPortletKeys.MESSAGE_BOARDS_ADMIN, "order-by-type",
-				orderByType);
-		}
-		else {
-			orderByType = _portalPreferences.getValue(
-				MBPortletKeys.MESSAGE_BOARDS_ADMIN, "order-by-type", "asc");
-		}
-
-		_orderByType = orderByType;
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType("asc");
 	}
 
 	public PortletURL getPortletURL() {
@@ -568,9 +530,7 @@ public class MBEntriesManagementToolbarDisplayContext {
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
-	private String _orderByCol;
-	private String _orderByType;
-	private final PortalPreferences _portalPreferences;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final ThemeDisplay _themeDisplay;
 	private final TrashHelper _trashHelper;
 

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/display/context/WorkflowTaskDisplayContext.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/display/context/WorkflowTaskDisplayContext.java
@@ -104,8 +104,14 @@ public class WorkflowTaskDisplayContext {
 		_httpServletRequest = PortalUtil.getHttpServletRequest(
 			liferayPortletRequest);
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			_httpServletRequest, PortletKeys.MY_WORKFLOW_TASK);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				_httpServletRequest, PortletKeys.MY_WORKFLOW_TASK
+			).defaultOrderByCol(
+				"last-activity-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)_liferayPortletRequest.getAttribute(
@@ -311,7 +317,7 @@ public class WorkflowTaskDisplayContext {
 	}
 
 	public String getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByType("asc");
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	public String getPortletResource() {
@@ -829,7 +835,7 @@ public class WorkflowTaskDisplayContext {
 	}
 
 	private String _getOrderByCol() {
-		return _managementBarOrderByHandler.getOrderByCol("last-activity-date");
+		return _managementBarOrderByHandler.getOrderByCol();
 	}
 
 	private UnsafeConsumer<DropdownItem, Exception> _getOrderByDropdownItem(

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/display/context/WorkflowTaskDisplayContext.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/display/context/WorkflowTaskDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItemList;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringBundler;
@@ -37,8 +38,6 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
@@ -105,8 +104,8 @@ public class WorkflowTaskDisplayContext {
 		_httpServletRequest = PortalUtil.getHttpServletRequest(
 			liferayPortletRequest);
 
-		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
-			_httpServletRequest);
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			_httpServletRequest, PortletKeys.MY_WORKFLOW_TASK);
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)_liferayPortletRequest.getAttribute(
@@ -312,18 +311,7 @@ public class WorkflowTaskDisplayContext {
 	}
 
 	public String getOrderByType() {
-		if (Validator.isNotNull(_orderByType)) {
-			return _orderByType;
-		}
-
-		_orderByType = ParamUtil.getString(_httpServletRequest, "orderByType");
-
-		if (Validator.isNull(_orderByType)) {
-			_orderByType = _portalPreferences.getValue(
-				PortletKeys.MY_WORKFLOW_TASK, "order-by-type", "asc");
-		}
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType("asc");
 	}
 
 	public String getPortletResource() {
@@ -841,19 +829,7 @@ public class WorkflowTaskDisplayContext {
 	}
 
 	private String _getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		_orderByCol = ParamUtil.getString(_httpServletRequest, "orderByCol");
-
-		if (Validator.isNull(_orderByCol)) {
-			_orderByCol = _portalPreferences.getValue(
-				PortletKeys.MY_WORKFLOW_TASK, "order-by-col",
-				"last-activity-date");
-		}
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol("last-activity-date");
 	}
 
 	private UnsafeConsumer<DropdownItem, Exception> _getOrderByDropdownItem(
@@ -1106,10 +1082,8 @@ public class WorkflowTaskDisplayContext {
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private String _navigation;
-	private String _orderByCol;
-	private String _orderByType;
-	private final PortalPreferences _portalPreferences;
 	private String _portletResource;
 	private final Map<Long, Role> _roles = new HashMap<>();
 	private final Map<Long, User> _users = new HashMap<>();

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowDefinitionLinkDisplayContext.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowDefinitionLinkDisplayContext.java
@@ -17,6 +17,7 @@ package com.liferay.portal.workflow.web.internal.display.context;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringPool;
@@ -31,8 +32,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.theme.PortletDisplay;
@@ -103,8 +102,8 @@ public class WorkflowDefinitionLinkDisplayContext {
 		_workflowDefinitionLinkRequestHelper =
 			new WorkflowDefinitionLinkRequestHelper(renderRequest);
 
-		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
-			_httpServletRequest);
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			_httpServletRequest, WorkflowPortletKeys.CONTROL_PANEL_WORKFLOW);
 
 		_resourceBundleLoader = resourceBundleLoader;
 	}
@@ -195,55 +194,13 @@ public class WorkflowDefinitionLinkDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		_orderByCol = ParamUtil.getString(_httpServletRequest, "orderByCol");
-
-		if (Validator.isNull(_orderByCol)) {
-			_orderByCol = _portalPreferences.getValue(
-				WorkflowPortletKeys.CONTROL_PANEL_WORKFLOW,
-				"definition-link-order-by-col", "resource");
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				_httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				_portalPreferences.setValue(
-					WorkflowPortletKeys.CONTROL_PANEL_WORKFLOW,
-					"definition-link-order-by-col", _orderByCol);
-			}
-		}
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol(
+			"definition-link-order-by-col", "resource");
 	}
 
 	public String getOrderByType() {
-		if (_orderByType != null) {
-			return _orderByType;
-		}
-
-		_orderByType = ParamUtil.getString(_httpServletRequest, "orderByType");
-
-		if (Validator.isNull(_orderByType)) {
-			_orderByType = _portalPreferences.getValue(
-				WorkflowPortletKeys.CONTROL_PANEL_WORKFLOW,
-				"definition-link-order-by-type", "asc");
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				_httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				_portalPreferences.setValue(
-					WorkflowPortletKeys.CONTROL_PANEL_WORKFLOW,
-					"definition-link-order-by-type", _orderByType);
-			}
-		}
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType(
+			"definition-link-order-by-type", "asc");
 	}
 
 	public PortletURL getPortletURL() {
@@ -710,9 +667,7 @@ public class WorkflowDefinitionLinkDisplayContext {
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
-	private String _orderByCol;
-	private String _orderByType;
-	private final PortalPreferences _portalPreferences;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private final ResourceBundleLoader _resourceBundleLoader;
 	private final WorkflowDefinitionLinkLocalService
 		_workflowDefinitionLinkLocalService;

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowDefinitionLinkDisplayContext.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowDefinitionLinkDisplayContext.java
@@ -102,8 +102,14 @@ public class WorkflowDefinitionLinkDisplayContext {
 		_workflowDefinitionLinkRequestHelper =
 			new WorkflowDefinitionLinkRequestHelper(renderRequest);
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			_httpServletRequest, WorkflowPortletKeys.CONTROL_PANEL_WORKFLOW);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				_httpServletRequest, WorkflowPortletKeys.CONTROL_PANEL_WORKFLOW
+			).defaultOrderByCol(
+				"resource"
+			).defaultOrderByType(
+				"asc"
+			).build();
 
 		_resourceBundleLoader = resourceBundleLoader;
 	}
@@ -195,12 +201,12 @@ public class WorkflowDefinitionLinkDisplayContext {
 
 	public String getOrderByCol() {
 		return _managementBarOrderByHandler.getOrderByCol(
-			"definition-link-order-by-col", "resource");
+			"definition-link-order-by-col");
 	}
 
 	public String getOrderByType() {
 		return _managementBarOrderByHandler.getOrderByType(
-			"definition-link-order-by-type", "asc");
+			"definition-link-order-by-type");
 	}
 
 	public PortletURL getPortletURL() {

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowInstanceViewDisplayContext.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowInstanceViewDisplayContext.java
@@ -78,8 +78,14 @@ public class WorkflowInstanceViewDisplayContext
 
 		super(liferayPortletRequest, liferayPortletResponse);
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			httpServletRequest, WorkflowPortletKeys.USER_WORKFLOW);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest, WorkflowPortletKeys.USER_WORKFLOW
+			).defaultOrderByCol(
+				"last-activity-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 	}
 
 	public String getAssetIconCssClass(WorkflowInstance workflowInstance) {
@@ -225,12 +231,12 @@ public class WorkflowInstanceViewDisplayContext
 
 	public String getOrderByCol() {
 		return _managementBarOrderByHandler.getOrderByCol(
-			"instance-order-by-col", "last-activity-date");
+			"instance-order-by-col");
 	}
 
 	public String getOrderByType() {
 		return _managementBarOrderByHandler.getOrderByType(
-			"instance-order-by-type", "asc");
+			"instance-order-by-type");
 	}
 
 	public List<WorkflowHandler<?>> getSearchableAssetsWorkflowHandlers() {

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowInstanceViewDisplayContext.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowInstanceViewDisplayContext.java
@@ -18,6 +18,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItemList;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringPool;
@@ -76,6 +77,9 @@ public class WorkflowInstanceViewDisplayContext
 		throws PortalException {
 
 		super(liferayPortletRequest, liferayPortletResponse);
+
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			httpServletRequest, WorkflowPortletKeys.USER_WORKFLOW);
 	}
 
 	public String getAssetIconCssClass(WorkflowInstance workflowInstance) {
@@ -220,55 +224,13 @@ public class WorkflowInstanceViewDisplayContext
 	}
 
 	public String getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		_orderByCol = ParamUtil.getString(httpServletRequest, "orderByCol");
-
-		if (Validator.isNull(_orderByCol)) {
-			_orderByCol = portalPreferences.getValue(
-				WorkflowPortletKeys.USER_WORKFLOW, "instance-order-by-col",
-				"last-activity-date");
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				portalPreferences.setValue(
-					WorkflowPortletKeys.USER_WORKFLOW, "instance-order-by-col",
-					_orderByCol);
-			}
-		}
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol(
+			"instance-order-by-col", "last-activity-date");
 	}
 
 	public String getOrderByType() {
-		if (_orderByType != null) {
-			return _orderByType;
-		}
-
-		_orderByType = ParamUtil.getString(httpServletRequest, "orderByType");
-
-		if (Validator.isNull(_orderByType)) {
-			_orderByType = portalPreferences.getValue(
-				WorkflowPortletKeys.USER_WORKFLOW, "instance-order-by-type",
-				"asc");
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				portalPreferences.setValue(
-					WorkflowPortletKeys.USER_WORKFLOW, "instance-order-by-type",
-					_orderByType);
-			}
-		}
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType(
+			"instance-order-by-type", "asc");
 	}
 
 	public List<WorkflowHandler<?>> getSearchableAssetsWorkflowHandlers() {
@@ -578,9 +540,8 @@ public class WorkflowInstanceViewDisplayContext
 
 	private String _displayStyle;
 	private String _keywords;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private String _navigation;
-	private String _orderByCol;
-	private String _orderByType;
 	private WorkflowInstanceSearch _searchContainer;
 
 }

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UsersDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UsersDisplayContext.java
@@ -62,9 +62,15 @@ public class UsersDisplayContext {
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			httpServletRequest,
-			SiteMembershipsPortletKeys.SITE_MEMBERSHIPS_ADMIN);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				httpServletRequest,
+				SiteMembershipsPortletKeys.SITE_MEMBERSHIPS_ADMIN
+			).defaultOrderByCol(
+				"modified-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 	}
 
 	public String getDisplayStyle() {
@@ -118,11 +124,11 @@ public class UsersDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		return _managementBarOrderByHandler.getOrderByCol("modified-date");
+		return _managementBarOrderByHandler.getOrderByCol();
 	}
 
 	public String getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByType("asc");
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	public PortletURL getPortletURL() {

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UsersDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UsersDisplayContext.java
@@ -14,6 +14,7 @@
 
 package com.liferay.site.memberships.web.internal.display.context;
 
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -21,8 +22,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.SearchDisplayStyleUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
@@ -63,8 +62,9 @@ public class UsersDisplayContext {
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 
-		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
-			_httpServletRequest);
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			httpServletRequest,
+			SiteMembershipsPortletKeys.SITE_MEMBERSHIPS_ADMIN);
 	}
 
 	public String getDisplayStyle() {
@@ -118,45 +118,11 @@ public class UsersDisplayContext {
 	}
 
 	public String getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		_orderByCol = ParamUtil.getString(_httpServletRequest, "orderByCol");
-
-		if (Validator.isNull(_orderByCol)) {
-			_orderByCol = _portalPreferences.getValue(
-				SiteMembershipsPortletKeys.SITE_MEMBERSHIPS_ADMIN,
-				"order-by-col", "modified-date");
-		}
-		else {
-			_portalPreferences.setValue(
-				SiteMembershipsPortletKeys.SITE_MEMBERSHIPS_ADMIN,
-				"order-by-col", _orderByCol);
-		}
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol("modified-date");
 	}
 
 	public String getOrderByType() {
-		if (_orderByType != null) {
-			return _orderByType;
-		}
-
-		_orderByType = ParamUtil.getString(_httpServletRequest, "orderByType");
-
-		if (Validator.isNull(_orderByType)) {
-			_orderByType = _portalPreferences.getValue(
-				SiteMembershipsPortletKeys.SITE_MEMBERSHIPS_ADMIN,
-				"order-by-type", "asc");
-		}
-		else {
-			_portalPreferences.setValue(
-				SiteMembershipsPortletKeys.SITE_MEMBERSHIPS_ADMIN,
-				"order-by-type", _orderByType);
-		}
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType("asc");
 	}
 
 	public PortletURL getPortletURL() {
@@ -337,10 +303,8 @@ public class UsersDisplayContext {
 	private Long _groupId;
 	private final HttpServletRequest _httpServletRequest;
 	private String _keywords;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private String _navigation;
-	private String _orderByCol;
-	private String _orderByType;
-	private final PortalPreferences _portalPreferences;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
 	private Role _role;

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/admin/display/context/ReportsEngineDisplayContext.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/admin/display/context/ReportsEngineDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItemList;
+import com.liferay.frontend.taglib.servlet.taglib.util.ManagementBarOrderByHandler;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringPool;
@@ -75,8 +76,8 @@ public class ReportsEngineDisplayContext {
 		_httpServletRequest = PortalUtil.getHttpServletRequest(
 			liferayPortletRequest);
 
-		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
-			_httpServletRequest);
+		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
+			_httpServletRequest, ReportsEngineConsolePortletKeys.REPORTS_ADMIN);
 
 		_reportsEngineRequestHelper = new ReportsEngineRequestHelper(
 			_httpServletRequest);
@@ -188,29 +189,7 @@ public class ReportsEngineDisplayContext {
 	}
 
 	public String getOrderByType() {
-		if (_orderByType != null) {
-			return _orderByType;
-		}
-
-		_orderByType = ParamUtil.getString(_httpServletRequest, "orderByType");
-
-		if (Validator.isNull(_orderByType)) {
-			_orderByType = _portalPreferences.getValue(
-				ReportsEngineConsolePortletKeys.REPORTS_ADMIN, "order-by-type",
-				"asc");
-		}
-		else {
-			boolean saveOrderBy = ParamUtil.getBoolean(
-				_httpServletRequest, "saveOrderBy");
-
-			if (saveOrderBy) {
-				_portalPreferences.setValue(
-					ReportsEngineConsolePortletKeys.REPORTS_ADMIN,
-					"order-by-type", _orderByType);
-			}
-		}
-
-		return _orderByType;
+		return _managementBarOrderByHandler.getOrderByType("asc");
 	}
 
 	public PortletURL getPortletURL() {
@@ -466,19 +445,7 @@ public class ReportsEngineDisplayContext {
 	}
 
 	private String _getOrderByCol() {
-		if (_orderByCol != null) {
-			return _orderByCol;
-		}
-
-		_orderByCol = ParamUtil.getString(_httpServletRequest, "orderByCol");
-
-		if (Validator.isNull(_orderByCol)) {
-			_orderByCol = _portalPreferences.getValue(
-				ReportsEngineConsolePortletKeys.REPORTS_ADMIN, "order-by-col",
-				"create-date");
-		}
-
-		return _orderByCol;
+		return _managementBarOrderByHandler.getOrderByCol("create-date");
 	}
 
 	private UnsafeConsumer<DropdownItem, Exception> _getOrderByDropdownItem(
@@ -552,10 +519,8 @@ public class ReportsEngineDisplayContext {
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
+	private final ManagementBarOrderByHandler _managementBarOrderByHandler;
 	private String _navigation;
-	private String _orderByCol;
-	private String _orderByType;
-	private final PortalPreferences _portalPreferences;
 	private final ReportsEngineRequestHelper _reportsEngineRequestHelper;
 	private SearchContainer<?> _searchContainer;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/admin/display/context/ReportsEngineDisplayContext.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/admin/display/context/ReportsEngineDisplayContext.java
@@ -76,8 +76,15 @@ public class ReportsEngineDisplayContext {
 		_httpServletRequest = PortalUtil.getHttpServletRequest(
 			liferayPortletRequest);
 
-		_managementBarOrderByHandler = new ManagementBarOrderByHandler(
-			_httpServletRequest, ReportsEngineConsolePortletKeys.REPORTS_ADMIN);
+		_managementBarOrderByHandler =
+			new ManagementBarOrderByHandler.ManagementBarOrderByHandlerBuilder(
+				_httpServletRequest,
+				ReportsEngineConsolePortletKeys.REPORTS_ADMIN
+			).defaultOrderByCol(
+				"create-date"
+			).defaultOrderByType(
+				"asc"
+			).build();
 
 		_reportsEngineRequestHelper = new ReportsEngineRequestHelper(
 			_httpServletRequest);
@@ -189,7 +196,7 @@ public class ReportsEngineDisplayContext {
 	}
 
 	public String getOrderByType() {
-		return _managementBarOrderByHandler.getOrderByType("asc");
+		return _managementBarOrderByHandler.getOrderByType();
 	}
 
 	public PortletURL getPortletURL() {
@@ -445,7 +452,7 @@ public class ReportsEngineDisplayContext {
 	}
 
 	private String _getOrderByCol() {
-		return _managementBarOrderByHandler.getOrderByCol("create-date");
+		return _managementBarOrderByHandler.getOrderByCol();
 	}
 
 	private UnsafeConsumer<DropdownItem, Exception> _getOrderByDropdownItem(


### PR DESCRIPTION
**Steps to Reproduce:**

1. Go to Site Builder > Collections.
2. Create a collection "beta test"
3. Create collection "alpha test".
4. Change to sort by title.
5. Navigate to a different menu option.
6. Go back to Site Builder > Collections.

**Actual Results:**
Sort is done by create date.

**Expected Results:**
Sort should be done by last chosen option (title).


This is a recurrent bug, and usually the retrieval/saving is done in many different ways, that's why a general approach was followed.