### PR TITLE
LPS-131305 add support for scoped entities + LPS-138882 rename paths

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -168,6 +168,7 @@ public class ObjectDefinitionResourceImpl
 					_objectFieldLocalService.getObjectFields(
 						objectDefinition.getObjectDefinitionId()),
 					ObjectFieldUtil::toObjectField, ObjectField.class);
+				scope = objectDefinition.getScope();
 				status = new Status() {
 					{
 						code = objectDefinition.getStatus();

--- a/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/storage/ObjectDDMStorageAdapter.java
+++ b/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/storage/ObjectDDMStorageAdapter.java
@@ -35,7 +35,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
-import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -137,11 +136,15 @@ public class ObjectDDMStorageAdapter implements DDMStorageAdapter {
 			long objectDefinitionId = _getObjectDefinitionId(
 				ddmStorageAdapterSaveRequest);
 
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					objectDefinitionId);
+
 			ObjectEntry addObjectEntry = _objectEntryManager.addObjectEntry(
 				_getDTOConverterContext(null, user, ddmForm.getDefaultLocale()),
 				user.getUserId(),
-				_getGroupId(ddmStorageAdapterSaveRequest, objectDefinitionId),
-				objectDefinitionId,
+				String.valueOf(ddmStorageAdapterSaveRequest.getScopeGroupId()),
+				objectDefinition,
 				new ObjectEntry() {
 					{
 						properties = _getObjectEntryProperties(
@@ -240,26 +243,6 @@ public class ObjectDDMStorageAdapter implements DDMStorageAdapter {
 			Collections.singletonMap(
 				"delete", Collections.singletonMap("delete", "")),
 			null, null, objectEntryId, locale, null, user);
-	}
-
-	private long _getGroupId(
-			DDMStorageAdapterSaveRequest ddmStorageAdapterSaveRequest,
-			long objectDefinitionId)
-		throws Exception {
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.getObjectDefinition(
-				objectDefinitionId);
-
-		ObjectScopeProvider objectScopeProvider =
-			_objectScopeProviderRegistry.getObjectScopeProvider(
-				objectDefinition.getScope());
-
-		if (objectScopeProvider.isGroupAware()) {
-			return ddmStorageAdapterSaveRequest.getScopeGroupId();
-		}
-
-		return 0;
 	}
 
 	private long _getObjectDefinitionId(

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.rest.manager.v1_0;
 
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -28,24 +29,26 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 public interface ObjectEntryManager {
 
 	public ObjectEntry addObjectEntry(
-			DTOConverterContext dtoConverterContext, long userId, long groupId,
-			long objectDefinitionId, ObjectEntry objectEntry)
+			DTOConverterContext dtoConverterContext, long userId,
+			String scopeId, ObjectDefinition objectDefinition,
+			ObjectEntry objectEntry)
 		throws Exception;
 
 	public ObjectEntry addOrUpdateObjectEntry(
 			DTOConverterContext dtoConverterContext,
-			String externalReferenceCode, long userId, long groupId,
-			long objectDefinitionId, ObjectEntry objectEntry)
+			String externalReferenceCode, long userId, String scopeId,
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
 		throws Exception;
 
 	public void deleteObjectEntry(long objectEntryId) throws Exception;
 
 	public void deleteObjectEntry(
-			String externalReferenceCode, long companyId, long groupId)
+			String externalReferenceCode, long companyId, String scopeId,
+			ObjectDefinition objectDefinition)
 		throws Exception;
 
 	public Page<ObjectEntry> getObjectEntries(
-			long companyId, long groupId, long objectDefinitionId,
+			long companyId, String scopeId, ObjectDefinition objectDefinition,
 			Aggregation aggregation, DTOConverterContext dtoConverterContext,
 			Filter filter, Pagination pagination, String search, Sort[] sorts)
 		throws Exception;
@@ -56,7 +59,8 @@ public interface ObjectEntryManager {
 
 	public ObjectEntry getObjectEntry(
 			DTOConverterContext dtoConverterContext,
-			String externalReferenceCode, long companyId, long groupId)
+			String externalReferenceCode, long companyId, String scopeId,
+			ObjectDefinition objectDefinition)
 		throws Exception;
 
 	public ObjectEntry updateObjectEntry(

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -36,19 +36,19 @@ public interface ObjectEntryManager {
 
 	public ObjectEntry addOrUpdateObjectEntry(
 			DTOConverterContext dtoConverterContext,
-			String externalReferenceCode, long userId, String scopeId,
+			String externalReferenceCode, long userId, String scopeKey,
 			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
 		throws Exception;
 
 	public void deleteObjectEntry(long objectEntryId) throws Exception;
 
 	public void deleteObjectEntry(
-			String externalReferenceCode, long companyId, String scopeId,
+			String externalReferenceCode, long companyId, String scopeKey,
 			ObjectDefinition objectDefinition)
 		throws Exception;
 
 	public Page<ObjectEntry> getObjectEntries(
-			long companyId, String scopeId, ObjectDefinition objectDefinition,
+			long companyId, String scopeKey, ObjectDefinition objectDefinition,
 			Aggregation aggregation, DTOConverterContext dtoConverterContext,
 			Filter filter, Pagination pagination, String search, Sort[] sorts)
 		throws Exception;
@@ -59,7 +59,7 @@ public interface ObjectEntryManager {
 
 	public ObjectEntry getObjectEntry(
 			DTOConverterContext dtoConverterContext,
-			String externalReferenceCode, long companyId, String scopeId,
+			String externalReferenceCode, long companyId, String scopeKey,
 			ObjectDefinition objectDefinition)
 		throws Exception;
 

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
@@ -66,28 +66,36 @@ public interface ObjectEntryResource {
 	public Response postObjectEntryBatch(String callbackURL, Object object)
 		throws Exception;
 
-	public void deleteObjectEntryByExternalReferenceCode(
-			String externalReferenceCode)
+	public void deleteByExternalReferenceCode(String externalReferenceCode)
 		throws Exception;
 
-	public ObjectEntry getObjectEntryByExternalReferenceCode(
-			String externalReferenceCode)
+	public ObjectEntry getByExternalReferenceCode(String externalReferenceCode)
 		throws Exception;
 
-	public ObjectEntry putObjectEntryByExternalReferenceCode(
+	public ObjectEntry putByExternalReferenceCode(
 			String externalReferenceCode, ObjectEntry objectEntry)
 		throws Exception;
 
-	public void deleteSiteObjectEntryByExternalReferenceCode(
-			Long siteId, String externalReferenceCode)
+	public Page<ObjectEntry> getScopeScopePage(
+			String scopeId, Boolean flatten, String search,
+			com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+			Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception;
 
-	public ObjectEntry getSiteObjectEntryByExternalReferenceCode(
-			Long siteId, String externalReferenceCode)
+	public ObjectEntry postScope(String scopeId, ObjectEntry objectEntry)
 		throws Exception;
 
-	public ObjectEntry putSiteObjectEntryByExternalReferenceCode(
-			Long siteId, String externalReferenceCode, ObjectEntry objectEntry)
+	public void deleteScopeByExternalReferenceCode(
+			String scopeId, String externalReferenceCode)
+		throws Exception;
+
+	public ObjectEntry getScopeByExternalReferenceCode(
+			String scopeId, String externalReferenceCode)
+		throws Exception;
+
+	public ObjectEntry putScopeByExternalReferenceCode(
+			String scopeId, String externalReferenceCode,
+			ObjectEntry objectEntry)
 		throws Exception;
 
 	public void deleteObjectEntry(Long objectEntryId) throws Exception;

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
@@ -76,25 +76,26 @@ public interface ObjectEntryResource {
 			String externalReferenceCode, ObjectEntry objectEntry)
 		throws Exception;
 
-	public Page<ObjectEntry> getScopeScopePage(
-			String scopeId, Boolean flatten, String search,
+	public Page<ObjectEntry> getScopeScopeKeyPage(
+			String scopeKey, Boolean flatten, String search,
 			com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
 			Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception;
 
-	public ObjectEntry postScope(String scopeId, ObjectEntry objectEntry)
+	public ObjectEntry postScopeScopeKey(
+			String scopeKey, ObjectEntry objectEntry)
 		throws Exception;
 
-	public void deleteScopeByExternalReferenceCode(
-			String scopeId, String externalReferenceCode)
+	public void deleteScopeScopeKeyByExternalReferenceCode(
+			String scopeKey, String externalReferenceCode)
 		throws Exception;
 
-	public ObjectEntry getScopeByExternalReferenceCode(
-			String scopeId, String externalReferenceCode)
+	public ObjectEntry getScopeScopeKeyByExternalReferenceCode(
+			String scopeKey, String externalReferenceCode)
 		throws Exception;
 
-	public ObjectEntry putScopeByExternalReferenceCode(
-			String scopeId, String externalReferenceCode,
+	public ObjectEntry putScopeScopeKeyByExternalReferenceCode(
+			String scopeKey, String externalReferenceCode,
 			ObjectEntry objectEntry)
 		throws Exception;
 

--- a/modules/apps/object/object-rest-impl/build.gradle
+++ b/modules/apps/object/object-rest-impl/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:headless:headless-delivery:headless-delivery-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:object:object-rest-api")

--- a/modules/apps/object/object-rest-impl/build.gradle
+++ b/modules/apps/object/object-rest-impl/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.apache.cxf", name: "cxf-core", version: "3.4.4"
 	compileOnly group: "org.apache.cxf", name: "cxf-rt-frontend-jaxrs", version: "3.4.4"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -170,93 +170,12 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntry"
             tags: ["ObjectEntry"]
-    "/scopes/{scopeId}":
-        get:
-            operationId: getScopeScopePage
-            parameters:
-                - in: path
-                  name: scopeId
-                  schema:
-                      type: string
-                - in: query
-                  name: aggregationTerms
-                  schema:
-                      items:
-                          type: string
-                      type: array
-                - in: query
-                  name: flatten
-                  schema:
-                      type: boolean
-                - in: query
-                  name: filter
-                  schema:
-                      type: string
-                - in: query
-                  name: page
-                  schema:
-                      type: integer
-                - in: query
-                  name: pageSize
-                  schema:
-                      type: integer
-                - in: query
-                  name: search
-                  schema:
-                      type: string
-                - in: query
-                  name: sort
-                  schema:
-                      type: string
-                - in: header
-                  name: Accept-Language
-                  schema:
-                      type: string
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ObjectEntry"
-                                type: array
-                        application/xml:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ObjectEntry"
-                                type: array
-            tags: ["ObjectEntry"]
-        post:
-            operationId: postScope
-            parameters:
-                - in: path
-                  name: scopeId
-                  schema:
-                      type: string
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/ObjectEntry"
-                    application/xml:
-                        schema:
-                            $ref: "#/components/schemas/ObjectEntry"
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ObjectEntry"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ObjectEntry"
-            tags: ["ObjectEntry"]
-    "/scopes/{scopeId}/by-external-reference-code/{externalReferenceCode}":
+    "/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}":
         delete:
-            operationId: deleteScopeByExternalReferenceCode
+            operationId: deleteScopeScopeKeyByExternalReferenceCode
             parameters:
                 - in: path
-                  name: scopeId
+                  name: scopeKey
                   required: true
                   schema:
                       type: string
@@ -272,10 +191,10 @@ paths:
                         application/xml: {}
             tags: ["ObjectEntry"]
         get:
-            operationId: getScopeByExternalReferenceCode
+            operationId: getScopeScopeKeyByExternalReferenceCode
             parameters:
                 - in: path
-                  name: scopeId
+                  name: scopeKey
                   required: true
                   schema:
                       type: string
@@ -295,10 +214,10 @@ paths:
                                 $ref: "#/components/schemas/ObjectEntry"
             tags: ["ObjectEntry"]
         put:
-            operationId: putScopeByExternalReferenceCode
+            operationId: putScopeScopeKeyByExternalReferenceCode
             parameters:
                 - in: path
-                  name: scopeId
+                  name: scopeKey
                   required: true
                   schema:
                       type: string
@@ -396,6 +315,87 @@ paths:
                   schema:
                       format: int64
                       type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ObjectEntry"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/ObjectEntry"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntry"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntry"
+            tags: ["ObjectEntry"]
+    /scopes/{scopeKey}:
+        get:
+            operationId: getScopeScopeKeyPage
+            parameters:
+                - in: path
+                  name: scopeKey
+                  schema:
+                      type: string
+                - in: query
+                  name: aggregationTerms
+                  schema:
+                      items:
+                          type: string
+                      type: array
+                - in: query
+                  name: flatten
+                  schema:
+                      type: boolean
+                - in: query
+                  name: filter
+                  schema:
+                      type: string
+                - in: query
+                  name: page
+                  schema:
+                      type: integer
+                - in: query
+                  name: pageSize
+                  schema:
+                      type: integer
+                - in: query
+                  name: search
+                  schema:
+                      type: string
+                - in: query
+                  name: sort
+                  schema:
+                      type: string
+                - in: header
+                  name: Accept-Language
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectEntry"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectEntry"
+                                type: array
+            tags: ["ObjectEntry"]
+        post:
+            operationId: postScopeScopeKey
+            parameters:
+                - in: path
+                  name: scopeKey
+                  schema:
+                      type: string
             requestBody:
                 content:
                     application/json:

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -111,9 +111,9 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntry"
             tags: ["ObjectEntry"]
-    "/object-entries/by-external-reference-code/{externalReferenceCode}":
+    "/by-external-reference-code/{externalReferenceCode}":
         delete:
-            operationId: deleteObjectEntryByExternalReferenceCode
+            operationId: deleteByExternalReferenceCode
             parameters:
                 - in: path
                   name: externalReferenceCode
@@ -127,7 +127,7 @@ paths:
                         application/xml: {}
             tags: ["ObjectEntry"]
         get:
-            operationId: getObjectEntryByExternalReferenceCode
+            operationId: getByExternalReferenceCode
             parameters:
                 - in: path
                   name: externalReferenceCode
@@ -145,7 +145,7 @@ paths:
                                 $ref: "#/components/schemas/ObjectEntry"
             tags: ["ObjectEntry"]
         put:
-            operationId: putObjectEntryByExternalReferenceCode
+            operationId: putByExternalReferenceCode
             parameters:
                 - in: path
                   name: externalReferenceCode
@@ -170,17 +170,96 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntry"
             tags: ["ObjectEntry"]
-    "/sites/{siteId}/object-entries/by-external-reference-code/{externalReferenceCode}":
-        delete:
-            operationId: deleteSiteObjectEntryByExternalReferenceCode
+    "/scopes/{scopeId}":
+        get:
+            operationId: getScopeScopePage
             parameters:
                 - in: path
-                  name: siteId
+                  name: scopeId
+                  schema:
+                      type: string
+                - in: query
+                  name: aggregationTerms
+                  schema:
+                      items:
+                          type: string
+                      type: array
+                - in: query
+                  name: flatten
+                  schema:
+                      type: boolean
+                - in: query
+                  name: filter
+                  schema:
+                      type: string
+                - in: query
+                  name: page
+                  schema:
+                      type: integer
+                - in: query
+                  name: pageSize
+                  schema:
+                      type: integer
+                - in: query
+                  name: search
+                  schema:
+                      type: string
+                - in: query
+                  name: sort
+                  schema:
+                      type: string
+                - in: header
+                  name: Accept-Language
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectEntry"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectEntry"
+                                type: array
+            tags: ["ObjectEntry"]
+        post:
+            operationId: postScope
+            parameters:
+                - in: path
+                  name: scopeId
+                  schema:
+                      type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ObjectEntry"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/ObjectEntry"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntry"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntry"
+            tags: ["ObjectEntry"]
+    "/scopes/{scopeId}/by-external-reference-code/{externalReferenceCode}":
+        delete:
+            operationId: deleteScopeByExternalReferenceCode
+            parameters:
+                - in: path
+                  name: scopeId
                   required: true
                   schema:
-                      format: int64
-                      minimum: 0
-                      type: integer
+                      type: string
                 - in: path
                   name: externalReferenceCode
                   required: true
@@ -193,15 +272,13 @@ paths:
                         application/xml: {}
             tags: ["ObjectEntry"]
         get:
-            operationId: getSiteObjectEntryByExternalReferenceCode
+            operationId: getScopeByExternalReferenceCode
             parameters:
                 - in: path
-                  name: siteId
+                  name: scopeId
                   required: true
                   schema:
-                      format: int64
-                      minimum: 0
-                      type: integer
+                      type: string
                 - in: path
                   name: externalReferenceCode
                   required: true
@@ -218,15 +295,13 @@ paths:
                                 $ref: "#/components/schemas/ObjectEntry"
             tags: ["ObjectEntry"]
         put:
-            operationId: putSiteObjectEntryByExternalReferenceCode
+            operationId: putScopeByExternalReferenceCode
             parameters:
                 - in: path
-                  name: siteId
+                  name: scopeId
                   required: true
                   schema:
-                      format: int64
-                      minimum: 0
-                      type: integer
+                      type: string
                 - in: path
                   name: externalReferenceCode
                   required: true

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -168,56 +168,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		return serviceRegistrations;
 	}
 
-	private void _excludeScopedMethods(
-		ObjectDefinition objectDefinition,
-		ObjectScopeProvider objectScopeProvider) {
-		try {
-			String factoryPid =
-				"com.liferay.portal.vulcan.internal.configuration." +
-					"VulcanConfiguration";
-
-			Configuration configuration =
-				_configurationAdmin.createFactoryConfiguration(
-					factoryPid, "?");
-
-			Method[] methods =
-				BaseObjectEntryResourceImpl.class.getMethods();
-
-			List<String> excludedOperationIds = new ArrayList<>();
-
-			for (Method method : methods) {
-				Path path = method.getAnnotation(Path.class);
-
-				if (path != null) {
-					String value = path.value();
-
-					boolean groupAware = objectScopeProvider.isGroupAware();
-					boolean hasScope = value.contains("scopes");
-
-					if ((!groupAware && hasScope) ||
-						(groupAware && !hasScope &&
-						 !value.equals("/{objectEntryId}"))) {
-
-						excludedOperationIds.add(method.getName());
-					}
-				}
-			}
-
-			configuration.update(
-				HashMapDictionaryBuilder.put(
-					"excludedOperationIds",
-					StringUtil.merge(excludedOperationIds, ",")
-				).put(
-					"path", objectDefinition.getRESTContextPath()
-				).build());
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception, exception);
-			}
-		}
-	}
-
 	public ObjectDefinition getObjectDefinition(
 		long companyId, String restContextPath) {
 
@@ -263,6 +213,55 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_bundleContext = bundleContext;
+	}
+
+	private void _excludeScopedMethods(
+		ObjectDefinition objectDefinition,
+		ObjectScopeProvider objectScopeProvider) {
+
+		try {
+			String factoryPid =
+				"com.liferay.portal.vulcan.internal.configuration." +
+					"VulcanConfiguration";
+
+			Configuration configuration =
+				_configurationAdmin.createFactoryConfiguration(factoryPid, "?");
+
+			Method[] methods = BaseObjectEntryResourceImpl.class.getMethods();
+
+			List<String> excludedOperationIds = new ArrayList<>();
+
+			for (Method method : methods) {
+				Path path = method.getAnnotation(Path.class);
+
+				if (path != null) {
+					String value = path.value();
+
+					boolean groupAware = objectScopeProvider.isGroupAware();
+					boolean hasScope = value.contains("scopes");
+
+					if ((!groupAware && hasScope) ||
+						(groupAware && !hasScope &&
+						 !value.equals("/{objectEntryId}"))) {
+
+						excludedOperationIds.add(method.getName());
+					}
+				}
+			}
+
+			configuration.update(
+				HashMapDictionaryBuilder.put(
+					"excludedOperationIds",
+					StringUtil.merge(excludedOperationIds, ",")
+				).put(
+					"path", objectDefinition.getRESTContextPath()
+				).build());
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -87,8 +87,11 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 							"liferay.object.definition.id",
 							objectDefinition.getObjectDefinitionId()
 						).put(
+							"liferay.object.definition.name",
+							objectDefinition.getShortName()
+						).put(
 							"osgi.jaxrs.application.base",
-							"/" + objectDefinition.getRESTContextPath()
+							objectDefinition.getRESTContextPath()
 						).put(
 							"osgi.jaxrs.extension.select",
 							"(osgi.jaxrs.name=Liferay.Vulcan)"
@@ -125,7 +128,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"osgi.jaxrs.extension", "true"
 					).put(
 						"osgi.jaxrs.name",
-						objectDefinition.getRESTContextPath() +
+						objectDefinition.getName() +
 							"ObjectDefinitionContextProvider"
 					).build()),
 				_bundleContext.registerService(
@@ -138,7 +141,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"osgi.jaxrs.extension", "true"
 					).put(
 						"osgi.jaxrs.name",
-						objectDefinition.getRESTContextPath() +
+						objectDefinition.getName() +
 							"RequiredObjectFieldExceptionMapper"
 					).build()));
 		}
@@ -149,20 +152,15 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ObjectDefinitionGraphQLDTOContributor.of(
 					objectDefinition, _objectEntryManager,
 					_objectFieldLocalService.getObjectFields(
-						objectDefinition.getObjectDefinitionId())),
+						objectDefinition.getObjectDefinitionId()),
+					objectScopeProvider),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"dto.name", objectDefinition.getDBTableName()
 				).build()));
 
 		Map<Long, ObjectDefinition> objectDefinitions =
-			_objectDefinitionsMap.get(objectDefinition.getRESTContextPath());
-
-		if (objectDefinitions == null) {
-			objectDefinitions = new HashMap<>();
-
-			_objectDefinitionsMap.put(
-				objectDefinition.getRESTContextPath(), objectDefinitions);
-		}
+			_objectDefinitionsMap.computeIfAbsent(
+				objectDefinition.getRESTContextPath(), k -> new HashMap<>());
 
 		objectDefinitions.put(
 			objectDefinition.getCompanyId(), objectDefinition);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -234,18 +234,20 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			for (Method method : methods) {
 				Path path = method.getAnnotation(Path.class);
 
-				if (path != null) {
-					String value = path.value();
+				if (path == null) {
+					continue;
+				}
 
-					boolean groupAware = objectScopeProvider.isGroupAware();
-					boolean hasScope = value.contains("scopes");
+				String value = path.value();
 
-					if ((!groupAware && hasScope) ||
-						(groupAware && !hasScope &&
-						 !value.equals("/{objectEntryId}"))) {
+				boolean groupAware = objectScopeProvider.isGroupAware();
+				boolean hasScope = value.contains("scopes");
 
-						excludedOperationIds.add(method.getName());
-					}
+				if ((!groupAware && hasScope) ||
+					(groupAware && !hasScope &&
+					 !value.equals("/{objectEntryId}"))) {
+
+					excludedOperationIds.add(method.getName());
 				}
 			}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -19,12 +19,20 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.internal.graphql.dto.v1_0.ObjectDefinitionGraphQLDTOContributor;
 import com.liferay.object.rest.internal.jaxrs.context.provider.ObjectDefinitionContextProvider;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectFieldExceptionMapper;
+import com.liferay.object.rest.internal.resource.v1_0.BaseObjectEntryResourceImpl;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
+import com.liferay.object.scope.ObjectScopeProvider;
+import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOContributor;
+
+import java.lang.reflect.Method;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,12 +41,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.Path;
 import javax.ws.rs.ext.ExceptionMapper;
 
 import org.apache.cxf.jaxrs.ext.ContextProvider;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentFactory;
 import org.osgi.service.component.ComponentInstance;
 import org.osgi.service.component.annotations.Activate;
@@ -57,8 +68,14 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
 
+		ObjectScopeProvider objectScopeProvider =
+			_objectScopeProviderRegistry.getObjectScopeProvider(
+				objectDefinition.getScope());
+
 		if (!_objectDefinitionsMap.containsKey(
 				objectDefinition.getRESTContextPath())) {
+
+			_excludeScopedMethods(objectDefinition, objectScopeProvider);
 
 			_componentInstancesMap.put(
 				objectDefinition.getRESTContextPath(),
@@ -153,6 +170,56 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		return serviceRegistrations;
 	}
 
+	private void _excludeScopedMethods(
+		ObjectDefinition objectDefinition,
+		ObjectScopeProvider objectScopeProvider) {
+		try {
+			String factoryPid =
+				"com.liferay.portal.vulcan.internal.configuration." +
+					"VulcanConfiguration";
+
+			Configuration configuration =
+				_configurationAdmin.createFactoryConfiguration(
+					factoryPid, "?");
+
+			Method[] methods =
+				BaseObjectEntryResourceImpl.class.getMethods();
+
+			List<String> excludedOperationIds = new ArrayList<>();
+
+			for (Method method : methods) {
+				Path path = method.getAnnotation(Path.class);
+
+				if (path != null) {
+					String value = path.value();
+
+					boolean groupAware = objectScopeProvider.isGroupAware();
+					boolean hasScope = value.contains("scopes");
+
+					if ((!groupAware && hasScope) ||
+						(groupAware && !hasScope &&
+						 !value.equals("/{objectEntryId}"))) {
+
+						excludedOperationIds.add(method.getName());
+					}
+				}
+			}
+
+			configuration.update(
+				HashMapDictionaryBuilder.put(
+					"excludedOperationIds",
+					StringUtil.merge(excludedOperationIds, ",")
+				).put(
+					"path", objectDefinition.getRESTContextPath()
+				).build());
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
+		}
+	}
+
 	public ObjectDefinition getObjectDefinition(
 		long companyId, String restContextPath) {
 
@@ -200,9 +267,15 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_bundleContext = bundleContext;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectDefinitionDeployerImpl.class);
+
 	private BundleContext _bundleContext;
 	private final Map<String, List<ComponentInstance>> _componentInstancesMap =
 		new HashMap<>();
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
@@ -225,6 +298,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Reference
+	private ObjectScopeProviderRegistry _objectScopeProviderRegistry;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -86,7 +86,7 @@ public class ObjectDefinitionGraphQLDTOContributor
 		return _toMap(
 			_objectEntryManager.addObjectEntry(
 				dtoConverterContext, dtoConverterContext.getUserId(),
-				(String)dtoConverterContext.getAttribute("scopeId"),
+				(String)dtoConverterContext.getAttribute("scopeKey"),
 				_objectDefinition, _toObjectEntry(dto)));
 	}
 
@@ -119,7 +119,7 @@ public class ObjectDefinitionGraphQLDTOContributor
 
 		Page<ObjectEntry> page = _objectEntryManager.getObjectEntries(
 			(Long)dtoConverterContext.getAttribute("companyId"),
-			(String)dtoConverterContext.getAttribute("scopeId"),
+			(String)dtoConverterContext.getAttribute("scopeKey"),
 			_objectDefinition, aggregation, dtoConverterContext, filter,
 			pagination, search, sorts);
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/application/ObjectEntryApplication.java
@@ -18,7 +18,6 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.internal.jaxrs.container.request.filter.ObjectDefinitionIdContainerRequestFilter;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.OpenAPIResourceImpl;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.vulcan.openapi.DTOProperty;
@@ -56,7 +55,7 @@ public class ObjectEntryApplication extends Application {
 				_applicationName, _objectDefinitionId));
 		objects.add(
 			new OpenAPIResourceImpl(
-				_openAPIResource, _getOpenAPISchemaFilter(),
+				_openAPIResource, _getOpenAPISchemaFilter(_applicationPath),
 				new HashSet<Class<?>>() {
 					{
 						add(ObjectEntryResourceImpl.class);
@@ -70,6 +69,10 @@ public class ObjectEntryApplication extends Application {
 	@Activate
 	protected void activate(Map<String, Object> properties) {
 		_applicationName = (String)properties.get("osgi.jaxrs.name");
+		_applicationPath = (String)properties.get(
+			"osgi.jaxrs.application.base");
+		_objectDefinitionName = (String)properties.get(
+			"liferay.object.definition.name");
 
 		_objectDefinitionId = (Long)properties.get(
 			"liferay.object.definition.id");
@@ -78,8 +81,12 @@ public class ObjectEntryApplication extends Application {
 			_objectDefinitionId);
 	}
 
-	private OpenAPISchemaFilter _getOpenAPISchemaFilter() {
+	private OpenAPISchemaFilter _getOpenAPISchemaFilter(
+		String applicationPath) {
+
 		OpenAPISchemaFilter openAPISchemaFilter = new OpenAPISchemaFilter();
+
+		openAPISchemaFilter.setApplicationPath(applicationPath);
 
 		DTOProperty dtoProperty = new DTOProperty("ObjectEntry", "object");
 
@@ -96,19 +103,18 @@ public class ObjectEntryApplication extends Application {
 		openAPISchemaFilter.setDTOProperty(dtoProperty);
 		openAPISchemaFilter.setSchemaMappings(
 			HashMapBuilder.put(
-				"ObjectEntry", _applicationName
+				"ObjectEntry", _objectDefinitionName
 			).put(
-				"PageObjectEntry", "Page" + _applicationName
+				"PageObjectEntry", "Page" + _objectDefinitionName
 			).build());
 
 		return openAPISchemaFilter;
 	}
 
 	private String _applicationName;
+	private String _applicationPath;
 	private Long _objectDefinitionId;
-
-	@Reference
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private String _objectDefinitionName;
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
@@ -49,7 +49,7 @@ public class ObjectDefinitionContextProvider
 		String restContextPath = (String)message.getContextualProperty(
 			"org.apache.cxf.message.Message.BASE_PATH");
 
-		restContextPath = StringUtil.removeSubstring(restContextPath, "/o/");
+		restContextPath = StringUtil.removeSubstring(restContextPath, "/o");
 		restContextPath = StringUtil.replaceLast(restContextPath, '/', "");
 
 		return _objectDefinitionDeployerImpl.getObjectDefinition(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
@@ -49,7 +49,7 @@ public class ObjectDefinitionContextProvider
 		String restContextPath = (String)message.getContextualProperty(
 			"org.apache.cxf.message.Message.BASE_PATH");
 
-		restContextPath = StringUtil.removeSubstring(restContextPath, "/o");
+		restContextPath = restContextPath.substring(2);
 		restContextPath = StringUtil.replaceLast(restContextPath, '/', "");
 
 		return _objectDefinitionDeployerImpl.getObjectDefinition(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.rest.internal.manager.v1_0;
 
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
@@ -21,7 +22,6 @@ import com.liferay.object.rest.internal.dto.v1_0.converter.ObjectEntryDTOConvert
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -38,6 +39,7 @@ import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
 import java.io.Serializable;
@@ -208,7 +210,15 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 				objectDefinition.getScope());
 
 		if (objectScopeProvider.isGroupAware()) {
-			return GetterUtil.getLong(scopeId);
+			if (Objects.equals("site", objectDefinition.getScope())) {
+				return GroupUtil.getGroupId(
+					objectDefinition.getCompanyId(), scopeId,
+					_groupLocalService);
+			}
+
+			return GroupUtil.getDepotGroupId(
+				scopeId, objectDefinition.getCompanyId(),
+				_depotEntryLocalService, _groupLocalService);
 		}
 
 		return 0;
@@ -265,7 +275,10 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 	}
 
 	@Reference
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private ObjectEntryDTOConverter _objectEntryDTOConverter;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
@@ -67,7 +67,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 	@Override
 	public ObjectEntry addObjectEntry(
 			DTOConverterContext dtoConverterContext, long userId,
-			String scopeId, ObjectDefinition objectDefinition,
+			String scopeKey, ObjectDefinition objectDefinition,
 			ObjectEntry objectEntry)
 		throws Exception {
 
@@ -76,7 +76,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 		return _objectEntryDTOConverter.toDTO(
 			dtoConverterContext,
 			_objectEntryLocalService.addObjectEntry(
-				userId, _getGroupId(objectDefinition, scopeId),
+				userId, _getGroupId(objectDefinition, scopeKey),
 				objectDefinitionId,
 				_toObjectValues(
 					objectDefinitionId, objectEntry.getProperties(),
@@ -87,7 +87,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 	@Override
 	public ObjectEntry addOrUpdateObjectEntry(
 			DTOConverterContext dtoConverterContext,
-			String externalReferenceCode, long userId, String scopeId,
+			String externalReferenceCode, long userId, String scopeKey,
 			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
 		throws Exception {
 
@@ -97,7 +97,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 			dtoConverterContext,
 			_objectEntryLocalService.addOrUpdateObjectEntry(
 				externalReferenceCode, userId,
-				_getGroupId(objectDefinition, scopeId), objectDefinitionId,
+				_getGroupId(objectDefinition, scopeKey), objectDefinitionId,
 				_toObjectValues(
 					objectDefinitionId, objectEntry.getProperties(),
 					dtoConverterContext.getLocale()),
@@ -111,18 +111,18 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 
 	@Override
 	public void deleteObjectEntry(
-			String externalReferenceCode, long companyId, String scopeId,
+			String externalReferenceCode, long companyId, String scopeKey,
 			ObjectDefinition objectDefinition)
 		throws Exception {
 
 		_objectEntryLocalService.deleteObjectEntry(
 			externalReferenceCode, companyId,
-			_getGroupId(objectDefinition, scopeId));
+			_getGroupId(objectDefinition, scopeKey));
 	}
 
 	@Override
 	public Page<ObjectEntry> getObjectEntries(
-			long companyId, String scopeId, ObjectDefinition objectDefinition,
+			long companyId, String scopeKey, ObjectDefinition objectDefinition,
 			Aggregation aggregation, DTOConverterContext dtoConverterContext,
 			Filter filter, Pagination pagination, String search, Sort[] sorts)
 		throws Exception {
@@ -150,7 +150,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 					"objectDefinitionId", objectDefinitionId);
 				searchContext.setCompanyId(companyId);
 				searchContext.setGroupIds(
-					new long[] {_getGroupId(objectDefinition, scopeId)});
+					new long[] {_getGroupId(objectDefinition, scopeKey)});
 			},
 			sorts,
 			document -> getObjectEntry(
@@ -171,7 +171,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 	@Override
 	public ObjectEntry getObjectEntry(
 			DTOConverterContext dtoConverterContext,
-			String externalReferenceCode, long companyId, String scope,
+			String externalReferenceCode, long companyId, String scopeKey,
 			ObjectDefinition objectDefinition)
 		throws Exception {
 
@@ -179,7 +179,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 			dtoConverterContext,
 			_objectEntryLocalService.getObjectEntry(
 				externalReferenceCode, companyId,
-				_getGroupId(objectDefinition, scope)));
+				_getGroupId(objectDefinition, scopeKey)));
 	}
 
 	@Override
@@ -203,7 +203,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 	}
 
 	private long _getGroupId(
-		ObjectDefinition objectDefinition, String scopeId) {
+		ObjectDefinition objectDefinition, String scopeKey) {
 
 		ObjectScopeProvider objectScopeProvider =
 			_objectScopeProviderRegistry.getObjectScopeProvider(
@@ -212,12 +212,12 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 		if (objectScopeProvider.isGroupAware()) {
 			if (Objects.equals("site", objectDefinition.getScope())) {
 				return GroupUtil.getGroupId(
-					objectDefinition.getCompanyId(), scopeId,
+					objectDefinition.getCompanyId(), scopeKey,
 					_groupLocalService);
 			}
 
 			return GroupUtil.getDepotGroupId(
-				scopeId, objectDefinition.getCompanyId(),
+				scopeKey, objectDefinition.getCompanyId(),
 				_depotEntryLocalService, _groupLocalService);
 		}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -163,10 +163,10 @@ public abstract class BaseObjectEntryResourceImpl
 			@Parameter(in = ParameterIn.PATH, name = "externalReferenceCode")
 		}
 	)
-	@Path("/object-entries/by-external-reference-code/{externalReferenceCode}")
+	@Path("/by-external-reference-code/{externalReferenceCode}")
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "ObjectEntry")})
-	public void deleteObjectEntryByExternalReferenceCode(
+	public void deleteByExternalReferenceCode(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode)
@@ -180,10 +180,10 @@ public abstract class BaseObjectEntryResourceImpl
 			@Parameter(in = ParameterIn.PATH, name = "externalReferenceCode")
 		}
 	)
-	@Path("/object-entries/by-external-reference-code/{externalReferenceCode}")
+	@Path("/by-external-reference-code/{externalReferenceCode}")
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "ObjectEntry")})
-	public ObjectEntry getObjectEntryByExternalReferenceCode(
+	public ObjectEntry getByExternalReferenceCode(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode)
@@ -199,14 +199,58 @@ public abstract class BaseObjectEntryResourceImpl
 			@Parameter(in = ParameterIn.PATH, name = "externalReferenceCode")
 		}
 	)
-	@Path("/object-entries/by-external-reference-code/{externalReferenceCode}")
+	@Path("/by-external-reference-code/{externalReferenceCode}")
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "ObjectEntry")})
-	public ObjectEntry putObjectEntryByExternalReferenceCode(
+	public ObjectEntry putByExternalReferenceCode(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode,
+			ObjectEntry objectEntry)
+		throws Exception {
+
+		return new ObjectEntry();
+	}
+
+	@GET
+	@Override
+	@Parameters(
+		value = {
+			@Parameter(in = ParameterIn.PATH, name = "scopeId"),
+			@Parameter(in = ParameterIn.QUERY, name = "flatten"),
+			@Parameter(in = ParameterIn.QUERY, name = "search"),
+			@Parameter(in = ParameterIn.QUERY, name = "filter"),
+			@Parameter(in = ParameterIn.QUERY, name = "page"),
+			@Parameter(in = ParameterIn.QUERY, name = "pageSize"),
+			@Parameter(in = ParameterIn.QUERY, name = "sort")
+		}
+	)
+	@Path("/scopes/{scopeId}")
+	@Produces({"application/json", "application/xml"})
+	@Tags(value = {@Tag(name = "ObjectEntry")})
+	public Page<ObjectEntry> getScopeScopePage(
+			@Parameter(hidden = true) @PathParam("scopeId") String scopeId,
+			@Parameter(hidden = true) @QueryParam("flatten") Boolean flatten,
+			@Parameter(hidden = true) @QueryParam("search") String search,
+			@Context com.liferay.portal.vulcan.aggregation.Aggregation
+				aggregation,
+			@Context Filter filter, @Context Pagination pagination,
+			@Context Sort[] sorts)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@Consumes({"application/json", "application/xml"})
+	@Override
+	@Parameters(value = {@Parameter(in = ParameterIn.PATH, name = "scopeId")})
+	@Path("/scopes/{scopeId}")
+	@POST
+	@Produces({"application/json", "application/xml"})
+	@Tags(value = {@Tag(name = "ObjectEntry")})
+	public ObjectEntry postScope(
+			@Parameter(hidden = true) @PathParam("scopeId") String scopeId,
 			ObjectEntry objectEntry)
 		throws Exception {
 
@@ -217,17 +261,18 @@ public abstract class BaseObjectEntryResourceImpl
 	@Override
 	@Parameters(
 		value = {
-			@Parameter(in = ParameterIn.PATH, name = "siteId"),
+			@Parameter(in = ParameterIn.PATH, name = "scopeId"),
 			@Parameter(in = ParameterIn.PATH, name = "externalReferenceCode")
 		}
 	)
 	@Path(
-		"/sites/{siteId}/object-entries/by-external-reference-code/{externalReferenceCode}"
+		"/scopes/{scopeId}/by-external-reference-code/{externalReferenceCode}"
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "ObjectEntry")})
-	public void deleteSiteObjectEntryByExternalReferenceCode(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
+	public void deleteScopeByExternalReferenceCode(
+			@NotNull @Parameter(hidden = true) @PathParam("scopeId") String
+				scopeId,
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode)
@@ -238,17 +283,18 @@ public abstract class BaseObjectEntryResourceImpl
 	@Override
 	@Parameters(
 		value = {
-			@Parameter(in = ParameterIn.PATH, name = "siteId"),
+			@Parameter(in = ParameterIn.PATH, name = "scopeId"),
 			@Parameter(in = ParameterIn.PATH, name = "externalReferenceCode")
 		}
 	)
 	@Path(
-		"/sites/{siteId}/object-entries/by-external-reference-code/{externalReferenceCode}"
+		"/scopes/{scopeId}/by-external-reference-code/{externalReferenceCode}"
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "ObjectEntry")})
-	public ObjectEntry getSiteObjectEntryByExternalReferenceCode(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
+	public ObjectEntry getScopeByExternalReferenceCode(
+			@NotNull @Parameter(hidden = true) @PathParam("scopeId") String
+				scopeId,
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode)
@@ -261,18 +307,19 @@ public abstract class BaseObjectEntryResourceImpl
 	@Override
 	@Parameters(
 		value = {
-			@Parameter(in = ParameterIn.PATH, name = "siteId"),
+			@Parameter(in = ParameterIn.PATH, name = "scopeId"),
 			@Parameter(in = ParameterIn.PATH, name = "externalReferenceCode")
 		}
 	)
 	@Path(
-		"/sites/{siteId}/object-entries/by-external-reference-code/{externalReferenceCode}"
+		"/scopes/{scopeId}/by-external-reference-code/{externalReferenceCode}"
 	)
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "ObjectEntry")})
-	public ObjectEntry putSiteObjectEntryByExternalReferenceCode(
-			@NotNull @Parameter(hidden = true) @PathParam("siteId") Long siteId,
+	public ObjectEntry putScopeByExternalReferenceCode(
+			@NotNull @Parameter(hidden = true) @PathParam("scopeId") String
+				scopeId,
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -217,7 +217,7 @@ public abstract class BaseObjectEntryResourceImpl
 	@Override
 	@Parameters(
 		value = {
-			@Parameter(in = ParameterIn.PATH, name = "scopeId"),
+			@Parameter(in = ParameterIn.PATH, name = "scopeKey"),
 			@Parameter(in = ParameterIn.QUERY, name = "flatten"),
 			@Parameter(in = ParameterIn.QUERY, name = "search"),
 			@Parameter(in = ParameterIn.QUERY, name = "filter"),
@@ -226,11 +226,11 @@ public abstract class BaseObjectEntryResourceImpl
 			@Parameter(in = ParameterIn.QUERY, name = "sort")
 		}
 	)
-	@Path("/scopes/{scopeId}")
+	@Path("/scopes/{scopeKey}")
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "ObjectEntry")})
-	public Page<ObjectEntry> getScopeScopePage(
-			@Parameter(hidden = true) @PathParam("scopeId") String scopeId,
+	public Page<ObjectEntry> getScopeScopeKeyPage(
+			@Parameter(hidden = true) @PathParam("scopeKey") String scopeKey,
 			@Parameter(hidden = true) @QueryParam("flatten") Boolean flatten,
 			@Parameter(hidden = true) @QueryParam("search") String search,
 			@Context com.liferay.portal.vulcan.aggregation.Aggregation
@@ -244,13 +244,13 @@ public abstract class BaseObjectEntryResourceImpl
 
 	@Consumes({"application/json", "application/xml"})
 	@Override
-	@Parameters(value = {@Parameter(in = ParameterIn.PATH, name = "scopeId")})
-	@Path("/scopes/{scopeId}")
+	@Parameters(value = {@Parameter(in = ParameterIn.PATH, name = "scopeKey")})
+	@Path("/scopes/{scopeKey}")
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "ObjectEntry")})
-	public ObjectEntry postScope(
-			@Parameter(hidden = true) @PathParam("scopeId") String scopeId,
+	public ObjectEntry postScopeScopeKey(
+			@Parameter(hidden = true) @PathParam("scopeKey") String scopeKey,
 			ObjectEntry objectEntry)
 		throws Exception {
 
@@ -261,18 +261,18 @@ public abstract class BaseObjectEntryResourceImpl
 	@Override
 	@Parameters(
 		value = {
-			@Parameter(in = ParameterIn.PATH, name = "scopeId"),
+			@Parameter(in = ParameterIn.PATH, name = "scopeKey"),
 			@Parameter(in = ParameterIn.PATH, name = "externalReferenceCode")
 		}
 	)
 	@Path(
-		"/scopes/{scopeId}/by-external-reference-code/{externalReferenceCode}"
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}"
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "ObjectEntry")})
-	public void deleteScopeByExternalReferenceCode(
-			@NotNull @Parameter(hidden = true) @PathParam("scopeId") String
-				scopeId,
+	public void deleteScopeScopeKeyByExternalReferenceCode(
+			@NotNull @Parameter(hidden = true) @PathParam("scopeKey") String
+				scopeKey,
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode)
@@ -283,18 +283,18 @@ public abstract class BaseObjectEntryResourceImpl
 	@Override
 	@Parameters(
 		value = {
-			@Parameter(in = ParameterIn.PATH, name = "scopeId"),
+			@Parameter(in = ParameterIn.PATH, name = "scopeKey"),
 			@Parameter(in = ParameterIn.PATH, name = "externalReferenceCode")
 		}
 	)
 	@Path(
-		"/scopes/{scopeId}/by-external-reference-code/{externalReferenceCode}"
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}"
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "ObjectEntry")})
-	public ObjectEntry getScopeByExternalReferenceCode(
-			@NotNull @Parameter(hidden = true) @PathParam("scopeId") String
-				scopeId,
+	public ObjectEntry getScopeScopeKeyByExternalReferenceCode(
+			@NotNull @Parameter(hidden = true) @PathParam("scopeKey") String
+				scopeKey,
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode)
@@ -307,19 +307,19 @@ public abstract class BaseObjectEntryResourceImpl
 	@Override
 	@Parameters(
 		value = {
-			@Parameter(in = ParameterIn.PATH, name = "scopeId"),
+			@Parameter(in = ParameterIn.PATH, name = "scopeKey"),
 			@Parameter(in = ParameterIn.PATH, name = "externalReferenceCode")
 		}
 	)
 	@Path(
-		"/scopes/{scopeId}/by-external-reference-code/{externalReferenceCode}"
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}"
 	)
 	@Produces({"application/json", "application/xml"})
 	@PUT
 	@Tags(value = {@Tag(name = "ObjectEntry")})
