### PR TITLE
LPS-119674 Cannot publish Staging over IPV6 connection

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -206,9 +206,9 @@ AUI.add(
 				},
 
 				_isActionUrl(url) {
-					var uri = new A.Url(url);
+					const uri = new URL(url);
 
-					return Number(uri.getParameter('p_p_lifecycle')) === 1;
+					return Number(uri.searchParams.get('p_p_lifecycle')) === 1;
 				},
 
 				_notifyRowToggle() {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -214,9 +214,9 @@ AUI.add(
 						);
 					}
 
-					var iframeURL = new A.Url(uri);
+					const iframeURL = new URL(uri);
 
-					var namespace = iframeURL.getParameter('p_p_id');
+					const namespace = iframeURL.searchParams.get('p_p_id');
 
 					var bodyCssClass = ['dialog-iframe-popup'];
 
@@ -227,8 +227,8 @@ AUI.add(
 						bodyCssClass.push(config.dialogIframe.bodyCssClass);
 					}
 
-					iframeURL.addParameter(
-						'_' + namespace + '_bodyCssClass',
+					iframeURL.searchParams.set(
+						`_${namespace}_bodyCssClass`,
 						bodyCssClass.join(' ')
 					);
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/form_navigator_steps/steps.jspf
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/form_navigator_steps/steps.jspf
@@ -255,13 +255,13 @@
 		var redirect = A.one('#<portlet:namespace />redirect');
 
 		if (redirect) {
-			var url = new A.Url(
+			const url = new URL(
 				redirect.val() ||
 					'<%= formNavigatorStepsDisplayContext.getPortletURL() %>'
 			);
 
-			url.setAnchor(null);
-			url.setParameter('<portlet:namespace />historyKey', sectionId);
+			url.hash = '';
+			url.searchParams.set('<portlet:namespace />historyKey', sectionId);
 
 			redirect.val(url.toString());
 		}
@@ -338,12 +338,15 @@
 		);
 	}
 	else {
-		var currentUrl = new A.Url(location.href);
+		const currentUrl = new URL(location.href);
 
-		var currentAnchor = currentUrl.getAnchor();
+		let currentAnchor;
 
-		if (!currentAnchor) {
-			currentAnchor = currentUrl.getParameter(
+		if (currentUrl.hash) {
+			currentAnchor = currentUrl.hash.substring(1);
+		}
+		else {
+			currentAnchor = currentUrl.searchParams.get(
 				'<portlet:namespace />historyKey'
 			);
 		}


### PR DESCRIPTION
FIxes: https://issues.liferay.com/browse/LPS-119674

See details and steps to reproduce in the JIRA ticket. Note that it doesn't have to be the modal in staging. The bug is on all legacy modals, for example the one on Calendar widget in the gifs below.

@jbalsas correctly spotted the root cause of the issue in [this comment](https://issues.liferay.com/browse/LPS-119674?focusedCommentId=2499415&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2499415): the [regex](https://github.com/liferay/alloy-ui/blob/2c240fab9760bb33909d531c0f9753a5e4de3bd4/src/aui-url/js/aui-url.js#L38-L41) in AUI `Url` library only covers IPv4 format. In this PR, we are removing all four usages of `A.Url` in DXP, replacing them with JS native `URL`. It correctly covers IPv6 format.

Notes:
- I could not find use cases to live test usages outside modals, but the changes should be safe. I tested them all with sample URLs.
- I noticed in several places backend warnings for URLs:
```
... WARN  [PortalImpl:1044] Redirect URL http://[::1]:8080/group/guest/~/control_panel/manage?p_p_id=com_liferay_portal_workflow_kaleo_forms_web_portlet_KaleoFormsAdminPortlet&p_p_lifecycle=0&p_p_state=normal&p_p_state_rcv=1 is not allowed
```

Before PR:
![before](https://user-images.githubusercontent.com/5435511/132878321-13b714bc-895a-4e24-8905-4b48d6b03f21.gif)

After PR:
![after](https://user-images.githubusercontent.com/5435511/132878309-b233976a-816b-48cc-b00e-015ba4bb6243.gif)







