### PR TITLE
LPS-137932 Get field by FieldReference

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -511,7 +511,7 @@ public class StructuredContentResourceTest
 								data = RandomTestUtil.randomString(10);
 							}
 						};
-						name = "MyText";
+						name = "Foo";
 					}
 				}
 			});

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-ddm-structure.json
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-ddm-structure.json
@@ -6,6 +6,7 @@
 	"fields": [
 		{
 			"dataType": "string",
+			"fieldReference": "Foo",
 			"indexType": "keyword",
 			"label": {
 				"en_US": "TextFieldNameLabel"

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-structured-content-template.xsl
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-structured-content-template.xsl
@@ -1,1 +1,1 @@
-<div>${MyText.getData()}</div>
+<div>${Foo.getData()}</div>


### PR DESCRIPTION
Related ticket -> [LPS-137932](https://issues.liferay.com/browse/LPS-137932)

----
**Context**
Headless Delivery API returns a 500 error trying to patch an existing Structured Content from a custom Content Structure.

**Steps to reproduce**
- Create a Web Content Structure
- Create a Web Content selecting the new Structure from step 1
- Make a Patch request specifying the structure from step 2, updating one of the content fields

**Expected result** 
The structured content is patched and a 200 HTTP status is returned

**Result** 
500 Error

----
**Solution proposed**
The problem in the code is that when trying to access the Field like this:
`Field field = fields.get(contentField.getName());`
In the Headless layer, `contentField.getName()` references to the Field Reference, that could be modified (see next picture)
![image](https://user-images.githubusercontent.com/17163902/133665253-d8bda2fd-1f19-43f3-8a1f-aa5df1148d0d.png)
But, for `Fields`, the name is the first one created aleatorily. So, when the Field Reference is modified, it will never appear and return a null value.

What the PR does is to get that first name created aleatorily using the field reference provided by the user in the request. My concern is that I don't know if this search of the proper name could be redundant and if there is another way that I didn't see where I can use the field reference value directly and avoid some loops and code.