-	public ObjectEntry putScopeByExternalReferenceCode(
-			@NotNull @Parameter(hidden = true) @PathParam("scopeId") String
-				scopeId,
+	public ObjectEntry putScopeScopeKeyByExternalReferenceCode(
+			@NotNull @Parameter(hidden = true) @PathParam("scopeKey") String
+				scopeKey,
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -77,26 +77,36 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
+	public void deleteByExternalReferenceCode(String externalReferenceCode)
+		throws Exception {
+
+		_objectEntryManager.deleteObjectEntry(
+			externalReferenceCode, contextCompany.getCompanyId(), null,
+			_objectDefinition);
+	}
+
+	@Override
 	public void deleteObjectEntry(Long objectEntryId) throws Exception {
 		_objectEntryManager.deleteObjectEntry(objectEntryId);
 	}
 
 	@Override
-	public void deleteObjectEntryByExternalReferenceCode(
-			String externalReferenceCode)
+	public void deleteScopeByExternalReferenceCode(
+			String scopeId, String externalReferenceCode)
 		throws Exception {
 
 		_objectEntryManager.deleteObjectEntry(
-			externalReferenceCode, contextCompany.getCompanyId(), 0L);
+			externalReferenceCode, contextCompany.getCompanyId(), scopeId,
+			_objectDefinition);
 	}
 
 	@Override
-	public void deleteSiteObjectEntryByExternalReferenceCode(
-			Long siteId, String externalReferenceCode)
+	public ObjectEntry getByExternalReferenceCode(String externalReferenceCode)
 		throws Exception {
 
-		_objectEntryManager.deleteObjectEntry(
-			externalReferenceCode, contextCompany.getCompanyId(), siteId);
+		return _objectEntryManager.getObjectEntry(
+			_getDTOConverterContext(null), externalReferenceCode,
+			contextCompany.getCompanyId(), null, _objectDefinition);
 	}
 
 	@Override
@@ -117,8 +127,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		throws Exception {
 
 		return _objectEntryManager.getObjectEntries(
-			contextCompany.getCompanyId(), 0,
-			_objectDefinition.getObjectDefinitionId(), aggregation,
+			contextCompany.getCompanyId(), null, _objectDefinition, aggregation,
 			_getDTOConverterContext(null), filter, pagination, search, sorts);
 	}
 
@@ -129,23 +138,26 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
-	public ObjectEntry getObjectEntryByExternalReferenceCode(
-			String externalReferenceCode)
+	public ObjectEntry getScopeByExternalReferenceCode(
+			String scopeId, String externalReferenceCode)
 		throws Exception {
 
 		return _objectEntryManager.getObjectEntry(
 			_getDTOConverterContext(null), externalReferenceCode,
-			contextCompany.getCompanyId(), 0L);
+			contextCompany.getCompanyId(), scopeId, _objectDefinition);
 	}
 
 	@Override
