### PR TITLE
LPS-138140

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/CreationMenu.js
@@ -57,7 +57,7 @@ function CreationMenu({primaryItems}) {
 					) : (
 						<ClayButtonWithIcon
 							className="nav-btn nav-btn-monospaced"
-							data-tooltip-align="top"
+							data-tooltip-align="top-left"
 							onClick={() =>
 								triggerAction(primaryItems[0], dataSetContext)
 							}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-138140

From @Odrakir1:
> The issue was causing a misplacement of the tooltip text when the screen was smaller than 1250px. I have changed the tooltip alignment value for that it won't get affected when the screen is shrinked.