### PR TITLE
LPS-139095 Check for nulls before check if a message is an answer or not

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -736,7 +736,7 @@ public class MessageBoardMessageResourceImpl
 
 		Boolean showAsAnswer = messageBoardMessage.getShowAsAnswer();
 
-		if (showAsAnswer != null) {
+		if ((showAsAnswer != null) && (showAsAnswer != mbMessage.isAnswer())) {
 			_mbMessageService.updateAnswer(
 				mbMessage.getMessageId(), showAsAnswer, false);
 
@@ -772,9 +772,7 @@ public class MessageBoardMessageResourceImpl
 			messageBoardMessage.getArticleBody(),
 			_createServiceContext(mbMessage.getGroupId(), messageBoardMessage));
 
-		if (messageBoardMessage.getShowAsAnswer() != mbMessage.isAnswer()) {
-			_updateAnswer(mbMessage, messageBoardMessage);
-		}
+		_updateAnswer(mbMessage, messageBoardMessage);
 
 		return _toMessageBoardMessage(mbMessage);
 	}


### PR DESCRIPTION
Related ticket -> [LPS-139095](https://issues.liferay.com/browse/LPS-139095)

---

**Context**
When calling the `putMessageBoardMessage` method for MessageBoardMessage using the following request body:
```
{
  "headline": "PUT Test"
}
```

**Expected Behavior**
It should replace the specified Message Board Message with the information sent in the request body.

**Actual Behavior**
It returned the following message: ` "status": "INTERNAL_SERVER_ERROR"`
This PUT command only works if you include the "showAsAnswer" field in the request body:
```
{
  "headline": "PUT Test",
  "showAsAnswer": false
}
```

The `INTERNAL_SERVER_ERROR` is NPE produced trying to access to `messageBoardMessage.getShowAsAnswer()` before check if there is a value for `showAsAnswer`

In the PR I change the order of the checks to update an answer checking first if there is a value for `showAsAnswer` and then if this value is different from the value of the mbMessage, as we did before.