-	public ObjectEntry getSiteObjectEntryByExternalReferenceCode(
-			Long siteId, String externalReferenceCode)
+	public Page<ObjectEntry> getScopeScopePage(
+			String scopeId, Boolean flatten, String search,
+			Aggregation aggregation, Filter filter, Pagination pagination,
+			Sort[] sorts)
 		throws Exception {
 
-		return _objectEntryManager.getObjectEntry(
-			_getDTOConverterContext(null), externalReferenceCode,
-			contextCompany.getCompanyId(), siteId);
+		return _objectEntryManager.getObjectEntries(
+			contextCompany.getCompanyId(), scopeId, _objectDefinition,
+			aggregation, _getDTOConverterContext(null), filter, pagination,
+			search, sorts);
 	}
 
 	@Override
@@ -153,8 +165,27 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		throws Exception {
 
 		return _objectEntryManager.addObjectEntry(
-			_getDTOConverterContext(null), contextUser.getUserId(), 0,
-			_objectDefinition.getObjectDefinitionId(), objectEntry);
+			_getDTOConverterContext(null), contextUser.getUserId(), null,
+			_objectDefinition, objectEntry);
+	}
+
+	@Override
+	public ObjectEntry postScope(String scopeId, ObjectEntry objectEntry)
+		throws Exception {
+
+		return _objectEntryManager.addObjectEntry(
+			_getDTOConverterContext(null), contextUser.getUserId(), scopeId,
+			_objectDefinition, objectEntry);
+	}
+
+	@Override
+	public ObjectEntry putByExternalReferenceCode(
+			String externalReferenceCode, ObjectEntry objectEntry)
+		throws Exception {
+
+		return _objectEntryManager.addOrUpdateObjectEntry(
+			_getDTOConverterContext(null), externalReferenceCode,
+			contextUser.getUserId(), null, _objectDefinition, objectEntry);
 	}
 
 	@Override
