### PR TITLE
LPS-138982 Update `liferay-font-awesome` to 3.4.2

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/package.json
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"liferay-font-awesome": "3.4.1"
+		"liferay-font-awesome": "3.4.2"
 	},
 	"name": "frontend-theme-font-awesome-web",
 	"version": "3.0.9"

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/flexibleLayout/apps/js-theme/package.json
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/flexibleLayout/apps/js-theme/package.json
@@ -2,7 +2,7 @@
 	"devDependencies": {
 		"compass-mixins": "0.12.10",
 		"gulp": "4.0.2",
-		"liferay-font-awesome": "3.4.0",
+		"liferay-font-awesome": "3.4.2",
 		"liferay-frontend-common-css": "1.0.4",
 		"liferay-frontend-theme-styled": "5.0.0",
 		"liferay-frontend-theme-unstyled": "5.0.0",

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/flexibleLayoutLegacy/themes/js-theme/package.json
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/flexibleLayoutLegacy/themes/js-theme/package.json
@@ -2,7 +2,7 @@
 	"devDependencies": {
 		"compass-mixins": "0.12.10",
 		"gulp": "4.0.2",
-		"liferay-font-awesome": "3.4.0",
+		"liferay-font-awesome": "3.4.2",
 		"liferay-frontend-common-css": "1.0.4",
 		"liferay-frontend-theme-styled": "5.0.0",
 		"liferay-frontend-theme-unstyled": "5.0.0",

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/flexibleLayoutWildcard/themes/js-theme/package.json
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/flexibleLayoutWildcard/themes/js-theme/package.json
@@ -2,7 +2,7 @@
 	"devDependencies": {
 		"compass-mixins": "0.12.10",
 		"gulp": "4.0.2",
-		"liferay-font-awesome": "3.4.0",
+		"liferay-font-awesome": "3.4.2",
 		"liferay-frontend-common-css": "1.0.4",
 		"liferay-frontend-theme-styled": "5.0.0",
 		"liferay-frontend-theme-unstyled": "5.0.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -9612,16 +9612,6 @@ leaflet@1.7.1:
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.7.1.tgz#10d684916edfe1bf41d688a3b97127c0322a2a19"
   integrity sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==
 
-less@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/less/-/less-1.4.1.tgz#4a93e97abb5c33514434a8e80749fe9f5eb871f6"
-  integrity sha1-SpPpertcM1FENKjoB0n+n164cfY=
-  optionalDependencies:
-    mime "1.2.x"
-    mkdirp "~0.3.4"
-    request ">=2.12.0"
-    ycssmin ">=1.0.1"
-
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -9655,12 +9645,10 @@ liferay-ckeditor@4.16.2-liferay.1:
   resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.16.2-liferay.1.tgz#f78cdb74d3f8802d691acb072e1f026c196a1aa1"
   integrity sha512-k6M0sNJbx+sWOBDwgTBUcwuROfkopBb5QXvR/tLtZ4aWGTI6prqX/LKAe4gSvGy0p9Q/AyYQU7SMzeb+WlgJzQ==
 
-liferay-font-awesome@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/liferay-font-awesome/-/liferay-font-awesome-3.4.1.tgz#a53e12af499f7f68395168b5eebbab0d8d396e6e"
-  integrity sha512-43g2Iyr/BvCMKPNlbob7I8TIZZ480K/pQP2EfPabmgvMQG/VLZJALMauxd8OgV0IxdgJJ4IDQU7wW7gOiu7scQ==
-  dependencies:
-    less "1.4.1"
+liferay-font-awesome@3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/liferay-font-awesome/-/liferay-font-awesome-3.4.2.tgz#346556045e5d9a6168592ef5c10f2ed3e49e5382"
+  integrity sha512-kO7/22o6tPyF+WMZUvbPtAmaRETxoKCv47tPglsRnck62sOyIM8wh/Chxysv/Z18YOrmKFru1LbC7kBeRPY+pQ==
 
 liferay-frontend-common-css@1.0.4, liferay-frontend-common-css@^1.0.4:
   version "1.0.4"
@@ -10851,11 +10839,6 @@ mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, 
   dependencies:
     mime-db "1.44.0"
 
-mime@1.2.x:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
-  integrity sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=
-
 mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
@@ -10964,11 +10947,6 @@ mixin-deep@^1.2.0:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mkdirp@~0.3.4:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
-  integrity sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=
 
 moment@2.24.0, moment@^2.22.2, moment@^2.24.0:
   version "2.24.0"
@@ -13387,7 +13365,7 @@ request-promise-native@^1.0.5, request-promise-native@^1.0.7:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@>=2.12.0, request@^2.87.0, request@^2.88.0:
+request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -16463,11 +16441,6 @@ yazl@^2.1.0:
   integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
   dependencies:
     buffer-crc32 "~0.2.3"
-
-ycssmin@>=1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ycssmin/-/ycssmin-1.0.1.tgz#7cdde8db78cfab00d2901c3b2301e304faf4df16"
-  integrity sha1-fN3o23jPqwDSkBw7IwHjBPr03xY=
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-138982

New version contains a single change: https://github.com/liferay/alloy-font-awesome/pull/5

@holatuwol @jbalsas 

Notes: 
- For this PR, I ran `yarn add` on DXP module. That updated the `yarn-lock` file, interestingly removing the offending `mime@1.2.x`.  [Advisor](https://www.npmjs.com/advisories/535) states 'Update to version 2.0.3 or later', and we still have `mime@1.6.0` in `yarn.lock`. That means some other library is using it and this issue may popup again in the future.
- I only increased version on SDK modules. `yarn add` created `yarn.lock` in SDK modules, I am not sure if we want that.

Testing:
```cmd
⋊> ~/temp mkdir test
⋊> ~/temp cd test/ 
⋊> ~/t/test echo '{}' > package.json
⋊> ~/t/test npm install liferay-font-awesome@3.4.1
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated mkdirp@0.3.5: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN test No description
npm WARN test No repository field.
npm WARN test No license field.

+ liferay-font-awesome@3.4.1
added 52 packages from 67 contributors and audited 52 packages in 5.061s
found 1 moderate severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details
⋊> ~/t/test npm install liferay-font-awesome@3.4.2
npm WARN test No description
npm WARN test No repository field.
npm WARN test No license field.

+ liferay-font-awesome@3.4.2
removed 51 packages, updated 1 package and audited 1 package in 4.251s
found 0 vulnerabilities

⋊> ~/t/test npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
found 0 vulnerabilities
 in 1 scanned package
⋊> ~/t/test     
```