### PR TITLE
LPS-135874 Check for anonymous users in Questions

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardThreadDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardThreadDTOConverter.java
@@ -95,9 +95,6 @@ public class MessageBoardThreadDTOConverter
 				articleBody = mbMessage.getBody();
 				creator = CreatorUtil.toCreator(
 					_portal, dtoConverterContext.getUriInfoOptional(), user);
-				creatorStatistics = CreatorStatisticsUtil.toCreatorStatistics(
-					mbMessage.getGroupId(), languageId,
-					_mbStatsUserLocalService, uriInfoOptional.get(), user);
 				customFields = CustomFieldsUtil.toCustomFields(
 					dtoConverterContext.isAcceptAllLanguages(),
 					MBMessage.class.getName(), mbMessage.getMessageId(),
@@ -152,6 +149,23 @@ public class MessageBoardThreadDTOConverter
 				threadType = _toThreadType(
 					languageId, mbThread.getGroupId(), mbThread.getPriority());
 				viewCount = mbThread.getViewCount();
+
+				setCreatorStatistics(
+					() -> {
+						if (mbMessage.isAnonymous() || (user == null) ||
+							user.isDefaultUser()) {
+
+							return null;
+						}
+
+						Optional<UriInfo> uriInfoOptional =
+							dtoConverterContext.getUriInfoOptional();
+
+						return CreatorStatisticsUtil.toCreatorStatistics(
+							mbMessage.getGroupId(), languageId,
+							_mbStatsUserLocalService,
+							uriInfoOptional.orElse(null), user);
+					});
 			}
 		};
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardThreadDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardThreadDTOConverter.java
@@ -82,8 +82,6 @@ public class MessageBoardThreadDTOConverter
 			dtoConverterContext.getLocale());
 		MBMessage mbMessage = _mbMessageLocalService.getMessage(
 			mbThread.getRootMessageId());
