### PR TITLE
LPS-135708 Visual glitch when typing on Rich Text Field on Forms

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
@@ -15,15 +15,19 @@
 package com.liferay.frontend.editor.ckeditor.web.internal.editor.configuration;
 
 import com.liferay.frontend.editor.ckeditor.web.internal.constants.CKEditorConstants;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.ColorScheme;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Map;
 
@@ -40,12 +44,28 @@ public class BaseCKEditorConfigContributor extends BaseEditorConfigContributor {
 
 		jsonObject.put("allowedContent", Boolean.TRUE);
 
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("cke_editable html-editor");
+
+		ColorScheme colorScheme = themeDisplay.getColorScheme();
+
+		if (Validator.isNotNull(colorScheme.getCssClass())) {
+			sb.append(StringPool.SPACE);
+			sb.append(HtmlUtil.escape(colorScheme.getCssClass()));
+		}
+
 		String cssClasses = GetterUtil.getString(
 			inputEditorTaglibAttributes.get(
 				CKEditorConstants.ATTRIBUTE_NAMESPACE + ":cssClasses"));
 
+		if (Validator.isNotNull(cssClasses)) {
+			sb.append(StringPool.SPACE);
+			sb.append(HtmlUtil.escape(cssClasses));
+		}
+
 		jsonObject.put(
-			"bodyClass", "html-editor " + HtmlUtil.escape(cssClasses)
+			"bodyClass", sb.toString()
 		).put(
 			"contentsCss",
 			JSONUtil.putAll(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -16,18 +16,15 @@ package com.liferay.frontend.editor.ckeditor.web.internal.editor.configuration;
 
 import com.liferay.document.library.kernel.util.AudioProcessorUtil;
 import com.liferay.frontend.editor.ckeditor.web.internal.constants.CKEditorConstants;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.model.ColorScheme;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xuggler.XugglerUtil;
 
@@ -55,18 +52,8 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			jsonObject, inputEditorTaglibAttributes, themeDisplay,
 			requestBackedPortletURLFactory);
 
-		jsonObject.put("autoSaveTimeout", 3000);
-
-		ColorScheme colorScheme = themeDisplay.getColorScheme();
-
-		String cssClasses = (String)inputEditorTaglibAttributes.get(
-			CKEditorConstants.ATTRIBUTE_NAMESPACE + ":cssClasses");
-
 		jsonObject.put(
-			"bodyClass",
-			StringBundler.concat(
-				"html-editor ", HtmlUtil.escape(colorScheme.getCssClass()), " ",
-				HtmlUtil.escape(cssClasses))
+			"autoSaveTimeout", 3000
 		).put(
 			"closeNoticeTimeout", 8000
 		).put(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -12,10 +12,8 @@
  * details.
  */
 
-import {useEventListener} from '@liferay/frontend-js-react-web';
-import {debounce} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 
 import {Editor} from './Editor';
 
@@ -34,15 +32,6 @@ const ClassicEditor = React.forwardRef(
 		ref
 	) => {
 		const editorRef = useRef();
-
-		const [toolbarSet, setToolbarSet] = useState(initialToolbarSet);
-
-		const getConfig = () => {
-			return {
-				toolbar: toolbarSet,
-				...editorConfig,
-			};
-		};
 
 		const getHTML = useCallback(() => {
 			let data = contents;
@@ -95,10 +84,6 @@ const ClassicEditor = React.forwardRef(
 		);
 
 		useEffect(() => {
-			setToolbarSet(initialToolbarSet);
-		}, [initialToolbarSet]);
-
-		useEffect(() => {
 			window[name] = {
 				getHTML,
 				getText() {
@@ -106,12 +91,6 @@ const ClassicEditor = React.forwardRef(
 				},
 			};
 		}, [contents, getHTML, name]);
-
-		const onResize = debounce(() => {
-			setToolbarSet(initialToolbarSet);
-		}, 200);
-
-		useEventListener('resize', onResize, true, window);
 
 		return (
 			<div id={`${name}Container`}>
@@ -122,7 +101,10 @@ const ClassicEditor = React.forwardRef(
 				)}
 				<Editor
 					className="lfr-editable"
-					config={getConfig()}
+					config={{
+						toolbar: initialToolbarSet,
+						...editorConfig,
+					}}
 					data={contents}
 					name={name}
 					onBeforeLoad={(CKEDITOR) => {


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-135708

See details and steps to reproduce in the JIRA ticket, and the 'before' gif below.

@diogocordeiro @alinedoleron  @diegonvs 

The root cause of the issue is that CKEditor sets the `cke_editable` class [through JS](https://github.com/ckeditor/ckeditor4/blob/4.16.1/core/editable.js#L884), after the initial render. This results in FOUC on the first setting of data, and, far more noticeably, in the case of content sync in Forms (see gif below). To fix this, we are setting the `cke_editable` class in configuration, through `config.bodyClass`.

Notes:
- This PR does not fix https://issues.liferay.com/browse/LPS-137029, that one has a different root cause.
- `cke_editable` can be safely set to base CKEditor configuration. All editors based on CKEditor 4 will have the same issue.
- After this PR, there is no longer the `null` class on editable. That was caused by [this string concatenation](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java#L69-L71).
- We are removing duplicated `:cssClasses` attribute handling from `CKEditorConfigContributor`
- We are adding `colorScheme` handling to the base class. This seems like something that should be applied to all CKEditor-based editors.
- The PR contains an additional commit, https://github.com/liferay-frontend/liferay-portal/commit/9697faee265b42a5b98abffdc9aea8e2cbee94a9. It is just code cleanup, with no effect in logic. It is completely unrelated to this ticket.

Before PR:
![before](https://user-images.githubusercontent.com/5435511/133273342-116b571f-ac44-4fb7-9300-0b0d79771d36.gif)

After PR:
![after](https://user-images.githubusercontent.com/5435511/133273288-0b355545-84bb-49c4-a4fc-3af7a2c71580.gif)

