### PR TITLE
LPS-131281 Add actions to Object APIs

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
@@ -27,10 +27,9 @@ import java.util.Map;
 public class ObjectFieldUtil {
 
 	public static ObjectField toObjectField(
-		Map<String, Map<String, String>> actions,
 		com.liferay.object.model.ObjectField serviceBuilderObjectField) {
 
-		ObjectField objectField = new ObjectField() {
+		return new ObjectField() {
 			{
 				id = serviceBuilderObjectField.getObjectFieldId();
 				indexed = serviceBuilderObjectField.getIndexed();
@@ -48,6 +47,13 @@ public class ObjectFieldUtil {
 					serviceBuilderObjectField.getType());
 			}
 		};
+	}
+
+	public static ObjectField toObjectField(
+		Map<String, Map<String, String>> actions,
+		com.liferay.object.model.ObjectField serviceBuilderObjectField) {
+
+		ObjectField objectField = toObjectField(serviceBuilderObjectField);
 
 		objectField.setActions(actions);
 

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectLayoutResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectLayoutResourceTest.java
@@ -90,7 +90,7 @@ public class ObjectLayoutResourceTest extends BaseObjectLayoutResourceTestCase {
 	protected ObjectLayout randomObjectLayout() throws Exception {
 		ObjectLayout objectLayout = super.randomObjectLayout();
 
-		objectLayout.setDefaultObjectLayout(true);
+		objectLayout.setDefaultObjectLayout(false);
 		objectLayout.setName(
 			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
 		objectLayout.setObjectDefinitionId(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectFieldPersistence.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectFieldPersistence.java
@@ -169,6 +169,62 @@ public interface ObjectFieldPersistence extends BasePersistence<ObjectField> {
 		throws NoSuchObjectFieldException;
 
 	/**
+	 * Returns all the object fields that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @return the matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByUuid(String uuid);
+
+	/**
+	 * Returns a range of all the object fields that the user has permission to view where uuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByUuid(
+		String uuid, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the object fields that the user has permissions to view where uuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByUuid(
+		String uuid, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+			orderByComparator);
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set of object fields that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param uuid the uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public ObjectField[] filterFindByUuid_PrevAndNext(
+			long objectFieldId, String uuid,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+				orderByComparator)
+		throws NoSuchObjectFieldException;
+
+	/**
 	 * Removes all the object fields where uuid = &#63; from the database.
 	 *
 	 * @param uuid the uuid
@@ -182,6 +238,14 @@ public interface ObjectFieldPersistence extends BasePersistence<ObjectField> {
 	 * @return the number of matching object fields
 	 */
 	public int countByUuid(String uuid);
+
+	/**
+	 * Returns the number of object fields that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @return the number of matching object fields that the user has permission to view
+	 */
+	public int filterCountByUuid(String uuid);
 
 	/**
 	 * Returns all the object fields where uuid = &#63; and companyId = &#63;.
@@ -322,6 +386,67 @@ public interface ObjectFieldPersistence extends BasePersistence<ObjectField> {
 		throws NoSuchObjectFieldException;
 
 	/**
+	 * Returns all the object fields that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @return the matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByUuid_C(
+		String uuid, long companyId);
+
+	/**
+	 * Returns a range of all the object fields that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByUuid_C(
+		String uuid, long companyId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the object fields that the user has permissions to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByUuid_C(
+		String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+			orderByComparator);
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set of object fields that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public ObjectField[] filterFindByUuid_C_PrevAndNext(
+			long objectFieldId, String uuid, long companyId,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+				orderByComparator)
+		throws NoSuchObjectFieldException;
+
+	/**
 	 * Removes all the object fields where uuid = &#63; and companyId = &#63; from the database.
 	 *
 	 * @param uuid the uuid
@@ -337,6 +462,15 @@ public interface ObjectFieldPersistence extends BasePersistence<ObjectField> {
 	 * @return the number of matching object fields
 	 */
 	public int countByUuid_C(String uuid, long companyId);
+
+	/**
+	 * Returns the number of object fields that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @return the number of matching object fields that the user has permission to view
+	 */
+	public int filterCountByUuid_C(String uuid, long companyId);
 
 	/**
 	 * Returns all the object fields where listTypeDefinitionId = &#63;.
@@ -468,6 +602,63 @@ public interface ObjectFieldPersistence extends BasePersistence<ObjectField> {
 		throws NoSuchObjectFieldException;
 
 	/**
+	 * Returns all the object fields that the user has permission to view where listTypeDefinitionId = &#63;.
+	 *
+	 * @param listTypeDefinitionId the list type definition ID
+	 * @return the matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByListTypeDefinitionId(
+		long listTypeDefinitionId);
+
+	/**
+	 * Returns a range of all the object fields that the user has permission to view where listTypeDefinitionId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param listTypeDefinitionId the list type definition ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByListTypeDefinitionId(
+		long listTypeDefinitionId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the object fields that the user has permissions to view where listTypeDefinitionId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param listTypeDefinitionId the list type definition ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByListTypeDefinitionId(
+		long listTypeDefinitionId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+			orderByComparator);
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set of object fields that the user has permission to view where listTypeDefinitionId = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param listTypeDefinitionId the list type definition ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public ObjectField[] filterFindByListTypeDefinitionId_PrevAndNext(
+			long objectFieldId, long listTypeDefinitionId,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+				orderByComparator)
+		throws NoSuchObjectFieldException;
+
+	/**
 	 * Removes all the object fields where listTypeDefinitionId = &#63; from the database.
 	 *
 	 * @param listTypeDefinitionId the list type definition ID
@@ -481,6 +672,14 @@ public interface ObjectFieldPersistence extends BasePersistence<ObjectField> {
 	 * @return the number of matching object fields
 	 */
 	public int countByListTypeDefinitionId(long listTypeDefinitionId);
+
+	/**
+	 * Returns the number of object fields that the user has permission to view where listTypeDefinitionId = &#63;.
+	 *
+	 * @param listTypeDefinitionId the list type definition ID
+	 * @return the number of matching object fields that the user has permission to view
+	 */
+	public int filterCountByListTypeDefinitionId(long listTypeDefinitionId);
 
 	/**
 	 * Returns all the object fields where objectDefinitionId = &#63;.
@@ -612,6 +811,63 @@ public interface ObjectFieldPersistence extends BasePersistence<ObjectField> {
 		throws NoSuchObjectFieldException;
 
 	/**
+	 * Returns all the object fields that the user has permission to view where objectDefinitionId = &#63;.
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @return the matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByObjectDefinitionId(
+		long objectDefinitionId);
+
+	/**
+	 * Returns a range of all the object fields that the user has permission to view where objectDefinitionId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByObjectDefinitionId(
+		long objectDefinitionId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the object fields that the user has permissions to view where objectDefinitionId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByObjectDefinitionId(
+		long objectDefinitionId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+			orderByComparator);
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set of object fields that the user has permission to view where objectDefinitionId = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param objectDefinitionId the object definition ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public ObjectField[] filterFindByObjectDefinitionId_PrevAndNext(
+			long objectFieldId, long objectDefinitionId,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+				orderByComparator)
+		throws NoSuchObjectFieldException;
+
+	/**
 	 * Removes all the object fields where objectDefinitionId = &#63; from the database.
 	 *
 	 * @param objectDefinitionId the object definition ID
@@ -625,6 +881,14 @@ public interface ObjectFieldPersistence extends BasePersistence<ObjectField> {
 	 * @return the number of matching object fields
 	 */
 	public int countByObjectDefinitionId(long objectDefinitionId);
+
+	/**
+	 * Returns the number of object fields that the user has permission to view where objectDefinitionId = &#63;.
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @return the number of matching object fields that the user has permission to view
+	 */
+	public int filterCountByObjectDefinitionId(long objectDefinitionId);
 
 	/**
 	 * Returns all the object fields where objectDefinitionId = &#63; and dbTableName = &#63;.
@@ -765,6 +1029,67 @@ public interface ObjectFieldPersistence extends BasePersistence<ObjectField> {
 		throws NoSuchObjectFieldException;
 
 	/**
+	 * Returns all the object fields that the user has permission to view where objectDefinitionId = &#63; and dbTableName = &#63;.
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param dbTableName the db table name
+	 * @return the matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByODI_DTN(
+		long objectDefinitionId, String dbTableName);
+
+	/**
+	 * Returns a range of all the object fields that the user has permission to view where objectDefinitionId = &#63; and dbTableName = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param dbTableName the db table name
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByODI_DTN(
+		long objectDefinitionId, String dbTableName, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the object fields that the user has permissions to view where objectDefinitionId = &#63; and dbTableName = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param dbTableName the db table name
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields that the user has permission to view
+	 */
+	public java.util.List<ObjectField> filterFindByODI_DTN(
+		long objectDefinitionId, String dbTableName, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+			orderByComparator);
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set of object fields that the user has permission to view where objectDefinitionId = &#63; and dbTableName = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param objectDefinitionId the object definition ID
+	 * @param dbTableName the db table name
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public ObjectField[] filterFindByODI_DTN_PrevAndNext(
+			long objectFieldId, long objectDefinitionId, String dbTableName,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+				orderByComparator)
+		throws NoSuchObjectFieldException;
+
+	/**
 	 * Removes all the object fields where objectDefinitionId = &#63; and dbTableName = &#63; from the database.
 	 *
 	 * @param objectDefinitionId the object definition ID
@@ -780,6 +1105,16 @@ public interface ObjectFieldPersistence extends BasePersistence<ObjectField> {
 	 * @return the number of matching object fields
 	 */
 	public int countByODI_DTN(long objectDefinitionId, String dbTableName);
+
+	/**
+	 * Returns the number of object fields that the user has permission to view where objectDefinitionId = &#63; and dbTableName = &#63;.
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param dbTableName the db table name
+	 * @return the number of matching object fields that the user has permission to view
+	 */
+	public int filterCountByODI_DTN(
+		long objectDefinitionId, String dbTableName);
 
 	/**
 	 * Returns the object field where objectDefinitionId = &#63; and name = &#63; or throws a <code>NoSuchObjectFieldException</code> if it could not be found.

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectFieldUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectFieldUtil.java
@@ -269,6 +269,73 @@ public class ObjectFieldUtil {
 	}
 
 	/**
+	 * Returns all the object fields that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @return the matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByUuid(String uuid) {
+		return getPersistence().filterFindByUuid(uuid);
+	}
+
+	/**
+	 * Returns a range of all the object fields that the user has permission to view where uuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByUuid(
+		String uuid, int start, int end) {
+
+		return getPersistence().filterFindByUuid(uuid, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the object fields that the user has permissions to view where uuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByUuid(
+		String uuid, int start, int end,
+		OrderByComparator<ObjectField> orderByComparator) {
+
+		return getPersistence().filterFindByUuid(
+			uuid, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set of object fields that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param uuid the uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public static ObjectField[] filterFindByUuid_PrevAndNext(
+			long objectFieldId, String uuid,
+			OrderByComparator<ObjectField> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectFieldException {
+
+		return getPersistence().filterFindByUuid_PrevAndNext(
+			objectFieldId, uuid, orderByComparator);
+	}
+
+	/**
 	 * Removes all the object fields where uuid = &#63; from the database.
 	 *
 	 * @param uuid the uuid
@@ -285,6 +352,16 @@ public class ObjectFieldUtil {
 	 */
 	public static int countByUuid(String uuid) {
 		return getPersistence().countByUuid(uuid);
+	}
+
+	/**
+	 * Returns the number of object fields that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @return the number of matching object fields that the user has permission to view
+	 */
+	public static int filterCountByUuid(String uuid) {
+		return getPersistence().filterCountByUuid(uuid);
 	}
 
 	/**
@@ -451,6 +528,79 @@ public class ObjectFieldUtil {
 	}
 
 	/**
+	 * Returns all the object fields that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @return the matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByUuid_C(
+		String uuid, long companyId) {
+
+		return getPersistence().filterFindByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of all the object fields that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByUuid_C(
+		String uuid, long companyId, int start, int end) {
+
+		return getPersistence().filterFindByUuid_C(uuid, companyId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the object fields that the user has permissions to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByUuid_C(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator<ObjectField> orderByComparator) {
+
+		return getPersistence().filterFindByUuid_C(
+			uuid, companyId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set of object fields that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public static ObjectField[] filterFindByUuid_C_PrevAndNext(
+			long objectFieldId, String uuid, long companyId,
+			OrderByComparator<ObjectField> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectFieldException {
+
+		return getPersistence().filterFindByUuid_C_PrevAndNext(
+			objectFieldId, uuid, companyId, orderByComparator);
+	}
+
+	/**
 	 * Removes all the object fields where uuid = &#63; and companyId = &#63; from the database.
 	 *
 	 * @param uuid the uuid
@@ -469,6 +619,17 @@ public class ObjectFieldUtil {
 	 */
 	public static int countByUuid_C(String uuid, long companyId) {
 		return getPersistence().countByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns the number of object fields that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @return the number of matching object fields that the user has permission to view
+	 */
+	public static int filterCountByUuid_C(String uuid, long companyId) {
+		return getPersistence().filterCountByUuid_C(uuid, companyId);
 	}
 
 	/**
@@ -631,6 +792,77 @@ public class ObjectFieldUtil {
 	}
 
 	/**
+	 * Returns all the object fields that the user has permission to view where listTypeDefinitionId = &#63;.
+	 *
+	 * @param listTypeDefinitionId the list type definition ID
+	 * @return the matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByListTypeDefinitionId(
+		long listTypeDefinitionId) {
+
+		return getPersistence().filterFindByListTypeDefinitionId(
+			listTypeDefinitionId);
+	}
+
+	/**
+	 * Returns a range of all the object fields that the user has permission to view where listTypeDefinitionId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param listTypeDefinitionId the list type definition ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByListTypeDefinitionId(
+		long listTypeDefinitionId, int start, int end) {
+
+		return getPersistence().filterFindByListTypeDefinitionId(
+			listTypeDefinitionId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the object fields that the user has permissions to view where listTypeDefinitionId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param listTypeDefinitionId the list type definition ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByListTypeDefinitionId(
+		long listTypeDefinitionId, int start, int end,
+		OrderByComparator<ObjectField> orderByComparator) {
+
+		return getPersistence().filterFindByListTypeDefinitionId(
+			listTypeDefinitionId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set of object fields that the user has permission to view where listTypeDefinitionId = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param listTypeDefinitionId the list type definition ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public static ObjectField[] filterFindByListTypeDefinitionId_PrevAndNext(
+			long objectFieldId, long listTypeDefinitionId,
+			OrderByComparator<ObjectField> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectFieldException {
+
+		return getPersistence().filterFindByListTypeDefinitionId_PrevAndNext(
+			objectFieldId, listTypeDefinitionId, orderByComparator);
+	}
+
+	/**
 	 * Removes all the object fields where listTypeDefinitionId = &#63; from the database.
 	 *
 	 * @param listTypeDefinitionId the list type definition ID
@@ -647,6 +879,19 @@ public class ObjectFieldUtil {
 	 */
 	public static int countByListTypeDefinitionId(long listTypeDefinitionId) {
 		return getPersistence().countByListTypeDefinitionId(
+			listTypeDefinitionId);
+	}
+
+	/**
+	 * Returns the number of object fields that the user has permission to view where listTypeDefinitionId = &#63;.
+	 *
+	 * @param listTypeDefinitionId the list type definition ID
+	 * @return the number of matching object fields that the user has permission to view
+	 */
+	public static int filterCountByListTypeDefinitionId(
+		long listTypeDefinitionId) {
+
+		return getPersistence().filterCountByListTypeDefinitionId(
 			listTypeDefinitionId);
 	}
 
@@ -808,6 +1053,77 @@ public class ObjectFieldUtil {
 	}
 
 	/**
+	 * Returns all the object fields that the user has permission to view where objectDefinitionId = &#63;.
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @return the matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByObjectDefinitionId(
+		long objectDefinitionId) {
+
+		return getPersistence().filterFindByObjectDefinitionId(
+			objectDefinitionId);
+	}
+
+	/**
+	 * Returns a range of all the object fields that the user has permission to view where objectDefinitionId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByObjectDefinitionId(
+		long objectDefinitionId, int start, int end) {
+
+		return getPersistence().filterFindByObjectDefinitionId(
+			objectDefinitionId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the object fields that the user has permissions to view where objectDefinitionId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByObjectDefinitionId(
+		long objectDefinitionId, int start, int end,
+		OrderByComparator<ObjectField> orderByComparator) {
+
+		return getPersistence().filterFindByObjectDefinitionId(
+			objectDefinitionId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set of object fields that the user has permission to view where objectDefinitionId = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param objectDefinitionId the object definition ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public static ObjectField[] filterFindByObjectDefinitionId_PrevAndNext(
+			long objectFieldId, long objectDefinitionId,
+			OrderByComparator<ObjectField> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectFieldException {
+
+		return getPersistence().filterFindByObjectDefinitionId_PrevAndNext(
+			objectFieldId, objectDefinitionId, orderByComparator);
+	}
+
+	/**
 	 * Removes all the object fields where objectDefinitionId = &#63; from the database.
 	 *
 	 * @param objectDefinitionId the object definition ID
@@ -824,6 +1140,17 @@ public class ObjectFieldUtil {
 	 */
 	public static int countByObjectDefinitionId(long objectDefinitionId) {
 		return getPersistence().countByObjectDefinitionId(objectDefinitionId);
+	}
+
+	/**
+	 * Returns the number of object fields that the user has permission to view where objectDefinitionId = &#63;.
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @return the number of matching object fields that the user has permission to view
+	 */
+	public static int filterCountByObjectDefinitionId(long objectDefinitionId) {
+		return getPersistence().filterCountByObjectDefinitionId(
+			objectDefinitionId);
 	}
 
 	/**
@@ -994,6 +1321,81 @@ public class ObjectFieldUtil {
 	}
 
 	/**
+	 * Returns all the object fields that the user has permission to view where objectDefinitionId = &#63; and dbTableName = &#63;.
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param dbTableName the db table name
+	 * @return the matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByODI_DTN(
+		long objectDefinitionId, String dbTableName) {
+
+		return getPersistence().filterFindByODI_DTN(
+			objectDefinitionId, dbTableName);
+	}
+
+	/**
+	 * Returns a range of all the object fields that the user has permission to view where objectDefinitionId = &#63; and dbTableName = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param dbTableName the db table name
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByODI_DTN(
+		long objectDefinitionId, String dbTableName, int start, int end) {
+
+		return getPersistence().filterFindByODI_DTN(
+			objectDefinitionId, dbTableName, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the object fields that the user has permissions to view where objectDefinitionId = &#63; and dbTableName = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param dbTableName the db table name
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields that the user has permission to view
+	 */
+	public static List<ObjectField> filterFindByODI_DTN(
+		long objectDefinitionId, String dbTableName, int start, int end,
+		OrderByComparator<ObjectField> orderByComparator) {
+
+		return getPersistence().filterFindByODI_DTN(
+			objectDefinitionId, dbTableName, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set of object fields that the user has permission to view where objectDefinitionId = &#63; and dbTableName = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param objectDefinitionId the object definition ID
+	 * @param dbTableName the db table name
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public static ObjectField[] filterFindByODI_DTN_PrevAndNext(
+			long objectFieldId, long objectDefinitionId, String dbTableName,
+			OrderByComparator<ObjectField> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectFieldException {
+
+		return getPersistence().filterFindByODI_DTN_PrevAndNext(
+			objectFieldId, objectDefinitionId, dbTableName, orderByComparator);
+	}
+
+	/**
 	 * Removes all the object fields where objectDefinitionId = &#63; and dbTableName = &#63; from the database.
 	 *
 	 * @param objectDefinitionId the object definition ID
@@ -1016,6 +1418,20 @@ public class ObjectFieldUtil {
 		long objectDefinitionId, String dbTableName) {
 
 		return getPersistence().countByODI_DTN(objectDefinitionId, dbTableName);
+	}
+
+	/**
+	 * Returns the number of object fields that the user has permission to view where objectDefinitionId = &#63; and dbTableName = &#63;.
+	 *
+	 * @param objectDefinitionId the object definition ID
+	 * @param dbTableName the db table name
+	 * @return the number of matching object fields that the user has permission to view
+	 */
+	public static int filterCountByODI_DTN(
+		long objectDefinitionId, String dbTableName) {
+
+		return getPersistence().filterCountByODI_DTN(
+			objectDefinitionId, dbTableName);
 	}
 
 	/**

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
@@ -15,10 +15,12 @@
 package com.liferay.object.rest.internal.manager.v1_0;
 
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.internal.dto.v1_0.converter.ObjectEntryDTOConverter;
+import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
@@ -30,16 +32,20 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
@@ -53,8 +59,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.UriInfo;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -72,7 +80,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 			String scopeKey)
 		throws Exception {
 
-		return _objectEntryDTOConverter.toDTO(
+		return _toObjectEntry(
 			dtoConverterContext,
 			_objectEntryLocalService.addObjectEntry(
 				userId, _getGroupId(objectDefinition, scopeKey),
@@ -92,7 +100,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 			String scopeKey)
 		throws Exception {
 
-		return _objectEntryDTOConverter.toDTO(
+		return _toObjectEntry(
 			dtoConverterContext,
 			_objectEntryLocalService.addOrUpdateObjectEntry(
 				externalReferenceCode, userId,
@@ -128,10 +136,31 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 			Filter filter, Pagination pagination, String search, Sort[] sorts)
 		throws Exception {
 
+		long groupId = _getGroupId(objectDefinition, scopeKey);
+
 		long objectDefinitionId = objectDefinition.getObjectDefinitionId();
 
+		Optional<UriInfo> uriInfoOptional =
+			dtoConverterContext.getUriInfoOptional();
+
+		UriInfo uriInfo = uriInfoOptional.orElse(null);
+
 		return SearchUtil.search(
-			new HashMap<>(),
+			HashMapBuilder.put(
+				"create",
+				ActionUtil.addAction(
+					ActionKeys.ADD_ENTRY, ObjectEntryResourceImpl.class, 0L,
+					"postObjectEntry", null, objectDefinition.getUserId(),
+					_getObjectEntriesPermissionName(objectDefinitionId),
+					groupId, uriInfo)
+			).put(
+				"get",
+				ActionUtil.addAction(
+					ActionKeys.VIEW, ObjectEntryResourceImpl.class, 0L,
+					"getObjectEntriesPage", null, objectDefinition.getUserId(),
+					_getObjectEntriesPermissionName(objectDefinitionId),
+					groupId, uriInfo)
+			).build(),
 			booleanQuery -> {
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
@@ -152,8 +181,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 				searchContext.setAttribute(
 					"objectDefinitionId", objectDefinitionId);
 				searchContext.setCompanyId(companyId);
-				searchContext.setGroupIds(
-					new long[] {_getGroupId(objectDefinition, scopeKey)});
+				searchContext.setGroupIds(new long[] {groupId});
 			},
 			sorts,
 			document -> getObjectEntry(
@@ -166,7 +194,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 			DTOConverterContext dtoConverterContext, long objectEntryId)
 		throws Exception {
 
-		return _objectEntryDTOConverter.toDTO(
+		return _toObjectEntry(
 			dtoConverterContext,
 			_objectEntryLocalService.getObjectEntry(objectEntryId));
 	}
@@ -178,7 +206,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 			ObjectDefinition objectDefinition, String scopeKey)
 		throws Exception {
 
-		return _objectEntryDTOConverter.toDTO(
+		return _toObjectEntry(
 			dtoConverterContext,
 			_objectEntryLocalService.getObjectEntry(
 				externalReferenceCode, companyId,
@@ -194,7 +222,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
 			_objectEntryLocalService.getObjectEntry(objectEntryId);
 
-		return _objectEntryDTOConverter.toDTO(
+		return _toObjectEntry(
 			dtoConverterContext,
 			_objectEntryLocalService.updateObjectEntry(
 				userId, objectEntryId,
@@ -227,6 +255,14 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 		return 0;
 	}
 
+	private String _getObjectEntriesPermissionName(long objectDefinitionId) {
+		return ObjectConstants.RESOURCE_NAME + "#" + objectDefinitionId;
+	}
+
+	private String _getObjectEntryPermissionName(long objectDefinitionId) {
+		return ObjectDefinition.class.getName() + "#" + objectDefinitionId;
+	}
+
 	private Date _toDate(Locale locale, String valueString) {
 		if (Validator.isNull(valueString)) {
 			return null;
@@ -246,6 +282,53 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 					parseException2);
 			}
 		}
+	}
+
+	private ObjectEntry _toObjectEntry(
+		DTOConverterContext dtoConverterContext,
+		com.liferay.object.model.ObjectEntry objectEntry) {
+
+		Optional<UriInfo> uriInfoOptional =
+			dtoConverterContext.getUriInfoOptional();
+
+		UriInfo uriInfo = uriInfoOptional.orElse(null);
+
+		return _objectEntryDTOConverter.toDTO(
+			new DefaultDTOConverterContext(
+				dtoConverterContext.isAcceptAllLanguages(),
+				HashMapBuilder.put(
+					"delete",
+					ActionUtil.addAction(
+						ActionKeys.DELETE, ObjectEntryResourceImpl.class,
+						objectEntry.getObjectEntryId(), "deleteObjectEntry",
+						null, objectEntry.getUserId(),
+						_getObjectEntryPermissionName(
+							objectEntry.getObjectDefinitionId()),
+						objectEntry.getGroupId(), uriInfo)
+				).put(
+					"get",
+					ActionUtil.addAction(
+						ActionKeys.VIEW, ObjectEntryResourceImpl.class,
+						objectEntry.getObjectEntryId(), "getObjectEntry", null,
+						objectEntry.getUserId(),
+						_getObjectEntryPermissionName(
+							objectEntry.getObjectDefinitionId()),
+						objectEntry.getGroupId(), uriInfo)
+				).put(
+					"update",
+					ActionUtil.addAction(
+						ActionKeys.UPDATE, ObjectEntryResourceImpl.class,
+						objectEntry.getObjectEntryId(), "putObjectEntry", null,
+						objectEntry.getUserId(),
+						_getObjectEntryPermissionName(
+							objectEntry.getObjectDefinitionId()),
+						objectEntry.getGroupId(), uriInfo)
+				).build(),
+				dtoConverterContext.getDTOConverterRegistry(),
+				dtoConverterContext.getHttpServletRequest(),
+				objectEntry.getObjectEntryId(), dtoConverterContext.getLocale(),
+				uriInfo, dtoConverterContext.getUser()),
+			objectEntry);
 	}
 
 	private Map<String, Serializable> _toObjectValues(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -34,7 +34,6 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import java.io.Serializable;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 
 import javax.ws.rs.NotFoundException;
@@ -225,10 +224,8 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		Long objectEntryId) {
 
 		return new DefaultDTOConverterContext(
-			contextAcceptLanguage.isAcceptAllLanguages(),
-			Collections.singletonMap(
-				"delete", Collections.singletonMap("delete", "")),
-			null, contextHttpServletRequest, objectEntryId,
+			contextAcceptLanguage.isAcceptAllLanguages(), null, null,
+			contextHttpServletRequest, objectEntryId,
 			contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 			contextUser);
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectFieldModelResourcePermission.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectFieldModelResourcePermission.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.internal.security.permission.resource;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+	immediate = true,
+	property = "model.class.name=com.liferay.object.model.ObjectField",
+	service = ModelResourcePermission.class
+)
+public class ObjectFieldModelResourcePermission
+	implements ModelResourcePermission<ObjectField> {
+
+	@Override
+	public void check(
+			PermissionChecker permissionChecker, long objectFieldId,
+			String actionId)
+		throws PortalException {
+
+		check(
+			permissionChecker,
+			_objectFieldLocalService.getObjectField(objectFieldId), actionId);
+	}
+
+	@Override
+	public void check(
+			PermissionChecker permissionChecker, ObjectField objectField,
+			String actionId)
+		throws PortalException {
+
+		_objectDefinitionModelResourcePermission.check(
+			permissionChecker,
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectField.getObjectDefinitionId()),
+			actionId);
+	}
+
+	@Override
+	public boolean contains(
+			PermissionChecker permissionChecker, long objectFieldId,
+			String actionId)
+		throws PortalException {
+
+		return contains(
+			permissionChecker,
+			_objectFieldLocalService.getObjectField(objectFieldId), actionId);
+	}
+
+	@Override
+	public boolean contains(
+			PermissionChecker permissionChecker, ObjectField objectField,
+			String actionId)
+		throws PortalException {
+
+		return _objectDefinitionModelResourcePermission.contains(
+			permissionChecker,
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectField.getObjectDefinitionId()),
+			actionId);
+	}
+
+	@Override
+	public String getModelName() {
+		return ObjectField.class.getName();
+	}
+
+	@Override
+	public PortletResourcePermission getPortletResourcePermission() {
+		return null;
+	}
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.object.model.ObjectDefinition)"
+	)
+	private ModelResourcePermission<ObjectDefinition>
+		_objectDefinitionModelResourcePermission;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -29,9 +29,11 @@ import com.liferay.object.service.persistence.ObjectDefinitionPersistence;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
+import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -155,6 +157,10 @@ public class ObjectFieldLocalServiceImpl
 					objectField.getDBTableName(),
 					objectField.getDBColumnName()));
 		}
+
+		_resourceLocalService.deleteResource(
+			objectField.getCompanyId(), ObjectField.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, objectField.getObjectFieldId());
 
 		return objectField;
 	}
@@ -287,7 +293,12 @@ public class ObjectFieldLocalServiceImpl
 		objectField.setRequired(required);
 		objectField.setType(type);
 
-		return objectFieldLocalService.updateObjectField(objectField);
+		_resourceLocalService.addResources(
+			objectField.getCompanyId(), 0, objectField.getUserId(),
+			ObjectField.class.getName(), objectField.getObjectFieldId(), false,
+			true, true);
+
+		return objectFieldPersistence.update(objectField);
 	}
 
 	private void _validateIndexed(
@@ -373,6 +384,10 @@ public class ObjectFieldLocalServiceImpl
 			"modifieddate", "status", "statusbyuserid", "statusbyusername",
 			"statusdate", "userid", "username"
 		});
+
+	@Reference
+	private ResourceLocalService _resourceLocalService;
+
 	private final Set<String> _types = SetUtil.fromArray(
 		new String[] {
 			"BigDecimal", "Blob", "Boolean", "Date", "Double", "Integer",

--- a/modules/apps/object/object-service/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/object/object-service/src/main/resources/resource-actions/default.xml
@@ -40,4 +40,24 @@
 			</guest-unsupported>
 		</permissions>
 	</model-resource>
+	<model-resource>
+		<model-name>com.liferay.object.model.ObjectField</model-name>
+		<portlet-ref>
+			<portlet-name>com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet</portlet-name>
+		</portlet-ref>
+		<weight>1</weight>
+		<permissions>
+			<supports>
+				<action-key>DELETE</action-key>
+				<action-key>PERMISSIONS</action-key>
+				<action-key>UPDATE</action-key>
+				<action-key>VIEW</action-key>
+			</supports>
+			<guest-unsupported>
+				<action-key>DELETE</action-key>
+				<action-key>PERMISSIONS</action-key>
+				<action-key>UPDATE</action-key>
+			</guest-unsupported>
+		</permissions>
+	</model-resource>
 </resource-action-mapping>

--- a/modules/apps/object/object-service/src/main/resources/resource-actions/resource-actions.xml.tpl
+++ b/modules/apps/object/object-service/src/main/resources/resource-actions/resource-actions.xml.tpl
@@ -36,7 +36,7 @@
 		<weight>1</weight>
 		<permissions>
 			<supports>
-				<action-key>ADD_OBJECT_ENTRY</action-key>
+				<action-key>ADD_ENTRY</action-key>
 				<action-key>PERMISSIONS</action-key>
 			</supports>
 			<guest-defaults />

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1490,9 +1490,7 @@ public class GraphQLServletExtender {
 
 		DefaultDTOConverterContext defaultDTOConverterContext =
 			new DefaultDTOConverterContext(
-				acceptLanguage.isAcceptAllLanguages(),
-				Collections.singletonMap(
-					"delete", Collections.singletonMap("delete", "")),
+				acceptLanguage.isAcceptAllLanguages(), null,
 				_dtoConverterRegistry, null,
 				acceptLanguage.getPreferredLocale(), null,
 				_portal.getUser(httpServletRequest));


### PR DESCRIPTION
Added actions to the Object Admin API endpoints, ObjectDefinition and ObjectField entities, and to the object entries. 

To have a cleaner actions implementation and ensure a consistent usage of APIs and Services, I've added permission logic to ObjectFields and also added some new permissions to the object entry resource permission template. This way, this logic is called by the actions infrastructure created in Vulcan and we don't have inconsistencies between the APIs and the services.

A sample of an ObjectDefinitionsPage get request:
```
{
  "actions": {
    "get": {
      "method": "GET",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions"
    },
    "create": {
      "method": "POST",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions"
    }
  },
  "facets": [],
  "items": [
    {
      "actions": {
        "get": {
          "method": "GET",
          "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/38404"
        }
      },...
]}
```
A sample of an ObjectDefinition ObjectFields get request:
```
{
  "actions": {
    "get": {
      "method": "GET",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/38404/object-fields"
    },
    "create": {
      "method": "POST",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/38404/object-fields"
    }
  },
  "facets": [],
  "items": [
    {
      "actions": {
        "get": {
          "method": "GET",
          "href": "http://localhost:8080/o/object-admin/v1.0/object-fields/38405"
        },
        "update": {
          "method": "PUT",
          "href": "http://localhost:8080/o/object-admin/v1.0/object-fields/38405"
        }
      },
      "id": 38405,...
]}
```

A sample for an ObjectEntry page get request:
```
{
  "actions": {
    "get": {
      "method": "GET",
      "href": "http://localhost:8080/o/c_sampleobjectdefinitions/"
    },
    "create": {
      "method": "POST",
      "href": "http://localhost:8080/o/c_sampleobjectdefinitions/"
    }
  },
  "facets": [],
  "items": [
    {
      "actions": {
        "get": {
          "method": "GET",
          "href": "http://localhost:8080/o/c_sampleobjectdefinitions/42197"
        },
        "update": {
          "method": "PUT",
          "href": "http://localhost:8080/o/c_sampleobjectdefinitions/42197"
        },
        "delete": {
          "method": "DELETE",
          "href": "http://localhost:8080/o/c_sampleobjectdefinitions/42197"
        }
      },
      "creator": {
        "additionalName": "",
        "contentType": "UserAccount",
        "familyName": "Test",
        "givenName": "Test",
        "id": 20127,
        "name": "Test Test"
      },
      "dateCreated": "2021-09-10T08:40:33Z",
      "dateModified": "2021-09-10T08:40:33Z",
      "externalReferenceCode": "",
      "id": 42197,
      "c_sampleObjectDefinitionId": 42197,
      "how": 180.5,
      "item": 5,
      "able": 10,
      "george": "The unsearchable brown fox jumps over the lazy dog. 0",
      "jig": 45,
      "baker": true,
      "dog": "The quick brown fox jumps over the lazy dog. 0!",
      "easy": "test0",
      "fox": "The english brown fox trusted the lazy dog. 0!",
      "charlie": "2021-09-10T08:40:33Z"
    },...
]}
```

I've needed to use an ActionUtil.addAction deprecated method. Maybe we can remove the deprecation, as this method it is also used in all the generated Base...ResourceImpl generation classes.