-		Optional<UriInfo> uriInfoOptional =
-			dtoConverterContext.getUriInfoOptional();
 		User user = _userLocalService.fetchUser(mbThread.getUserId());
 
 		return new MessageBoardThread() {

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/CreatorRow.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/CreatorRow.es.js
@@ -29,19 +29,24 @@ export default withRouter(
 	}) => (
 		<Link
 			className="align-items-center border-light btn btn-secondary c-ml-md-3 c-mt-3 c-mt-md-0 c-p-3 d-inline-flex justify-content-center position-relative questions-user"
-			to={`/questions/${sectionTitle}/creator/${creator.id}`}
+			to={`/questions/${sectionTitle}${
+				creator ? `/creator/${creator.id}` : ''
+			}`}
 		>
 			<UserIcon
-				fullName={creator.name}
-				portraitURL={creator.image}
-				userId={String(creator.id)}
+				fullName={creator?.name}
+				portraitURL={creator?.image}
+				userId={String(creator?.id)}
 			/>
 
 			<div className="c-ml-3 text-left">
 				<p className="c-mb-0 small">{timeDifference(dateCreated)}</p>
 
 				<p className="c-mb-0 font-weight-bold text-dark">
-					{creator.name}
+					{creator?.name ||
+						Liferay.Language.get(
+							'anonymous-user-configuration-name'
+						)}
 				</p>
 			</div>
 

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionRow.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionRow.es.js
@@ -38,6 +38,20 @@ export default ({currentSection, items, question, showSectionLabel}) => {
 			: question.messageBoardSection &&
 			  question.messageBoardSection.title;
 
+	const creatorInformation = question.creator
+		? {
+				link: `/questions/${sectionTitle}/creator/${question.creator.id}`,
+				name: question.creator.name,
+				portraitURL: question.creator.image,
+				userId: String(question.creator.id),
+		  }
+		: {
+				link: `/questions/${sectionTitle}`,
+				name: '',
+				portraitURL: '',
+				userId: '0',
+		  };
+
 	return (
 		<div className="c-mt-4 c-p-3 position-relative question-row text-secondary">
 			<div className="align-items-center d-flex flex-wrap justify-content-between">
@@ -150,22 +164,21 @@ export default ({currentSection, items, question, showSectionLabel}) => {
 
 			<div className="align-items-sm-center align-items-start d-flex flex-column-reverse flex-sm-row justify-content-between">
 				<div className="c-mt-3 c-mt-sm-0 stretched-link-layer">
-					{question.creator && (
-						<Link
-							to={`/questions/${sectionTitle}/creator/${question.creator.id}`}
-						>
-							<UserIcon
-								fullName={question.creator.name}
-								portraitURL={question.creator.image}
-								size="sm"
-								userId={String(question.creator.id)}
-							/>
+					<Link to={creatorInformation.link}>
+						<UserIcon
+							fullName={creatorInformation.name}
+							portraitURL={creatorInformation.portraitURL}
+							size="sm"
+							userId={creatorInformation.userId}
+						/>
 
-							<strong className="c-ml-2 text-dark">
-								{question.creator.name}
-							</strong>
-						</Link>
-					)}
+						<strong className="c-ml-2 text-dark">
+							{creatorInformation.name ||
+								Liferay.Language.get(
+									'anonymous-user-configuration-name'
+								)}
+						</strong>
+					</Link>
 
 					<span className="c-ml-2 small">
 						{'- ' + dateToInternationalHuman(question.dateModified)}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/RelatedQuestions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/RelatedQuestions.es.js
@@ -115,18 +115,33 @@ export default withRouter(
 
 								<div className="c-mt-3 small stretched-link-layer">
 									<UserIcon
-										fullName={relatedQuestion.creator?.name}
+										fullName={
+											relatedQuestion.creator
+												? relatedQuestion.creator.name
+												: ''
+										}
 										portraitURL={
-											relatedQuestion.creator?.image
+											relatedQuestion.creator
+												? relatedQuestion.creator.image
+												: ''
 										}
 										size="sm"
-										userId={String(
-											relatedQuestion.creator?.id
-										)}
+										userId={
+											relatedQuestion.creator
+												? String(
+														relatedQuestion.creator
+															.id
+												  )
+												: '0'
+										}
 									/>
 
 									<span className="c-ml-2 font-weight-bold">
-										{relatedQuestion.creator.name}
+										{relatedQuestion.creator
+											? relatedQuestion.creator.name
+											: Liferay.Language.get(
+													'anonymous-user-configuration-name'
+											  )}
 									</span>
 
 									<span className="text-secondary">

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/UserPopover.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/UserPopover.es.js
@@ -27,30 +27,39 @@ export default ({creator, statistics}) => {
 			header={
 				<div className="align-items-center d-flex">
 					<UserIcon
-						fullName={creator.name}
-						portraitURL={creator.image}
-						userId={String(creator.id)}
+						fullName={creator?.name}
+						portraitURL={creator?.image}
+						userId={String(creator?.id)}
 					/>
 
 					<div className="c-ml-2">
 						<h4 className="font-weight-light h6 text-secondary">
-							{statistics.rank}
+							{statistics?.rank}
 						</h4>
 
-						<h3 className="h5">{creator.name}</h3>
+						<h3 className="h5">
+							{creator?.name ||
+								Liferay.Language.get(
+									'anonymous-user-configuration-name'
+								)}
+						</h3>
 					</div>
 				</div>
 			}
 		>
 			<div className="text-secondary">
-				<p className="c-mb-0">Posts: {statistics.postsNumber}</p>
+				<p className="c-mb-0">Posts: {statistics?.postsNumber}</p>
 				<p className="c-mb-0">
 					Join Date:{' '}
-					{dateToBriefInternationalHuman(statistics.joinDate)}
+					{statistics
+						? dateToBriefInternationalHuman(statistics.joinDate)
+						: ''}
 				</p>
 				<p className="c-mb-0">
 					Last Post Date:{' '}
-					{dateToBriefInternationalHuman(statistics.lastPostDate)}
+					{statistics
+						? dateToBriefInternationalHuman(statistics.lastPostDate)
+						: ''}
 				</p>
 			</div>
 		</ClayPopover>


### PR DESCRIPTION
Related ticket -> [LPS-135874](https://issues.liferay.com/browse/LPS-135874)

Reproduce this bug in the master branch is a little bit tricky because it is necessary to create a thread and set the userId to 0.
Then, just navigate to the thread created and the application will crash. With this fix, we will avoid that crash and will show an "Anonymous User" instead of the original user.

**Explanation**
Assuming that the anonymizing process could set the userId of some questions to 0, it could generate an NPE when retrieving the creator of a question.

This PR avoids that NPE and returns an empty creator instead.

Due to this empty creator, it is necessary to handle that empty creator in Questions App and show default values in that case.