### PR TITLE
LPS-137758 Add "share via Twitter" button in TextToolbar

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
@@ -63,9 +63,11 @@
 			editor.on('showToolbar', (event) => {
 				const toolbarCommand = event.data.toolbarCommand;
 
+				const config = event.data.config;
+
 				editor.balloonToolbars.hide();
 
-				editor.execCommand(toolbarCommand);
+				editor.execCommand(toolbarCommand, config);
 			});
 		},
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/linktoolbar/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/linktoolbar/plugin.js
@@ -297,7 +297,7 @@
 			});
 
 			editor.addCommand('linkToolbar', {
-				exec(editor) {
+				exec(editor, config) {
 					instance._createToolbar();
 
 					if (!instance._toolbar) {
@@ -325,7 +325,18 @@
 						link = startElement;
 					}
 
-					const linkInput = instance._toolbar.getItem('LinkInput');
+					const linkInput =
+						instance._toolbar.getItem('LinkInput') ??
+						config.linkInputValue;
+
+					const linkTargetValue =
+						startElement.getAttribute('target') ??
+						config.target ??
+						'';
+
+					instance._toolbar
+						.getItem('LinkTarget')
+						.setSelectValue(linkTargetValue);
 
 					if (linkInput) {
 						if (link) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/LinkUtils.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/LinkUtils.js
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const REGEX_BOOKMARK_SCHEME = /^#.*/i;
+const REGEX_EMAIL_SCHEME = /^[a-z0-9\u0430-\u044F._-]+@/i;
+const REGEX_URI_SCHEME = /^(?:[a-z][a-z0-9+\-.]*):|^\//i;
+
+(function () {
+
+	/**
+	 * Link class utility. Provides methods for create, delete and update links.
+	 *
+	 * @class CKEDITOR.Link
+	 * @constructor
+	 * @param {Object} editor The CKEditor instance.
+	 */
+	class Link {
+		constructor(editor, config) {
+			this._editor = editor;
+			this.appendProtocol =
+				config && config.appendProtocol === false ? false : true;
+		}
+
+		/**
+		 * Advances the editor selection to the next available position after a
+		 * given link or the one in the current selection.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.Link
+		 * @method advanceSelection
+		 * @param {CKEDITOR.dom.element} link The link element which link style should be removed.
+		 */
+		advanceSelection(link) {
+			link = link || this.getFromSelection();
+
+			const range = this._editor.getSelection().getRanges()[0];
+
+			if (link) {
+				range.moveToElementEditEnd(link);
+
+				const nextNode = range.getNextEditableNode();
+
+				if (
+					nextNode &&
+					!this._editor.element.equals(
+						nextNode.getCommonAncestor(link)
+					)
+				) {
+					const whitespace = /\s/.exec(nextNode.getText());
+
+					const offset = whitespace ? whitespace.index + 1 : 0;
+
+					range.setStart(nextNode, offset);
+					range.setEnd(nextNode, offset);
+				}
+			}
+
+			this._editor.getSelection().selectRanges([range]);
+		}
+
+		/**
+		 * Create a link with given URI as href.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.Link
+		 * @method create
+		 * @param {Object} attrs A config object with link attributes. These might be arbitrary DOM attributes.
+		 * @param {Object} modifySelection A config object with an advance attribute to indicate if the selection should be moved after the link creation.
+		 * @param {String} URI The URI of the link.
+		 */
+		create(URI, attrs, modifySelection) {
+			const selection = this._editor.getSelection();
+
+			const range = selection.getRanges()[0];
+
+			if (range.collapsed) {
+				const text = new CKEDITOR.dom.text(URI, this._editor.document);
+				range.insertNode(text);
+				range.selectNodeContents(text);
+			}
+
+			URI = this._getCompleteURI(URI);
+
+			const linkAttrs = CKEDITOR.tools.object.merge(
+				{
+					'data-cke-saved-href': URI,
+					href: URI,
+				},
+				attrs
+			);
+
+			const style = new CKEDITOR.style({
+				attributes: linkAttrs,
+				element: 'a',
+			});
+
+			style.type = CKEDITOR.STYLE_INLINE;
+			style.applyToRange(range, this._editor);
+
+			if (modifySelection && modifySelection.advance) {
+				this.advanceSelection();
+			}
+			else {
+				range.select();
+			}
+
+			return URI;
+		}
+
+		/**
+		 * Retrieves a link from the current selection.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.Link
+		 * @method getFromSelection
+		 * @return {CKEDITOR.dom.element} The retrieved link or null if not found.
+		 */
+		getFromSelection() {
+			const selection = this._editor.getSelection();
+
+			const selectedElement = selection.getSelectedElement();
+
+			if (selectedElement && selectedElement.is('a')) {
+				return selectedElement;
+			}
+
+			if (selectedElement && CKEDITOR.env.ie) {
+				const children = selectedElement.getChildren();
+
+				const count = children.count();
+
+				for (let i = 0; i < count; i++) {
+					const node = children.getItem(i);
+
+					if (node.is('a')) {
+						return node;
+					}
+				}
+			}
+
+			const range = selection.getRanges()[0];
+
+			if (range) {
+				range.shrink(CKEDITOR.SHRINK_TEXT);
+
+				return this._editor
+					.elementPath(range.getCommonAncestor())
+					.contains('a', 1);
+			}
+
+			return null;
+		}
+
+		/**
+		 * Removes a link from the editor.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.Link
+		 * @method remove
+		 * @param {CKEDITOR.dom.element} link The link element which link style should be removed.
+		 * @param {Object} modifySelection A config object with an advance attribute to indicate if the selection should be moved after the link creation.
+		 */
+		remove(link, modifySelection) {
+			const editor = this._editor;
+
+			if (link) {
+				if (modifySelection && modifySelection.advance) {
+					this.advanceSelection();
+				}
+
+				link.remove(editor);
+			}
+			else {
+				const style = new CKEDITOR.style({
+					alwaysRemoveElement: 1,
+					element: 'a',
+					type: CKEDITOR.STYLE_INLINE,
+				});
+
+				// 'removeStyle()' removes the style from the editor's current selection.
+				//  We need to force the selection to be the whole link element
+				//  to remove it properly.
+
+				const selection = editor.getSelection();
+				selection.selectElement(selection.getStartElement());
+
+				editor.removeStyle(style);
+			}
+		}
+
+		/**
+		 * Updates the href of an already existing link.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.Link
+		 * @method update
+		 * @param {CKEDITOR.dom.element} link The link element which href should be removed.
+		 * @param {Object|String} attrs The attributes to update or remove. Attributes with null values will be removed.
+		 * @param {Object} modifySelection A config object with an advance attribute to indicate if the selection should be moved after the link creation.
+		 */
+		update(attrs, link, modifySelection) {
+			const instance = this;
+
+			link = link || this.getFromSelection();
+
+			if (typeof attrs === 'string') {
+				const uri = instance._getCompleteURI(attrs);
+
+				link.setAttributes({
+					'data-cke-saved-href': uri,
+					href: uri,
+				});
+			}
+			else if (typeof attrs === 'object') {
+				const removeAttrs = [];
+
+				const setAttrs = {};
+
+				Object.keys(attrs).forEach((key) => {
+					if (attrs[key] === null) {
+						if (key === 'href') {
+							removeAttrs.push('data-cke-saved-href');
+						}
+
+						removeAttrs.push(key);
+					}
+					else {
+						if (key === 'href') {
+							const uri = instance._getCompleteURI(attrs[key]);
+
+							setAttrs['data-cke-saved-href'] = uri;
+							setAttrs[key] = uri;
+						}
+						else {
+							setAttrs[key] = attrs[key];
+						}
+					}
+				});
+
+				link.removeAttributes(removeAttrs);
+				link.setAttributes(setAttrs);
+			}
+
+			if (modifySelection && modifySelection.advance) {
+				this.advanceSelection(link);
+			}
+		}
+
+		/**
+		 * Checks if the URI begins with a '#' symbol to determine if it's an on page bookmark.
+		 * If it doesn't, it then checks if the URI has an '@' symbol. If it does and the URI
+		 * looks like an email and doesn't have 'mailto:', 'mailto:' is added to the URI.
+		 * If it doesn't and the URI doesn't have a scheme, the default 'http' scheme with
+		 * hierarchical path '//' is added to the URI.
+		 *
+		 * @instance
+		 * @memberof CKEDITOR.Link
+		 * @method _getCompleteURI
+		 * @param {String} URI The URI of the link.
+		 * @protected
+		 * @return {String} The URI updated with the protocol.
+		 */
+		_getCompleteURI(URI) {
+			if (REGEX_BOOKMARK_SCHEME.test(URI)) {
+				return URI;
+			}
+			else if (REGEX_EMAIL_SCHEME.test(URI)) {
+				URI = 'mailto:' + URI;
+			}
+			else if (!REGEX_URI_SCHEME.test(URI)) {
+				URI = this.appendProtocol ? 'http://' + URI : URI;
+			}
+
+			return URI;
+		}
+	}
+
+	Liferay.LinkUtilsCKEditor = Link;
+})();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+let linkUtils = null;
+
 (function () {
 	const pluginName = 'toolbarbuttons';
 
@@ -21,6 +23,14 @@
 
 	CKEDITOR.plugins.add(pluginName, {
 		init(editor) {
+			const path = this.path;
+
+			const dependencies = [CKEDITOR.getUrl(path + 'LinkUtils.js')];
+
+			CKEDITOR.scriptLoader.load(dependencies, () => {
+				linkUtils = new Liferay.LinkUtilsCKEditor(editor);
+			});
+
 			editor.ui.addBalloonToolbarButton('ImageAlignLeft', {
 				command: 'justifyleft',
 				icon: 'align-image-left',
@@ -47,6 +57,76 @@
 				},
 				icon: 'link',
 				title: editor.lang.link.title,
+			});
+
+			editor.ui.addBalloonToolbarButton('Twitter', {
+
+				//
+
+				_MAX_TWEET_LENGTH: 280,
+				_getHref(url, via) {
+					const selectedText = editor
+						.getSelection()
+						.getSelectedText()
+						.substring(0, this._MAX_TWEET_LENGTH);
+
+					// TODO - These parameters need to be revisited to see when to use `url` and `via`.
+					// There is a doc about it in https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/guides/parameter-reference1
+					// Where:
+					// url -> URL included with the Tweet.
+					// via -> Attribute the source of a Tweet to a Twitter username.(a.k.a the twitter handle)
+
+					// const url = this.props.url;
+					// const via = this.props.via;
+
+					let twitterHref =
+						'https://twitter.com/intent/tweet?text=' + selectedText;
+
+					if (url) {
+						twitterHref += '&url=' + url;
+					}
+
+					if (via) {
+						twitterHref += '&via=' + via;
+					}
+
+					return twitterHref;
+				},
+				_isActive() {
+					const link = linkUtils.getFromSelection();
+
+					return (
+						link &&
+						link
+							.getAttribute('href')
+							.indexOf('twitter.com/intent/tweet') !== -1
+					);
+				},
+				click() {
+					if (this._isActive()) {
+						linkUtils.remove(linkUtils.getFromSelection());
+					}
+					else {
+						const INITIAL_TARGET = '_blank';
+
+						const linkInputValue = linkUtils.create(
+							this._getHref(),
+							{
+								target: INITIAL_TARGET,
+							}
+						);
+
+						editor.fire('showToolbar', {
+							config: {
+								linkInputValue,
+								target: INITIAL_TARGET,
+							},
+							toolbarCommand: 'linkToolbar',
+						});
+					}
+				},
+				icon: 'twitter',
+				title: Liferay.Language.get('share-on-twitter'),
 			});
 
 			editor.ui.addRichCombo('TableHeaders', {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/uiselect/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/uiselect/plugin.js
@@ -151,6 +151,17 @@
 
 				return instance;
 			},
+			setSelectValue(value) {
+				const newSelectedIndex = this.items.findIndex(
+					(item) => item.value === value
+				);
+
+				const selectId = this._id;
+
+				document.getElementById(
+					selectId
+				).selectedIndex = newSelectedIndex;
+			},
 		},
 	});
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/config/DefaultBalloonEditorConfiguration.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/config/DefaultBalloonEditorConfiguration.js
@@ -50,7 +50,7 @@ const DEFAULT_BALLOON_EDITOR_CONFIG = {
 	toolbarLink: 'LinkRemove,LinkTarget,LinkInput,LinkConfirm,LinkBrowse',
 	toolbarTable: 'TableHeaders,TableRow,TableColumn,TableCell,TableDelete',
 	toolbarText:
-		'Styles,Bold,Italic,Underline,BulletedList,NumberedList,TextLink,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,LineHeight,BGColor,RemoveFormat',
+		'Styles,Bold,Italic,Underline,BulletedList,NumberedList,TextLink,Twitter,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,LineHeight,BGColor,RemoveFormat',
 	toolbarVideo: 'VideoAlignLeft,VideoAlignCenter,VideoAlignRight',
 };
 

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -7924,6 +7924,7 @@ sha=SHA
 sha-256=SHA-256
 sha-384=SHA-384
 shadow=Shadow
+share-on-twitter=Share on Twitter
 share-this-application-on-an-open-social-platform=Share this application on an OpenSocial platform.
 share-x=Share {0}
 shared-by-me=Shared by Me


### PR DESCRIPTION
# Demo Video

https://user-images.githubusercontent.com/7663513/134252717-7fe84cd0-f318-4b60-8bd8-e039c76de71b.mov

https://user-images.githubusercontent.com/7663513/134252783-10f9efc0-5e28-4596-8d33-cc1399ecdbd9.mov


PS: pudim.com.br really exists and it's one of the oldest brazilian domains

# What needed to be changed?

I created another button in toolbarbuttons plugin, called Twitter, where it calls the linkToolbar by firing an event containing some parameters like the parsed URL and the value of the select to be used, in this case, for twitter links it should be `_blank`.

Also, was necessary import LinkUtils class from AlloyEditor and I needed to "require" it in toolbarbuttons, where I consider it inadequate because Twitter is not a default button(yet?) and We should add this script only when Twitter button is enabled.

# Questions

1. https://github.com/liferay-frontend/liferay-portal/pull/1472#discussion_r713451196
2. https://github.com/liferay-frontend/liferay-portal/pull/1472/files#r713451631