### PR TITLE
LPS-139450 expose scope key

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -263,6 +263,34 @@ public class ObjectEntry implements Serializable {
 	protected Map<String, Object> properties = new HashMap<>();
 
 	@Schema
+	public String getScopeKey() {
+		return scopeKey;
+	}
+
+	public void setScopeKey(String scopeKey) {
+		this.scopeKey = scopeKey;
+	}
+
+	@JsonIgnore
+	public void setScopeKey(
+		UnsafeSupplier<String, Exception> scopeKeyUnsafeSupplier) {
+
+		try {
+			scopeKey = scopeKeyUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String scopeKey;
+
+	@Schema
 	@Valid
 	public Status getStatus() {
 		return status;
@@ -401,6 +429,20 @@ public class ObjectEntry implements Serializable {
 			sb.append("\"properties\": ");
 
 			sb.append(_toJSON(properties));
+		}
+
+		if (scopeKey != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"scopeKey\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(scopeKey));
+
+			sb.append("\"");
 		}
 
 		if (status != null) {

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -49,7 +49,8 @@ public interface ObjectEntryManager {
 		throws Exception;
 
 	public ObjectEntry fetchObjectEntry(
-		DTOConverterContext dtoConverterContext, long objectEntryId);
+		DTOConverterContext dtoConverterContext,
+		ObjectDefinition objectDefinition, long objectEntryId);
 
 	public Page<ObjectEntry> getObjectEntries(
 			long companyId, ObjectDefinition objectDefinition, String scopeKey,

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -58,7 +58,8 @@ public interface ObjectEntryManager {
 		throws Exception;
 
 	public ObjectEntry getObjectEntry(
-			DTOConverterContext dtoConverterContext, long objectEntryId)
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, long objectEntryId)
 		throws Exception;
 
 	public ObjectEntry getObjectEntry(
@@ -69,7 +70,8 @@ public interface ObjectEntryManager {
 
 	public ObjectEntry updateObjectEntry(
 			DTOConverterContext dtoConverterContext, long userId,
-			long objectEntryId, ObjectEntry objectEntry)
+			ObjectDefinition objectDefinition, long objectEntryId,
+			ObjectEntry objectEntry)
 		throws Exception;
 
 }

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -49,8 +49,9 @@ public interface ObjectEntryManager {
 		throws Exception;
 
 	public ObjectEntry fetchObjectEntry(
-		DTOConverterContext dtoConverterContext,
-		ObjectDefinition objectDefinition, long objectEntryId);
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, long objectEntryId)
+		throws Exception;
 
 	public Page<ObjectEntry> getObjectEntries(
 			long companyId, ObjectDefinition objectDefinition, String scopeKey,

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -30,6 +30,9 @@ components:
                         type: object
                     type: object
                     x-json-map: true
+                scopeKey:
+                    readOnly: true
+                    type: string
                 status:
                     $ref: "#/components/schemas/Status"
                     readOnly: true

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -61,6 +61,7 @@ public class ObjectEntryDTOConverter
 				externalReferenceCode = objectEntry.getExternalReferenceCode();
 				id = objectEntry.getObjectEntryId();
 				properties = (Map)objectEntry.getValues();
+				scopeKey = (String)dtoConverterContext.getAttribute("scopeKey");
 				status = new Status() {
 					{
 						code = objectEntry.getStatus();

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -108,7 +108,8 @@ public class ObjectDefinitionGraphQLDTOContributor
 		throws Exception {
 
 		return _toMap(
-			_objectEntryManager.getObjectEntry(dtoConverterContext, id));
+			_objectEntryManager.getObjectEntry(
+				dtoConverterContext, _objectDefinition, id));
 	}
 
 	@Override
@@ -174,8 +175,8 @@ public class ObjectDefinitionGraphQLDTOContributor
 
 		return _toMap(
 			_objectEntryManager.updateObjectEntry(
-				dtoConverterContext, dtoConverterContext.getUserId(), id,
-				_toObjectEntry(dto)));
+				dtoConverterContext, dtoConverterContext.getUserId(),
+				_objectDefinition, id, _toObjectEntry(dto)));
 	}
 
 	private ObjectDefinitionGraphQLDTOContributor(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
@@ -26,10 +26,6 @@ import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
@@ -135,9 +131,9 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 
 	@Override
 	public ObjectEntry fetchObjectEntry(
-		DTOConverterContext dtoConverterContext,
-		ObjectDefinition objectDefinition,
-		long objectEntryId) {
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, long objectEntryId)
+		throws Exception {
 
 		com.liferay.object.model.ObjectEntry objectEntry =
 			_objectEntryLocalService.fetchObjectEntry(objectEntryId);
@@ -289,36 +285,6 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 		return ObjectDefinition.class.getName() + "#" + objectDefinitionId;
 	}
 
-	private String _getScopeKey(
-		ObjectDefinition objectDefinition,
-		com.liferay.object.model.ObjectEntry objectEntry) {
-
-		ObjectScopeProvider objectScopeProvider =
-			_objectScopeProviderRegistry.getObjectScopeProvider(
-				objectDefinition.getScope());
-
-		if (objectScopeProvider.isGroupAware()) {
-			Group group = null;
-
-			try {
-				group = _groupLocalService.getGroup(objectEntry.getGroupId());
-			}
-			catch (PortalException portalException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(portalException, portalException);
-				}
-			}
-
-			if (group == null) {
-				return null;
-			}
-
-			return group.getGroupKey();
-		}
-
-		return null;
-	}
-
 	private Date _toDate(Locale locale, String valueString) {
 		if (Validator.isNull(valueString)) {
 			return null;
@@ -341,9 +307,10 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 	}
 
 	private ObjectEntry _toObjectEntry(
-		DTOConverterContext dtoConverterContext,
-		ObjectDefinition objectDefinition,
-		com.liferay.object.model.ObjectEntry objectEntry) {
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition,
+			com.liferay.object.model.ObjectEntry objectEntry)
+		throws Exception {
 
 		Optional<UriInfo> uriInfoOptional =
 			dtoConverterContext.getUriInfoOptional();
@@ -387,7 +354,7 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 				uriInfo, dtoConverterContext.getUser());
 
 		defaultDTOConverterContext.setAttribute(
-			"scopeKey", _getScopeKey(objectDefinition, objectEntry));
+			"objectDefinition", objectDefinition);
 
 		return _objectEntryDTOConverter.toDTO(
 			defaultDTOConverterContext, objectEntry);
@@ -421,9 +388,6 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 
 		return values;
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ObjectEntryManagerImpl.class);
 
 	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -384,6 +384,10 @@ public abstract class BaseObjectEntryResourceImpl
 			existingObjectEntry.setProperties(objectEntry.getProperties());
 		}
 
+		if (objectEntry.getScopeKey() != null) {
+			existingObjectEntry.setScopeKey(objectEntry.getScopeKey());
+		}
+
 		preparePatch(objectEntry, existingObjectEntry);
 
 		return putObjectEntry(objectEntryId, existingObjectEntry);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -133,7 +133,8 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	@Override
 	public ObjectEntry getObjectEntry(Long objectEntryId) throws Exception {
 		return _objectEntryManager.getObjectEntry(
-			_getDTOConverterContext(objectEntryId), objectEntryId);
+			_getDTOConverterContext(objectEntryId), _objectDefinition,
+			objectEntryId);
 	}
 
 	@Override
@@ -195,7 +196,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 		return _objectEntryManager.updateObjectEntry(
 			_getDTOConverterContext(objectEntryId), contextUser.getUserId(),
-			objectEntryId, objectEntry);
+			_objectDefinition, objectEntryId, objectEntry);
 	}
 
 	@Override


### PR DESCRIPTION
Expose ScokeKey for entities that have an scope right now (only asset libraries and sites). I'm exposing the group name to avoid hardcoding ids in enduser apps.

It's messier than I thought because the logic is conditional based on the `ObjectDefinition` and although it's probably cached, I want to avoid querying from cache/DB inside the converter if I can avoid it, as the GraphQL adapter and the REST application already have it as a field.