### PR TITLE
LPS-139275 change test generation to use null instead of random strings in search params

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -238,7 +238,7 @@ public abstract class BaseAccountResourceTestCase {
 	@Test
 	public void testGetAccountsPage() throws Exception {
 		Page<Account> page = accountResource.getAccountsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
@@ -426,7 +426,7 @@ public abstract class BaseCatalogResourceTestCase {
 	@Test
 	public void testGetCatalogsPage() throws Exception {
 		Page<Catalog> page = catalogResource.getCatalogsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
@@ -204,7 +204,7 @@ public abstract class BaseOptionResourceTestCase {
 	@Test
 	public void testGetOptionsPage() throws Exception {
 		Page<Option> page = optionResource.getOptionsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
@@ -447,8 +447,7 @@ public abstract class BaseOptionValueResourceTestCase {
 		Page<OptionValue> page =
 			optionValueResource.
 				getOptionByExternalReferenceCodeOptionValuesPage(
-					externalReferenceCode, RandomTestUtil.randomString(),
-					Pagination.of(1, 10), null);
+					externalReferenceCode, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -731,7 +730,7 @@ public abstract class BaseOptionValueResourceTestCase {
 
 		Page<OptionValue> page =
 			optionValueResource.getOptionIdOptionValuesPage(
-				id, RandomTestUtil.randomString(), Pagination.of(1, 10), null);
+				id, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
@@ -202,7 +202,7 @@ public abstract class BaseProductGroupResourceTestCase {
 	@Test
 	public void testGetProductGroupsPage() throws Exception {
 		Page<ProductGroup> page = productGroupResource.getProductGroupsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
@@ -338,8 +338,7 @@ public abstract class BaseProductOptionResourceTestCase {
 		Page<ProductOption> page =
 			productOptionResource.
 				getProductByExternalReferenceCodeProductOptionsPage(
-					externalReferenceCode, RandomTestUtil.randomString(),
-					Pagination.of(1, 10), null);
+					externalReferenceCode, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -614,7 +613,7 @@ public abstract class BaseProductOptionResourceTestCase {
 
 		Page<ProductOption> page =
 			productOptionResource.getProductIdProductOptionsPage(
-				id, RandomTestUtil.randomString(), Pagination.of(1, 10), null);
+				id, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
@@ -209,8 +209,7 @@ public abstract class BaseProductOptionValueResourceTestCase {
 		Page<ProductOptionValue> page =
 			productOptionValueResource.
 				getProductOptionIdProductOptionValuesPage(
-					id, RandomTestUtil.randomString(), Pagination.of(1, 10),
-					null);
+					id, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -212,7 +212,7 @@ public abstract class BaseProductResourceTestCase {
 	@Test
 	public void testGetProductsPage() throws Exception {
 		Page<Product> page = productResource.getProductsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
@@ -444,7 +444,7 @@ public abstract class BaseSkuResourceTestCase {
 	@Test
 	public void testGetSkusPage() throws Exception {
 		Page<Sku> page = skuResource.getSkusPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
@@ -202,7 +202,7 @@ public abstract class BaseSpecificationResourceTestCase {
 	@Test
 	public void testGetSpecificationsPage() throws Exception {
 		Page<Specification> page = specificationResource.getSpecificationsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -208,7 +208,7 @@ public abstract class BaseChannelResourceTestCase {
 	@Test
 	public void testGetChannelsPage() throws Exception {
 		Page<Channel> page = channelResource.getChannelsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
@@ -189,7 +189,7 @@ public abstract class BaseTaxCategoryResourceTestCase {
 	@Test
 	public void testGetTaxCategoriesPage() throws Exception {
 		Page<TaxCategory> page = taxCategoryResource.getTaxCategoriesPage(
-			RandomTestUtil.randomString(), Pagination.of(1, 10));
+			null, Pagination.of(1, 10));
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
@@ -253,7 +253,7 @@ public abstract class BaseOrderResourceTestCase {
 	@Test
 	public void testGetOrdersPage() throws Exception {
 		Page<Order> page = orderResource.getOrdersPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeChannelResourceTestCase.java
@@ -376,7 +376,7 @@ public abstract class BaseOrderTypeChannelResourceTestCase {
 
 		Page<OrderTypeChannel> page =
 			orderTypeChannelResource.getOrderTypeIdOrderTypeChannelsPage(
-				id, RandomTestUtil.randomString(), Pagination.of(1, 10), null);
+				id, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -202,7 +202,7 @@ public abstract class BaseOrderTypeResourceTestCase {
 	@Test
 	public void testGetOrderTypesPage() throws Exception {
 		Page<OrderType> page = orderTypeResource.getOrderTypesPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountGroupResourceTestCase.java
@@ -386,8 +386,7 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 
 		Page<DiscountAccountGroup> page =
 			discountAccountGroupResource.getDiscountIdDiscountAccountGroupsPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountResourceTestCase.java
@@ -376,8 +376,7 @@ public abstract class BaseDiscountAccountResourceTestCase {
 
 		Page<DiscountAccount> page =
 			discountAccountResource.getDiscountIdDiscountAccountsPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountCategoryResourceTestCase.java
@@ -377,8 +377,7 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 
 		Page<DiscountCategory> page =
 			discountCategoryResource.getDiscountIdDiscountCategoriesPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountChannelResourceTestCase.java
@@ -376,8 +376,7 @@ public abstract class BaseDiscountChannelResourceTestCase {
 
 		Page<DiscountChannel> page =
 			discountChannelResource.getDiscountIdDiscountChannelsPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountOrderTypeResourceTestCase.java
@@ -379,8 +379,7 @@ public abstract class BaseDiscountOrderTypeResourceTestCase {
 
 		Page<DiscountOrderType> page =
 			discountOrderTypeResource.getDiscountIdDiscountOrderTypesPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductGroupResourceTestCase.java
@@ -386,8 +386,7 @@ public abstract class BaseDiscountProductGroupResourceTestCase {
 
 		Page<DiscountProductGroup> page =
 			discountProductGroupResource.getDiscountIdDiscountProductGroupsPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductResourceTestCase.java
@@ -376,8 +376,7 @@ public abstract class BaseDiscountProductResourceTestCase {
 
 		Page<DiscountProduct> page =
 			discountProductResource.getDiscountIdDiscountProductsPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
@@ -214,7 +214,7 @@ public abstract class BaseDiscountResourceTestCase {
 	@Test
 	public void testGetDiscountsPage() throws Exception {
 		Page<Discount> page = discountResource.getDiscountsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
@@ -517,8 +517,7 @@ public abstract class BaseDiscountRuleResourceTestCase {
 
 		Page<DiscountRule> page =
 			discountRuleResource.getDiscountIdDiscountRulesPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountSkuResourceTestCase.java
@@ -369,8 +369,7 @@ public abstract class BaseDiscountSkuResourceTestCase {
 
 		Page<DiscountSku> page =
 			discountSkuResource.getDiscountIdDiscountSkusPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceEntryResourceTestCase.java
@@ -425,8 +425,7 @@ public abstract class BasePriceEntryResourceTestCase {
 
 		Page<PriceEntry> page =
 			priceEntryResource.getPriceListIdPriceEntriesPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountGroupResourceTestCase.java
@@ -392,8 +392,7 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 		Page<PriceListAccountGroup> page =
 			priceListAccountGroupResource.
 				getPriceListIdPriceListAccountGroupsPage(
-					id, RandomTestUtil.randomString(), null,
-					Pagination.of(1, 10), null);
+					id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountResourceTestCase.java
@@ -377,8 +377,7 @@ public abstract class BasePriceListAccountResourceTestCase {
 
 		Page<PriceListAccount> page =
 			priceListAccountResource.getPriceListIdPriceListAccountsPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListChannelResourceTestCase.java
@@ -377,8 +377,7 @@ public abstract class BasePriceListChannelResourceTestCase {
 
 		Page<PriceListChannel> page =
 			priceListChannelResource.getPriceListIdPriceListChannelsPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListOrderTypeResourceTestCase.java
@@ -373,7 +373,7 @@ public abstract class BasePriceListOrderTypeResourceTestCase {
 
 		Page<PriceListOrderType> page =
 			priceListOrderTypeResource.getPriceListIdPriceListOrderTypesPage(
-				id, RandomTestUtil.randomString(), Pagination.of(1, 10));
+				id, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
@@ -210,7 +210,7 @@ public abstract class BasePriceListResourceTestCase {
 	@Test
 	public void testGetPriceListsPage() throws Exception {
 		Page<PriceList> page = priceListResource.getPriceListsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierCategoryResourceTestCase.java
@@ -392,8 +392,7 @@ public abstract class BasePriceModifierCategoryResourceTestCase {
 		Page<PriceModifierCategory> page =
 			priceModifierCategoryResource.
 				getPriceModifierIdPriceModifierCategoriesPage(
-					id, RandomTestUtil.randomString(), null,
-					Pagination.of(1, 10), null);
+					id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductGroupResourceTestCase.java
@@ -398,8 +398,7 @@ public abstract class BasePriceModifierProductGroupResourceTestCase {
 		Page<PriceModifierProductGroup> page =
 			priceModifierProductGroupResource.
 				getPriceModifierIdPriceModifierProductGroupsPage(
-					id, RandomTestUtil.randomString(), null,
-					Pagination.of(1, 10), null);
+					id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductResourceTestCase.java
@@ -390,8 +390,7 @@ public abstract class BasePriceModifierProductResourceTestCase {
 		Page<PriceModifierProduct> page =
 			priceModifierProductResource.
 				getPriceModifierIdPriceModifierProductsPage(
-					id, RandomTestUtil.randomString(), null,
-					Pagination.of(1, 10), null);
+					id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
@@ -375,8 +375,7 @@ public abstract class BasePriceModifierResourceTestCase {
 
 		Page<PriceModifier> page =
 			priceModifierResource.getPriceListIdPriceModifiersPage(
-				id, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-				null);
+				id, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
@@ -208,7 +208,7 @@ public abstract class BaseShipmentResourceTestCase {
 	@Test
 	public void testGetShipmentsPage() throws Exception {
 		Page<Shipment> page = shipmentResource.getShipmentsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -220,8 +220,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		Page<StructuredContent> page =
 			structuredContentResource.getSiteStructuredContentsPage(
-				siteId, null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -228,8 +228,7 @@ public abstract class BaseKeywordResourceTestCase {
 			testGetAssetLibraryKeywordsPage_getIrrelevantAssetLibraryId();
 
 		Page<Keyword> page = keywordResource.getAssetLibraryKeywordsPage(
-			assetLibraryId, RandomTestUtil.randomString(), null,
-			Pagination.of(1, 10), null);
+			assetLibraryId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -597,7 +596,7 @@ public abstract class BaseKeywordResourceTestCase {
 	@Test
 	public void testGetKeywordsRankedPage() throws Exception {
 		Page<Keyword> page = keywordResource.getKeywordsRankedPage(
-			null, RandomTestUtil.randomString(), Pagination.of(1, 10));
+			null, null, Pagination.of(1, 10));
 
 		long totalCount = page.getTotalCount();
 
@@ -841,8 +840,7 @@ public abstract class BaseKeywordResourceTestCase {
 		Long irrelevantSiteId = testGetSiteKeywordsPage_getIrrelevantSiteId();
 
 		Page<Keyword> page = keywordResource.getSiteKeywordsPage(
-			siteId, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-			null);
+			siteId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -319,8 +319,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 		Page<TaxonomyCategory> page =
 			taxonomyCategoryResource.getTaxonomyCategoryTaxonomyCategoriesPage(
-				parentTaxonomyCategoryId, RandomTestUtil.randomString(), null,
-				Pagination.of(1, 10), null);
+				parentTaxonomyCategoryId, null, null, Pagination.of(1, 10),
+				null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -949,8 +949,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Page<TaxonomyCategory> page =
 			taxonomyCategoryResource.
 				getTaxonomyVocabularyTaxonomyCategoriesPage(
-					taxonomyVocabularyId, RandomTestUtil.randomString(), null,
-					Pagination.of(1, 10), null);
+					taxonomyVocabularyId, null, null, Pagination.of(1, 10),
+					null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -232,8 +232,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 
 		Page<TaxonomyVocabulary> page =
 			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
-				assetLibraryId, RandomTestUtil.randomString(), null,
-				Pagination.of(1, 10), null);
+				assetLibraryId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -663,8 +662,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 
 		Page<TaxonomyVocabulary> page =
 			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-				siteId, RandomTestUtil.randomString(), null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -206,7 +206,7 @@ public abstract class BaseAccountResourceTestCase {
 	@Test
 	public void testGetAccountsPage() throws Exception {
 		Page<Account> page = accountResource.getAccountsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 
@@ -906,8 +906,7 @@ public abstract class BaseAccountResourceTestCase {
 			testGetOrganizationAccountsPage_getIrrelevantOrganizationId();
 
 		Page<Account> page = accountResource.getOrganizationAccountsPage(
-			organizationId, RandomTestUtil.randomString(), null,
-			Pagination.of(1, 10), null);
+			organizationId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -209,8 +209,7 @@ public abstract class BaseOrganizationResourceTestCase {
 	@Test
 	public void testGetOrganizationsPage() throws Exception {
 		Page<Organization> page = organizationResource.getOrganizationsPage(
-			null, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-			null);
+			null, null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 
@@ -707,8 +706,7 @@ public abstract class BaseOrganizationResourceTestCase {
 
 		Page<Organization> page =
 			organizationResource.getOrganizationChildOrganizationsPage(
-				organizationId, null, RandomTestUtil.randomString(), null,
-				Pagination.of(1, 10), null);
+				organizationId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1078,8 +1076,8 @@ public abstract class BaseOrganizationResourceTestCase {
 
 		Page<Organization> page =
 			organizationResource.getOrganizationOrganizationsPage(
-				parentOrganizationId, null, RandomTestUtil.randomString(), null,
-				Pagination.of(1, 10), null);
+				parentOrganizationId, null, null, null, Pagination.of(1, 10),
+				null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -287,8 +287,8 @@ public abstract class BaseUserAccountResourceTestCase {
 		Page<UserAccount> page =
 			userAccountResource.
 				getAccountUserAccountsByExternalReferenceCodePage(
-					externalReferenceCode, RandomTestUtil.randomString(), null,
-					Pagination.of(1, 10), null);
+					externalReferenceCode, null, null, Pagination.of(1, 10),
+					null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -755,8 +755,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			testGetAccountUserAccountsPage_getIrrelevantAccountId();
 
 		Page<UserAccount> page = userAccountResource.getAccountUserAccountsPage(
-			accountId, RandomTestUtil.randomString(), null,
-			Pagination.of(1, 10), null);
+			accountId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1195,8 +1194,7 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		Page<UserAccount> page =
 			userAccountResource.getOrganizationUserAccountsPage(
-				organizationId, RandomTestUtil.randomString(), null,
-				Pagination.of(1, 10), null);
+				organizationId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1510,8 +1508,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			testGetSiteUserAccountsPage_getIrrelevantSiteId();
 
 		Page<UserAccount> page = userAccountResource.getSiteUserAccountsPage(
-			siteId, RandomTestUtil.randomString(), null, Pagination.of(1, 10),
-			null);
+			siteId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1794,7 +1791,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	@Test
 	public void testGetUserAccountsPage() throws Exception {
 		Page<UserAccount> page = userAccountResource.getUserAccountsPage(
-			RandomTestUtil.randomString(), null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -347,8 +347,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 
 		Page<BlogPostingImage> page =
 			blogPostingImageResource.getSiteBlogPostingImagesPage(
-				siteId, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -485,8 +485,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 			testGetSiteBlogPostingsPage_getIrrelevantSiteId();
 
 		Page<BlogPosting> page = blogPostingResource.getSiteBlogPostingsPage(
-			siteId, RandomTestUtil.randomString(), null, null,
-			Pagination.of(1, 10), null);
+			siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -205,8 +205,7 @@ public abstract class BaseCommentResourceTestCase {
 			testGetBlogPostingCommentsPage_getIrrelevantBlogPostingId();
 
 		Page<Comment> page = commentResource.getBlogPostingCommentsPage(
-			blogPostingId, RandomTestUtil.randomString(), null, null,
-			Pagination.of(1, 10), null);
+			blogPostingId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -647,8 +646,7 @@ public abstract class BaseCommentResourceTestCase {
 			testGetCommentCommentsPage_getIrrelevantParentCommentId();
 
 		Page<Comment> page = commentResource.getCommentCommentsPage(
-			parentCommentId, RandomTestUtil.randomString(), null, null,
-			Pagination.of(1, 10), null);
+			parentCommentId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -949,8 +947,7 @@ public abstract class BaseCommentResourceTestCase {
 			testGetDocumentCommentsPage_getIrrelevantDocumentId();
 
 		Page<Comment> page = commentResource.getDocumentCommentsPage(
-			documentId, RandomTestUtil.randomString(), null, null,
-			Pagination.of(1, 10), null);
+			documentId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1249,8 +1246,7 @@ public abstract class BaseCommentResourceTestCase {
 			testGetStructuredContentCommentsPage_getIrrelevantStructuredContentId();
 
 		Page<Comment> page = commentResource.getStructuredContentCommentsPage(
-			structuredContentId, RandomTestUtil.randomString(), null, null,
-			Pagination.of(1, 10), null);
+			structuredContentId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
@@ -224,8 +224,7 @@ public abstract class BaseContentElementResourceTestCase {
 
 		Page<ContentElement> page =
 			contentElementResource.getAssetLibraryContentElementsPage(
-				assetLibraryId, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				assetLibraryId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -547,8 +546,7 @@ public abstract class BaseContentElementResourceTestCase {
 
 		Page<ContentElement> page =
 			contentElementResource.getSiteContentElementsPage(
-				siteId, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -229,8 +229,7 @@ public abstract class BaseContentStructureResourceTestCase {
 
 		Page<ContentStructure> page =
 			contentStructureResource.getAssetLibraryContentStructuresPage(
-				assetLibraryId, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				assetLibraryId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -753,8 +752,7 @@ public abstract class BaseContentStructureResourceTestCase {
 
 		Page<ContentStructure> page =
 			contentStructureResource.getSiteContentStructuresPage(
-				siteId, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
@@ -232,8 +232,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 
 		Page<ContentTemplate> page =
 			contentTemplateResource.getAssetLibraryContentTemplatesPage(
-				assetLibraryId, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				assetLibraryId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -556,8 +555,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 
 		Page<ContentTemplate> page =
 			contentTemplateResource.getSiteContentTemplatesPage(
-				siteId, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -231,8 +231,8 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 		Page<DocumentFolder> page =
 			documentFolderResource.getAssetLibraryDocumentFoldersPage(
-				assetLibraryId, null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				assetLibraryId, null, null, null, null, Pagination.of(1, 10),
+				null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -945,8 +945,8 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 		Page<DocumentFolder> page =
 			documentFolderResource.getDocumentFolderDocumentFoldersPage(
-				parentDocumentFolderId, null, RandomTestUtil.randomString(),
-				null, null, Pagination.of(1, 10), null);
+				parentDocumentFolderId, null, null, null, null,
+				Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1301,8 +1301,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 		Page<DocumentFolder> page =
 			documentFolderResource.getSiteDocumentFoldersPage(
-				siteId, null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -242,8 +242,7 @@ public abstract class BaseDocumentResourceTestCase {
 			testGetAssetLibraryDocumentsPage_getIrrelevantAssetLibraryId();
 
 		Page<Document> page = documentResource.getAssetLibraryDocumentsPage(
-			assetLibraryId, null, RandomTestUtil.randomString(), null, null,
-			Pagination.of(1, 10), null);
+			assetLibraryId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -628,8 +627,8 @@ public abstract class BaseDocumentResourceTestCase {
 			testGetDocumentFolderDocumentsPage_getIrrelevantDocumentFolderId();
 
 		Page<Document> page = documentResource.getDocumentFolderDocumentsPage(
-			documentFolderId, null, RandomTestUtil.randomString(), null, null,
-			Pagination.of(1, 10), null);
+			documentFolderId, null, null, null, null, Pagination.of(1, 10),
+			null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1218,8 +1217,7 @@ public abstract class BaseDocumentResourceTestCase {
 		Long irrelevantSiteId = testGetSiteDocumentsPage_getIrrelevantSiteId();
 
 		Page<Document> page = documentResource.getSiteDocumentsPage(
-			siteId, null, RandomTestUtil.randomString(), null, null,
-			Pagination.of(1, 10), null);
+			siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -582,8 +582,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Page<KnowledgeBaseArticle> page =
 			knowledgeBaseArticleResource.
 				getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
-					parentKnowledgeBaseArticleId, null,
-					RandomTestUtil.randomString(), null, null,
+					parentKnowledgeBaseArticleId, null, null, null, null,
 					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
@@ -971,8 +970,8 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Page<KnowledgeBaseArticle> page =
 			knowledgeBaseArticleResource.
 				getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
-					knowledgeBaseFolderId, null, RandomTestUtil.randomString(),
-					null, null, Pagination.of(1, 10), null);
+					knowledgeBaseFolderId, null, null, null, null,
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1355,8 +1354,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 
 		Page<KnowledgeBaseArticle> page =
 			knowledgeBaseArticleResource.getSiteKnowledgeBaseArticlesPage(
-				siteId, null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -576,8 +576,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Page<MessageBoardMessage> page =
 			messageBoardMessageResource.
 				getMessageBoardMessageMessageBoardMessagesPage(
-					parentMessageBoardMessageId, null,
-					RandomTestUtil.randomString(), null, null,
+					parentMessageBoardMessageId, null, null, null, null,
 					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
@@ -960,8 +959,8 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Page<MessageBoardMessage> page =
 			messageBoardMessageResource.
 				getMessageBoardThreadMessageBoardMessagesPage(
-					messageBoardThreadId, RandomTestUtil.randomString(), null,
-					null, Pagination.of(1, 10), null);
+					messageBoardThreadId, null, null, null,
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1339,8 +1338,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 
 		Page<MessageBoardMessage> page =
 			messageBoardMessageResource.getSiteMessageBoardMessagesPage(
-				siteId, null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -535,8 +535,8 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Page<MessageBoardSection> page =
 			messageBoardSectionResource.
 				getMessageBoardSectionMessageBoardSectionsPage(
-					parentMessageBoardSectionId, RandomTestUtil.randomString(),
-					null, null, Pagination.of(1, 10), null);
+					parentMessageBoardSectionId, null, null, null,
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -914,8 +914,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 
 		Page<MessageBoardSection> page =
 			messageBoardSectionResource.getSiteMessageBoardSectionsPage(
-				siteId, null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -228,8 +228,8 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Page<MessageBoardThread> page =
 			messageBoardThreadResource.
 				getMessageBoardSectionMessageBoardThreadsPage(
-					messageBoardSectionId, RandomTestUtil.randomString(), null,
-					null, Pagination.of(1, 10), null);
+					messageBoardSectionId, null, null, null,
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1184,8 +1184,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 
 		Page<MessageBoardThread> page =
 			messageBoardThreadResource.getSiteMessageBoardThreadsPage(
-				siteId, null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -209,8 +209,7 @@ public abstract class BaseSitePageResourceTestCase {
 		Long irrelevantSiteId = testGetSiteSitePagesPage_getIrrelevantSiteId();
 
 		Page<SitePage> page = sitePageResource.getSiteSitePagesPage(
-			siteId, RandomTestUtil.randomString(), null, null,
-			Pagination.of(1, 10), null);
+			siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -242,8 +242,8 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Page<StructuredContentFolder> page =
 			structuredContentFolderResource.
 				getAssetLibraryStructuredContentFoldersPage(
-					assetLibraryId, null, RandomTestUtil.randomString(), null,
-					null, Pagination.of(1, 10), null);
+					assetLibraryId, null, null, null, null,
+					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -697,8 +697,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 
 		Page<StructuredContentFolder> page =
 			structuredContentFolderResource.getSiteStructuredContentFoldersPage(
-				siteId, null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1265,8 +1264,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Page<StructuredContentFolder> page =
 			structuredContentFolderResource.
 				getStructuredContentFolderStructuredContentFoldersPage(
-					parentStructuredContentFolderId,
-					RandomTestUtil.randomString(), null, null,
+					parentStructuredContentFolderId, null, null, null,
 					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -242,8 +242,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		Page<StructuredContent> page =
 			structuredContentResource.getAssetLibraryStructuredContentsPage(
-				assetLibraryId, null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				assetLibraryId, null, null, null, null, Pagination.of(1, 10),
+				null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -670,8 +670,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		Page<StructuredContent> page =
 			structuredContentResource.getContentStructureStructuredContentsPage(
-				contentStructureId, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				contentStructureId, null, null, null, Pagination.of(1, 10),
+				null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1015,8 +1015,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		Page<StructuredContent> page =
 			structuredContentResource.getSiteStructuredContentsPage(
-				siteId, null, RandomTestUtil.randomString(), null, null,
-				Pagination.of(1, 10), null);
+				siteId, null, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
@@ -1830,8 +1829,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Page<StructuredContent> page =
 			structuredContentResource.
 				getStructuredContentFolderStructuredContentsPage(
-					structuredContentFolderId, null,
-					RandomTestUtil.randomString(), null, null,
+					structuredContentFolderId, null, null, null, null,
 					Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -212,8 +212,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 		Long irrelevantSiteId = testGetSiteWikiNodesPage_getIrrelevantSiteId();
 
 		Page<WikiNode> page = wikiNodeResource.getSiteWikiNodesPage(
-			siteId, RandomTestUtil.randomString(), null, null,
-			Pagination.of(1, 10), null);
+			siteId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -387,8 +387,7 @@ public abstract class BaseWikiPageResourceTestCase {
 			testGetWikiNodeWikiPagesPage_getIrrelevantWikiNodeId();
 
 		Page<WikiPage> page = wikiPageResource.getWikiNodeWikiPagesPage(
-			wikiNodeId, RandomTestUtil.randomString(), null, null,
-			Pagination.of(1, 10), null);
+			wikiNodeId, null, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
@@ -204,7 +204,7 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 	public void testGetObjectDefinitionsPage() throws Exception {
 		Page<ObjectDefinition> page =
 			objectDefinitionResource.getObjectDefinitionsPage(
-				RandomTestUtil.randomString(), Pagination.of(1, 10));
+				null, Pagination.of(1, 10));
 
 		long totalCount = page.getTotalCount();
 

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
@@ -202,8 +202,7 @@ public abstract class BaseObjectFieldResourceTestCase {
 
 		Page<ObjectField> page =
 			objectFieldResource.getObjectDefinitionObjectFieldsPage(
-				objectDefinitionId, RandomTestUtil.randomString(),
-				Pagination.of(1, 10));
+				objectDefinitionId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
@@ -195,8 +195,7 @@ public abstract class BaseObjectLayoutResourceTestCase {
 
 		Page<ObjectLayout> page =
 			objectLayoutResource.getObjectDefinitionObjectLayoutsPage(
-				objectDefinitionId, RandomTestUtil.randomString(),
-				Pagination.of(1, 10));
+				objectDefinitionId, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(0, page.getTotalCount());
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -412,6 +412,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 						<#if stringUtil.equals(javaMethodParameter.parameterName, "pagination")>
 							Pagination.of(1, 10)
+						<#elseif stringUtil.equals(javaMethodParameter.parameterName, "search")>
+							null
 						<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
 							${javaMethodParameter.parameterName}
 						<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>


### PR DESCRIPTION
Change generation of search param to null to avoid false negatives and an issue with the Object APIs.

-- Tests will fail