### PR TITLE
LPS-137955 | Fix test WYSIWYGUsecase#CanEditTextInPreviewSourceContent

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -318,7 +318,7 @@ definition {
 	@priority = "4"
 	@refactorneeded
 	test CanEditTextInPreviewSourceContent {
-		property portal.upstream = "quarantine";
+		property portal.acceptance = "true";
 
 		JSONWebcontent.addWebContent(
 			content = "",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -87,14 +87,12 @@ definition {
 	test CanAddHyperlinkToExistingText {
 		property portal.acceptance = "true";
 
-		JSONGroup.addGroup(groupName = "Test Site Name");
-
 		JSONWebcontent.addWebContent(
 			content = "Test Link",
-			groupName = "Test Site Name",
+			groupName = "WYSIWYG Site Name",
 			title = "Test Web Content");
 
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "wysiwyg-site-name");
 
 		WebContent.viewTitle(webContentTitle = "Test Web Content");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -320,6 +320,11 @@ definition {
 	test CanEditTextInPreviewSourceContent {
 		property portal.upstream = "quarantine";
 
+		JSONWebcontent.addWebContent(
+			content = "",
+			groupName = "WYSIWYG Site Name",
+			title = "Web Content Title");
+
 		Open(locator1 = "http://www.standards-schmandards.com/exhibits/wysiwyg/sampledoc.htm");
 
 		SelectFieldText(locator1 = "//body");
@@ -329,10 +334,6 @@ definition {
 		Navigator.openURL();
 
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "wysiwyg-site-name");
-
-		VerifyElementPresent(
-			key_assetTitle = "Web Content Title",
-			locator1 = "WC#ENTRY_LIST_TITLE");
 
 		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
 


### PR DESCRIPTION
**Background**
Test has been failing due to not having an existing web content to edit beforehand. Fix is to add a web content in setup phase of the test.

**Test Plan**
- [x] Make sure test passes and can edit text in preview source content view

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-137955