### PR TITLE
LPS-134021 Lowercase data attributes keys, so we avoid React warnings

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/get_data_attributes.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/get_data_attributes.js
@@ -15,7 +15,7 @@
 export default function getDataAttributes(data) {
 	return data
 		? Object.entries(data).reduce((acc, [key, value]) => {
-				acc[`data-${key}`] = value;
+				acc[`data-${key.toLowerCase()}`] = value;
 
 				return acc;
 		  }, {})


### PR DESCRIPTION
Related ticket: https://issues.liferay.com/browse/LPS-134021

## Proposed solution
Lowercasing data attributes keys

## Steps to reproduce
Go to Content & Data > Web Content  and observe the browser console
 
### Expected result
There are no warnings in the browser console

### Actual result
A warning is displayed saying that data attributes should be lowercased
![image](https://user-images.githubusercontent.com/2444936/133105650-aebbdeba-824f-4118-a469-387bc87e4583.png)
