### PR TITLE
LPS-137967 Add serviceContext attribute to handle message board notifications redirections with urlSubject

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
@@ -560,7 +560,7 @@ public class MessageBoardThreadResourceImpl
 				).build());
 		}
 
-		serviceContext.setAttribute("entryURL", link);
+		serviceContext.setAttribute("link", link);
 
 		if (messageBoardThread.getId() == null) {
 			serviceContext.setCommand("add");

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -1909,6 +1909,12 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			return entryURL;
 		}
 
+		String link = GetterUtil.getString(serviceContext.getAttribute("link"));
+
+		if (Validator.isNotNull(link)) {
+			return link + message.getUrlSubject();
+		}
+
 		HttpServletRequest httpServletRequest = serviceContext.getRequest();
 
 		if (httpServletRequest == null) {


### PR DESCRIPTION
Related ticket -> [LPS-137967](https://issues.liferay.com/browse/LPS-137967)

The bug is related to the redirection of the notifications in Questions. When a user is subscribed to a tag and a second user creates a new question with that tag, the notification link is not navigating to the new question but to the questions list instead.

**Steps to reproduce:**
- UserA subscribed to a tag from questions
- As userB creates a question using the subscribed tag
- Login as userA
- Go to the notifications and click on it

**Expected Result:**
It is better for a user can navigate to the questions details.

**Actual Result:**
Users can navigate to the questions list page.

---
With this PR, I am adding a new attribute to serviceContext so I can create the URL of the redirection in the service.