### PR TITLE
LPS-138088 blogs-web info-bar unstyled due to cadmin

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -1,6 +1,21 @@
 @import 'atlas-variables';
+@import 'cadmin-variables';
 
 @import 'common_main';
+
+html#{$cadmin-selector} {
+	.portlet-blogs {
+		.cadmin {
+			.info-bar-container {
+				min-height: 35px;
+
+				.info-bar-center {
+					margin-top: 5px;
+				}
+			}
+		}
+	}
+}
 
 .portlet-blogs {
 	.taglib-custom-attributes-list {
@@ -253,14 +268,6 @@
 			ul {
 				margin-top: 6px;
 			}
-		}
-	}
-
-	.info-bar-container {
-		min-height: 35px;
-
-		.info-bar-center {
-			margin-top: 5px;
 		}
 	}
 

--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -583,6 +583,58 @@ html#{$cadmin-selector} {
 				}
 			}
 		}
+
+		// Info Bar
+
+		.info-bar-container {
+			background-color: #fff;
+			border-bottom: 1px solid #edf0f2;
+			min-height: 47px;
+
+			.info-bar {
+				padding: 0;
+			}
+
+			@include media-breakpoint-up(sm, $cadmin-grid-breakpoints) {
+				min-height: 59px;
+			}
+
+			.info-bar-default {
+				.taglib-workflow-status .workflow-version {
+					color: #6b6c7e;
+				}
+
+				.btn {
+					margin: 7px 0 7px 15px;
+
+					@include media-breakpoint-up(sm, $cadmin-grid-breakpoints) {
+						margin: 13px 0 13px 15px;
+					}
+				}
+			}
+
+			.info-bar-center {
+				left: 50%;
+				margin-top: 16px;
+				position: absolute;
+				text-align: center;
+				transform: translate(-50%);
+				width: 100%;
+
+				@include media-breakpoint-up(sm) {
+					margin-top: 20px;
+				}
+			}
+
+			&.affix {
+				min-height: 35px;
+				transition: min-height 0.15s ease;
+
+				.info-bar-center {
+					margin-top: 5px;
+				}
+			}
+		}
 	}
 
 	.portal-popup,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-138088

Blogs `info-bar` is contained inside the isolated `control-menu-container`. This adds `info-bar` styles to cadmin and updates blogs-web css.

![blogs-web-info-bar](https://user-images.githubusercontent.com/788266/132756273-7cbc02c2-ccd5-4772-90cf-6ad203d6a9dc.jpg)
