### PR TITLE
LPS-139265 | Add test suite to run all clay functional tests only

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -45,6 +45,7 @@ ci.test.available.suites=\
     forms,\
     forms-functional,\
     frontend,\
+    frontend-clay,\
     gauntlet,\
     gauntlet-bucket,\
     gradle-plugins,\
@@ -155,7 +156,8 @@ ci.test.suite.description[echo-acceptance]=Test Echo (WCM) team acceptance tests
 ci.test.suite.description[echo-upgrade]=Test Echo (WCM) team upgrade tests.
 ci.test.suite.description[environments]=Test environment acceptance functional tests on all available environment stacks.
 ci.test.suite.description[export-import]=Test exportimport tests.
-ci.test.suite.description[frontend]=Test frontend tests.
+ci.test.suite.description[frontend]=Test all Frontend Infra team tests.
+ci.test.suite.description[frontend-clay]=Test Frontend Infra team Clay tests.
 ci.test.suite.description[forms]=Test forms tests.
 ci.test.suite.description[forms-functional]=Test only functional forms tests.
 ci.test.suite.description[gauntlet]=Test upstream tests.

--- a/test.properties
+++ b/test.properties
@@ -2936,6 +2936,21 @@
         (testray.main.component.name == "Forms")
 
     #
+    # Frontend Clay
+    #
+
+    test.batch.dist.app.servers[frontend-clay]=tomcat
+
+    test.batch.names[frontend-clay]=\
+        functional-tomcat90-mysql57-jdk8
+
+    test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][frontend-clay]=\
+        (portal.upstream == true) AND \
+        (\
+            (testray.component.names ~ "Clay")\
+        )
+
+    #
     # Frontend Infra
     #
 


### PR DESCRIPTION
**Description**
PR test suite to run all available clay functional tests only.

**Test Plan**
- [x] Run ci:test:frontend-clay and check it runs all clay functional tests.
![frontend-clay_testsuite](https://user-images.githubusercontent.com/35235266/133336045-141d0d98-6be9-46b7-9947-188683732e32.png)


**Description**
https://issues.liferay.com/browse/LPS-139265