### PR TITLE
LPS-138087 Autogenerate get...Pages tests for top level entities

### DIFF
--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -221,6 +221,20 @@ public abstract class BaseKeywordResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Keyword keyword, List<Keyword> keywords) {
+		boolean contains = false;
+
+		for (Keyword item : keywords) {
+			if (equals(keyword, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(keywords + " does not contain " + keyword, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Keyword> keywords1, List<Keyword> keywords2) {
 

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseSelectionResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseSelectionResourceTestCase.java
@@ -229,6 +229,23 @@ public abstract class BaseSelectionResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		Selection selection, List<Selection> selections) {
+
+		boolean contains = false;
+
+		for (Selection item : selections) {
+			if (equals(selection, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			selections + " does not contain " + selection, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Selection> selections1, List<Selection> selections2) {
 

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
@@ -225,6 +225,20 @@ public abstract class BaseStatusResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Status status, List<Status> statuses) {
+		boolean contains = false;
+
+		for (Status item : statuses) {
+			if (equals(status, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(statuses + " does not contain " + status, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Status> statuses1, List<Status> statuses2) {
 

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -222,6 +222,25 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		TaxonomyCategory taxonomyCategory,
+		List<TaxonomyCategory> taxonomyCategories) {
+
+		boolean contains = false;
+
+		for (TaxonomyCategory item : taxonomyCategories) {
+			if (equals(taxonomyCategory, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			taxonomyCategories + " does not contain " + taxonomyCategory,
+			contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<TaxonomyCategory> taxonomyCategories1,
 		List<TaxonomyCategory> taxonomyCategories2) {

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -230,6 +230,25 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		TaxonomyVocabulary taxonomyVocabulary,
+		List<TaxonomyVocabulary> taxonomyVocabularies) {
+
+		boolean contains = false;
+
+		for (TaxonomyVocabulary item : taxonomyVocabularies) {
+			if (equals(taxonomyVocabulary, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			taxonomyVocabularies + " does not contain " + taxonomyVocabulary,
+			contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<TaxonomyVocabulary> taxonomyVocabularies1,
 		List<TaxonomyVocabulary> taxonomyVocabularies2) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
@@ -519,18 +519,17 @@ public abstract class BaseAccountAddressResourceTestCase {
 	public void testGetAccountByExternalReferenceCodeAccountAddressesPage()
 		throws Exception {
 
-		Page<AccountAddress> page =
-			accountAddressResource.
-				getAccountByExternalReferenceCodeAccountAddressesPage(
-					testGetAccountByExternalReferenceCodeAccountAddressesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetAccountByExternalReferenceCodeAccountAddressesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetAccountByExternalReferenceCodeAccountAddressesPage_getIrrelevantExternalReferenceCode();
+
+		Page<AccountAddress> page =
+			accountAddressResource.
+				getAccountByExternalReferenceCodeAccountAddressesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			AccountAddress irrelevantAccountAddress =
@@ -562,7 +561,7 @@ public abstract class BaseAccountAddressResourceTestCase {
 		page =
 			accountAddressResource.
 				getAccountByExternalReferenceCodeAccountAddressesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -678,16 +677,15 @@ public abstract class BaseAccountAddressResourceTestCase {
 
 	@Test
 	public void testGetAccountIdAccountAddressesPage() throws Exception {
-		Page<AccountAddress> page =
-			accountAddressResource.getAccountIdAccountAddressesPage(
-				testGetAccountIdAccountAddressesPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetAccountIdAccountAddressesPage_getId();
 		Long irrelevantId =
 			testGetAccountIdAccountAddressesPage_getIrrelevantId();
+
+		Page<AccountAddress> page =
+			accountAddressResource.getAccountIdAccountAddressesPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			AccountAddress irrelevantAccountAddress =
@@ -714,7 +712,7 @@ public abstract class BaseAccountAddressResourceTestCase {
 				id, randomAccountAddress());
 
 		page = accountAddressResource.getAccountIdAccountAddressesPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -854,6 +852,23 @@ public abstract class BaseAccountAddressResourceTestCase {
 
 			assertEquals(accountAddress1, accountAddress2);
 		}
+	}
+
+	protected void assertContains(
+		AccountAddress accountAddress, List<AccountAddress> accountAddresses) {
+
+		boolean contains = false;
+
+		for (AccountAddress item : accountAddresses) {
+			if (equals(accountAddress, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			accountAddresses + " does not contain " + accountAddress, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
@@ -25,8 +25,10 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.commerce.admin.account.client.dto.v1_0.AccountGroup;
 import com.liferay.headless.commerce.admin.account.client.http.HttpInvoker;
 import com.liferay.headless.commerce.admin.account.client.pagination.Page;
+import com.liferay.headless.commerce.admin.account.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.account.client.resource.v1_0.AccountGroupResource;
 import com.liferay.headless.commerce.admin.account.client.serdes.v1_0.AccountGroupSerDes;
+import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -41,21 +43,26 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import java.text.DateFormat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +74,9 @@ import javax.annotation.Generated;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 
+import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.lang.time.DateUtils;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -194,7 +203,251 @@ public abstract class BaseAccountGroupResourceTestCase {
 
 	@Test
 	public void testGetAccountGroupsPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<AccountGroup> page = accountGroupResource.getAccountGroupsPage(
+			null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		AccountGroup accountGroup1 = testGetAccountGroupsPage_addAccountGroup(
+			randomAccountGroup());
+
+		AccountGroup accountGroup2 = testGetAccountGroupsPage_addAccountGroup(
+			randomAccountGroup());
+
+		page = accountGroupResource.getAccountGroupsPage(
+			null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(accountGroup1, (List<AccountGroup>)page.getItems());
+		assertContains(accountGroup2, (List<AccountGroup>)page.getItems());
+		assertValid(page);
+
+		accountGroupResource.deleteAccountGroup(accountGroup1.getId());
+
+		accountGroupResource.deleteAccountGroup(accountGroup2.getId());
+	}
+
+	@Test
+	public void testGetAccountGroupsPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		AccountGroup accountGroup1 = randomAccountGroup();
+
+		accountGroup1 = testGetAccountGroupsPage_addAccountGroup(accountGroup1);
+
+		for (EntityField entityField : entityFields) {
+			Page<AccountGroup> page = accountGroupResource.getAccountGroupsPage(
+				getFilterString(entityField, "between", accountGroup1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(accountGroup1),
+				(List<AccountGroup>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetAccountGroupsPageWithFilterStringEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.STRING);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		AccountGroup accountGroup1 = testGetAccountGroupsPage_addAccountGroup(
+			randomAccountGroup());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		AccountGroup accountGroup2 = testGetAccountGroupsPage_addAccountGroup(
+			randomAccountGroup());
+
+		for (EntityField entityField : entityFields) {
+			Page<AccountGroup> page = accountGroupResource.getAccountGroupsPage(
+				getFilterString(entityField, "eq", accountGroup1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(accountGroup1),
+				(List<AccountGroup>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetAccountGroupsPageWithPagination() throws Exception {
+		Page<AccountGroup> totalPage =
+			accountGroupResource.getAccountGroupsPage(null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
+		AccountGroup accountGroup1 = testGetAccountGroupsPage_addAccountGroup(
+			randomAccountGroup());
+
+		AccountGroup accountGroup2 = testGetAccountGroupsPage_addAccountGroup(
+			randomAccountGroup());
+
+		AccountGroup accountGroup3 = testGetAccountGroupsPage_addAccountGroup(
+			randomAccountGroup());
+
+		Page<AccountGroup> page1 = accountGroupResource.getAccountGroupsPage(
+			null, Pagination.of(1, totalCount + 2), null);
+
+		List<AccountGroup> accountGroups1 =
+			(List<AccountGroup>)page1.getItems();
+
+		Assert.assertEquals(
+			accountGroups1.toString(), totalCount + 2, accountGroups1.size());
+
+		Page<AccountGroup> page2 = accountGroupResource.getAccountGroupsPage(
+			null, Pagination.of(2, totalCount + 2), null);
+
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+		List<AccountGroup> accountGroups2 =
+			(List<AccountGroup>)page2.getItems();
+
+		Assert.assertEquals(
+			accountGroups2.toString(), 1, accountGroups2.size());
+
+		Page<AccountGroup> page3 = accountGroupResource.getAccountGroupsPage(
+			null, Pagination.of(1, totalCount + 3), null);
+
+		assertContains(accountGroup1, (List<AccountGroup>)page3.getItems());
+		assertContains(accountGroup2, (List<AccountGroup>)page3.getItems());
+		assertContains(accountGroup3, (List<AccountGroup>)page3.getItems());
+	}
+
+	@Test
+	public void testGetAccountGroupsPageWithSortDateTime() throws Exception {
+		testGetAccountGroupsPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, accountGroup1, accountGroup2) -> {
+				BeanUtils.setProperty(
+					accountGroup1, entityField.getName(),
+					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAccountGroupsPageWithSortInteger() throws Exception {
+		testGetAccountGroupsPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, accountGroup1, accountGroup2) -> {
+				BeanUtils.setProperty(accountGroup1, entityField.getName(), 0);
+				BeanUtils.setProperty(accountGroup2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetAccountGroupsPageWithSortString() throws Exception {
+		testGetAccountGroupsPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, accountGroup1, accountGroup2) -> {
+				Class<?> clazz = accountGroup1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanUtils.setProperty(
+						accountGroup1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanUtils.setProperty(
+						accountGroup2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanUtils.setProperty(
+						accountGroup1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanUtils.setProperty(
+						accountGroup2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanUtils.setProperty(
+						accountGroup1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanUtils.setProperty(
+						accountGroup2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetAccountGroupsPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer
+				<EntityField, AccountGroup, AccountGroup, Exception>
+					unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		AccountGroup accountGroup1 = randomAccountGroup();
+		AccountGroup accountGroup2 = randomAccountGroup();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(entityField, accountGroup1, accountGroup2);
+		}
+
+		accountGroup1 = testGetAccountGroupsPage_addAccountGroup(accountGroup1);
+
+		accountGroup2 = testGetAccountGroupsPage_addAccountGroup(accountGroup2);
+
+		for (EntityField entityField : entityFields) {
+			Page<AccountGroup> ascPage =
+				accountGroupResource.getAccountGroupsPage(
+					null, Pagination.of(1, 2), entityField.getName() + ":asc");
+
+			assertEquals(
+				Arrays.asList(accountGroup1, accountGroup2),
+				(List<AccountGroup>)ascPage.getItems());
+
+			Page<AccountGroup> descPage =
+				accountGroupResource.getAccountGroupsPage(
+					null, Pagination.of(1, 2), entityField.getName() + ":desc");
+
+			assertEquals(
+				Arrays.asList(accountGroup2, accountGroup1),
+				(List<AccountGroup>)descPage.getItems());
+		}
+	}
+
+	protected AccountGroup testGetAccountGroupsPage_addAccountGroup(
+			AccountGroup accountGroup)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -204,7 +457,7 @@ public abstract class BaseAccountGroupResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -214,7 +467,7 @@ public abstract class BaseAccountGroupResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/accountGroups");
 
-		Assert.assertEquals(0, accountGroupsJSONObject.get("totalCount"));
+		long totalCount = accountGroupsJSONObject.getLong("totalCount");
 
 		AccountGroup accountGroup1 = testGraphQLAccountGroup_addAccountGroup();
 		AccountGroup accountGroup2 = testGraphQLAccountGroup_addAccountGroup();
@@ -223,10 +476,16 @@ public abstract class BaseAccountGroupResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/accountGroups");
 
-		Assert.assertEquals(2, accountGroupsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, accountGroupsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(accountGroup1, accountGroup2),
+		assertContains(
+			accountGroup1,
+			Arrays.asList(
+				AccountGroupSerDes.toDTOs(
+					accountGroupsJSONObject.getString("items"))));
+		assertContains(
+			accountGroup2,
 			Arrays.asList(
 				AccountGroupSerDes.toDTOs(
 					accountGroupsJSONObject.getString("items"))));
@@ -491,6 +750,9 @@ public abstract class BaseAccountGroupResourceTestCase {
 		Assert.assertTrue(false);
 	}
 
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
 	protected AccountGroup testGraphQLAccountGroup_addAccountGroup()
 		throws Exception {
 
@@ -525,6 +787,23 @@ public abstract class BaseAccountGroupResourceTestCase {
 
 			assertEquals(accountGroup1, accountGroup2);
 		}
+	}
+
+	protected void assertContains(
+		AccountGroup accountGroup, List<AccountGroup> accountGroups) {
+
+		boolean contains = false;
+
+		for (AccountGroup item : accountGroups) {
+			if (equals(accountGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			accountGroups + " does not contain " + accountGroup, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountMemberResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountMemberResourceTestCase.java
@@ -201,18 +201,17 @@ public abstract class BaseAccountMemberResourceTestCase {
 	public void testGetAccountByExternalReferenceCodeAccountMembersPage()
 		throws Exception {
 
-		Page<AccountMember> page =
-			accountMemberResource.
-				getAccountByExternalReferenceCodeAccountMembersPage(
-					testGetAccountByExternalReferenceCodeAccountMembersPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetAccountByExternalReferenceCodeAccountMembersPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetAccountByExternalReferenceCodeAccountMembersPage_getIrrelevantExternalReferenceCode();
+
+		Page<AccountMember> page =
+			accountMemberResource.
+				getAccountByExternalReferenceCodeAccountMembersPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			AccountMember irrelevantAccountMember =
@@ -244,7 +243,7 @@ public abstract class BaseAccountMemberResourceTestCase {
 		page =
 			accountMemberResource.
 				getAccountByExternalReferenceCodeAccountMembersPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -391,16 +390,15 @@ public abstract class BaseAccountMemberResourceTestCase {
 
 	@Test
 	public void testGetAccountIdAccountMembersPage() throws Exception {
-		Page<AccountMember> page =
-			accountMemberResource.getAccountIdAccountMembersPage(
-				testGetAccountIdAccountMembersPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetAccountIdAccountMembersPage_getId();
 		Long irrelevantId =
 			testGetAccountIdAccountMembersPage_getIrrelevantId();
+
+		Page<AccountMember> page =
+			accountMemberResource.getAccountIdAccountMembersPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			AccountMember irrelevantAccountMember =
@@ -427,7 +425,7 @@ public abstract class BaseAccountMemberResourceTestCase {
 				id, randomAccountMember());
 
 		page = accountMemberResource.getAccountIdAccountMembersPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -580,6 +578,23 @@ public abstract class BaseAccountMemberResourceTestCase {
 
 			assertEquals(accountMember1, accountMember2);
 		}
+	}
+
+	protected void assertContains(
+		AccountMember accountMember, List<AccountMember> accountMembers) {
+
+		boolean contains = false;
+
+		for (AccountMember item : accountMembers) {
+			if (equals(accountMember, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			accountMembers + " does not contain " + accountMember, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountOrganizationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountOrganizationResourceTestCase.java
@@ -201,18 +201,17 @@ public abstract class BaseAccountOrganizationResourceTestCase {
 	public void testGetAccountByExternalReferenceCodeAccountOrganizationsPage()
 		throws Exception {
 
-		Page<AccountOrganization> page =
-			accountOrganizationResource.
-				getAccountByExternalReferenceCodeAccountOrganizationsPage(
-					testGetAccountByExternalReferenceCodeAccountOrganizationsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetAccountByExternalReferenceCodeAccountOrganizationsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetAccountByExternalReferenceCodeAccountOrganizationsPage_getIrrelevantExternalReferenceCode();
+
+		Page<AccountOrganization> page =
+			accountOrganizationResource.
+				getAccountByExternalReferenceCodeAccountOrganizationsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			AccountOrganization irrelevantAccountOrganization =
@@ -244,7 +243,7 @@ public abstract class BaseAccountOrganizationResourceTestCase {
 		page =
 			accountOrganizationResource.
 				getAccountByExternalReferenceCodeAccountOrganizationsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -388,16 +387,15 @@ public abstract class BaseAccountOrganizationResourceTestCase {
 
 	@Test
 	public void testGetAccountIdAccountOrganizationsPage() throws Exception {
-		Page<AccountOrganization> page =
-			accountOrganizationResource.getAccountIdAccountOrganizationsPage(
-				testGetAccountIdAccountOrganizationsPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetAccountIdAccountOrganizationsPage_getId();
 		Long irrelevantId =
 			testGetAccountIdAccountOrganizationsPage_getIrrelevantId();
+
+		Page<AccountOrganization> page =
+			accountOrganizationResource.getAccountIdAccountOrganizationsPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			AccountOrganization irrelevantAccountOrganization =
@@ -426,7 +424,7 @@ public abstract class BaseAccountOrganizationResourceTestCase {
 				id, randomAccountOrganization());
 
 		page = accountOrganizationResource.getAccountIdAccountOrganizationsPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -585,6 +583,25 @@ public abstract class BaseAccountOrganizationResourceTestCase {
 
 			assertEquals(accountOrganization1, accountOrganization2);
 		}
+	}
+
+	protected void assertContains(
+		AccountOrganization accountOrganization,
+		List<AccountOrganization> accountOrganizations) {
+
+		boolean contains = false;
+
+		for (AccountOrganization item : accountOrganizations) {
+			if (equals(accountOrganization, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			accountOrganizations + " does not contain " + accountOrganization,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -237,21 +238,21 @@ public abstract class BaseAccountResourceTestCase {
 	@Test
 	public void testGetAccountsPage() throws Exception {
 		Page<Account> page = accountResource.getAccountsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Account account1 = testGetAccountsPage_addAccount(randomAccount());
 
 		Account account2 = testGetAccountsPage_addAccount(randomAccount());
 
 		page = accountResource.getAccountsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(account1, account2), (List<Account>)page.getItems());
+		assertContains(account1, (List<Account>)page.getItems());
+		assertContains(account2, (List<Account>)page.getItems());
 		assertValid(page);
 
 		accountResource.deleteAccount(account1.getId());
@@ -310,6 +311,11 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGetAccountsPageWithPagination() throws Exception {
+		Page<Account> totalPage = accountResource.getAccountsPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Account account1 = testGetAccountsPage_addAccount(randomAccount());
 
 		Account account2 = testGetAccountsPage_addAccount(randomAccount());
@@ -317,27 +323,28 @@ public abstract class BaseAccountResourceTestCase {
 		Account account3 = testGetAccountsPage_addAccount(randomAccount());
 
 		Page<Account> page1 = accountResource.getAccountsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Account> accounts1 = (List<Account>)page1.getItems();
 
-		Assert.assertEquals(accounts1.toString(), 2, accounts1.size());
+		Assert.assertEquals(
+			accounts1.toString(), totalCount + 2, accounts1.size());
 
 		Page<Account> page2 = accountResource.getAccountsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Account> accounts2 = (List<Account>)page2.getItems();
 
 		Assert.assertEquals(accounts2.toString(), 1, accounts2.size());
 
 		Page<Account> page3 = accountResource.getAccountsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(account1, account2, account3),
-			(List<Account>)page3.getItems());
+		assertContains(account1, (List<Account>)page3.getItems());
+		assertContains(account2, (List<Account>)page3.getItems());
+		assertContains(account3, (List<Account>)page3.getItems());
 	}
 
 	@Test
@@ -468,7 +475,7 @@ public abstract class BaseAccountResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -478,7 +485,7 @@ public abstract class BaseAccountResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/accounts");
 
-		Assert.assertEquals(0, accountsJSONObject.get("totalCount"));
+		long totalCount = accountsJSONObject.getLong("totalCount");
 
 		Account account1 = testGraphQLAccount_addAccount();
 		Account account2 = testGraphQLAccount_addAccount();
@@ -487,10 +494,15 @@ public abstract class BaseAccountResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/accounts");
 
-		Assert.assertEquals(2, accountsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, accountsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(account1, account2),
+		assertContains(
+			account1,
+			Arrays.asList(
+				AccountSerDes.toDTOs(accountsJSONObject.getString("items"))));
+		assertContains(
+			account2,
 			Arrays.asList(
 				AccountSerDes.toDTOs(accountsJSONObject.getString("items"))));
 	}
@@ -773,6 +785,20 @@ public abstract class BaseAccountResourceTestCase {
 
 			assertEquals(account1, account2);
 		}
+	}
+
+	protected void assertContains(Account account, List<Account> accounts) {
+		boolean contains = false;
+
+		for (Account item : accounts) {
+			if (equals(account, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(accounts + " does not contain " + account, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseUserResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseUserResourceTestCase.java
@@ -251,6 +251,20 @@ public abstract class BaseUserResourceTestCase {
 		}
 	}
 
+	protected void assertContains(User user, List<User> users) {
+		boolean contains = false;
+
+		for (User item : users) {
+			if (equals(user, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(users + " does not contain " + user, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<User> users1, List<User> users2) {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -201,17 +201,16 @@ public abstract class BaseAttachmentResourceTestCase {
 	public void testGetProductByExternalReferenceCodeAttachmentsPage()
 		throws Exception {
 
-		Page<Attachment> page =
-			attachmentResource.getProductByExternalReferenceCodeAttachmentsPage(
-				testGetProductByExternalReferenceCodeAttachmentsPage_getExternalReferenceCode(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetProductByExternalReferenceCodeAttachmentsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetProductByExternalReferenceCodeAttachmentsPage_getIrrelevantExternalReferenceCode();
+
+		Page<Attachment> page =
+			attachmentResource.getProductByExternalReferenceCodeAttachmentsPage(
+				externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			Attachment irrelevantAttachment =
@@ -242,7 +241,7 @@ public abstract class BaseAttachmentResourceTestCase {
 
 		page =
 			attachmentResource.getProductByExternalReferenceCodeAttachmentsPage(
-				externalReferenceCode, Pagination.of(1, 2));
+				externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -395,17 +394,16 @@ public abstract class BaseAttachmentResourceTestCase {
 	public void testGetProductByExternalReferenceCodeImagesPage()
 		throws Exception {
 
-		Page<Attachment> page =
-			attachmentResource.getProductByExternalReferenceCodeImagesPage(
-				testGetProductByExternalReferenceCodeImagesPage_getExternalReferenceCode(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetProductByExternalReferenceCodeImagesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetProductByExternalReferenceCodeImagesPage_getIrrelevantExternalReferenceCode();
+
+		Page<Attachment> page =
+			attachmentResource.getProductByExternalReferenceCodeImagesPage(
+				externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			Attachment irrelevantAttachment =
@@ -434,7 +432,7 @@ public abstract class BaseAttachmentResourceTestCase {
 				externalReferenceCode, randomAttachment());
 
 		page = attachmentResource.getProductByExternalReferenceCodeImagesPage(
-			externalReferenceCode, Pagination.of(1, 2));
+			externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -583,13 +581,13 @@ public abstract class BaseAttachmentResourceTestCase {
 
 	@Test
 	public void testGetProductIdAttachmentsPage() throws Exception {
-		Page<Attachment> page = attachmentResource.getProductIdAttachmentsPage(
-			testGetProductIdAttachmentsPage_getId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetProductIdAttachmentsPage_getId();
 		Long irrelevantId = testGetProductIdAttachmentsPage_getIrrelevantId();
+
+		Page<Attachment> page = attachmentResource.getProductIdAttachmentsPage(
+			id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			Attachment irrelevantAttachment =
@@ -614,7 +612,7 @@ public abstract class BaseAttachmentResourceTestCase {
 			id, randomAttachment());
 
 		page = attachmentResource.getProductIdAttachmentsPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -741,13 +739,13 @@ public abstract class BaseAttachmentResourceTestCase {
 
 	@Test
 	public void testGetProductIdImagesPage() throws Exception {
-		Page<Attachment> page = attachmentResource.getProductIdImagesPage(
-			testGetProductIdImagesPage_getId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetProductIdImagesPage_getId();
 		Long irrelevantId = testGetProductIdImagesPage_getIrrelevantId();
+
+		Page<Attachment> page = attachmentResource.getProductIdImagesPage(
+			id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			Attachment irrelevantAttachment =
@@ -772,7 +770,7 @@ public abstract class BaseAttachmentResourceTestCase {
 			id, randomAttachment());
 
 		page = attachmentResource.getProductIdImagesPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -929,6 +927,23 @@ public abstract class BaseAttachmentResourceTestCase {
 
 			assertEquals(attachment1, attachment2);
 		}
+	}
+
+	protected void assertContains(
+		Attachment attachment, List<Attachment> attachments) {
+
+		boolean contains = false;
+
+		for (Attachment item : attachments) {
+			if (equals(attachment, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			attachments + " does not contain " + attachment, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -425,21 +426,21 @@ public abstract class BaseCatalogResourceTestCase {
 	@Test
 	public void testGetCatalogsPage() throws Exception {
 		Page<Catalog> page = catalogResource.getCatalogsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Catalog catalog1 = testGetCatalogsPage_addCatalog(randomCatalog());
 
 		Catalog catalog2 = testGetCatalogsPage_addCatalog(randomCatalog());
 
 		page = catalogResource.getCatalogsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(catalog1, catalog2), (List<Catalog>)page.getItems());
+		assertContains(catalog1, (List<Catalog>)page.getItems());
+		assertContains(catalog2, (List<Catalog>)page.getItems());
 		assertValid(page);
 
 		catalogResource.deleteCatalog(catalog1.getId());
@@ -498,6 +499,11 @@ public abstract class BaseCatalogResourceTestCase {
 
 	@Test
 	public void testGetCatalogsPageWithPagination() throws Exception {
+		Page<Catalog> totalPage = catalogResource.getCatalogsPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Catalog catalog1 = testGetCatalogsPage_addCatalog(randomCatalog());
 
 		Catalog catalog2 = testGetCatalogsPage_addCatalog(randomCatalog());
@@ -505,27 +511,28 @@ public abstract class BaseCatalogResourceTestCase {
 		Catalog catalog3 = testGetCatalogsPage_addCatalog(randomCatalog());
 
 		Page<Catalog> page1 = catalogResource.getCatalogsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Catalog> catalogs1 = (List<Catalog>)page1.getItems();
 
-		Assert.assertEquals(catalogs1.toString(), 2, catalogs1.size());
+		Assert.assertEquals(
+			catalogs1.toString(), totalCount + 2, catalogs1.size());
 
 		Page<Catalog> page2 = catalogResource.getCatalogsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Catalog> catalogs2 = (List<Catalog>)page2.getItems();
 
 		Assert.assertEquals(catalogs2.toString(), 1, catalogs2.size());
 
 		Page<Catalog> page3 = catalogResource.getCatalogsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(catalog1, catalog2, catalog3),
-			(List<Catalog>)page3.getItems());
+		assertContains(catalog1, (List<Catalog>)page3.getItems());
+		assertContains(catalog2, (List<Catalog>)page3.getItems());
+		assertContains(catalog3, (List<Catalog>)page3.getItems());
 	}
 
 	@Test
@@ -656,7 +663,7 @@ public abstract class BaseCatalogResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -666,7 +673,7 @@ public abstract class BaseCatalogResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/catalogs");
 
-		Assert.assertEquals(0, catalogsJSONObject.get("totalCount"));
+		long totalCount = catalogsJSONObject.getLong("totalCount");
 
 		Catalog catalog1 = testGraphQLCatalog_addCatalog();
 		Catalog catalog2 = testGraphQLCatalog_addCatalog();
@@ -675,10 +682,15 @@ public abstract class BaseCatalogResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/catalogs");
 
-		Assert.assertEquals(2, catalogsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, catalogsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(catalog1, catalog2),
+		assertContains(
+			catalog1,
+			Arrays.asList(
+				CatalogSerDes.toDTOs(catalogsJSONObject.getString("items"))));
+		assertContains(
+			catalog2,
 			Arrays.asList(
 				CatalogSerDes.toDTOs(catalogsJSONObject.getString("items"))));
 	}
@@ -866,6 +878,20 @@ public abstract class BaseCatalogResourceTestCase {
 
 			assertEquals(catalog1, catalog2);
 		}
+	}
+
+	protected void assertContains(Catalog catalog, List<Catalog> catalogs) {
+		boolean contains = false;
+
+		for (Catalog item : catalogs) {
+			if (equals(catalog, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(catalogs + " does not contain " + catalog, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
@@ -198,17 +198,16 @@ public abstract class BaseCategoryResourceTestCase {
 	public void testGetProductByExternalReferenceCodeCategoriesPage()
 		throws Exception {
 
-		Page<Category> page =
-			categoryResource.getProductByExternalReferenceCodeCategoriesPage(
-				testGetProductByExternalReferenceCodeCategoriesPage_getExternalReferenceCode(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetProductByExternalReferenceCodeCategoriesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetProductByExternalReferenceCodeCategoriesPage_getIrrelevantExternalReferenceCode();
+
+		Page<Category> page =
+			categoryResource.getProductByExternalReferenceCodeCategoriesPage(
+				externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			Category irrelevantCategory =
@@ -238,7 +237,7 @@ public abstract class BaseCategoryResourceTestCase {
 				externalReferenceCode, randomCategory());
 
 		page = categoryResource.getProductByExternalReferenceCodeCategoriesPage(
-			externalReferenceCode, Pagination.of(1, 2));
+			externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -327,13 +326,13 @@ public abstract class BaseCategoryResourceTestCase {
 
 	@Test
 	public void testGetProductIdCategoriesPage() throws Exception {
-		Page<Category> page = categoryResource.getProductIdCategoriesPage(
-			testGetProductIdCategoriesPage_getId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetProductIdCategoriesPage_getId();
 		Long irrelevantId = testGetProductIdCategoriesPage_getIrrelevantId();
+
+		Page<Category> page = categoryResource.getProductIdCategoriesPage(
+			id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			Category irrelevantCategory =
@@ -358,7 +357,7 @@ public abstract class BaseCategoryResourceTestCase {
 			id, randomCategory());
 
 		page = categoryResource.getProductIdCategoriesPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -461,6 +460,23 @@ public abstract class BaseCategoryResourceTestCase {
 
 			assertEquals(category1, category2);
 		}
+	}
+
+	protected void assertContains(
+		Category category, List<Category> categories) {
+
+		boolean contains = false;
+
+		for (Category item : categories) {
+			if (equals(category, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			categories + " does not contain " + category, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
@@ -25,8 +25,10 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.commerce.admin.catalog.client.dto.v1_0.OptionCategory;
 import com.liferay.headless.commerce.admin.catalog.client.http.HttpInvoker;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
+import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.OptionCategoryResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.OptionCategorySerDes;
+import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -41,21 +43,26 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import java.text.DateFormat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +74,9 @@ import javax.annotation.Generated;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 
+import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.lang.time.DateUtils;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -193,7 +202,271 @@ public abstract class BaseOptionCategoryResourceTestCase {
 
 	@Test
 	public void testGetOptionCategoriesPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<OptionCategory> page =
+			optionCategoryResource.getOptionCategoriesPage(
+				null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		OptionCategory optionCategory1 =
+			testGetOptionCategoriesPage_addOptionCategory(
+				randomOptionCategory());
+
+		OptionCategory optionCategory2 =
+			testGetOptionCategoriesPage_addOptionCategory(
+				randomOptionCategory());
+
+		page = optionCategoryResource.getOptionCategoriesPage(
+			null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(optionCategory1, (List<OptionCategory>)page.getItems());
+		assertContains(optionCategory2, (List<OptionCategory>)page.getItems());
+		assertValid(page);
+
+		optionCategoryResource.deleteOptionCategory(optionCategory1.getId());
+
+		optionCategoryResource.deleteOptionCategory(optionCategory2.getId());
+	}
+
+	@Test
+	public void testGetOptionCategoriesPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		OptionCategory optionCategory1 = randomOptionCategory();
+
+		optionCategory1 = testGetOptionCategoriesPage_addOptionCategory(
+			optionCategory1);
+
+		for (EntityField entityField : entityFields) {
+			Page<OptionCategory> page =
+				optionCategoryResource.getOptionCategoriesPage(
+					getFilterString(entityField, "between", optionCategory1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(optionCategory1),
+				(List<OptionCategory>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetOptionCategoriesPageWithFilterStringEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.STRING);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		OptionCategory optionCategory1 =
+			testGetOptionCategoriesPage_addOptionCategory(
+				randomOptionCategory());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		OptionCategory optionCategory2 =
+			testGetOptionCategoriesPage_addOptionCategory(
+				randomOptionCategory());
+
+		for (EntityField entityField : entityFields) {
+			Page<OptionCategory> page =
+				optionCategoryResource.getOptionCategoriesPage(
+					getFilterString(entityField, "eq", optionCategory1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(optionCategory1),
+				(List<OptionCategory>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetOptionCategoriesPageWithPagination() throws Exception {
+		Page<OptionCategory> totalPage =
+			optionCategoryResource.getOptionCategoriesPage(null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
+		OptionCategory optionCategory1 =
+			testGetOptionCategoriesPage_addOptionCategory(
+				randomOptionCategory());
+
+		OptionCategory optionCategory2 =
+			testGetOptionCategoriesPage_addOptionCategory(
+				randomOptionCategory());
+
+		OptionCategory optionCategory3 =
+			testGetOptionCategoriesPage_addOptionCategory(
+				randomOptionCategory());
+
+		Page<OptionCategory> page1 =
+			optionCategoryResource.getOptionCategoriesPage(
+				null, Pagination.of(1, totalCount + 2), null);
+
+		List<OptionCategory> optionCategories1 =
+			(List<OptionCategory>)page1.getItems();
+
+		Assert.assertEquals(
+			optionCategories1.toString(), totalCount + 2,
+			optionCategories1.size());
+
+		Page<OptionCategory> page2 =
+			optionCategoryResource.getOptionCategoriesPage(
+				null, Pagination.of(2, totalCount + 2), null);
+
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+		List<OptionCategory> optionCategories2 =
+			(List<OptionCategory>)page2.getItems();
+
+		Assert.assertEquals(
+			optionCategories2.toString(), 1, optionCategories2.size());
+
+		Page<OptionCategory> page3 =
+			optionCategoryResource.getOptionCategoriesPage(
+				null, Pagination.of(1, totalCount + 3), null);
+
+		assertContains(optionCategory1, (List<OptionCategory>)page3.getItems());
+		assertContains(optionCategory2, (List<OptionCategory>)page3.getItems());
+		assertContains(optionCategory3, (List<OptionCategory>)page3.getItems());
+	}
+
+	@Test
+	public void testGetOptionCategoriesPageWithSortDateTime() throws Exception {
+		testGetOptionCategoriesPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, optionCategory1, optionCategory2) -> {
+				BeanUtils.setProperty(
+					optionCategory1, entityField.getName(),
+					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOptionCategoriesPageWithSortInteger() throws Exception {
+		testGetOptionCategoriesPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, optionCategory1, optionCategory2) -> {
+				BeanUtils.setProperty(
+					optionCategory1, entityField.getName(), 0);
+				BeanUtils.setProperty(
+					optionCategory2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetOptionCategoriesPageWithSortString() throws Exception {
+		testGetOptionCategoriesPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, optionCategory1, optionCategory2) -> {
+				Class<?> clazz = optionCategory1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanUtils.setProperty(
+						optionCategory1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanUtils.setProperty(
+						optionCategory2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanUtils.setProperty(
+						optionCategory1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanUtils.setProperty(
+						optionCategory2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanUtils.setProperty(
+						optionCategory1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanUtils.setProperty(
+						optionCategory2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetOptionCategoriesPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer
+				<EntityField, OptionCategory, OptionCategory, Exception>
+					unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		OptionCategory optionCategory1 = randomOptionCategory();
+		OptionCategory optionCategory2 = randomOptionCategory();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(
+				entityField, optionCategory1, optionCategory2);
+		}
+
+		optionCategory1 = testGetOptionCategoriesPage_addOptionCategory(
+			optionCategory1);
+
+		optionCategory2 = testGetOptionCategoriesPage_addOptionCategory(
+			optionCategory2);
+
+		for (EntityField entityField : entityFields) {
+			Page<OptionCategory> ascPage =
+				optionCategoryResource.getOptionCategoriesPage(
+					null, Pagination.of(1, 2), entityField.getName() + ":asc");
+
+			assertEquals(
+				Arrays.asList(optionCategory1, optionCategory2),
+				(List<OptionCategory>)ascPage.getItems());
+
+			Page<OptionCategory> descPage =
+				optionCategoryResource.getOptionCategoriesPage(
+					null, Pagination.of(1, 2), entityField.getName() + ":desc");
+
+			assertEquals(
+				Arrays.asList(optionCategory2, optionCategory1),
+				(List<OptionCategory>)descPage.getItems());
+		}
+	}
+
+	protected OptionCategory testGetOptionCategoriesPage_addOptionCategory(
+			OptionCategory optionCategory)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -203,7 +476,7 @@ public abstract class BaseOptionCategoryResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -213,7 +486,7 @@ public abstract class BaseOptionCategoryResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/optionCategories");
 
-		Assert.assertEquals(0, optionCategoriesJSONObject.get("totalCount"));
+		long totalCount = optionCategoriesJSONObject.getLong("totalCount");
 
 		OptionCategory optionCategory1 =
 			testGraphQLOptionCategory_addOptionCategory();
@@ -224,10 +497,16 @@ public abstract class BaseOptionCategoryResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/optionCategories");
 
-		Assert.assertEquals(2, optionCategoriesJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, optionCategoriesJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(optionCategory1, optionCategory2),
+		assertContains(
+			optionCategory1,
+			Arrays.asList(
+				OptionCategorySerDes.toDTOs(
+					optionCategoriesJSONObject.getString("items"))));
+		assertContains(
+			optionCategory2,
 			Arrays.asList(
 				OptionCategorySerDes.toDTOs(
 					optionCategoriesJSONObject.getString("items"))));
@@ -380,6 +659,9 @@ public abstract class BaseOptionCategoryResourceTestCase {
 		Assert.assertTrue(false);
 	}
 
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
 	protected OptionCategory testGraphQLOptionCategory_addOptionCategory()
 		throws Exception {
 
@@ -415,6 +697,23 @@ public abstract class BaseOptionCategoryResourceTestCase {
 
 			assertEquals(optionCategory1, optionCategory2);
 		}
+	}
+
+	protected void assertContains(
+		OptionCategory optionCategory, List<OptionCategory> optionCategories) {
+
+		boolean contains = false;
+
+		for (OptionCategory item : optionCategories) {
+			if (equals(optionCategory, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			optionCategories + " does not contain " + optionCategory, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -203,21 +204,21 @@ public abstract class BaseOptionResourceTestCase {
 	@Test
 	public void testGetOptionsPage() throws Exception {
 		Page<Option> page = optionResource.getOptionsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Option option1 = testGetOptionsPage_addOption(randomOption());
 
 		Option option2 = testGetOptionsPage_addOption(randomOption());
 
 		page = optionResource.getOptionsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(option1, option2), (List<Option>)page.getItems());
+		assertContains(option1, (List<Option>)page.getItems());
+		assertContains(option2, (List<Option>)page.getItems());
 		assertValid(page);
 
 		optionResource.deleteOption(option1.getId());
@@ -276,6 +277,11 @@ public abstract class BaseOptionResourceTestCase {
 
 	@Test
 	public void testGetOptionsPageWithPagination() throws Exception {
+		Page<Option> totalPage = optionResource.getOptionsPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Option option1 = testGetOptionsPage_addOption(randomOption());
 
 		Option option2 = testGetOptionsPage_addOption(randomOption());
@@ -283,27 +289,28 @@ public abstract class BaseOptionResourceTestCase {
 		Option option3 = testGetOptionsPage_addOption(randomOption());
 
 		Page<Option> page1 = optionResource.getOptionsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Option> options1 = (List<Option>)page1.getItems();
 
-		Assert.assertEquals(options1.toString(), 2, options1.size());
+		Assert.assertEquals(
+			options1.toString(), totalCount + 2, options1.size());
 
 		Page<Option> page2 = optionResource.getOptionsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Option> options2 = (List<Option>)page2.getItems();
 
 		Assert.assertEquals(options2.toString(), 1, options2.size());
 
 		Page<Option> page3 = optionResource.getOptionsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(option1, option2, option3),
-			(List<Option>)page3.getItems());
+		assertContains(option1, (List<Option>)page3.getItems());
+		assertContains(option2, (List<Option>)page3.getItems());
+		assertContains(option3, (List<Option>)page3.getItems());
 	}
 
 	@Test
@@ -434,7 +441,7 @@ public abstract class BaseOptionResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -444,7 +451,7 @@ public abstract class BaseOptionResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/options");
 
-		Assert.assertEquals(0, optionsJSONObject.get("totalCount"));
+		long totalCount = optionsJSONObject.getLong("totalCount");
 
 		Option option1 = testGraphQLOption_addOption();
 		Option option2 = testGraphQLOption_addOption();
@@ -453,10 +460,15 @@ public abstract class BaseOptionResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/options");
 
-		Assert.assertEquals(2, optionsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, optionsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(option1, option2),
+		assertContains(
+			option1,
+			Arrays.asList(
+				OptionSerDes.toDTOs(optionsJSONObject.getString("items"))));
+		assertContains(
+			option2,
 			Arrays.asList(
 				OptionSerDes.toDTOs(optionsJSONObject.getString("items"))));
 	}
@@ -721,6 +733,20 @@ public abstract class BaseOptionResourceTestCase {
 
 			assertEquals(option1, option2);
 		}
+	}
+
+	protected void assertContains(Option option, List<Option> options) {
+		boolean contains = false;
+
+		for (Option item : options) {
+			if (equals(option, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(options + " does not contain " + option, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
@@ -439,18 +439,18 @@ public abstract class BaseOptionValueResourceTestCase {
 	public void testGetOptionByExternalReferenceCodeOptionValuesPage()
 		throws Exception {
 
-		Page<OptionValue> page =
-			optionValueResource.
-				getOptionByExternalReferenceCodeOptionValuesPage(
-					testGetOptionByExternalReferenceCodeOptionValuesPage_getExternalReferenceCode(),
-					RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetOptionByExternalReferenceCodeOptionValuesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetOptionByExternalReferenceCodeOptionValuesPage_getIrrelevantExternalReferenceCode();
+
+		Page<OptionValue> page =
+			optionValueResource.
+				getOptionByExternalReferenceCodeOptionValuesPage(
+					externalReferenceCode, RandomTestUtil.randomString(),
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			OptionValue irrelevantOptionValue =
@@ -483,7 +483,7 @@ public abstract class BaseOptionValueResourceTestCase {
 		page =
 			optionValueResource.
 				getOptionByExternalReferenceCodeOptionValuesPage(
-					externalReferenceCode, null, Pagination.of(1, 2), null);
+					externalReferenceCode, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -726,15 +726,14 @@ public abstract class BaseOptionValueResourceTestCase {
 
 	@Test
 	public void testGetOptionIdOptionValuesPage() throws Exception {
-		Page<OptionValue> page =
-			optionValueResource.getOptionIdOptionValuesPage(
-				testGetOptionIdOptionValuesPage_getId(),
-				RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetOptionIdOptionValuesPage_getId();
 		Long irrelevantId = testGetOptionIdOptionValuesPage_getIrrelevantId();
+
+		Page<OptionValue> page =
+			optionValueResource.getOptionIdOptionValuesPage(
+				id, RandomTestUtil.randomString(), Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			OptionValue irrelevantOptionValue =
@@ -761,7 +760,7 @@ public abstract class BaseOptionValueResourceTestCase {
 				id, randomOptionValue());
 
 		page = optionValueResource.getOptionIdOptionValuesPage(
-			id, null, Pagination.of(1, 2), null);
+			id, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1018,6 +1017,23 @@ public abstract class BaseOptionValueResourceTestCase {
 
 			assertEquals(optionValue1, optionValue2);
 		}
+	}
+
+	protected void assertContains(
+		OptionValue optionValue, List<OptionValue> optionValues) {
+
+		boolean contains = false;
+
+		for (OptionValue item : optionValues) {
+			if (equals(optionValue, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			optionValues + " does not contain " + optionValue, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductAccountGroupResourceTestCase.java
@@ -325,18 +325,17 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 	public void testGetProductByExternalReferenceCodeProductAccountGroupsPage()
 		throws Exception {
 
-		Page<ProductAccountGroup> page =
-			productAccountGroupResource.
-				getProductByExternalReferenceCodeProductAccountGroupsPage(
-					testGetProductByExternalReferenceCodeProductAccountGroupsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetProductByExternalReferenceCodeProductAccountGroupsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetProductByExternalReferenceCodeProductAccountGroupsPage_getIrrelevantExternalReferenceCode();
+
+		Page<ProductAccountGroup> page =
+			productAccountGroupResource.
+				getProductByExternalReferenceCodeProductAccountGroupsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			ProductAccountGroup irrelevantProductAccountGroup =
@@ -368,7 +367,7 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 		page =
 			productAccountGroupResource.
 				getProductByExternalReferenceCodeProductAccountGroupsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -466,16 +465,15 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 
 	@Test
 	public void testGetProductIdProductAccountGroupsPage() throws Exception {
-		Page<ProductAccountGroup> page =
-			productAccountGroupResource.getProductIdProductAccountGroupsPage(
-				testGetProductIdProductAccountGroupsPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetProductIdProductAccountGroupsPage_getId();
 		Long irrelevantId =
 			testGetProductIdProductAccountGroupsPage_getIrrelevantId();
+
+		Page<ProductAccountGroup> page =
+			productAccountGroupResource.getProductIdProductAccountGroupsPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			ProductAccountGroup irrelevantProductAccountGroup =
@@ -504,7 +502,7 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 				id, randomProductAccountGroup());
 
 		page = productAccountGroupResource.getProductIdProductAccountGroupsPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -633,6 +631,25 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 
 			assertEquals(productAccountGroup1, productAccountGroup2);
 		}
+	}
+
+	protected void assertContains(
+		ProductAccountGroup productAccountGroup,
+		List<ProductAccountGroup> productAccountGroups) {
+
+		boolean contains = false;
+
+		for (ProductAccountGroup item : productAccountGroups) {
+			if (equals(productAccountGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productAccountGroups + " does not contain " + productAccountGroup,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductChannelResourceTestCase.java
@@ -325,18 +325,17 @@ public abstract class BaseProductChannelResourceTestCase {
 	public void testGetProductByExternalReferenceCodeProductChannelsPage()
 		throws Exception {
 
-		Page<ProductChannel> page =
-			productChannelResource.
-				getProductByExternalReferenceCodeProductChannelsPage(
-					testGetProductByExternalReferenceCodeProductChannelsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetProductByExternalReferenceCodeProductChannelsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetProductByExternalReferenceCodeProductChannelsPage_getIrrelevantExternalReferenceCode();
+
+		Page<ProductChannel> page =
+			productChannelResource.
+				getProductByExternalReferenceCodeProductChannelsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			ProductChannel irrelevantProductChannel =
@@ -368,7 +367,7 @@ public abstract class BaseProductChannelResourceTestCase {
 		page =
 			productChannelResource.
 				getProductByExternalReferenceCodeProductChannelsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -461,16 +460,15 @@ public abstract class BaseProductChannelResourceTestCase {
 
 	@Test
 	public void testGetProductIdProductChannelsPage() throws Exception {
-		Page<ProductChannel> page =
-			productChannelResource.getProductIdProductChannelsPage(
-				testGetProductIdProductChannelsPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetProductIdProductChannelsPage_getId();
 		Long irrelevantId =
 			testGetProductIdProductChannelsPage_getIrrelevantId();
+
+		Page<ProductChannel> page =
+			productChannelResource.getProductIdProductChannelsPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			ProductChannel irrelevantProductChannel =
@@ -497,7 +495,7 @@ public abstract class BaseProductChannelResourceTestCase {
 				id, randomProductChannel());
 
 		page = productChannelResource.getProductIdProductChannelsPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -617,6 +615,23 @@ public abstract class BaseProductChannelResourceTestCase {
 
 			assertEquals(productChannel1, productChannel2);
 		}
+	}
+
+	protected void assertContains(
+		ProductChannel productChannel, List<ProductChannel> productChannels) {
+
+		boolean contains = false;
+
+		for (ProductChannel item : productChannels) {
+			if (equals(productChannel, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productChannels + " does not contain " + productChannel, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationResourceTestCase.java
@@ -280,6 +280,25 @@ public abstract class BaseProductConfigurationResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		ProductConfiguration productConfiguration,
+		List<ProductConfiguration> productConfigurations) {
+
+		boolean contains = false;
+
+		for (ProductConfiguration item : productConfigurations) {
+			if (equals(productConfiguration, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productConfigurations + " does not contain " + productConfiguration,
+			contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<ProductConfiguration> productConfigurations1,
 		List<ProductConfiguration> productConfigurations2) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupProductResourceTestCase.java
@@ -242,18 +242,17 @@ public abstract class BaseProductGroupProductResourceTestCase {
 	public void testGetProductGroupByExternalReferenceCodeProductGroupProductsPage()
 		throws Exception {
 
-		Page<ProductGroupProduct> page =
-			productGroupProductResource.
-				getProductGroupByExternalReferenceCodeProductGroupProductsPage(
-					testGetProductGroupByExternalReferenceCodeProductGroupProductsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetProductGroupByExternalReferenceCodeProductGroupProductsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetProductGroupByExternalReferenceCodeProductGroupProductsPage_getIrrelevantExternalReferenceCode();
+
+		Page<ProductGroupProduct> page =
+			productGroupProductResource.
+				getProductGroupByExternalReferenceCodeProductGroupProductsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			ProductGroupProduct irrelevantProductGroupProduct =
@@ -285,7 +284,7 @@ public abstract class BaseProductGroupProductResourceTestCase {
 		page =
 			productGroupProductResource.
 				getProductGroupByExternalReferenceCodeProductGroupProductsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -409,17 +408,16 @@ public abstract class BaseProductGroupProductResourceTestCase {
 	public void testGetProductGroupIdProductGroupProductsPage()
 		throws Exception {
 
-		Page<ProductGroupProduct> page =
-			productGroupProductResource.
-				getProductGroupIdProductGroupProductsPage(
-					testGetProductGroupIdProductGroupProductsPage_getId(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetProductGroupIdProductGroupProductsPage_getId();
 		Long irrelevantId =
 			testGetProductGroupIdProductGroupProductsPage_getIrrelevantId();
+
+		Page<ProductGroupProduct> page =
+			productGroupProductResource.
+				getProductGroupIdProductGroupProductsPage(
+					id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			ProductGroupProduct irrelevantProductGroupProduct =
@@ -450,7 +448,7 @@ public abstract class BaseProductGroupProductResourceTestCase {
 		page =
 			productGroupProductResource.
 				getProductGroupIdProductGroupProductsPage(
-					id, Pagination.of(1, 2));
+					id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -605,6 +603,25 @@ public abstract class BaseProductGroupProductResourceTestCase {
 
 			assertEquals(productGroupProduct1, productGroupProduct2);
 		}
+	}
+
+	protected void assertContains(
+		ProductGroupProduct productGroupProduct,
+		List<ProductGroupProduct> productGroupProducts) {
+
+		boolean contains = false;
+
+		for (ProductGroupProduct item : productGroupProducts) {
+			if (equals(productGroupProduct, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productGroupProducts + " does not contain " + productGroupProduct,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -201,9 +202,9 @@ public abstract class BaseProductGroupResourceTestCase {
 	@Test
 	public void testGetProductGroupsPage() throws Exception {
 		Page<ProductGroup> page = productGroupResource.getProductGroupsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		ProductGroup productGroup1 = testGetProductGroupsPage_addProductGroup(
 			randomProductGroup());
@@ -212,13 +213,12 @@ public abstract class BaseProductGroupResourceTestCase {
 			randomProductGroup());
 
 		page = productGroupResource.getProductGroupsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(productGroup1, productGroup2),
-			(List<ProductGroup>)page.getItems());
+		assertContains(productGroup1, (List<ProductGroup>)page.getItems());
+		assertContains(productGroup2, (List<ProductGroup>)page.getItems());
 		assertValid(page);
 
 		productGroupResource.deleteProductGroup(productGroup1.getId());
@@ -283,6 +283,11 @@ public abstract class BaseProductGroupResourceTestCase {
 
 	@Test
 	public void testGetProductGroupsPageWithPagination() throws Exception {
+		Page<ProductGroup> totalPage =
+			productGroupResource.getProductGroupsPage(null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		ProductGroup productGroup1 = testGetProductGroupsPage_addProductGroup(
 			randomProductGroup());
 
@@ -293,18 +298,18 @@ public abstract class BaseProductGroupResourceTestCase {
 			randomProductGroup());
 
 		Page<ProductGroup> page1 = productGroupResource.getProductGroupsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<ProductGroup> productGroups1 =
 			(List<ProductGroup>)page1.getItems();
 
 		Assert.assertEquals(
-			productGroups1.toString(), 2, productGroups1.size());
+			productGroups1.toString(), totalCount + 2, productGroups1.size());
 
 		Page<ProductGroup> page2 = productGroupResource.getProductGroupsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<ProductGroup> productGroups2 =
 			(List<ProductGroup>)page2.getItems();
@@ -313,11 +318,11 @@ public abstract class BaseProductGroupResourceTestCase {
 			productGroups2.toString(), 1, productGroups2.size());
 
 		Page<ProductGroup> page3 = productGroupResource.getProductGroupsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(productGroup1, productGroup2, productGroup3),
-			(List<ProductGroup>)page3.getItems());
+		assertContains(productGroup1, (List<ProductGroup>)page3.getItems());
+		assertContains(productGroup2, (List<ProductGroup>)page3.getItems());
+		assertContains(productGroup3, (List<ProductGroup>)page3.getItems());
 	}
 
 	@Test
@@ -452,7 +457,7 @@ public abstract class BaseProductGroupResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -462,7 +467,7 @@ public abstract class BaseProductGroupResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/productGroups");
 
-		Assert.assertEquals(0, productGroupsJSONObject.get("totalCount"));
+		long totalCount = productGroupsJSONObject.getLong("totalCount");
 
 		ProductGroup productGroup1 = testGraphQLProductGroup_addProductGroup();
 		ProductGroup productGroup2 = testGraphQLProductGroup_addProductGroup();
@@ -471,10 +476,16 @@ public abstract class BaseProductGroupResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/productGroups");
 
-		Assert.assertEquals(2, productGroupsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, productGroupsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(productGroup1, productGroup2),
+		assertContains(
+			productGroup1,
+			Arrays.asList(
+				ProductGroupSerDes.toDTOs(
+					productGroupsJSONObject.getString("items"))));
+		assertContains(
+			productGroup2,
 			Arrays.asList(
 				ProductGroupSerDes.toDTOs(
 					productGroupsJSONObject.getString("items"))));
@@ -776,6 +787,23 @@ public abstract class BaseProductGroupResourceTestCase {
 
 			assertEquals(productGroup1, productGroup2);
 		}
+	}
+
+	protected void assertContains(
+		ProductGroup productGroup, List<ProductGroup> productGroups) {
+
+		boolean contains = false;
+
+		for (ProductGroup item : productGroups) {
+			if (equals(productGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productGroups + " does not contain " + productGroup, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
@@ -330,18 +330,18 @@ public abstract class BaseProductOptionResourceTestCase {
 	public void testGetProductByExternalReferenceCodeProductOptionsPage()
 		throws Exception {
 
-		Page<ProductOption> page =
-			productOptionResource.
-				getProductByExternalReferenceCodeProductOptionsPage(
-					testGetProductByExternalReferenceCodeProductOptionsPage_getExternalReferenceCode(),
-					RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetProductByExternalReferenceCodeProductOptionsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetProductByExternalReferenceCodeProductOptionsPage_getIrrelevantExternalReferenceCode();
+
+		Page<ProductOption> page =
+			productOptionResource.
+				getProductByExternalReferenceCodeProductOptionsPage(
+					externalReferenceCode, RandomTestUtil.randomString(),
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			ProductOption irrelevantProductOption =
@@ -374,7 +374,7 @@ public abstract class BaseProductOptionResourceTestCase {
 		page =
 			productOptionResource.
 				getProductByExternalReferenceCodeProductOptionsPage(
-					externalReferenceCode, null, Pagination.of(1, 2), null);
+					externalReferenceCode, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -608,16 +608,15 @@ public abstract class BaseProductOptionResourceTestCase {
 
 	@Test
 	public void testGetProductIdProductOptionsPage() throws Exception {
-		Page<ProductOption> page =
-			productOptionResource.getProductIdProductOptionsPage(
-				testGetProductIdProductOptionsPage_getId(),
-				RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetProductIdProductOptionsPage_getId();
 		Long irrelevantId =
 			testGetProductIdProductOptionsPage_getIrrelevantId();
+
+		Page<ProductOption> page =
+			productOptionResource.getProductIdProductOptionsPage(
+				id, RandomTestUtil.randomString(), Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			ProductOption irrelevantProductOption =
@@ -644,7 +643,7 @@ public abstract class BaseProductOptionResourceTestCase {
 				id, randomProductOption());
 
 		page = productOptionResource.getProductIdProductOptionsPage(
-			id, null, Pagination.of(1, 2), null);
+			id, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -894,6 +893,23 @@ public abstract class BaseProductOptionResourceTestCase {
 
 			assertEquals(productOption1, productOption2);
 		}
+	}
+
+	protected void assertContains(
+		ProductOption productOption, List<ProductOption> productOptions) {
+
+		boolean contains = false;
+
+		for (ProductOption item : productOptions) {
+			if (equals(productOption, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productOptions + " does not contain " + productOption, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
@@ -202,17 +202,17 @@ public abstract class BaseProductOptionValueResourceTestCase {
 	public void testGetProductOptionIdProductOptionValuesPage()
 		throws Exception {
 
-		Page<ProductOptionValue> page =
-			productOptionValueResource.
-				getProductOptionIdProductOptionValuesPage(
-					testGetProductOptionIdProductOptionValuesPage_getId(),
-					RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetProductOptionIdProductOptionValuesPage_getId();
 		Long irrelevantId =
 			testGetProductOptionIdProductOptionValuesPage_getIrrelevantId();
+
+		Page<ProductOptionValue> page =
+			productOptionValueResource.
+				getProductOptionIdProductOptionValuesPage(
+					id, RandomTestUtil.randomString(), Pagination.of(1, 10),
+					null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			ProductOptionValue irrelevantProductOptionValue =
@@ -243,7 +243,7 @@ public abstract class BaseProductOptionValueResourceTestCase {
 		page =
 			productOptionValueResource.
 				getProductOptionIdProductOptionValuesPage(
-					id, null, Pagination.of(1, 2), null);
+					id, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -525,6 +525,25 @@ public abstract class BaseProductOptionValueResourceTestCase {
 
 			assertEquals(productOptionValue1, productOptionValue2);
 		}
+	}
+
+	protected void assertContains(
+		ProductOptionValue productOptionValue,
+		List<ProductOptionValue> productOptionValues) {
+
+		boolean contains = false;
+
+		for (ProductOptionValue item : productOptionValues) {
+			if (equals(productOptionValue, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productOptionValues + " does not contain " + productOptionValue,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -211,21 +212,21 @@ public abstract class BaseProductResourceTestCase {
 	@Test
 	public void testGetProductsPage() throws Exception {
 		Page<Product> page = productResource.getProductsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Product product1 = testGetProductsPage_addProduct(randomProduct());
 
 		Product product2 = testGetProductsPage_addProduct(randomProduct());
 
 		page = productResource.getProductsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(product1, product2), (List<Product>)page.getItems());
+		assertContains(product1, (List<Product>)page.getItems());
+		assertContains(product2, (List<Product>)page.getItems());
 		assertValid(page);
 
 		productResource.deleteProduct(product1.getId());
@@ -284,6 +285,11 @@ public abstract class BaseProductResourceTestCase {
 
 	@Test
 	public void testGetProductsPageWithPagination() throws Exception {
+		Page<Product> totalPage = productResource.getProductsPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Product product1 = testGetProductsPage_addProduct(randomProduct());
 
 		Product product2 = testGetProductsPage_addProduct(randomProduct());
@@ -291,27 +297,28 @@ public abstract class BaseProductResourceTestCase {
 		Product product3 = testGetProductsPage_addProduct(randomProduct());
 
 		Page<Product> page1 = productResource.getProductsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Product> products1 = (List<Product>)page1.getItems();
 
-		Assert.assertEquals(products1.toString(), 2, products1.size());
+		Assert.assertEquals(
+			products1.toString(), totalCount + 2, products1.size());
 
 		Page<Product> page2 = productResource.getProductsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Product> products2 = (List<Product>)page2.getItems();
 
 		Assert.assertEquals(products2.toString(), 1, products2.size());
 
 		Page<Product> page3 = productResource.getProductsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(product1, product2, product3),
-			(List<Product>)page3.getItems());
+		assertContains(product1, (List<Product>)page3.getItems());
+		assertContains(product2, (List<Product>)page3.getItems());
+		assertContains(product3, (List<Product>)page3.getItems());
 	}
 
 	@Test
@@ -442,7 +449,7 @@ public abstract class BaseProductResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -452,7 +459,7 @@ public abstract class BaseProductResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/products");
 
-		Assert.assertEquals(0, productsJSONObject.get("totalCount"));
+		long totalCount = productsJSONObject.getLong("totalCount");
 
 		Product product1 = testGraphQLProduct_addProduct();
 		Product product2 = testGraphQLProduct_addProduct();
@@ -461,10 +468,15 @@ public abstract class BaseProductResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/products");
 
-		Assert.assertEquals(2, productsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, productsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(product1, product2),
+		assertContains(
+			product1,
+			Arrays.asList(
+				ProductSerDes.toDTOs(productsJSONObject.getString("items"))));
+		assertContains(
+			product2,
 			Arrays.asList(
 				ProductSerDes.toDTOs(productsJSONObject.getString("items"))));
 	}
@@ -774,6 +786,20 @@ public abstract class BaseProductResourceTestCase {
 
 			assertEquals(product1, product2);
 		}
+	}
+
+	protected void assertContains(Product product, List<Product> products) {
+		boolean contains = false;
+
+		for (Product item : products) {
+			if (equals(product, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(products + " does not contain " + product, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductShippingConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductShippingConfigurationResourceTestCase.java
@@ -286,6 +286,28 @@ public abstract class BaseProductShippingConfigurationResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		ProductShippingConfiguration productShippingConfiguration,
+		List<ProductShippingConfiguration> productShippingConfigurations) {
+
+		boolean contains = false;
+
+		for (ProductShippingConfiguration item :
+				productShippingConfigurations) {
+
+			if (equals(productShippingConfiguration, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productShippingConfigurations + " does not contain " +
+				productShippingConfiguration,
+			contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<ProductShippingConfiguration> productShippingConfigurations1,
 		List<ProductShippingConfiguration> productShippingConfigurations2) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
@@ -197,16 +197,15 @@ public abstract class BaseProductSpecificationResourceTestCase {
 
 	@Test
 	public void testGetProductIdProductSpecificationsPage() throws Exception {
-		Page<ProductSpecification> page =
-			productSpecificationResource.getProductIdProductSpecificationsPage(
-				testGetProductIdProductSpecificationsPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetProductIdProductSpecificationsPage_getId();
 		Long irrelevantId =
 			testGetProductIdProductSpecificationsPage_getIrrelevantId();
+
+		Page<ProductSpecification> page =
+			productSpecificationResource.getProductIdProductSpecificationsPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			ProductSpecification irrelevantProductSpecification =
@@ -236,7 +235,7 @@ public abstract class BaseProductSpecificationResourceTestCase {
 
 		page =
 			productSpecificationResource.getProductIdProductSpecificationsPage(
-				id, Pagination.of(1, 2));
+				id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -383,6 +382,25 @@ public abstract class BaseProductSpecificationResourceTestCase {
 
 			assertEquals(productSpecification1, productSpecification2);
 		}
+	}
+
+	protected void assertContains(
+		ProductSpecification productSpecification,
+		List<ProductSpecification> productSpecifications) {
+
+		boolean contains = false;
+
+		for (ProductSpecification item : productSpecifications) {
+			if (equals(productSpecification, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productSpecifications + " does not contain " + productSpecification,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSubscriptionConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSubscriptionConfigurationResourceTestCase.java
@@ -292,6 +292,29 @@ public abstract class BaseProductSubscriptionConfigurationResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		ProductSubscriptionConfiguration productSubscriptionConfiguration,
+		List<ProductSubscriptionConfiguration>
+			productSubscriptionConfigurations) {
+
+		boolean contains = false;
+
+		for (ProductSubscriptionConfiguration item :
+				productSubscriptionConfigurations) {
+
+			if (equals(productSubscriptionConfiguration, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productSubscriptionConfigurations + " does not contain " +
+				productSubscriptionConfiguration,
+			contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<ProductSubscriptionConfiguration>
 			productSubscriptionConfigurations1,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
@@ -393,6 +393,26 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		ProductTaxConfiguration productTaxConfiguration,
+		List<ProductTaxConfiguration> productTaxConfigurations) {
+
+		boolean contains = false;
+
+		for (ProductTaxConfiguration item : productTaxConfigurations) {
+			if (equals(productTaxConfiguration, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productTaxConfigurations + " does not contain " +
+				productTaxConfiguration,
+			contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<ProductTaxConfiguration> productTaxConfigurations1,
 		List<ProductTaxConfiguration> productTaxConfigurations2) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
@@ -199,18 +199,18 @@ public abstract class BaseRelatedProductResourceTestCase {
 	public void testGetProductByExternalReferenceCodeRelatedProductsPage()
 		throws Exception {
 
-		Page<RelatedProduct> page =
-			relatedProductResource.
-				getProductByExternalReferenceCodeRelatedProductsPage(
-					testGetProductByExternalReferenceCodeRelatedProductsPage_getExternalReferenceCode(),
-					RandomTestUtil.randomString(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetProductByExternalReferenceCodeRelatedProductsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetProductByExternalReferenceCodeRelatedProductsPage_getIrrelevantExternalReferenceCode();
+
+		Page<RelatedProduct> page =
+			relatedProductResource.
+				getProductByExternalReferenceCodeRelatedProductsPage(
+					externalReferenceCode, RandomTestUtil.randomString(),
+					Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			RelatedProduct irrelevantRelatedProduct =
@@ -243,7 +243,7 @@ public abstract class BaseRelatedProductResourceTestCase {
 		page =
 			relatedProductResource.
 				getProductByExternalReferenceCodeRelatedProductsPage(
-					externalReferenceCode, null, Pagination.of(1, 2));
+					externalReferenceCode, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -359,16 +359,15 @@ public abstract class BaseRelatedProductResourceTestCase {
 
 	@Test
 	public void testGetProductIdRelatedProductsPage() throws Exception {
-		Page<RelatedProduct> page =
-			relatedProductResource.getProductIdRelatedProductsPage(
-				testGetProductIdRelatedProductsPage_getId(),
-				RandomTestUtil.randomString(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetProductIdRelatedProductsPage_getId();
 		Long irrelevantId =
 			testGetProductIdRelatedProductsPage_getIrrelevantId();
+
+		Page<RelatedProduct> page =
+			relatedProductResource.getProductIdRelatedProductsPage(
+				id, RandomTestUtil.randomString(), Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			RelatedProduct irrelevantRelatedProduct =
@@ -395,7 +394,7 @@ public abstract class BaseRelatedProductResourceTestCase {
 				id, randomRelatedProduct());
 
 		page = relatedProductResource.getProductIdRelatedProductsPage(
-			id, null, Pagination.of(1, 2));
+			id, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -658,6 +657,23 @@ public abstract class BaseRelatedProductResourceTestCase {
 
 			assertEquals(relatedProduct1, relatedProduct2);
 		}
+	}
+
+	protected void assertContains(
+		RelatedProduct relatedProduct, List<RelatedProduct> relatedProducts) {
+
+		boolean contains = false;
+
+		for (RelatedProduct item : relatedProducts) {
+			if (equals(relatedProduct, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			relatedProducts + " does not contain " + relatedProduct, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -210,16 +211,15 @@ public abstract class BaseSkuResourceTestCase {
 	public void testGetProductByExternalReferenceCodeSkusPage()
 		throws Exception {
 
-		Page<Sku> page = skuResource.getProductByExternalReferenceCodeSkusPage(
-			testGetProductByExternalReferenceCodeSkusPage_getExternalReferenceCode(),
-			Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetProductByExternalReferenceCodeSkusPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetProductByExternalReferenceCodeSkusPage_getIrrelevantExternalReferenceCode();
+
+		Page<Sku> page = skuResource.getProductByExternalReferenceCodeSkusPage(
+			externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			Sku irrelevantSku =
@@ -243,7 +243,7 @@ public abstract class BaseSkuResourceTestCase {
 			externalReferenceCode, randomSku());
 
 		page = skuResource.getProductByExternalReferenceCodeSkusPage(
-			externalReferenceCode, Pagination.of(1, 2));
+			externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -338,13 +338,13 @@ public abstract class BaseSkuResourceTestCase {
 
 	@Test
 	public void testGetProductIdSkusPage() throws Exception {
-		Page<Sku> page = skuResource.getProductIdSkusPage(
-			testGetProductIdSkusPage_getId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetProductIdSkusPage_getId();
 		Long irrelevantId = testGetProductIdSkusPage_getIrrelevantId();
+
+		Page<Sku> page = skuResource.getProductIdSkusPage(
+			id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			Sku irrelevantSku = testGetProductIdSkusPage_addSku(
@@ -364,7 +364,7 @@ public abstract class BaseSkuResourceTestCase {
 
 		Sku sku2 = testGetProductIdSkusPage_addSku(id, randomSku());
 
-		page = skuResource.getProductIdSkusPage(id, Pagination.of(1, 2));
+		page = skuResource.getProductIdSkusPage(id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -444,20 +444,20 @@ public abstract class BaseSkuResourceTestCase {
 	@Test
 	public void testGetSkusPage() throws Exception {
 		Page<Sku> page = skuResource.getSkusPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Sku sku1 = testGetSkusPage_addSku(randomSku());
 
 		Sku sku2 = testGetSkusPage_addSku(randomSku());
 
-		page = skuResource.getSkusPage(null, null, Pagination.of(1, 2), null);
+		page = skuResource.getSkusPage(null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(sku1, sku2), (List<Sku>)page.getItems());
+		assertContains(sku1, (List<Sku>)page.getItems());
+		assertContains(sku2, (List<Sku>)page.getItems());
 		assertValid(page);
 
 		skuResource.deleteSku(sku1.getId());
@@ -514,6 +514,10 @@ public abstract class BaseSkuResourceTestCase {
 
 	@Test
 	public void testGetSkusPageWithPagination() throws Exception {
+		Page<Sku> totalPage = skuResource.getSkusPage(null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Sku sku1 = testGetSkusPage_addSku(randomSku());
 
 		Sku sku2 = testGetSkusPage_addSku(randomSku());
@@ -521,26 +525,27 @@ public abstract class BaseSkuResourceTestCase {
 		Sku sku3 = testGetSkusPage_addSku(randomSku());
 
 		Page<Sku> page1 = skuResource.getSkusPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Sku> skus1 = (List<Sku>)page1.getItems();
 
-		Assert.assertEquals(skus1.toString(), 2, skus1.size());
+		Assert.assertEquals(skus1.toString(), totalCount + 2, skus1.size());
 
 		Page<Sku> page2 = skuResource.getSkusPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Sku> skus2 = (List<Sku>)page2.getItems();
 
 		Assert.assertEquals(skus2.toString(), 1, skus2.size());
 
 		Page<Sku> page3 = skuResource.getSkusPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(sku1, sku2, sku3), (List<Sku>)page3.getItems());
+		assertContains(sku1, (List<Sku>)page3.getItems());
+		assertContains(sku2, (List<Sku>)page3.getItems());
+		assertContains(sku3, (List<Sku>)page3.getItems());
 	}
 
 	@Test
@@ -667,7 +672,7 @@ public abstract class BaseSkuResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -677,7 +682,7 @@ public abstract class BaseSkuResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/skus");
 
-		Assert.assertEquals(0, skusJSONObject.get("totalCount"));
+		long totalCount = skusJSONObject.getLong("totalCount");
 
 		Sku sku1 = testGraphQLSku_addSku();
 		Sku sku2 = testGraphQLSku_addSku();
@@ -686,10 +691,14 @@ public abstract class BaseSkuResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/skus");
 
-		Assert.assertEquals(2, skusJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, skusJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(sku1, sku2),
+		assertContains(
+			sku1,
+			Arrays.asList(SkuSerDes.toDTOs(skusJSONObject.getString("items"))));
+		assertContains(
+			sku2,
 			Arrays.asList(SkuSerDes.toDTOs(skusJSONObject.getString("items"))));
 	}
 
@@ -934,6 +943,20 @@ public abstract class BaseSkuResourceTestCase {
 
 			assertEquals(sku1, sku2);
 		}
+	}
+
+	protected void assertContains(Sku sku, List<Sku> skus) {
+		boolean contains = false;
+
+		for (Sku item : skus) {
+			if (equals(sku, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(skus + " does not contain " + sku, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(List<Sku> skus1, List<Sku> skus2) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -201,9 +202,9 @@ public abstract class BaseSpecificationResourceTestCase {
 	@Test
 	public void testGetSpecificationsPage() throws Exception {
 		Page<Specification> page = specificationResource.getSpecificationsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Specification specification1 =
 			testGetSpecificationsPage_addSpecification(randomSpecification());
@@ -212,13 +213,12 @@ public abstract class BaseSpecificationResourceTestCase {
 			testGetSpecificationsPage_addSpecification(randomSpecification());
 
 		page = specificationResource.getSpecificationsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(specification1, specification2),
-			(List<Specification>)page.getItems());
+		assertContains(specification1, (List<Specification>)page.getItems());
+		assertContains(specification2, (List<Specification>)page.getItems());
 		assertValid(page);
 
 		specificationResource.deleteSpecification(specification1.getId());
@@ -287,6 +287,11 @@ public abstract class BaseSpecificationResourceTestCase {
 
 	@Test
 	public void testGetSpecificationsPageWithPagination() throws Exception {
+		Page<Specification> totalPage =
+			specificationResource.getSpecificationsPage(null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Specification specification1 =
 			testGetSpecificationsPage_addSpecification(randomSpecification());
 
@@ -297,18 +302,18 @@ public abstract class BaseSpecificationResourceTestCase {
 			testGetSpecificationsPage_addSpecification(randomSpecification());
 
 		Page<Specification> page1 = specificationResource.getSpecificationsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Specification> specifications1 =
 			(List<Specification>)page1.getItems();
 
 		Assert.assertEquals(
-			specifications1.toString(), 2, specifications1.size());
+			specifications1.toString(), totalCount + 2, specifications1.size());
 
 		Page<Specification> page2 = specificationResource.getSpecificationsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Specification> specifications2 =
 			(List<Specification>)page2.getItems();
@@ -317,11 +322,11 @@ public abstract class BaseSpecificationResourceTestCase {
 			specifications2.toString(), 1, specifications2.size());
 
 		Page<Specification> page3 = specificationResource.getSpecificationsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(specification1, specification2, specification3),
-			(List<Specification>)page3.getItems());
+		assertContains(specification1, (List<Specification>)page3.getItems());
+		assertContains(specification2, (List<Specification>)page3.getItems());
+		assertContains(specification3, (List<Specification>)page3.getItems());
 	}
 
 	@Test
@@ -459,7 +464,7 @@ public abstract class BaseSpecificationResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -469,7 +474,7 @@ public abstract class BaseSpecificationResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/specifications");
 
-		Assert.assertEquals(0, specificationsJSONObject.get("totalCount"));
+		long totalCount = specificationsJSONObject.getLong("totalCount");
 
 		Specification specification1 =
 			testGraphQLSpecification_addSpecification();
@@ -480,10 +485,16 @@ public abstract class BaseSpecificationResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/specifications");
 
-		Assert.assertEquals(2, specificationsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, specificationsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(specification1, specification2),
+		assertContains(
+			specification1,
+			Arrays.asList(
+				SpecificationSerDes.toDTOs(
+					specificationsJSONObject.getString("items"))));
+		assertContains(
+			specification2,
 			Arrays.asList(
 				SpecificationSerDes.toDTOs(
 					specificationsJSONObject.getString("items"))));
@@ -673,6 +684,23 @@ public abstract class BaseSpecificationResourceTestCase {
 
 			assertEquals(specification1, specification2);
 		}
+	}
+
+	protected void assertContains(
+		Specification specification, List<Specification> specifications) {
+
+		boolean contains = false;
+
+		for (Specification item : specifications) {
+			if (equals(specification, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			specifications + " does not contain " + specification, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -207,21 +208,21 @@ public abstract class BaseChannelResourceTestCase {
 	@Test
 	public void testGetChannelsPage() throws Exception {
 		Page<Channel> page = channelResource.getChannelsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Channel channel1 = testGetChannelsPage_addChannel(randomChannel());
 
 		Channel channel2 = testGetChannelsPage_addChannel(randomChannel());
 
 		page = channelResource.getChannelsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(channel1, channel2), (List<Channel>)page.getItems());
+		assertContains(channel1, (List<Channel>)page.getItems());
+		assertContains(channel2, (List<Channel>)page.getItems());
 		assertValid(page);
 
 		channelResource.deleteChannel(channel1.getId());
@@ -280,6 +281,11 @@ public abstract class BaseChannelResourceTestCase {
 
 	@Test
 	public void testGetChannelsPageWithPagination() throws Exception {
+		Page<Channel> totalPage = channelResource.getChannelsPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Channel channel1 = testGetChannelsPage_addChannel(randomChannel());
 
 		Channel channel2 = testGetChannelsPage_addChannel(randomChannel());
@@ -287,27 +293,28 @@ public abstract class BaseChannelResourceTestCase {
 		Channel channel3 = testGetChannelsPage_addChannel(randomChannel());
 
 		Page<Channel> page1 = channelResource.getChannelsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Channel> channels1 = (List<Channel>)page1.getItems();
 
-		Assert.assertEquals(channels1.toString(), 2, channels1.size());
+		Assert.assertEquals(
+			channels1.toString(), totalCount + 2, channels1.size());
 
 		Page<Channel> page2 = channelResource.getChannelsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Channel> channels2 = (List<Channel>)page2.getItems();
 
 		Assert.assertEquals(channels2.toString(), 1, channels2.size());
 
 		Page<Channel> page3 = channelResource.getChannelsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(channel1, channel2, channel3),
-			(List<Channel>)page3.getItems());
+		assertContains(channel1, (List<Channel>)page3.getItems());
+		assertContains(channel2, (List<Channel>)page3.getItems());
+		assertContains(channel3, (List<Channel>)page3.getItems());
 	}
 
 	@Test
@@ -438,7 +445,7 @@ public abstract class BaseChannelResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -448,7 +455,7 @@ public abstract class BaseChannelResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/channels");
 
-		Assert.assertEquals(0, channelsJSONObject.get("totalCount"));
+		long totalCount = channelsJSONObject.getLong("totalCount");
 
 		Channel channel1 = testGraphQLChannel_addChannel();
 		Channel channel2 = testGraphQLChannel_addChannel();
@@ -457,10 +464,15 @@ public abstract class BaseChannelResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/channels");
 
-		Assert.assertEquals(2, channelsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, channelsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(channel1, channel2),
+		assertContains(
+			channel1,
+			Arrays.asList(
+				ChannelSerDes.toDTOs(channelsJSONObject.getString("items"))));
+		assertContains(
+			channel2,
 			Arrays.asList(
 				ChannelSerDes.toDTOs(channelsJSONObject.getString("items"))));
 	}
@@ -670,6 +682,20 @@ public abstract class BaseChannelResourceTestCase {
 
 			assertEquals(channel1, channel2);
 		}
+	}
+
+	protected void assertContains(Channel channel, List<Channel> channels) {
+		boolean contains = false;
+
+		for (Channel item : channels) {
+			if (equals(channel, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(channels + " does not contain " + channel, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -188,9 +189,9 @@ public abstract class BaseTaxCategoryResourceTestCase {
 	@Test
 	public void testGetTaxCategoriesPage() throws Exception {
 		Page<TaxCategory> page = taxCategoryResource.getTaxCategoriesPage(
-			RandomTestUtil.randomString(), Pagination.of(1, 2));
+			RandomTestUtil.randomString(), Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		TaxCategory taxCategory1 = testGetTaxCategoriesPage_addTaxCategory(
 			randomTaxCategory());
@@ -199,18 +200,22 @@ public abstract class BaseTaxCategoryResourceTestCase {
 			randomTaxCategory());
 
 		page = taxCategoryResource.getTaxCategoriesPage(
-			null, Pagination.of(1, 2));
+			null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(taxCategory1, taxCategory2),
-			(List<TaxCategory>)page.getItems());
+		assertContains(taxCategory1, (List<TaxCategory>)page.getItems());
+		assertContains(taxCategory2, (List<TaxCategory>)page.getItems());
 		assertValid(page);
 	}
 
 	@Test
 	public void testGetTaxCategoriesPageWithPagination() throws Exception {
+		Page<TaxCategory> totalPage = taxCategoryResource.getTaxCategoriesPage(
+			null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		TaxCategory taxCategory1 = testGetTaxCategoriesPage_addTaxCategory(
 			randomTaxCategory());
 
@@ -221,17 +226,17 @@ public abstract class BaseTaxCategoryResourceTestCase {
 			randomTaxCategory());
 
 		Page<TaxCategory> page1 = taxCategoryResource.getTaxCategoriesPage(
-			null, Pagination.of(1, 2));
+			null, Pagination.of(1, totalCount + 2));
 
 		List<TaxCategory> taxCategories1 = (List<TaxCategory>)page1.getItems();
 
 		Assert.assertEquals(
-			taxCategories1.toString(), 2, taxCategories1.size());
+			taxCategories1.toString(), totalCount + 2, taxCategories1.size());
 
 		Page<TaxCategory> page2 = taxCategoryResource.getTaxCategoriesPage(
-			null, Pagination.of(2, 2));
+			null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<TaxCategory> taxCategories2 = (List<TaxCategory>)page2.getItems();
 
@@ -239,11 +244,11 @@ public abstract class BaseTaxCategoryResourceTestCase {
 			taxCategories2.toString(), 1, taxCategories2.size());
 
 		Page<TaxCategory> page3 = taxCategoryResource.getTaxCategoriesPage(
-			null, Pagination.of(1, 3));
+			null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(taxCategory1, taxCategory2, taxCategory3),
-			(List<TaxCategory>)page3.getItems());
+		assertContains(taxCategory1, (List<TaxCategory>)page3.getItems());
+		assertContains(taxCategory2, (List<TaxCategory>)page3.getItems());
+		assertContains(taxCategory3, (List<TaxCategory>)page3.getItems());
 	}
 
 	protected TaxCategory testGetTaxCategoriesPage_addTaxCategory(
@@ -261,7 +266,7 @@ public abstract class BaseTaxCategoryResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -271,7 +276,7 @@ public abstract class BaseTaxCategoryResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/taxCategories");
 
-		Assert.assertEquals(0, taxCategoriesJSONObject.get("totalCount"));
+		long totalCount = taxCategoriesJSONObject.getLong("totalCount");
 
 		TaxCategory taxCategory1 = testGraphQLTaxCategory_addTaxCategory();
 		TaxCategory taxCategory2 = testGraphQLTaxCategory_addTaxCategory();
@@ -280,10 +285,16 @@ public abstract class BaseTaxCategoryResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/taxCategories");
 
-		Assert.assertEquals(2, taxCategoriesJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, taxCategoriesJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(taxCategory1, taxCategory2),
+		assertContains(
+			taxCategory1,
+			Arrays.asList(
+				TaxCategorySerDes.toDTOs(
+					taxCategoriesJSONObject.getString("items"))));
+		assertContains(
+			taxCategory2,
 			Arrays.asList(
 				TaxCategorySerDes.toDTOs(
 					taxCategoriesJSONObject.getString("items"))));
@@ -380,6 +391,23 @@ public abstract class BaseTaxCategoryResourceTestCase {
 
 			assertEquals(taxCategory1, taxCategory2);
 		}
+	}
+
+	protected void assertContains(
+		TaxCategory taxCategory, List<TaxCategory> taxCategories) {
+
+		boolean contains = false;
+
+		for (TaxCategory item : taxCategories) {
+			if (equals(taxCategory, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			taxCategories + " does not contain " + taxCategory, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/build.gradle
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	testIntegrationCompile project(":apps:commerce:headless:headless-commerce:headless-commerce-admin-inventory-api")
 	testIntegrationCompile project(":apps:commerce:headless:headless-commerce:headless-commerce-admin-inventory-client")
 	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")
+	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")
 	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationCompile project(":core:petra:petra-function")
 	testIntegrationCompile project(":core:petra:petra-string")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -469,18 +470,17 @@ public abstract class BaseWarehouseItemResourceTestCase {
 	public void testGetWarehousByExternalReferenceCodeWarehouseItemsPage()
 		throws Exception {
 
-		Page<WarehouseItem> page =
-			warehouseItemResource.
-				getWarehousByExternalReferenceCodeWarehouseItemsPage(
-					testGetWarehousByExternalReferenceCodeWarehouseItemsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetWarehousByExternalReferenceCodeWarehouseItemsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetWarehousByExternalReferenceCodeWarehouseItemsPage_getIrrelevantExternalReferenceCode();
+
+		Page<WarehouseItem> page =
+			warehouseItemResource.
+				getWarehousByExternalReferenceCodeWarehouseItemsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			WarehouseItem irrelevantWarehouseItem =
@@ -512,7 +512,7 @@ public abstract class BaseWarehouseItemResourceTestCase {
 		page =
 			warehouseItemResource.
 				getWarehousByExternalReferenceCodeWarehouseItemsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -628,16 +628,15 @@ public abstract class BaseWarehouseItemResourceTestCase {
 
 	@Test
 	public void testGetWarehousIdWarehouseItemsPage() throws Exception {
-		Page<WarehouseItem> page =
-			warehouseItemResource.getWarehousIdWarehouseItemsPage(
-				testGetWarehousIdWarehouseItemsPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetWarehousIdWarehouseItemsPage_getId();
 		Long irrelevantId =
 			testGetWarehousIdWarehouseItemsPage_getIrrelevantId();
+
+		Page<WarehouseItem> page =
+			warehouseItemResource.getWarehousIdWarehouseItemsPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			WarehouseItem irrelevantWarehouseItem =
@@ -664,7 +663,7 @@ public abstract class BaseWarehouseItemResourceTestCase {
 				id, randomWarehouseItem());
 
 		page = warehouseItemResource.getWarehousIdWarehouseItemsPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -774,9 +773,9 @@ public abstract class BaseWarehouseItemResourceTestCase {
 		Page<WarehouseItem> page =
 			warehouseItemResource.getWarehouseItemsUpdatedPage(
 				RandomTestUtil.nextDate(), RandomTestUtil.nextDate(),
-				Pagination.of(1, 2));
+				Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		WarehouseItem warehouseItem1 =
 			testGetWarehouseItemsUpdatedPage_addWarehouseItem(
@@ -787,13 +786,12 @@ public abstract class BaseWarehouseItemResourceTestCase {
 				randomWarehouseItem());
 
 		page = warehouseItemResource.getWarehouseItemsUpdatedPage(
-			null, null, Pagination.of(1, 2));
+			null, null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(warehouseItem1, warehouseItem2),
-			(List<WarehouseItem>)page.getItems());
+		assertContains(warehouseItem1, (List<WarehouseItem>)page.getItems());
+		assertContains(warehouseItem2, (List<WarehouseItem>)page.getItems());
 		assertValid(page);
 
 		warehouseItemResource.deleteWarehouseItem(warehouseItem1.getId());
@@ -804,6 +802,12 @@ public abstract class BaseWarehouseItemResourceTestCase {
 	@Test
 	public void testGetWarehouseItemsUpdatedPageWithPagination()
 		throws Exception {
+
+		Page<WarehouseItem> totalPage =
+			warehouseItemResource.getWarehouseItemsUpdatedPage(
+				null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
 
 		WarehouseItem warehouseItem1 =
 			testGetWarehouseItemsUpdatedPage_addWarehouseItem(
@@ -819,19 +823,19 @@ public abstract class BaseWarehouseItemResourceTestCase {
 
 		Page<WarehouseItem> page1 =
 			warehouseItemResource.getWarehouseItemsUpdatedPage(
-				null, null, Pagination.of(1, 2));
+				null, null, Pagination.of(1, totalCount + 2));
 
 		List<WarehouseItem> warehouseItems1 =
 			(List<WarehouseItem>)page1.getItems();
 
 		Assert.assertEquals(
-			warehouseItems1.toString(), 2, warehouseItems1.size());
+			warehouseItems1.toString(), totalCount + 2, warehouseItems1.size());
 
 		Page<WarehouseItem> page2 =
 			warehouseItemResource.getWarehouseItemsUpdatedPage(
-				null, null, Pagination.of(2, 2));
+				null, null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<WarehouseItem> warehouseItems2 =
 			(List<WarehouseItem>)page2.getItems();
@@ -841,11 +845,11 @@ public abstract class BaseWarehouseItemResourceTestCase {
 
 		Page<WarehouseItem> page3 =
 			warehouseItemResource.getWarehouseItemsUpdatedPage(
-				null, null, Pagination.of(1, 3));
+				null, null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(warehouseItem1, warehouseItem2, warehouseItem3),
-			(List<WarehouseItem>)page3.getItems());
+		assertContains(warehouseItem1, (List<WarehouseItem>)page3.getItems());
+		assertContains(warehouseItem2, (List<WarehouseItem>)page3.getItems());
+		assertContains(warehouseItem3, (List<WarehouseItem>)page3.getItems());
 	}
 
 	protected WarehouseItem testGetWarehouseItemsUpdatedPage_addWarehouseItem(
@@ -891,6 +895,23 @@ public abstract class BaseWarehouseItemResourceTestCase {
 
 			assertEquals(warehouseItem1, warehouseItem2);
 		}
+	}
+
+	protected void assertContains(
+		WarehouseItem warehouseItem, List<WarehouseItem> warehouseItems) {
+
+		boolean contains = false;
+
+		for (WarehouseItem item : warehouseItems) {
+			if (equals(warehouseItem, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			warehouseItems + " does not contain " + warehouseItem, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -25,8 +25,10 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.commerce.admin.inventory.client.dto.v1_0.Warehouse;
 import com.liferay.headless.commerce.admin.inventory.client.http.HttpInvoker;
 import com.liferay.headless.commerce.admin.inventory.client.pagination.Page;
+import com.liferay.headless.commerce.admin.inventory.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.inventory.client.resource.v1_0.WarehouseResource;
 import com.liferay.headless.commerce.admin.inventory.client.serdes.v1_0.WarehouseSerDes;
+import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -40,21 +42,26 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import java.text.DateFormat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +73,9 @@ import javax.annotation.Generated;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 
+import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.lang.time.DateUtils;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -404,7 +413,238 @@ public abstract class BaseWarehouseResourceTestCase {
 
 	@Test
 	public void testGetWarehousesPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<Warehouse> page = warehouseResource.getWarehousesPage(
+			null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		Warehouse warehouse1 = testGetWarehousesPage_addWarehouse(
+			randomWarehouse());
+
+		Warehouse warehouse2 = testGetWarehousesPage_addWarehouse(
+			randomWarehouse());
+
+		page = warehouseResource.getWarehousesPage(
+			null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(warehouse1, (List<Warehouse>)page.getItems());
+		assertContains(warehouse2, (List<Warehouse>)page.getItems());
+		assertValid(page);
+	}
+
+	@Test
+	public void testGetWarehousesPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Warehouse warehouse1 = randomWarehouse();
+
+		warehouse1 = testGetWarehousesPage_addWarehouse(warehouse1);
+
+		for (EntityField entityField : entityFields) {
+			Page<Warehouse> page = warehouseResource.getWarehousesPage(
+				getFilterString(entityField, "between", warehouse1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(warehouse1),
+				(List<Warehouse>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetWarehousesPageWithFilterStringEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.STRING);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Warehouse warehouse1 = testGetWarehousesPage_addWarehouse(
+			randomWarehouse());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Warehouse warehouse2 = testGetWarehousesPage_addWarehouse(
+			randomWarehouse());
+
+		for (EntityField entityField : entityFields) {
+			Page<Warehouse> page = warehouseResource.getWarehousesPage(
+				getFilterString(entityField, "eq", warehouse1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(warehouse1),
+				(List<Warehouse>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetWarehousesPageWithPagination() throws Exception {
+		Page<Warehouse> totalPage = warehouseResource.getWarehousesPage(
+			null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
+		Warehouse warehouse1 = testGetWarehousesPage_addWarehouse(
+			randomWarehouse());
+
+		Warehouse warehouse2 = testGetWarehousesPage_addWarehouse(
+			randomWarehouse());
+
+		Warehouse warehouse3 = testGetWarehousesPage_addWarehouse(
+			randomWarehouse());
+
+		Page<Warehouse> page1 = warehouseResource.getWarehousesPage(
+			null, Pagination.of(1, totalCount + 2), null);
+
+		List<Warehouse> warehouses1 = (List<Warehouse>)page1.getItems();
+
+		Assert.assertEquals(
+			warehouses1.toString(), totalCount + 2, warehouses1.size());
+
+		Page<Warehouse> page2 = warehouseResource.getWarehousesPage(
+			null, Pagination.of(2, totalCount + 2), null);
+
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+		List<Warehouse> warehouses2 = (List<Warehouse>)page2.getItems();
+
+		Assert.assertEquals(warehouses2.toString(), 1, warehouses2.size());
+
+		Page<Warehouse> page3 = warehouseResource.getWarehousesPage(
+			null, Pagination.of(1, totalCount + 3), null);
+
+		assertContains(warehouse1, (List<Warehouse>)page3.getItems());
+		assertContains(warehouse2, (List<Warehouse>)page3.getItems());
+		assertContains(warehouse3, (List<Warehouse>)page3.getItems());
+	}
+
+	@Test
+	public void testGetWarehousesPageWithSortDateTime() throws Exception {
+		testGetWarehousesPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, warehouse1, warehouse2) -> {
+				BeanUtils.setProperty(
+					warehouse1, entityField.getName(),
+					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetWarehousesPageWithSortInteger() throws Exception {
+		testGetWarehousesPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, warehouse1, warehouse2) -> {
+				BeanUtils.setProperty(warehouse1, entityField.getName(), 0);
+				BeanUtils.setProperty(warehouse2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetWarehousesPageWithSortString() throws Exception {
+		testGetWarehousesPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, warehouse1, warehouse2) -> {
+				Class<?> clazz = warehouse1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanUtils.setProperty(
+						warehouse1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanUtils.setProperty(
+						warehouse2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanUtils.setProperty(
+						warehouse1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanUtils.setProperty(
+						warehouse2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanUtils.setProperty(
+						warehouse1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanUtils.setProperty(
+						warehouse2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetWarehousesPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer<EntityField, Warehouse, Warehouse, Exception>
+				unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Warehouse warehouse1 = randomWarehouse();
+		Warehouse warehouse2 = randomWarehouse();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(entityField, warehouse1, warehouse2);
+		}
+
+		warehouse1 = testGetWarehousesPage_addWarehouse(warehouse1);
+
+		warehouse2 = testGetWarehousesPage_addWarehouse(warehouse2);
+
+		for (EntityField entityField : entityFields) {
+			Page<Warehouse> ascPage = warehouseResource.getWarehousesPage(
+				null, Pagination.of(1, 2), entityField.getName() + ":asc");
+
+			assertEquals(
+				Arrays.asList(warehouse1, warehouse2),
+				(List<Warehouse>)ascPage.getItems());
+
+			Page<Warehouse> descPage = warehouseResource.getWarehousesPage(
+				null, Pagination.of(1, 2), entityField.getName() + ":desc");
+
+			assertEquals(
+				Arrays.asList(warehouse2, warehouse1),
+				(List<Warehouse>)descPage.getItems());
+		}
+	}
+
+	protected Warehouse testGetWarehousesPage_addWarehouse(Warehouse warehouse)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -414,7 +654,7 @@ public abstract class BaseWarehouseResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -424,7 +664,7 @@ public abstract class BaseWarehouseResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/warehouses");
 
-		Assert.assertEquals(0, warehousesJSONObject.get("totalCount"));
+		long totalCount = warehousesJSONObject.getLong("totalCount");
 
 		Warehouse warehouse1 = testGraphQLWarehouse_addWarehouse();
 		Warehouse warehouse2 = testGraphQLWarehouse_addWarehouse();
@@ -433,10 +673,16 @@ public abstract class BaseWarehouseResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/warehouses");
 
-		Assert.assertEquals(2, warehousesJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, warehousesJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(warehouse1, warehouse2),
+		assertContains(
+			warehouse1,
+			Arrays.asList(
+				WarehouseSerDes.toDTOs(
+					warehousesJSONObject.getString("items"))));
+		assertContains(
+			warehouse2,
 			Arrays.asList(
 				WarehouseSerDes.toDTOs(
 					warehousesJSONObject.getString("items"))));
@@ -459,6 +705,9 @@ public abstract class BaseWarehouseResourceTestCase {
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
 
 	protected Warehouse testGraphQLWarehouse_addWarehouse() throws Exception {
 		throw new UnsupportedOperationException(
@@ -490,6 +739,23 @@ public abstract class BaseWarehouseResourceTestCase {
 
 			assertEquals(warehouse1, warehouse2);
 		}
+	}
+
+	protected void assertContains(
+		Warehouse warehouse, List<Warehouse> warehouses) {
+
+		boolean contains = false;
+
+		for (Warehouse item : warehouses) {
+			if (equals(warehouse, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			warehouses + " does not contain " + warehouse, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -358,6 +358,20 @@ public abstract class BaseAccountResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Account account, List<Account> accounts) {
+		boolean contains = false;
+
+		for (Account item : accounts) {
+			if (equals(account, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(accounts + " does not contain " + account, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Account> accounts1, List<Account> accounts2) {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
@@ -402,6 +402,23 @@ public abstract class BaseBillingAddressResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		BillingAddress billingAddress, List<BillingAddress> billingAddresses) {
+
+		boolean contains = false;
+
+		for (BillingAddress item : billingAddresses) {
+			if (equals(billingAddress, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			billingAddresses + " does not contain " + billingAddress, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<BillingAddress> billingAddresses1,
 		List<BillingAddress> billingAddresses2) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -420,6 +420,20 @@ public abstract class BaseChannelResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Channel channel, List<Channel> channels) {
+		boolean contains = false;
+
+		for (Channel item : channels) {
+			if (equals(channel, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(channels + " does not contain " + channel, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Channel> channels1, List<Channel> channels2) {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
@@ -430,17 +430,16 @@ public abstract class BaseOrderItemResourceTestCase {
 	public void testGetOrderByExternalReferenceCodeOrderItemsPage()
 		throws Exception {
 
-		Page<OrderItem> page =
-			orderItemResource.getOrderByExternalReferenceCodeOrderItemsPage(
-				testGetOrderByExternalReferenceCodeOrderItemsPage_getExternalReferenceCode(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetOrderByExternalReferenceCodeOrderItemsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetOrderByExternalReferenceCodeOrderItemsPage_getIrrelevantExternalReferenceCode();
+
+		Page<OrderItem> page =
+			orderItemResource.getOrderByExternalReferenceCodeOrderItemsPage(
+				externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			OrderItem irrelevantOrderItem =
@@ -469,7 +468,7 @@ public abstract class BaseOrderItemResourceTestCase {
 				externalReferenceCode, randomOrderItem());
 
 		page = orderItemResource.getOrderByExternalReferenceCodeOrderItemsPage(
-			externalReferenceCode, Pagination.of(1, 2));
+			externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -578,13 +577,13 @@ public abstract class BaseOrderItemResourceTestCase {
 
 	@Test
 	public void testGetOrderIdOrderItemsPage() throws Exception {
-		Page<OrderItem> page = orderItemResource.getOrderIdOrderItemsPage(
-			testGetOrderIdOrderItemsPage_getId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetOrderIdOrderItemsPage_getId();
 		Long irrelevantId = testGetOrderIdOrderItemsPage_getIrrelevantId();
+
+		Page<OrderItem> page = orderItemResource.getOrderIdOrderItemsPage(
+			id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			OrderItem irrelevantOrderItem =
@@ -609,7 +608,7 @@ public abstract class BaseOrderItemResourceTestCase {
 			id, randomOrderItem());
 
 		page = orderItemResource.getOrderIdOrderItemsPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -728,6 +727,23 @@ public abstract class BaseOrderItemResourceTestCase {
 
 			assertEquals(orderItem1, orderItem2);
 		}
+	}
+
+	protected void assertContains(
+		OrderItem orderItem, List<OrderItem> orderItems) {
+
+		boolean contains = false;
+
+		for (OrderItem item : orderItems) {
+			if (equals(orderItem, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			orderItems + " does not contain " + orderItem, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderNoteResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderNoteResourceTestCase.java
@@ -425,17 +425,16 @@ public abstract class BaseOrderNoteResourceTestCase {
 	public void testGetOrderByExternalReferenceCodeOrderNotesPage()
 		throws Exception {
 
-		Page<OrderNote> page =
-			orderNoteResource.getOrderByExternalReferenceCodeOrderNotesPage(
-				testGetOrderByExternalReferenceCodeOrderNotesPage_getExternalReferenceCode(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetOrderByExternalReferenceCodeOrderNotesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetOrderByExternalReferenceCodeOrderNotesPage_getIrrelevantExternalReferenceCode();
+
+		Page<OrderNote> page =
+			orderNoteResource.getOrderByExternalReferenceCodeOrderNotesPage(
+				externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			OrderNote irrelevantOrderNote =
@@ -464,7 +463,7 @@ public abstract class BaseOrderNoteResourceTestCase {
 				externalReferenceCode, randomOrderNote());
 
 		page = orderNoteResource.getOrderByExternalReferenceCodeOrderNotesPage(
-			externalReferenceCode, Pagination.of(1, 2));
+			externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -573,13 +572,13 @@ public abstract class BaseOrderNoteResourceTestCase {
 
 	@Test
 	public void testGetOrderIdOrderNotesPage() throws Exception {
-		Page<OrderNote> page = orderNoteResource.getOrderIdOrderNotesPage(
-			testGetOrderIdOrderNotesPage_getId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetOrderIdOrderNotesPage_getId();
 		Long irrelevantId = testGetOrderIdOrderNotesPage_getIrrelevantId();
+
+		Page<OrderNote> page = orderNoteResource.getOrderIdOrderNotesPage(
+			id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			OrderNote irrelevantOrderNote =
@@ -604,7 +603,7 @@ public abstract class BaseOrderNoteResourceTestCase {
 			id, randomOrderNote());
 
 		page = orderNoteResource.getOrderIdOrderNotesPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -723,6 +722,23 @@ public abstract class BaseOrderNoteResourceTestCase {
 
 			assertEquals(orderNote1, orderNote2);
 		}
+	}
+
+	protected void assertContains(
+		OrderNote orderNote, List<OrderNote> orderNotes) {
+
+		boolean contains = false;
+
+		for (OrderNote item : orderNotes) {
+			if (equals(orderNote, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			orderNotes + " does not contain " + orderNote, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -252,21 +253,21 @@ public abstract class BaseOrderResourceTestCase {
 	@Test
 	public void testGetOrdersPage() throws Exception {
 		Page<Order> page = orderResource.getOrdersPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Order order1 = testGetOrdersPage_addOrder(randomOrder());
 
 		Order order2 = testGetOrdersPage_addOrder(randomOrder());
 
 		page = orderResource.getOrdersPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(order1, order2), (List<Order>)page.getItems());
+		assertContains(order1, (List<Order>)page.getItems());
+		assertContains(order2, (List<Order>)page.getItems());
 		assertValid(page);
 
 		orderResource.deleteOrder(order1.getId());
@@ -325,6 +326,11 @@ public abstract class BaseOrderResourceTestCase {
 
 	@Test
 	public void testGetOrdersPageWithPagination() throws Exception {
+		Page<Order> totalPage = orderResource.getOrdersPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Order order1 = testGetOrdersPage_addOrder(randomOrder());
 
 		Order order2 = testGetOrdersPage_addOrder(randomOrder());
@@ -332,27 +338,27 @@ public abstract class BaseOrderResourceTestCase {
 		Order order3 = testGetOrdersPage_addOrder(randomOrder());
 
 		Page<Order> page1 = orderResource.getOrdersPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Order> orders1 = (List<Order>)page1.getItems();
 
-		Assert.assertEquals(orders1.toString(), 2, orders1.size());
+		Assert.assertEquals(orders1.toString(), totalCount + 2, orders1.size());
 
 		Page<Order> page2 = orderResource.getOrdersPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Order> orders2 = (List<Order>)page2.getItems();
 
 		Assert.assertEquals(orders2.toString(), 1, orders2.size());
 
 		Page<Order> page3 = orderResource.getOrdersPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(order1, order2, order3),
-			(List<Order>)page3.getItems());
+		assertContains(order1, (List<Order>)page3.getItems());
+		assertContains(order2, (List<Order>)page3.getItems());
+		assertContains(order3, (List<Order>)page3.getItems());
 	}
 
 	@Test
@@ -480,7 +486,7 @@ public abstract class BaseOrderResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -490,7 +496,7 @@ public abstract class BaseOrderResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/orders");
 
-		Assert.assertEquals(0, ordersJSONObject.get("totalCount"));
+		long totalCount = ordersJSONObject.getLong("totalCount");
 
 		Order order1 = testGraphQLOrder_addOrder();
 		Order order2 = testGraphQLOrder_addOrder();
@@ -499,10 +505,15 @@ public abstract class BaseOrderResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/orders");
 
-		Assert.assertEquals(2, ordersJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, ordersJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(order1, order2),
+		assertContains(
+			order1,
+			Arrays.asList(
+				OrderSerDes.toDTOs(ordersJSONObject.getString("items"))));
+		assertContains(
+			order2,
 			Arrays.asList(
 				OrderSerDes.toDTOs(ordersJSONObject.getString("items"))));
 	}
@@ -767,6 +778,20 @@ public abstract class BaseOrderResourceTestCase {
 
 			assertEquals(order1, order2);
 		}
+	}
+
+	protected void assertContains(Order order, List<Order> orders) {
+		boolean contains = false;
+
+		for (Order item : orders) {
+			if (equals(order, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(orders + " does not contain " + order, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeChannelResourceTestCase.java
@@ -215,18 +215,17 @@ public abstract class BaseOrderTypeChannelResourceTestCase {
 	public void testGetOrderTypeByExternalReferenceCodeOrderTypeChannelsPage()
 		throws Exception {
 
-		Page<OrderTypeChannel> page =
-			orderTypeChannelResource.
-				getOrderTypeByExternalReferenceCodeOrderTypeChannelsPage(
-					testGetOrderTypeByExternalReferenceCodeOrderTypeChannelsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetOrderTypeByExternalReferenceCodeOrderTypeChannelsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetOrderTypeByExternalReferenceCodeOrderTypeChannelsPage_getIrrelevantExternalReferenceCode();
+
+		Page<OrderTypeChannel> page =
+			orderTypeChannelResource.
+				getOrderTypeByExternalReferenceCodeOrderTypeChannelsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			OrderTypeChannel irrelevantOrderTypeChannel =
@@ -258,7 +257,7 @@ public abstract class BaseOrderTypeChannelResourceTestCase {
 		page =
 			orderTypeChannelResource.
 				getOrderTypeByExternalReferenceCodeOrderTypeChannelsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -371,16 +370,15 @@ public abstract class BaseOrderTypeChannelResourceTestCase {
 
 	@Test
 	public void testGetOrderTypeIdOrderTypeChannelsPage() throws Exception {
-		Page<OrderTypeChannel> page =
-			orderTypeChannelResource.getOrderTypeIdOrderTypeChannelsPage(
-				testGetOrderTypeIdOrderTypeChannelsPage_getId(),
-				RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetOrderTypeIdOrderTypeChannelsPage_getId();
 		Long irrelevantId =
 			testGetOrderTypeIdOrderTypeChannelsPage_getIrrelevantId();
+
+		Page<OrderTypeChannel> page =
+			orderTypeChannelResource.getOrderTypeIdOrderTypeChannelsPage(
+				id, RandomTestUtil.randomString(), Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			OrderTypeChannel irrelevantOrderTypeChannel =
@@ -407,7 +405,7 @@ public abstract class BaseOrderTypeChannelResourceTestCase {
 				id, randomOrderTypeChannel());
 
 		page = orderTypeChannelResource.getOrderTypeIdOrderTypeChannelsPage(
-			id, null, Pagination.of(1, 2), null);
+			id, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -672,6 +670,25 @@ public abstract class BaseOrderTypeChannelResourceTestCase {
 
 			assertEquals(orderTypeChannel1, orderTypeChannel2);
 		}
+	}
+
+	protected void assertContains(
+		OrderTypeChannel orderTypeChannel,
+		List<OrderTypeChannel> orderTypeChannels) {
+
+		boolean contains = false;
+
+		for (OrderTypeChannel item : orderTypeChannels) {
+			if (equals(orderTypeChannel, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			orderTypeChannels + " does not contain " + orderTypeChannel,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -201,9 +202,9 @@ public abstract class BaseOrderTypeResourceTestCase {
 	@Test
 	public void testGetOrderTypesPage() throws Exception {
 		Page<OrderType> page = orderTypeResource.getOrderTypesPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		OrderType orderType1 = testGetOrderTypesPage_addOrderType(
 			randomOrderType());
@@ -212,13 +213,12 @@ public abstract class BaseOrderTypeResourceTestCase {
 			randomOrderType());
 
 		page = orderTypeResource.getOrderTypesPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(orderType1, orderType2),
-			(List<OrderType>)page.getItems());
+		assertContains(orderType1, (List<OrderType>)page.getItems());
+		assertContains(orderType2, (List<OrderType>)page.getItems());
 		assertValid(page);
 
 		orderTypeResource.deleteOrderType(orderType1.getId());
@@ -281,6 +281,11 @@ public abstract class BaseOrderTypeResourceTestCase {
 
 	@Test
 	public void testGetOrderTypesPageWithPagination() throws Exception {
+		Page<OrderType> totalPage = orderTypeResource.getOrderTypesPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		OrderType orderType1 = testGetOrderTypesPage_addOrderType(
 			randomOrderType());
 
@@ -291,27 +296,28 @@ public abstract class BaseOrderTypeResourceTestCase {
 			randomOrderType());
 
 		Page<OrderType> page1 = orderTypeResource.getOrderTypesPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<OrderType> orderTypes1 = (List<OrderType>)page1.getItems();
 
-		Assert.assertEquals(orderTypes1.toString(), 2, orderTypes1.size());
+		Assert.assertEquals(
+			orderTypes1.toString(), totalCount + 2, orderTypes1.size());
 
 		Page<OrderType> page2 = orderTypeResource.getOrderTypesPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<OrderType> orderTypes2 = (List<OrderType>)page2.getItems();
 
 		Assert.assertEquals(orderTypes2.toString(), 1, orderTypes2.size());
 
 		Page<OrderType> page3 = orderTypeResource.getOrderTypesPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(orderType1, orderType2, orderType3),
-			(List<OrderType>)page3.getItems());
+		assertContains(orderType1, (List<OrderType>)page3.getItems());
+		assertContains(orderType2, (List<OrderType>)page3.getItems());
+		assertContains(orderType3, (List<OrderType>)page3.getItems());
 	}
 
 	@Test
@@ -442,7 +448,7 @@ public abstract class BaseOrderTypeResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -452,7 +458,7 @@ public abstract class BaseOrderTypeResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/orderTypes");
 
-		Assert.assertEquals(0, orderTypesJSONObject.get("totalCount"));
+		long totalCount = orderTypesJSONObject.getLong("totalCount");
 
 		OrderType orderType1 = testGraphQLOrderType_addOrderType();
 		OrderType orderType2 = testGraphQLOrderType_addOrderType();
@@ -461,10 +467,16 @@ public abstract class BaseOrderTypeResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/orderTypes");
 
-		Assert.assertEquals(2, orderTypesJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, orderTypesJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(orderType1, orderType2),
+		assertContains(
+			orderType1,
+			Arrays.asList(
+				OrderTypeSerDes.toDTOs(
+					orderTypesJSONObject.getString("items"))));
+		assertContains(
+			orderType2,
 			Arrays.asList(
 				OrderTypeSerDes.toDTOs(
 					orderTypesJSONObject.getString("items"))));
@@ -794,6 +806,23 @@ public abstract class BaseOrderTypeResourceTestCase {
 
 			assertEquals(orderType1, orderType2);
 		}
+	}
+
+	protected void assertContains(
+		OrderType orderType, List<OrderType> orderTypes) {
+
+		boolean contains = false;
+
+		for (OrderType item : orderTypes) {
+			if (equals(orderType, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			orderTypes + " does not contain " + orderType, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -469,6 +469,25 @@ public abstract class BaseShippingAddressResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		ShippingAddress shippingAddress,
+		List<ShippingAddress> shippingAddresses) {
+
+		boolean contains = false;
+
+		for (ShippingAddress item : shippingAddresses) {
+			if (equals(shippingAddress, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			shippingAddresses + " does not contain " + shippingAddress,
+			contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<ShippingAddress> shippingAddresses1,
 		List<ShippingAddress> shippingAddresses2) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountAccountGroupResourceTestCase.java
@@ -241,18 +241,17 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountAccountGroupsPage()
 		throws Exception {
 
-		Page<DiscountAccountGroup> page =
-			discountAccountGroupResource.
-				getDiscountByExternalReferenceCodeDiscountAccountGroupsPage(
-					testGetDiscountByExternalReferenceCodeDiscountAccountGroupsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountAccountGroupsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountAccountGroupsPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountAccountGroup> page =
+			discountAccountGroupResource.
+				getDiscountByExternalReferenceCodeDiscountAccountGroupsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountAccountGroup irrelevantDiscountAccountGroup =
@@ -284,7 +283,7 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 		page =
 			discountAccountGroupResource.
 				getDiscountByExternalReferenceCodeDiscountAccountGroupsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -408,16 +407,15 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountAccountGroupsPage() throws Exception {
-		Page<DiscountAccountGroup> page =
-			discountAccountGroupResource.getDiscountIdDiscountAccountGroupsPage(
-				testGetDiscountIdDiscountAccountGroupsPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountAccountGroupsPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountAccountGroupsPage_getIrrelevantId();
+
+		Page<DiscountAccountGroup> page =
+			discountAccountGroupResource.getDiscountIdDiscountAccountGroupsPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountAccountGroup irrelevantDiscountAccountGroup =
@@ -447,7 +445,7 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 
 		page =
 			discountAccountGroupResource.getDiscountIdDiscountAccountGroupsPage(
-				id, Pagination.of(1, 2));
+				id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -600,6 +598,25 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 
 			assertEquals(discountAccountGroup1, discountAccountGroup2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountAccountGroup discountAccountGroup,
+		List<DiscountAccountGroup> discountAccountGroups) {
+
+		boolean contains = false;
+
+		for (DiscountAccountGroup item : discountAccountGroups) {
+			if (equals(discountAccountGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountAccountGroups + " does not contain " + discountAccountGroup,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountCategoryResourceTestCase.java
@@ -236,18 +236,17 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountCategoriesPage()
 		throws Exception {
 
-		Page<DiscountCategory> page =
-			discountCategoryResource.
-				getDiscountByExternalReferenceCodeDiscountCategoriesPage(
-					testGetDiscountByExternalReferenceCodeDiscountCategoriesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountCategoriesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountCategoriesPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountCategory> page =
+			discountCategoryResource.
+				getDiscountByExternalReferenceCodeDiscountCategoriesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountCategory irrelevantDiscountCategory =
@@ -279,7 +278,7 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 		page =
 			discountCategoryResource.
 				getDiscountByExternalReferenceCodeDiscountCategoriesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -398,16 +397,15 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountCategoriesPage() throws Exception {
-		Page<DiscountCategory> page =
-			discountCategoryResource.getDiscountIdDiscountCategoriesPage(
-				testGetDiscountIdDiscountCategoriesPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountCategoriesPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountCategoriesPage_getIrrelevantId();
+
+		Page<DiscountCategory> page =
+			discountCategoryResource.getDiscountIdDiscountCategoriesPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountCategory irrelevantDiscountCategory =
@@ -434,7 +432,7 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 				id, randomDiscountCategory());
 
 		page = discountCategoryResource.getDiscountIdDiscountCategoriesPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -580,6 +578,25 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 
 			assertEquals(discountCategory1, discountCategory2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountCategory discountCategory,
+		List<DiscountCategory> discountCategories) {
+
+		boolean contains = false;
+
+		for (DiscountCategory item : discountCategories) {
+			if (equals(discountCategory, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountCategories + " does not contain " + discountCategory,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountProductResourceTestCase.java
@@ -236,18 +236,17 @@ public abstract class BaseDiscountProductResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountProductsPage()
 		throws Exception {
 
-		Page<DiscountProduct> page =
-			discountProductResource.
-				getDiscountByExternalReferenceCodeDiscountProductsPage(
-					testGetDiscountByExternalReferenceCodeDiscountProductsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountProductsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountProductsPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountProduct> page =
+			discountProductResource.
+				getDiscountByExternalReferenceCodeDiscountProductsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountProduct irrelevantDiscountProduct =
@@ -279,7 +278,7 @@ public abstract class BaseDiscountProductResourceTestCase {
 		page =
 			discountProductResource.
 				getDiscountByExternalReferenceCodeDiscountProductsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -395,16 +394,15 @@ public abstract class BaseDiscountProductResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountProductsPage() throws Exception {
-		Page<DiscountProduct> page =
-			discountProductResource.getDiscountIdDiscountProductsPage(
-				testGetDiscountIdDiscountProductsPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountProductsPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountProductsPage_getIrrelevantId();
+
+		Page<DiscountProduct> page =
+			discountProductResource.getDiscountIdDiscountProductsPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountProduct irrelevantDiscountProduct =
@@ -431,7 +429,7 @@ public abstract class BaseDiscountProductResourceTestCase {
 				id, randomDiscountProduct());
 
 		page = discountProductResource.getDiscountIdDiscountProductsPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -572,6 +570,25 @@ public abstract class BaseDiscountProductResourceTestCase {
 
 			assertEquals(discountProduct1, discountProduct2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountProduct discountProduct,
+		List<DiscountProduct> discountProducts) {
+
+		boolean contains = false;
+
+		for (DiscountProduct item : discountProducts) {
+			if (equals(discountProduct, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountProducts + " does not contain " + discountProduct,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.commerce.admin.pricing.client.dto.v1_0.Discount;
 import com.liferay.headless.commerce.admin.pricing.client.http.HttpInvoker;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
+import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v1_0.DiscountResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v1_0.DiscountSerDes;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -41,6 +42,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -201,7 +203,70 @@ public abstract class BaseDiscountResourceTestCase {
 
 	@Test
 	public void testGetDiscountsPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<Discount> page = discountResource.getDiscountsPage(
+			Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		Discount discount1 = testGetDiscountsPage_addDiscount(randomDiscount());
+
+		Discount discount2 = testGetDiscountsPage_addDiscount(randomDiscount());
+
+		page = discountResource.getDiscountsPage(Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(discount1, (List<Discount>)page.getItems());
+		assertContains(discount2, (List<Discount>)page.getItems());
+		assertValid(page);
+
+		discountResource.deleteDiscount(discount1.getId());
+
+		discountResource.deleteDiscount(discount2.getId());
+	}
+
+	@Test
+	public void testGetDiscountsPageWithPagination() throws Exception {
+		Page<Discount> totalPage = discountResource.getDiscountsPage(null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
+		Discount discount1 = testGetDiscountsPage_addDiscount(randomDiscount());
+
+		Discount discount2 = testGetDiscountsPage_addDiscount(randomDiscount());
+
+		Discount discount3 = testGetDiscountsPage_addDiscount(randomDiscount());
+
+		Page<Discount> page1 = discountResource.getDiscountsPage(
+			Pagination.of(1, totalCount + 2));
+
+		List<Discount> discounts1 = (List<Discount>)page1.getItems();
+
+		Assert.assertEquals(
+			discounts1.toString(), totalCount + 2, discounts1.size());
+
+		Page<Discount> page2 = discountResource.getDiscountsPage(
+			Pagination.of(2, totalCount + 2));
+
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+		List<Discount> discounts2 = (List<Discount>)page2.getItems();
+
+		Assert.assertEquals(discounts2.toString(), 1, discounts2.size());
+
+		Page<Discount> page3 = discountResource.getDiscountsPage(
+			Pagination.of(1, totalCount + 3));
+
+		assertContains(discount1, (List<Discount>)page3.getItems());
+		assertContains(discount2, (List<Discount>)page3.getItems());
+		assertContains(discount3, (List<Discount>)page3.getItems());
+	}
+
+	protected Discount testGetDiscountsPage_addDiscount(Discount discount)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -211,7 +276,7 @@ public abstract class BaseDiscountResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -221,7 +286,7 @@ public abstract class BaseDiscountResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/discounts");
 
-		Assert.assertEquals(0, discountsJSONObject.get("totalCount"));
+		long totalCount = discountsJSONObject.getLong("totalCount");
 
 		Discount discount1 = testGraphQLDiscount_addDiscount();
 		Discount discount2 = testGraphQLDiscount_addDiscount();
@@ -230,10 +295,15 @@ public abstract class BaseDiscountResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/discounts");
 
-		Assert.assertEquals(2, discountsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, discountsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(discount1, discount2),
+		assertContains(
+			discount1,
+			Arrays.asList(
+				DiscountSerDes.toDTOs(discountsJSONObject.getString("items"))));
+		assertContains(
+			discount2,
 			Arrays.asList(
 				DiscountSerDes.toDTOs(discountsJSONObject.getString("items"))));
 	}
@@ -506,6 +576,21 @@ public abstract class BaseDiscountResourceTestCase {
 
 			assertEquals(discount1, discount2);
 		}
+	}
+
+	protected void assertContains(Discount discount, List<Discount> discounts) {
+		boolean contains = false;
+
+		for (Discount item : discounts) {
+			if (equals(discount, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discounts + " does not contain " + discount, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountRuleResourceTestCase.java
@@ -197,18 +197,17 @@ public abstract class BaseDiscountRuleResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountRulesPage()
 		throws Exception {
 
-		Page<DiscountRule> page =
-			discountRuleResource.
-				getDiscountByExternalReferenceCodeDiscountRulesPage(
-					testGetDiscountByExternalReferenceCodeDiscountRulesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountRulesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountRulesPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountRule> page =
+			discountRuleResource.
+				getDiscountByExternalReferenceCodeDiscountRulesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountRule irrelevantDiscountRule =
@@ -240,7 +239,7 @@ public abstract class BaseDiscountRuleResourceTestCase {
 		page =
 			discountRuleResource.
 				getDiscountByExternalReferenceCodeDiscountRulesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -479,16 +478,15 @@ public abstract class BaseDiscountRuleResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountRulesPage() throws Exception {
-		Page<DiscountRule> page =
-			discountRuleResource.getDiscountIdDiscountRulesPage(
-				testGetDiscountIdDiscountRulesPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountRulesPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountRulesPage_getIrrelevantId();
+
+		Page<DiscountRule> page =
+			discountRuleResource.getDiscountIdDiscountRulesPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountRule irrelevantDiscountRule =
@@ -515,7 +513,7 @@ public abstract class BaseDiscountRuleResourceTestCase {
 				id, randomDiscountRule());
 
 		page = discountRuleResource.getDiscountIdDiscountRulesPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -650,6 +648,23 @@ public abstract class BaseDiscountRuleResourceTestCase {
 
 			assertEquals(discountRule1, discountRule2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountRule discountRule, List<DiscountRule> discountRules) {
+
+		boolean contains = false;
+
+		for (DiscountRule item : discountRules) {
+			if (equals(discountRule, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountRules + " does not contain " + discountRule, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceEntryResourceTestCase.java
@@ -430,18 +430,17 @@ public abstract class BasePriceEntryResourceTestCase {
 	public void testGetPriceListByExternalReferenceCodePriceEntriesPage()
 		throws Exception {
 
-		Page<PriceEntry> page =
-			priceEntryResource.
-				getPriceListByExternalReferenceCodePriceEntriesPage(
-					testGetPriceListByExternalReferenceCodePriceEntriesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceEntriesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceEntriesPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceEntry> page =
+			priceEntryResource.
+				getPriceListByExternalReferenceCodePriceEntriesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceEntry irrelevantPriceEntry =
@@ -473,7 +472,7 @@ public abstract class BasePriceEntryResourceTestCase {
 		page =
 			priceEntryResource.
 				getPriceListByExternalReferenceCodePriceEntriesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -585,16 +584,15 @@ public abstract class BasePriceEntryResourceTestCase {
 
 	@Test
 	public void testGetPriceListIdPriceEntriesPage() throws Exception {
-		Page<PriceEntry> page =
-			priceEntryResource.getPriceListIdPriceEntriesPage(
-				testGetPriceListIdPriceEntriesPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceListIdPriceEntriesPage_getId();
 		Long irrelevantId =
 			testGetPriceListIdPriceEntriesPage_getIrrelevantId();
+
+		Page<PriceEntry> page =
+			priceEntryResource.getPriceListIdPriceEntriesPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceEntry irrelevantPriceEntry =
@@ -621,7 +619,7 @@ public abstract class BasePriceEntryResourceTestCase {
 				id, randomPriceEntry());
 
 		page = priceEntryResource.getPriceListIdPriceEntriesPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -752,6 +750,23 @@ public abstract class BasePriceEntryResourceTestCase {
 
 			assertEquals(priceEntry1, priceEntry2);
 		}
+	}
+
+	protected void assertContains(
+		PriceEntry priceEntry, List<PriceEntry> priceEntries) {
+
+		boolean contains = false;
+
+		for (PriceEntry item : priceEntries) {
+			if (equals(priceEntry, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceEntries + " does not contain " + priceEntry, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
@@ -245,18 +245,17 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 	public void testGetPriceListByExternalReferenceCodePriceListAccountGroupPage()
 		throws Exception {
 
-		Page<PriceListAccountGroup> page =
-			priceListAccountGroupResource.
-				getPriceListByExternalReferenceCodePriceListAccountGroupPage(
-					testGetPriceListByExternalReferenceCodePriceListAccountGroupPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListAccountGroupPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListAccountGroupPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceListAccountGroup> page =
+			priceListAccountGroupResource.
+				getPriceListByExternalReferenceCodePriceListAccountGroupPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceListAccountGroup irrelevantPriceListAccountGroup =
@@ -288,7 +287,7 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 		page =
 			priceListAccountGroupResource.
 				getPriceListByExternalReferenceCodePriceListAccountGroupPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -414,17 +413,16 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 	public void testGetPriceListIdPriceListAccountGroupsPage()
 		throws Exception {
 
-		Page<PriceListAccountGroup> page =
-			priceListAccountGroupResource.
-				getPriceListIdPriceListAccountGroupsPage(
-					testGetPriceListIdPriceListAccountGroupsPage_getId(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceListIdPriceListAccountGroupsPage_getId();
 		Long irrelevantId =
 			testGetPriceListIdPriceListAccountGroupsPage_getIrrelevantId();
+
+		Page<PriceListAccountGroup> page =
+			priceListAccountGroupResource.
+				getPriceListIdPriceListAccountGroupsPage(
+					id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceListAccountGroup irrelevantPriceListAccountGroup =
@@ -455,7 +453,7 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 		page =
 			priceListAccountGroupResource.
 				getPriceListIdPriceListAccountGroupsPage(
-					id, Pagination.of(1, 2));
+					id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -613,6 +611,26 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 
 			assertEquals(priceListAccountGroup1, priceListAccountGroup2);
 		}
+	}
+
+	protected void assertContains(
+		PriceListAccountGroup priceListAccountGroup,
+		List<PriceListAccountGroup> priceListAccountGroups) {
+
+		boolean contains = false;
+
+		for (PriceListAccountGroup item : priceListAccountGroups) {
+			if (equals(priceListAccountGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceListAccountGroups + " does not contain " +
+				priceListAccountGroup,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
@@ -25,8 +25,10 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.commerce.admin.pricing.client.dto.v1_0.PriceList;
 import com.liferay.headless.commerce.admin.pricing.client.http.HttpInvoker;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
+import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v1_0.PriceListResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v1_0.PriceListSerDes;
+import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -41,21 +43,26 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import java.text.DateFormat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +74,7 @@ import javax.annotation.Generated;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 
+import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.BeanUtilsBean;
 import org.apache.commons.lang.time.DateUtils;
 
@@ -197,7 +205,242 @@ public abstract class BasePriceListResourceTestCase {
 
 	@Test
 	public void testGetPriceListsPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<PriceList> page = priceListResource.getPriceListsPage(
+			null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		PriceList priceList1 = testGetPriceListsPage_addPriceList(
+			randomPriceList());
+
+		PriceList priceList2 = testGetPriceListsPage_addPriceList(
+			randomPriceList());
+
+		page = priceListResource.getPriceListsPage(
+			null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(priceList1, (List<PriceList>)page.getItems());
+		assertContains(priceList2, (List<PriceList>)page.getItems());
+		assertValid(page);
+
+		priceListResource.deletePriceList(priceList1.getId());
+
+		priceListResource.deletePriceList(priceList2.getId());
+	}
+
+	@Test
+	public void testGetPriceListsPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		PriceList priceList1 = randomPriceList();
+
+		priceList1 = testGetPriceListsPage_addPriceList(priceList1);
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceList> page = priceListResource.getPriceListsPage(
+				getFilterString(entityField, "between", priceList1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceList1),
+				(List<PriceList>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetPriceListsPageWithFilterStringEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.STRING);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		PriceList priceList1 = testGetPriceListsPage_addPriceList(
+			randomPriceList());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PriceList priceList2 = testGetPriceListsPage_addPriceList(
+			randomPriceList());
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceList> page = priceListResource.getPriceListsPage(
+				getFilterString(entityField, "eq", priceList1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceList1),
+				(List<PriceList>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetPriceListsPageWithPagination() throws Exception {
+		Page<PriceList> totalPage = priceListResource.getPriceListsPage(
+			null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
+		PriceList priceList1 = testGetPriceListsPage_addPriceList(
+			randomPriceList());
+
+		PriceList priceList2 = testGetPriceListsPage_addPriceList(
+			randomPriceList());
+
+		PriceList priceList3 = testGetPriceListsPage_addPriceList(
+			randomPriceList());
+
+		Page<PriceList> page1 = priceListResource.getPriceListsPage(
+			null, Pagination.of(1, totalCount + 2), null);
+
+		List<PriceList> priceLists1 = (List<PriceList>)page1.getItems();
+
+		Assert.assertEquals(
+			priceLists1.toString(), totalCount + 2, priceLists1.size());
+
+		Page<PriceList> page2 = priceListResource.getPriceListsPage(
+			null, Pagination.of(2, totalCount + 2), null);
+
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+		List<PriceList> priceLists2 = (List<PriceList>)page2.getItems();
+
+		Assert.assertEquals(priceLists2.toString(), 1, priceLists2.size());
+
+		Page<PriceList> page3 = priceListResource.getPriceListsPage(
+			null, Pagination.of(1, totalCount + 3), null);
+
+		assertContains(priceList1, (List<PriceList>)page3.getItems());
+		assertContains(priceList2, (List<PriceList>)page3.getItems());
+		assertContains(priceList3, (List<PriceList>)page3.getItems());
+	}
+
+	@Test
+	public void testGetPriceListsPageWithSortDateTime() throws Exception {
+		testGetPriceListsPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, priceList1, priceList2) -> {
+				BeanUtils.setProperty(
+					priceList1, entityField.getName(),
+					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPriceListsPageWithSortInteger() throws Exception {
+		testGetPriceListsPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, priceList1, priceList2) -> {
+				BeanUtils.setProperty(priceList1, entityField.getName(), 0);
+				BeanUtils.setProperty(priceList2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetPriceListsPageWithSortString() throws Exception {
+		testGetPriceListsPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, priceList1, priceList2) -> {
+				Class<?> clazz = priceList1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanUtils.setProperty(
+						priceList1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanUtils.setProperty(
+						priceList2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanUtils.setProperty(
+						priceList1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanUtils.setProperty(
+						priceList2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanUtils.setProperty(
+						priceList1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanUtils.setProperty(
+						priceList2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetPriceListsPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer<EntityField, PriceList, PriceList, Exception>
+				unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		PriceList priceList1 = randomPriceList();
+		PriceList priceList2 = randomPriceList();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(entityField, priceList1, priceList2);
+		}
+
+		priceList1 = testGetPriceListsPage_addPriceList(priceList1);
+
+		priceList2 = testGetPriceListsPage_addPriceList(priceList2);
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceList> ascPage = priceListResource.getPriceListsPage(
+				null, Pagination.of(1, 2), entityField.getName() + ":asc");
+
+			assertEquals(
+				Arrays.asList(priceList1, priceList2),
+				(List<PriceList>)ascPage.getItems());
+
+			Page<PriceList> descPage = priceListResource.getPriceListsPage(
+				null, Pagination.of(1, 2), entityField.getName() + ":desc");
+
+			assertEquals(
+				Arrays.asList(priceList2, priceList1),
+				(List<PriceList>)descPage.getItems());
+		}
+	}
+
+	protected PriceList testGetPriceListsPage_addPriceList(PriceList priceList)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -207,7 +450,7 @@ public abstract class BasePriceListResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -217,7 +460,7 @@ public abstract class BasePriceListResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/priceLists");
 
-		Assert.assertEquals(0, priceListsJSONObject.get("totalCount"));
+		long totalCount = priceListsJSONObject.getLong("totalCount");
 
 		PriceList priceList1 = testGraphQLPriceList_addPriceList();
 		PriceList priceList2 = testGraphQLPriceList_addPriceList();
@@ -226,10 +469,16 @@ public abstract class BasePriceListResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/priceLists");
 
-		Assert.assertEquals(2, priceListsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, priceListsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(priceList1, priceList2),
+		assertContains(
+			priceList1,
+			Arrays.asList(
+				PriceListSerDes.toDTOs(
+					priceListsJSONObject.getString("items"))));
+		assertContains(
+			priceList2,
 			Arrays.asList(
 				PriceListSerDes.toDTOs(
 					priceListsJSONObject.getString("items"))));
@@ -477,6 +726,9 @@ public abstract class BasePriceListResourceTestCase {
 		Assert.assertTrue(false);
 	}
 
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
 	protected PriceList testGraphQLPriceList_addPriceList() throws Exception {
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
@@ -507,6 +759,23 @@ public abstract class BasePriceListResourceTestCase {
 
 			assertEquals(priceList1, priceList2);
 		}
+	}
+
+	protected void assertContains(
+		PriceList priceList, List<PriceList> priceLists) {
+
+		boolean contains = false;
+
+		for (PriceList item : priceLists) {
+			if (equals(priceList, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceLists + " does not contain " + priceList, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
@@ -198,18 +198,17 @@ public abstract class BaseTierPriceResourceTestCase {
 	public void testGetPriceEntryByExternalReferenceCodeTierPricesPage()
 		throws Exception {
 
-		Page<TierPrice> page =
-			tierPriceResource.
-				getPriceEntryByExternalReferenceCodeTierPricesPage(
-					testGetPriceEntryByExternalReferenceCodeTierPricesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceEntryByExternalReferenceCodeTierPricesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceEntryByExternalReferenceCodeTierPricesPage_getIrrelevantExternalReferenceCode();
+
+		Page<TierPrice> page =
+			tierPriceResource.
+				getPriceEntryByExternalReferenceCodeTierPricesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			TierPrice irrelevantTierPrice =
@@ -241,7 +240,7 @@ public abstract class BaseTierPriceResourceTestCase {
 		page =
 			tierPriceResource.
 				getPriceEntryByExternalReferenceCodeTierPricesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -353,13 +352,13 @@ public abstract class BaseTierPriceResourceTestCase {
 
 	@Test
 	public void testGetPriceEntryIdTierPricesPage() throws Exception {
-		Page<TierPrice> page = tierPriceResource.getPriceEntryIdTierPricesPage(
-			testGetPriceEntryIdTierPricesPage_getId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceEntryIdTierPricesPage_getId();
 		Long irrelevantId = testGetPriceEntryIdTierPricesPage_getIrrelevantId();
+
+		Page<TierPrice> page = tierPriceResource.getPriceEntryIdTierPricesPage(
+			id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			TierPrice irrelevantTierPrice =
@@ -384,7 +383,7 @@ public abstract class BaseTierPriceResourceTestCase {
 			id, randomTierPrice());
 
 		page = tierPriceResource.getPriceEntryIdTierPricesPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -729,6 +728,23 @@ public abstract class BaseTierPriceResourceTestCase {
 
 			assertEquals(tierPrice1, tierPrice2);
 		}
+	}
+
+	protected void assertContains(
+		TierPrice tierPrice, List<TierPrice> tierPrices) {
+
+		boolean contains = false;
+
+		for (TierPrice item : tierPrices) {
+			if (equals(tierPrice, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			tierPrices + " does not contain " + tierPrice, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountGroupResourceTestCase.java
@@ -361,6 +361,23 @@ public abstract class BaseAccountGroupResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		AccountGroup accountGroup, List<AccountGroup> accountGroups) {
+
+		boolean contains = false;
+
+		for (AccountGroup item : accountGroups) {
+			if (equals(accountGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			accountGroups + " does not contain " + accountGroup, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<AccountGroup> accountGroups1, List<AccountGroup> accountGroups2) {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
@@ -345,6 +345,20 @@ public abstract class BaseAccountResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Account account, List<Account> accounts) {
+		boolean contains = false;
+
+		for (Account item : accounts) {
+			if (equals(account, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(accounts + " does not contain " + account, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Account> accounts1, List<Account> accounts2) {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
@@ -354,6 +354,23 @@ public abstract class BaseCategoryResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		Category category, List<Category> categories) {
+
+		boolean contains = false;
+
+		for (Category item : categories) {
+			if (equals(category, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			categories + " does not contain " + category, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Category> categories1, List<Category> categories2) {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
@@ -351,6 +351,20 @@ public abstract class BaseChannelResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Channel channel, List<Channel> channels) {
+		boolean contains = false;
+
+		for (Channel item : channels) {
+			if (equals(channel, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(channels + " does not contain " + channel, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Channel> channels1, List<Channel> channels2) {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountGroupResourceTestCase.java
@@ -220,18 +220,17 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountAccountGroupsPage()
 		throws Exception {
 
-		Page<DiscountAccountGroup> page =
-			discountAccountGroupResource.
-				getDiscountByExternalReferenceCodeDiscountAccountGroupsPage(
-					testGetDiscountByExternalReferenceCodeDiscountAccountGroupsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountAccountGroupsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountAccountGroupsPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountAccountGroup> page =
+			discountAccountGroupResource.
+				getDiscountByExternalReferenceCodeDiscountAccountGroupsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountAccountGroup irrelevantDiscountAccountGroup =
@@ -263,7 +262,7 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 		page =
 			discountAccountGroupResource.
 				getDiscountByExternalReferenceCodeDiscountAccountGroupsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -381,16 +380,16 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountAccountGroupsPage() throws Exception {
-		Page<DiscountAccountGroup> page =
-			discountAccountGroupResource.getDiscountIdDiscountAccountGroupsPage(
-				testGetDiscountIdDiscountAccountGroupsPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountAccountGroupsPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountAccountGroupsPage_getIrrelevantId();
+
+		Page<DiscountAccountGroup> page =
+			discountAccountGroupResource.getDiscountIdDiscountAccountGroupsPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountAccountGroup irrelevantDiscountAccountGroup =
@@ -420,7 +419,7 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 
 		page =
 			discountAccountGroupResource.getDiscountIdDiscountAccountGroupsPage(
-				id, null, null, Pagination.of(1, 2), null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -770,6 +769,25 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 
 			assertEquals(discountAccountGroup1, discountAccountGroup2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountAccountGroup discountAccountGroup,
+		List<DiscountAccountGroup> discountAccountGroups) {
+
+		boolean contains = false;
+
+		for (DiscountAccountGroup item : discountAccountGroups) {
+			if (equals(discountAccountGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountAccountGroups + " does not contain " + discountAccountGroup,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountResourceTestCase.java
@@ -216,18 +216,17 @@ public abstract class BaseDiscountAccountResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountAccountsPage()
 		throws Exception {
 
-		Page<DiscountAccount> page =
-			discountAccountResource.
-				getDiscountByExternalReferenceCodeDiscountAccountsPage(
-					testGetDiscountByExternalReferenceCodeDiscountAccountsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountAccountsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountAccountsPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountAccount> page =
+			discountAccountResource.
+				getDiscountByExternalReferenceCodeDiscountAccountsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountAccount irrelevantDiscountAccount =
@@ -259,7 +258,7 @@ public abstract class BaseDiscountAccountResourceTestCase {
 		page =
 			discountAccountResource.
 				getDiscountByExternalReferenceCodeDiscountAccountsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -371,16 +370,16 @@ public abstract class BaseDiscountAccountResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountAccountsPage() throws Exception {
-		Page<DiscountAccount> page =
-			discountAccountResource.getDiscountIdDiscountAccountsPage(
-				testGetDiscountIdDiscountAccountsPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountAccountsPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountAccountsPage_getIrrelevantId();
+
+		Page<DiscountAccount> page =
+			discountAccountResource.getDiscountIdDiscountAccountsPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountAccount irrelevantDiscountAccount =
@@ -407,7 +406,7 @@ public abstract class BaseDiscountAccountResourceTestCase {
 				id, randomDiscountAccount());
 
 		page = discountAccountResource.getDiscountIdDiscountAccountsPage(
-			id, null, null, Pagination.of(1, 2), null);
+			id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -739,6 +738,25 @@ public abstract class BaseDiscountAccountResourceTestCase {
 
 			assertEquals(discountAccount1, discountAccount2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountAccount discountAccount,
+		List<DiscountAccount> discountAccounts) {
+
+		boolean contains = false;
+
+		for (DiscountAccount item : discountAccounts) {
+			if (equals(discountAccount, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountAccounts + " does not contain " + discountAccount,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountCategoryResourceTestCase.java
@@ -216,18 +216,17 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountCategoriesPage()
 		throws Exception {
 
-		Page<DiscountCategory> page =
-			discountCategoryResource.
-				getDiscountByExternalReferenceCodeDiscountCategoriesPage(
-					testGetDiscountByExternalReferenceCodeDiscountCategoriesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountCategoriesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountCategoriesPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountCategory> page =
+			discountCategoryResource.
+				getDiscountByExternalReferenceCodeDiscountCategoriesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountCategory irrelevantDiscountCategory =
@@ -259,7 +258,7 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 		page =
 			discountCategoryResource.
 				getDiscountByExternalReferenceCodeDiscountCategoriesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -372,16 +371,16 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountCategoriesPage() throws Exception {
-		Page<DiscountCategory> page =
-			discountCategoryResource.getDiscountIdDiscountCategoriesPage(
-				testGetDiscountIdDiscountCategoriesPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountCategoriesPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountCategoriesPage_getIrrelevantId();
+
+		Page<DiscountCategory> page =
+			discountCategoryResource.getDiscountIdDiscountCategoriesPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountCategory irrelevantDiscountCategory =
@@ -408,7 +407,7 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 				id, randomDiscountCategory());
 
 		page = discountCategoryResource.getDiscountIdDiscountCategoriesPage(
-			id, null, null, Pagination.of(1, 2), null);
+			id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -743,6 +742,25 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 
 			assertEquals(discountCategory1, discountCategory2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountCategory discountCategory,
+		List<DiscountCategory> discountCategories) {
+
+		boolean contains = false;
+
+		for (DiscountCategory item : discountCategories) {
+			if (equals(discountCategory, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountCategories + " does not contain " + discountCategory,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountChannelResourceTestCase.java
@@ -216,18 +216,17 @@ public abstract class BaseDiscountChannelResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountChannelsPage()
 		throws Exception {
 
-		Page<DiscountChannel> page =
-			discountChannelResource.
-				getDiscountByExternalReferenceCodeDiscountChannelsPage(
-					testGetDiscountByExternalReferenceCodeDiscountChannelsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountChannelsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountChannelsPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountChannel> page =
+			discountChannelResource.
+				getDiscountByExternalReferenceCodeDiscountChannelsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountChannel irrelevantDiscountChannel =
@@ -259,7 +258,7 @@ public abstract class BaseDiscountChannelResourceTestCase {
 		page =
 			discountChannelResource.
 				getDiscountByExternalReferenceCodeDiscountChannelsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -371,16 +370,16 @@ public abstract class BaseDiscountChannelResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountChannelsPage() throws Exception {
-		Page<DiscountChannel> page =
-			discountChannelResource.getDiscountIdDiscountChannelsPage(
-				testGetDiscountIdDiscountChannelsPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountChannelsPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountChannelsPage_getIrrelevantId();
+
+		Page<DiscountChannel> page =
+			discountChannelResource.getDiscountIdDiscountChannelsPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountChannel irrelevantDiscountChannel =
@@ -407,7 +406,7 @@ public abstract class BaseDiscountChannelResourceTestCase {
 				id, randomDiscountChannel());
 
 		page = discountChannelResource.getDiscountIdDiscountChannelsPage(
-			id, null, null, Pagination.of(1, 2), null);
+			id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -739,6 +738,25 @@ public abstract class BaseDiscountChannelResourceTestCase {
 
 			assertEquals(discountChannel1, discountChannel2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountChannel discountChannel,
+		List<DiscountChannel> discountChannels) {
+
+		boolean contains = false;
+
+		for (DiscountChannel item : discountChannels) {
+			if (equals(discountChannel, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountChannels + " does not contain " + discountChannel,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountOrderTypeResourceTestCase.java
@@ -217,18 +217,17 @@ public abstract class BaseDiscountOrderTypeResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountOrderTypesPage()
 		throws Exception {
 
-		Page<DiscountOrderType> page =
-			discountOrderTypeResource.
-				getDiscountByExternalReferenceCodeDiscountOrderTypesPage(
-					testGetDiscountByExternalReferenceCodeDiscountOrderTypesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountOrderTypesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountOrderTypesPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountOrderType> page =
+			discountOrderTypeResource.
+				getDiscountByExternalReferenceCodeDiscountOrderTypesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountOrderType irrelevantDiscountOrderType =
@@ -260,7 +259,7 @@ public abstract class BaseDiscountOrderTypeResourceTestCase {
 		page =
 			discountOrderTypeResource.
 				getDiscountByExternalReferenceCodeDiscountOrderTypesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -374,16 +373,16 @@ public abstract class BaseDiscountOrderTypeResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountOrderTypesPage() throws Exception {
-		Page<DiscountOrderType> page =
-			discountOrderTypeResource.getDiscountIdDiscountOrderTypesPage(
-				testGetDiscountIdDiscountOrderTypesPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountOrderTypesPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountOrderTypesPage_getIrrelevantId();
+
+		Page<DiscountOrderType> page =
+			discountOrderTypeResource.getDiscountIdDiscountOrderTypesPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountOrderType irrelevantDiscountOrderType =
@@ -411,7 +410,7 @@ public abstract class BaseDiscountOrderTypeResourceTestCase {
 				id, randomDiscountOrderType());
 
 		page = discountOrderTypeResource.getDiscountIdDiscountOrderTypesPage(
-			id, null, null, Pagination.of(1, 2), null);
+			id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -746,6 +745,25 @@ public abstract class BaseDiscountOrderTypeResourceTestCase {
 
 			assertEquals(discountOrderType1, discountOrderType2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountOrderType discountOrderType,
+		List<DiscountOrderType> discountOrderTypes) {
+
+		boolean contains = false;
+
+		for (DiscountOrderType item : discountOrderTypes) {
+			if (equals(discountOrderType, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountOrderTypes + " does not contain " + discountOrderType,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductGroupResourceTestCase.java
@@ -220,18 +220,17 @@ public abstract class BaseDiscountProductGroupResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountProductGroupsPage()
 		throws Exception {
 
-		Page<DiscountProductGroup> page =
-			discountProductGroupResource.
-				getDiscountByExternalReferenceCodeDiscountProductGroupsPage(
-					testGetDiscountByExternalReferenceCodeDiscountProductGroupsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountProductGroupsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountProductGroupsPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountProductGroup> page =
+			discountProductGroupResource.
+				getDiscountByExternalReferenceCodeDiscountProductGroupsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountProductGroup irrelevantDiscountProductGroup =
@@ -263,7 +262,7 @@ public abstract class BaseDiscountProductGroupResourceTestCase {
 		page =
 			discountProductGroupResource.
 				getDiscountByExternalReferenceCodeDiscountProductGroupsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -381,16 +380,16 @@ public abstract class BaseDiscountProductGroupResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountProductGroupsPage() throws Exception {
-		Page<DiscountProductGroup> page =
-			discountProductGroupResource.getDiscountIdDiscountProductGroupsPage(
-				testGetDiscountIdDiscountProductGroupsPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountProductGroupsPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountProductGroupsPage_getIrrelevantId();
+
+		Page<DiscountProductGroup> page =
+			discountProductGroupResource.getDiscountIdDiscountProductGroupsPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountProductGroup irrelevantDiscountProductGroup =
@@ -420,7 +419,7 @@ public abstract class BaseDiscountProductGroupResourceTestCase {
 
 		page =
 			discountProductGroupResource.getDiscountIdDiscountProductGroupsPage(
-				id, null, null, Pagination.of(1, 2), null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -770,6 +769,25 @@ public abstract class BaseDiscountProductGroupResourceTestCase {
 
 			assertEquals(discountProductGroup1, discountProductGroup2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountProductGroup discountProductGroup,
+		List<DiscountProductGroup> discountProductGroups) {
+
+		boolean contains = false;
+
+		for (DiscountProductGroup item : discountProductGroups) {
+			if (equals(discountProductGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountProductGroups + " does not contain " + discountProductGroup,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductResourceTestCase.java
@@ -216,18 +216,17 @@ public abstract class BaseDiscountProductResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountProductsPage()
 		throws Exception {
 
-		Page<DiscountProduct> page =
-			discountProductResource.
-				getDiscountByExternalReferenceCodeDiscountProductsPage(
-					testGetDiscountByExternalReferenceCodeDiscountProductsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountProductsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountProductsPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountProduct> page =
+			discountProductResource.
+				getDiscountByExternalReferenceCodeDiscountProductsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountProduct irrelevantDiscountProduct =
@@ -259,7 +258,7 @@ public abstract class BaseDiscountProductResourceTestCase {
 		page =
 			discountProductResource.
 				getDiscountByExternalReferenceCodeDiscountProductsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -371,16 +370,16 @@ public abstract class BaseDiscountProductResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountProductsPage() throws Exception {
-		Page<DiscountProduct> page =
-			discountProductResource.getDiscountIdDiscountProductsPage(
-				testGetDiscountIdDiscountProductsPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountProductsPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountProductsPage_getIrrelevantId();
+
+		Page<DiscountProduct> page =
+			discountProductResource.getDiscountIdDiscountProductsPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountProduct irrelevantDiscountProduct =
@@ -407,7 +406,7 @@ public abstract class BaseDiscountProductResourceTestCase {
 				id, randomDiscountProduct());
 
 		page = discountProductResource.getDiscountIdDiscountProductsPage(
-			id, null, null, Pagination.of(1, 2), null);
+			id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -739,6 +738,25 @@ public abstract class BaseDiscountProductResourceTestCase {
 
 			assertEquals(discountProduct1, discountProduct2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountProduct discountProduct,
+		List<DiscountProduct> discountProducts) {
+
+		boolean contains = false;
+
+		for (DiscountProduct item : discountProducts) {
+			if (equals(discountProduct, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountProducts + " does not contain " + discountProduct,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -213,22 +214,21 @@ public abstract class BaseDiscountResourceTestCase {
 	@Test
 	public void testGetDiscountsPage() throws Exception {
 		Page<Discount> page = discountResource.getDiscountsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Discount discount1 = testGetDiscountsPage_addDiscount(randomDiscount());
 
 		Discount discount2 = testGetDiscountsPage_addDiscount(randomDiscount());
 
 		page = discountResource.getDiscountsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(discount1, discount2),
-			(List<Discount>)page.getItems());
+		assertContains(discount1, (List<Discount>)page.getItems());
+		assertContains(discount2, (List<Discount>)page.getItems());
 		assertValid(page);
 
 		discountResource.deleteDiscount(discount1.getId());
@@ -289,6 +289,11 @@ public abstract class BaseDiscountResourceTestCase {
 
 	@Test
 	public void testGetDiscountsPageWithPagination() throws Exception {
+		Page<Discount> totalPage = discountResource.getDiscountsPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Discount discount1 = testGetDiscountsPage_addDiscount(randomDiscount());
 
 		Discount discount2 = testGetDiscountsPage_addDiscount(randomDiscount());
@@ -296,27 +301,28 @@ public abstract class BaseDiscountResourceTestCase {
 		Discount discount3 = testGetDiscountsPage_addDiscount(randomDiscount());
 
 		Page<Discount> page1 = discountResource.getDiscountsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Discount> discounts1 = (List<Discount>)page1.getItems();
 
-		Assert.assertEquals(discounts1.toString(), 2, discounts1.size());
+		Assert.assertEquals(
+			discounts1.toString(), totalCount + 2, discounts1.size());
 
 		Page<Discount> page2 = discountResource.getDiscountsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Discount> discounts2 = (List<Discount>)page2.getItems();
 
 		Assert.assertEquals(discounts2.toString(), 1, discounts2.size());
 
 		Page<Discount> page3 = discountResource.getDiscountsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(discount1, discount2, discount3),
-			(List<Discount>)page3.getItems());
+		assertContains(discount1, (List<Discount>)page3.getItems());
+		assertContains(discount2, (List<Discount>)page3.getItems());
+		assertContains(discount3, (List<Discount>)page3.getItems());
 	}
 
 	@Test
@@ -447,7 +453,7 @@ public abstract class BaseDiscountResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -457,7 +463,7 @@ public abstract class BaseDiscountResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/discounts");
 
-		Assert.assertEquals(0, discountsJSONObject.get("totalCount"));
+		long totalCount = discountsJSONObject.getLong("totalCount");
 
 		Discount discount1 = testGraphQLDiscount_addDiscount();
 		Discount discount2 = testGraphQLDiscount_addDiscount();
@@ -466,10 +472,15 @@ public abstract class BaseDiscountResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/discounts");
 
-		Assert.assertEquals(2, discountsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, discountsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(discount1, discount2),
+		assertContains(
+			discount1,
+			Arrays.asList(
+				DiscountSerDes.toDTOs(discountsJSONObject.getString("items"))));
+		assertContains(
+			discount2,
 			Arrays.asList(
 				DiscountSerDes.toDTOs(discountsJSONObject.getString("items"))));
 	}
@@ -794,6 +805,21 @@ public abstract class BaseDiscountResourceTestCase {
 
 			assertEquals(discount1, discount2);
 		}
+	}
+
+	protected void assertContains(Discount discount, List<Discount> discounts) {
+		boolean contains = false;
+
+		for (Discount item : discounts) {
+			if (equals(discount, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discounts + " does not contain " + discount, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
@@ -353,18 +353,17 @@ public abstract class BaseDiscountRuleResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountRulesPage()
 		throws Exception {
 
-		Page<DiscountRule> page =
-			discountRuleResource.
-				getDiscountByExternalReferenceCodeDiscountRulesPage(
-					testGetDiscountByExternalReferenceCodeDiscountRulesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountRulesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountRulesPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountRule> page =
+			discountRuleResource.
+				getDiscountByExternalReferenceCodeDiscountRulesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountRule irrelevantDiscountRule =
@@ -396,7 +395,7 @@ public abstract class BaseDiscountRuleResourceTestCase {
 		page =
 			discountRuleResource.
 				getDiscountByExternalReferenceCodeDiscountRulesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -512,16 +511,16 @@ public abstract class BaseDiscountRuleResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountRulesPage() throws Exception {
-		Page<DiscountRule> page =
-			discountRuleResource.getDiscountIdDiscountRulesPage(
-				testGetDiscountIdDiscountRulesPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountRulesPage_getId();
 		Long irrelevantId =
 			testGetDiscountIdDiscountRulesPage_getIrrelevantId();
+
+		Page<DiscountRule> page =
+			discountRuleResource.getDiscountIdDiscountRulesPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountRule irrelevantDiscountRule =
@@ -548,7 +547,7 @@ public abstract class BaseDiscountRuleResourceTestCase {
 				id, randomDiscountRule());
 
 		page = discountRuleResource.getDiscountIdDiscountRulesPage(
-			id, null, null, Pagination.of(1, 2), null);
+			id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -878,6 +877,23 @@ public abstract class BaseDiscountRuleResourceTestCase {
 
 			assertEquals(discountRule1, discountRule2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountRule discountRule, List<DiscountRule> discountRules) {
+
+		boolean contains = false;
+
+		for (DiscountRule item : discountRules) {
+			if (equals(discountRule, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountRules + " does not contain " + discountRule, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountSkuResourceTestCase.java
@@ -214,18 +214,17 @@ public abstract class BaseDiscountSkuResourceTestCase {
 	public void testGetDiscountByExternalReferenceCodeDiscountSkusPage()
 		throws Exception {
 
-		Page<DiscountSku> page =
-			discountSkuResource.
-				getDiscountByExternalReferenceCodeDiscountSkusPage(
-					testGetDiscountByExternalReferenceCodeDiscountSkusPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountSkusPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetDiscountByExternalReferenceCodeDiscountSkusPage_getIrrelevantExternalReferenceCode();
+
+		Page<DiscountSku> page =
+			discountSkuResource.
+				getDiscountByExternalReferenceCodeDiscountSkusPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			DiscountSku irrelevantDiscountSku =
@@ -257,7 +256,7 @@ public abstract class BaseDiscountSkuResourceTestCase {
 		page =
 			discountSkuResource.
 				getDiscountByExternalReferenceCodeDiscountSkusPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -365,15 +364,15 @@ public abstract class BaseDiscountSkuResourceTestCase {
 
 	@Test
 	public void testGetDiscountIdDiscountSkusPage() throws Exception {
-		Page<DiscountSku> page =
-			discountSkuResource.getDiscountIdDiscountSkusPage(
-				testGetDiscountIdDiscountSkusPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetDiscountIdDiscountSkusPage_getId();
 		Long irrelevantId = testGetDiscountIdDiscountSkusPage_getIrrelevantId();
+
+		Page<DiscountSku> page =
+			discountSkuResource.getDiscountIdDiscountSkusPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			DiscountSku irrelevantDiscountSku =
@@ -400,7 +399,7 @@ public abstract class BaseDiscountSkuResourceTestCase {
 				id, randomDiscountSku());
 
 		page = discountSkuResource.getDiscountIdDiscountSkusPage(
-			id, null, null, Pagination.of(1, 2), null);
+			id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -714,6 +713,23 @@ public abstract class BaseDiscountSkuResourceTestCase {
 
 			assertEquals(discountSku1, discountSku2);
 		}
+	}
+
+	protected void assertContains(
+		DiscountSku discountSku, List<DiscountSku> discountSkus) {
+
+		boolean contains = false;
+
+		for (DiscountSku item : discountSkus) {
+			if (equals(discountSku, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			discountSkus + " does not contain " + discountSku, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
@@ -346,6 +346,23 @@ public abstract class BaseOrderTypeResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		OrderType orderType, List<OrderType> orderTypes) {
+
+		boolean contains = false;
+
+		for (OrderType item : orderTypes) {
+			if (equals(orderType, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			orderTypes + " does not contain " + orderType, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<OrderType> orderTypes1, List<OrderType> orderTypes2) {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceEntryResourceTestCase.java
@@ -269,18 +269,17 @@ public abstract class BasePriceEntryResourceTestCase {
 	public void testGetPriceListByExternalReferenceCodePriceEntriesPage()
 		throws Exception {
 
-		Page<PriceEntry> page =
-			priceEntryResource.
-				getPriceListByExternalReferenceCodePriceEntriesPage(
-					testGetPriceListByExternalReferenceCodePriceEntriesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceEntriesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceEntriesPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceEntry> page =
+			priceEntryResource.
+				getPriceListByExternalReferenceCodePriceEntriesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceEntry irrelevantPriceEntry =
@@ -312,7 +311,7 @@ public abstract class BasePriceEntryResourceTestCase {
 		page =
 			priceEntryResource.
 				getPriceListByExternalReferenceCodePriceEntriesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -420,16 +419,16 @@ public abstract class BasePriceEntryResourceTestCase {
 
 	@Test
 	public void testGetPriceListIdPriceEntriesPage() throws Exception {
-		Page<PriceEntry> page =
-			priceEntryResource.getPriceListIdPriceEntriesPage(
-				testGetPriceListIdPriceEntriesPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceListIdPriceEntriesPage_getId();
 		Long irrelevantId =
 			testGetPriceListIdPriceEntriesPage_getIrrelevantId();
+
+		Page<PriceEntry> page =
+			priceEntryResource.getPriceListIdPriceEntriesPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceEntry irrelevantPriceEntry =
@@ -456,7 +455,7 @@ public abstract class BasePriceEntryResourceTestCase {
 				id, randomPriceEntry());
 
 		page = priceEntryResource.getPriceListIdPriceEntriesPage(
-			id, null, null, Pagination.of(1, 2), null);
+			id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -770,6 +769,23 @@ public abstract class BasePriceEntryResourceTestCase {
 
 			assertEquals(priceEntry1, priceEntry2);
 		}
+	}
+
+	protected void assertContains(
+		PriceEntry priceEntry, List<PriceEntry> priceEntries) {
+
+		boolean contains = false;
+
+		for (PriceEntry item : priceEntries) {
+			if (equals(priceEntry, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceEntries + " does not contain " + priceEntry, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountGroupResourceTestCase.java
@@ -223,18 +223,17 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 	public void testGetPriceListByExternalReferenceCodePriceListAccountGroupsPage()
 		throws Exception {
 
-		Page<PriceListAccountGroup> page =
-			priceListAccountGroupResource.
-				getPriceListByExternalReferenceCodePriceListAccountGroupsPage(
-					testGetPriceListByExternalReferenceCodePriceListAccountGroupsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListAccountGroupsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListAccountGroupsPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceListAccountGroup> page =
+			priceListAccountGroupResource.
+				getPriceListByExternalReferenceCodePriceListAccountGroupsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceListAccountGroup irrelevantPriceListAccountGroup =
@@ -266,7 +265,7 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 		page =
 			priceListAccountGroupResource.
 				getPriceListByExternalReferenceCodePriceListAccountGroupsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -386,18 +385,17 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 	public void testGetPriceListIdPriceListAccountGroupsPage()
 		throws Exception {
 
-		Page<PriceListAccountGroup> page =
-			priceListAccountGroupResource.
-				getPriceListIdPriceListAccountGroupsPage(
-					testGetPriceListIdPriceListAccountGroupsPage_getId(),
-					RandomTestUtil.randomString(), null, Pagination.of(1, 2),
-					null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceListIdPriceListAccountGroupsPage_getId();
 		Long irrelevantId =
 			testGetPriceListIdPriceListAccountGroupsPage_getIrrelevantId();
+
+		Page<PriceListAccountGroup> page =
+			priceListAccountGroupResource.
+				getPriceListIdPriceListAccountGroupsPage(
+					id, RandomTestUtil.randomString(), null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceListAccountGroup irrelevantPriceListAccountGroup =
@@ -428,7 +426,7 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 		page =
 			priceListAccountGroupResource.
 				getPriceListIdPriceListAccountGroupsPage(
-					id, null, null, Pagination.of(1, 2), null);
+					id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -783,6 +781,26 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 
 			assertEquals(priceListAccountGroup1, priceListAccountGroup2);
 		}
+	}
+
+	protected void assertContains(
+		PriceListAccountGroup priceListAccountGroup,
+		List<PriceListAccountGroup> priceListAccountGroups) {
+
+		boolean contains = false;
+
+		for (PriceListAccountGroup item : priceListAccountGroups) {
+			if (equals(priceListAccountGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceListAccountGroups + " does not contain " +
+				priceListAccountGroup,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountResourceTestCase.java
@@ -216,18 +216,17 @@ public abstract class BasePriceListAccountResourceTestCase {
 	public void testGetPriceListByExternalReferenceCodePriceListAccountsPage()
 		throws Exception {
 
-		Page<PriceListAccount> page =
-			priceListAccountResource.
-				getPriceListByExternalReferenceCodePriceListAccountsPage(
-					testGetPriceListByExternalReferenceCodePriceListAccountsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListAccountsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListAccountsPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceListAccount> page =
+			priceListAccountResource.
+				getPriceListByExternalReferenceCodePriceListAccountsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceListAccount irrelevantPriceListAccount =
@@ -259,7 +258,7 @@ public abstract class BasePriceListAccountResourceTestCase {
 		page =
 			priceListAccountResource.
 				getPriceListByExternalReferenceCodePriceListAccountsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -372,16 +371,16 @@ public abstract class BasePriceListAccountResourceTestCase {
 
 	@Test
 	public void testGetPriceListIdPriceListAccountsPage() throws Exception {
-		Page<PriceListAccount> page =
-			priceListAccountResource.getPriceListIdPriceListAccountsPage(
-				testGetPriceListIdPriceListAccountsPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceListIdPriceListAccountsPage_getId();
 		Long irrelevantId =
 			testGetPriceListIdPriceListAccountsPage_getIrrelevantId();
+
+		Page<PriceListAccount> page =
+			priceListAccountResource.getPriceListIdPriceListAccountsPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceListAccount irrelevantPriceListAccount =
@@ -408,7 +407,7 @@ public abstract class BasePriceListAccountResourceTestCase {
 				id, randomPriceListAccount());
 
 		page = priceListAccountResource.getPriceListIdPriceListAccountsPage(
-			id, null, null, Pagination.of(1, 2), null);
+			id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -743,6 +742,25 @@ public abstract class BasePriceListAccountResourceTestCase {
 
 			assertEquals(priceListAccount1, priceListAccount2);
 		}
+	}
+
+	protected void assertContains(
+		PriceListAccount priceListAccount,
+		List<PriceListAccount> priceListAccounts) {
+
+		boolean contains = false;
+
+		for (PriceListAccount item : priceListAccounts) {
+			if (equals(priceListAccount, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceListAccounts + " does not contain " + priceListAccount,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListChannelResourceTestCase.java
@@ -216,18 +216,17 @@ public abstract class BasePriceListChannelResourceTestCase {
 	public void testGetPriceListByExternalReferenceCodePriceListChannelsPage()
 		throws Exception {
 
-		Page<PriceListChannel> page =
-			priceListChannelResource.
-				getPriceListByExternalReferenceCodePriceListChannelsPage(
-					testGetPriceListByExternalReferenceCodePriceListChannelsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListChannelsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListChannelsPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceListChannel> page =
+			priceListChannelResource.
+				getPriceListByExternalReferenceCodePriceListChannelsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceListChannel irrelevantPriceListChannel =
@@ -259,7 +258,7 @@ public abstract class BasePriceListChannelResourceTestCase {
 		page =
 			priceListChannelResource.
 				getPriceListByExternalReferenceCodePriceListChannelsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -372,16 +371,16 @@ public abstract class BasePriceListChannelResourceTestCase {
 
 	@Test
 	public void testGetPriceListIdPriceListChannelsPage() throws Exception {
-		Page<PriceListChannel> page =
-			priceListChannelResource.getPriceListIdPriceListChannelsPage(
-				testGetPriceListIdPriceListChannelsPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceListIdPriceListChannelsPage_getId();
 		Long irrelevantId =
 			testGetPriceListIdPriceListChannelsPage_getIrrelevantId();
+
+		Page<PriceListChannel> page =
+			priceListChannelResource.getPriceListIdPriceListChannelsPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceListChannel irrelevantPriceListChannel =
@@ -408,7 +407,7 @@ public abstract class BasePriceListChannelResourceTestCase {
 				id, randomPriceListChannel());
 
 		page = priceListChannelResource.getPriceListIdPriceListChannelsPage(
-			id, null, null, Pagination.of(1, 2), null);
+			id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -743,6 +742,25 @@ public abstract class BasePriceListChannelResourceTestCase {
 
 			assertEquals(priceListChannel1, priceListChannel2);
 		}
+	}
+
+	protected void assertContains(
+		PriceListChannel priceListChannel,
+		List<PriceListChannel> priceListChannels) {
+
+		boolean contains = false;
+
+		for (PriceListChannel item : priceListChannels) {
+			if (equals(priceListChannel, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceListChannels + " does not contain " + priceListChannel,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListDiscountResourceTestCase.java
@@ -212,18 +212,17 @@ public abstract class BasePriceListDiscountResourceTestCase {
 	public void testGetPriceListByExternalReferenceCodePriceListDiscountsPage()
 		throws Exception {
 
-		Page<PriceListDiscount> page =
-			priceListDiscountResource.
-				getPriceListByExternalReferenceCodePriceListDiscountsPage(
-					testGetPriceListByExternalReferenceCodePriceListDiscountsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListDiscountsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListDiscountsPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceListDiscount> page =
+			priceListDiscountResource.
+				getPriceListByExternalReferenceCodePriceListDiscountsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceListDiscount irrelevantPriceListDiscount =
@@ -255,7 +254,7 @@ public abstract class BasePriceListDiscountResourceTestCase {
 		page =
 			priceListDiscountResource.
 				getPriceListByExternalReferenceCodePriceListDiscountsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -369,16 +368,15 @@ public abstract class BasePriceListDiscountResourceTestCase {
 
 	@Test
 	public void testGetPriceListIdPriceListDiscountsPage() throws Exception {
-		Page<PriceListDiscount> page =
-			priceListDiscountResource.getPriceListIdPriceListDiscountsPage(
-				testGetPriceListIdPriceListDiscountsPage_getId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceListIdPriceListDiscountsPage_getId();
 		Long irrelevantId =
 			testGetPriceListIdPriceListDiscountsPage_getIrrelevantId();
+
+		Page<PriceListDiscount> page =
+			priceListDiscountResource.getPriceListIdPriceListDiscountsPage(
+				id, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceListDiscount irrelevantPriceListDiscount =
@@ -406,7 +404,7 @@ public abstract class BasePriceListDiscountResourceTestCase {
 				id, randomPriceListDiscount());
 
 		page = priceListDiscountResource.getPriceListIdPriceListDiscountsPage(
-			id, Pagination.of(1, 2));
+			id, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -539,6 +537,25 @@ public abstract class BasePriceListDiscountResourceTestCase {
 
 			assertEquals(priceListDiscount1, priceListDiscount2);
 		}
+	}
+
+	protected void assertContains(
+		PriceListDiscount priceListDiscount,
+		List<PriceListDiscount> priceListDiscounts) {
+
+		boolean contains = false;
+
+		for (PriceListDiscount item : priceListDiscounts) {
+			if (equals(priceListDiscount, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceListDiscounts + " does not contain " + priceListDiscount,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListOrderTypeResourceTestCase.java
@@ -210,18 +210,17 @@ public abstract class BasePriceListOrderTypeResourceTestCase {
 	public void testGetPriceListByExternalReferenceCodePriceListOrderTypesPage()
 		throws Exception {
 
-		Page<PriceListOrderType> page =
-			priceListOrderTypeResource.
-				getPriceListByExternalReferenceCodePriceListOrderTypesPage(
-					testGetPriceListByExternalReferenceCodePriceListOrderTypesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListOrderTypesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceListOrderTypesPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceListOrderType> page =
+			priceListOrderTypeResource.
+				getPriceListByExternalReferenceCodePriceListOrderTypesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceListOrderType irrelevantPriceListOrderType =
@@ -253,7 +252,7 @@ public abstract class BasePriceListOrderTypeResourceTestCase {
 		page =
 			priceListOrderTypeResource.
 				getPriceListByExternalReferenceCodePriceListOrderTypesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -368,16 +367,15 @@ public abstract class BasePriceListOrderTypeResourceTestCase {
 
 	@Test
 	public void testGetPriceListIdPriceListOrderTypesPage() throws Exception {
-		Page<PriceListOrderType> page =
-			priceListOrderTypeResource.getPriceListIdPriceListOrderTypesPage(
-				testGetPriceListIdPriceListOrderTypesPage_getId(),
-				RandomTestUtil.randomString(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceListIdPriceListOrderTypesPage_getId();
 		Long irrelevantId =
 			testGetPriceListIdPriceListOrderTypesPage_getIrrelevantId();
+
+		Page<PriceListOrderType> page =
+			priceListOrderTypeResource.getPriceListIdPriceListOrderTypesPage(
+				id, RandomTestUtil.randomString(), Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceListOrderType irrelevantPriceListOrderType =
@@ -406,7 +404,7 @@ public abstract class BasePriceListOrderTypeResourceTestCase {
 				id, randomPriceListOrderType());
 
 		page = priceListOrderTypeResource.getPriceListIdPriceListOrderTypesPage(
-			id, null, Pagination.of(1, 2));
+			id, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -542,6 +540,25 @@ public abstract class BasePriceListOrderTypeResourceTestCase {
 
 			assertEquals(priceListOrderType1, priceListOrderType2);
 		}
+	}
+
+	protected void assertContains(
+		PriceListOrderType priceListOrderType,
+		List<PriceListOrderType> priceListOrderTypes) {
+
+		boolean contains = false;
+
+		for (PriceListOrderType item : priceListOrderTypes) {
+			if (equals(priceListOrderType, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceListOrderTypes + " does not contain " + priceListOrderType,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -209,9 +210,9 @@ public abstract class BasePriceListResourceTestCase {
 	@Test
 	public void testGetPriceListsPage() throws Exception {
 		Page<PriceList> page = priceListResource.getPriceListsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		PriceList priceList1 = testGetPriceListsPage_addPriceList(
 			randomPriceList());
@@ -220,13 +221,12 @@ public abstract class BasePriceListResourceTestCase {
 			randomPriceList());
 
 		page = priceListResource.getPriceListsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(priceList1, priceList2),
-			(List<PriceList>)page.getItems());
+		assertContains(priceList1, (List<PriceList>)page.getItems());
+		assertContains(priceList2, (List<PriceList>)page.getItems());
 		assertValid(page);
 
 		priceListResource.deletePriceList(priceList1.getId());
@@ -289,6 +289,11 @@ public abstract class BasePriceListResourceTestCase {
 
 	@Test
 	public void testGetPriceListsPageWithPagination() throws Exception {
+		Page<PriceList> totalPage = priceListResource.getPriceListsPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		PriceList priceList1 = testGetPriceListsPage_addPriceList(
 			randomPriceList());
 
@@ -299,27 +304,28 @@ public abstract class BasePriceListResourceTestCase {
 			randomPriceList());
 
 		Page<PriceList> page1 = priceListResource.getPriceListsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<PriceList> priceLists1 = (List<PriceList>)page1.getItems();
 
-		Assert.assertEquals(priceLists1.toString(), 2, priceLists1.size());
+		Assert.assertEquals(
+			priceLists1.toString(), totalCount + 2, priceLists1.size());
 
 		Page<PriceList> page2 = priceListResource.getPriceListsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<PriceList> priceLists2 = (List<PriceList>)page2.getItems();
 
 		Assert.assertEquals(priceLists2.toString(), 1, priceLists2.size());
 
 		Page<PriceList> page3 = priceListResource.getPriceListsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(priceList1, priceList2, priceList3),
-			(List<PriceList>)page3.getItems());
+		assertContains(priceList1, (List<PriceList>)page3.getItems());
+		assertContains(priceList2, (List<PriceList>)page3.getItems());
+		assertContains(priceList3, (List<PriceList>)page3.getItems());
 	}
 
 	@Test
@@ -450,7 +456,7 @@ public abstract class BasePriceListResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -460,7 +466,7 @@ public abstract class BasePriceListResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/priceLists");
 
-		Assert.assertEquals(0, priceListsJSONObject.get("totalCount"));
+		long totalCount = priceListsJSONObject.getLong("totalCount");
 
 		PriceList priceList1 = testGraphQLPriceList_addPriceList();
 		PriceList priceList2 = testGraphQLPriceList_addPriceList();
@@ -469,10 +475,16 @@ public abstract class BasePriceListResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/priceLists");
 
-		Assert.assertEquals(2, priceListsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, priceListsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(priceList1, priceList2),
+		assertContains(
+			priceList1,
+			Arrays.asList(
+				PriceListSerDes.toDTOs(
+					priceListsJSONObject.getString("items"))));
+		assertContains(
+			priceList2,
 			Arrays.asList(
 				PriceListSerDes.toDTOs(
 					priceListsJSONObject.getString("items"))));
@@ -802,6 +814,23 @@ public abstract class BasePriceListResourceTestCase {
 
 			assertEquals(priceList1, priceList2);
 		}
+	}
+
+	protected void assertContains(
+		PriceList priceList, List<PriceList> priceLists) {
+
+		boolean contains = false;
+
+		for (PriceList item : priceLists) {
+			if (equals(priceList, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceLists + " does not contain " + priceList, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierCategoryResourceTestCase.java
@@ -223,18 +223,17 @@ public abstract class BasePriceModifierCategoryResourceTestCase {
 	public void testGetPriceModifierByExternalReferenceCodePriceModifierCategoriesPage()
 		throws Exception {
 
-		Page<PriceModifierCategory> page =
-			priceModifierCategoryResource.
-				getPriceModifierByExternalReferenceCodePriceModifierCategoriesPage(
-					testGetPriceModifierByExternalReferenceCodePriceModifierCategoriesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceModifierByExternalReferenceCodePriceModifierCategoriesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceModifierByExternalReferenceCodePriceModifierCategoriesPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceModifierCategory> page =
+			priceModifierCategoryResource.
+				getPriceModifierByExternalReferenceCodePriceModifierCategoriesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceModifierCategory irrelevantPriceModifierCategory =
@@ -266,7 +265,7 @@ public abstract class BasePriceModifierCategoryResourceTestCase {
 		page =
 			priceModifierCategoryResource.
 				getPriceModifierByExternalReferenceCodePriceModifierCategoriesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -386,18 +385,17 @@ public abstract class BasePriceModifierCategoryResourceTestCase {
 	public void testGetPriceModifierIdPriceModifierCategoriesPage()
 		throws Exception {
 
-		Page<PriceModifierCategory> page =
-			priceModifierCategoryResource.
-				getPriceModifierIdPriceModifierCategoriesPage(
-					testGetPriceModifierIdPriceModifierCategoriesPage_getId(),
-					RandomTestUtil.randomString(), null, Pagination.of(1, 2),
-					null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceModifierIdPriceModifierCategoriesPage_getId();
 		Long irrelevantId =
 			testGetPriceModifierIdPriceModifierCategoriesPage_getIrrelevantId();
+
+		Page<PriceModifierCategory> page =
+			priceModifierCategoryResource.
+				getPriceModifierIdPriceModifierCategoriesPage(
+					id, RandomTestUtil.randomString(), null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceModifierCategory irrelevantPriceModifierCategory =
@@ -428,7 +426,7 @@ public abstract class BasePriceModifierCategoryResourceTestCase {
 		page =
 			priceModifierCategoryResource.
 				getPriceModifierIdPriceModifierCategoriesPage(
-					id, null, null, Pagination.of(1, 2), null);
+					id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -785,6 +783,26 @@ public abstract class BasePriceModifierCategoryResourceTestCase {
 
 			assertEquals(priceModifierCategory1, priceModifierCategory2);
 		}
+	}
+
+	protected void assertContains(
+		PriceModifierCategory priceModifierCategory,
+		List<PriceModifierCategory> priceModifierCategories) {
+
+		boolean contains = false;
+
+		for (PriceModifierCategory item : priceModifierCategories) {
+			if (equals(priceModifierCategory, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceModifierCategories + " does not contain " +
+				priceModifierCategory,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductGroupResourceTestCase.java
@@ -227,18 +227,17 @@ public abstract class BasePriceModifierProductGroupResourceTestCase {
 	public void testGetPriceModifierByExternalReferenceCodePriceModifierProductGroupsPage()
 		throws Exception {
 
-		Page<PriceModifierProductGroup> page =
-			priceModifierProductGroupResource.
-				getPriceModifierByExternalReferenceCodePriceModifierProductGroupsPage(
-					testGetPriceModifierByExternalReferenceCodePriceModifierProductGroupsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceModifierByExternalReferenceCodePriceModifierProductGroupsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceModifierByExternalReferenceCodePriceModifierProductGroupsPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceModifierProductGroup> page =
+			priceModifierProductGroupResource.
+				getPriceModifierByExternalReferenceCodePriceModifierProductGroupsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceModifierProductGroup irrelevantPriceModifierProductGroup =
@@ -270,7 +269,7 @@ public abstract class BasePriceModifierProductGroupResourceTestCase {
 		page =
 			priceModifierProductGroupResource.
 				getPriceModifierByExternalReferenceCodePriceModifierProductGroupsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -392,18 +391,17 @@ public abstract class BasePriceModifierProductGroupResourceTestCase {
 	public void testGetPriceModifierIdPriceModifierProductGroupsPage()
 		throws Exception {
 
-		Page<PriceModifierProductGroup> page =
-			priceModifierProductGroupResource.
-				getPriceModifierIdPriceModifierProductGroupsPage(
-					testGetPriceModifierIdPriceModifierProductGroupsPage_getId(),
-					RandomTestUtil.randomString(), null, Pagination.of(1, 2),
-					null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceModifierIdPriceModifierProductGroupsPage_getId();
 		Long irrelevantId =
 			testGetPriceModifierIdPriceModifierProductGroupsPage_getIrrelevantId();
+
+		Page<PriceModifierProductGroup> page =
+			priceModifierProductGroupResource.
+				getPriceModifierIdPriceModifierProductGroupsPage(
+					id, RandomTestUtil.randomString(), null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceModifierProductGroup irrelevantPriceModifierProductGroup =
@@ -434,7 +432,7 @@ public abstract class BasePriceModifierProductGroupResourceTestCase {
 		page =
 			priceModifierProductGroupResource.
 				getPriceModifierIdPriceModifierProductGroupsPage(
-					id, null, null, Pagination.of(1, 2), null);
+					id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -804,6 +802,26 @@ public abstract class BasePriceModifierProductGroupResourceTestCase {
 			assertEquals(
 				priceModifierProductGroup1, priceModifierProductGroup2);
 		}
+	}
+
+	protected void assertContains(
+		PriceModifierProductGroup priceModifierProductGroup,
+		List<PriceModifierProductGroup> priceModifierProductGroups) {
+
+		boolean contains = false;
+
+		for (PriceModifierProductGroup item : priceModifierProductGroups) {
+			if (equals(priceModifierProductGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceModifierProductGroups + " does not contain " +
+				priceModifierProductGroup,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductResourceTestCase.java
@@ -221,18 +221,17 @@ public abstract class BasePriceModifierProductResourceTestCase {
 	public void testGetPriceModifierByExternalReferenceCodePriceModifierProductsPage()
 		throws Exception {
 
-		Page<PriceModifierProduct> page =
-			priceModifierProductResource.
-				getPriceModifierByExternalReferenceCodePriceModifierProductsPage(
-					testGetPriceModifierByExternalReferenceCodePriceModifierProductsPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceModifierByExternalReferenceCodePriceModifierProductsPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceModifierByExternalReferenceCodePriceModifierProductsPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceModifierProduct> page =
+			priceModifierProductResource.
+				getPriceModifierByExternalReferenceCodePriceModifierProductsPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceModifierProduct irrelevantPriceModifierProduct =
@@ -264,7 +263,7 @@ public abstract class BasePriceModifierProductResourceTestCase {
 		page =
 			priceModifierProductResource.
 				getPriceModifierByExternalReferenceCodePriceModifierProductsPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -384,18 +383,17 @@ public abstract class BasePriceModifierProductResourceTestCase {
 	public void testGetPriceModifierIdPriceModifierProductsPage()
 		throws Exception {
 
-		Page<PriceModifierProduct> page =
-			priceModifierProductResource.
-				getPriceModifierIdPriceModifierProductsPage(
-					testGetPriceModifierIdPriceModifierProductsPage_getId(),
-					RandomTestUtil.randomString(), null, Pagination.of(1, 2),
-					null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceModifierIdPriceModifierProductsPage_getId();
 		Long irrelevantId =
 			testGetPriceModifierIdPriceModifierProductsPage_getIrrelevantId();
+
+		Page<PriceModifierProduct> page =
+			priceModifierProductResource.
+				getPriceModifierIdPriceModifierProductsPage(
+					id, RandomTestUtil.randomString(), null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceModifierProduct irrelevantPriceModifierProduct =
@@ -426,7 +424,7 @@ public abstract class BasePriceModifierProductResourceTestCase {
 		page =
 			priceModifierProductResource.
 				getPriceModifierIdPriceModifierProductsPage(
-					id, null, null, Pagination.of(1, 2), null);
+					id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -780,6 +778,25 @@ public abstract class BasePriceModifierProductResourceTestCase {
 
 			assertEquals(priceModifierProduct1, priceModifierProduct2);
 		}
+	}
+
+	protected void assertContains(
+		PriceModifierProduct priceModifierProduct,
+		List<PriceModifierProduct> priceModifierProducts) {
+
+		boolean contains = false;
+
+		for (PriceModifierProduct item : priceModifierProducts) {
+			if (equals(priceModifierProduct, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceModifierProducts + " does not contain " + priceModifierProduct,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
@@ -211,18 +211,17 @@ public abstract class BasePriceModifierResourceTestCase {
 	public void testGetPriceListByExternalReferenceCodePriceModifiersPage()
 		throws Exception {
 
-		Page<PriceModifier> page =
-			priceModifierResource.
-				getPriceListByExternalReferenceCodePriceModifiersPage(
-					testGetPriceListByExternalReferenceCodePriceModifiersPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceModifiersPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceListByExternalReferenceCodePriceModifiersPage_getIrrelevantExternalReferenceCode();
+
+		Page<PriceModifier> page =
+			priceModifierResource.
+				getPriceListByExternalReferenceCodePriceModifiersPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			PriceModifier irrelevantPriceModifier =
@@ -254,7 +253,7 @@ public abstract class BasePriceModifierResourceTestCase {
 		page =
 			priceModifierResource.
 				getPriceListByExternalReferenceCodePriceModifiersPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -370,16 +369,16 @@ public abstract class BasePriceModifierResourceTestCase {
 
 	@Test
 	public void testGetPriceListIdPriceModifiersPage() throws Exception {
-		Page<PriceModifier> page =
-			priceModifierResource.getPriceListIdPriceModifiersPage(
-				testGetPriceListIdPriceModifiersPage_getId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long id = testGetPriceListIdPriceModifiersPage_getId();
 		Long irrelevantId =
 			testGetPriceListIdPriceModifiersPage_getIrrelevantId();
+
+		Page<PriceModifier> page =
+			priceModifierResource.getPriceListIdPriceModifiersPage(
+				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantId != null) {
 			PriceModifier irrelevantPriceModifier =
@@ -406,7 +405,7 @@ public abstract class BasePriceModifierResourceTestCase {
 				id, randomPriceModifier());
 
 		page = priceModifierResource.getPriceListIdPriceModifiersPage(
-			id, null, null, Pagination.of(1, 2), null);
+			id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -988,6 +987,23 @@ public abstract class BasePriceModifierResourceTestCase {
 
 			assertEquals(priceModifier1, priceModifier2);
 		}
+	}
+
+	protected void assertContains(
+		PriceModifier priceModifier, List<PriceModifier> priceModifiers) {
+
+		boolean contains = false;
+
+		for (PriceModifier item : priceModifiers) {
+			if (equals(priceModifier, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			priceModifiers + " does not contain " + priceModifier, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
@@ -361,6 +361,23 @@ public abstract class BaseProductGroupResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		ProductGroup productGroup, List<ProductGroup> productGroups) {
+
+		boolean contains = false;
+
+		for (ProductGroup item : productGroups) {
+			if (equals(productGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productGroups + " does not contain " + productGroup, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<ProductGroup> productGroups1, List<ProductGroup> productGroups2) {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
@@ -405,6 +405,20 @@ public abstract class BaseProductResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Product product, List<Product> products) {
+		boolean contains = false;
+
+		for (Product item : products) {
+			if (equals(product, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(products + " does not contain " + product, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Product> products1, List<Product> products2) {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
@@ -333,6 +333,20 @@ public abstract class BaseSkuResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Sku sku, List<Sku> skus) {
+		boolean contains = false;
+
+		for (Sku item : skus) {
+			if (equals(sku, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(skus + " does not contain " + sku, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(List<Sku> skus1, List<Sku> skus2) {
 		Assert.assertEquals(skus1.size(), skus2.size());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
@@ -201,18 +201,17 @@ public abstract class BaseTierPriceResourceTestCase {
 	public void testGetPriceEntryByExternalReferenceCodeTierPricesPage()
 		throws Exception {
 
-		Page<TierPrice> page =
-			tierPriceResource.
-				getPriceEntryByExternalReferenceCodeTierPricesPage(
-					testGetPriceEntryByExternalReferenceCodeTierPricesPage_getExternalReferenceCode(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetPriceEntryByExternalReferenceCodeTierPricesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetPriceEntryByExternalReferenceCodeTierPricesPage_getIrrelevantExternalReferenceCode();
+
+		Page<TierPrice> page =
+			tierPriceResource.
+				getPriceEntryByExternalReferenceCodeTierPricesPage(
+					externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			TierPrice irrelevantTierPrice =
@@ -244,7 +243,7 @@ public abstract class BaseTierPriceResourceTestCase {
 		page =
 			tierPriceResource.
 				getPriceEntryByExternalReferenceCodeTierPricesPage(
-					externalReferenceCode, Pagination.of(1, 2));
+					externalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -356,15 +355,14 @@ public abstract class BaseTierPriceResourceTestCase {
 
 	@Test
 	public void testGetPriceEntryIdTierPricesPage() throws Exception {
-		Page<TierPrice> page = tierPriceResource.getPriceEntryIdTierPricesPage(
-			testGetPriceEntryIdTierPricesPage_getPriceEntryId(),
-			Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long priceEntryId = testGetPriceEntryIdTierPricesPage_getPriceEntryId();
 		Long irrelevantPriceEntryId =
 			testGetPriceEntryIdTierPricesPage_getIrrelevantPriceEntryId();
+
+		Page<TierPrice> page = tierPriceResource.getPriceEntryIdTierPricesPage(
+			priceEntryId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantPriceEntryId != null) {
 			TierPrice irrelevantTierPrice =
@@ -389,7 +387,7 @@ public abstract class BaseTierPriceResourceTestCase {
 			priceEntryId, randomTierPrice());
 
 		page = tierPriceResource.getPriceEntryIdTierPricesPage(
-			priceEntryId, Pagination.of(1, 2));
+			priceEntryId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -736,6 +734,23 @@ public abstract class BaseTierPriceResourceTestCase {
 
 			assertEquals(tierPrice1, tierPrice2);
 		}
+	}
+
+	protected void assertContains(
+		TierPrice tierPrice, List<TierPrice> tierPrices) {
+
+		boolean contains = false;
+
+		for (TierPrice item : tierPrices) {
+			if (equals(tierPrice, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			tierPrices + " does not contain " + tierPrice, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
@@ -341,14 +341,14 @@ public abstract class BaseShipmentItemResourceTestCase {
 
 	@Test
 	public void testGetShipmentItemsPage() throws Exception {
-		Page<ShipmentItem> page = shipmentItemResource.getShipmentItemsPage(
-			testGetShipmentItemsPage_getShipmentId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long shipmentId = testGetShipmentItemsPage_getShipmentId();
 		Long irrelevantShipmentId =
 			testGetShipmentItemsPage_getIrrelevantShipmentId();
+
+		Page<ShipmentItem> page = shipmentItemResource.getShipmentItemsPage(
+			shipmentId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantShipmentId != null) {
 			ShipmentItem irrelevantShipmentItem =
@@ -373,7 +373,7 @@ public abstract class BaseShipmentItemResourceTestCase {
 			shipmentId, randomShipmentItem());
 
 		page = shipmentItemResource.getShipmentItemsPage(
-			shipmentId, Pagination.of(1, 2));
+			shipmentId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -456,7 +456,7 @@ public abstract class BaseShipmentItemResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("shipmentId", shipmentId);
 				}
@@ -477,7 +477,7 @@ public abstract class BaseShipmentItemResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/shipmentItems");
 
-		Assert.assertEquals(2, shipmentItemsJSONObject.get("totalCount"));
+		Assert.assertEquals(2, shipmentItemsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(shipmentItem1, shipmentItem2),
@@ -539,6 +539,23 @@ public abstract class BaseShipmentItemResourceTestCase {
 
 			assertEquals(shipmentItem1, shipmentItem2);
 		}
+	}
+
+	protected void assertContains(
+		ShipmentItem shipmentItem, List<ShipmentItem> shipmentItems) {
+
+		boolean contains = false;
+
+		for (ShipmentItem item : shipmentItems) {
+			if (equals(shipmentItem, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			shipmentItems + " does not contain " + shipmentItem, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -207,22 +208,21 @@ public abstract class BaseShipmentResourceTestCase {
 	@Test
 	public void testGetShipmentsPage() throws Exception {
 		Page<Shipment> page = shipmentResource.getShipmentsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Shipment shipment1 = testGetShipmentsPage_addShipment(randomShipment());
 
 		Shipment shipment2 = testGetShipmentsPage_addShipment(randomShipment());
 
 		page = shipmentResource.getShipmentsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(shipment1, shipment2),
-			(List<Shipment>)page.getItems());
+		assertContains(shipment1, (List<Shipment>)page.getItems());
+		assertContains(shipment2, (List<Shipment>)page.getItems());
 		assertValid(page);
 
 		shipmentResource.deleteShipment(shipment1.getId());
@@ -283,6 +283,11 @@ public abstract class BaseShipmentResourceTestCase {
 
 	@Test
 	public void testGetShipmentsPageWithPagination() throws Exception {
+		Page<Shipment> totalPage = shipmentResource.getShipmentsPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Shipment shipment1 = testGetShipmentsPage_addShipment(randomShipment());
 
 		Shipment shipment2 = testGetShipmentsPage_addShipment(randomShipment());
@@ -290,27 +295,28 @@ public abstract class BaseShipmentResourceTestCase {
 		Shipment shipment3 = testGetShipmentsPage_addShipment(randomShipment());
 
 		Page<Shipment> page1 = shipmentResource.getShipmentsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Shipment> shipments1 = (List<Shipment>)page1.getItems();
 
-		Assert.assertEquals(shipments1.toString(), 2, shipments1.size());
+		Assert.assertEquals(
+			shipments1.toString(), totalCount + 2, shipments1.size());
 
 		Page<Shipment> page2 = shipmentResource.getShipmentsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Shipment> shipments2 = (List<Shipment>)page2.getItems();
 
 		Assert.assertEquals(shipments2.toString(), 1, shipments2.size());
 
 		Page<Shipment> page3 = shipmentResource.getShipmentsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(shipment1, shipment2, shipment3),
-			(List<Shipment>)page3.getItems());
+		assertContains(shipment1, (List<Shipment>)page3.getItems());
+		assertContains(shipment2, (List<Shipment>)page3.getItems());
+		assertContains(shipment3, (List<Shipment>)page3.getItems());
 	}
 
 	@Test
@@ -441,7 +447,7 @@ public abstract class BaseShipmentResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -451,7 +457,7 @@ public abstract class BaseShipmentResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/shipments");
 
-		Assert.assertEquals(0, shipmentsJSONObject.get("totalCount"));
+		long totalCount = shipmentsJSONObject.getLong("totalCount");
 
 		Shipment shipment1 = testGraphQLShipment_addShipment();
 		Shipment shipment2 = testGraphQLShipment_addShipment();
@@ -460,10 +466,15 @@ public abstract class BaseShipmentResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/shipments");
 
-		Assert.assertEquals(2, shipmentsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, shipmentsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(shipment1, shipment2),
+		assertContains(
+			shipment1,
+			Arrays.asList(
+				ShipmentSerDes.toDTOs(shipmentsJSONObject.getString("items"))));
+		assertContains(
+			shipment2,
 			Arrays.asList(
 				ShipmentSerDes.toDTOs(shipmentsJSONObject.getString("items"))));
 	}
@@ -710,6 +721,21 @@ public abstract class BaseShipmentResourceTestCase {
 
 			assertEquals(shipment1, shipment2);
 		}
+	}
+
+	protected void assertContains(Shipment shipment, List<Shipment> shipments) {
+		boolean contains = false;
+
+		for (Shipment item : shipments) {
+			if (equals(shipment, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			shipments + " does not contain " + shipment, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -346,6 +346,25 @@ public abstract class BaseShippingAddressResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		ShippingAddress shippingAddress,
+		List<ShippingAddress> shippingAddresses) {
+
+		boolean contains = false;
+
+		for (ShippingAddress item : shippingAddresses) {
+			if (equals(shippingAddress, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			shippingAddresses + " does not contain " + shippingAddress,
+			contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<ShippingAddress> shippingAddresses1,
 		List<ShippingAddress> shippingAddresses2) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
@@ -325,18 +325,17 @@ public abstract class BaseAvailabilityEstimateResourceTestCase {
 	public void testGetCommerceAdminSiteSettingGroupAvailabilityEstimatePage()
 		throws Exception {
 
-		Page<AvailabilityEstimate> page =
-			availabilityEstimateResource.
-				getCommerceAdminSiteSettingGroupAvailabilityEstimatePage(
-					testGetCommerceAdminSiteSettingGroupAvailabilityEstimatePage_getGroupId(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long groupId =
 			testGetCommerceAdminSiteSettingGroupAvailabilityEstimatePage_getGroupId();
 		Long irrelevantGroupId =
 			testGetCommerceAdminSiteSettingGroupAvailabilityEstimatePage_getIrrelevantGroupId();
+
+		Page<AvailabilityEstimate> page =
+			availabilityEstimateResource.
+				getCommerceAdminSiteSettingGroupAvailabilityEstimatePage(
+					groupId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantGroupId != null) {
 			AvailabilityEstimate irrelevantAvailabilityEstimate =
@@ -367,7 +366,7 @@ public abstract class BaseAvailabilityEstimateResourceTestCase {
 		page =
 			availabilityEstimateResource.
 				getCommerceAdminSiteSettingGroupAvailabilityEstimatePage(
-					groupId, Pagination.of(1, 2));
+					groupId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -528,6 +527,25 @@ public abstract class BaseAvailabilityEstimateResourceTestCase {
 
 			assertEquals(availabilityEstimate1, availabilityEstimate2);
 		}
+	}
+
+	protected void assertContains(
+		AvailabilityEstimate availabilityEstimate,
+		List<AvailabilityEstimate> availabilityEstimates) {
+
+		boolean contains = false;
+
+		for (AvailabilityEstimate item : availabilityEstimates) {
+			if (equals(availabilityEstimate, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			availabilityEstimates + " does not contain " + availabilityEstimate,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
@@ -196,18 +196,17 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 	public void testGetCommerceAdminSiteSettingGroupMeasurementUnitPage()
 		throws Exception {
 
-		Page<MeasurementUnit> page =
-			measurementUnitResource.
-				getCommerceAdminSiteSettingGroupMeasurementUnitPage(
-					testGetCommerceAdminSiteSettingGroupMeasurementUnitPage_getGroupId(),
-					null, Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long groupId =
 			testGetCommerceAdminSiteSettingGroupMeasurementUnitPage_getGroupId();
 		Long irrelevantGroupId =
 			testGetCommerceAdminSiteSettingGroupMeasurementUnitPage_getIrrelevantGroupId();
+
+		Page<MeasurementUnit> page =
+			measurementUnitResource.
+				getCommerceAdminSiteSettingGroupMeasurementUnitPage(
+					groupId, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantGroupId != null) {
 			MeasurementUnit irrelevantMeasurementUnit =
@@ -238,7 +237,7 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 		page =
 			measurementUnitResource.
 				getCommerceAdminSiteSettingGroupMeasurementUnitPage(
-					groupId, null, Pagination.of(1, 2));
+					groupId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -515,6 +514,25 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 
 			assertEquals(measurementUnit1, measurementUnit2);
 		}
+	}
+
+	protected void assertContains(
+		MeasurementUnit measurementUnit,
+		List<MeasurementUnit> measurementUnits) {
+
+		boolean contains = false;
+
+		for (MeasurementUnit item : measurementUnits) {
+			if (equals(measurementUnit, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			measurementUnits + " does not contain " + measurementUnit,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
@@ -190,17 +190,16 @@ public abstract class BaseTaxCategoryResourceTestCase {
 	public void testGetCommerceAdminSiteSettingGroupTaxCategoryPage()
 		throws Exception {
 
-		Page<TaxCategory> page =
-			taxCategoryResource.getCommerceAdminSiteSettingGroupTaxCategoryPage(
-				testGetCommerceAdminSiteSettingGroupTaxCategoryPage_getGroupId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long groupId =
 			testGetCommerceAdminSiteSettingGroupTaxCategoryPage_getGroupId();
 		Long irrelevantGroupId =
 			testGetCommerceAdminSiteSettingGroupTaxCategoryPage_getIrrelevantGroupId();
+
+		Page<TaxCategory> page =
+			taxCategoryResource.getCommerceAdminSiteSettingGroupTaxCategoryPage(
+				groupId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantGroupId != null) {
 			TaxCategory irrelevantTaxCategory =
@@ -230,7 +229,7 @@ public abstract class BaseTaxCategoryResourceTestCase {
 
 		page =
 			taxCategoryResource.getCommerceAdminSiteSettingGroupTaxCategoryPage(
-				groupId, Pagination.of(1, 2));
+				groupId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -494,6 +493,23 @@ public abstract class BaseTaxCategoryResourceTestCase {
 
 			assertEquals(taxCategory1, taxCategory2);
 		}
+	}
+
+	protected void assertContains(
+		TaxCategory taxCategory, List<TaxCategory> taxCategories) {
+
+		boolean contains = false;
+
+		for (TaxCategory item : taxCategories) {
+			if (equals(taxCategory, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			taxCategories + " does not contain " + taxCategory, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -207,17 +207,16 @@ public abstract class BaseWarehouseResourceTestCase {
 	public void testGetCommerceAdminSiteSettingGroupWarehousePage()
 		throws Exception {
 
-		Page<Warehouse> page =
-			warehouseResource.getCommerceAdminSiteSettingGroupWarehousePage(
-				testGetCommerceAdminSiteSettingGroupWarehousePage_getGroupId(),
-				null, Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long groupId =
 			testGetCommerceAdminSiteSettingGroupWarehousePage_getGroupId();
 		Long irrelevantGroupId =
 			testGetCommerceAdminSiteSettingGroupWarehousePage_getIrrelevantGroupId();
+
+		Page<Warehouse> page =
+			warehouseResource.getCommerceAdminSiteSettingGroupWarehousePage(
+				groupId, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantGroupId != null) {
 			Warehouse irrelevantWarehouse =
@@ -245,7 +244,7 @@ public abstract class BaseWarehouseResourceTestCase {
 				groupId, randomWarehouse());
 
 		page = warehouseResource.getCommerceAdminSiteSettingGroupWarehousePage(
-			groupId, null, Pagination.of(1, 2));
+			groupId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -496,6 +495,23 @@ public abstract class BaseWarehouseResourceTestCase {
 
 			assertEquals(warehouse1, warehouse2);
 		}
+	}
+
+	protected void assertContains(
+		Warehouse warehouse, List<Warehouse> warehouses) {
+
+		boolean contains = false;
+
+		for (Warehouse item : warehouses) {
+			if (equals(warehouse, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			warehouses + " does not contain " + warehouse, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
@@ -359,6 +359,20 @@ public abstract class BaseAddressResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Address address, List<Address> addresses) {
+		boolean contains = false;
+
+		for (Address item : addresses) {
+			if (equals(address, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(addresses + " does not contain " + address, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Address> addresses1, List<Address> addresses2) {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartCommentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartCommentResourceTestCase.java
@@ -364,13 +364,13 @@ public abstract class BaseCartCommentResourceTestCase {
 
 	@Test
 	public void testGetCartCommentsPage() throws Exception {
-		Page<CartComment> page = cartCommentResource.getCartCommentsPage(
-			testGetCartCommentsPage_getCartId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long cartId = testGetCartCommentsPage_getCartId();
 		Long irrelevantCartId = testGetCartCommentsPage_getIrrelevantCartId();
+
+		Page<CartComment> page = cartCommentResource.getCartCommentsPage(
+			cartId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantCartId != null) {
 			CartComment irrelevantCartComment =
@@ -395,7 +395,7 @@ public abstract class BaseCartCommentResourceTestCase {
 			cartId, randomCartComment());
 
 		page = cartCommentResource.getCartCommentsPage(
-			cartId, Pagination.of(1, 2));
+			cartId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -474,7 +474,7 @@ public abstract class BaseCartCommentResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("cartId", cartId);
 				}
@@ -495,7 +495,7 @@ public abstract class BaseCartCommentResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/cartComments");
 
-		Assert.assertEquals(2, cartCommentsJSONObject.get("totalCount"));
+		Assert.assertEquals(2, cartCommentsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(cartComment1, cartComment2),
@@ -557,6 +557,23 @@ public abstract class BaseCartCommentResourceTestCase {
 
 			assertEquals(cartComment1, cartComment2);
 		}
+	}
+
+	protected void assertContains(
+		CartComment cartComment, List<CartComment> cartComments) {
+
+		boolean contains = false;
+
+		for (CartComment item : cartComments) {
+			if (equals(cartComment, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			cartComments + " does not contain " + cartComment, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
@@ -358,13 +358,13 @@ public abstract class BaseCartItemResourceTestCase {
 
 	@Test
 	public void testGetCartItemsPage() throws Exception {
-		Page<CartItem> page = cartItemResource.getCartItemsPage(
-			testGetCartItemsPage_getCartId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long cartId = testGetCartItemsPage_getCartId();
 		Long irrelevantCartId = testGetCartItemsPage_getIrrelevantCartId();
+
+		Page<CartItem> page = cartItemResource.getCartItemsPage(
+			cartId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantCartId != null) {
 			CartItem irrelevantCartItem = testGetCartItemsPage_addCartItem(
@@ -387,7 +387,7 @@ public abstract class BaseCartItemResourceTestCase {
 		CartItem cartItem2 = testGetCartItemsPage_addCartItem(
 			cartId, randomCartItem());
 
-		page = cartItemResource.getCartItemsPage(cartId, Pagination.of(1, 2));
+		page = cartItemResource.getCartItemsPage(cartId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -464,7 +464,7 @@ public abstract class BaseCartItemResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("cartId", cartId);
 				}
@@ -485,7 +485,7 @@ public abstract class BaseCartItemResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/cartItems");
 
-		Assert.assertEquals(2, cartItemsJSONObject.get("totalCount"));
+		Assert.assertEquals(2, cartItemsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(cartItem1, cartItem2),
@@ -540,6 +540,21 @@ public abstract class BaseCartItemResourceTestCase {
 
 			assertEquals(cartItem1, cartItem2);
 		}
+	}
+
+	protected void assertContains(CartItem cartItem, List<CartItem> cartItems) {
+		boolean contains = false;
+
+		for (CartItem item : cartItems) {
+			if (equals(cartItem, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			cartItems + " does not contain " + cartItem, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
@@ -401,18 +401,17 @@ public abstract class BaseCartResourceTestCase {
 
 	@Test
 	public void testGetChannelCartsPage() throws Exception {
-		Page<Cart> page = cartResource.getChannelCartsPage(
-			testGetChannelCartsPage_getAccountId(),
-			testGetChannelCartsPage_getChannelId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long accountId = testGetChannelCartsPage_getAccountId();
 		Long irrelevantAccountId =
 			testGetChannelCartsPage_getIrrelevantAccountId();
 		Long channelId = testGetChannelCartsPage_getChannelId();
 		Long irrelevantChannelId =
 			testGetChannelCartsPage_getIrrelevantChannelId();
+
+		Page<Cart> page = cartResource.getChannelCartsPage(
+			accountId, channelId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantAccountId != null) && (irrelevantChannelId != null)) {
 			Cart irrelevantCart = testGetChannelCartsPage_addCart(
@@ -436,7 +435,7 @@ public abstract class BaseCartResourceTestCase {
 			accountId, channelId, randomCart());
 
 		page = cartResource.getChannelCartsPage(
-			accountId, channelId, Pagination.of(1, 2));
+			accountId, channelId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -558,6 +557,20 @@ public abstract class BaseCartResourceTestCase {
 
 			assertEquals(cart1, cart2);
 		}
+	}
+
+	protected void assertContains(Cart cart, List<Cart> carts) {
+		boolean contains = false;
+
+		for (Cart item : carts) {
+			if (equals(cart, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(carts + " does not contain " + cart, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BasePaymentMethodResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BasePaymentMethodResourceTestCase.java
@@ -195,15 +195,14 @@ public abstract class BasePaymentMethodResourceTestCase {
 
 	@Test
 	public void testGetCartPaymentMethodsPage() throws Exception {
-		Page<PaymentMethod> page =
-			paymentMethodResource.getCartPaymentMethodsPage(
-				testGetCartPaymentMethodsPage_getCartId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long cartId = testGetCartPaymentMethodsPage_getCartId();
 		Long irrelevantCartId =
 			testGetCartPaymentMethodsPage_getIrrelevantCartId();
+
+		Page<PaymentMethod> page =
+			paymentMethodResource.getCartPaymentMethodsPage(cartId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantCartId != null) {
 			PaymentMethod irrelevantPaymentMethod =
@@ -286,6 +285,23 @@ public abstract class BasePaymentMethodResourceTestCase {
 
 			assertEquals(paymentMethod1, paymentMethod2);
 		}
+	}
+
+	protected void assertContains(
+		PaymentMethod paymentMethod, List<PaymentMethod> paymentMethods) {
+
+		boolean contains = false;
+
+		for (PaymentMethod item : paymentMethods) {
+			if (equals(paymentMethod, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			paymentMethods + " does not contain " + paymentMethod, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseShippingMethodResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseShippingMethodResourceTestCase.java
@@ -194,15 +194,14 @@ public abstract class BaseShippingMethodResourceTestCase {
 
 	@Test
 	public void testGetCartShippingMethodsPage() throws Exception {
-		Page<ShippingMethod> page =
-			shippingMethodResource.getCartShippingMethodsPage(
-				testGetCartShippingMethodsPage_getCartId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long cartId = testGetCartShippingMethodsPage_getCartId();
 		Long irrelevantCartId =
 			testGetCartShippingMethodsPage_getIrrelevantCartId();
+
+		Page<ShippingMethod> page =
+			shippingMethodResource.getCartShippingMethodsPage(cartId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantCartId != null) {
 			ShippingMethod irrelevantShippingMethod =
@@ -292,6 +291,23 @@ public abstract class BaseShippingMethodResourceTestCase {
 
 			assertEquals(shippingMethod1, shippingMethod2);
 		}
+	}
+
+	protected void assertContains(
+		ShippingMethod shippingMethod, List<ShippingMethod> shippingMethods) {
+
+		boolean contains = false;
+
+		for (ShippingMethod item : shippingMethods) {
+			if (equals(shippingMethod, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			shippingMethods + " does not contain " + shippingMethod, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -197,20 +197,18 @@ public abstract class BaseAttachmentResourceTestCase {
 
 	@Test
 	public void testGetChannelProductAttachmentsPage() throws Exception {
-		Page<Attachment> page =
-			attachmentResource.getChannelProductAttachmentsPage(
-				testGetChannelProductAttachmentsPage_getChannelId(),
-				testGetChannelProductAttachmentsPage_getProductId(), null,
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long channelId = testGetChannelProductAttachmentsPage_getChannelId();
 		Long irrelevantChannelId =
 			testGetChannelProductAttachmentsPage_getIrrelevantChannelId();
 		Long productId = testGetChannelProductAttachmentsPage_getProductId();
 		Long irrelevantProductId =
 			testGetChannelProductAttachmentsPage_getIrrelevantProductId();
+
+		Page<Attachment> page =
+			attachmentResource.getChannelProductAttachmentsPage(
+				channelId, productId, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantChannelId != null) && (irrelevantProductId != null)) {
 			Attachment irrelevantAttachment =
@@ -239,7 +237,7 @@ public abstract class BaseAttachmentResourceTestCase {
 				channelId, productId, randomAttachment());
 
 		page = attachmentResource.getChannelProductAttachmentsPage(
-			channelId, productId, null, Pagination.of(1, 2));
+			channelId, productId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -331,19 +329,17 @@ public abstract class BaseAttachmentResourceTestCase {
 
 	@Test
 	public void testGetChannelProductImagesPage() throws Exception {
-		Page<Attachment> page = attachmentResource.getChannelProductImagesPage(
-			testGetChannelProductImagesPage_getChannelId(),
-			testGetChannelProductImagesPage_getProductId(), null,
-			Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long channelId = testGetChannelProductImagesPage_getChannelId();
 		Long irrelevantChannelId =
 			testGetChannelProductImagesPage_getIrrelevantChannelId();
 		Long productId = testGetChannelProductImagesPage_getProductId();
 		Long irrelevantProductId =
 			testGetChannelProductImagesPage_getIrrelevantProductId();
+
+		Page<Attachment> page = attachmentResource.getChannelProductImagesPage(
+			channelId, productId, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantChannelId != null) && (irrelevantProductId != null)) {
 			Attachment irrelevantAttachment =
@@ -370,7 +366,7 @@ public abstract class BaseAttachmentResourceTestCase {
 			channelId, productId, randomAttachment());
 
 		page = attachmentResource.getChannelProductImagesPage(
-			channelId, productId, null, Pagination.of(1, 2));
+			channelId, productId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -488,6 +484,23 @@ public abstract class BaseAttachmentResourceTestCase {
 
 			assertEquals(attachment1, attachment2);
 		}
+	}
+
+	protected void assertContains(
+		Attachment attachment, List<Attachment> attachments) {
+
+		boolean contains = false;
+
+		for (Attachment item : attachments) {
+			if (equals(attachment, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			attachments + " does not contain " + attachment, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
@@ -194,19 +194,17 @@ public abstract class BaseCategoryResourceTestCase {
 
 	@Test
 	public void testGetChannelProductCategoriesPage() throws Exception {
-		Page<Category> page = categoryResource.getChannelProductCategoriesPage(
-			testGetChannelProductCategoriesPage_getChannelId(),
-			testGetChannelProductCategoriesPage_getProductId(),
-			Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long channelId = testGetChannelProductCategoriesPage_getChannelId();
 		Long irrelevantChannelId =
 			testGetChannelProductCategoriesPage_getIrrelevantChannelId();
 		Long productId = testGetChannelProductCategoriesPage_getProductId();
 		Long irrelevantProductId =
 			testGetChannelProductCategoriesPage_getIrrelevantProductId();
+
+		Page<Category> page = categoryResource.getChannelProductCategoriesPage(
+			channelId, productId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantChannelId != null) && (irrelevantProductId != null)) {
 			Category irrelevantCategory =
@@ -232,7 +230,7 @@ public abstract class BaseCategoryResourceTestCase {
 			channelId, productId, randomCategory());
 
 		page = categoryResource.getChannelProductCategoriesPage(
-			channelId, productId, Pagination.of(1, 2));
+			channelId, productId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -346,6 +344,23 @@ public abstract class BaseCategoryResourceTestCase {
 
 			assertEquals(category1, category2);
 		}
+	}
+
+	protected void assertContains(
+		Category category, List<Category> categories) {
+
+		boolean contains = false;
+
+		for (Category item : categories) {
+			if (equals(category, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			categories + " does not contain " + category, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
@@ -198,20 +198,18 @@ public abstract class BaseProductOptionResourceTestCase {
 
 	@Test
 	public void testGetChannelProductOptionsPage() throws Exception {
-		Page<ProductOption> page =
-			productOptionResource.getChannelProductOptionsPage(
-				testGetChannelProductOptionsPage_getChannelId(),
-				testGetChannelProductOptionsPage_getProductId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long channelId = testGetChannelProductOptionsPage_getChannelId();
 		Long irrelevantChannelId =
 			testGetChannelProductOptionsPage_getIrrelevantChannelId();
 		Long productId = testGetChannelProductOptionsPage_getProductId();
 		Long irrelevantProductId =
 			testGetChannelProductOptionsPage_getIrrelevantProductId();
+
+		Page<ProductOption> page =
+			productOptionResource.getChannelProductOptionsPage(
+				channelId, productId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantChannelId != null) && (irrelevantProductId != null)) {
 			ProductOption irrelevantProductOption =
@@ -239,7 +237,7 @@ public abstract class BaseProductOptionResourceTestCase {
 				channelId, productId, randomProductOption());
 
 		page = productOptionResource.getChannelProductOptionsPage(
-			channelId, productId, Pagination.of(1, 2));
+			channelId, productId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -368,6 +366,23 @@ public abstract class BaseProductOptionResourceTestCase {
 
 			assertEquals(productOption1, productOption2);
 		}
+	}
+
+	protected void assertContains(
+		ProductOption productOption, List<ProductOption> productOptions) {
+
+		boolean contains = false;
+
+		for (ProductOption item : productOptions) {
+			if (equals(productOption, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productOptions + " does not contain " + productOption, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -215,15 +215,14 @@ public abstract class BaseProductResourceTestCase {
 
 	@Test
 	public void testGetChannelProductsPage() throws Exception {
-		Page<Product> page = productResource.getChannelProductsPage(
-			testGetChannelProductsPage_getChannelId(), null, null,
-			Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long channelId = testGetChannelProductsPage_getChannelId();
 		Long irrelevantChannelId =
 			testGetChannelProductsPage_getIrrelevantChannelId();
+
+		Page<Product> page = productResource.getChannelProductsPage(
+			channelId, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantChannelId != null) {
 			Product irrelevantProduct = testGetChannelProductsPage_addProduct(
@@ -247,7 +246,7 @@ public abstract class BaseProductResourceTestCase {
 			channelId, randomProduct());
 
 		page = productResource.getChannelProductsPage(
-			channelId, null, null, Pagination.of(1, 2), null);
+			channelId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -581,6 +580,20 @@ public abstract class BaseProductResourceTestCase {
 
 			assertEquals(product1, product2);
 		}
+	}
+
+	protected void assertContains(Product product, List<Product> products) {
+		boolean contains = false;
+
+		for (Product item : products) {
+			if (equals(product, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(products + " does not contain " + product, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
@@ -201,15 +201,6 @@ public abstract class BaseProductSpecificationResourceTestCase {
 	public void testGetChannelProductProductSpecificationsPage()
 		throws Exception {
 
-		Page<ProductSpecification> page =
-			productSpecificationResource.
-				getChannelProductProductSpecificationsPage(
-					testGetChannelProductProductSpecificationsPage_getChannelId(),
-					testGetChannelProductProductSpecificationsPage_getProductId(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long channelId =
 			testGetChannelProductProductSpecificationsPage_getChannelId();
 		Long irrelevantChannelId =
@@ -218,6 +209,13 @@ public abstract class BaseProductSpecificationResourceTestCase {
 			testGetChannelProductProductSpecificationsPage_getProductId();
 		Long irrelevantProductId =
 			testGetChannelProductProductSpecificationsPage_getIrrelevantProductId();
+
+		Page<ProductSpecification> page =
+			productSpecificationResource.
+				getChannelProductProductSpecificationsPage(
+					channelId, productId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantChannelId != null) && (irrelevantProductId != null)) {
 			ProductSpecification irrelevantProductSpecification =
@@ -250,7 +248,7 @@ public abstract class BaseProductSpecificationResourceTestCase {
 		page =
 			productSpecificationResource.
 				getChannelProductProductSpecificationsPage(
-					channelId, productId, Pagination.of(1, 2));
+					channelId, productId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -397,6 +395,25 @@ public abstract class BaseProductSpecificationResourceTestCase {
 
 			assertEquals(productSpecification1, productSpecification2);
 		}
+	}
+
+	protected void assertContains(
+		ProductSpecification productSpecification,
+		List<ProductSpecification> productSpecifications) {
+
+		boolean contains = false;
+
+		for (ProductSpecification item : productSpecifications) {
+			if (equals(productSpecification, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			productSpecifications + " does not contain " + productSpecification,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
@@ -193,14 +193,6 @@ public abstract class BaseRelatedProductResourceTestCase {
 
 	@Test
 	public void testGetChannelProductRelatedProductsPage() throws Exception {
-		Page<RelatedProduct> page =
-			relatedProductResource.getChannelProductRelatedProductsPage(
-				testGetChannelProductRelatedProductsPage_getChannelId(),
-				testGetChannelProductRelatedProductsPage_getProductId(),
-				RandomTestUtil.randomString(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long channelId =
 			testGetChannelProductRelatedProductsPage_getChannelId();
 		Long irrelevantChannelId =
@@ -209,6 +201,13 @@ public abstract class BaseRelatedProductResourceTestCase {
 			testGetChannelProductRelatedProductsPage_getProductId();
 		Long irrelevantProductId =
 			testGetChannelProductRelatedProductsPage_getIrrelevantProductId();
+
+		Page<RelatedProduct> page =
+			relatedProductResource.getChannelProductRelatedProductsPage(
+				channelId, productId, RandomTestUtil.randomString(),
+				Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantChannelId != null) && (irrelevantProductId != null)) {
 			RelatedProduct irrelevantRelatedProduct =
@@ -237,7 +236,7 @@ public abstract class BaseRelatedProductResourceTestCase {
 				channelId, productId, randomRelatedProduct());
 
 		page = relatedProductResource.getChannelProductRelatedProductsPage(
-			channelId, productId, null, Pagination.of(1, 2));
+			channelId, productId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -371,6 +370,23 @@ public abstract class BaseRelatedProductResourceTestCase {
 
 			assertEquals(relatedProduct1, relatedProduct2);
 		}
+	}
+
+	protected void assertContains(
+		RelatedProduct relatedProduct, List<RelatedProduct> relatedProducts) {
+
+		boolean contains = false;
+
+		for (RelatedProduct item : relatedProducts) {
+			if (equals(relatedProduct, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			relatedProducts + " does not contain " + relatedProduct, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
@@ -197,19 +197,17 @@ public abstract class BaseSkuResourceTestCase {
 
 	@Test
 	public void testGetChannelProductSkusPage() throws Exception {
-		Page<Sku> page = skuResource.getChannelProductSkusPage(
-			testGetChannelProductSkusPage_getChannelId(),
-			testGetChannelProductSkusPage_getProductId(), null,
-			Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long channelId = testGetChannelProductSkusPage_getChannelId();
 		Long irrelevantChannelId =
 			testGetChannelProductSkusPage_getIrrelevantChannelId();
 		Long productId = testGetChannelProductSkusPage_getProductId();
 		Long irrelevantProductId =
 			testGetChannelProductSkusPage_getIrrelevantProductId();
+
+		Page<Sku> page = skuResource.getChannelProductSkusPage(
+			channelId, productId, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantChannelId != null) && (irrelevantProductId != null)) {
 			Sku irrelevantSku = testGetChannelProductSkusPage_addSku(
@@ -234,7 +232,7 @@ public abstract class BaseSkuResourceTestCase {
 			channelId, productId, randomSku());
 
 		page = skuResource.getChannelProductSkusPage(
-			channelId, productId, null, Pagination.of(1, 2));
+			channelId, productId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -340,6 +338,20 @@ public abstract class BaseSkuResourceTestCase {
 
 			assertEquals(sku1, sku2);
 		}
+	}
+
+	protected void assertContains(Sku sku, List<Sku> skus) {
+		boolean contains = false;
+
+		for (Sku item : skus) {
+			if (equals(sku, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(skus + " does not contain " + sku, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(List<Sku> skus1, List<Sku> skus2) {

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionFieldLinkResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionFieldLinkResourceTestCase.java
@@ -196,18 +196,17 @@ public abstract class BaseDataDefinitionFieldLinkResourceTestCase {
 	public void testGetDataDefinitionDataDefinitionFieldLinkPage()
 		throws Exception {
 
-		Page<DataDefinitionFieldLink> page =
-			dataDefinitionFieldLinkResource.
-				getDataDefinitionDataDefinitionFieldLinkPage(
-					testGetDataDefinitionDataDefinitionFieldLinkPage_getDataDefinitionId(),
-					RandomTestUtil.randomString());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long dataDefinitionId =
 			testGetDataDefinitionDataDefinitionFieldLinkPage_getDataDefinitionId();
 		Long irrelevantDataDefinitionId =
 			testGetDataDefinitionDataDefinitionFieldLinkPage_getIrrelevantDataDefinitionId();
+
+		Page<DataDefinitionFieldLink> page =
+			dataDefinitionFieldLinkResource.
+				getDataDefinitionDataDefinitionFieldLinkPage(
+					dataDefinitionId, RandomTestUtil.randomString());
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantDataDefinitionId != null) {
 			DataDefinitionFieldLink irrelevantDataDefinitionFieldLink =
@@ -307,6 +306,26 @@ public abstract class BaseDataDefinitionFieldLinkResourceTestCase {
 
 			assertEquals(dataDefinitionFieldLink1, dataDefinitionFieldLink2);
 		}
+	}
+
+	protected void assertContains(
+		DataDefinitionFieldLink dataDefinitionFieldLink,
+		List<DataDefinitionFieldLink> dataDefinitionFieldLinks) {
+
+		boolean contains = false;
+
+		for (DataDefinitionFieldLink item : dataDefinitionFieldLinks) {
+			if (equals(dataDefinitionFieldLink, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			dataDefinitionFieldLinks + " does not contain " +
+				dataDefinitionFieldLink,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
@@ -211,18 +211,18 @@ public abstract class BaseDataDefinitionResourceTestCase {
 	public void testGetDataDefinitionByContentTypeContentTypePage()
 		throws Exception {
 
-		Page<DataDefinition> page =
-			dataDefinitionResource.
-				getDataDefinitionByContentTypeContentTypePage(
-					testGetDataDefinitionByContentTypeContentTypePage_getContentType(),
-					RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String contentType =
 			testGetDataDefinitionByContentTypeContentTypePage_getContentType();
 		String irrelevantContentType =
 			testGetDataDefinitionByContentTypeContentTypePage_getIrrelevantContentType();
+
+		Page<DataDefinition> page =
+			dataDefinitionResource.
+				getDataDefinitionByContentTypeContentTypePage(
+					contentType, RandomTestUtil.randomString(),
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantContentType != null) {
 			DataDefinition irrelevantDataDefinition =
@@ -253,7 +253,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		page =
 			dataDefinitionResource.
 				getDataDefinitionByContentTypeContentTypePage(
-					contentType, null, Pagination.of(1, 2), null);
+					contentType, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -759,15 +759,6 @@ public abstract class BaseDataDefinitionResourceTestCase {
 	public void testGetSiteDataDefinitionByContentTypeContentTypePage()
 		throws Exception {
 
-		Page<DataDefinition> page =
-			dataDefinitionResource.
-				getSiteDataDefinitionByContentTypeContentTypePage(
-					testGetSiteDataDefinitionByContentTypeContentTypePage_getSiteId(),
-					testGetSiteDataDefinitionByContentTypeContentTypePage_getContentType(),
-					RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId =
 			testGetSiteDataDefinitionByContentTypeContentTypePage_getSiteId();
 		Long irrelevantSiteId =
@@ -776,6 +767,14 @@ public abstract class BaseDataDefinitionResourceTestCase {
 			testGetSiteDataDefinitionByContentTypeContentTypePage_getContentType();
 		String irrelevantContentType =
 			testGetSiteDataDefinitionByContentTypeContentTypePage_getIrrelevantContentType();
+
+		Page<DataDefinition> page =
+			dataDefinitionResource.
+				getSiteDataDefinitionByContentTypeContentTypePage(
+					siteId, contentType, RandomTestUtil.randomString(),
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantSiteId != null) && (irrelevantContentType != null)) {
 			DataDefinition irrelevantDataDefinition =
@@ -808,7 +807,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		page =
 			dataDefinitionResource.
 				getSiteDataDefinitionByContentTypeContentTypePage(
-					siteId, contentType, null, Pagination.of(1, 2), null);
+					siteId, contentType, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1205,6 +1204,23 @@ public abstract class BaseDataDefinitionResourceTestCase {
 
 			assertEquals(dataDefinition1, dataDefinition2);
 		}
+	}
+
+	protected void assertContains(
+		DataDefinition dataDefinition, List<DataDefinition> dataDefinitions) {
+
+		boolean contains = false;
+
+		for (DataDefinition item : dataDefinitions) {
+			if (equals(dataDefinition, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			dataDefinitions + " does not contain " + dataDefinition, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
@@ -222,17 +222,17 @@ public abstract class BaseDataLayoutResourceTestCase {
 
 	@Test
 	public void testGetDataDefinitionDataLayoutsPage() throws Exception {
-		Page<DataLayout> page =
-			dataLayoutResource.getDataDefinitionDataLayoutsPage(
-				testGetDataDefinitionDataLayoutsPage_getDataDefinitionId(),
-				RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long dataDefinitionId =
 			testGetDataDefinitionDataLayoutsPage_getDataDefinitionId();
 		Long irrelevantDataDefinitionId =
 			testGetDataDefinitionDataLayoutsPage_getIrrelevantDataDefinitionId();
+
+		Page<DataLayout> page =
+			dataLayoutResource.getDataDefinitionDataLayoutsPage(
+				dataDefinitionId, RandomTestUtil.randomString(),
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantDataDefinitionId != null) {
 			DataLayout irrelevantDataLayout =
@@ -259,7 +259,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 				dataDefinitionId, randomDataLayout());
 
 		page = dataLayoutResource.getDataDefinitionDataLayoutsPage(
-			dataDefinitionId, null, Pagination.of(1, 2), null);
+			dataDefinitionId, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -751,6 +751,23 @@ public abstract class BaseDataLayoutResourceTestCase {
 
 			assertEquals(dataLayout1, dataLayout2);
 		}
+	}
+
+	protected void assertContains(
+		DataLayout dataLayout, List<DataLayout> dataLayouts) {
+
+		boolean contains = false;
+
+		for (DataLayout item : dataLayouts) {
+			if (equals(dataLayout, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			dataLayouts + " does not contain " + dataLayout, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
@@ -219,17 +219,17 @@ public abstract class BaseDataListViewResourceTestCase {
 
 	@Test
 	public void testGetDataDefinitionDataListViewsPage() throws Exception {
-		Page<DataListView> page =
-			dataListViewResource.getDataDefinitionDataListViewsPage(
-				testGetDataDefinitionDataListViewsPage_getDataDefinitionId(),
-				RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long dataDefinitionId =
 			testGetDataDefinitionDataListViewsPage_getDataDefinitionId();
 		Long irrelevantDataDefinitionId =
 			testGetDataDefinitionDataListViewsPage_getIrrelevantDataDefinitionId();
+
+		Page<DataListView> page =
+			dataListViewResource.getDataDefinitionDataListViewsPage(
+				dataDefinitionId, RandomTestUtil.randomString(),
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantDataDefinitionId != null) {
 			DataListView irrelevantDataListView =
@@ -256,7 +256,7 @@ public abstract class BaseDataListViewResourceTestCase {
 				dataDefinitionId, randomDataListView());
 
 		page = dataListViewResource.getDataDefinitionDataListViewsPage(
-			dataDefinitionId, null, Pagination.of(1, 2), null);
+			dataDefinitionId, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -670,6 +670,23 @@ public abstract class BaseDataListViewResourceTestCase {
 
 			assertEquals(dataListView1, dataListView2);
 		}
+	}
+
+	protected void assertContains(
+		DataListView dataListView, List<DataListView> dataListViews) {
+
+		boolean contains = false;
+
+		for (DataListView item : dataListViews) {
+			if (equals(dataListView, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			dataListViews + " does not contain " + dataListView, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
@@ -277,18 +277,18 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 	public void testGetDataDefinitionDataRecordCollectionsPage()
 		throws Exception {
 
-		Page<DataRecordCollection> page =
-			dataRecordCollectionResource.
-				getDataDefinitionDataRecordCollectionsPage(
-					testGetDataDefinitionDataRecordCollectionsPage_getDataDefinitionId(),
-					RandomTestUtil.randomString(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long dataDefinitionId =
 			testGetDataDefinitionDataRecordCollectionsPage_getDataDefinitionId();
 		Long irrelevantDataDefinitionId =
 			testGetDataDefinitionDataRecordCollectionsPage_getIrrelevantDataDefinitionId();
+
+		Page<DataRecordCollection> page =
+			dataRecordCollectionResource.
+				getDataDefinitionDataRecordCollectionsPage(
+					dataDefinitionId, RandomTestUtil.randomString(),
+					Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantDataDefinitionId != null) {
 			DataRecordCollection irrelevantDataRecordCollection =
@@ -320,7 +320,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		page =
 			dataRecordCollectionResource.
 				getDataDefinitionDataRecordCollectionsPage(
-					dataDefinitionId, null, Pagination.of(1, 2));
+					dataDefinitionId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -808,6 +808,25 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 
 			assertEquals(dataRecordCollection1, dataRecordCollection2);
 		}
+	}
+
+	protected void assertContains(
+		DataRecordCollection dataRecordCollection,
+		List<DataRecordCollection> dataRecordCollections) {
+
+		boolean contains = false;
+
+		for (DataRecordCollection item : dataRecordCollections) {
+			if (equals(dataRecordCollection, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			dataRecordCollections + " does not contain " + dataRecordCollection,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
@@ -195,17 +195,17 @@ public abstract class BaseDataRecordResourceTestCase {
 
 	@Test
 	public void testGetDataDefinitionDataRecordsPage() throws Exception {
-		Page<DataRecord> page =
-			dataRecordResource.getDataDefinitionDataRecordsPage(
-				testGetDataDefinitionDataRecordsPage_getDataDefinitionId(),
-				null, RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long dataDefinitionId =
 			testGetDataDefinitionDataRecordsPage_getDataDefinitionId();
 		Long irrelevantDataDefinitionId =
 			testGetDataDefinitionDataRecordsPage_getIrrelevantDataDefinitionId();
+
+		Page<DataRecord> page =
+			dataRecordResource.getDataDefinitionDataRecordsPage(
+				dataDefinitionId, null, RandomTestUtil.randomString(),
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantDataDefinitionId != null) {
 			DataRecord irrelevantDataRecord =
@@ -233,7 +233,7 @@ public abstract class BaseDataRecordResourceTestCase {
 				dataDefinitionId, randomDataRecord());
 
 		page = dataRecordResource.getDataDefinitionDataRecordsPage(
-			dataDefinitionId, null, null, Pagination.of(1, 2), null);
+			dataDefinitionId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -464,17 +464,17 @@ public abstract class BaseDataRecordResourceTestCase {
 
 	@Test
 	public void testGetDataRecordCollectionDataRecordsPage() throws Exception {
-		Page<DataRecord> page =
-			dataRecordResource.getDataRecordCollectionDataRecordsPage(
-				testGetDataRecordCollectionDataRecordsPage_getDataRecordCollectionId(),
-				null, RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long dataRecordCollectionId =
 			testGetDataRecordCollectionDataRecordsPage_getDataRecordCollectionId();
 		Long irrelevantDataRecordCollectionId =
 			testGetDataRecordCollectionDataRecordsPage_getIrrelevantDataRecordCollectionId();
+
+		Page<DataRecord> page =
+			dataRecordResource.getDataRecordCollectionDataRecordsPage(
+				dataRecordCollectionId, null, RandomTestUtil.randomString(),
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantDataRecordCollectionId != null) {
 			DataRecord irrelevantDataRecord =
@@ -503,7 +503,7 @@ public abstract class BaseDataRecordResourceTestCase {
 				dataRecordCollectionId, randomDataRecord());
 
 		page = dataRecordResource.getDataRecordCollectionDataRecordsPage(
-			dataRecordCollectionId, null, null, Pagination.of(1, 2), null);
+			dataRecordCollectionId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -936,6 +936,23 @@ public abstract class BaseDataRecordResourceTestCase {
 
 			assertEquals(dataRecord1, dataRecord2);
 		}
+	}
+
+	protected void assertContains(
+		DataRecord dataRecord, List<DataRecord> dataRecords) {
+
+		boolean contains = false;
+
+		for (DataRecord item : dataRecords) {
+			if (equals(dataRecord, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			dataRecords + " does not contain " + dataRecord, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-test/src/testIntegration/java/com/liferay/frontend/view/state/rest/resource/v1_0/test/BaseActiveViewResourceTestCase.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-test/src/testIntegration/java/com/liferay/frontend/view/state/rest/resource/v1_0/test/BaseActiveViewResourceTestCase.java
@@ -144,6 +144,21 @@ public abstract class BaseActiveViewResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Object activeView, List<Object> activeViews) {
+		boolean contains = false;
+
+		for (Object item : activeViews) {
+			if (equals(activeView, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			activeViews + " does not contain " + activeView, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Object> activeViews1, List<Object> activeViews2) {
 

--- a/modules/apps/headless/headless-admin-batch-planner/headless-admin-batch-planner-test/src/testIntegration/java/com/liferay/headless/admin/batch/planner/resource/v1_0/test/BaseLogResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-batch-planner/headless-admin-batch-planner-test/src/testIntegration/java/com/liferay/headless/admin/batch/planner/resource/v1_0/test/BaseLogResourceTestCase.java
@@ -197,13 +197,13 @@ public abstract class BaseLogResourceTestCase {
 
 	@Test
 	public void testGetPlanLogsPage() throws Exception {
-		Page<Log> page = logResource.getPlanLogsPage(
-			testGetPlanLogsPage_getPlanId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long planId = testGetPlanLogsPage_getPlanId();
 		Long irrelevantPlanId = testGetPlanLogsPage_getIrrelevantPlanId();
+
+		Page<Log> page = logResource.getPlanLogsPage(
+			planId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantPlanId != null) {
 			Log irrelevantLog = testGetPlanLogsPage_addLog(
@@ -223,7 +223,7 @@ public abstract class BaseLogResourceTestCase {
 
 		Log log2 = testGetPlanLogsPage_addLog(planId, randomLog());
 
-		page = logResource.getPlanLogsPage(planId, Pagination.of(1, 2));
+		page = logResource.getPlanLogsPage(planId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -307,6 +307,20 @@ public abstract class BaseLogResourceTestCase {
 
 			assertEquals(log1, log2);
 		}
+	}
+
+	protected void assertContains(Log log, List<Log> logs) {
+		boolean contains = false;
+
+		for (Log item : logs) {
+			if (equals(log, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(logs + " does not contain " + log, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(List<Log> logs1, List<Log> logs2) {

--- a/modules/apps/headless/headless-admin-batch-planner/headless-admin-batch-planner-test/src/testIntegration/java/com/liferay/headless/admin/batch/planner/resource/v1_0/test/BasePlanResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-batch-planner/headless-admin-batch-planner-test/src/testIntegration/java/com/liferay/headless/admin/batch/planner/resource/v1_0/test/BasePlanResourceTestCase.java
@@ -26,6 +26,7 @@ import com.liferay.headless.admin.batch.planner.client.dto.v1_0.Log;
 import com.liferay.headless.admin.batch.planner.client.dto.v1_0.Plan;
 import com.liferay.headless.admin.batch.planner.client.http.HttpInvoker;
 import com.liferay.headless.admin.batch.planner.client.pagination.Page;
+import com.liferay.headless.admin.batch.planner.client.pagination.Pagination;
 import com.liferay.headless.admin.batch.planner.client.resource.v1_0.PlanResource;
 import com.liferay.headless.admin.batch.planner.client.serdes.v1_0.PlanSerDes;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -41,6 +42,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -198,7 +200,66 @@ public abstract class BasePlanResourceTestCase {
 
 	@Test
 	public void testGetPlansPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<Plan> page = planResource.getPlansPage(Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		Plan plan1 = testGetPlansPage_addPlan(randomPlan());
+
+		Plan plan2 = testGetPlansPage_addPlan(randomPlan());
+
+		page = planResource.getPlansPage(Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(plan1, (List<Plan>)page.getItems());
+		assertContains(plan2, (List<Plan>)page.getItems());
+		assertValid(page);
+
+		planResource.deletePlan(plan1.getId());
+
+		planResource.deletePlan(plan2.getId());
+	}
+
+	@Test
+	public void testGetPlansPageWithPagination() throws Exception {
+		Page<Plan> totalPage = planResource.getPlansPage(null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
+		Plan plan1 = testGetPlansPage_addPlan(randomPlan());
+
+		Plan plan2 = testGetPlansPage_addPlan(randomPlan());
+
+		Plan plan3 = testGetPlansPage_addPlan(randomPlan());
+
+		Page<Plan> page1 = planResource.getPlansPage(
+			Pagination.of(1, totalCount + 2));
+
+		List<Plan> plans1 = (List<Plan>)page1.getItems();
+
+		Assert.assertEquals(plans1.toString(), totalCount + 2, plans1.size());
+
+		Page<Plan> page2 = planResource.getPlansPage(
+			Pagination.of(2, totalCount + 2));
+
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+		List<Plan> plans2 = (List<Plan>)page2.getItems();
+
+		Assert.assertEquals(plans2.toString(), 1, plans2.size());
+
+		Page<Plan> page3 = planResource.getPlansPage(
+			Pagination.of(1, totalCount + 3));
+
+		assertContains(plan1, (List<Plan>)page3.getItems());
+		assertContains(plan2, (List<Plan>)page3.getItems());
+		assertContains(plan3, (List<Plan>)page3.getItems());
+	}
+
+	protected Plan testGetPlansPage_addPlan(Plan plan) throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -302,6 +363,20 @@ public abstract class BasePlanResourceTestCase {
 
 			assertEquals(plan1, plan2);
 		}
+	}
+
+	protected void assertContains(Plan plan, List<Plan> plans) {
+		boolean contains = false;
+
+		for (Plan item : plans) {
+			if (equals(plan, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(plans + " does not contain " + plan, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-batch-planner/headless-admin-batch-planner-test/src/testIntegration/java/com/liferay/headless/admin/batch/planner/resource/v1_0/test/PlanResourceTest.java
+++ b/modules/apps/headless/headless-admin-batch-planner/headless-admin-batch-planner-test/src/testIntegration/java/com/liferay/headless/admin/batch/planner/resource/v1_0/test/PlanResourceTest.java
@@ -16,18 +16,10 @@ package com.liferay.headless.admin.batch.planner.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.batch.planner.client.dto.v1_0.Plan;
-import com.liferay.headless.admin.batch.planner.client.pagination.Page;
-import com.liferay.headless.admin.batch.planner.client.pagination.Pagination;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import org.junit.Assert;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -36,34 +28,6 @@ import org.junit.runner.RunWith;
 @DataGuard(scope = DataGuard.Scope.METHOD)
 @RunWith(Arquillian.class)
 public class PlanResourceTest extends BasePlanResourceTestCase {
-
-	@Override
-	@Test
-	public void testGetPlansPage() throws Exception {
-		Page<Plan> plansPage = planResource.getPlansPage(Pagination.of(1, 5));
-
-		Assert.assertEquals(0, plansPage.getTotalCount());
-
-		Collection<Plan> plans = plansPage.getItems();
-
-		Assert.assertTrue(plans.isEmpty());
-
-		List<Plan> randomPlans = new ArrayList<>();
-		int randomPlansCount = RandomTestUtil.randomInt(5, 10);
-
-		for (int i = 0; i < randomPlansCount; i++) {
-			randomPlans.add(_addPlan());
-		}
-
-		plansPage = planResource.getPlansPage(Pagination.of(1, 5));
-
-		Assert.assertEquals(randomPlansCount, plansPage.getTotalCount());
-
-		plans = plansPage.getItems();
-
-		Assert.assertEquals(plans.toString(), 5, plans.size());
-		Assert.assertTrue(randomPlans.containsAll(plans));
-	}
 
 	@Override
 	protected Plan randomPlan() {
@@ -90,6 +54,11 @@ public class PlanResourceTest extends BasePlanResourceTestCase {
 	@Override
 	protected Plan testGetPlan_addPlan() throws Exception {
 		return _addPlan();
+	}
+
+	@Override
+	protected Plan testGetPlansPage_addPlan(Plan plan) throws Exception {
+		return planResource.postPlan(plan);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
@@ -205,16 +205,15 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 
 	@Test
 	public void testGetSiteDisplayPageTemplatesPage() throws Exception {
-		Page<DisplayPageTemplate> page =
-			displayPageTemplateResource.getSiteDisplayPageTemplatesPage(
-				testGetSiteDisplayPageTemplatesPage_getSiteId(),
-				Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteDisplayPageTemplatesPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteDisplayPageTemplatesPage_getIrrelevantSiteId();
+
+		Page<DisplayPageTemplate> page =
+			displayPageTemplateResource.getSiteDisplayPageTemplatesPage(
+				siteId, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			DisplayPageTemplate irrelevantDisplayPageTemplate =
@@ -241,7 +240,7 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 				siteId, randomDisplayPageTemplate());
 
 		page = displayPageTemplateResource.getSiteDisplayPageTemplatesPage(
-			siteId, Pagination.of(1, 2), null);
+			siteId, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -509,6 +508,25 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 
 			assertEquals(displayPageTemplate1, displayPageTemplate2);
 		}
+	}
+
+	protected void assertContains(
+		DisplayPageTemplate displayPageTemplate,
+		List<DisplayPageTemplate> displayPageTemplates) {
+
+		boolean contains = false;
+
+		for (DisplayPageTemplate item : displayPageTemplates) {
+			if (equals(displayPageTemplate, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			displayPageTemplates + " does not contain " + displayPageTemplate,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BasePageDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BasePageDefinitionResourceTestCase.java
@@ -220,6 +220,23 @@ public abstract class BasePageDefinitionResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		PageDefinition pageDefinition, List<PageDefinition> pageDefinitions) {
+
+		boolean contains = false;
+
+		for (PageDefinition item : pageDefinitions) {
+			if (equals(pageDefinition, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			pageDefinitions + " does not contain " + pageDefinition, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<PageDefinition> pageDefinitions1,
 		List<PageDefinition> pageDefinitions2) {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -214,17 +214,16 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 	@Test
 	public void testGetSiteStructuredContentsPage() throws Exception {
-		Page<StructuredContent> page =
-			structuredContentResource.getSiteStructuredContentsPage(
-				testGetSiteStructuredContentsPage_getSiteId(), null,
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteStructuredContentsPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteStructuredContentsPage_getIrrelevantSiteId();
+
+		Page<StructuredContent> page =
+			structuredContentResource.getSiteStructuredContentsPage(
+				siteId, null, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			StructuredContent irrelevantStructuredContent =
@@ -252,7 +251,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 				siteId, randomStructuredContent());
 
 		page = structuredContentResource.getSiteStructuredContentsPage(
-			siteId, null, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -541,7 +540,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -564,7 +563,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/structuredContents");
 
-		Assert.assertEquals(2, structuredContentsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			2, structuredContentsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(structuredContent1, structuredContent2),
@@ -700,16 +700,16 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 	@Test
 	public void testGetStructuredContentsVersionsPage() throws Exception {
-		Page<StructuredContent> page =
-			structuredContentResource.getStructuredContentsVersionsPage(
-				testGetStructuredContentsVersionsPage_getStructuredContentId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long structuredContentId =
 			testGetStructuredContentsVersionsPage_getStructuredContentId();
 		Long irrelevantStructuredContentId =
 			testGetStructuredContentsVersionsPage_getIrrelevantStructuredContentId();
+
+		Page<StructuredContent> page =
+			structuredContentResource.getStructuredContentsVersionsPage(
+				structuredContentId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantStructuredContentId != null) {
 			StructuredContent irrelevantStructuredContent =
@@ -812,6 +812,25 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 			assertEquals(structuredContent1, structuredContent2);
 		}
+	}
+
+	protected void assertContains(
+		StructuredContent structuredContent,
+		List<StructuredContent> structuredContents) {
+
+		boolean contains = false;
+
+		for (StructuredContent item : structuredContents) {
+			if (equals(structuredContent, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			structuredContents + " does not contain " + structuredContent,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.admin.list.type.client.dto.v1_0.ListTypeDefinition;
 import com.liferay.headless.admin.list.type.client.http.HttpInvoker;
 import com.liferay.headless.admin.list.type.client.pagination.Page;
+import com.liferay.headless.admin.list.type.client.pagination.Pagination;
 import com.liferay.headless.admin.list.type.client.resource.v1_0.ListTypeDefinitionResource;
 import com.liferay.headless.admin.list.type.client.serdes.v1_0.ListTypeDefinitionSerDes;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -41,6 +42,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -195,7 +197,101 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 
 	@Test
 	public void testGetListTypeDefinitionsPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<ListTypeDefinition> page =
+			listTypeDefinitionResource.getListTypeDefinitionsPage(
+				Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		ListTypeDefinition listTypeDefinition1 =
+			testGetListTypeDefinitionsPage_addListTypeDefinition(
+				randomListTypeDefinition());
+
+		ListTypeDefinition listTypeDefinition2 =
+			testGetListTypeDefinitionsPage_addListTypeDefinition(
+				randomListTypeDefinition());
+
+		page = listTypeDefinitionResource.getListTypeDefinitionsPage(
+			Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(
+			listTypeDefinition1, (List<ListTypeDefinition>)page.getItems());
+		assertContains(
+			listTypeDefinition2, (List<ListTypeDefinition>)page.getItems());
+		assertValid(page);
+
+		listTypeDefinitionResource.deleteListTypeDefinition(
+			listTypeDefinition1.getId());
+
+		listTypeDefinitionResource.deleteListTypeDefinition(
+			listTypeDefinition2.getId());
+	}
+
+	@Test
+	public void testGetListTypeDefinitionsPageWithPagination()
+		throws Exception {
+
+		Page<ListTypeDefinition> totalPage =
+			listTypeDefinitionResource.getListTypeDefinitionsPage(null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
+		ListTypeDefinition listTypeDefinition1 =
+			testGetListTypeDefinitionsPage_addListTypeDefinition(
+				randomListTypeDefinition());
+
+		ListTypeDefinition listTypeDefinition2 =
+			testGetListTypeDefinitionsPage_addListTypeDefinition(
+				randomListTypeDefinition());
+
+		ListTypeDefinition listTypeDefinition3 =
+			testGetListTypeDefinitionsPage_addListTypeDefinition(
+				randomListTypeDefinition());
+
+		Page<ListTypeDefinition> page1 =
+			listTypeDefinitionResource.getListTypeDefinitionsPage(
+				Pagination.of(1, totalCount + 2));
+
+		List<ListTypeDefinition> listTypeDefinitions1 =
+			(List<ListTypeDefinition>)page1.getItems();
+
+		Assert.assertEquals(
+			listTypeDefinitions1.toString(), totalCount + 2,
+			listTypeDefinitions1.size());
+
+		Page<ListTypeDefinition> page2 =
+			listTypeDefinitionResource.getListTypeDefinitionsPage(
+				Pagination.of(2, totalCount + 2));
+
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+		List<ListTypeDefinition> listTypeDefinitions2 =
+			(List<ListTypeDefinition>)page2.getItems();
+
+		Assert.assertEquals(
+			listTypeDefinitions2.toString(), 1, listTypeDefinitions2.size());
+
+		Page<ListTypeDefinition> page3 =
+			listTypeDefinitionResource.getListTypeDefinitionsPage(
+				Pagination.of(1, totalCount + 3));
+
+		assertContains(
+			listTypeDefinition1, (List<ListTypeDefinition>)page3.getItems());
+		assertContains(
+			listTypeDefinition2, (List<ListTypeDefinition>)page3.getItems());
+		assertContains(
+			listTypeDefinition3, (List<ListTypeDefinition>)page3.getItems());
+	}
+
+	protected ListTypeDefinition
+			testGetListTypeDefinitionsPage_addListTypeDefinition(
+				ListTypeDefinition listTypeDefinition)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -205,7 +301,7 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -216,7 +312,7 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 				invokeGraphQLQuery(graphQLField), "JSONObject/data",
 				"JSONObject/listTypeDefinitions");
 
-		Assert.assertEquals(0, listTypeDefinitionsJSONObject.get("totalCount"));
+		long totalCount = listTypeDefinitionsJSONObject.getLong("totalCount");
 
 		ListTypeDefinition listTypeDefinition1 =
 			testGraphQLListTypeDefinition_addListTypeDefinition();
@@ -227,10 +323,17 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/listTypeDefinitions");
 
-		Assert.assertEquals(2, listTypeDefinitionsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2,
+			listTypeDefinitionsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(listTypeDefinition1, listTypeDefinition2),
+		assertContains(
+			listTypeDefinition1,
+			Arrays.asList(
+				ListTypeDefinitionSerDes.toDTOs(
+					listTypeDefinitionsJSONObject.getString("items"))));
+		assertContains(
+			listTypeDefinition2,
 			Arrays.asList(
 				ListTypeDefinitionSerDes.toDTOs(
 					listTypeDefinitionsJSONObject.getString("items"))));
@@ -461,6 +564,25 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 
 			assertEquals(listTypeDefinition1, listTypeDefinition2);
 		}
+	}
+
+	protected void assertContains(
+		ListTypeDefinition listTypeDefinition,
+		List<ListTypeDefinition> listTypeDefinitions) {
+
+		boolean contains = false;
+
+		for (ListTypeDefinition item : listTypeDefinitions) {
+			if (equals(listTypeDefinition, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			listTypeDefinitions + " does not contain " + listTypeDefinition,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
@@ -199,17 +199,16 @@ public abstract class BaseListTypeEntryResourceTestCase {
 	public void testGetListTypeDefinitionListTypeEntriesPage()
 		throws Exception {
 
-		Page<ListTypeEntry> page =
-			listTypeEntryResource.getListTypeDefinitionListTypeEntriesPage(
-				testGetListTypeDefinitionListTypeEntriesPage_getListTypeDefinitionId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long listTypeDefinitionId =
 			testGetListTypeDefinitionListTypeEntriesPage_getListTypeDefinitionId();
 		Long irrelevantListTypeDefinitionId =
 			testGetListTypeDefinitionListTypeEntriesPage_getIrrelevantListTypeDefinitionId();
+
+		Page<ListTypeEntry> page =
+			listTypeEntryResource.getListTypeDefinitionListTypeEntriesPage(
+				listTypeDefinitionId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantListTypeDefinitionId != null) {
 			ListTypeEntry irrelevantListTypeEntry =
@@ -238,7 +237,7 @@ public abstract class BaseListTypeEntryResourceTestCase {
 				listTypeDefinitionId, randomListTypeEntry());
 
 		page = listTypeEntryResource.getListTypeDefinitionListTypeEntriesPage(
-			listTypeDefinitionId, Pagination.of(1, 2));
+			listTypeDefinitionId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -379,6 +378,23 @@ public abstract class BaseListTypeEntryResourceTestCase {
 
 			assertEquals(listTypeEntry1, listTypeEntry2);
 		}
+	}
+
+	protected void assertContains(
+		ListTypeEntry listTypeEntry, List<ListTypeEntry> listTypeEntries) {
+
+		boolean contains = false;
+
+		for (ListTypeEntry item : listTypeEntries) {
+			if (equals(listTypeEntry, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			listTypeEntries + " does not contain " + listTypeEntry, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/ListTypeDefinitionResourceTest.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/ListTypeDefinitionResourceTest.java
@@ -17,13 +17,10 @@ package com.liferay.headless.admin.list.type.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.list.type.client.dto.v1_0.ListTypeDefinition;
 import com.liferay.headless.admin.list.type.client.dto.v1_0.ListTypeEntry;
-import com.liferay.headless.admin.list.type.client.pagination.Page;
-import com.liferay.headless.admin.list.type.client.pagination.Pagination;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.util.Collections;
 
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,25 +31,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class ListTypeDefinitionResourceTest
 	extends BaseListTypeDefinitionResourceTestCase {
-
-	@Override
-	@Test
-	public void testGetListTypeDefinitionsPage() throws Exception {
-		Page<ListTypeDefinition> listTypeDefinitionsPage =
-			listTypeDefinitionResource.getListTypeDefinitionsPage(
-				Pagination.of(1, 10));
-
-		long totalCount = listTypeDefinitionsPage.getTotalCount();
-
-		_addListTypeDefinition(randomListTypeDefinition());
-
-		listTypeDefinitionsPage =
-			listTypeDefinitionResource.getListTypeDefinitionsPage(
-				Pagination.of(1, 10));
-
-		Assert.assertEquals(
-			totalCount + 1, listTypeDefinitionsPage.getTotalCount());
-	}
 
 	@Ignore
 	@Override
@@ -106,6 +84,15 @@ public class ListTypeDefinitionResourceTest
 		throws Exception {
 
 		return _addListTypeDefinition(randomListTypeDefinition());
+	}
+
+	@Override
+	protected ListTypeDefinition
+			testGetListTypeDefinitionsPage_addListTypeDefinition(
+				ListTypeDefinition listTypeDefinition)
+		throws Exception {
+
+		return _addListTypeDefinition(listTypeDefinition);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -221,16 +222,16 @@ public abstract class BaseKeywordResourceTestCase {
 
 	@Test
 	public void testGetAssetLibraryKeywordsPage() throws Exception {
-		Page<Keyword> page = keywordResource.getAssetLibraryKeywordsPage(
-			testGetAssetLibraryKeywordsPage_getAssetLibraryId(),
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryKeywordsPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
 			testGetAssetLibraryKeywordsPage_getIrrelevantAssetLibraryId();
+
+		Page<Keyword> page = keywordResource.getAssetLibraryKeywordsPage(
+			assetLibraryId, RandomTestUtil.randomString(), null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAssetLibraryId != null) {
 			Keyword irrelevantKeyword =
@@ -256,7 +257,7 @@ public abstract class BaseKeywordResourceTestCase {
 			assetLibraryId, randomKeyword());
 
 		page = keywordResource.getAssetLibraryKeywordsPage(
-			assetLibraryId, null, null, Pagination.of(1, 2), null);
+			assetLibraryId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -596,9 +597,9 @@ public abstract class BaseKeywordResourceTestCase {
 	@Test
 	public void testGetKeywordsRankedPage() throws Exception {
 		Page<Keyword> page = keywordResource.getKeywordsRankedPage(
-			null, RandomTestUtil.randomString(), Pagination.of(1, 2));
+			null, RandomTestUtil.randomString(), Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Keyword keyword1 = testGetKeywordsRankedPage_addKeyword(
 			randomKeyword());
@@ -607,12 +608,12 @@ public abstract class BaseKeywordResourceTestCase {
 			randomKeyword());
 
 		page = keywordResource.getKeywordsRankedPage(
-			null, null, Pagination.of(1, 2));
+			null, null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(keyword1, keyword2), (List<Keyword>)page.getItems());
+		assertContains(keyword1, (List<Keyword>)page.getItems());
+		assertContains(keyword2, (List<Keyword>)page.getItems());
 		assertValid(page);
 
 		keywordResource.deleteKeyword(keyword1.getId());
@@ -622,6 +623,11 @@ public abstract class BaseKeywordResourceTestCase {
 
 	@Test
 	public void testGetKeywordsRankedPageWithPagination() throws Exception {
+		Page<Keyword> totalPage = keywordResource.getKeywordsRankedPage(
+			null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Keyword keyword1 = testGetKeywordsRankedPage_addKeyword(
 			randomKeyword());
 
@@ -632,27 +638,28 @@ public abstract class BaseKeywordResourceTestCase {
 			randomKeyword());
 
 		Page<Keyword> page1 = keywordResource.getKeywordsRankedPage(
-			null, null, Pagination.of(1, 2));
+			null, null, Pagination.of(1, totalCount + 2));
 
 		List<Keyword> keywords1 = (List<Keyword>)page1.getItems();
 
-		Assert.assertEquals(keywords1.toString(), 2, keywords1.size());
+		Assert.assertEquals(
+			keywords1.toString(), totalCount + 2, keywords1.size());
 
 		Page<Keyword> page2 = keywordResource.getKeywordsRankedPage(
-			null, null, Pagination.of(2, 2));
+			null, null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Keyword> keywords2 = (List<Keyword>)page2.getItems();
 
 		Assert.assertEquals(keywords2.toString(), 1, keywords2.size());
 
 		Page<Keyword> page3 = keywordResource.getKeywordsRankedPage(
-			null, null, Pagination.of(1, 3));
+			null, null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(keyword1, keyword2, keyword3),
-			(List<Keyword>)page3.getItems());
+		assertContains(keyword1, (List<Keyword>)page3.getItems());
+		assertContains(keyword2, (List<Keyword>)page3.getItems());
+		assertContains(keyword3, (List<Keyword>)page3.getItems());
 	}
 
 	protected Keyword testGetKeywordsRankedPage_addKeyword(Keyword keyword)
@@ -830,14 +837,14 @@ public abstract class BaseKeywordResourceTestCase {
 
 	@Test
 	public void testGetSiteKeywordsPage() throws Exception {
-		Page<Keyword> page = keywordResource.getSiteKeywordsPage(
-			testGetSiteKeywordsPage_getSiteId(), RandomTestUtil.randomString(),
-			null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteKeywordsPage_getSiteId();
 		Long irrelevantSiteId = testGetSiteKeywordsPage_getIrrelevantSiteId();
+
+		Page<Keyword> page = keywordResource.getSiteKeywordsPage(
+			siteId, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+			null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			Keyword irrelevantKeyword = testGetSiteKeywordsPage_addKeyword(
@@ -861,7 +868,7 @@ public abstract class BaseKeywordResourceTestCase {
 			siteId, randomKeyword());
 
 		page = keywordResource.getSiteKeywordsPage(
-			siteId, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1112,7 +1119,7 @@ public abstract class BaseKeywordResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -1133,7 +1140,7 @@ public abstract class BaseKeywordResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/keywords");
 
-		Assert.assertEquals(2, keywordsJSONObject.get("totalCount"));
+		Assert.assertEquals(2, keywordsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(keyword1, keyword2),
@@ -1347,6 +1354,20 @@ public abstract class BaseKeywordResourceTestCase {
 
 			assertEquals(keyword1, keyword2);
 		}
+	}
+
+	protected void assertContains(Keyword keyword, List<Keyword> keywords) {
+		boolean contains = false;
+
+		for (Keyword item : keywords) {
+			if (equals(keyword, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(keywords + " does not contain " + keyword, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -46,6 +46,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -212,9 +213,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	public void testGetTaxonomyCategoryRankedPage() throws Exception {
 		Page<TaxonomyCategory> page =
 			taxonomyCategoryResource.getTaxonomyCategoryRankedPage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		TaxonomyCategory taxonomyCategory1 =
 			testGetTaxonomyCategoryRankedPage_addTaxonomyCategory(
@@ -225,13 +226,14 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				randomTaxonomyCategory());
 
 		page = taxonomyCategoryResource.getTaxonomyCategoryRankedPage(
-			null, Pagination.of(1, 2));
+			null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(taxonomyCategory1, taxonomyCategory2),
-			(List<TaxonomyCategory>)page.getItems());
+		assertContains(
+			taxonomyCategory1, (List<TaxonomyCategory>)page.getItems());
+		assertContains(
+			taxonomyCategory2, (List<TaxonomyCategory>)page.getItems());
 		assertValid(page);
 
 		taxonomyCategoryResource.deleteTaxonomyCategory(
@@ -244,6 +246,11 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	@Test
 	public void testGetTaxonomyCategoryRankedPageWithPagination()
 		throws Exception {
+
+		Page<TaxonomyCategory> totalPage =
+			taxonomyCategoryResource.getTaxonomyCategoryRankedPage(null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
 
 		TaxonomyCategory taxonomyCategory1 =
 			testGetTaxonomyCategoryRankedPage_addTaxonomyCategory(
@@ -259,19 +266,20 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 		Page<TaxonomyCategory> page1 =
 			taxonomyCategoryResource.getTaxonomyCategoryRankedPage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, totalCount + 2));
 
 		List<TaxonomyCategory> taxonomyCategories1 =
 			(List<TaxonomyCategory>)page1.getItems();
 
 		Assert.assertEquals(
-			taxonomyCategories1.toString(), 2, taxonomyCategories1.size());
+			taxonomyCategories1.toString(), totalCount + 2,
+			taxonomyCategories1.size());
 
 		Page<TaxonomyCategory> page2 =
 			taxonomyCategoryResource.getTaxonomyCategoryRankedPage(
-				null, Pagination.of(2, 2));
+				null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<TaxonomyCategory> taxonomyCategories2 =
 			(List<TaxonomyCategory>)page2.getItems();
@@ -281,12 +289,14 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 		Page<TaxonomyCategory> page3 =
 			taxonomyCategoryResource.getTaxonomyCategoryRankedPage(
-				null, Pagination.of(1, 3));
+				null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(
-				taxonomyCategory1, taxonomyCategory2, taxonomyCategory3),
-			(List<TaxonomyCategory>)page3.getItems());
+		assertContains(
+			taxonomyCategory1, (List<TaxonomyCategory>)page3.getItems());
+		assertContains(
+			taxonomyCategory2, (List<TaxonomyCategory>)page3.getItems());
+		assertContains(
+			taxonomyCategory3, (List<TaxonomyCategory>)page3.getItems());
 	}
 
 	protected TaxonomyCategory
@@ -302,17 +312,17 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	public void testGetTaxonomyCategoryTaxonomyCategoriesPage()
 		throws Exception {
 
-		Page<TaxonomyCategory> page =
-			taxonomyCategoryResource.getTaxonomyCategoryTaxonomyCategoriesPage(
-				testGetTaxonomyCategoryTaxonomyCategoriesPage_getParentTaxonomyCategoryId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String parentTaxonomyCategoryId =
 			testGetTaxonomyCategoryTaxonomyCategoriesPage_getParentTaxonomyCategoryId();
 		String irrelevantParentTaxonomyCategoryId =
 			testGetTaxonomyCategoryTaxonomyCategoriesPage_getIrrelevantParentTaxonomyCategoryId();
+
+		Page<TaxonomyCategory> page =
+			taxonomyCategoryResource.getTaxonomyCategoryTaxonomyCategoriesPage(
+				parentTaxonomyCategoryId, RandomTestUtil.randomString(), null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantParentTaxonomyCategoryId != null) {
 			TaxonomyCategory irrelevantTaxonomyCategory =
@@ -344,7 +354,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 		page =
 			taxonomyCategoryResource.getTaxonomyCategoryTaxonomyCategoriesPage(
-				parentTaxonomyCategoryId, null, null, Pagination.of(1, 2),
+				parentTaxonomyCategoryId, null, null, Pagination.of(1, 10),
 				null);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -931,19 +941,18 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	public void testGetTaxonomyVocabularyTaxonomyCategoriesPage()
 		throws Exception {
 
-		Page<TaxonomyCategory> page =
-			taxonomyCategoryResource.
-				getTaxonomyVocabularyTaxonomyCategoriesPage(
-					testGetTaxonomyVocabularyTaxonomyCategoriesPage_getTaxonomyVocabularyId(),
-					RandomTestUtil.randomString(), null, Pagination.of(1, 2),
-					null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long taxonomyVocabularyId =
 			testGetTaxonomyVocabularyTaxonomyCategoriesPage_getTaxonomyVocabularyId();
 		Long irrelevantTaxonomyVocabularyId =
 			testGetTaxonomyVocabularyTaxonomyCategoriesPage_getIrrelevantTaxonomyVocabularyId();
+
+		Page<TaxonomyCategory> page =
+			taxonomyCategoryResource.
+				getTaxonomyVocabularyTaxonomyCategoriesPage(
+					taxonomyVocabularyId, RandomTestUtil.randomString(), null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantTaxonomyVocabularyId != null) {
 			TaxonomyCategory irrelevantTaxonomyCategory =
@@ -976,7 +985,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		page =
 			taxonomyCategoryResource.
 				getTaxonomyVocabularyTaxonomyCategoriesPage(
-					taxonomyVocabularyId, null, null, Pagination.of(1, 2),
+					taxonomyVocabularyId, null, null, Pagination.of(1, 10),
 					null);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -1343,6 +1352,25 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 			assertEquals(taxonomyCategory1, taxonomyCategory2);
 		}
+	}
+
+	protected void assertContains(
+		TaxonomyCategory taxonomyCategory,
+		List<TaxonomyCategory> taxonomyCategories) {
+
+		boolean contains = false;
+
+		for (TaxonomyCategory item : taxonomyCategories) {
+			if (equals(taxonomyCategory, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			taxonomyCategories + " does not contain " + taxonomyCategory,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -225,17 +225,17 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 
 	@Test
 	public void testGetAssetLibraryTaxonomyVocabulariesPage() throws Exception {
-		Page<TaxonomyVocabulary> page =
-			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
-				testGetAssetLibraryTaxonomyVocabulariesPage_getAssetLibraryId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryTaxonomyVocabulariesPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
 			testGetAssetLibraryTaxonomyVocabulariesPage_getIrrelevantAssetLibraryId();
+
+		Page<TaxonomyVocabulary> page =
+			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
+				assetLibraryId, RandomTestUtil.randomString(), null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAssetLibraryId != null) {
 			TaxonomyVocabulary irrelevantTaxonomyVocabulary =
@@ -267,7 +267,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 
 		page =
 			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
-				assetLibraryId, null, null, Pagination.of(1, 2), null);
+				assetLibraryId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -657,16 +657,16 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 
 	@Test
 	public void testGetSiteTaxonomyVocabulariesPage() throws Exception {
-		Page<TaxonomyVocabulary> page =
-			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-				testGetSiteTaxonomyVocabulariesPage_getSiteId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteTaxonomyVocabulariesPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteTaxonomyVocabulariesPage_getIrrelevantSiteId();
+
+		Page<TaxonomyVocabulary> page =
+			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+				siteId, RandomTestUtil.randomString(), null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			TaxonomyVocabulary irrelevantTaxonomyVocabulary =
@@ -693,7 +693,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 				siteId, randomTaxonomyVocabulary());
 
 		page = taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-			siteId, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -989,7 +989,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -1015,7 +1015,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			"JSONObject/taxonomyVocabularies");
 
 		Assert.assertEquals(
-			2, taxonomyVocabulariesJSONObject.get("totalCount"));
+			2, taxonomyVocabulariesJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(taxonomyVocabulary1, taxonomyVocabulary2),
@@ -1525,6 +1525,25 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 
 			assertEquals(taxonomyVocabulary1, taxonomyVocabulary2);
 		}
+	}
+
+	protected void assertContains(
+		TaxonomyVocabulary taxonomyVocabulary,
+		List<TaxonomyVocabulary> taxonomyVocabularies) {
+
+		boolean contains = false;
+
+		for (TaxonomyVocabulary item : taxonomyVocabularies) {
+			if (equals(taxonomyVocabulary, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			taxonomyVocabularies + " does not contain " + taxonomyVocabulary,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -205,21 +206,21 @@ public abstract class BaseAccountResourceTestCase {
 	@Test
 	public void testGetAccountsPage() throws Exception {
 		Page<Account> page = accountResource.getAccountsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Account account1 = testGetAccountsPage_addAccount(randomAccount());
 
 		Account account2 = testGetAccountsPage_addAccount(randomAccount());
 
 		page = accountResource.getAccountsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(account1, account2), (List<Account>)page.getItems());
+		assertContains(account1, (List<Account>)page.getItems());
+		assertContains(account2, (List<Account>)page.getItems());
 		assertValid(page);
 
 		accountResource.deleteAccount(account1.getId());
@@ -278,6 +279,11 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGetAccountsPageWithPagination() throws Exception {
+		Page<Account> totalPage = accountResource.getAccountsPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Account account1 = testGetAccountsPage_addAccount(randomAccount());
 
 		Account account2 = testGetAccountsPage_addAccount(randomAccount());
@@ -285,27 +291,28 @@ public abstract class BaseAccountResourceTestCase {
 		Account account3 = testGetAccountsPage_addAccount(randomAccount());
 
 		Page<Account> page1 = accountResource.getAccountsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Account> accounts1 = (List<Account>)page1.getItems();
 
-		Assert.assertEquals(accounts1.toString(), 2, accounts1.size());
+		Assert.assertEquals(
+			accounts1.toString(), totalCount + 2, accounts1.size());
 
 		Page<Account> page2 = accountResource.getAccountsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Account> accounts2 = (List<Account>)page2.getItems();
 
 		Assert.assertEquals(accounts2.toString(), 1, accounts2.size());
 
 		Page<Account> page3 = accountResource.getAccountsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(account1, account2, account3),
-			(List<Account>)page3.getItems());
+		assertContains(account1, (List<Account>)page3.getItems());
+		assertContains(account2, (List<Account>)page3.getItems());
+		assertContains(account3, (List<Account>)page3.getItems());
 	}
 
 	@Test
@@ -436,7 +443,7 @@ public abstract class BaseAccountResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -446,7 +453,7 @@ public abstract class BaseAccountResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/accounts");
 
-		Assert.assertEquals(0, accountsJSONObject.get("totalCount"));
+		long totalCount = accountsJSONObject.getLong("totalCount");
 
 		Account account1 = testGraphQLAccount_addAccount();
 		Account account2 = testGraphQLAccount_addAccount();
@@ -455,10 +462,15 @@ public abstract class BaseAccountResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/accounts");
 
-		Assert.assertEquals(2, accountsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, accountsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(account1, account2),
+		assertContains(
+			account1,
+			Arrays.asList(
+				AccountSerDes.toDTOs(accountsJSONObject.getString("items"))));
+		assertContains(
+			account2,
 			Arrays.asList(
 				AccountSerDes.toDTOs(accountsJSONObject.getString("items"))));
 	}
@@ -888,16 +900,16 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGetOrganizationAccountsPage() throws Exception {
-		Page<Account> page = accountResource.getOrganizationAccountsPage(
-			testGetOrganizationAccountsPage_getOrganizationId(),
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String organizationId =
 			testGetOrganizationAccountsPage_getOrganizationId();
 		String irrelevantOrganizationId =
 			testGetOrganizationAccountsPage_getIrrelevantOrganizationId();
+
+		Page<Account> page = accountResource.getOrganizationAccountsPage(
+			organizationId, RandomTestUtil.randomString(), null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantOrganizationId != null) {
 			Account irrelevantAccount =
@@ -923,7 +935,7 @@ public abstract class BaseAccountResourceTestCase {
 			organizationId, randomAccount());
 
 		page = accountResource.getOrganizationAccountsPage(
-			organizationId, null, null, Pagination.of(1, 2), null);
+			organizationId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1294,6 +1306,20 @@ public abstract class BaseAccountResourceTestCase {
 
 			assertEquals(account1, account2);
 		}
+	}
+
+	protected void assertContains(Account account, List<Account> accounts) {
+		boolean contains = false;
+
+		for (Account item : accounts) {
+			if (equals(account, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(accounts + " does not contain " + account, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -256,14 +256,6 @@ public abstract class BaseAccountRoleResourceTestCase {
 	public void testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage()
 		throws Exception {
 
-		Page<AccountRole> page =
-			accountRoleResource.
-				getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage(
-					testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getAccountExternalReferenceCode(),
-					testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getUserAccountExternalReferenceCode());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String accountExternalReferenceCode =
 			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getAccountExternalReferenceCode();
 		String irrelevantAccountExternalReferenceCode =
@@ -272,6 +264,14 @@ public abstract class BaseAccountRoleResourceTestCase {
 			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getUserAccountExternalReferenceCode();
 		String irrelevantUserAccountExternalReferenceCode =
 			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getIrrelevantUserAccountExternalReferenceCode();
+
+		Page<AccountRole> page =
+			accountRoleResource.
+				getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage(
+					accountExternalReferenceCode,
+					userAccountExternalReferenceCode);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantAccountExternalReferenceCode != null) &&
 			(irrelevantUserAccountExternalReferenceCode != null)) {
@@ -365,18 +365,18 @@ public abstract class BaseAccountRoleResourceTestCase {
 	public void testGetAccountAccountRolesByExternalReferenceCodePage()
 		throws Exception {
 
-		Page<AccountRole> page =
-			accountRoleResource.
-				getAccountAccountRolesByExternalReferenceCodePage(
-					testGetAccountAccountRolesByExternalReferenceCodePage_getExternalReferenceCode(),
-					RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetAccountAccountRolesByExternalReferenceCodePage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetAccountAccountRolesByExternalReferenceCodePage_getIrrelevantExternalReferenceCode();
+
+		Page<AccountRole> page =
+			accountRoleResource.
+				getAccountAccountRolesByExternalReferenceCodePage(
+					externalReferenceCode, RandomTestUtil.randomString(),
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			AccountRole irrelevantAccountRole =
@@ -409,7 +409,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 		page =
 			accountRoleResource.
 				getAccountAccountRolesByExternalReferenceCodePage(
-					externalReferenceCode, null, Pagination.of(1, 2), null);
+					externalReferenceCode, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -704,14 +704,6 @@ public abstract class BaseAccountRoleResourceTestCase {
 	public void testGetAccountByExternalReferenceCodeUserAccountByEmailAddressAccountRolesPage()
 		throws Exception {
 
-		Page<AccountRole> page =
-			accountRoleResource.
-				getAccountByExternalReferenceCodeUserAccountByEmailAddressAccountRolesPage(
-					testGetAccountByExternalReferenceCodeUserAccountByEmailAddressAccountRolesPage_getExternalReferenceCode(),
-					testGetAccountByExternalReferenceCodeUserAccountByEmailAddressAccountRolesPage_getEmailAddress());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetAccountByExternalReferenceCodeUserAccountByEmailAddressAccountRolesPage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
@@ -720,6 +712,13 @@ public abstract class BaseAccountRoleResourceTestCase {
 			testGetAccountByExternalReferenceCodeUserAccountByEmailAddressAccountRolesPage_getEmailAddress();
 		String irrelevantEmailAddress =
 			testGetAccountByExternalReferenceCodeUserAccountByEmailAddressAccountRolesPage_getIrrelevantEmailAddress();
+
+		Page<AccountRole> page =
+			accountRoleResource.
+				getAccountByExternalReferenceCodeUserAccountByEmailAddressAccountRolesPage(
+					externalReferenceCode, emailAddress);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantExternalReferenceCode != null) &&
 			(irrelevantEmailAddress != null)) {
@@ -806,15 +805,15 @@ public abstract class BaseAccountRoleResourceTestCase {
 
 	@Test
 	public void testGetAccountAccountRolesPage() throws Exception {
-		Page<AccountRole> page = accountRoleResource.getAccountAccountRolesPage(
-			testGetAccountAccountRolesPage_getAccountId(),
-			RandomTestUtil.randomString(), Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long accountId = testGetAccountAccountRolesPage_getAccountId();
 		Long irrelevantAccountId =
 			testGetAccountAccountRolesPage_getIrrelevantAccountId();
+
+		Page<AccountRole> page = accountRoleResource.getAccountAccountRolesPage(
+			accountId, RandomTestUtil.randomString(), Pagination.of(1, 10),
+			null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAccountId != null) {
 			AccountRole irrelevantAccountRole =
@@ -841,7 +840,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 				accountId, randomAccountRole());
 
 		page = accountRoleResource.getAccountAccountRolesPage(
-			accountId, null, Pagination.of(1, 2), null);
+			accountId, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1148,6 +1147,23 @@ public abstract class BaseAccountRoleResourceTestCase {
 
 			assertEquals(accountRole1, accountRole2);
 		}
+	}
+
+	protected void assertContains(
+		AccountRole accountRole, List<AccountRole> accountRoles) {
+
+		boolean contains = false;
+
+		for (AccountRole item : accountRoles) {
+			if (equals(accountRole, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			accountRoles + " does not contain " + accountRole, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
@@ -254,16 +254,16 @@ public abstract class BaseEmailAddressResourceTestCase {
 
 	@Test
 	public void testGetOrganizationEmailAddressesPage() throws Exception {
-		Page<EmailAddress> page =
-			emailAddressResource.getOrganizationEmailAddressesPage(
-				testGetOrganizationEmailAddressesPage_getOrganizationId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String organizationId =
 			testGetOrganizationEmailAddressesPage_getOrganizationId();
 		String irrelevantOrganizationId =
 			testGetOrganizationEmailAddressesPage_getIrrelevantOrganizationId();
+
+		Page<EmailAddress> page =
+			emailAddressResource.getOrganizationEmailAddressesPage(
+				organizationId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantOrganizationId != null) {
 			EmailAddress irrelevantEmailAddress =
@@ -325,16 +325,16 @@ public abstract class BaseEmailAddressResourceTestCase {
 
 	@Test
 	public void testGetUserAccountEmailAddressesPage() throws Exception {
-		Page<EmailAddress> page =
-			emailAddressResource.getUserAccountEmailAddressesPage(
-				testGetUserAccountEmailAddressesPage_getUserAccountId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long userAccountId =
 			testGetUserAccountEmailAddressesPage_getUserAccountId();
 		Long irrelevantUserAccountId =
 			testGetUserAccountEmailAddressesPage_getIrrelevantUserAccountId();
+
+		Page<EmailAddress> page =
+			emailAddressResource.getUserAccountEmailAddressesPage(
+				userAccountId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantUserAccountId != null) {
 			EmailAddress irrelevantEmailAddress =
@@ -428,6 +428,23 @@ public abstract class BaseEmailAddressResourceTestCase {
 
 			assertEquals(emailAddress1, emailAddress2);
 		}
+	}
+
+	protected void assertContains(
+		EmailAddress emailAddress, List<EmailAddress> emailAddresses) {
+
+		boolean contains = false;
+
+		for (EmailAddress item : emailAddresses) {
+			if (equals(emailAddress, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			emailAddresses + " does not contain " + emailAddress, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -208,10 +209,10 @@ public abstract class BaseOrganizationResourceTestCase {
 	@Test
 	public void testGetOrganizationsPage() throws Exception {
 		Page<Organization> page = organizationResource.getOrganizationsPage(
-			null, RandomTestUtil.randomString(), null, Pagination.of(1, 2),
+			null, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
 			null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Organization organization1 = testGetOrganizationsPage_addOrganization(
 			randomOrganization());
@@ -220,13 +221,12 @@ public abstract class BaseOrganizationResourceTestCase {
 			randomOrganization());
 
 		page = organizationResource.getOrganizationsPage(
-			null, null, null, Pagination.of(1, 2), null);
+			null, null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(organization1, organization2),
-			(List<Organization>)page.getItems());
+		assertContains(organization1, (List<Organization>)page.getItems());
+		assertContains(organization2, (List<Organization>)page.getItems());
 		assertValid(page);
 
 		organizationResource.deleteOrganization(organization1.getId());
@@ -292,6 +292,12 @@ public abstract class BaseOrganizationResourceTestCase {
 
 	@Test
 	public void testGetOrganizationsPageWithPagination() throws Exception {
+		Page<Organization> totalPage =
+			organizationResource.getOrganizationsPage(
+				null, null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Organization organization1 = testGetOrganizationsPage_addOrganization(
 			randomOrganization());
 
@@ -302,18 +308,18 @@ public abstract class BaseOrganizationResourceTestCase {
 			randomOrganization());
 
 		Page<Organization> page1 = organizationResource.getOrganizationsPage(
-			null, null, null, Pagination.of(1, 2), null);
+			null, null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<Organization> organizations1 =
 			(List<Organization>)page1.getItems();
 
 		Assert.assertEquals(
-			organizations1.toString(), 2, organizations1.size());
+			organizations1.toString(), totalCount + 2, organizations1.size());
 
 		Page<Organization> page2 = organizationResource.getOrganizationsPage(
-			null, null, null, Pagination.of(2, 2), null);
+			null, null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Organization> organizations2 =
 			(List<Organization>)page2.getItems();
@@ -322,11 +328,11 @@ public abstract class BaseOrganizationResourceTestCase {
 			organizations2.toString(), 1, organizations2.size());
 
 		Page<Organization> page3 = organizationResource.getOrganizationsPage(
-			null, null, null, Pagination.of(1, 3), null);
+			null, null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(organization1, organization2, organization3),
-			(List<Organization>)page3.getItems());
+		assertContains(organization1, (List<Organization>)page3.getItems());
+		assertContains(organization2, (List<Organization>)page3.getItems());
+		assertContains(organization3, (List<Organization>)page3.getItems());
 	}
 
 	@Test
@@ -461,7 +467,7 @@ public abstract class BaseOrganizationResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -471,7 +477,7 @@ public abstract class BaseOrganizationResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/organizations");
 
-		Assert.assertEquals(0, organizationsJSONObject.get("totalCount"));
+		long totalCount = organizationsJSONObject.getLong("totalCount");
 
 		Organization organization1 = testGraphQLOrganization_addOrganization();
 		Organization organization2 = testGraphQLOrganization_addOrganization();
@@ -480,10 +486,16 @@ public abstract class BaseOrganizationResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/organizations");
 
-		Assert.assertEquals(2, organizationsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, organizationsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(organization1, organization2),
+		assertContains(
+			organization1,
+			Arrays.asList(
+				OrganizationSerDes.toDTOs(
+					organizationsJSONObject.getString("items"))));
+		assertContains(
+			organization2,
 			Arrays.asList(
 				OrganizationSerDes.toDTOs(
 					organizationsJSONObject.getString("items"))));
@@ -688,18 +700,17 @@ public abstract class BaseOrganizationResourceTestCase {
 
 	@Test
 	public void testGetOrganizationChildOrganizationsPage() throws Exception {
-		Page<Organization> page =
-			organizationResource.getOrganizationChildOrganizationsPage(
-				testGetOrganizationChildOrganizationsPage_getOrganizationId(),
-				null, RandomTestUtil.randomString(), null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String organizationId =
 			testGetOrganizationChildOrganizationsPage_getOrganizationId();
 		String irrelevantOrganizationId =
 			testGetOrganizationChildOrganizationsPage_getIrrelevantOrganizationId();
+
+		Page<Organization> page =
+			organizationResource.getOrganizationChildOrganizationsPage(
+				organizationId, null, RandomTestUtil.randomString(), null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantOrganizationId != null) {
 			Organization irrelevantOrganization =
@@ -727,7 +738,7 @@ public abstract class BaseOrganizationResourceTestCase {
 				organizationId, randomOrganization());
 
 		page = organizationResource.getOrganizationChildOrganizationsPage(
-			organizationId, null, null, null, Pagination.of(1, 2), null);
+			organizationId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1060,18 +1071,17 @@ public abstract class BaseOrganizationResourceTestCase {
 
 	@Test
 	public void testGetOrganizationOrganizationsPage() throws Exception {
-		Page<Organization> page =
-			organizationResource.getOrganizationOrganizationsPage(
-				testGetOrganizationOrganizationsPage_getParentOrganizationId(),
-				null, RandomTestUtil.randomString(), null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String parentOrganizationId =
 			testGetOrganizationOrganizationsPage_getParentOrganizationId();
 		String irrelevantParentOrganizationId =
 			testGetOrganizationOrganizationsPage_getIrrelevantParentOrganizationId();
+
+		Page<Organization> page =
+			organizationResource.getOrganizationOrganizationsPage(
+				parentOrganizationId, null, RandomTestUtil.randomString(), null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantParentOrganizationId != null) {
 			Organization irrelevantOrganization =
@@ -1100,7 +1110,7 @@ public abstract class BaseOrganizationResourceTestCase {
 				parentOrganizationId, randomOrganization());
 
 		page = organizationResource.getOrganizationOrganizationsPage(
-			parentOrganizationId, null, null, null, Pagination.of(1, 2), null);
+			parentOrganizationId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1436,6 +1446,23 @@ public abstract class BaseOrganizationResourceTestCase {
 		Assert.assertTrue(
 			userAccount1 + " does not equal " + userAccount2,
 			equals(userAccount1, userAccount2));
+	}
+
+	protected void assertContains(
+		Organization organization, List<Organization> organizations) {
+
+		boolean contains = false;
+
+		for (Organization item : organizations) {
+			if (equals(organization, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			organizations + " does not contain " + organization, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
@@ -195,15 +195,15 @@ public abstract class BasePhoneResourceTestCase {
 
 	@Test
 	public void testGetOrganizationPhonesPage() throws Exception {
-		Page<Phone> page = phoneResource.getOrganizationPhonesPage(
-			testGetOrganizationPhonesPage_getOrganizationId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String organizationId =
 			testGetOrganizationPhonesPage_getOrganizationId();
 		String irrelevantOrganizationId =
 			testGetOrganizationPhonesPage_getIrrelevantOrganizationId();
+
+		Page<Phone> page = phoneResource.getOrganizationPhonesPage(
+			organizationId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantOrganizationId != null) {
 			Phone irrelevantPhone = testGetOrganizationPhonesPage_addPhone(
@@ -313,14 +313,14 @@ public abstract class BasePhoneResourceTestCase {
 
 	@Test
 	public void testGetUserAccountPhonesPage() throws Exception {
-		Page<Phone> page = phoneResource.getUserAccountPhonesPage(
-			testGetUserAccountPhonesPage_getUserAccountId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long userAccountId = testGetUserAccountPhonesPage_getUserAccountId();
 		Long irrelevantUserAccountId =
 			testGetUserAccountPhonesPage_getIrrelevantUserAccountId();
+
+		Page<Phone> page = phoneResource.getUserAccountPhonesPage(
+			userAccountId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantUserAccountId != null) {
 			Phone irrelevantPhone = testGetUserAccountPhonesPage_addPhone(
@@ -399,6 +399,20 @@ public abstract class BasePhoneResourceTestCase {
 
 			assertEquals(phone1, phone2);
 		}
+	}
+
+	protected void assertContains(Phone phone, List<Phone> phones) {
+		boolean contains = false;
+
+		for (Phone item : phones) {
+			if (equals(phone, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(phones + " does not contain " + phone, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -205,16 +205,16 @@ public abstract class BasePostalAddressResourceTestCase {
 
 	@Test
 	public void testGetOrganizationPostalAddressesPage() throws Exception {
-		Page<PostalAddress> page =
-			postalAddressResource.getOrganizationPostalAddressesPage(
-				testGetOrganizationPostalAddressesPage_getOrganizationId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String organizationId =
 			testGetOrganizationPostalAddressesPage_getOrganizationId();
 		String irrelevantOrganizationId =
 			testGetOrganizationPostalAddressesPage_getIrrelevantOrganizationId();
+
+		Page<PostalAddress> page =
+			postalAddressResource.getOrganizationPostalAddressesPage(
+				organizationId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantOrganizationId != null) {
 			PostalAddress irrelevantPostalAddress =
@@ -341,16 +341,16 @@ public abstract class BasePostalAddressResourceTestCase {
 
 	@Test
 	public void testGetUserAccountPostalAddressesPage() throws Exception {
-		Page<PostalAddress> page =
-			postalAddressResource.getUserAccountPostalAddressesPage(
-				testGetUserAccountPostalAddressesPage_getUserAccountId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long userAccountId =
 			testGetUserAccountPostalAddressesPage_getUserAccountId();
 		Long irrelevantUserAccountId =
 			testGetUserAccountPostalAddressesPage_getIrrelevantUserAccountId();
+
+		Page<PostalAddress> page =
+			postalAddressResource.getUserAccountPostalAddressesPage(
+				userAccountId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantUserAccountId != null) {
 			PostalAddress irrelevantPostalAddress =
@@ -445,6 +445,23 @@ public abstract class BasePostalAddressResourceTestCase {
 
 			assertEquals(postalAddress1, postalAddress2);
 		}
+	}
+
+	protected void assertContains(
+		PostalAddress postalAddress, List<PostalAddress> postalAddresses) {
+
+		boolean contains = false;
+
+		for (PostalAddress item : postalAddresses) {
+			if (equals(postalAddress, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			postalAddresses + " does not contain " + postalAddress, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -197,49 +198,57 @@ public abstract class BaseRoleResourceTestCase {
 
 	@Test
 	public void testGetRolesPage() throws Exception {
-		Page<Role> page = roleResource.getRolesPage(null, Pagination.of(1, 2));
+		Page<Role> page = roleResource.getRolesPage(null, Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Role role1 = testGetRolesPage_addRole(randomRole());
 
 		Role role2 = testGetRolesPage_addRole(randomRole());
 
-		page = roleResource.getRolesPage(null, Pagination.of(1, 2));
+		page = roleResource.getRolesPage(null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(role1, role2), (List<Role>)page.getItems());
+		assertContains(role1, (List<Role>)page.getItems());
+		assertContains(role2, (List<Role>)page.getItems());
 		assertValid(page);
 	}
 
 	@Test
 	public void testGetRolesPageWithPagination() throws Exception {
+		Page<Role> totalPage = roleResource.getRolesPage(null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		Role role1 = testGetRolesPage_addRole(randomRole());
 
 		Role role2 = testGetRolesPage_addRole(randomRole());
 
 		Role role3 = testGetRolesPage_addRole(randomRole());
 
-		Page<Role> page1 = roleResource.getRolesPage(null, Pagination.of(1, 2));
+		Page<Role> page1 = roleResource.getRolesPage(
+			null, Pagination.of(1, totalCount + 2));
 
 		List<Role> roles1 = (List<Role>)page1.getItems();
 
-		Assert.assertEquals(roles1.toString(), 2, roles1.size());
+		Assert.assertEquals(roles1.toString(), totalCount + 2, roles1.size());
 
-		Page<Role> page2 = roleResource.getRolesPage(null, Pagination.of(2, 2));
+		Page<Role> page2 = roleResource.getRolesPage(
+			null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Role> roles2 = (List<Role>)page2.getItems();
 
 		Assert.assertEquals(roles2.toString(), 1, roles2.size());
 
-		Page<Role> page3 = roleResource.getRolesPage(null, Pagination.of(1, 3));
+		Page<Role> page3 = roleResource.getRolesPage(
+			null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(role1, role2, role3), (List<Role>)page3.getItems());
+		assertContains(role1, (List<Role>)page3.getItems());
+		assertContains(role2, (List<Role>)page3.getItems());
+		assertContains(role3, (List<Role>)page3.getItems());
 	}
 
 	protected Role testGetRolesPage_addRole(Role role) throws Exception {
@@ -254,7 +263,7 @@ public abstract class BaseRoleResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -264,7 +273,7 @@ public abstract class BaseRoleResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/roles");
 
-		Assert.assertEquals(0, rolesJSONObject.get("totalCount"));
+		long totalCount = rolesJSONObject.getLong("totalCount");
 
 		Role role1 = testGraphQLRole_addRole();
 		Role role2 = testGraphQLRole_addRole();
@@ -273,10 +282,15 @@ public abstract class BaseRoleResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/roles");
 
-		Assert.assertEquals(2, rolesJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, rolesJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(role1, role2),
+		assertContains(
+			role1,
+			Arrays.asList(
+				RoleSerDes.toDTOs(rolesJSONObject.getString("items"))));
+		assertContains(
+			role2,
 			Arrays.asList(
 				RoleSerDes.toDTOs(rolesJSONObject.getString("items"))));
 	}
@@ -491,6 +505,20 @@ public abstract class BaseRoleResourceTestCase {
 
 			assertEquals(role1, role2);
 		}
+	}
+
+	protected void assertContains(Role role, List<Role> roles) {
+		boolean contains = false;
+
+		for (Role item : roles) {
+			if (equals(role, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(roles + " does not contain " + role, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -197,13 +197,13 @@ public abstract class BaseSegmentResourceTestCase {
 
 	@Test
 	public void testGetSiteSegmentsPage() throws Exception {
-		Page<Segment> page = segmentResource.getSiteSegmentsPage(
-			testGetSiteSegmentsPage_getSiteId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteSegmentsPage_getSiteId();
 		Long irrelevantSiteId = testGetSiteSegmentsPage_getIrrelevantSiteId();
+
+		Page<Segment> page = segmentResource.getSiteSegmentsPage(
+			siteId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			Segment irrelevantSegment = testGetSiteSegmentsPage_addSegment(
@@ -226,7 +226,8 @@ public abstract class BaseSegmentResourceTestCase {
 		Segment segment2 = testGetSiteSegmentsPage_addSegment(
 			siteId, randomSegment());
 
-		page = segmentResource.getSiteSegmentsPage(siteId, Pagination.of(1, 2));
+		page = segmentResource.getSiteSegmentsPage(
+			siteId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -299,7 +300,7 @@ public abstract class BaseSegmentResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -320,7 +321,7 @@ public abstract class BaseSegmentResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/segments");
 
-		Assert.assertEquals(2, segmentsJSONObject.get("totalCount"));
+		Assert.assertEquals(2, segmentsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(segment1, segment2),
@@ -330,12 +331,6 @@ public abstract class BaseSegmentResourceTestCase {
 
 	@Test
 	public void testGetSiteUserAccountSegmentsPage() throws Exception {
-		Page<Segment> page = segmentResource.getSiteUserAccountSegmentsPage(
-			testGetSiteUserAccountSegmentsPage_getSiteId(),
-			testGetSiteUserAccountSegmentsPage_getUserAccountId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteUserAccountSegmentsPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteUserAccountSegmentsPage_getIrrelevantSiteId();
@@ -343,6 +338,11 @@ public abstract class BaseSegmentResourceTestCase {
 			testGetSiteUserAccountSegmentsPage_getUserAccountId();
 		Long irrelevantUserAccountId =
 			testGetSiteUserAccountSegmentsPage_getIrrelevantUserAccountId();
+
+		Page<Segment> page = segmentResource.getSiteUserAccountSegmentsPage(
+			siteId, userAccountId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantSiteId != null) && (irrelevantUserAccountId != null)) {
 			Segment irrelevantSegment =
@@ -441,6 +441,20 @@ public abstract class BaseSegmentResourceTestCase {
 
 			assertEquals(segment1, segment2);
 		}
+	}
+
+	protected void assertContains(Segment segment, List<Segment> segments) {
+		boolean contains = false;
+
+		for (Segment item : segments) {
+			if (equals(segment, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(segments + " does not contain " + segment, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
@@ -194,14 +194,14 @@ public abstract class BaseSegmentUserResourceTestCase {
 
 	@Test
 	public void testGetSegmentUserAccountsPage() throws Exception {
-		Page<SegmentUser> page = segmentUserResource.getSegmentUserAccountsPage(
-			testGetSegmentUserAccountsPage_getSegmentId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long segmentId = testGetSegmentUserAccountsPage_getSegmentId();
 		Long irrelevantSegmentId =
 			testGetSegmentUserAccountsPage_getIrrelevantSegmentId();
+
+		Page<SegmentUser> page = segmentUserResource.getSegmentUserAccountsPage(
+			segmentId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSegmentId != null) {
 			SegmentUser irrelevantSegmentUser =
@@ -228,7 +228,7 @@ public abstract class BaseSegmentUserResourceTestCase {
 				segmentId, randomSegmentUser());
 
 		page = segmentUserResource.getSegmentUserAccountsPage(
-			segmentId, Pagination.of(1, 2));
+			segmentId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -338,6 +338,23 @@ public abstract class BaseSegmentUserResourceTestCase {
 
 			assertEquals(segmentUser1, segmentUser2);
 		}
+	}
+
+	protected void assertContains(
+		SegmentUser segmentUser, List<SegmentUser> segmentUsers) {
+
+		boolean contains = false;
+
+		for (SegmentUser item : segmentUsers) {
+			if (equals(segmentUser, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			segmentUsers + " does not contain " + segmentUser, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.admin.user.client.dto.v1_0.Site;
 import com.liferay.headless.admin.user.client.http.HttpInvoker;
 import com.liferay.headless.admin.user.client.pagination.Page;
+import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.resource.v1_0.SiteResource;
 import com.liferay.headless.admin.user.client.serdes.v1_0.SiteSerDes;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -40,6 +41,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -199,7 +201,65 @@ public abstract class BaseSiteResourceTestCase {
 
 	@Test
 	public void testGetMyUserAccountSitesPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<Site> page = siteResource.getMyUserAccountSitesPage(
+			Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		Site site1 = testGetMyUserAccountSitesPage_addSite(randomSite());
+
+		Site site2 = testGetMyUserAccountSitesPage_addSite(randomSite());
+
+		page = siteResource.getMyUserAccountSitesPage(Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(site1, (List<Site>)page.getItems());
+		assertContains(site2, (List<Site>)page.getItems());
+		assertValid(page);
+	}
+
+	@Test
+	public void testGetMyUserAccountSitesPageWithPagination() throws Exception {
+		Page<Site> totalPage = siteResource.getMyUserAccountSitesPage(null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
+		Site site1 = testGetMyUserAccountSitesPage_addSite(randomSite());
+
+		Site site2 = testGetMyUserAccountSitesPage_addSite(randomSite());
+
+		Site site3 = testGetMyUserAccountSitesPage_addSite(randomSite());
+
+		Page<Site> page1 = siteResource.getMyUserAccountSitesPage(
+			Pagination.of(1, totalCount + 2));
+
+		List<Site> sites1 = (List<Site>)page1.getItems();
+
+		Assert.assertEquals(sites1.toString(), totalCount + 2, sites1.size());
+
+		Page<Site> page2 = siteResource.getMyUserAccountSitesPage(
+			Pagination.of(2, totalCount + 2));
+
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+		List<Site> sites2 = (List<Site>)page2.getItems();
+
+		Assert.assertEquals(sites2.toString(), 1, sites2.size());
+
+		Page<Site> page3 = siteResource.getMyUserAccountSitesPage(
+			Pagination.of(1, totalCount + 3));
+
+		assertContains(site1, (List<Site>)page3.getItems());
+		assertContains(site2, (List<Site>)page3.getItems());
+		assertContains(site3, (List<Site>)page3.getItems());
+	}
+
+	protected Site testGetMyUserAccountSitesPage_addSite(Site site)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -348,6 +408,20 @@ public abstract class BaseSiteResourceTestCase {
 
 			assertEquals(site1, site2);
 		}
+	}
+
+	protected void assertContains(Site site, List<Site> sites) {
+		boolean contains = false;
+
+		for (Site item : sites) {
+			if (equals(site, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(sites + " does not contain " + site, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSubscriptionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSubscriptionResourceTestCase.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -197,9 +198,9 @@ public abstract class BaseSubscriptionResourceTestCase {
 	public void testGetMyUserAccountSubscriptionsPage() throws Exception {
 		Page<Subscription> page =
 			subscriptionResource.getMyUserAccountSubscriptionsPage(
-				RandomTestUtil.randomString(), Pagination.of(1, 2));
+				RandomTestUtil.randomString(), Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		Subscription subscription1 =
 			testGetMyUserAccountSubscriptionsPage_addSubscription(
@@ -210,19 +211,23 @@ public abstract class BaseSubscriptionResourceTestCase {
 				randomSubscription());
 
 		page = subscriptionResource.getMyUserAccountSubscriptionsPage(
-			null, Pagination.of(1, 2));
+			null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(subscription1, subscription2),
-			(List<Subscription>)page.getItems());
+		assertContains(subscription1, (List<Subscription>)page.getItems());
+		assertContains(subscription2, (List<Subscription>)page.getItems());
 		assertValid(page);
 	}
 
 	@Test
 	public void testGetMyUserAccountSubscriptionsPageWithPagination()
 		throws Exception {
+
+		Page<Subscription> totalPage =
+			subscriptionResource.getMyUserAccountSubscriptionsPage(null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
 
 		Subscription subscription1 =
 			testGetMyUserAccountSubscriptionsPage_addSubscription(
@@ -238,19 +243,19 @@ public abstract class BaseSubscriptionResourceTestCase {
 
 		Page<Subscription> page1 =
 			subscriptionResource.getMyUserAccountSubscriptionsPage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, totalCount + 2));
 
 		List<Subscription> subscriptions1 =
 			(List<Subscription>)page1.getItems();
 
 		Assert.assertEquals(
-			subscriptions1.toString(), 2, subscriptions1.size());
+			subscriptions1.toString(), totalCount + 2, subscriptions1.size());
 
 		Page<Subscription> page2 =
 			subscriptionResource.getMyUserAccountSubscriptionsPage(
-				null, Pagination.of(2, 2));
+				null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<Subscription> subscriptions2 =
 			(List<Subscription>)page2.getItems();
@@ -260,11 +265,11 @@ public abstract class BaseSubscriptionResourceTestCase {
 
 		Page<Subscription> page3 =
 			subscriptionResource.getMyUserAccountSubscriptionsPage(
-				null, Pagination.of(1, 3));
+				null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(subscription1, subscription2, subscription3),
-			(List<Subscription>)page3.getItems());
+		assertContains(subscription1, (List<Subscription>)page3.getItems());
+		assertContains(subscription2, (List<Subscription>)page3.getItems());
+		assertContains(subscription3, (List<Subscription>)page3.getItems());
 	}
 
 	protected Subscription
@@ -404,6 +409,23 @@ public abstract class BaseSubscriptionResourceTestCase {
 
 			assertEquals(subscription1, subscription2);
 		}
+	}
+
+	protected void assertContains(
+		Subscription subscription, List<Subscription> subscriptions) {
+
+		boolean contains = false;
+
+		for (Subscription item : subscriptions) {
+			if (equals(subscription, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			subscriptions + " does not contain " + subscription, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -278,19 +279,18 @@ public abstract class BaseUserAccountResourceTestCase {
 	public void testGetAccountUserAccountsByExternalReferenceCodePage()
 		throws Exception {
 
-		Page<UserAccount> page =
-			userAccountResource.
-				getAccountUserAccountsByExternalReferenceCodePage(
-					testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode(),
-					RandomTestUtil.randomString(), null, Pagination.of(1, 2),
-					null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String externalReferenceCode =
 			testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
 			testGetAccountUserAccountsByExternalReferenceCodePage_getIrrelevantExternalReferenceCode();
+
+		Page<UserAccount> page =
+			userAccountResource.
+				getAccountUserAccountsByExternalReferenceCodePage(
+					externalReferenceCode, RandomTestUtil.randomString(), null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantExternalReferenceCode != null) {
 			UserAccount irrelevantUserAccount =
@@ -323,7 +323,7 @@ public abstract class BaseUserAccountResourceTestCase {
 		page =
 			userAccountResource.
 				getAccountUserAccountsByExternalReferenceCodePage(
-					externalReferenceCode, null, null, Pagination.of(1, 2),
+					externalReferenceCode, null, null, Pagination.of(1, 10),
 					null);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -750,15 +750,15 @@ public abstract class BaseUserAccountResourceTestCase {
 
 	@Test
 	public void testGetAccountUserAccountsPage() throws Exception {
-		Page<UserAccount> page = userAccountResource.getAccountUserAccountsPage(
-			testGetAccountUserAccountsPage_getAccountId(),
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long accountId = testGetAccountUserAccountsPage_getAccountId();
 		Long irrelevantAccountId =
 			testGetAccountUserAccountsPage_getIrrelevantAccountId();
+
+		Page<UserAccount> page = userAccountResource.getAccountUserAccountsPage(
+			accountId, RandomTestUtil.randomString(), null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAccountId != null) {
 			UserAccount irrelevantUserAccount =
@@ -785,7 +785,7 @@ public abstract class BaseUserAccountResourceTestCase {
 				accountId, randomUserAccount());
 
 		page = userAccountResource.getAccountUserAccountsPage(
-			accountId, null, null, Pagination.of(1, 2), null);
+			accountId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1188,17 +1188,17 @@ public abstract class BaseUserAccountResourceTestCase {
 
 	@Test
 	public void testGetOrganizationUserAccountsPage() throws Exception {
-		Page<UserAccount> page =
-			userAccountResource.getOrganizationUserAccountsPage(
-				testGetOrganizationUserAccountsPage_getOrganizationId(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String organizationId =
 			testGetOrganizationUserAccountsPage_getOrganizationId();
 		String irrelevantOrganizationId =
 			testGetOrganizationUserAccountsPage_getIrrelevantOrganizationId();
+
+		Page<UserAccount> page =
+			userAccountResource.getOrganizationUserAccountsPage(
+				organizationId, RandomTestUtil.randomString(), null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantOrganizationId != null) {
 			UserAccount irrelevantUserAccount =
@@ -1226,7 +1226,7 @@ public abstract class BaseUserAccountResourceTestCase {
 				organizationId, randomUserAccount());
 
 		page = userAccountResource.getOrganizationUserAccountsPage(
-			organizationId, null, null, Pagination.of(1, 2), null);
+			organizationId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1505,15 +1505,15 @@ public abstract class BaseUserAccountResourceTestCase {
 
 	@Test
 	public void testGetSiteUserAccountsPage() throws Exception {
-		Page<UserAccount> page = userAccountResource.getSiteUserAccountsPage(
-			testGetSiteUserAccountsPage_getSiteId(),
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteUserAccountsPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteUserAccountsPage_getIrrelevantSiteId();
+
+		Page<UserAccount> page = userAccountResource.getSiteUserAccountsPage(
+			siteId, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
+			null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			UserAccount irrelevantUserAccount =
@@ -1538,7 +1538,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			siteId, randomUserAccount());
 
 		page = userAccountResource.getSiteUserAccountsPage(
-			siteId, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1794,9 +1794,9 @@ public abstract class BaseUserAccountResourceTestCase {
 	@Test
 	public void testGetUserAccountsPage() throws Exception {
 		Page<UserAccount> page = userAccountResource.getUserAccountsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		UserAccount userAccount1 = testGetUserAccountsPage_addUserAccount(
 			randomUserAccount());
@@ -1805,13 +1805,12 @@ public abstract class BaseUserAccountResourceTestCase {
 			randomUserAccount());
 
 		page = userAccountResource.getUserAccountsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(userAccount1, userAccount2),
-			(List<UserAccount>)page.getItems());
+		assertContains(userAccount1, (List<UserAccount>)page.getItems());
+		assertContains(userAccount2, (List<UserAccount>)page.getItems());
 		assertValid(page);
 
 		userAccountResource.deleteUserAccount(userAccount1.getId());
@@ -1876,6 +1875,11 @@ public abstract class BaseUserAccountResourceTestCase {
 
 	@Test
 	public void testGetUserAccountsPageWithPagination() throws Exception {
+		Page<UserAccount> totalPage = userAccountResource.getUserAccountsPage(
+			null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		UserAccount userAccount1 = testGetUserAccountsPage_addUserAccount(
 			randomUserAccount());
 
@@ -1886,27 +1890,28 @@ public abstract class BaseUserAccountResourceTestCase {
 			randomUserAccount());
 
 		Page<UserAccount> page1 = userAccountResource.getUserAccountsPage(
-			null, null, Pagination.of(1, 2), null);
+			null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<UserAccount> userAccounts1 = (List<UserAccount>)page1.getItems();
 
-		Assert.assertEquals(userAccounts1.toString(), 2, userAccounts1.size());
+		Assert.assertEquals(
+			userAccounts1.toString(), totalCount + 2, userAccounts1.size());
 
 		Page<UserAccount> page2 = userAccountResource.getUserAccountsPage(
-			null, null, Pagination.of(2, 2), null);
+			null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<UserAccount> userAccounts2 = (List<UserAccount>)page2.getItems();
 
 		Assert.assertEquals(userAccounts2.toString(), 1, userAccounts2.size());
 
 		Page<UserAccount> page3 = userAccountResource.getUserAccountsPage(
-			null, null, Pagination.of(1, 3), null);
+			null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(userAccount1, userAccount2, userAccount3),
-			(List<UserAccount>)page3.getItems());
+		assertContains(userAccount1, (List<UserAccount>)page3.getItems());
+		assertContains(userAccount2, (List<UserAccount>)page3.getItems());
+		assertContains(userAccount3, (List<UserAccount>)page3.getItems());
 	}
 
 	@Test
@@ -2039,7 +2044,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -2049,7 +2054,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/userAccounts");
 
-		Assert.assertEquals(0, userAccountsJSONObject.get("totalCount"));
+		long totalCount = userAccountsJSONObject.getLong("totalCount");
 
 		UserAccount userAccount1 = testGraphQLUserAccount_addUserAccount();
 		UserAccount userAccount2 = testGraphQLUserAccount_addUserAccount();
@@ -2058,10 +2063,16 @@ public abstract class BaseUserAccountResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/userAccounts");
 
-		Assert.assertEquals(2, userAccountsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, userAccountsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(userAccount1, userAccount2),
+		assertContains(
+			userAccount1,
+			Arrays.asList(
+				UserAccountSerDes.toDTOs(
+					userAccountsJSONObject.getString("items"))));
+		assertContains(
+			userAccount2,
 			Arrays.asList(
 				UserAccountSerDes.toDTOs(
 					userAccountsJSONObject.getString("items"))));
@@ -2459,6 +2470,23 @@ public abstract class BaseUserAccountResourceTestCase {
 
 			assertEquals(userAccount1, userAccount2);
 		}
+	}
+
+	protected void assertContains(
+		UserAccount userAccount, List<UserAccount> userAccounts) {
+
+		boolean contains = false;
+
+		for (UserAccount item : userAccounts) {
+			if (equals(userAccount, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			userAccounts + " does not contain " + userAccount, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
@@ -193,15 +193,15 @@ public abstract class BaseWebUrlResourceTestCase {
 
 	@Test
 	public void testGetOrganizationWebUrlsPage() throws Exception {
-		Page<WebUrl> page = webUrlResource.getOrganizationWebUrlsPage(
-			testGetOrganizationWebUrlsPage_getOrganizationId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		String organizationId =
 			testGetOrganizationWebUrlsPage_getOrganizationId();
 		String irrelevantOrganizationId =
 			testGetOrganizationWebUrlsPage_getIrrelevantOrganizationId();
+
+		Page<WebUrl> page = webUrlResource.getOrganizationWebUrlsPage(
+			organizationId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantOrganizationId != null) {
 			WebUrl irrelevantWebUrl = testGetOrganizationWebUrlsPage_addWebUrl(
@@ -256,14 +256,14 @@ public abstract class BaseWebUrlResourceTestCase {
 
 	@Test
 	public void testGetUserAccountWebUrlsPage() throws Exception {
-		Page<WebUrl> page = webUrlResource.getUserAccountWebUrlsPage(
-			testGetUserAccountWebUrlsPage_getUserAccountId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long userAccountId = testGetUserAccountWebUrlsPage_getUserAccountId();
 		Long irrelevantUserAccountId =
 			testGetUserAccountWebUrlsPage_getIrrelevantUserAccountId();
+
+		Page<WebUrl> page = webUrlResource.getUserAccountWebUrlsPage(
+			userAccountId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantUserAccountId != null) {
 			WebUrl irrelevantWebUrl = testGetUserAccountWebUrlsPage_addWebUrl(
@@ -398,6 +398,20 @@ public abstract class BaseWebUrlResourceTestCase {
 
 			assertEquals(webUrl1, webUrl2);
 		}
+	}
+
+	protected void assertContains(WebUrl webUrl, List<WebUrl> webUrls) {
+		boolean contains = false;
+
+		for (WebUrl item : webUrls) {
+			if (equals(webUrl, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(webUrls + " does not contain " + webUrl, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseAssigneeResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseAssigneeResourceTestCase.java
@@ -192,17 +192,16 @@ public abstract class BaseAssigneeResourceTestCase {
 
 	@Test
 	public void testGetWorkflowTaskAssignableUsersPage() throws Exception {
-		Page<Assignee> page =
-			assigneeResource.getWorkflowTaskAssignableUsersPage(
-				testGetWorkflowTaskAssignableUsersPage_getWorkflowTaskId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long workflowTaskId =
 			testGetWorkflowTaskAssignableUsersPage_getWorkflowTaskId();
 		Long irrelevantWorkflowTaskId =
 			testGetWorkflowTaskAssignableUsersPage_getIrrelevantWorkflowTaskId();
+
+		Page<Assignee> page =
+			assigneeResource.getWorkflowTaskAssignableUsersPage(
+				workflowTaskId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantWorkflowTaskId != null) {
 			Assignee irrelevantAssignee =
@@ -227,7 +226,7 @@ public abstract class BaseAssigneeResourceTestCase {
 			workflowTaskId, randomAssignee());
 
 		page = assigneeResource.getWorkflowTaskAssignableUsersPage(
-			workflowTaskId, Pagination.of(1, 2));
+			workflowTaskId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -332,6 +331,21 @@ public abstract class BaseAssigneeResourceTestCase {
 
 			assertEquals(assignee1, assignee2);
 		}
+	}
+
+	protected void assertContains(Assignee assignee, List<Assignee> assignees) {
+		boolean contains = false;
+
+		for (Assignee item : assignees) {
+			if (equals(assignee, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			assignees + " does not contain " + assignee, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseTransitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseTransitionResourceTestCase.java
@@ -198,17 +198,16 @@ public abstract class BaseTransitionResourceTestCase {
 
 	@Test
 	public void testGetWorkflowInstanceNextTransitionsPage() throws Exception {
-		Page<Transition> page =
-			transitionResource.getWorkflowInstanceNextTransitionsPage(
-				testGetWorkflowInstanceNextTransitionsPage_getWorkflowInstanceId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long workflowInstanceId =
 			testGetWorkflowInstanceNextTransitionsPage_getWorkflowInstanceId();
 		Long irrelevantWorkflowInstanceId =
 			testGetWorkflowInstanceNextTransitionsPage_getIrrelevantWorkflowInstanceId();
+
+		Page<Transition> page =
+			transitionResource.getWorkflowInstanceNextTransitionsPage(
+				workflowInstanceId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantWorkflowInstanceId != null) {
 			Transition irrelevantTransition =
@@ -235,7 +234,7 @@ public abstract class BaseTransitionResourceTestCase {
 				workflowInstanceId, randomTransition());
 
 		page = transitionResource.getWorkflowInstanceNextTransitionsPage(
-			workflowInstanceId, Pagination.of(1, 2));
+			workflowInstanceId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -317,17 +316,16 @@ public abstract class BaseTransitionResourceTestCase {
 
 	@Test
 	public void testGetWorkflowTaskNextTransitionsPage() throws Exception {
-		Page<Transition> page =
-			transitionResource.getWorkflowTaskNextTransitionsPage(
-				testGetWorkflowTaskNextTransitionsPage_getWorkflowTaskId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long workflowTaskId =
 			testGetWorkflowTaskNextTransitionsPage_getWorkflowTaskId();
 		Long irrelevantWorkflowTaskId =
 			testGetWorkflowTaskNextTransitionsPage_getIrrelevantWorkflowTaskId();
+
+		Page<Transition> page =
+			transitionResource.getWorkflowTaskNextTransitionsPage(
+				workflowTaskId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantWorkflowTaskId != null) {
 			Transition irrelevantTransition =
@@ -354,7 +352,7 @@ public abstract class BaseTransitionResourceTestCase {
 				workflowTaskId, randomTransition());
 
 		page = transitionResource.getWorkflowTaskNextTransitionsPage(
-			workflowTaskId, Pagination.of(1, 2));
+			workflowTaskId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -459,6 +457,23 @@ public abstract class BaseTransitionResourceTestCase {
 
 			assertEquals(transition1, transition2);
 		}
+	}
+
+	protected void assertContains(
+		Transition transition, List<Transition> transitions) {
+
+		boolean contains = false;
+
+		for (Transition item : transitions) {
+			if (equals(transition, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			transitions + " does not contain " + transition, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -210,9 +211,9 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 	public void testGetWorkflowDefinitionsPage() throws Exception {
 		Page<WorkflowDefinition> page =
 			workflowDefinitionResource.getWorkflowDefinitionsPage(
-				null, Pagination.of(1, 2), null);
+				null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		WorkflowDefinition workflowDefinition1 =
 			testGetWorkflowDefinitionsPage_addWorkflowDefinition(
@@ -223,19 +224,26 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 				randomWorkflowDefinition());
 
 		page = workflowDefinitionResource.getWorkflowDefinitionsPage(
-			null, Pagination.of(1, 2), null);
+			null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(workflowDefinition1, workflowDefinition2),
-			(List<WorkflowDefinition>)page.getItems());
+		assertContains(
+			workflowDefinition1, (List<WorkflowDefinition>)page.getItems());
+		assertContains(
+			workflowDefinition2, (List<WorkflowDefinition>)page.getItems());
 		assertValid(page);
 	}
 
 	@Test
 	public void testGetWorkflowDefinitionsPageWithPagination()
 		throws Exception {
+
+		Page<WorkflowDefinition> totalPage =
+			workflowDefinitionResource.getWorkflowDefinitionsPage(
+				null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
 
 		WorkflowDefinition workflowDefinition1 =
 			testGetWorkflowDefinitionsPage_addWorkflowDefinition(
@@ -251,19 +259,20 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 
 		Page<WorkflowDefinition> page1 =
 			workflowDefinitionResource.getWorkflowDefinitionsPage(
-				null, Pagination.of(1, 2), null);
+				null, Pagination.of(1, totalCount + 2), null);
 
 		List<WorkflowDefinition> workflowDefinitions1 =
 			(List<WorkflowDefinition>)page1.getItems();
 
 		Assert.assertEquals(
-			workflowDefinitions1.toString(), 2, workflowDefinitions1.size());
+			workflowDefinitions1.toString(), totalCount + 2,
+			workflowDefinitions1.size());
 
 		Page<WorkflowDefinition> page2 =
 			workflowDefinitionResource.getWorkflowDefinitionsPage(
-				null, Pagination.of(2, 2), null);
+				null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<WorkflowDefinition> workflowDefinitions2 =
 			(List<WorkflowDefinition>)page2.getItems();
@@ -273,12 +282,14 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 
 		Page<WorkflowDefinition> page3 =
 			workflowDefinitionResource.getWorkflowDefinitionsPage(
-				null, Pagination.of(1, 3), null);
+				null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(
-				workflowDefinition1, workflowDefinition2, workflowDefinition3),
-			(List<WorkflowDefinition>)page3.getItems());
+		assertContains(
+			workflowDefinition1, (List<WorkflowDefinition>)page3.getItems());
+		assertContains(
+			workflowDefinition2, (List<WorkflowDefinition>)page3.getItems());
+		assertContains(
+			workflowDefinition3, (List<WorkflowDefinition>)page3.getItems());
 	}
 
 	@Test
@@ -543,6 +554,25 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 
 			assertEquals(workflowDefinition1, workflowDefinition2);
 		}
+	}
+
+	protected void assertContains(
+		WorkflowDefinition workflowDefinition,
+		List<WorkflowDefinition> workflowDefinitions) {
+
+		boolean contains = false;
+
+		for (WorkflowDefinition item : workflowDefinitions) {
+			if (equals(workflowDefinition, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			workflowDefinitions + " does not contain " + workflowDefinition,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowInstanceResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowInstanceResourceTestCase.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -201,9 +202,10 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 	public void testGetWorkflowInstancesPage() throws Exception {
 		Page<WorkflowInstance> page =
 			workflowInstanceResource.getWorkflowInstancesPage(
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2));
+				RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		WorkflowInstance workflowInstance1 =
 			testGetWorkflowInstancesPage_addWorkflowInstance(
@@ -214,13 +216,14 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 				randomWorkflowInstance());
 
 		page = workflowInstanceResource.getWorkflowInstancesPage(
-			null, null, null, Pagination.of(1, 2));
+			null, null, null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(workflowInstance1, workflowInstance2),
-			(List<WorkflowInstance>)page.getItems());
+		assertContains(
+			workflowInstance1, (List<WorkflowInstance>)page.getItems());
+		assertContains(
+			workflowInstance2, (List<WorkflowInstance>)page.getItems());
 		assertValid(page);
 
 		workflowInstanceResource.deleteWorkflowInstance(
@@ -232,6 +235,12 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 
 	@Test
 	public void testGetWorkflowInstancesPageWithPagination() throws Exception {
+		Page<WorkflowInstance> totalPage =
+			workflowInstanceResource.getWorkflowInstancesPage(
+				null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		WorkflowInstance workflowInstance1 =
 			testGetWorkflowInstancesPage_addWorkflowInstance(
 				randomWorkflowInstance());
@@ -246,19 +255,20 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 
 		Page<WorkflowInstance> page1 =
 			workflowInstanceResource.getWorkflowInstancesPage(
-				null, null, null, Pagination.of(1, 2));
+				null, null, null, Pagination.of(1, totalCount + 2));
 
 		List<WorkflowInstance> workflowInstances1 =
 			(List<WorkflowInstance>)page1.getItems();
 
 		Assert.assertEquals(
-			workflowInstances1.toString(), 2, workflowInstances1.size());
+			workflowInstances1.toString(), totalCount + 2,
+			workflowInstances1.size());
 
 		Page<WorkflowInstance> page2 =
 			workflowInstanceResource.getWorkflowInstancesPage(
-				null, null, null, Pagination.of(2, 2));
+				null, null, null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<WorkflowInstance> workflowInstances2 =
 			(List<WorkflowInstance>)page2.getItems();
@@ -268,12 +278,14 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 
 		Page<WorkflowInstance> page3 =
 			workflowInstanceResource.getWorkflowInstancesPage(
-				null, null, null, Pagination.of(1, 3));
+				null, null, null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(
-				workflowInstance1, workflowInstance2, workflowInstance3),
-			(List<WorkflowInstance>)page3.getItems());
+		assertContains(
+			workflowInstance1, (List<WorkflowInstance>)page3.getItems());
+		assertContains(
+			workflowInstance2, (List<WorkflowInstance>)page3.getItems());
+		assertContains(
+			workflowInstance3, (List<WorkflowInstance>)page3.getItems());
 	}
 
 	protected WorkflowInstance testGetWorkflowInstancesPage_addWorkflowInstance(
@@ -291,7 +303,7 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -301,7 +313,7 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/workflowInstances");
 
-		Assert.assertEquals(0, workflowInstancesJSONObject.get("totalCount"));
+		long totalCount = workflowInstancesJSONObject.getLong("totalCount");
 
 		WorkflowInstance workflowInstance1 =
 			testGraphQLWorkflowInstance_addWorkflowInstance();
@@ -312,10 +324,16 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/workflowInstances");
 
-		Assert.assertEquals(2, workflowInstancesJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, workflowInstancesJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(workflowInstance1, workflowInstance2),
+		assertContains(
+			workflowInstance1,
+			Arrays.asList(
+				WorkflowInstanceSerDes.toDTOs(
+					workflowInstancesJSONObject.getString("items"))));
+		assertContains(
+			workflowInstance2,
 			Arrays.asList(
 				WorkflowInstanceSerDes.toDTOs(
 					workflowInstancesJSONObject.getString("items"))));
@@ -527,6 +545,25 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 
 			assertEquals(workflowInstance1, workflowInstance2);
 		}
+	}
+
+	protected void assertContains(
+		WorkflowInstance workflowInstance,
+		List<WorkflowInstance> workflowInstances) {
+
+		boolean contains = false;
+
+		for (WorkflowInstance item : workflowInstances) {
+			if (equals(workflowInstance, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			workflowInstances + " does not contain " + workflowInstance,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -199,17 +199,16 @@ public abstract class BaseWorkflowLogResourceTestCase {
 
 	@Test
 	public void testGetWorkflowInstanceWorkflowLogsPage() throws Exception {
-		Page<WorkflowLog> page =
-			workflowLogResource.getWorkflowInstanceWorkflowLogsPage(
-				testGetWorkflowInstanceWorkflowLogsPage_getWorkflowInstanceId(),
-				null, Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long workflowInstanceId =
 			testGetWorkflowInstanceWorkflowLogsPage_getWorkflowInstanceId();
 		Long irrelevantWorkflowInstanceId =
 			testGetWorkflowInstanceWorkflowLogsPage_getIrrelevantWorkflowInstanceId();
+
+		Page<WorkflowLog> page =
+			workflowLogResource.getWorkflowInstanceWorkflowLogsPage(
+				workflowInstanceId, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantWorkflowInstanceId != null) {
 			WorkflowLog irrelevantWorkflowLog =
@@ -237,7 +236,7 @@ public abstract class BaseWorkflowLogResourceTestCase {
 				workflowInstanceId, randomWorkflowLog());
 
 		page = workflowLogResource.getWorkflowInstanceWorkflowLogsPage(
-			workflowInstanceId, null, Pagination.of(1, 2));
+			workflowInstanceId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -378,17 +377,16 @@ public abstract class BaseWorkflowLogResourceTestCase {
 
 	@Test
 	public void testGetWorkflowTaskWorkflowLogsPage() throws Exception {
-		Page<WorkflowLog> page =
-			workflowLogResource.getWorkflowTaskWorkflowLogsPage(
-				testGetWorkflowTaskWorkflowLogsPage_getWorkflowTaskId(), null,
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long workflowTaskId =
 			testGetWorkflowTaskWorkflowLogsPage_getWorkflowTaskId();
 		Long irrelevantWorkflowTaskId =
 			testGetWorkflowTaskWorkflowLogsPage_getIrrelevantWorkflowTaskId();
+
+		Page<WorkflowLog> page =
+			workflowLogResource.getWorkflowTaskWorkflowLogsPage(
+				workflowTaskId, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantWorkflowTaskId != null) {
 			WorkflowLog irrelevantWorkflowLog =
@@ -415,7 +413,7 @@ public abstract class BaseWorkflowLogResourceTestCase {
 				workflowTaskId, randomWorkflowLog());
 
 		page = workflowLogResource.getWorkflowTaskWorkflowLogsPage(
-			workflowTaskId, null, Pagination.of(1, 2));
+			workflowTaskId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -527,6 +525,23 @@ public abstract class BaseWorkflowLogResourceTestCase {
 
 			assertEquals(workflowLog1, workflowLog2);
 		}
+	}
+
+	protected void assertContains(
+		WorkflowLog workflowLog, List<WorkflowLog> workflowLogs) {
+
+		boolean contains = false;
+
+		for (WorkflowLog item : workflowLogs) {
+			if (equals(workflowLog, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			workflowLogs + " does not contain " + workflowLog, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskAssignableUsersResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskAssignableUsersResourceTestCase.java
@@ -254,6 +254,26 @@ public abstract class BaseWorkflowTaskAssignableUsersResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		WorkflowTaskAssignableUsers workflowTaskAssignableUsers,
+		List<WorkflowTaskAssignableUsers> workflowTaskAssignableUserses) {
+
+		boolean contains = false;
+
+		for (WorkflowTaskAssignableUsers item : workflowTaskAssignableUserses) {
+			if (equals(workflowTaskAssignableUsers, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			workflowTaskAssignableUserses + " does not contain " +
+				workflowTaskAssignableUsers,
+			contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<WorkflowTaskAssignableUsers> workflowTaskAssignableUserses1,
 		List<WorkflowTaskAssignableUsers> workflowTaskAssignableUserses2) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -201,17 +202,16 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 	@Test
 	public void testGetWorkflowInstanceWorkflowTasksPage() throws Exception {
-		Page<WorkflowTask> page =
-			workflowTaskResource.getWorkflowInstanceWorkflowTasksPage(
-				testGetWorkflowInstanceWorkflowTasksPage_getWorkflowInstanceId(),
-				null, Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long workflowInstanceId =
 			testGetWorkflowInstanceWorkflowTasksPage_getWorkflowInstanceId();
 		Long irrelevantWorkflowInstanceId =
 			testGetWorkflowInstanceWorkflowTasksPage_getIrrelevantWorkflowInstanceId();
+
+		Page<WorkflowTask> page =
+			workflowTaskResource.getWorkflowInstanceWorkflowTasksPage(
+				workflowInstanceId, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantWorkflowInstanceId != null) {
 			WorkflowTask irrelevantWorkflowTask =
@@ -239,7 +239,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 				workflowInstanceId, randomWorkflowTask());
 
 		page = workflowTaskResource.getWorkflowInstanceWorkflowTasksPage(
-			workflowInstanceId, null, Pagination.of(1, 2));
+			workflowInstanceId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -327,18 +327,17 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 	public void testGetWorkflowInstanceWorkflowTasksAssignedToMePage()
 		throws Exception {
 
-		Page<WorkflowTask> page =
-			workflowTaskResource.
-				getWorkflowInstanceWorkflowTasksAssignedToMePage(
-					testGetWorkflowInstanceWorkflowTasksAssignedToMePage_getWorkflowInstanceId(),
-					null, Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long workflowInstanceId =
 			testGetWorkflowInstanceWorkflowTasksAssignedToMePage_getWorkflowInstanceId();
 		Long irrelevantWorkflowInstanceId =
 			testGetWorkflowInstanceWorkflowTasksAssignedToMePage_getIrrelevantWorkflowInstanceId();
+
+		Page<WorkflowTask> page =
+			workflowTaskResource.
+				getWorkflowInstanceWorkflowTasksAssignedToMePage(
+					workflowInstanceId, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantWorkflowInstanceId != null) {
 			WorkflowTask irrelevantWorkflowTask =
@@ -371,7 +370,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 		page =
 			workflowTaskResource.
 				getWorkflowInstanceWorkflowTasksAssignedToMePage(
-					workflowInstanceId, null, Pagination.of(1, 2));
+					workflowInstanceId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -462,18 +461,17 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 	public void testGetWorkflowInstanceWorkflowTasksAssignedToUserPage()
 		throws Exception {
 
-		Page<WorkflowTask> page =
-			workflowTaskResource.
-				getWorkflowInstanceWorkflowTasksAssignedToUserPage(
-					testGetWorkflowInstanceWorkflowTasksAssignedToUserPage_getWorkflowInstanceId(),
-					null, null, Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long workflowInstanceId =
 			testGetWorkflowInstanceWorkflowTasksAssignedToUserPage_getWorkflowInstanceId();
 		Long irrelevantWorkflowInstanceId =
 			testGetWorkflowInstanceWorkflowTasksAssignedToUserPage_getIrrelevantWorkflowInstanceId();
+
+		Page<WorkflowTask> page =
+			workflowTaskResource.
+				getWorkflowInstanceWorkflowTasksAssignedToUserPage(
+					workflowInstanceId, null, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantWorkflowInstanceId != null) {
 			WorkflowTask irrelevantWorkflowTask =
@@ -506,7 +504,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 		page =
 			workflowTaskResource.
 				getWorkflowInstanceWorkflowTasksAssignedToUserPage(
-					workflowInstanceId, null, null, Pagination.of(1, 2));
+					workflowInstanceId, null, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -624,21 +622,184 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 	@Test
 	public void testGetWorkflowTasksAssignedToMePage() throws Exception {
-		Assert.assertTrue(false);
+		Page<WorkflowTask> page =
+			workflowTaskResource.getWorkflowTasksAssignedToMePage(
+				Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		WorkflowTask workflowTask1 =
+			testGetWorkflowTasksAssignedToMePage_addWorkflowTask(
+				randomWorkflowTask());
+
+		WorkflowTask workflowTask2 =
+			testGetWorkflowTasksAssignedToMePage_addWorkflowTask(
+				randomWorkflowTask());
+
+		page = workflowTaskResource.getWorkflowTasksAssignedToMePage(
+			Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(workflowTask1, (List<WorkflowTask>)page.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page.getItems());
+		assertValid(page);
+	}
+
+	@Test
+	public void testGetWorkflowTasksAssignedToMePageWithPagination()
+		throws Exception {
+
+		Page<WorkflowTask> totalPage =
+			workflowTaskResource.getWorkflowTasksAssignedToMePage(null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
+		WorkflowTask workflowTask1 =
+			testGetWorkflowTasksAssignedToMePage_addWorkflowTask(
+				randomWorkflowTask());
+
+		WorkflowTask workflowTask2 =
+			testGetWorkflowTasksAssignedToMePage_addWorkflowTask(
+				randomWorkflowTask());
+
+		WorkflowTask workflowTask3 =
+			testGetWorkflowTasksAssignedToMePage_addWorkflowTask(
+				randomWorkflowTask());
+
+		Page<WorkflowTask> page1 =
+			workflowTaskResource.getWorkflowTasksAssignedToMePage(
+				Pagination.of(1, totalCount + 2));
+
+		List<WorkflowTask> workflowTasks1 =
+			(List<WorkflowTask>)page1.getItems();
+
+		Assert.assertEquals(
+			workflowTasks1.toString(), totalCount + 2, workflowTasks1.size());
+
+		Page<WorkflowTask> page2 =
+			workflowTaskResource.getWorkflowTasksAssignedToMePage(
+				Pagination.of(2, totalCount + 2));
+
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+		List<WorkflowTask> workflowTasks2 =
+			(List<WorkflowTask>)page2.getItems();
+
+		Assert.assertEquals(
+			workflowTasks2.toString(), 1, workflowTasks2.size());
+
+		Page<WorkflowTask> page3 =
+			workflowTaskResource.getWorkflowTasksAssignedToMePage(
+				Pagination.of(1, totalCount + 3));
+
+		assertContains(workflowTask1, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask3, (List<WorkflowTask>)page3.getItems());
+	}
+
+	protected WorkflowTask testGetWorkflowTasksAssignedToMePage_addWorkflowTask(
+			WorkflowTask workflowTask)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
 	public void testGetWorkflowTasksAssignedToMyRolesPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<WorkflowTask> page =
+			workflowTaskResource.getWorkflowTasksAssignedToMyRolesPage(
+				Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		WorkflowTask workflowTask1 =
+			testGetWorkflowTasksAssignedToMyRolesPage_addWorkflowTask(
+				randomWorkflowTask());
+
+		WorkflowTask workflowTask2 =
+			testGetWorkflowTasksAssignedToMyRolesPage_addWorkflowTask(
+				randomWorkflowTask());
+
+		page = workflowTaskResource.getWorkflowTasksAssignedToMyRolesPage(
+			Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(workflowTask1, (List<WorkflowTask>)page.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page.getItems());
+		assertValid(page);
+	}
+
+	@Test
+	public void testGetWorkflowTasksAssignedToMyRolesPageWithPagination()
+		throws Exception {
+
+		Page<WorkflowTask> totalPage =
+			workflowTaskResource.getWorkflowTasksAssignedToMyRolesPage(null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
+		WorkflowTask workflowTask1 =
+			testGetWorkflowTasksAssignedToMyRolesPage_addWorkflowTask(
+				randomWorkflowTask());
+
+		WorkflowTask workflowTask2 =
+			testGetWorkflowTasksAssignedToMyRolesPage_addWorkflowTask(
+				randomWorkflowTask());
+
+		WorkflowTask workflowTask3 =
+			testGetWorkflowTasksAssignedToMyRolesPage_addWorkflowTask(
+				randomWorkflowTask());
+
+		Page<WorkflowTask> page1 =
+			workflowTaskResource.getWorkflowTasksAssignedToMyRolesPage(
+				Pagination.of(1, totalCount + 2));
+
+		List<WorkflowTask> workflowTasks1 =
+			(List<WorkflowTask>)page1.getItems();
+
+		Assert.assertEquals(
+			workflowTasks1.toString(), totalCount + 2, workflowTasks1.size());
+
+		Page<WorkflowTask> page2 =
+			workflowTaskResource.getWorkflowTasksAssignedToMyRolesPage(
+				Pagination.of(2, totalCount + 2));
+
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+		List<WorkflowTask> workflowTasks2 =
+			(List<WorkflowTask>)page2.getItems();
+
+		Assert.assertEquals(
+			workflowTasks2.toString(), 1, workflowTasks2.size());
+
+		Page<WorkflowTask> page3 =
+			workflowTaskResource.getWorkflowTasksAssignedToMyRolesPage(
+				Pagination.of(1, totalCount + 3));
+
+		assertContains(workflowTask1, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask3, (List<WorkflowTask>)page3.getItems());
+	}
+
+	protected WorkflowTask
+			testGetWorkflowTasksAssignedToMyRolesPage_addWorkflowTask(
+				WorkflowTask workflowTask)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
 	public void testGetWorkflowTasksAssignedToRolePage() throws Exception {
 		Page<WorkflowTask> page =
 			workflowTaskResource.getWorkflowTasksAssignedToRolePage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		WorkflowTask workflowTask1 =
 			testGetWorkflowTasksAssignedToRolePage_addWorkflowTask(
@@ -649,19 +810,23 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 				randomWorkflowTask());
 
 		page = workflowTaskResource.getWorkflowTasksAssignedToRolePage(
-			null, Pagination.of(1, 2));
+			null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(workflowTask1, workflowTask2),
-			(List<WorkflowTask>)page.getItems());
+		assertContains(workflowTask1, (List<WorkflowTask>)page.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page.getItems());
 		assertValid(page);
 	}
 
 	@Test
 	public void testGetWorkflowTasksAssignedToRolePageWithPagination()
 		throws Exception {
+
+		Page<WorkflowTask> totalPage =
+			workflowTaskResource.getWorkflowTasksAssignedToRolePage(null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
 
 		WorkflowTask workflowTask1 =
 			testGetWorkflowTasksAssignedToRolePage_addWorkflowTask(
@@ -677,19 +842,19 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 		Page<WorkflowTask> page1 =
 			workflowTaskResource.getWorkflowTasksAssignedToRolePage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, totalCount + 2));
 
 		List<WorkflowTask> workflowTasks1 =
 			(List<WorkflowTask>)page1.getItems();
 
 		Assert.assertEquals(
-			workflowTasks1.toString(), 2, workflowTasks1.size());
+			workflowTasks1.toString(), totalCount + 2, workflowTasks1.size());
 
 		Page<WorkflowTask> page2 =
 			workflowTaskResource.getWorkflowTasksAssignedToRolePage(
-				null, Pagination.of(2, 2));
+				null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<WorkflowTask> workflowTasks2 =
 			(List<WorkflowTask>)page2.getItems();
@@ -699,11 +864,11 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 		Page<WorkflowTask> page3 =
 			workflowTaskResource.getWorkflowTasksAssignedToRolePage(
-				null, Pagination.of(1, 3));
+				null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(workflowTask1, workflowTask2, workflowTask3),
-			(List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask1, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask3, (List<WorkflowTask>)page3.getItems());
 	}
 
 	protected WorkflowTask
@@ -719,9 +884,9 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 	public void testGetWorkflowTasksAssignedToUserPage() throws Exception {
 		Page<WorkflowTask> page =
 			workflowTaskResource.getWorkflowTasksAssignedToUserPage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		WorkflowTask workflowTask1 =
 			testGetWorkflowTasksAssignedToUserPage_addWorkflowTask(
@@ -732,19 +897,23 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 				randomWorkflowTask());
 
 		page = workflowTaskResource.getWorkflowTasksAssignedToUserPage(
-			null, Pagination.of(1, 2));
+			null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(workflowTask1, workflowTask2),
-			(List<WorkflowTask>)page.getItems());
+		assertContains(workflowTask1, (List<WorkflowTask>)page.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page.getItems());
 		assertValid(page);
 	}
 
 	@Test
 	public void testGetWorkflowTasksAssignedToUserPageWithPagination()
 		throws Exception {
+
+		Page<WorkflowTask> totalPage =
+			workflowTaskResource.getWorkflowTasksAssignedToUserPage(null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
 
 		WorkflowTask workflowTask1 =
 			testGetWorkflowTasksAssignedToUserPage_addWorkflowTask(
@@ -760,19 +929,19 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 		Page<WorkflowTask> page1 =
 			workflowTaskResource.getWorkflowTasksAssignedToUserPage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, totalCount + 2));
 
 		List<WorkflowTask> workflowTasks1 =
 			(List<WorkflowTask>)page1.getItems();
 
 		Assert.assertEquals(
-			workflowTasks1.toString(), 2, workflowTasks1.size());
+			workflowTasks1.toString(), totalCount + 2, workflowTasks1.size());
 
 		Page<WorkflowTask> page2 =
 			workflowTaskResource.getWorkflowTasksAssignedToUserPage(
-				null, Pagination.of(2, 2));
+				null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<WorkflowTask> workflowTasks2 =
 			(List<WorkflowTask>)page2.getItems();
@@ -782,11 +951,11 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 		Page<WorkflowTask> page3 =
 			workflowTaskResource.getWorkflowTasksAssignedToUserPage(
-				null, Pagination.of(1, 3));
+				null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(workflowTask1, workflowTask2, workflowTask3),
-			(List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask1, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask3, (List<WorkflowTask>)page3.getItems());
 	}
 
 	protected WorkflowTask
@@ -802,9 +971,9 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 	public void testGetWorkflowTasksAssignedToUserRolesPage() throws Exception {
 		Page<WorkflowTask> page =
 			workflowTaskResource.getWorkflowTasksAssignedToUserRolesPage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		WorkflowTask workflowTask1 =
 			testGetWorkflowTasksAssignedToUserRolesPage_addWorkflowTask(
@@ -815,19 +984,24 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 				randomWorkflowTask());
 
 		page = workflowTaskResource.getWorkflowTasksAssignedToUserRolesPage(
-			null, Pagination.of(1, 2));
+			null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(workflowTask1, workflowTask2),
-			(List<WorkflowTask>)page.getItems());
+		assertContains(workflowTask1, (List<WorkflowTask>)page.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page.getItems());
 		assertValid(page);
 	}
 
 	@Test
 	public void testGetWorkflowTasksAssignedToUserRolesPageWithPagination()
 		throws Exception {
+
+		Page<WorkflowTask> totalPage =
+			workflowTaskResource.getWorkflowTasksAssignedToUserRolesPage(
+				null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
 
 		WorkflowTask workflowTask1 =
 			testGetWorkflowTasksAssignedToUserRolesPage_addWorkflowTask(
@@ -843,19 +1017,19 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 		Page<WorkflowTask> page1 =
 			workflowTaskResource.getWorkflowTasksAssignedToUserRolesPage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, totalCount + 2));
 
 		List<WorkflowTask> workflowTasks1 =
 			(List<WorkflowTask>)page1.getItems();
 
 		Assert.assertEquals(
-			workflowTasks1.toString(), 2, workflowTasks1.size());
+			workflowTasks1.toString(), totalCount + 2, workflowTasks1.size());
 
 		Page<WorkflowTask> page2 =
 			workflowTaskResource.getWorkflowTasksAssignedToUserRolesPage(
-				null, Pagination.of(2, 2));
+				null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<WorkflowTask> workflowTasks2 =
 			(List<WorkflowTask>)page2.getItems();
@@ -865,11 +1039,11 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 		Page<WorkflowTask> page3 =
 			workflowTaskResource.getWorkflowTasksAssignedToUserRolesPage(
-				null, Pagination.of(1, 3));
+				null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(workflowTask1, workflowTask2, workflowTask3),
-			(List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask1, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask3, (List<WorkflowTask>)page3.getItems());
 	}
 
 	protected WorkflowTask
@@ -910,9 +1084,9 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 	public void testGetWorkflowTasksSubmittingUserPage() throws Exception {
 		Page<WorkflowTask> page =
 			workflowTaskResource.getWorkflowTasksSubmittingUserPage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		WorkflowTask workflowTask1 =
 			testGetWorkflowTasksSubmittingUserPage_addWorkflowTask(
@@ -923,19 +1097,23 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 				randomWorkflowTask());
 
 		page = workflowTaskResource.getWorkflowTasksSubmittingUserPage(
-			null, Pagination.of(1, 2));
+			null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(workflowTask1, workflowTask2),
-			(List<WorkflowTask>)page.getItems());
+		assertContains(workflowTask1, (List<WorkflowTask>)page.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page.getItems());
 		assertValid(page);
 	}
 
 	@Test
 	public void testGetWorkflowTasksSubmittingUserPageWithPagination()
 		throws Exception {
+
+		Page<WorkflowTask> totalPage =
+			workflowTaskResource.getWorkflowTasksSubmittingUserPage(null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
 
 		WorkflowTask workflowTask1 =
 			testGetWorkflowTasksSubmittingUserPage_addWorkflowTask(
@@ -951,19 +1129,19 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 		Page<WorkflowTask> page1 =
 			workflowTaskResource.getWorkflowTasksSubmittingUserPage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, totalCount + 2));
 
 		List<WorkflowTask> workflowTasks1 =
 			(List<WorkflowTask>)page1.getItems();
 
 		Assert.assertEquals(
-			workflowTasks1.toString(), 2, workflowTasks1.size());
+			workflowTasks1.toString(), totalCount + 2, workflowTasks1.size());
 
 		Page<WorkflowTask> page2 =
 			workflowTaskResource.getWorkflowTasksSubmittingUserPage(
-				null, Pagination.of(2, 2));
+				null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<WorkflowTask> workflowTasks2 =
 			(List<WorkflowTask>)page2.getItems();
@@ -973,11 +1151,11 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 		Page<WorkflowTask> page3 =
 			workflowTaskResource.getWorkflowTasksSubmittingUserPage(
-				null, Pagination.of(1, 3));
+				null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(workflowTask1, workflowTask2, workflowTask3),
-			(List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask1, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask2, (List<WorkflowTask>)page3.getItems());
+		assertContains(workflowTask3, (List<WorkflowTask>)page3.getItems());
 	}
 
 	protected WorkflowTask
@@ -1212,6 +1390,23 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 			assertEquals(workflowTask1, workflowTask2);
 		}
+	}
+
+	protected void assertContains(
+		WorkflowTask workflowTask, List<WorkflowTask> workflowTasks) {
+
+		boolean contains = false;
+
+		for (WorkflowTask item : workflowTasks) {
+			if (equals(workflowTask, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			workflowTasks + " does not contain " + workflowTask, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskTransitionsResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskTransitionsResourceTestCase.java
@@ -250,6 +250,26 @@ public abstract class BaseWorkflowTaskTransitionsResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		WorkflowTaskTransitions workflowTaskTransitions,
+		List<WorkflowTaskTransitions> workflowTaskTransitionses) {
+
+		boolean contains = false;
+
+		for (WorkflowTaskTransitions item : workflowTaskTransitionses) {
+			if (equals(workflowTaskTransitions, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			workflowTaskTransitionses + " does not contain " +
+				workflowTaskTransitions,
+			contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<WorkflowTaskTransitions> workflowTaskTransitionses1,
 		List<WorkflowTaskTransitions> workflowTaskTransitionses2) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -341,17 +341,16 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 
 	@Test
 	public void testGetSiteBlogPostingImagesPage() throws Exception {
-		Page<BlogPostingImage> page =
-			blogPostingImageResource.getSiteBlogPostingImagesPage(
-				testGetSiteBlogPostingImagesPage_getSiteId(),
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteBlogPostingImagesPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteBlogPostingImagesPage_getIrrelevantSiteId();
+
+		Page<BlogPostingImage> page =
+			blogPostingImageResource.getSiteBlogPostingImagesPage(
+				siteId, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			BlogPostingImage irrelevantBlogPostingImage =
@@ -378,7 +377,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 				siteId, randomBlogPostingImage());
 
 		page = blogPostingImageResource.getSiteBlogPostingImagesPage(
-			siteId, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -673,7 +672,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -696,7 +695,8 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/blogPostingImages");
 
-		Assert.assertEquals(2, blogPostingImagesJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			2, blogPostingImagesJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(blogPostingImage1, blogPostingImage2),
@@ -863,6 +863,25 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 
 			assertEquals(blogPostingImage1, blogPostingImage2);
 		}
+	}
+
+	protected void assertContains(
+		BlogPostingImage blogPostingImage,
+		List<BlogPostingImage> blogPostingImages) {
+
+		boolean contains = false;
+
+		for (BlogPostingImage item : blogPostingImages) {
+			if (equals(blogPostingImage, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			blogPostingImages + " does not contain " + blogPostingImage,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -480,16 +480,15 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 	@Test
 	public void testGetSiteBlogPostingsPage() throws Exception {
-		Page<BlogPosting> page = blogPostingResource.getSiteBlogPostingsPage(
-			testGetSiteBlogPostingsPage_getSiteId(),
-			RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-			null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteBlogPostingsPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteBlogPostingsPage_getIrrelevantSiteId();
+
+		Page<BlogPosting> page = blogPostingResource.getSiteBlogPostingsPage(
+			siteId, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			BlogPosting irrelevantBlogPosting =
@@ -514,7 +513,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 			siteId, randomBlogPosting());
 
 		page = blogPostingResource.getSiteBlogPostingsPage(
-			siteId, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -775,7 +774,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -796,7 +795,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/blogPostings");
 
-		Assert.assertEquals(2, blogPostingsJSONObject.get("totalCount"));
+		Assert.assertEquals(2, blogPostingsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(blogPosting1, blogPosting2),
@@ -1313,6 +1312,23 @@ public abstract class BaseBlogPostingResourceTestCase {
 	protected void assertEquals(Rating rating1, Rating rating2) {
 		Assert.assertTrue(
 			rating1 + " does not equal " + rating2, equals(rating1, rating2));
+	}
+
+	protected void assertContains(
+		BlogPosting blogPosting, List<BlogPosting> blogPostings) {
+
+		boolean contains = false;
+
+		for (BlogPosting item : blogPostings) {
+			if (equals(blogPosting, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			blogPostings + " does not contain " + blogPosting, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -200,16 +200,15 @@ public abstract class BaseCommentResourceTestCase {
 
 	@Test
 	public void testGetBlogPostingCommentsPage() throws Exception {
-		Page<Comment> page = commentResource.getBlogPostingCommentsPage(
-			testGetBlogPostingCommentsPage_getBlogPostingId(),
-			RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-			null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long blogPostingId = testGetBlogPostingCommentsPage_getBlogPostingId();
 		Long irrelevantBlogPostingId =
 			testGetBlogPostingCommentsPage_getIrrelevantBlogPostingId();
+
+		Page<Comment> page = commentResource.getBlogPostingCommentsPage(
+			blogPostingId, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantBlogPostingId != null) {
 			Comment irrelevantComment =
@@ -235,7 +234,7 @@ public abstract class BaseCommentResourceTestCase {
 			blogPostingId, randomComment());
 
 		page = commentResource.getBlogPostingCommentsPage(
-			blogPostingId, null, null, null, Pagination.of(1, 2), null);
+			blogPostingId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -643,16 +642,15 @@ public abstract class BaseCommentResourceTestCase {
 
 	@Test
 	public void testGetCommentCommentsPage() throws Exception {
-		Page<Comment> page = commentResource.getCommentCommentsPage(
-			testGetCommentCommentsPage_getParentCommentId(),
-			RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-			null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long parentCommentId = testGetCommentCommentsPage_getParentCommentId();
 		Long irrelevantParentCommentId =
 			testGetCommentCommentsPage_getIrrelevantParentCommentId();
+
+		Page<Comment> page = commentResource.getCommentCommentsPage(
+			parentCommentId, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantParentCommentId != null) {
 			Comment irrelevantComment = testGetCommentCommentsPage_addComment(
@@ -677,7 +675,7 @@ public abstract class BaseCommentResourceTestCase {
 			parentCommentId, randomComment());
 
 		page = commentResource.getCommentCommentsPage(
-			parentCommentId, null, null, null, Pagination.of(1, 2), null);
+			parentCommentId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -946,16 +944,15 @@ public abstract class BaseCommentResourceTestCase {
 
 	@Test
 	public void testGetDocumentCommentsPage() throws Exception {
-		Page<Comment> page = commentResource.getDocumentCommentsPage(
-			testGetDocumentCommentsPage_getDocumentId(),
-			RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-			null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long documentId = testGetDocumentCommentsPage_getDocumentId();
 		Long irrelevantDocumentId =
 			testGetDocumentCommentsPage_getIrrelevantDocumentId();
+
+		Page<Comment> page = commentResource.getDocumentCommentsPage(
+			documentId, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantDocumentId != null) {
 			Comment irrelevantComment = testGetDocumentCommentsPage_addComment(
@@ -980,7 +977,7 @@ public abstract class BaseCommentResourceTestCase {
 			documentId, randomComment());
 
 		page = commentResource.getDocumentCommentsPage(
-			documentId, null, null, null, Pagination.of(1, 2), null);
+			documentId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1246,17 +1243,16 @@ public abstract class BaseCommentResourceTestCase {
 
 	@Test
 	public void testGetStructuredContentCommentsPage() throws Exception {
-		Page<Comment> page = commentResource.getStructuredContentCommentsPage(
-			testGetStructuredContentCommentsPage_getStructuredContentId(),
-			RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-			null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long structuredContentId =
 			testGetStructuredContentCommentsPage_getStructuredContentId();
 		Long irrelevantStructuredContentId =
 			testGetStructuredContentCommentsPage_getIrrelevantStructuredContentId();
+
+		Page<Comment> page = commentResource.getStructuredContentCommentsPage(
+			structuredContentId, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantStructuredContentId != null) {
 			Comment irrelevantComment =
@@ -1282,7 +1278,7 @@ public abstract class BaseCommentResourceTestCase {
 			structuredContentId, randomComment());
 
 		page = commentResource.getStructuredContentCommentsPage(
-			structuredContentId, null, null, null, Pagination.of(1, 2), null);
+			structuredContentId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1603,6 +1599,20 @@ public abstract class BaseCommentResourceTestCase {
 
 			assertEquals(comment1, comment2);
 		}
+	}
+
+	protected void assertContains(Comment comment, List<Comment> comments) {
+		boolean contains = false;
+
+		for (Comment item : comments) {
+			if (equals(comment, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(comments + " does not contain " + comment, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
@@ -217,18 +217,17 @@ public abstract class BaseContentElementResourceTestCase {
 
 	@Test
 	public void testGetAssetLibraryContentElementsPage() throws Exception {
-		Page<ContentElement> page =
-			contentElementResource.getAssetLibraryContentElementsPage(
-				testGetAssetLibraryContentElementsPage_getAssetLibraryId(),
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryContentElementsPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
 			testGetAssetLibraryContentElementsPage_getIrrelevantAssetLibraryId();
+
+		Page<ContentElement> page =
+			contentElementResource.getAssetLibraryContentElementsPage(
+				assetLibraryId, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAssetLibraryId != null) {
 			ContentElement irrelevantContentElement =
@@ -256,7 +255,7 @@ public abstract class BaseContentElementResourceTestCase {
 				assetLibraryId, randomContentElement());
 
 		page = contentElementResource.getAssetLibraryContentElementsPage(
-			assetLibraryId, null, null, null, Pagination.of(1, 2), null);
+			assetLibraryId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -542,17 +541,16 @@ public abstract class BaseContentElementResourceTestCase {
 
 	@Test
 	public void testGetSiteContentElementsPage() throws Exception {
-		Page<ContentElement> page =
-			contentElementResource.getSiteContentElementsPage(
-				testGetSiteContentElementsPage_getSiteId(),
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteContentElementsPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteContentElementsPage_getIrrelevantSiteId();
+
+		Page<ContentElement> page =
+			contentElementResource.getSiteContentElementsPage(
+				siteId, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			ContentElement irrelevantContentElement =
@@ -579,7 +577,7 @@ public abstract class BaseContentElementResourceTestCase {
 				siteId, randomContentElement());
 
 		page = contentElementResource.getSiteContentElementsPage(
-			siteId, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -861,7 +859,7 @@ public abstract class BaseContentElementResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -884,7 +882,7 @@ public abstract class BaseContentElementResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/contentElements");
 
-		Assert.assertEquals(2, contentElementsJSONObject.get("totalCount"));
+		Assert.assertEquals(2, contentElementsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentElement1, contentElement2),
@@ -931,6 +929,23 @@ public abstract class BaseContentElementResourceTestCase {
 
 			assertEquals(contentElement1, contentElement2);
 		}
+	}
+
+	protected void assertContains(
+		ContentElement contentElement, List<ContentElement> contentElements) {
+
+		boolean contains = false;
+
+		for (ContentElement item : contentElements) {
+			if (equals(contentElement, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			contentElements + " does not contain " + contentElement, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -214,15 +214,6 @@ public abstract class BaseContentSetElementResourceTestCase {
 	public void testGetAssetLibraryContentSetByKeyContentSetElementsPage()
 		throws Exception {
 
-		Page<ContentSetElement> page =
-			contentSetElementResource.
-				getAssetLibraryContentSetByKeyContentSetElementsPage(
-					testGetAssetLibraryContentSetByKeyContentSetElementsPage_getAssetLibraryId(),
-					testGetAssetLibraryContentSetByKeyContentSetElementsPage_getKey(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryContentSetByKeyContentSetElementsPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
@@ -231,6 +222,13 @@ public abstract class BaseContentSetElementResourceTestCase {
 			testGetAssetLibraryContentSetByKeyContentSetElementsPage_getKey();
 		String irrelevantKey =
 			testGetAssetLibraryContentSetByKeyContentSetElementsPage_getIrrelevantKey();
+
+		Page<ContentSetElement> page =
+			contentSetElementResource.
+				getAssetLibraryContentSetByKeyContentSetElementsPage(
+					assetLibraryId, key, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantAssetLibraryId != null) && (irrelevantKey != null)) {
 			ContentSetElement irrelevantContentSetElement =
@@ -263,7 +261,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 		page =
 			contentSetElementResource.
 				getAssetLibraryContentSetByKeyContentSetElementsPage(
-					assetLibraryId, key, Pagination.of(1, 2));
+					assetLibraryId, key, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -372,15 +370,6 @@ public abstract class BaseContentSetElementResourceTestCase {
 	public void testGetAssetLibraryContentSetByUuidContentSetElementsPage()
 		throws Exception {
 
-		Page<ContentSetElement> page =
-			contentSetElementResource.
-				getAssetLibraryContentSetByUuidContentSetElementsPage(
-					testGetAssetLibraryContentSetByUuidContentSetElementsPage_getAssetLibraryId(),
-					testGetAssetLibraryContentSetByUuidContentSetElementsPage_getUuid(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryContentSetByUuidContentSetElementsPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
@@ -389,6 +378,13 @@ public abstract class BaseContentSetElementResourceTestCase {
 			testGetAssetLibraryContentSetByUuidContentSetElementsPage_getUuid();
 		String irrelevantUuid =
 			testGetAssetLibraryContentSetByUuidContentSetElementsPage_getIrrelevantUuid();
+
+		Page<ContentSetElement> page =
+			contentSetElementResource.
+				getAssetLibraryContentSetByUuidContentSetElementsPage(
+					assetLibraryId, uuid, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantAssetLibraryId != null) && (irrelevantUuid != null)) {
 			ContentSetElement irrelevantContentSetElement =
@@ -421,7 +417,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 		page =
 			contentSetElementResource.
 				getAssetLibraryContentSetByUuidContentSetElementsPage(
-					assetLibraryId, uuid, Pagination.of(1, 2));
+					assetLibraryId, uuid, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -528,17 +524,16 @@ public abstract class BaseContentSetElementResourceTestCase {
 
 	@Test
 	public void testGetContentSetContentSetElementsPage() throws Exception {
-		Page<ContentSetElement> page =
-			contentSetElementResource.getContentSetContentSetElementsPage(
-				testGetContentSetContentSetElementsPage_getContentSetId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long contentSetId =
 			testGetContentSetContentSetElementsPage_getContentSetId();
 		Long irrelevantContentSetId =
 			testGetContentSetContentSetElementsPage_getIrrelevantContentSetId();
+
+		Page<ContentSetElement> page =
+			contentSetElementResource.getContentSetContentSetElementsPage(
+				contentSetId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantContentSetId != null) {
 			ContentSetElement irrelevantContentSetElement =
@@ -567,7 +562,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 				contentSetId, randomContentSetElement());
 
 		page = contentSetElementResource.getContentSetContentSetElementsPage(
-			contentSetId, Pagination.of(1, 2));
+			contentSetId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -655,15 +650,6 @@ public abstract class BaseContentSetElementResourceTestCase {
 	public void testGetSiteContentSetByKeyContentSetElementsPage()
 		throws Exception {
 
-		Page<ContentSetElement> page =
-			contentSetElementResource.
-				getSiteContentSetByKeyContentSetElementsPage(
-					testGetSiteContentSetByKeyContentSetElementsPage_getSiteId(),
-					testGetSiteContentSetByKeyContentSetElementsPage_getKey(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId =
 			testGetSiteContentSetByKeyContentSetElementsPage_getSiteId();
 		Long irrelevantSiteId =
@@ -671,6 +657,13 @@ public abstract class BaseContentSetElementResourceTestCase {
 		String key = testGetSiteContentSetByKeyContentSetElementsPage_getKey();
 		String irrelevantKey =
 			testGetSiteContentSetByKeyContentSetElementsPage_getIrrelevantKey();
+
+		Page<ContentSetElement> page =
+			contentSetElementResource.
+				getSiteContentSetByKeyContentSetElementsPage(
+					siteId, key, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantSiteId != null) && (irrelevantKey != null)) {
 			ContentSetElement irrelevantContentSetElement =
@@ -702,7 +695,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 		page =
 			contentSetElementResource.
 				getSiteContentSetByKeyContentSetElementsPage(
-					siteId, key, Pagination.of(1, 2));
+					siteId, key, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -807,15 +800,6 @@ public abstract class BaseContentSetElementResourceTestCase {
 	public void testGetSiteContentSetByUuidContentSetElementsPage()
 		throws Exception {
 
-		Page<ContentSetElement> page =
-			contentSetElementResource.
-				getSiteContentSetByUuidContentSetElementsPage(
-					testGetSiteContentSetByUuidContentSetElementsPage_getSiteId(),
-					testGetSiteContentSetByUuidContentSetElementsPage_getUuid(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId =
 			testGetSiteContentSetByUuidContentSetElementsPage_getSiteId();
 		Long irrelevantSiteId =
@@ -824,6 +808,13 @@ public abstract class BaseContentSetElementResourceTestCase {
 			testGetSiteContentSetByUuidContentSetElementsPage_getUuid();
 		String irrelevantUuid =
 			testGetSiteContentSetByUuidContentSetElementsPage_getIrrelevantUuid();
+
+		Page<ContentSetElement> page =
+			contentSetElementResource.
+				getSiteContentSetByUuidContentSetElementsPage(
+					siteId, uuid, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantSiteId != null) && (irrelevantUuid != null)) {
 			ContentSetElement irrelevantContentSetElement =
@@ -855,7 +846,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 		page =
 			contentSetElementResource.
 				getSiteContentSetByUuidContentSetElementsPage(
-					siteId, uuid, Pagination.of(1, 2));
+					siteId, uuid, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -995,6 +986,25 @@ public abstract class BaseContentSetElementResourceTestCase {
 
 			assertEquals(contentSetElement1, contentSetElement2);
 		}
+	}
+
+	protected void assertContains(
+		ContentSetElement contentSetElement,
+		List<ContentSetElement> contentSetElements) {
+
+		boolean contains = false;
+
+		for (ContentSetElement item : contentSetElements) {
+			if (equals(contentSetElement, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			contentSetElements + " does not contain " + contentSetElement,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -222,18 +222,17 @@ public abstract class BaseContentStructureResourceTestCase {
 
 	@Test
 	public void testGetAssetLibraryContentStructuresPage() throws Exception {
-		Page<ContentStructure> page =
-			contentStructureResource.getAssetLibraryContentStructuresPage(
-				testGetAssetLibraryContentStructuresPage_getAssetLibraryId(),
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryContentStructuresPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
 			testGetAssetLibraryContentStructuresPage_getIrrelevantAssetLibraryId();
+
+		Page<ContentStructure> page =
+			contentStructureResource.getAssetLibraryContentStructuresPage(
+				assetLibraryId, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAssetLibraryId != null) {
 			ContentStructure irrelevantContentStructure =
@@ -263,7 +262,7 @@ public abstract class BaseContentStructureResourceTestCase {
 				assetLibraryId, randomContentStructure());
 
 		page = contentStructureResource.getAssetLibraryContentStructuresPage(
-			assetLibraryId, null, null, null, Pagination.of(1, 2), null);
+			assetLibraryId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -748,17 +747,16 @@ public abstract class BaseContentStructureResourceTestCase {
 
 	@Test
 	public void testGetSiteContentStructuresPage() throws Exception {
-		Page<ContentStructure> page =
-			contentStructureResource.getSiteContentStructuresPage(
-				testGetSiteContentStructuresPage_getSiteId(),
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteContentStructuresPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteContentStructuresPage_getIrrelevantSiteId();
+
+		Page<ContentStructure> page =
+			contentStructureResource.getSiteContentStructuresPage(
+				siteId, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			ContentStructure irrelevantContentStructure =
@@ -785,7 +783,7 @@ public abstract class BaseContentStructureResourceTestCase {
 				siteId, randomContentStructure());
 
 		page = contentStructureResource.getSiteContentStructuresPage(
-			siteId, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1074,7 +1072,7 @@ public abstract class BaseContentStructureResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -1097,7 +1095,8 @@ public abstract class BaseContentStructureResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/contentStructures");
 
-		Assert.assertEquals(2, contentStructuresJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			2, contentStructuresJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentStructure1, contentStructure2),
@@ -1209,6 +1208,25 @@ public abstract class BaseContentStructureResourceTestCase {
 
 			assertEquals(contentStructure1, contentStructure2);
 		}
+	}
+
+	protected void assertContains(
+		ContentStructure contentStructure,
+		List<ContentStructure> contentStructures) {
+
+		boolean contains = false;
+
+		for (ContentStructure item : contentStructures) {
+			if (equals(contentStructure, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			contentStructures + " does not contain " + contentStructure,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
@@ -225,18 +225,17 @@ public abstract class BaseContentTemplateResourceTestCase {
 
 	@Test
 	public void testGetAssetLibraryContentTemplatesPage() throws Exception {
-		Page<ContentTemplate> page =
-			contentTemplateResource.getAssetLibraryContentTemplatesPage(
-				testGetAssetLibraryContentTemplatesPage_getAssetLibraryId(),
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryContentTemplatesPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
 			testGetAssetLibraryContentTemplatesPage_getIrrelevantAssetLibraryId();
+
+		Page<ContentTemplate> page =
+			contentTemplateResource.getAssetLibraryContentTemplatesPage(
+				assetLibraryId, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAssetLibraryId != null) {
 			ContentTemplate irrelevantContentTemplate =
@@ -265,7 +264,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 				assetLibraryId, randomContentTemplate());
 
 		page = contentTemplateResource.getAssetLibraryContentTemplatesPage(
-			assetLibraryId, null, null, null, Pagination.of(1, 2), null);
+			assetLibraryId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -551,17 +550,16 @@ public abstract class BaseContentTemplateResourceTestCase {
 
 	@Test
 	public void testGetSiteContentTemplatesPage() throws Exception {
-		Page<ContentTemplate> page =
-			contentTemplateResource.getSiteContentTemplatesPage(
-				testGetSiteContentTemplatesPage_getSiteId(),
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteContentTemplatesPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteContentTemplatesPage_getIrrelevantSiteId();
+
+		Page<ContentTemplate> page =
+			contentTemplateResource.getSiteContentTemplatesPage(
+				siteId, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			ContentTemplate irrelevantContentTemplate =
@@ -588,7 +586,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 				siteId, randomContentTemplate());
 
 		page = contentTemplateResource.getSiteContentTemplatesPage(
-			siteId, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -873,7 +871,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -896,7 +894,8 @@ public abstract class BaseContentTemplateResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/contentTemplates");
 
-		Assert.assertEquals(2, contentTemplatesJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			2, contentTemplatesJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentTemplate1, contentTemplate2),
@@ -1018,6 +1017,25 @@ public abstract class BaseContentTemplateResourceTestCase {
 
 			assertEquals(contentTemplate1, contentTemplate2);
 		}
+	}
+
+	protected void assertContains(
+		ContentTemplate contentTemplate,
+		List<ContentTemplate> contentTemplates) {
+
+		boolean contains = false;
+
+		for (ContentTemplate item : contentTemplates) {
+			if (equals(contentTemplate, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			contentTemplates + " does not contain " + contentTemplate,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -224,18 +224,17 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 	@Test
 	public void testGetAssetLibraryDocumentFoldersPage() throws Exception {
-		Page<DocumentFolder> page =
-			documentFolderResource.getAssetLibraryDocumentFoldersPage(
-				testGetAssetLibraryDocumentFoldersPage_getAssetLibraryId(),
-				null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryDocumentFoldersPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
 			testGetAssetLibraryDocumentFoldersPage_getIrrelevantAssetLibraryId();
+
+		Page<DocumentFolder> page =
+			documentFolderResource.getAssetLibraryDocumentFoldersPage(
+				assetLibraryId, null, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAssetLibraryId != null) {
 			DocumentFolder irrelevantDocumentFolder =
@@ -263,7 +262,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				assetLibraryId, randomDocumentFolder());
 
 		page = documentFolderResource.getAssetLibraryDocumentFoldersPage(
-			assetLibraryId, null, null, null, null, Pagination.of(1, 2), null);
+			assetLibraryId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -939,18 +938,17 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 	@Test
 	public void testGetDocumentFolderDocumentFoldersPage() throws Exception {
-		Page<DocumentFolder> page =
-			documentFolderResource.getDocumentFolderDocumentFoldersPage(
-				testGetDocumentFolderDocumentFoldersPage_getParentDocumentFolderId(),
-				null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long parentDocumentFolderId =
 			testGetDocumentFolderDocumentFoldersPage_getParentDocumentFolderId();
 		Long irrelevantParentDocumentFolderId =
 			testGetDocumentFolderDocumentFoldersPage_getIrrelevantParentDocumentFolderId();
+
+		Page<DocumentFolder> page =
+			documentFolderResource.getDocumentFolderDocumentFoldersPage(
+				parentDocumentFolderId, null, RandomTestUtil.randomString(),
+				null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantParentDocumentFolderId != null) {
 			DocumentFolder irrelevantDocumentFolder =
@@ -979,8 +977,8 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				parentDocumentFolderId, randomDocumentFolder());
 
 		page = documentFolderResource.getDocumentFolderDocumentFoldersPage(
-			parentDocumentFolderId, null, null, null, null, Pagination.of(1, 2),
-			null);
+			parentDocumentFolderId, null, null, null, null,
+			Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1297,17 +1295,16 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 	@Test
 	public void testGetSiteDocumentFoldersPage() throws Exception {
-		Page<DocumentFolder> page =
-			documentFolderResource.getSiteDocumentFoldersPage(
-				testGetSiteDocumentFoldersPage_getSiteId(), null,
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteDocumentFoldersPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteDocumentFoldersPage_getIrrelevantSiteId();
+
+		Page<DocumentFolder> page =
+			documentFolderResource.getSiteDocumentFoldersPage(
+				siteId, null, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			DocumentFolder irrelevantDocumentFolder =
@@ -1335,7 +1332,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				siteId, randomDocumentFolder());
 
 		page = documentFolderResource.getSiteDocumentFoldersPage(
-			siteId, null, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1621,7 +1618,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -1644,7 +1641,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/documentFolders");
 
-		Assert.assertEquals(2, documentFoldersJSONObject.get("totalCount"));
+		Assert.assertEquals(2, documentFoldersJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(documentFolder1, documentFolder2),
@@ -1874,6 +1871,23 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 			assertEquals(documentFolder1, documentFolder2);
 		}
+	}
+
+	protected void assertContains(
+		DocumentFolder documentFolder, List<DocumentFolder> documentFolders) {
+
+		boolean contains = false;
+
+		for (DocumentFolder item : documentFolders) {
+			if (equals(documentFolder, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			documentFolders + " does not contain " + documentFolder, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -236,17 +236,16 @@ public abstract class BaseDocumentResourceTestCase {
 
 	@Test
 	public void testGetAssetLibraryDocumentsPage() throws Exception {
-		Page<Document> page = documentResource.getAssetLibraryDocumentsPage(
-			testGetAssetLibraryDocumentsPage_getAssetLibraryId(), null,
-			RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-			null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryDocumentsPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
 			testGetAssetLibraryDocumentsPage_getIrrelevantAssetLibraryId();
+
+		Page<Document> page = documentResource.getAssetLibraryDocumentsPage(
+			assetLibraryId, null, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAssetLibraryId != null) {
 			Document irrelevantDocument =
@@ -272,7 +271,7 @@ public abstract class BaseDocumentResourceTestCase {
 			assetLibraryId, randomDocument());
 
 		page = documentResource.getAssetLibraryDocumentsPage(
-			assetLibraryId, null, null, null, null, Pagination.of(1, 2), null);
+			assetLibraryId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -623,17 +622,16 @@ public abstract class BaseDocumentResourceTestCase {
 
 	@Test
 	public void testGetDocumentFolderDocumentsPage() throws Exception {
-		Page<Document> page = documentResource.getDocumentFolderDocumentsPage(
-			testGetDocumentFolderDocumentsPage_getDocumentFolderId(), null,
-			RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-			null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long documentFolderId =
 			testGetDocumentFolderDocumentsPage_getDocumentFolderId();
 		Long irrelevantDocumentFolderId =
 			testGetDocumentFolderDocumentsPage_getIrrelevantDocumentFolderId();
+
+		Page<Document> page = documentResource.getDocumentFolderDocumentsPage(
+			documentFolderId, null, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantDocumentFolderId != null) {
 			Document irrelevantDocument =
@@ -659,7 +657,7 @@ public abstract class BaseDocumentResourceTestCase {
 			documentFolderId, randomDocument());
 
 		page = documentResource.getDocumentFolderDocumentsPage(
-			documentFolderId, null, null, null, null, Pagination.of(1, 2),
+			documentFolderId, null, null, null, null, Pagination.of(1, 10),
 			null);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -1216,15 +1214,14 @@ public abstract class BaseDocumentResourceTestCase {
 
 	@Test
 	public void testGetSiteDocumentsPage() throws Exception {
-		Page<Document> page = documentResource.getSiteDocumentsPage(
-			testGetSiteDocumentsPage_getSiteId(), null,
-			RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-			null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteDocumentsPage_getSiteId();
 		Long irrelevantSiteId = testGetSiteDocumentsPage_getIrrelevantSiteId();
+
+		Page<Document> page = documentResource.getSiteDocumentsPage(
+			siteId, null, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			Document irrelevantDocument = testGetSiteDocumentsPage_addDocument(
@@ -1249,7 +1246,7 @@ public abstract class BaseDocumentResourceTestCase {
 			siteId, randomDocument());
 
 		page = documentResource.getSiteDocumentsPage(
-			siteId, null, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1504,7 +1501,7 @@ public abstract class BaseDocumentResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -1525,7 +1522,7 @@ public abstract class BaseDocumentResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/documents");
 
-		Assert.assertEquals(2, documentsJSONObject.get("totalCount"));
+		Assert.assertEquals(2, documentsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(document1, document2),
@@ -1967,6 +1964,21 @@ public abstract class BaseDocumentResourceTestCase {
 	protected void assertEquals(Rating rating1, Rating rating2) {
 		Assert.assertTrue(
 			rating1 + " does not equal " + rating2, equals(rating1, rating2));
+	}
+
+	protected void assertContains(Document document, List<Document> documents) {
+		boolean contains = false;
+
+		for (Document item : documents) {
+			if (equals(document, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			documents + " does not contain " + document, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -574,19 +574,19 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	public void testGetKnowledgeBaseArticleKnowledgeBaseArticlesPage()
 		throws Exception {
 
-		Page<KnowledgeBaseArticle> page =
-			knowledgeBaseArticleResource.
-				getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
-					testGetKnowledgeBaseArticleKnowledgeBaseArticlesPage_getParentKnowledgeBaseArticleId(),
-					null, RandomTestUtil.randomString(), null, null,
-					Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long parentKnowledgeBaseArticleId =
 			testGetKnowledgeBaseArticleKnowledgeBaseArticlesPage_getParentKnowledgeBaseArticleId();
 		Long irrelevantParentKnowledgeBaseArticleId =
 			testGetKnowledgeBaseArticleKnowledgeBaseArticlesPage_getIrrelevantParentKnowledgeBaseArticleId();
+
+		Page<KnowledgeBaseArticle> page =
+			knowledgeBaseArticleResource.
+				getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
+					parentKnowledgeBaseArticleId, null,
+					RandomTestUtil.randomString(), null, null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantParentKnowledgeBaseArticleId != null) {
 			KnowledgeBaseArticle irrelevantKnowledgeBaseArticle =
@@ -620,7 +620,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			knowledgeBaseArticleResource.
 				getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
 					parentKnowledgeBaseArticleId, null, null, null, null,
-					Pagination.of(1, 2), null);
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -963,19 +963,18 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	public void testGetKnowledgeBaseFolderKnowledgeBaseArticlesPage()
 		throws Exception {
 
-		Page<KnowledgeBaseArticle> page =
-			knowledgeBaseArticleResource.
-				getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
-					testGetKnowledgeBaseFolderKnowledgeBaseArticlesPage_getKnowledgeBaseFolderId(),
-					null, RandomTestUtil.randomString(), null, null,
-					Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long knowledgeBaseFolderId =
 			testGetKnowledgeBaseFolderKnowledgeBaseArticlesPage_getKnowledgeBaseFolderId();
 		Long irrelevantKnowledgeBaseFolderId =
 			testGetKnowledgeBaseFolderKnowledgeBaseArticlesPage_getIrrelevantKnowledgeBaseFolderId();
+
+		Page<KnowledgeBaseArticle> page =
+			knowledgeBaseArticleResource.
+				getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
+					knowledgeBaseFolderId, null, RandomTestUtil.randomString(),
+					null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantKnowledgeBaseFolderId != null) {
 			KnowledgeBaseArticle irrelevantKnowledgeBaseArticle =
@@ -1009,7 +1008,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			knowledgeBaseArticleResource.
 				getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
 					knowledgeBaseFolderId, null, null, null, null,
-					Pagination.of(1, 2), null);
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1350,17 +1349,16 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 
 	@Test
 	public void testGetSiteKnowledgeBaseArticlesPage() throws Exception {
-		Page<KnowledgeBaseArticle> page =
-			knowledgeBaseArticleResource.getSiteKnowledgeBaseArticlesPage(
-				testGetSiteKnowledgeBaseArticlesPage_getSiteId(), null,
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteKnowledgeBaseArticlesPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteKnowledgeBaseArticlesPage_getIrrelevantSiteId();
+
+		Page<KnowledgeBaseArticle> page =
+			knowledgeBaseArticleResource.getSiteKnowledgeBaseArticlesPage(
+				siteId, null, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			KnowledgeBaseArticle irrelevantKnowledgeBaseArticle =
@@ -1389,7 +1387,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 				siteId, randomKnowledgeBaseArticle());
 
 		page = knowledgeBaseArticleResource.getSiteKnowledgeBaseArticlesPage(
-			siteId, null, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1691,7 +1689,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -1717,7 +1715,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			"JSONObject/knowledgeBaseArticles");
 
 		Assert.assertEquals(
-			2, knowledgeBaseArticlesJSONObject.get("totalCount"));
+			2, knowledgeBaseArticlesJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(knowledgeBaseArticle1, knowledgeBaseArticle2),
@@ -2277,6 +2275,25 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	protected void assertEquals(Rating rating1, Rating rating2) {
 		Assert.assertTrue(
 			rating1 + " does not equal " + rating2, equals(rating1, rating2));
+	}
+
+	protected void assertContains(
+		KnowledgeBaseArticle knowledgeBaseArticle,
+		List<KnowledgeBaseArticle> knowledgeBaseArticles) {
+
+		boolean contains = false;
+
+		for (KnowledgeBaseArticle item : knowledgeBaseArticles) {
+			if (equals(knowledgeBaseArticle, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			knowledgeBaseArticles + " does not contain " + knowledgeBaseArticle,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -212,17 +212,17 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 	public void testGetKnowledgeBaseArticleKnowledgeBaseAttachmentsPage()
 		throws Exception {
 
-		Page<KnowledgeBaseAttachment> page =
-			knowledgeBaseAttachmentResource.
-				getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
-					testGetKnowledgeBaseArticleKnowledgeBaseAttachmentsPage_getKnowledgeBaseArticleId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long knowledgeBaseArticleId =
 			testGetKnowledgeBaseArticleKnowledgeBaseAttachmentsPage_getKnowledgeBaseArticleId();
 		Long irrelevantKnowledgeBaseArticleId =
 			testGetKnowledgeBaseArticleKnowledgeBaseAttachmentsPage_getIrrelevantKnowledgeBaseArticleId();
+
+		Page<KnowledgeBaseAttachment> page =
+			knowledgeBaseAttachmentResource.
+				getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
+					knowledgeBaseArticleId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantKnowledgeBaseArticleId != null) {
 			KnowledgeBaseAttachment irrelevantKnowledgeBaseAttachment =
@@ -507,6 +507,26 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 
 			assertEquals(knowledgeBaseAttachment1, knowledgeBaseAttachment2);
 		}
+	}
+
+	protected void assertContains(
+		KnowledgeBaseAttachment knowledgeBaseAttachment,
+		List<KnowledgeBaseAttachment> knowledgeBaseAttachments) {
+
+		boolean contains = false;
+
+		for (KnowledgeBaseAttachment item : knowledgeBaseAttachments) {
+			if (equals(knowledgeBaseAttachment, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			knowledgeBaseAttachments + " does not contain " +
+				knowledgeBaseAttachment,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -472,18 +472,17 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	public void testGetKnowledgeBaseFolderKnowledgeBaseFoldersPage()
 		throws Exception {
 
-		Page<KnowledgeBaseFolder> page =
-			knowledgeBaseFolderResource.
-				getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
-					testGetKnowledgeBaseFolderKnowledgeBaseFoldersPage_getParentKnowledgeBaseFolderId(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long parentKnowledgeBaseFolderId =
 			testGetKnowledgeBaseFolderKnowledgeBaseFoldersPage_getParentKnowledgeBaseFolderId();
 		Long irrelevantParentKnowledgeBaseFolderId =
 			testGetKnowledgeBaseFolderKnowledgeBaseFoldersPage_getIrrelevantParentKnowledgeBaseFolderId();
+
+		Page<KnowledgeBaseFolder> page =
+			knowledgeBaseFolderResource.
+				getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
+					parentKnowledgeBaseFolderId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantParentKnowledgeBaseFolderId != null) {
 			KnowledgeBaseFolder irrelevantKnowledgeBaseFolder =
@@ -516,7 +515,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		page =
 			knowledgeBaseFolderResource.
 				getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
-					parentKnowledgeBaseFolderId, Pagination.of(1, 2));
+					parentKnowledgeBaseFolderId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -641,16 +640,15 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 
 	@Test
 	public void testGetSiteKnowledgeBaseFoldersPage() throws Exception {
-		Page<KnowledgeBaseFolder> page =
-			knowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
-				testGetSiteKnowledgeBaseFoldersPage_getSiteId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteKnowledgeBaseFoldersPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteKnowledgeBaseFoldersPage_getIrrelevantSiteId();
+
+		Page<KnowledgeBaseFolder> page =
+			knowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
+				siteId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			KnowledgeBaseFolder irrelevantKnowledgeBaseFolder =
@@ -677,7 +675,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 				siteId, randomKnowledgeBaseFolder());
 
 		page = knowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
-			siteId, Pagination.of(1, 2));
+			siteId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -774,7 +772,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -800,7 +798,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			"JSONObject/knowledgeBaseFolders");
 
 		Assert.assertEquals(
-			2, knowledgeBaseFoldersJSONObject.get("totalCount"));
+			2, knowledgeBaseFoldersJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(knowledgeBaseFolder1, knowledgeBaseFolder2),
@@ -1243,6 +1241,25 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 
 			assertEquals(knowledgeBaseFolder1, knowledgeBaseFolder2);
 		}
+	}
+
+	protected void assertContains(
+		KnowledgeBaseFolder knowledgeBaseFolder,
+		List<KnowledgeBaseFolder> knowledgeBaseFolders) {
+
+		boolean contains = false;
+
+		for (KnowledgeBaseFolder item : knowledgeBaseFolders) {
+			if (equals(knowledgeBaseFolder, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			knowledgeBaseFolders + " does not contain " + knowledgeBaseFolder,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
@@ -211,15 +211,15 @@ public abstract class BaseLanguageResourceTestCase {
 
 	@Test
 	public void testGetAssetLibraryLanguagesPage() throws Exception {
-		Page<Language> page = languageResource.getAssetLibraryLanguagesPage(
-			testGetAssetLibraryLanguagesPage_getAssetLibraryId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryLanguagesPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
 			testGetAssetLibraryLanguagesPage_getIrrelevantAssetLibraryId();
+
+		Page<Language> page = languageResource.getAssetLibraryLanguagesPage(
+			assetLibraryId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAssetLibraryId != null) {
 			Language irrelevantLanguage =
@@ -276,13 +276,12 @@ public abstract class BaseLanguageResourceTestCase {
 
 	@Test
 	public void testGetSiteLanguagesPage() throws Exception {
-		Page<Language> page = languageResource.getSiteLanguagesPage(
-			testGetSiteLanguagesPage_getSiteId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteLanguagesPage_getSiteId();
 		Long irrelevantSiteId = testGetSiteLanguagesPage_getIrrelevantSiteId();
+
+		Page<Language> page = languageResource.getSiteLanguagesPage(siteId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			Language irrelevantLanguage = testGetSiteLanguagesPage_addLanguage(
@@ -359,7 +358,7 @@ public abstract class BaseLanguageResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/languages");
 
-		Assert.assertEquals(2, languagesJSONObject.get("totalCount"));
+		Assert.assertEquals(2, languagesJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(language1, language2),
@@ -397,6 +396,21 @@ public abstract class BaseLanguageResourceTestCase {
 
 			assertEquals(language1, language2);
 		}
+	}
+
+	protected void assertContains(Language language, List<Language> languages) {
+		boolean contains = false;
+
+		for (Language item : languages) {
+			if (equals(language, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			languages + " does not contain " + language, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -349,17 +349,17 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 	public void testGetMessageBoardMessageMessageBoardAttachmentsPage()
 		throws Exception {
 
-		Page<MessageBoardAttachment> page =
-			messageBoardAttachmentResource.
-				getMessageBoardMessageMessageBoardAttachmentsPage(
-					testGetMessageBoardMessageMessageBoardAttachmentsPage_getMessageBoardMessageId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long messageBoardMessageId =
 			testGetMessageBoardMessageMessageBoardAttachmentsPage_getMessageBoardMessageId();
 		Long irrelevantMessageBoardMessageId =
 			testGetMessageBoardMessageMessageBoardAttachmentsPage_getIrrelevantMessageBoardMessageId();
+
+		Page<MessageBoardAttachment> page =
+			messageBoardAttachmentResource.
+				getMessageBoardMessageMessageBoardAttachmentsPage(
+					messageBoardMessageId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantMessageBoardMessageId != null) {
 			MessageBoardAttachment irrelevantMessageBoardAttachment =
@@ -469,17 +469,17 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 	public void testGetMessageBoardThreadMessageBoardAttachmentsPage()
 		throws Exception {
 
-		Page<MessageBoardAttachment> page =
-			messageBoardAttachmentResource.
-				getMessageBoardThreadMessageBoardAttachmentsPage(
-					testGetMessageBoardThreadMessageBoardAttachmentsPage_getMessageBoardThreadId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long messageBoardThreadId =
 			testGetMessageBoardThreadMessageBoardAttachmentsPage_getMessageBoardThreadId();
 		Long irrelevantMessageBoardThreadId =
 			testGetMessageBoardThreadMessageBoardAttachmentsPage_getIrrelevantMessageBoardThreadId();
+
+		Page<MessageBoardAttachment> page =
+			messageBoardAttachmentResource.
+				getMessageBoardThreadMessageBoardAttachmentsPage(
+					messageBoardThreadId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantMessageBoardThreadId != null) {
 			MessageBoardAttachment irrelevantMessageBoardAttachment =
@@ -626,6 +626,26 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 
 			assertEquals(messageBoardAttachment1, messageBoardAttachment2);
 		}
+	}
+
+	protected void assertContains(
+		MessageBoardAttachment messageBoardAttachment,
+		List<MessageBoardAttachment> messageBoardAttachments) {
+
+		boolean contains = false;
+
+		for (MessageBoardAttachment item : messageBoardAttachments) {
+			if (equals(messageBoardAttachment, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			messageBoardAttachments + " does not contain " +
+				messageBoardAttachment,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -568,19 +568,19 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	public void testGetMessageBoardMessageMessageBoardMessagesPage()
 		throws Exception {
 
-		Page<MessageBoardMessage> page =
-			messageBoardMessageResource.
-				getMessageBoardMessageMessageBoardMessagesPage(
-					testGetMessageBoardMessageMessageBoardMessagesPage_getParentMessageBoardMessageId(),
-					null, RandomTestUtil.randomString(), null, null,
-					Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long parentMessageBoardMessageId =
 			testGetMessageBoardMessageMessageBoardMessagesPage_getParentMessageBoardMessageId();
 		Long irrelevantParentMessageBoardMessageId =
 			testGetMessageBoardMessageMessageBoardMessagesPage_getIrrelevantParentMessageBoardMessageId();
+
+		Page<MessageBoardMessage> page =
+			messageBoardMessageResource.
+				getMessageBoardMessageMessageBoardMessagesPage(
+					parentMessageBoardMessageId, null,
+					RandomTestUtil.randomString(), null, null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantParentMessageBoardMessageId != null) {
 			MessageBoardMessage irrelevantMessageBoardMessage =
@@ -614,7 +614,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			messageBoardMessageResource.
 				getMessageBoardMessageMessageBoardMessagesPage(
 					parentMessageBoardMessageId, null, null, null, null,
-					Pagination.of(1, 2), null);
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -952,19 +952,18 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	public void testGetMessageBoardThreadMessageBoardMessagesPage()
 		throws Exception {
 
-		Page<MessageBoardMessage> page =
-			messageBoardMessageResource.
-				getMessageBoardThreadMessageBoardMessagesPage(
-					testGetMessageBoardThreadMessageBoardMessagesPage_getMessageBoardThreadId(),
-					RandomTestUtil.randomString(), null, null,
-					Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long messageBoardThreadId =
 			testGetMessageBoardThreadMessageBoardMessagesPage_getMessageBoardThreadId();
 		Long irrelevantMessageBoardThreadId =
 			testGetMessageBoardThreadMessageBoardMessagesPage_getIrrelevantMessageBoardThreadId();
+
+		Page<MessageBoardMessage> page =
+			messageBoardMessageResource.
+				getMessageBoardThreadMessageBoardMessagesPage(
+					messageBoardThreadId, RandomTestUtil.randomString(), null,
+					null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantMessageBoardThreadId != null) {
 			MessageBoardMessage irrelevantMessageBoardMessage =
@@ -997,8 +996,8 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		page =
 			messageBoardMessageResource.
 				getMessageBoardThreadMessageBoardMessagesPage(
-					messageBoardThreadId, null, null, null, Pagination.of(1, 2),
-					null);
+					messageBoardThreadId, null, null, null,
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1334,17 +1333,16 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 
 	@Test
 	public void testGetSiteMessageBoardMessagesPage() throws Exception {
-		Page<MessageBoardMessage> page =
-			messageBoardMessageResource.getSiteMessageBoardMessagesPage(
-				testGetSiteMessageBoardMessagesPage_getSiteId(), null,
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteMessageBoardMessagesPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteMessageBoardMessagesPage_getIrrelevantSiteId();
+
+		Page<MessageBoardMessage> page =
+			messageBoardMessageResource.getSiteMessageBoardMessagesPage(
+				siteId, null, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			MessageBoardMessage irrelevantMessageBoardMessage =
@@ -1372,7 +1370,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 				siteId, randomMessageBoardMessage());
 
 		page = messageBoardMessageResource.getSiteMessageBoardMessagesPage(
-			siteId, null, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1669,7 +1667,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -1695,7 +1693,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			"JSONObject/messageBoardMessages");
 
 		Assert.assertEquals(
-			2, messageBoardMessagesJSONObject.get("totalCount"));
+			2, messageBoardMessagesJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardMessage1, messageBoardMessage2),
@@ -2157,6 +2155,25 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	protected void assertEquals(Rating rating1, Rating rating2) {
 		Assert.assertTrue(
 			rating1 + " does not equal " + rating2, equals(rating1, rating2));
+	}
+
+	protected void assertContains(
+		MessageBoardMessage messageBoardMessage,
+		List<MessageBoardMessage> messageBoardMessages) {
+
+		boolean contains = false;
+
+		for (MessageBoardMessage item : messageBoardMessages) {
+			if (equals(messageBoardMessage, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			messageBoardMessages + " does not contain " + messageBoardMessage,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -527,19 +527,18 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	public void testGetMessageBoardSectionMessageBoardSectionsPage()
 		throws Exception {
 
-		Page<MessageBoardSection> page =
-			messageBoardSectionResource.
-				getMessageBoardSectionMessageBoardSectionsPage(
-					testGetMessageBoardSectionMessageBoardSectionsPage_getParentMessageBoardSectionId(),
-					RandomTestUtil.randomString(), null, null,
-					Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long parentMessageBoardSectionId =
 			testGetMessageBoardSectionMessageBoardSectionsPage_getParentMessageBoardSectionId();
 		Long irrelevantParentMessageBoardSectionId =
 			testGetMessageBoardSectionMessageBoardSectionsPage_getIrrelevantParentMessageBoardSectionId();
+
+		Page<MessageBoardSection> page =
+			messageBoardSectionResource.
+				getMessageBoardSectionMessageBoardSectionsPage(
+					parentMessageBoardSectionId, RandomTestUtil.randomString(),
+					null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantParentMessageBoardSectionId != null) {
 			MessageBoardSection irrelevantMessageBoardSection =
@@ -573,7 +572,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			messageBoardSectionResource.
 				getMessageBoardSectionMessageBoardSectionsPage(
 					parentMessageBoardSectionId, null, null, null,
-					Pagination.of(1, 2), null);
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -909,17 +908,16 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 
 	@Test
 	public void testGetSiteMessageBoardSectionsPage() throws Exception {
-		Page<MessageBoardSection> page =
-			messageBoardSectionResource.getSiteMessageBoardSectionsPage(
-				testGetSiteMessageBoardSectionsPage_getSiteId(), null,
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteMessageBoardSectionsPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteMessageBoardSectionsPage_getIrrelevantSiteId();
+
+		Page<MessageBoardSection> page =
+			messageBoardSectionResource.getSiteMessageBoardSectionsPage(
+				siteId, null, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			MessageBoardSection irrelevantMessageBoardSection =
@@ -947,7 +945,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 				siteId, randomMessageBoardSection());
 
 		page = messageBoardSectionResource.getSiteMessageBoardSectionsPage(
-			siteId, null, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1244,7 +1242,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -1270,7 +1268,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			"JSONObject/messageBoardSections");
 
 		Assert.assertEquals(
-			2, messageBoardSectionsJSONObject.get("totalCount"));
+			2, messageBoardSectionsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardSection1, messageBoardSection2),
@@ -1518,6 +1516,25 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 
 			assertEquals(messageBoardSection1, messageBoardSection2);
 		}
+	}
+
+	protected void assertContains(
+		MessageBoardSection messageBoardSection,
+		List<MessageBoardSection> messageBoardSections) {
+
+		boolean contains = false;
+
+		for (MessageBoardSection item : messageBoardSections) {
+			if (equals(messageBoardSection, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			messageBoardSections + " does not contain " + messageBoardSection,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -219,19 +220,18 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	public void testGetMessageBoardSectionMessageBoardThreadsPage()
 		throws Exception {
 
-		Page<MessageBoardThread> page =
-			messageBoardThreadResource.
-				getMessageBoardSectionMessageBoardThreadsPage(
-					testGetMessageBoardSectionMessageBoardThreadsPage_getMessageBoardSectionId(),
-					RandomTestUtil.randomString(), null, null,
-					Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long messageBoardSectionId =
 			testGetMessageBoardSectionMessageBoardThreadsPage_getMessageBoardSectionId();
 		Long irrelevantMessageBoardSectionId =
 			testGetMessageBoardSectionMessageBoardThreadsPage_getIrrelevantMessageBoardSectionId();
+
+		Page<MessageBoardThread> page =
+			messageBoardThreadResource.
+				getMessageBoardSectionMessageBoardThreadsPage(
+					messageBoardSectionId, RandomTestUtil.randomString(), null,
+					null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantMessageBoardSectionId != null) {
 			MessageBoardThread irrelevantMessageBoardThread =
@@ -265,7 +265,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			messageBoardThreadResource.
 				getMessageBoardSectionMessageBoardThreadsPage(
 					messageBoardSectionId, null, null, null,
-					Pagination.of(1, 2), null);
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -602,9 +602,9 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Page<MessageBoardThread> page =
 			messageBoardThreadResource.getMessageBoardThreadsRankedPage(
 				RandomTestUtil.nextDate(), RandomTestUtil.nextDate(), null,
-				Pagination.of(1, 2), null);
+				Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		MessageBoardThread messageBoardThread1 =
 			testGetMessageBoardThreadsRankedPage_addMessageBoardThread(
@@ -615,13 +615,14 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 				randomMessageBoardThread());
 
 		page = messageBoardThreadResource.getMessageBoardThreadsRankedPage(
-			null, null, null, Pagination.of(1, 2), null);
+			null, null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(messageBoardThread1, messageBoardThread2),
-			(List<MessageBoardThread>)page.getItems());
+		assertContains(
+			messageBoardThread1, (List<MessageBoardThread>)page.getItems());
+		assertContains(
+			messageBoardThread2, (List<MessageBoardThread>)page.getItems());
 		assertValid(page);
 
 		messageBoardThreadResource.deleteMessageBoardThread(
@@ -634,6 +635,12 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	@Test
 	public void testGetMessageBoardThreadsRankedPageWithPagination()
 		throws Exception {
+
+		Page<MessageBoardThread> totalPage =
+			messageBoardThreadResource.getMessageBoardThreadsRankedPage(
+				null, null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
 
 		MessageBoardThread messageBoardThread1 =
 			testGetMessageBoardThreadsRankedPage_addMessageBoardThread(
@@ -649,19 +656,20 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 
 		Page<MessageBoardThread> page1 =
 			messageBoardThreadResource.getMessageBoardThreadsRankedPage(
-				null, null, null, Pagination.of(1, 2), null);
+				null, null, null, Pagination.of(1, totalCount + 2), null);
 
 		List<MessageBoardThread> messageBoardThreads1 =
 			(List<MessageBoardThread>)page1.getItems();
 
 		Assert.assertEquals(
-			messageBoardThreads1.toString(), 2, messageBoardThreads1.size());
+			messageBoardThreads1.toString(), totalCount + 2,
+			messageBoardThreads1.size());
 
 		Page<MessageBoardThread> page2 =
 			messageBoardThreadResource.getMessageBoardThreadsRankedPage(
-				null, null, null, Pagination.of(2, 2), null);
+				null, null, null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<MessageBoardThread> messageBoardThreads2 =
 			(List<MessageBoardThread>)page2.getItems();
@@ -671,12 +679,14 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 
 		Page<MessageBoardThread> page3 =
 			messageBoardThreadResource.getMessageBoardThreadsRankedPage(
-				null, null, null, Pagination.of(1, 3), null);
+				null, null, null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(
-				messageBoardThread1, messageBoardThread2, messageBoardThread3),
-			(List<MessageBoardThread>)page3.getItems());
+		assertContains(
+			messageBoardThread1, (List<MessageBoardThread>)page3.getItems());
+		assertContains(
+			messageBoardThread2, (List<MessageBoardThread>)page3.getItems());
+		assertContains(
+			messageBoardThread3, (List<MessageBoardThread>)page3.getItems());
 	}
 
 	@Test
@@ -1168,17 +1178,16 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 
 	@Test
 	public void testGetSiteMessageBoardThreadsPage() throws Exception {
-		Page<MessageBoardThread> page =
-			messageBoardThreadResource.getSiteMessageBoardThreadsPage(
-				testGetSiteMessageBoardThreadsPage_getSiteId(), null,
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteMessageBoardThreadsPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteMessageBoardThreadsPage_getIrrelevantSiteId();
+
+		Page<MessageBoardThread> page =
+			messageBoardThreadResource.getSiteMessageBoardThreadsPage(
+				siteId, null, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			MessageBoardThread irrelevantMessageBoardThread =
@@ -1206,7 +1215,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 				siteId, randomMessageBoardThread());
 
 		page = messageBoardThreadResource.getSiteMessageBoardThreadsPage(
-			siteId, null, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1502,7 +1511,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -1526,7 +1535,8 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/messageBoardThreads");
 
-		Assert.assertEquals(2, messageBoardThreadsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			2, messageBoardThreadsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardThread1, messageBoardThread2),
@@ -1919,6 +1929,25 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	protected void assertEquals(Rating rating1, Rating rating2) {
 		Assert.assertTrue(
 			rating1 + " does not equal " + rating2, equals(rating1, rating2));
+	}
+
+	protected void assertContains(
+		MessageBoardThread messageBoardThread,
+		List<MessageBoardThread> messageBoardThreads) {
+
+		boolean contains = false;
+
+		for (MessageBoardThread item : messageBoardThreads) {
+			if (equals(messageBoardThread, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			messageBoardThreads + " does not contain " + messageBoardThread,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -415,16 +415,15 @@ public abstract class BaseNavigationMenuResourceTestCase {
 
 	@Test
 	public void testGetSiteNavigationMenusPage() throws Exception {
-		Page<NavigationMenu> page =
-			navigationMenuResource.getSiteNavigationMenusPage(
-				testGetSiteNavigationMenusPage_getSiteId(),
-				Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteNavigationMenusPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteNavigationMenusPage_getIrrelevantSiteId();
+
+		Page<NavigationMenu> page =
+			navigationMenuResource.getSiteNavigationMenusPage(
+				siteId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			NavigationMenu irrelevantNavigationMenu =
@@ -451,7 +450,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 				siteId, randomNavigationMenu());
 
 		page = navigationMenuResource.getSiteNavigationMenusPage(
-			siteId, Pagination.of(1, 2));
+			siteId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -541,7 +540,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -564,7 +563,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/navigationMenus");
 
-		Assert.assertEquals(2, navigationMenusJSONObject.get("totalCount"));
+		Assert.assertEquals(2, navigationMenusJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(navigationMenu1, navigationMenu2),
@@ -791,6 +790,23 @@ public abstract class BaseNavigationMenuResourceTestCase {
 
 			assertEquals(navigationMenu1, navigationMenu2);
 		}
+	}
+
+	protected void assertContains(
+		NavigationMenu navigationMenu, List<NavigationMenu> navigationMenus) {
+
+		boolean contains = false;
+
+		for (NavigationMenu item : navigationMenus) {
+			if (equals(navigationMenu, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			navigationMenus + " does not contain " + navigationMenu, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -205,14 +205,14 @@ public abstract class BaseSitePageResourceTestCase {
 
 	@Test
 	public void testGetSiteSitePagesPage() throws Exception {
-		Page<SitePage> page = sitePageResource.getSiteSitePagesPage(
-			testGetSiteSitePagesPage_getSiteId(), RandomTestUtil.randomString(),
-			null, null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteSitePagesPage_getSiteId();
 		Long irrelevantSiteId = testGetSiteSitePagesPage_getIrrelevantSiteId();
+
+		Page<SitePage> page = sitePageResource.getSiteSitePagesPage(
+			siteId, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			SitePage irrelevantSitePage = testGetSiteSitePagesPage_addSitePage(
@@ -236,7 +236,7 @@ public abstract class BaseSitePageResourceTestCase {
 			siteId, randomSitePage());
 
 		page = sitePageResource.getSiteSitePagesPage(
-			siteId, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -502,13 +502,6 @@ public abstract class BaseSitePageResourceTestCase {
 	public void testGetSiteSitePageFriendlyUrlPathExperiencesPage()
 		throws Exception {
 
-		Page<SitePage> page =
-			sitePageResource.getSiteSitePageFriendlyUrlPathExperiencesPage(
-				testGetSiteSitePageFriendlyUrlPathExperiencesPage_getSiteId(),
-				testGetSiteSitePageFriendlyUrlPathExperiencesPage_getFriendlyUrlPath());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId =
 			testGetSiteSitePageFriendlyUrlPathExperiencesPage_getSiteId();
 		Long irrelevantSiteId =
@@ -517,6 +510,12 @@ public abstract class BaseSitePageResourceTestCase {
 			testGetSiteSitePageFriendlyUrlPathExperiencesPage_getFriendlyUrlPath();
 		String irrelevantFriendlyUrlPath =
 			testGetSiteSitePageFriendlyUrlPathExperiencesPage_getIrrelevantFriendlyUrlPath();
+
+		Page<SitePage> page =
+			sitePageResource.getSiteSitePageFriendlyUrlPathExperiencesPage(
+				siteId, friendlyUrlPath);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantSiteId != null) && (irrelevantFriendlyUrlPath != null)) {
 			SitePage irrelevantSitePage =
@@ -651,6 +650,21 @@ public abstract class BaseSitePageResourceTestCase {
 
 			assertEquals(sitePage1, sitePage2);
 		}
+	}
+
+	protected void assertContains(SitePage sitePage, List<SitePage> sitePages) {
+		boolean contains = false;
+
+		for (SitePage item : sitePages) {
+			if (equals(sitePage, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			sitePages + " does not contain " + sitePage, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -234,19 +234,18 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	public void testGetAssetLibraryStructuredContentFoldersPage()
 		throws Exception {
 
-		Page<StructuredContentFolder> page =
-			structuredContentFolderResource.
-				getAssetLibraryStructuredContentFoldersPage(
-					testGetAssetLibraryStructuredContentFoldersPage_getAssetLibraryId(),
-					null, RandomTestUtil.randomString(), null, null,
-					Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryStructuredContentFoldersPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
 			testGetAssetLibraryStructuredContentFoldersPage_getIrrelevantAssetLibraryId();
+
+		Page<StructuredContentFolder> page =
+			structuredContentFolderResource.
+				getAssetLibraryStructuredContentFoldersPage(
+					assetLibraryId, null, RandomTestUtil.randomString(), null,
+					null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAssetLibraryId != null) {
 			StructuredContentFolder irrelevantStructuredContentFolder =
@@ -279,8 +278,8 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		page =
 			structuredContentFolderResource.
 				getAssetLibraryStructuredContentFoldersPage(
-					assetLibraryId, null, null, null, null, Pagination.of(1, 2),
-					null);
+					assetLibraryId, null, null, null, null,
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -692,17 +691,16 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 
 	@Test
 	public void testGetSiteStructuredContentFoldersPage() throws Exception {
-		Page<StructuredContentFolder> page =
-			structuredContentFolderResource.getSiteStructuredContentFoldersPage(
-				testGetSiteStructuredContentFoldersPage_getSiteId(), null,
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteStructuredContentFoldersPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteStructuredContentFoldersPage_getIrrelevantSiteId();
+
+		Page<StructuredContentFolder> page =
+			structuredContentFolderResource.getSiteStructuredContentFoldersPage(
+				siteId, null, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			StructuredContentFolder irrelevantStructuredContentFolder =
@@ -734,7 +732,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 
 		page =
 			structuredContentFolderResource.getSiteStructuredContentFoldersPage(
-				siteId, null, null, null, null, Pagination.of(1, 2), null);
+				siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1046,7 +1044,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -1072,7 +1070,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			"JSONObject/structuredContentFolders");
 
 		Assert.assertEquals(
-			2, structuredContentFoldersJSONObject.get("totalCount"));
+			2, structuredContentFoldersJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(structuredContentFolder1, structuredContentFolder2),
@@ -1259,19 +1257,19 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	public void testGetStructuredContentFolderStructuredContentFoldersPage()
 		throws Exception {
 
-		Page<StructuredContentFolder> page =
-			structuredContentFolderResource.
-				getStructuredContentFolderStructuredContentFoldersPage(
-					testGetStructuredContentFolderStructuredContentFoldersPage_getParentStructuredContentFolderId(),
-					RandomTestUtil.randomString(), null, null,
-					Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long parentStructuredContentFolderId =
 			testGetStructuredContentFolderStructuredContentFoldersPage_getParentStructuredContentFolderId();
 		Long irrelevantParentStructuredContentFolderId =
 			testGetStructuredContentFolderStructuredContentFoldersPage_getIrrelevantParentStructuredContentFolderId();
+
+		Page<StructuredContentFolder> page =
+			structuredContentFolderResource.
+				getStructuredContentFolderStructuredContentFoldersPage(
+					parentStructuredContentFolderId,
+					RandomTestUtil.randomString(), null, null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantParentStructuredContentFolderId != null) {
 			StructuredContentFolder irrelevantStructuredContentFolder =
@@ -1307,7 +1305,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			structuredContentFolderResource.
 				getStructuredContentFolderStructuredContentFoldersPage(
 					parentStructuredContentFolderId, null, null, null,
-					Pagination.of(1, 2), null);
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -2054,6 +2052,26 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 
 			assertEquals(structuredContentFolder1, structuredContentFolder2);
 		}
+	}
+
+	protected void assertContains(
+		StructuredContentFolder structuredContentFolder,
+		List<StructuredContentFolder> structuredContentFolders) {
+
+		boolean contains = false;
+
+		for (StructuredContentFolder item : structuredContentFolders) {
+			if (equals(structuredContentFolder, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			structuredContentFolders + " does not contain " +
+				structuredContentFolder,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -235,18 +235,17 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 	@Test
 	public void testGetAssetLibraryStructuredContentsPage() throws Exception {
-		Page<StructuredContent> page =
-			structuredContentResource.getAssetLibraryStructuredContentsPage(
-				testGetAssetLibraryStructuredContentsPage_getAssetLibraryId(),
-				null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long assetLibraryId =
 			testGetAssetLibraryStructuredContentsPage_getAssetLibraryId();
 		Long irrelevantAssetLibraryId =
 			testGetAssetLibraryStructuredContentsPage_getIrrelevantAssetLibraryId();
+
+		Page<StructuredContent> page =
+			structuredContentResource.getAssetLibraryStructuredContentsPage(
+				assetLibraryId, null, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantAssetLibraryId != null) {
 			StructuredContent irrelevantStructuredContent =
@@ -276,7 +275,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 				assetLibraryId, randomStructuredContent());
 
 		page = structuredContentResource.getAssetLibraryStructuredContentsPage(
-			assetLibraryId, null, null, null, null, Pagination.of(1, 2), null);
+			assetLibraryId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -664,18 +663,17 @@ public abstract class BaseStructuredContentResourceTestCase {
 	public void testGetContentStructureStructuredContentsPage()
 		throws Exception {
 
-		Page<StructuredContent> page =
-			structuredContentResource.getContentStructureStructuredContentsPage(
-				testGetContentStructureStructuredContentsPage_getContentStructureId(),
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long contentStructureId =
 			testGetContentStructureStructuredContentsPage_getContentStructureId();
 		Long irrelevantContentStructureId =
 			testGetContentStructureStructuredContentsPage_getIrrelevantContentStructureId();
+
+		Page<StructuredContent> page =
+			structuredContentResource.getContentStructureStructuredContentsPage(
+				contentStructureId, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantContentStructureId != null) {
 			StructuredContent irrelevantStructuredContent =
@@ -707,7 +705,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		page =
 			structuredContentResource.getContentStructureStructuredContentsPage(
-				contentStructureId, null, null, null, Pagination.of(1, 2),
+				contentStructureId, null, null, null, Pagination.of(1, 10),
 				null);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -1011,17 +1009,16 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 	@Test
 	public void testGetSiteStructuredContentsPage() throws Exception {
-		Page<StructuredContent> page =
-			structuredContentResource.getSiteStructuredContentsPage(
-				testGetSiteStructuredContentsPage_getSiteId(), null,
-				RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-				null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteStructuredContentsPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteStructuredContentsPage_getIrrelevantSiteId();
+
+		Page<StructuredContent> page =
+			structuredContentResource.getSiteStructuredContentsPage(
+				siteId, null, RandomTestUtil.randomString(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			StructuredContent irrelevantStructuredContent =
@@ -1049,7 +1046,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 				siteId, randomStructuredContent());
 
 		page = structuredContentResource.getSiteStructuredContentsPage(
-			siteId, null, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -1344,7 +1341,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -1367,7 +1364,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/structuredContents");
 
-		Assert.assertEquals(2, structuredContentsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			2, structuredContentsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(structuredContent1, structuredContent2),
@@ -1824,19 +1822,19 @@ public abstract class BaseStructuredContentResourceTestCase {
 	public void testGetStructuredContentFolderStructuredContentsPage()
 		throws Exception {
 
-		Page<StructuredContent> page =
-			structuredContentResource.
-				getStructuredContentFolderStructuredContentsPage(
-					testGetStructuredContentFolderStructuredContentsPage_getStructuredContentFolderId(),
-					null, RandomTestUtil.randomString(), null, null,
-					Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long structuredContentFolderId =
 			testGetStructuredContentFolderStructuredContentsPage_getStructuredContentFolderId();
 		Long irrelevantStructuredContentFolderId =
 			testGetStructuredContentFolderStructuredContentsPage_getIrrelevantStructuredContentFolderId();
+
+		Page<StructuredContent> page =
+			structuredContentResource.
+				getStructuredContentFolderStructuredContentsPage(
+					structuredContentFolderId, null,
+					RandomTestUtil.randomString(), null, null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantStructuredContentFolderId != null) {
 			StructuredContent irrelevantStructuredContent =
@@ -1870,7 +1868,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			structuredContentResource.
 				getStructuredContentFolderStructuredContentsPage(
 					structuredContentFolderId, null, null, null, null,
-					Pagination.of(1, 2), null);
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -2755,6 +2753,25 @@ public abstract class BaseStructuredContentResourceTestCase {
 	protected void assertEquals(Rating rating1, Rating rating2) {
 		Assert.assertTrue(
 			rating1 + " does not equal " + rating2, equals(rating1, rating2));
+	}
+
+	protected void assertContains(
+		StructuredContent structuredContent,
+		List<StructuredContent> structuredContents) {
+
+		boolean contains = false;
+
+		for (StructuredContent item : structuredContents) {
+			if (equals(structuredContent, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			structuredContents + " does not contain " + structuredContent,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -208,14 +208,14 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 	@Test
 	public void testGetSiteWikiNodesPage() throws Exception {
-		Page<WikiNode> page = wikiNodeResource.getSiteWikiNodesPage(
-			testGetSiteWikiNodesPage_getSiteId(), RandomTestUtil.randomString(),
-			null, null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteWikiNodesPage_getSiteId();
 		Long irrelevantSiteId = testGetSiteWikiNodesPage_getIrrelevantSiteId();
+
+		Page<WikiNode> page = wikiNodeResource.getSiteWikiNodesPage(
+			siteId, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			WikiNode irrelevantWikiNode = testGetSiteWikiNodesPage_addWikiNode(
@@ -239,7 +239,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 			siteId, randomWikiNode());
 
 		page = wikiNodeResource.getSiteWikiNodesPage(
-			siteId, null, null, null, Pagination.of(1, 2), null);
+			siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -493,7 +493,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -514,7 +514,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/wikiNodes");
 
-		Assert.assertEquals(2, wikiNodesJSONObject.get("totalCount"));
+		Assert.assertEquals(2, wikiNodesJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(wikiNode1, wikiNode2),
@@ -1132,6 +1132,21 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 			assertEquals(wikiNode1, wikiNode2);
 		}
+	}
+
+	protected void assertContains(WikiNode wikiNode, List<WikiNode> wikiNodes) {
+		boolean contains = false;
+
+		for (WikiNode item : wikiNodes) {
+			if (equals(wikiNode, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			wikiNodes + " does not contain " + wikiNode, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
@@ -336,16 +336,16 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 
 	@Test
 	public void testGetWikiPageWikiPageAttachmentsPage() throws Exception {
-		Page<WikiPageAttachment> page =
-			wikiPageAttachmentResource.getWikiPageWikiPageAttachmentsPage(
-				testGetWikiPageWikiPageAttachmentsPage_getWikiPageId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long wikiPageId =
 			testGetWikiPageWikiPageAttachmentsPage_getWikiPageId();
 		Long irrelevantWikiPageId =
 			testGetWikiPageWikiPageAttachmentsPage_getIrrelevantWikiPageId();
+
+		Page<WikiPageAttachment> page =
+			wikiPageAttachmentResource.getWikiPageWikiPageAttachmentsPage(
+				wikiPageId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantWikiPageId != null) {
 			WikiPageAttachment irrelevantWikiPageAttachment =
@@ -480,6 +480,25 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 
 			assertEquals(wikiPageAttachment1, wikiPageAttachment2);
 		}
+	}
+
+	protected void assertContains(
+		WikiPageAttachment wikiPageAttachment,
+		List<WikiPageAttachment> wikiPageAttachments) {
+
+		boolean contains = false;
+
+		for (WikiPageAttachment item : wikiPageAttachments) {
+			if (equals(wikiPageAttachment, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			wikiPageAttachments + " does not contain " + wikiPageAttachment,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -382,16 +382,15 @@ public abstract class BaseWikiPageResourceTestCase {
 
 	@Test
 	public void testGetWikiNodeWikiPagesPage() throws Exception {
-		Page<WikiPage> page = wikiPageResource.getWikiNodeWikiPagesPage(
-			testGetWikiNodeWikiPagesPage_getWikiNodeId(),
-			RandomTestUtil.randomString(), null, null, Pagination.of(1, 2),
-			null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long wikiNodeId = testGetWikiNodeWikiPagesPage_getWikiNodeId();
 		Long irrelevantWikiNodeId =
 			testGetWikiNodeWikiPagesPage_getIrrelevantWikiNodeId();
+
+		Page<WikiPage> page = wikiPageResource.getWikiNodeWikiPagesPage(
+			wikiNodeId, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantWikiNodeId != null) {
 			WikiPage irrelevantWikiPage =
@@ -417,7 +416,7 @@ public abstract class BaseWikiPageResourceTestCase {
 			wikiNodeId, randomWikiPage());
 
 		page = wikiPageResource.getWikiNodeWikiPagesPage(
-			wikiNodeId, null, null, null, Pagination.of(1, 2), null);
+			wikiNodeId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -690,15 +689,15 @@ public abstract class BaseWikiPageResourceTestCase {
 
 	@Test
 	public void testGetWikiPageWikiPagesPage() throws Exception {
-		Page<WikiPage> page = wikiPageResource.getWikiPageWikiPagesPage(
-			testGetWikiPageWikiPagesPage_getParentWikiPageId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long parentWikiPageId =
 			testGetWikiPageWikiPagesPage_getParentWikiPageId();
 		Long irrelevantParentWikiPageId =
 			testGetWikiPageWikiPagesPage_getIrrelevantParentWikiPageId();
+
+		Page<WikiPage> page = wikiPageResource.getWikiPageWikiPagesPage(
+			parentWikiPageId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantParentWikiPageId != null) {
 			WikiPage irrelevantWikiPage =
@@ -1038,6 +1037,21 @@ public abstract class BaseWikiPageResourceTestCase {
 
 			assertEquals(wikiPage1, wikiPage2);
 		}
+	}
+
+	protected void assertContains(WikiPage wikiPage, List<WikiPage> wikiPages) {
+		boolean contains = false;
+
+		for (WikiPage item : wikiPages) {
+			if (equals(wikiPage, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			wikiPages + " does not contain " + wikiPage, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
@@ -352,6 +352,23 @@ public abstract class BaseFormDocumentResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		FormDocument formDocument, List<FormDocument> formDocuments) {
+
+		boolean contains = false;
+
+		for (FormDocument item : formDocuments) {
+			if (equals(formDocument, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			formDocuments + " does not contain " + formDocument, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<FormDocument> formDocuments1, List<FormDocument> formDocuments2) {
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -269,14 +269,14 @@ public abstract class BaseFormRecordResourceTestCase {
 
 	@Test
 	public void testGetFormFormRecordsPage() throws Exception {
-		Page<FormRecord> page = formRecordResource.getFormFormRecordsPage(
-			testGetFormFormRecordsPage_getFormId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long formId = testGetFormFormRecordsPage_getFormId();
 		Long irrelevantFormId =
 			testGetFormFormRecordsPage_getIrrelevantFormId();
+
+		Page<FormRecord> page = formRecordResource.getFormFormRecordsPage(
+			formId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantFormId != null) {
 			FormRecord irrelevantFormRecord =
@@ -301,7 +301,7 @@ public abstract class BaseFormRecordResourceTestCase {
 			formId, randomFormRecord());
 
 		page = formRecordResource.getFormFormRecordsPage(
-			formId, Pagination.of(1, 2));
+			formId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -483,6 +483,23 @@ public abstract class BaseFormRecordResourceTestCase {
 
 			assertEquals(formRecord1, formRecord2);
 		}
+	}
+
+	protected void assertContains(
+		FormRecord formRecord, List<FormRecord> formRecords) {
+
+		boolean contains = false;
+
+		for (FormRecord item : formRecords) {
+			if (equals(formRecord, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			formRecords + " does not contain " + formRecord, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -255,13 +255,13 @@ public abstract class BaseFormResourceTestCase {
 
 	@Test
 	public void testGetSiteFormsPage() throws Exception {
-		Page<Form> page = formResource.getSiteFormsPage(
-			testGetSiteFormsPage_getSiteId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteFormsPage_getSiteId();
 		Long irrelevantSiteId = testGetSiteFormsPage_getIrrelevantSiteId();
+
+		Page<Form> page = formResource.getSiteFormsPage(
+			siteId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			Form irrelevantForm = testGetSiteFormsPage_addForm(
@@ -281,7 +281,7 @@ public abstract class BaseFormResourceTestCase {
 
 		Form form2 = testGetSiteFormsPage_addForm(siteId, randomForm());
 
-		page = formResource.getSiteFormsPage(siteId, Pagination.of(1, 2));
+		page = formResource.getSiteFormsPage(siteId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -347,7 +347,7 @@ public abstract class BaseFormResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -368,7 +368,7 @@ public abstract class BaseFormResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/forms");
 
-		Assert.assertEquals(2, formsJSONObject.get("totalCount"));
+		Assert.assertEquals(2, formsJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(form1, form2),
@@ -429,6 +429,20 @@ public abstract class BaseFormResourceTestCase {
 		Assert.assertTrue(
 			formDocument1 + " does not equal " + formDocument2,
 			equals(formDocument1, formDocument2));
+	}
+
+	protected void assertContains(Form form, List<Form> forms) {
+		boolean contains = false;
+
+		for (Form item : forms) {
+			if (equals(form, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(forms + " does not contain " + form, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -260,15 +260,15 @@ public abstract class BaseFormStructureResourceTestCase {
 
 	@Test
 	public void testGetSiteFormStructuresPage() throws Exception {
-		Page<FormStructure> page =
-			formStructureResource.getSiteFormStructuresPage(
-				testGetSiteFormStructuresPage_getSiteId(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long siteId = testGetSiteFormStructuresPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteFormStructuresPage_getIrrelevantSiteId();
+
+		Page<FormStructure> page =
+			formStructureResource.getSiteFormStructuresPage(
+				siteId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantSiteId != null) {
 			FormStructure irrelevantFormStructure =
@@ -295,7 +295,7 @@ public abstract class BaseFormStructureResourceTestCase {
 				siteId, randomFormStructure());
 
 		page = formStructureResource.getSiteFormStructuresPage(
-			siteId, Pagination.of(1, 2));
+			siteId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -379,7 +379,7 @@ public abstract class BaseFormStructureResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 
 					put("siteKey", "\"" + siteId + "\"");
 				}
@@ -402,7 +402,7 @@ public abstract class BaseFormStructureResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/formStructures");
 
-		Assert.assertEquals(2, formStructuresJSONObject.get("totalCount"));
+		Assert.assertEquals(2, formStructuresJSONObject.getLong("totalCount"));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(formStructure1, formStructure2),
@@ -446,6 +446,23 @@ public abstract class BaseFormStructureResourceTestCase {
 
 			assertEquals(formStructure1, formStructure2);
 		}
+	}
+
+	protected void assertContains(
+		FormStructure formStructure, List<FormStructure> formStructures) {
+
+		boolean contains = false;
+
+		for (FormStructure item : formStructures) {
+			if (equals(formStructure, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			formStructures + " does not contain " + formStructure, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -203,9 +204,9 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 	public void testGetObjectDefinitionsPage() throws Exception {
 		Page<ObjectDefinition> page =
 			objectDefinitionResource.getObjectDefinitionsPage(
-				RandomTestUtil.randomString(), Pagination.of(1, 2));
+				RandomTestUtil.randomString(), Pagination.of(1, 10));
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		ObjectDefinition objectDefinition1 =
 			testGetObjectDefinitionsPage_addObjectDefinition(
@@ -216,13 +217,14 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 				randomObjectDefinition());
 
 		page = objectDefinitionResource.getObjectDefinitionsPage(
-			null, Pagination.of(1, 2));
+			null, Pagination.of(1, 10));
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(objectDefinition1, objectDefinition2),
-			(List<ObjectDefinition>)page.getItems());
+		assertContains(
+			objectDefinition1, (List<ObjectDefinition>)page.getItems());
+		assertContains(
+			objectDefinition2, (List<ObjectDefinition>)page.getItems());
 		assertValid(page);
 
 		objectDefinitionResource.deleteObjectDefinition(
@@ -234,6 +236,11 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 
 	@Test
 	public void testGetObjectDefinitionsPageWithPagination() throws Exception {
+		Page<ObjectDefinition> totalPage =
+			objectDefinitionResource.getObjectDefinitionsPage(null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		ObjectDefinition objectDefinition1 =
 			testGetObjectDefinitionsPage_addObjectDefinition(
 				randomObjectDefinition());
@@ -248,19 +255,20 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 
 		Page<ObjectDefinition> page1 =
 			objectDefinitionResource.getObjectDefinitionsPage(
-				null, Pagination.of(1, 2));
+				null, Pagination.of(1, totalCount + 2));
 
 		List<ObjectDefinition> objectDefinitions1 =
 			(List<ObjectDefinition>)page1.getItems();
 
 		Assert.assertEquals(
-			objectDefinitions1.toString(), 2, objectDefinitions1.size());
+			objectDefinitions1.toString(), totalCount + 2,
+			objectDefinitions1.size());
 
 		Page<ObjectDefinition> page2 =
 			objectDefinitionResource.getObjectDefinitionsPage(
-				null, Pagination.of(2, 2));
+				null, Pagination.of(2, totalCount + 2));
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<ObjectDefinition> objectDefinitions2 =
 			(List<ObjectDefinition>)page2.getItems();
@@ -270,12 +278,14 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 
 		Page<ObjectDefinition> page3 =
 			objectDefinitionResource.getObjectDefinitionsPage(
-				null, Pagination.of(1, 3));
+				null, Pagination.of(1, totalCount + 3));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(
-				objectDefinition1, objectDefinition2, objectDefinition3),
-			(List<ObjectDefinition>)page3.getItems());
+		assertContains(
+			objectDefinition1, (List<ObjectDefinition>)page3.getItems());
+		assertContains(
+			objectDefinition2, (List<ObjectDefinition>)page3.getItems());
+		assertContains(
+			objectDefinition3, (List<ObjectDefinition>)page3.getItems());
 	}
 
 	protected ObjectDefinition testGetObjectDefinitionsPage_addObjectDefinition(
@@ -293,7 +303,7 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 			new HashMap<String, Object>() {
 				{
 					put("page", 1);
-					put("pageSize", 2);
+					put("pageSize", 10);
 				}
 			},
 			new GraphQLField("items", getGraphQLFields()),
@@ -303,7 +313,7 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/objectDefinitions");
 
-		Assert.assertEquals(0, objectDefinitionsJSONObject.get("totalCount"));
+		long totalCount = objectDefinitionsJSONObject.getLong("totalCount");
 
 		ObjectDefinition objectDefinition1 =
 			testGraphQLObjectDefinition_addObjectDefinition();
@@ -314,10 +324,16 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/objectDefinitions");
 
-		Assert.assertEquals(2, objectDefinitionsJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, objectDefinitionsJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(objectDefinition1, objectDefinition2),
+		assertContains(
+			objectDefinition1,
+			Arrays.asList(
+				ObjectDefinitionSerDes.toDTOs(
+					objectDefinitionsJSONObject.getString("items"))));
+		assertContains(
+			objectDefinition2,
 			Arrays.asList(
 				ObjectDefinitionSerDes.toDTOs(
 					objectDefinitionsJSONObject.getString("items"))));
@@ -595,6 +611,25 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 
 			assertEquals(objectDefinition1, objectDefinition2);
 		}
+	}
+
+	protected void assertContains(
+		ObjectDefinition objectDefinition,
+		List<ObjectDefinition> objectDefinitions) {
+
+		boolean contains = false;
+
+		for (ObjectDefinition item : objectDefinitions) {
+			if (equals(objectDefinition, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			objectDefinitions + " does not contain " + objectDefinition,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
@@ -194,17 +194,17 @@ public abstract class BaseObjectFieldResourceTestCase {
 
 	@Test
 	public void testGetObjectDefinitionObjectFieldsPage() throws Exception {
-		Page<ObjectField> page =
-			objectFieldResource.getObjectDefinitionObjectFieldsPage(
-				testGetObjectDefinitionObjectFieldsPage_getObjectDefinitionId(),
-				RandomTestUtil.randomString(), Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long objectDefinitionId =
 			testGetObjectDefinitionObjectFieldsPage_getObjectDefinitionId();
 		Long irrelevantObjectDefinitionId =
 			testGetObjectDefinitionObjectFieldsPage_getIrrelevantObjectDefinitionId();
+
+		Page<ObjectField> page =
+			objectFieldResource.getObjectDefinitionObjectFieldsPage(
+				objectDefinitionId, RandomTestUtil.randomString(),
+				Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantObjectDefinitionId != null) {
 			ObjectField irrelevantObjectField =
@@ -232,7 +232,7 @@ public abstract class BaseObjectFieldResourceTestCase {
 				objectDefinitionId, randomObjectField());
 
 		page = objectFieldResource.getObjectDefinitionObjectFieldsPage(
-			objectDefinitionId, null, Pagination.of(1, 2));
+			objectDefinitionId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -479,6 +479,23 @@ public abstract class BaseObjectFieldResourceTestCase {
 
 			assertEquals(objectField1, objectField2);
 		}
+	}
+
+	protected void assertContains(
+		ObjectField objectField, List<ObjectField> objectFields) {
+
+		boolean contains = false;
+
+		for (ObjectField item : objectFields) {
+			if (equals(objectField, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			objectFields + " does not contain " + objectField, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
@@ -196,18 +196,17 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 	public void testGetObjectDefinitionObjectRelationshipsPage()
 		throws Exception {
 
-		Page<ObjectRelationship> page =
-			objectRelationshipResource.
-				getObjectDefinitionObjectRelationshipsPage(
-					testGetObjectDefinitionObjectRelationshipsPage_getObjectDefinitionId(),
-					Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long objectDefinitionId =
 			testGetObjectDefinitionObjectRelationshipsPage_getObjectDefinitionId();
 		Long irrelevantObjectDefinitionId =
 			testGetObjectDefinitionObjectRelationshipsPage_getIrrelevantObjectDefinitionId();
+
+		Page<ObjectRelationship> page =
+			objectRelationshipResource.
+				getObjectDefinitionObjectRelationshipsPage(
+					objectDefinitionId, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantObjectDefinitionId != null) {
 			ObjectRelationship irrelevantObjectRelationship =
@@ -239,7 +238,7 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 		page =
 			objectRelationshipResource.
 				getObjectDefinitionObjectRelationshipsPage(
-					objectDefinitionId, Pagination.of(1, 2));
+					objectDefinitionId, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -392,6 +391,25 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 
 			assertEquals(objectRelationship1, objectRelationship2);
 		}
+	}
+
+	protected void assertContains(
+		ObjectRelationship objectRelationship,
+		List<ObjectRelationship> objectRelationships) {
+
+		boolean contains = false;
+
+		for (ObjectRelationship item : objectRelationships) {
+			if (equals(objectRelationship, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			objectRelationships + " does not contain " + objectRelationship,
+			contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -17,21 +17,15 @@ package com.liferay.object.admin.rest.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.admin.rest.client.dto.v1_0.ObjectDefinition;
 import com.liferay.object.admin.rest.client.dto.v1_0.ObjectField;
-import com.liferay.object.admin.rest.client.pagination.Page;
-import com.liferay.object.admin.rest.client.pagination.Pagination;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,82 +53,10 @@ public class ObjectDefinitionResourceTest
 		}
 	}
 
-	@Override
-	@Test
-	public void testGetObjectDefinitionsPage() throws Exception {
-		Page<ObjectDefinition> objectDefinitionsPage =
-			objectDefinitionResource.getObjectDefinitionsPage(
-				null, Pagination.of(1, 10));
-
-		long totalCount = objectDefinitionsPage.getTotalCount();
-
-		_addObjectDefinition(randomObjectDefinition());
-
-		objectDefinitionsPage =
-			objectDefinitionResource.getObjectDefinitionsPage(
-				null, Pagination.of(1, 10));
-
-		Assert.assertEquals(
-			totalCount + 1, objectDefinitionsPage.getTotalCount());
-	}
-
-	@Override
-	@Test
-	public void testGetObjectDefinitionsPageWithPagination() throws Exception {
-		Page<ObjectDefinition> objectDefinitionsPage =
-			objectDefinitionResource.getObjectDefinitionsPage(
-				null, Pagination.of(1, 2));
-
-		long totalCount = objectDefinitionsPage.getTotalCount();
-
-		_addObjectDefinition(randomObjectDefinition());
-		_addObjectDefinition(randomObjectDefinition());
-
-		objectDefinitionsPage =
-			objectDefinitionResource.getObjectDefinitionsPage(
-				null, Pagination.of(1, 2));
-
-		List<ObjectDefinition> objectDefinitions =
-			(List<ObjectDefinition>)objectDefinitionsPage.getItems();
-
-		Assert.assertEquals(
-			objectDefinitions.toString(), 2, objectDefinitions.size());
-
-		objectDefinitionsPage =
-			objectDefinitionResource.getObjectDefinitionsPage(
-				null, Pagination.of(2, 2));
-
-		Assert.assertEquals(
-			totalCount + 2, objectDefinitionsPage.getTotalCount());
-	}
-
 	@Ignore
 	@Override
 	@Test
 	public void testGraphQLGetObjectDefinitionNotFound() {
-	}
-
-	@Override
-	@Test
-	public void testGraphQLGetObjectDefinitionsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitions", new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
-
-		JSONObject objectDefinitionsJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(graphQLField), "JSONObject/data",
-			"JSONObject/objectDefinitions");
-
-		int totalCount = (int)objectDefinitionsJSONObject.get("totalCount");
-
-		testGraphQLObjectDefinition_addObjectDefinition();
-
-		objectDefinitionsJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(graphQLField), "JSONObject/data",
-			"JSONObject/objectDefinitions");
-
-		Assert.assertEquals(
-			totalCount + 1, objectDefinitionsJSONObject.get("totalCount"));
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeMetricResourceTestCase.java
@@ -220,6 +220,23 @@ public abstract class BaseAssigneeMetricResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		AssigneeMetric assigneeMetric, List<AssigneeMetric> assigneeMetrics) {
+
+		boolean contains = false;
+
+		for (AssigneeMetric item : assigneeMetrics) {
+			if (equals(assigneeMetric, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			assigneeMetrics + " does not contain " + assigneeMetric, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<AssigneeMetric> assigneeMetrics1,
 		List<AssigneeMetric> assigneeMetrics2) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeResourceTestCase.java
@@ -228,6 +228,21 @@ public abstract class BaseAssigneeResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Assignee assignee, List<Assignee> assignees) {
+		boolean contains = false;
+
+		for (Assignee item : assignees) {
+			if (equals(assignee, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			assignees + " does not contain " + assignee, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Assignee> assignees1, List<Assignee> assignees2) {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseCalendarResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseCalendarResourceTestCase.java
@@ -193,7 +193,28 @@ public abstract class BaseCalendarResourceTestCase {
 
 	@Test
 	public void testGetCalendarsPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<Calendar> page = calendarResource.getCalendarsPage();
+
+		long totalCount = page.getTotalCount();
+
+		Calendar calendar1 = testGetCalendarsPage_addCalendar(randomCalendar());
+
+		Calendar calendar2 = testGetCalendarsPage_addCalendar(randomCalendar());
+
+		page = calendarResource.getCalendarsPage();
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(calendar1, (List<Calendar>)page.getItems());
+		assertContains(calendar2, (List<Calendar>)page.getItems());
+		assertValid(page);
+	}
+
+	protected Calendar testGetCalendarsPage_addCalendar(Calendar calendar)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -226,6 +247,21 @@ public abstract class BaseCalendarResourceTestCase {
 
 			assertEquals(calendar1, calendar2);
 		}
+	}
+
+	protected void assertContains(Calendar calendar, List<Calendar> calendars) {
+		boolean contains = false;
+
+		for (Calendar item : calendars) {
+			if (equals(calendar, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			calendars + " does not contain " + calendar, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseHistogramMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseHistogramMetricResourceTestCase.java
@@ -232,6 +232,25 @@ public abstract class BaseHistogramMetricResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		HistogramMetric histogramMetric,
+		List<HistogramMetric> histogramMetrics) {
+
+		boolean contains = false;
+
+		for (HistogramMetric item : histogramMetrics) {
+			if (equals(histogramMetric, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			histogramMetrics + " does not contain " + histogramMetric,
+			contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<HistogramMetric> histogramMetrics1,
 		List<HistogramMetric> histogramMetrics2) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseIndexResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseIndexResourceTestCase.java
@@ -193,7 +193,26 @@ public abstract class BaseIndexResourceTestCase {
 
 	@Test
 	public void testGetIndexesPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<Index> page = indexResource.getIndexesPage();
+
+		long totalCount = page.getTotalCount();
+
+		Index index1 = testGetIndexesPage_addIndex(randomIndex());
+
+		Index index2 = testGetIndexesPage_addIndex(randomIndex());
+
+		page = indexResource.getIndexesPage();
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(index1, (List<Index>)page.getItems());
+		assertContains(index2, (List<Index>)page.getItems());
+		assertValid(page);
+	}
+
+	protected Index testGetIndexesPage_addIndex(Index index) throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -233,6 +252,20 @@ public abstract class BaseIndexResourceTestCase {
 
 			assertEquals(index1, index2);
 		}
+	}
+
+	protected void assertContains(Index index, List<Index> indexes) {
+		boolean contains = false;
+
+		for (Index item : indexes) {
+			if (equals(index, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(indexes + " does not contain " + index, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
@@ -204,16 +204,16 @@ public abstract class BaseInstanceResourceTestCase {
 
 	@Test
 	public void testGetProcessInstancesPage() throws Exception {
-		Page<Instance> page = instanceResource.getProcessInstancesPage(
-			testGetProcessInstancesPage_getProcessId(), null, null,
-			RandomTestUtil.nextDate(), RandomTestUtil.nextDate(), null, null,
-			null, Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long processId = testGetProcessInstancesPage_getProcessId();
 		Long irrelevantProcessId =
 			testGetProcessInstancesPage_getIrrelevantProcessId();
+
+		Page<Instance> page = instanceResource.getProcessInstancesPage(
+			processId, null, null, RandomTestUtil.nextDate(),
+			RandomTestUtil.nextDate(), null, null, null, Pagination.of(1, 10),
+			null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantProcessId != null) {
 			Instance irrelevantInstance =
@@ -240,7 +240,7 @@ public abstract class BaseInstanceResourceTestCase {
 
 		page = instanceResource.getProcessInstancesPage(
 			processId, null, null, null, null, null, null, null,
-			Pagination.of(1, 2), null);
+			Pagination.of(1, 10), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -608,6 +608,21 @@ public abstract class BaseInstanceResourceTestCase {
 
 			assertEquals(instance1, instance2);
 		}
+	}
+
+	protected void assertContains(Instance instance, List<Instance> instances) {
+		boolean contains = false;
+
+		for (Instance item : instances) {
+			if (equals(instance, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			instances + " does not contain " + instance, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeMetricResourceTestCase.java
@@ -194,17 +194,16 @@ public abstract class BaseNodeMetricResourceTestCase {
 
 	@Test
 	public void testGetProcessNodeMetricsPage() throws Exception {
-		Page<NodeMetric> page = nodeMetricResource.getProcessNodeMetricsPage(
-			testGetProcessNodeMetricsPage_getProcessId(), null,
-			RandomTestUtil.nextDate(), RandomTestUtil.nextDate(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			Pagination.of(1, 2), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long processId = testGetProcessNodeMetricsPage_getProcessId();
 		Long irrelevantProcessId =
 			testGetProcessNodeMetricsPage_getIrrelevantProcessId();
+
+		Page<NodeMetric> page = nodeMetricResource.getProcessNodeMetricsPage(
+			processId, null, RandomTestUtil.nextDate(),
+			RandomTestUtil.nextDate(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantProcessId != null) {
 			NodeMetric irrelevantNodeMetric =
@@ -230,7 +229,8 @@ public abstract class BaseNodeMetricResourceTestCase {
 			processId, randomNodeMetric());
 
 		page = nodeMetricResource.getProcessNodeMetricsPage(
-			processId, null, null, null, null, null, Pagination.of(1, 2), null);
+			processId, null, null, null, null, null, Pagination.of(1, 10),
+			null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -449,6 +449,23 @@ public abstract class BaseNodeMetricResourceTestCase {
 
 			assertEquals(nodeMetric1, nodeMetric2);
 		}
+	}
+
+	protected void assertContains(
+		NodeMetric nodeMetric, List<NodeMetric> nodeMetrics) {
+
+		boolean contains = false;
+
+		for (NodeMetric item : nodeMetrics) {
+			if (equals(nodeMetric, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			nodeMetrics + " does not contain " + nodeMetric, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
@@ -198,14 +198,13 @@ public abstract class BaseNodeResourceTestCase {
 
 	@Test
 	public void testGetProcessNodesPage() throws Exception {
-		Page<Node> page = nodeResource.getProcessNodesPage(
-			testGetProcessNodesPage_getProcessId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long processId = testGetProcessNodesPage_getProcessId();
 		Long irrelevantProcessId =
 			testGetProcessNodesPage_getIrrelevantProcessId();
+
+		Page<Node> page = nodeResource.getProcessNodesPage(processId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantProcessId != null) {
 			Node irrelevantNode = testGetProcessNodesPage_addNode(
@@ -308,6 +307,20 @@ public abstract class BaseNodeResourceTestCase {
 
 			assertEquals(node1, node2);
 		}
+	}
+
+	protected void assertContains(Node node, List<Node> nodes) {
+		boolean contains = false;
+
+		for (Node item : nodes) {
+			if (equals(node, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(nodes + " does not contain " + node, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessMetricResourceTestCase.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -195,9 +196,9 @@ public abstract class BaseProcessMetricResourceTestCase {
 	@Test
 	public void testGetProcessMetricsPage() throws Exception {
 		Page<ProcessMetric> page = processMetricResource.getProcessMetricsPage(
-			RandomTestUtil.randomString(), Pagination.of(1, 2), null);
+			RandomTestUtil.randomString(), Pagination.of(1, 10), null);
 
-		Assert.assertEquals(0, page.getTotalCount());
+		long totalCount = page.getTotalCount();
 
 		ProcessMetric processMetric1 =
 			testGetProcessMetricsPage_addProcessMetric(randomProcessMetric());
@@ -206,18 +207,22 @@ public abstract class BaseProcessMetricResourceTestCase {
 			testGetProcessMetricsPage_addProcessMetric(randomProcessMetric());
 
 		page = processMetricResource.getProcessMetricsPage(
-			null, Pagination.of(1, 2), null);
+			null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(processMetric1, processMetric2),
-			(List<ProcessMetric>)page.getItems());
+		assertContains(processMetric1, (List<ProcessMetric>)page.getItems());
+		assertContains(processMetric2, (List<ProcessMetric>)page.getItems());
 		assertValid(page);
 	}
 
 	@Test
 	public void testGetProcessMetricsPageWithPagination() throws Exception {
+		Page<ProcessMetric> totalPage =
+			processMetricResource.getProcessMetricsPage(null, null, null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
 		ProcessMetric processMetric1 =
 			testGetProcessMetricsPage_addProcessMetric(randomProcessMetric());
 
@@ -228,18 +233,18 @@ public abstract class BaseProcessMetricResourceTestCase {
 			testGetProcessMetricsPage_addProcessMetric(randomProcessMetric());
 
 		Page<ProcessMetric> page1 = processMetricResource.getProcessMetricsPage(
-			null, Pagination.of(1, 2), null);
+			null, Pagination.of(1, totalCount + 2), null);
 
 		List<ProcessMetric> processMetrics1 =
 			(List<ProcessMetric>)page1.getItems();
 
 		Assert.assertEquals(
-			processMetrics1.toString(), 2, processMetrics1.size());
+			processMetrics1.toString(), totalCount + 2, processMetrics1.size());
 
 		Page<ProcessMetric> page2 = processMetricResource.getProcessMetricsPage(
-			null, Pagination.of(2, 2), null);
+			null, Pagination.of(2, totalCount + 2), null);
 
-		Assert.assertEquals(3, page2.getTotalCount());
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
 		List<ProcessMetric> processMetrics2 =
 			(List<ProcessMetric>)page2.getItems();
@@ -248,11 +253,11 @@ public abstract class BaseProcessMetricResourceTestCase {
 			processMetrics2.toString(), 1, processMetrics2.size());
 
 		Page<ProcessMetric> page3 = processMetricResource.getProcessMetricsPage(
-			null, Pagination.of(1, 3), null);
+			null, Pagination.of(1, totalCount + 3), null);
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(processMetric1, processMetric2, processMetric3),
-			(List<ProcessMetric>)page3.getItems());
+		assertContains(processMetric1, (List<ProcessMetric>)page3.getItems());
+		assertContains(processMetric2, (List<ProcessMetric>)page3.getItems());
+		assertContains(processMetric3, (List<ProcessMetric>)page3.getItems());
 	}
 
 	@Test
@@ -429,6 +434,23 @@ public abstract class BaseProcessMetricResourceTestCase {
 
 			assertEquals(processMetric1, processMetric2);
 		}
+	}
+
+	protected void assertContains(
+		ProcessMetric processMetric, List<ProcessMetric> processMetrics) {
+
+		boolean contains = false;
+
+		for (ProcessMetric item : processMetrics) {
+			if (equals(processMetric, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			processMetrics + " does not contain " + processMetric, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
@@ -376,6 +376,20 @@ public abstract class BaseProcessResourceTestCase {
 		}
 	}
 
+	protected void assertContains(Process process, List<Process> processes) {
+		boolean contains = false;
+
+		for (Process item : processes) {
+			if (equals(process, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(processes + " does not contain " + process, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Process> processes1, List<Process> processes2) {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessVersionResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessVersionResourceTestCase.java
@@ -192,15 +192,14 @@ public abstract class BaseProcessVersionResourceTestCase {
 
 	@Test
 	public void testGetProcessProcessVersionsPage() throws Exception {
-		Page<ProcessVersion> page =
-			processVersionResource.getProcessProcessVersionsPage(
-				testGetProcessProcessVersionsPage_getProcessId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long processId = testGetProcessProcessVersionsPage_getProcessId();
 		Long irrelevantProcessId =
 			testGetProcessProcessVersionsPage_getIrrelevantProcessId();
+
+		Page<ProcessVersion> page =
+			processVersionResource.getProcessProcessVersionsPage(processId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantProcessId != null) {
 			ProcessVersion irrelevantProcessVersion =
@@ -286,6 +285,23 @@ public abstract class BaseProcessVersionResourceTestCase {
 
 			assertEquals(processVersion1, processVersion2);
 		}
+	}
+
+	protected void assertContains(
+		ProcessVersion processVersion, List<ProcessVersion> processVersions) {
+
+		boolean contains = false;
+
+		for (ProcessVersion item : processVersions) {
+			if (equals(processVersion, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			processVersions + " does not contain " + processVersion, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseReindexStatusResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseReindexStatusResourceTestCase.java
@@ -191,7 +191,32 @@ public abstract class BaseReindexStatusResourceTestCase {
 
 	@Test
 	public void testGetReindexStatusesPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<ReindexStatus> page =
+			reindexStatusResource.getReindexStatusesPage();
+
+		long totalCount = page.getTotalCount();
+
+		ReindexStatus reindexStatus1 =
+			testGetReindexStatusesPage_addReindexStatus(randomReindexStatus());
+
+		ReindexStatus reindexStatus2 =
+			testGetReindexStatusesPage_addReindexStatus(randomReindexStatus());
+
+		page = reindexStatusResource.getReindexStatusesPage();
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(reindexStatus1, (List<ReindexStatus>)page.getItems());
+		assertContains(reindexStatus2, (List<ReindexStatus>)page.getItems());
+		assertValid(page);
+	}
+
+	protected ReindexStatus testGetReindexStatusesPage_addReindexStatus(
+			ReindexStatus reindexStatus)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -227,6 +252,23 @@ public abstract class BaseReindexStatusResourceTestCase {
 
 			assertEquals(reindexStatus1, reindexStatus2);
 		}
+	}
+
+	protected void assertContains(
+		ReindexStatus reindexStatus, List<ReindexStatus> reindexStatuses) {
+
+		boolean contains = false;
+
+		for (ReindexStatus item : reindexStatuses) {
+			if (equals(reindexStatus, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			reindexStatuses + " does not contain " + reindexStatus, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -191,14 +191,13 @@ public abstract class BaseRoleResourceTestCase {
 
 	@Test
 	public void testGetProcessRolesPage() throws Exception {
-		Page<Role> page = roleResource.getProcessRolesPage(
-			testGetProcessRolesPage_getProcessId(), null);
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long processId = testGetProcessRolesPage_getProcessId();
 		Long irrelevantProcessId =
 			testGetProcessRolesPage_getIrrelevantProcessId();
+
+		Page<Role> page = roleResource.getProcessRolesPage(processId, null);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantProcessId != null) {
 			Role irrelevantRole = testGetProcessRolesPage_addRole(
@@ -271,6 +270,20 @@ public abstract class BaseRoleResourceTestCase {
 
 			assertEquals(role1, role2);
 		}
+	}
+
+	protected void assertContains(Role role, List<Role> roles) {
+		boolean contains = false;
+
+		for (Role item : roles) {
+			if (equals(role, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(roles + " does not contain " + role, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
@@ -198,14 +198,14 @@ public abstract class BaseSLAResourceTestCase {
 
 	@Test
 	public void testGetProcessSLAsPage() throws Exception {
-		Page<SLA> page = slaResource.getProcessSLAsPage(
-			testGetProcessSLAsPage_getProcessId(), null, Pagination.of(1, 2));
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long processId = testGetProcessSLAsPage_getProcessId();
 		Long irrelevantProcessId =
 			testGetProcessSLAsPage_getIrrelevantProcessId();
+
+		Page<SLA> page = slaResource.getProcessSLAsPage(
+			processId, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantProcessId != null) {
 			SLA irrelevantSLA = testGetProcessSLAsPage_addSLA(
@@ -226,7 +226,7 @@ public abstract class BaseSLAResourceTestCase {
 		SLA sla2 = testGetProcessSLAsPage_addSLA(processId, randomSLA());
 
 		page = slaResource.getProcessSLAsPage(
-			processId, null, Pagination.of(1, 2));
+			processId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -458,6 +458,20 @@ public abstract class BaseSLAResourceTestCase {
 
 			assertEquals(sla1, sla2);
 		}
+	}
+
+	protected void assertContains(SLA sla, List<SLA> slas) {
+		boolean contains = false;
+
+		for (SLA item : slas) {
+			if (equals(sla, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(slas + " does not contain " + sla, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(List<SLA> slas1, List<SLA> slas2) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
@@ -281,6 +281,23 @@ public abstract class BaseSLAResultResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		SLAResult slaResult, List<SLAResult> slaResults) {
+
+		boolean contains = false;
+
+		for (SLAResult item : slaResults) {
+			if (equals(slaResult, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			slaResults + " does not contain " + slaResult, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<SLAResult> slaResults1, List<SLAResult> slaResults2) {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
@@ -202,14 +202,13 @@ public abstract class BaseTaskResourceTestCase {
 
 	@Test
 	public void testGetProcessTasksPage() throws Exception {
-		Page<Task> page = taskResource.getProcessTasksPage(
-			testGetProcessTasksPage_getProcessId());
-
-		Assert.assertEquals(0, page.getTotalCount());
-
 		Long processId = testGetProcessTasksPage_getProcessId();
 		Long irrelevantProcessId =
 			testGetProcessTasksPage_getIrrelevantProcessId();
+
+		Page<Task> page = taskResource.getProcessTasksPage(processId);
+
+		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantProcessId != null) {
 			Task irrelevantTask = testGetProcessTasksPage_addTask(
@@ -428,6 +427,20 @@ public abstract class BaseTaskResourceTestCase {
 
 			assertEquals(task1, task2);
 		}
+	}
+
+	protected void assertContains(Task task, List<Task> tasks) {
+		boolean contains = false;
+
+		for (Task item : tasks) {
+			if (equals(task, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(tasks + " does not contain " + task, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTimeRangeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTimeRangeResourceTestCase.java
@@ -192,7 +192,30 @@ public abstract class BaseTimeRangeResourceTestCase {
 
 	@Test
 	public void testGetTimeRangesPage() throws Exception {
-		Assert.assertTrue(false);
+		Page<TimeRange> page = timeRangeResource.getTimeRangesPage();
+
+		long totalCount = page.getTotalCount();
+
+		TimeRange timeRange1 = testGetTimeRangesPage_addTimeRange(
+			randomTimeRange());
+
+		TimeRange timeRange2 = testGetTimeRangesPage_addTimeRange(
+			randomTimeRange());
+
+		page = timeRangeResource.getTimeRangesPage();
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(timeRange1, (List<TimeRange>)page.getItems());
+		assertContains(timeRange2, (List<TimeRange>)page.getItems());
+		assertValid(page);
+	}
+
+	protected TimeRange testGetTimeRangesPage_addTimeRange(TimeRange timeRange)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -210,7 +233,7 @@ public abstract class BaseTimeRangeResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/timeRanges");
 
-		Assert.assertEquals(0, timeRangesJSONObject.get("totalCount"));
+		long totalCount = timeRangesJSONObject.getLong("totalCount");
 
 		TimeRange timeRange1 = testGraphQLTimeRange_addTimeRange();
 		TimeRange timeRange2 = testGraphQLTimeRange_addTimeRange();
@@ -219,10 +242,16 @@ public abstract class BaseTimeRangeResourceTestCase {
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
 			"JSONObject/timeRanges");
 
-		Assert.assertEquals(2, timeRangesJSONObject.get("totalCount"));
+		Assert.assertEquals(
+			totalCount + 2, timeRangesJSONObject.getLong("totalCount"));
 
-		assertEqualsIgnoringOrder(
-			Arrays.asList(timeRange1, timeRange2),
+		assertContains(
+			timeRange1,
+			Arrays.asList(
+				TimeRangeSerDes.toDTOs(
+					timeRangesJSONObject.getString("items"))));
+		assertContains(
+			timeRange2,
 			Arrays.asList(
 				TimeRangeSerDes.toDTOs(
 					timeRangesJSONObject.getString("items"))));
@@ -258,6 +287,23 @@ public abstract class BaseTimeRangeResourceTestCase {
 
 			assertEquals(timeRange1, timeRange2);
 		}
+	}
+
+	protected void assertContains(
+		TimeRange timeRange, List<TimeRange> timeRanges) {
+
+		boolean contains = false;
+
+		for (TimeRange item : timeRanges) {
+			if (equals(timeRange, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			timeRanges + " does not contain " + timeRange, contains);
 	}
 
 	protected void assertEqualsIgnoringOrder(

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
@@ -351,6 +351,23 @@ public abstract class BaseExperimentResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		Experiment experiment, List<Experiment> experiments) {
+
+		boolean contains = false;
+
+		for (Experiment item : experiments) {
+			if (equals(experiment, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			experiments + " does not contain " + experiment, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Experiment> experiments1, List<Experiment> experiments2) {
 

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentRunResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentRunResourceTestCase.java
@@ -238,6 +238,23 @@ public abstract class BaseExperimentRunResourceTestCase {
 		}
 	}
 
+	protected void assertContains(
+		ExperimentRun experimentRun, List<ExperimentRun> experimentRuns) {
+
+		boolean contains = false;
+
+		for (ExperimentRun item : experimentRuns) {
+			if (equals(experimentRun, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			experimentRuns + " does not contain " + experimentRun, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<ExperimentRun> experimentRuns1,
 		List<ExperimentRun> experimentRuns2) {

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
@@ -231,6 +231,20 @@ public abstract class BaseStatusResourceTestCase {
 			equals(experiment1, experiment2));
 	}
 
+	protected void assertContains(Status status, List<Status> statuses) {
+		boolean contains = false;
+
+		for (Status item : statuses) {
+			if (equals(status, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(statuses + " does not contain " + status, contains);
+	}
+
 	protected void assertEqualsIgnoringOrder(
 		List<Status> statuses1, List<Status> statuses2) {
 


### PR DESCRIPTION
Improve autogeneration logic to generate the methods for get...Pages, get...PagesWithFilter, get...PagesWithPagination and get...PagesWithSort, that wasn't created before.

The generated logic is base on getting the current number of entities and then check that the count is equals to the old number plus the number of entities created