@@ -168,25 +199,14 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
-	public ObjectEntry putObjectEntryByExternalReferenceCode(
-			String externalReferenceCode, ObjectEntry objectEntry)
+	public ObjectEntry putScopeByExternalReferenceCode(
+			String scopeId, String externalReferenceCode,
+			ObjectEntry objectEntry)
 		throws Exception {
 
 		return _objectEntryManager.addOrUpdateObjectEntry(
 			_getDTOConverterContext(null), externalReferenceCode,
-			contextUser.getUserId(), 0L,
-			_objectDefinition.getObjectDefinitionId(), objectEntry);
-	}
-
-	@Override
-	public ObjectEntry putSiteObjectEntryByExternalReferenceCode(
-			Long siteId, String externalReferenceCode, ObjectEntry objectEntry)
-		throws Exception {
-
-		return _objectEntryManager.addOrUpdateObjectEntry(
-			_getDTOConverterContext(null), externalReferenceCode,
-			contextUser.getUserId(), siteId,
-			_objectDefinition.getObjectDefinitionId(), objectEntry);
+			contextUser.getUserId(), scopeId, _objectDefinition, objectEntry);
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -91,12 +91,12 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
-	public void deleteScopeByExternalReferenceCode(
-			String scopeId, String externalReferenceCode)
+	public void deleteScopeScopeKeyByExternalReferenceCode(
+			String scopeKey, String externalReferenceCode)
 		throws Exception {
 
 		_objectEntryManager.deleteObjectEntry(
-			externalReferenceCode, contextCompany.getCompanyId(), scopeId,
+			externalReferenceCode, contextCompany.getCompanyId(), scopeKey,
 			_objectDefinition);
 	}
 
@@ -138,24 +138,24 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
-	public ObjectEntry getScopeByExternalReferenceCode(
-			String scopeId, String externalReferenceCode)
+	public ObjectEntry getScopeScopeKeyByExternalReferenceCode(
+			String scopeKey, String externalReferenceCode)
 		throws Exception {
 
 		return _objectEntryManager.getObjectEntry(
 			_getDTOConverterContext(null), externalReferenceCode,
-			contextCompany.getCompanyId(), scopeId, _objectDefinition);
+			contextCompany.getCompanyId(), scopeKey, _objectDefinition);
 	}
 
 	@Override
-	public Page<ObjectEntry> getScopeScopePage(
-			String scopeId, Boolean flatten, String search,
+	public Page<ObjectEntry> getScopeScopeKeyPage(
+			String scopeKey, Boolean flatten, String search,
 			Aggregation aggregation, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception {
 
 		return _objectEntryManager.getObjectEntries(
-			contextCompany.getCompanyId(), scopeId, _objectDefinition,
+			contextCompany.getCompanyId(), scopeKey, _objectDefinition,
 			aggregation, _getDTOConverterContext(null), filter, pagination,
 			search, sorts);
 	}
@@ -170,11 +170,12 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
-	public ObjectEntry postScope(String scopeId, ObjectEntry objectEntry)
+	public ObjectEntry postScopeScopeKey(
+			String scopeKey, ObjectEntry objectEntry)
 		throws Exception {
 
 		return _objectEntryManager.addObjectEntry(
-			_getDTOConverterContext(null), contextUser.getUserId(), scopeId,
+			_getDTOConverterContext(null), contextUser.getUserId(), scopeKey,
 			_objectDefinition, objectEntry);
 	}
 
@@ -199,14 +200,14 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
-	public ObjectEntry putScopeByExternalReferenceCode(
-			String scopeId, String externalReferenceCode,
+	public ObjectEntry putScopeScopeKeyByExternalReferenceCode(
+			String scopeKey, String externalReferenceCode,
 			ObjectEntry objectEntry)
 		throws Exception {
 
 		return _objectEntryManager.addOrUpdateObjectEntry(
 			_getDTOConverterContext(null), externalReferenceCode,
-			contextUser.getUserId(), scopeId, _objectDefinition, objectEntry);
+			contextUser.getUserId(), scopeKey, _objectDefinition, objectEntry);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -88,7 +88,8 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return TextFormatter.formatPlural(StringUtil.toLowerCase(getName()));
+		return "/c/" +
+			TextFormatter.formatPlural(StringUtil.toLowerCase(getShortName()));
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -31,7 +31,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
@@ -99,9 +98,8 @@ public class ObjectRelationshipLocalServiceImpl
 
 			objectRelationship.setDBTableName(
 				StringBundler.concat(
-					"R_", user.getCompanyId(),
-					objectDefinition1.getShortName(), "_",
-					objectDefinition2.getShortName(), "_", name));
+					"R_", user.getCompanyId(), objectDefinition1.getShortName(),
+					"_", objectDefinition2.getShortName(), "_", name));
 
 			runSQL(
 				StringBundler.concat(

--- a/modules/apps/object/object-test/src/testFunctional/tests/macros/json/JSONObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/tests/macros/json/JSONObject.macro
@@ -83,7 +83,7 @@ definition {
 
 		var objectName = StringUtil.toLowerCase("${objectName}");
 		var curl = '''
-			${portalURL}/o/c_${objectName}s \
+			${portalURL}/o/c/${objectName}s \
 			-H 'Content-Type: application/json' \
 			-u ${userEmailAddress}:${userPassword} \
 			-d '{
@@ -169,7 +169,7 @@ definition {
 
 		var objectName = StringUtil.toLowerCase("${objectName}");
 		var curl = '''
-			${portalURL}/o/${objectName}s/${entryId} \
+			${portalURL}/o/c/${objectName}s/${entryId} \
 			-u ${userEmailAddress}:${userPassword}
 		''';
 
@@ -189,7 +189,7 @@ definition {
 
 		var objectName = StringUtil.toLowerCase("${objectName}");
 		var curl = '''
-			${portalURL}/o/${objectName}s \
+			${portalURL}/o/c/${objectName}s \
 			-u ${userEmailAddress}:${userPassword}
 		''';
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
@@ -89,8 +89,9 @@ public class ObjectDefinitionGraphQLTest {
 				TestPropsValues.getUserId(),
 				_objectDefinition.getObjectDefinitionId());
 
-		_objectDefinitionName = StringUtil.toLowerCase(
-			_objectDefinition.getName());
+		_objectDefinitionIdName = StringUtil.removeSubstring(
+			_objectDefinition.getPKObjectFieldName(), "c_");
+		_objectDefinitionName = _objectDefinition.getShortName();
 
 		_objectEntry = ObjectEntryLocalServiceUtil.addObjectEntry(
 			TestPropsValues.getUserId(), 0,
@@ -112,14 +113,18 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"mutation",
 						new GraphQLField(
-							"create" + _objectDefinitionName,
-							HashMapBuilder.<String, Object>put(
-								_objectDefinitionName,
-								StringBundler.concat(
-									"{", _objectFieldName, ": \"", value, "\"}")
-							).build(),
-							new GraphQLField(_objectFieldName)))),
-				"JSONObject/data", "JSONObject/create" + _objectDefinitionName,
+							"c",
+							new GraphQLField(
+								"create" + _objectDefinitionName,
+								HashMapBuilder.<String, Object>put(
+									_objectDefinitionName,
+									StringBundler.concat(
+										"{", _objectFieldName, ": \"", value,
+										"\"}")
+								).build(),
+								new GraphQLField(_objectFieldName))))),
+				"JSONObject/data", "JSONObject/c",
+				"JSONObject/create" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 	}
 
@@ -128,24 +133,25 @@ public class ObjectDefinitionGraphQLTest {
 		GraphQLField graphQLField = new GraphQLField(
 			"mutation",
 			new GraphQLField(
-				"delete" + _objectDefinitionName,
-				HashMapBuilder.<String, Object>put(
-					_objectDefinition.getPKObjectFieldName(),
-					_objectEntry.getObjectEntryId()
-				).build()));
+				"c",
+				new GraphQLField(
+					"delete" + _objectDefinitionName,
+					HashMapBuilder.<String, Object>put(
+						_objectDefinitionIdName, _objectEntry.getObjectEntryId()
+					).build())));
 
 		JSONObject jsonObject = _invoke(graphQLField);
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
-				jsonObject, "JSONObject/data",
+				jsonObject, "JSONObject/data", "JSONObject/c",
 				"Object/delete" + _objectDefinitionName));
 
 		jsonObject = _invoke(graphQLField);
 
 		Assert.assertFalse(
 			JSONUtil.getValueAsBoolean(
-				jsonObject, "JSONObject/data",
+				jsonObject, "JSONObject/data", "JSONObject/c",
 				"Object/delete" + _objectDefinitionName));
 	}
 
@@ -161,16 +167,19 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							key,
-							HashMapBuilder.<String, Object>put(
-								"filter",
-								"\"" + _objectFieldName +
-									" eq 'peter@liferay.com'\""
-							).build(),
+							"c",
 							new GraphQLField(
-								"items", new GraphQLField(_objectFieldName))))),
-				"JSONObject/data", "JSONObject/" + key, "Object/items",
-				"Object/0", "Object/" + _objectFieldName));
+								key,
+								HashMapBuilder.<String, Object>put(
+									"filter",
+									"\"" + _objectFieldName +
+										" eq 'peter@liferay.com'\""
+								).build(),
+								new GraphQLField(
+									"items",
+									new GraphQLField(_objectFieldName)))))),
+				"JSONObject/data", "JSONObject/c", "JSONObject/" + key,
+				"Object/items", "Object/0", "Object/" + _objectFieldName));
 		Assert.assertEquals(
 			"peter@liferay.com",
 			JSONUtil.getValueAsString(
@@ -178,16 +187,19 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							key,
-							HashMapBuilder.<String, Object>put(
-								"filter",
-								"\"contains(" + _objectFieldName +
-									",'peter@liferay.com')\""
-							).build(),
+							"c",
 							new GraphQLField(
-								"items", new GraphQLField(_objectFieldName))))),
-				"JSONObject/data", "JSONObject/" + key, "Object/items",
-				"Object/0", "Object/" + _objectFieldName));
+								key,
+								HashMapBuilder.<String, Object>put(
+									"filter",
+									"\"contains(" + _objectFieldName +
+										",'peter@liferay.com')\""
+								).build(),
+								new GraphQLField(
+									"items",
+									new GraphQLField(_objectFieldName)))))),
+				"JSONObject/data", "JSONObject/c", "JSONObject/" + key,
+				"Object/items", "Object/0", "Object/" + _objectFieldName));
 		Assert.assertEquals(
 			"peter@liferay.com",
 			JSONUtil.getValueAsString(
@@ -195,16 +207,19 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							key,
-							HashMapBuilder.<String, Object>put(
-								"filter",
-								"\"userId eq " + TestPropsValues.getUserId() +
-									"\""
-							).build(),
+							"c",
 							new GraphQLField(
-								"items", new GraphQLField(_objectFieldName))))),
-				"JSONObject/data", "JSONObject/" + key, "Object/items",
-				"Object/0", "Object/" + _objectFieldName));
+								key,
+								HashMapBuilder.<String, Object>put(
+									"filter",
+									"\"userId eq " +
+										TestPropsValues.getUserId() + "\""
+								).build(),
+								new GraphQLField(
+									"items",
+									new GraphQLField(_objectFieldName)))))),
+				"JSONObject/data", "JSONObject/c", "JSONObject/" + key,
+				"Object/items", "Object/0", "Object/" + _objectFieldName));
 	}
 
 	@Test
@@ -221,14 +236,17 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							key,
-							HashMapBuilder.<String, Object>put(
-								"filter",
-								"\"" + _objectFieldName +
-									" ne 'peter@liferay.com'\""
-							).build(),
-							new GraphQLField("totalCount")))),
-				"JSONObject/data", "JSONObject/" + key, "Object/totalCount"));
+							"c",
+							new GraphQLField(
+								key,
+								HashMapBuilder.<String, Object>put(
+									"filter",
+									"\"" + _objectFieldName +
+										" ne 'peter@liferay.com'\""
+								).build(),
+								new GraphQLField("totalCount"))))),
+				"JSONObject/data", "JSONObject/c", "JSONObject/" + key,
+				"Object/totalCount"));
 	}
 
 	@Test
@@ -242,13 +260,15 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"query",
 						new GraphQLField(
-							key,
-							HashMapBuilder.<String, Object>put(
-								_objectDefinition.getPKObjectFieldName(),
-								_objectEntry.getObjectEntryId()
-							).build(),
-							new GraphQLField(_objectFieldName)))),
-				"JSONObject/data", "JSONObject/" + key,
+							"c",
+							new GraphQLField(
+								key,
+								HashMapBuilder.<String, Object>put(
+									_objectDefinitionIdName,
+									_objectEntry.getObjectEntryId()
+								).build(),
+								new GraphQLField(_objectFieldName))))),
+				"JSONObject/data", "JSONObject/c", "JSONObject/" + key,
 				"Object/" + _objectFieldName));
 	}
 
@@ -260,29 +280,30 @@ public class ObjectDefinitionGraphQLTest {
 			new GraphQLField(
 				"mutation",
 				new GraphQLField(
-					"create" + _objectDefinitionName,
-					HashMapBuilder.<String, Object>put(
-						_objectDefinitionName,
-						StringBundler.concat(
-							"{", _objectFieldName, ": \"", value, "\"}")
-					).build(),
-					new GraphQLField(_objectFieldName),
+					"c",
 					new GraphQLField(
-						_objectDefinition.getPKObjectFieldName()))));
+						"create" + _objectDefinitionName,
+						HashMapBuilder.<String, Object>put(
+							_objectDefinitionName,
+							StringBundler.concat(
+								"{", _objectFieldName, ": \"", value, "\"}")
+						).build(),
+						new GraphQLField(_objectFieldName),
+						new GraphQLField(_objectDefinitionIdName)))));
 
 		Assert.assertEquals(
 			value,
 			JSONUtil.getValueAsString(
-				jsonObject, "JSONObject/data",
+				jsonObject, "JSONObject/data", "JSONObject/c",
 				"JSONObject/create" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 
 		value = RandomTestUtil.randomString();
 
 		Long objectEntryId = JSONUtil.getValueAsLong(
-			jsonObject, "JSONObject/data",
+			jsonObject, "JSONObject/data", "JSONObject/c",
 			"JSONObject/create" + _objectDefinitionName,
-			"Object/" + _objectDefinition.getPKObjectFieldName());
+			"Object/" + _objectDefinitionIdName);
 
 		Assert.assertEquals(
 			value,
@@ -291,17 +312,21 @@ public class ObjectDefinitionGraphQLTest {
 					new GraphQLField(
 						"mutation",
 						new GraphQLField(
-							"update" + _objectDefinitionName,
-							HashMapBuilder.<String, Object>put(
-								_objectDefinitionName,
-								StringBundler.concat(
-									"{", _objectFieldName, ": \"", value, "\"}")
-							).put(
-								_objectDefinition.getPKObjectFieldName(),
-								String.valueOf(objectEntryId)
-							).build(),
-							new GraphQLField(_objectFieldName)))),
-				"JSONObject/data", "JSONObject/update" + _objectDefinitionName,
+							"c",
+							new GraphQLField(
+								"update" + _objectDefinitionName,
+								HashMapBuilder.<String, Object>put(
+									_objectDefinitionIdName,
+									String.valueOf(objectEntryId)
+								).put(
+									_objectDefinitionName,
+									StringBundler.concat(
+										"{", _objectFieldName, ": \"", value,
+										"\"}")
+								).build(),
+								new GraphQLField(_objectFieldName))))),
+				"JSONObject/data", "JSONObject/c",
+				"JSONObject/update" + _objectDefinitionName,
 				"Object/" + _objectFieldName));
 	}
 
@@ -329,6 +354,7 @@ public class ObjectDefinitionGraphQLTest {
 	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition;
 
+	private String _objectDefinitionIdName;
 	private String _objectDefinitionName;
 	private ObjectEntry _objectEntry;
 	private String _objectFieldName;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ViewObjectEntriesDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ViewObjectEntriesDisplayContext.java
@@ -42,7 +42,7 @@ public class ViewObjectEntriesDisplayContext {
 	public ViewObjectEntriesDisplayContext(
 		HttpServletRequest httpServletRequest, String restContextPath) {
 
-		_apiURL = "/o/" + restContextPath;
+		_apiURL = "/o" + restContextPath;
 		_objectRequestHelper = new ObjectRequestHelper(httpServletRequest);
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation", version: "6.0.0"
 	compileOnly project(":apps:batch-engine:batch-engine-api")
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-liferay-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/dto/GraphQLDTOContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/dto/GraphQLDTOContributor.java
@@ -55,6 +55,10 @@ public interface GraphQLDTOContributor<D, R> {
 
 	public String getResourceName();
 
+	public String getTypeName();
+
+	public boolean hasScope();
+
 	public R updateDTO(D dto, DTOConverterContext dtoConverterContext, long id)
 		throws Exception;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/OpenAPISchemaFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/OpenAPISchemaFilter.java
@@ -22,12 +22,20 @@ import java.util.Map;
  */
 public class OpenAPISchemaFilter {
 
+	public String getApplicationPath() {
+		return _applicationPath;
+	}
+
 	public DTOProperty getDTOProperty() {
 		return _dtoProperty;
 	}
 
 	public Map<String, String> getSchemaMappings() {
 		return _schemaMappings;
+	}
+
+	public void setApplicationPath(String applicationPath) {
+		_applicationPath = applicationPath;
 	}
 
 	public void setDTOProperty(DTOProperty dtoProperty) {
@@ -38,6 +46,7 @@ public class OpenAPISchemaFilter {
 		_schemaMappings = schemaMappings;
 	}
 
+	private String _applicationPath;
 	private DTOProperty _dtoProperty;
 	private Map<String, String> _schemaMappings = new HashMap<>();
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
@@ -37,16 +37,16 @@ public class GroupUtil {
 	}
 
 	public static Long getDepotGroupId(
-		String assetLibraryId, long companyId,
+		String assetLibraryKey, long companyId,
 		DepotEntryLocalService depotEntryLocalService,
 		GroupLocalService groupLocalService) {
 
-		Group group = groupLocalService.fetchGroup(companyId, assetLibraryId);
+		Group group = groupLocalService.fetchGroup(companyId, assetLibraryKey);
 
 		if (group == null) {
 			try {
 				DepotEntry depotEntry = depotEntryLocalService.fetchDepotEntry(
-					GetterUtil.getLong(assetLibraryId));
+					GetterUtil.getLong(assetLibraryKey));
 
 				if (depotEntry == null) {
 					return null;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/openapi/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/openapi/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateAdaptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateAdaptor.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
-import com.liferay.portal.vulcan.internal.jaxrs.param.converter.provider.SiteParamConverterProvider;
+import com.liferay.portal.vulcan.util.GroupUtil;
 
 import java.io.Serializable;
 
@@ -146,10 +146,6 @@ public class VulcanBatchEngineTaskItemDelegateAdaptor<T>
 			return new HashMap<>();
 		}
 
-		SiteParamConverterProvider siteParamConverterProvider =
-			new SiteParamConverterProvider(
-				_depotEntryLocalService, _groupLocalService);
-
 		for (Map.Entry<String, Serializable> entry : parameters.entrySet()) {
 			String key = entry.getKey();
 			Serializable value = entry.getValue();
@@ -157,14 +153,16 @@ public class VulcanBatchEngineTaskItemDelegateAdaptor<T>
 			if (key.equals("assetLibraryId") && (value != null)) {
 				parameters.put(
 					key,
-					siteParamConverterProvider.getDepotGroupId(
-						String.valueOf(value), _company.getCompanyId()));
+					GroupUtil.getDepotGroupId(
+						String.valueOf(value), _company.getCompanyId(),
+						_depotEntryLocalService, _groupLocalService));
 			}
 			else if (key.equals("siteId") && (value != null)) {
 				parameters.put(
 					key,
-					siteParamConverterProvider.getGroupId(
-						_company.getCompanyId(), String.valueOf(value)));
+					GroupUtil.getGroupId(
+						_company.getCompanyId(), String.valueOf(value),
+						_groupLocalService));
 			}
 		}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/VulcanConfiguration.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/VulcanConfiguration.java
@@ -41,10 +41,7 @@ public interface VulcanConfiguration {
 	@Meta.AD(deflt = "true", name = "rest-api", required = false)
 	public boolean restEnabled();
 
-	@Meta.AD(
-		description = "changes-will-take-effect-once-the-portal-is-restarted-please-restart-the-portal-now",
-		name = "excluded-operation-ids", required = false
-	)
+	@Meta.AD(name = "excluded-operation-ids", required = false)
 	public String excludedOperationIds();
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -69,13 +69,13 @@ import com.liferay.portal.vulcan.internal.jaxrs.context.provider.AggregationCont
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.ContextProviderUtil;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.FilterContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.SortContextProvider;
-import com.liferay.portal.vulcan.internal.jaxrs.param.converter.provider.SiteParamConverterProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.validation.ValidationUtil;
 import com.liferay.portal.vulcan.internal.multipart.MultipartUtil;
 import com.liferay.portal.vulcan.multipart.BinaryFile;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.GroupUtil;
 
 import graphql.ExceptionWhileDataFetching;
 import graphql.GraphQLError;
@@ -944,10 +944,6 @@ public class GraphQLServletExtender {
 			}
 		}
 
-		SiteParamConverterProvider siteParamConverterProvider =
-			new SiteParamConverterProvider(
-				_depotEntryLocalService, _groupLocalService);
-
 		for (int i = 0; i < parameters.length; i++) {
 			Parameter parameter = parameters[i];
 
@@ -979,9 +975,9 @@ public class GraphQLServletExtender {
 			if (parameterName.equals("assetLibraryId") && (argument != null)) {
 				try {
 					argument = String.valueOf(
-						siteParamConverterProvider.getDepotGroupId(
-							(String)argument,
-							CompanyThreadLocal.getCompanyId()));
+						GroupUtil.getDepotGroupId(
+							(String)argument, CompanyThreadLocal.getCompanyId(),
+							_depotEntryLocalService, _groupLocalService));
 				}
 				catch (Exception exception) {
 					throw new Exception(
@@ -994,9 +990,9 @@ public class GraphQLServletExtender {
 			if (parameterName.equals("siteKey") && (argument != null)) {
 				try {
 					argument = String.valueOf(
-						siteParamConverterProvider.getGroupId(
-							CompanyThreadLocal.getCompanyId(),
-							(String)argument));
+						GroupUtil.getGroupId(
+							CompanyThreadLocal.getCompanyId(), (String)argument,
+							_groupLocalService));
 				}
 				catch (Exception exception) {
 					throw new Exception(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1594,6 +1594,9 @@ public class GraphQLServletExtender {
 		GraphQLObjectType.Builder graphQLObjectTypeBuilder =
 			new GraphQLObjectType.Builder();
 
+		graphQLObjectTypeBuilder.field(
+			_addField(Scalars.GraphQLLong, graphQLDTOContributor.getIdName()));
+
 		graphQLObjectTypeBuilder.name(graphQLDTOContributor.getTypeName());
 
 		for (GraphQLDTOProperty graphQLDTOProperty :

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1752,7 +1752,7 @@ public class GraphQLServletExtender {
 
 		if (graphQLDTOContributor.hasScope()) {
 			graphQLArguments.add(
-				_addArgument(Scalars.GraphQLString, "scopeId"));
+				_addArgument(Scalars.GraphQLString, "scopeKey"));
 		}
 
 		mutationGraphQLObjectTypeBuilder.field(
@@ -1772,9 +1772,9 @@ public class GraphQLServletExtender {
 						_getDTOConverterContext(
 							dataFetchingEnvironment,
 							HashMapBuilder.<String, Serializable>put(
-								"scopeId",
+								"scopeKey",
 								(String)dataFetchingEnvironment.getArgument(
-									"scopeId")
+									"scopeKey")
 							).build()))
 			).build());
 
@@ -1833,7 +1833,7 @@ public class GraphQLServletExtender {
 
 		if (graphQLDTOContributor.hasScope()) {
 			graphQLArguments.add(
-				_addArgument(Scalars.GraphQLString, "scopeId"));
+				_addArgument(Scalars.GraphQLString, "scopeKey"));
 		}
 
 		queryGraphQLObjectTypeBuilder.field(
@@ -1876,9 +1876,9 @@ public class GraphQLServletExtender {
 							HashMapBuilder.<String, Serializable>put(
 								"companyId", CompanyThreadLocal.getCompanyId()
 							).put(
-								"scopeId",
+								"scopeKey",
 								(String)dataFetchingEnvironment.getArgument(
-									"scopeId")
+									"scopeKey")
 							).build()),
 						_getFilter(
 							acceptLanguage,

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/ContextContainerRequestFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/ContextContainerRequestFilter.java
@@ -22,23 +22,20 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.internal.accept.language.AcceptLanguageImpl;
+import com.liferay.portal.vulcan.internal.configuration.util.ConfigurationUtil;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.ContextProviderUtil;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
-import java.util.Dictionary;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -56,7 +53,7 @@ import org.apache.cxf.jaxrs.impl.UriInfoImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.PhaseInterceptorChain;
 
-import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Javier Gamarra
@@ -65,7 +62,7 @@ import org.osgi.service.cm.Configuration;
 public class ContextContainerRequestFilter implements ContainerRequestFilter {
 
 	public ContextContainerRequestFilter(
-		Map<String, Configuration> configurations,
+		ConfigurationAdmin configurationAdmin,
 		ExpressionConvert<Filter> expressionConvert,
 		FilterParserProvider filterParserProvider,
 		GroupLocalService groupLocalService, Language language, Portal portal,
@@ -75,7 +72,7 @@ public class ContextContainerRequestFilter implements ContainerRequestFilter {
 		VulcanBatchEngineImportTaskResource
 			vulcanBatchEngineImportTaskResource) {
 
-		_configurations = configurations;
+		_configurationAdmin = configurationAdmin;
 		_expressionConvert = expressionConvert;
 		_filterParserProvider = filterParserProvider;
 		_groupLocalService = groupLocalService;
@@ -108,40 +105,26 @@ public class ContextContainerRequestFilter implements ContainerRequestFilter {
 	}
 
 	private void _filterExcludedOperationIds(
-		ContainerRequestContext containerRequestContext, Object instance,
-		Message message) {
+		ContainerRequestContext containerRequestContext, Message message) {
 
 		String path = StringUtil.removeSubstring(
 			(String)message.get(Message.BASE_PATH), "/o");
 
 		path = StringUtil.replaceLast(path, '/', "");
 
-		if (_configurations.containsKey(path)) {
-			Configuration configuration = _configurations.get(path);
+		Set<String> excludedOperationIds =
+			ConfigurationUtil.getExcludedOperationIds(
+				_configurationAdmin, path);
 
-			Dictionary<String, Object> properties =
-				configuration.getProperties();
+		Method method = (Method)message.get("org.apache.cxf.resource.method");
 
-			String excludedOperationIds = GetterUtil.getString(
-				properties.get("excludedOperationIds"));
-
-			Set<String> excludedOperationIdsList = SetUtil.fromArray(
-				excludedOperationIds.split(","));
-
-			Class<?> clazz = instance.getClass();
-
-			Method[] methods = clazz.getMethods();
-
-			for (Method method : methods) {
-				if (excludedOperationIdsList.contains(method.getName())) {
-					containerRequestContext.abortWith(
-						Response.status(
-							Response.Status.CONFLICT
-						).entity(
-							"Conflict with " + method.getName()
-						).build());
-				}
-			}
+		if (excludedOperationIds.contains(method.getName())) {
+			containerRequestContext.abortWith(
+				Response.status(
+					Response.Status.CONFLICT
+				).entity(
+					"Conflict with " + method.getName()
+				).build());
 		}
 	}
 
@@ -158,7 +141,7 @@ public class ContextContainerRequestFilter implements ContainerRequestFilter {
 		HttpServletRequest httpServletRequest =
 			ContextProviderUtil.getHttpServletRequest(message);
 
-		_filterExcludedOperationIds(containerRequestContext, instance, message);
+		_filterExcludedOperationIds(containerRequestContext, message);
 
 		Class<?> clazz = instance.getClass();
 
@@ -261,7 +244,7 @@ public class ContextContainerRequestFilter implements ContainerRequestFilter {
 		}
 	}
 
-	private final Map<String, Configuration> _configurations;
+	private final ConfigurationAdmin _configurationAdmin;
 	private final ExpressionConvert<Filter> _expressionConvert;
 	private final FilterParserProvider _filterParserProvider;
 	private final GroupLocalService _groupLocalService;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -30,7 +30,6 @@ import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
-import com.liferay.portal.vulcan.internal.configuration.util.ConfigurationUtil;
 import com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.CTContainerRequestFilter;
 import com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.ContextContainerRequestFilter;
 import com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.LogContainerRequestFilter;
@@ -142,11 +141,11 @@ public class VulcanFeature implements Feature {
 		featureContext.register(new CompanyContextProvider(_portal));
 		featureContext.register(
 			new ContextContainerRequestFilter(
-				ConfigurationUtil.getConfigurations(_configurationAdmin),
-				_expressionConvert, _filterParserProvider, _groupLocalService,
-				_language, _portal, _resourceActionLocalService,
-				_resourcePermissionLocalService, _roleLocalService,
-				_getScopeChecker(), _vulcanBatchEngineImportTaskResource));
+				_configurationAdmin, _expressionConvert, _filterParserProvider,
+				_groupLocalService, _language, _portal,
+				_resourceActionLocalService, _resourcePermissionLocalService,
+				_roleLocalService, _getScopeChecker(),
+				_vulcanBatchEngineImportTaskResource));
 		featureContext.register(
 			new FilterContextProvider(
 				_expressionConvert, _filterParserProvider, _language, _portal));

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/SiteParamConverterProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/SiteParamConverterProvider.java
@@ -95,22 +95,22 @@ public class SiteParamConverterProvider
 		return null;
 	}
 
-	public Long getDepotGroupId(String assetLibraryId, long companyId) {
-		if (assetLibraryId == null) {
+	public Long getDepotGroupId(String assetLibraryKey, long companyId) {
+		if (assetLibraryKey == null) {
 			return null;
 		}
 
 		return GroupUtil.getDepotGroupId(
-			assetLibraryId, companyId, _depotEntryLocalService,
+			assetLibraryKey, companyId, _depotEntryLocalService,
 			_groupLocalService);
 	}
 
-	public Long getGroupId(long companyId, String siteId) {
-		if (siteId == null) {
+	public Long getGroupId(long companyId, String siteKey) {
+		if (siteKey == null) {
 			return null;
 		}
 
-		return GroupUtil.getGroupId(companyId, siteId, _groupLocalService);
+		return GroupUtil.getGroupId(companyId, siteKey, _groupLocalService);
 	}
 
 	@Override

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portal.vulcan.internal.resource;
 
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
+import com.liferay.portal.vulcan.internal.configuration.util.ConfigurationUtil;
 import com.liferay.portal.vulcan.openapi.DTOProperty;
 import com.liferay.portal.vulcan.openapi.OpenAPISchemaFilter;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
@@ -57,7 +58,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Javier Gamarra
@@ -201,6 +204,15 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 				Map<String, List<String>> headers) {
 
 				String operationId = operation.getOperationId();
+
+				Set<String> excludedOperationIds =
+					ConfigurationUtil.getExcludedOperationIds(
+						_configurationAdmin,
+						openAPISchemaFilter.getApplicationPath());
+
+				if (excludedOperationIds.contains(operationId)) {
+					return Optional.empty();
+				}
 
 				for (Map.Entry<String, String> entry :
 						schemaMappings.entrySet()) {
@@ -441,5 +453,8 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 
 		};
 	}
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
 
 }


### PR DESCRIPTION
This add endpoints like /o/c/scopes/{scopeId}. I'm not using `/object-entries` as we do not want any reference to it in the paths/OpenAPI and we want to expose only the user chosen name.

This methods are disabled when the `ObjectDefinition` is scoped by company and can not be used via REST, GraphQL nor exposed in OpenAPI. The opposite is also true, when the `ObjectDefinition` is scoped by group/asset library, the general unscoped methods disappear.

I'm using scope instead of siteId to allow other types of scopes that are planned for the future. I'm using a string to be able to use everything, like the group/asset library name or the id (both will work).

I'm also renaming the APIs to use `/o/c/my-element` instead of `/o/c-my-element`. It also adds namespaces in GraphQL to be able to use queries like:

```
mutation {
  c {
    createMyElement(...) {
     ...
    }
  }
}
```

It's probable that some poshi tests that depends on the path will fail, let's see :)