### PR TITLE
LPS-139129 Add permission checks to remote apps

### DIFF
--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/constants/RemoteAppConstants.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/constants/RemoteAppConstants.java
@@ -19,6 +19,8 @@ package com.liferay.remote.app.constants;
  */
 public class RemoteAppConstants {
 
+	public static final String RESOURCE_NAME = "com.liferay.remote.app.model";
+
 	public static final String TYPE_CUSTOM_ELEMENT = "customElement";
 
 	public static final String TYPE_IFRAME = "iframe";

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryService.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryService.java
@@ -61,6 +61,9 @@ public interface RemoteAppEntryService extends BaseService {
 			String iFrameURL, Map<Locale, String> nameMap)
 		throws PortalException;
 
+	public RemoteAppEntry deleteRemoteAppEntry(long remoteAppEntryId)
+		throws PortalException;
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryServiceUtil.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryServiceUtil.java
@@ -55,6 +55,12 @@ public class RemoteAppEntryServiceUtil {
 		return getService().addIFrameRemoteAppEntry(iFrameURL, nameMap);
 	}
 
+	public static RemoteAppEntry deleteRemoteAppEntry(long remoteAppEntryId)
+		throws PortalException {
+
+		return getService().deleteRemoteAppEntry(remoteAppEntryId);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryServiceWrapper.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryServiceWrapper.java
@@ -54,6 +54,14 @@ public class RemoteAppEntryServiceWrapper
 			iFrameURL, nameMap);
 	}
 
+	@Override
+	public com.liferay.remote.app.model.RemoteAppEntry deleteRemoteAppEntry(
+			long remoteAppEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _remoteAppEntryService.deleteRemoteAppEntry(remoteAppEntryId);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/persistence/RemoteAppEntryPersistence.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/persistence/RemoteAppEntryPersistence.java
@@ -170,6 +170,62 @@ public interface RemoteAppEntryPersistence
 		throws NoSuchRemoteAppEntryException;
 
 	/**
+	 * Returns all the remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @return the matching remote app entries that the user has permission to view
+	 */
+	public java.util.List<RemoteAppEntry> filterFindByUuid(String uuid);
+
+	/**
+	 * Returns a range of all the remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries that the user has permission to view
+	 */
+	public java.util.List<RemoteAppEntry> filterFindByUuid(
+		String uuid, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the remote app entries that the user has permissions to view where uuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries that the user has permission to view
+	 */
+	public java.util.List<RemoteAppEntry> filterFindByUuid(
+		String uuid, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set of remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param uuid the uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	public RemoteAppEntry[] filterFindByUuid_PrevAndNext(
+			long remoteAppEntryId, String uuid,
+			com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+				orderByComparator)
+		throws NoSuchRemoteAppEntryException;
+
+	/**
 	 * Removes all the remote app entries where uuid = &#63; from the database.
 	 *
 	 * @param uuid the uuid
@@ -183,6 +239,14 @@ public interface RemoteAppEntryPersistence
 	 * @return the number of matching remote app entries
 	 */
 	public int countByUuid(String uuid);
+
+	/**
+	 * Returns the number of remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @return the number of matching remote app entries that the user has permission to view
+	 */
+	public int filterCountByUuid(String uuid);
 
 	/**
 	 * Returns all the remote app entries where uuid = &#63; and companyId = &#63;.
@@ -323,6 +387,67 @@ public interface RemoteAppEntryPersistence
 		throws NoSuchRemoteAppEntryException;
 
 	/**
+	 * Returns all the remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @return the matching remote app entries that the user has permission to view
+	 */
+	public java.util.List<RemoteAppEntry> filterFindByUuid_C(
+		String uuid, long companyId);
+
+	/**
+	 * Returns a range of all the remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries that the user has permission to view
+	 */
+	public java.util.List<RemoteAppEntry> filterFindByUuid_C(
+		String uuid, long companyId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the remote app entries that the user has permissions to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries that the user has permission to view
+	 */
+	public java.util.List<RemoteAppEntry> filterFindByUuid_C(
+		String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set of remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	public RemoteAppEntry[] filterFindByUuid_C_PrevAndNext(
+			long remoteAppEntryId, String uuid, long companyId,
+			com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+				orderByComparator)
+		throws NoSuchRemoteAppEntryException;
+
+	/**
 	 * Removes all the remote app entries where uuid = &#63; and companyId = &#63; from the database.
 	 *
 	 * @param uuid the uuid
@@ -338,6 +463,15 @@ public interface RemoteAppEntryPersistence
 	 * @return the number of matching remote app entries
 	 */
 	public int countByUuid_C(String uuid, long companyId);
+
+	/**
+	 * Returns the number of remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @return the number of matching remote app entries that the user has permission to view
+	 */
+	public int filterCountByUuid_C(String uuid, long companyId);
 
 	/**
 	 * Caches the remote app entry in the entity cache if it is enabled.

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/persistence/RemoteAppEntryUtil.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/persistence/RemoteAppEntryUtil.java
@@ -269,6 +269,73 @@ public class RemoteAppEntryUtil {
 	}
 
 	/**
+	 * Returns all the remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @return the matching remote app entries that the user has permission to view
+	 */
+	public static List<RemoteAppEntry> filterFindByUuid(String uuid) {
+		return getPersistence().filterFindByUuid(uuid);
+	}
+
+	/**
+	 * Returns a range of all the remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries that the user has permission to view
+	 */
+	public static List<RemoteAppEntry> filterFindByUuid(
+		String uuid, int start, int end) {
+
+		return getPersistence().filterFindByUuid(uuid, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the remote app entries that the user has permissions to view where uuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries that the user has permission to view
+	 */
+	public static List<RemoteAppEntry> filterFindByUuid(
+		String uuid, int start, int end,
+		OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		return getPersistence().filterFindByUuid(
+			uuid, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set of remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param uuid the uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	public static RemoteAppEntry[] filterFindByUuid_PrevAndNext(
+			long remoteAppEntryId, String uuid,
+			OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws com.liferay.remote.app.exception.NoSuchRemoteAppEntryException {
+
+		return getPersistence().filterFindByUuid_PrevAndNext(
+			remoteAppEntryId, uuid, orderByComparator);
+	}
+
+	/**
 	 * Removes all the remote app entries where uuid = &#63; from the database.
 	 *
 	 * @param uuid the uuid
@@ -285,6 +352,16 @@ public class RemoteAppEntryUtil {
 	 */
 	public static int countByUuid(String uuid) {
 		return getPersistence().countByUuid(uuid);
+	}
+
+	/**
+	 * Returns the number of remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @return the number of matching remote app entries that the user has permission to view
+	 */
+	public static int filterCountByUuid(String uuid) {
+		return getPersistence().filterCountByUuid(uuid);
 	}
 
 	/**
@@ -453,6 +530,79 @@ public class RemoteAppEntryUtil {
 	}
 
 	/**
+	 * Returns all the remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @return the matching remote app entries that the user has permission to view
+	 */
+	public static List<RemoteAppEntry> filterFindByUuid_C(
+		String uuid, long companyId) {
+
+		return getPersistence().filterFindByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of all the remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries that the user has permission to view
+	 */
+	public static List<RemoteAppEntry> filterFindByUuid_C(
+		String uuid, long companyId, int start, int end) {
+
+		return getPersistence().filterFindByUuid_C(uuid, companyId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the remote app entries that the user has permissions to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries that the user has permission to view
+	 */
+	public static List<RemoteAppEntry> filterFindByUuid_C(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		return getPersistence().filterFindByUuid_C(
+			uuid, companyId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set of remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	public static RemoteAppEntry[] filterFindByUuid_C_PrevAndNext(
+			long remoteAppEntryId, String uuid, long companyId,
+			OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws com.liferay.remote.app.exception.NoSuchRemoteAppEntryException {
+
+		return getPersistence().filterFindByUuid_C_PrevAndNext(
+			remoteAppEntryId, uuid, companyId, orderByComparator);
+	}
+
+	/**
 	 * Removes all the remote app entries where uuid = &#63; and companyId = &#63; from the database.
 	 *
 	 * @param uuid the uuid
@@ -471,6 +621,17 @@ public class RemoteAppEntryUtil {
 	 */
 	public static int countByUuid_C(String uuid, long companyId) {
 		return getPersistence().countByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns the number of remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @return the number of matching remote app entries that the user has permission to view
+	 */
+	public static int filterCountByUuid_C(String uuid, long companyId) {
+		return getPersistence().filterCountByUuid_C(uuid, companyId);
 	}
 
 	/**

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/security/permission/resource/RemoteAppAdminPortletResourcePermissionLogic.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/security/permission/resource/RemoteAppAdminPortletResourcePermissionLogic.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.internal.security.permission.resource;
+
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermissionLogic;
+
+/**
+ * @author Javier de Arcos
+ */
+public class RemoteAppAdminPortletResourcePermissionLogic
+	implements PortletResourcePermissionLogic {
+
+	@Override
+	public Boolean contains(
+		PermissionChecker permissionChecker, String name, Group group,
+		String actionId) {
+
+		if (permissionChecker.hasPermission(group, name, 0, actionId)) {
+			return true;
+		}
+
+		return false;
+	}
+
+}

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/security/permission/resource/RemoteAppAdminPortletResourcePermissionRegistrar.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/security/permission/resource/RemoteAppAdminPortletResourcePermissionRegistrar.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.internal.security.permission.resource;
+
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermissionFactory;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.remote.app.constants.RemoteAppConstants;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(immediate = true, service = {})
+public class RemoteAppAdminPortletResourcePermissionRegistrar {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistration = bundleContext.registerService(
+			PortletResourcePermission.class,
+			PortletResourcePermissionFactory.create(
+				RemoteAppConstants.RESOURCE_NAME,
+				new RemoteAppAdminPortletResourcePermissionLogic()),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"resource.name", RemoteAppConstants.RESOURCE_NAME
+			).build());
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceRegistration.unregister();
+	}
+
+	private ServiceRegistration<PortletResourcePermission> _serviceRegistration;
+
+}

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/security/permission/resource/RemoteAppEntryModelResourcePermission.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/security/permission/resource/RemoteAppEntryModelResourcePermission.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.internal.security.permission.resource;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.remote.app.constants.RemoteAppConstants;
+import com.liferay.remote.app.model.RemoteAppEntry;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+	immediate = true,
+	property = "model.class.name=com.liferay.remote.app.model.RemoteAppEntry",
+	service = ModelResourcePermission.class
+)
+public class RemoteAppEntryModelResourcePermission
+	implements ModelResourcePermission<RemoteAppEntry> {
+
+	@Override
+	public void check(
+			PermissionChecker permissionChecker, long remoteAppEntryId,
+			String actionId)
+		throws PortalException {
+
+		if (!contains(permissionChecker, remoteAppEntryId, actionId)) {
+			throw new PrincipalException.MustHavePermission(
+				permissionChecker, RemoteAppEntry.class.getName(),
+				remoteAppEntryId, actionId);
+		}
+	}
+
+	@Override
+	public void check(
+			PermissionChecker permissionChecker, RemoteAppEntry remoteAppEntry,
+			String actionId)
+		throws PortalException {
+
+		if (!contains(permissionChecker, remoteAppEntry, actionId)) {
+			throw new PrincipalException.MustHavePermission(
+				permissionChecker, RemoteAppEntry.class.getName(),
+				remoteAppEntry.getRemoteAppEntryId(), actionId);
+		}
+	}
+
+	@Override
+	public boolean contains(
+		PermissionChecker permissionChecker, long remoteAppEntryId,
+		String actionId) {
+
+		return permissionChecker.hasPermission(
+			null, RemoteAppEntry.class.getName(), remoteAppEntryId, actionId);
+	}
+
+	@Override
+	public boolean contains(
+		PermissionChecker permissionChecker, RemoteAppEntry remoteAppEntry,
+		String actionId) {
+
+		return permissionChecker.hasPermission(
+			null, RemoteAppEntry.class.getName(),
+			remoteAppEntry.getRemoteAppEntryId(), actionId);
+	}
+
+	@Override
+	public String getModelName() {
+		return RemoteAppEntry.class.getName();
+	}
+
+	@Override
+	public PortletResourcePermission getPortletResourcePermission() {
+		return _portletResourcePermission;
+	}
+
+	@Reference(
+		target = "(resource.name=" + RemoteAppConstants.RESOURCE_NAME + ")"
+	)
+	private PortletResourcePermission _portletResourcePermission;
+
+}

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/http/RemoteAppEntryServiceHttp.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/http/RemoteAppEntryServiceHttp.java
@@ -138,6 +138,47 @@ public class RemoteAppEntryServiceHttp {
 		}
 	}
 
+	public static com.liferay.remote.app.model.RemoteAppEntry
+			deleteRemoteAppEntry(
+				HttpPrincipal httpPrincipal, long remoteAppEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				RemoteAppEntryServiceUtil.class, "deleteRemoteAppEntry",
+				_deleteRemoteAppEntryParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, remoteAppEntryId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.remote.app.model.RemoteAppEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.remote.app.model.RemoteAppEntry getRemoteAppEntry(
 			HttpPrincipal httpPrincipal, long remoteAppEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -145,7 +186,7 @@ public class RemoteAppEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				RemoteAppEntryServiceUtil.class, "getRemoteAppEntry",
-				_getRemoteAppEntryParameterTypes2);
+				_getRemoteAppEntryParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, remoteAppEntryId);
@@ -190,7 +231,7 @@ public class RemoteAppEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				RemoteAppEntryServiceUtil.class,
 				"updateCustomElementRemoteAppEntry",
-				_updateCustomElementRemoteAppEntryParameterTypes3);
+				_updateCustomElementRemoteAppEntryParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, remoteAppEntryId, customElementCSSURLs,
@@ -234,7 +275,7 @@ public class RemoteAppEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				RemoteAppEntryServiceUtil.class, "updateIFrameRemoteAppEntry",
-				_updateIFrameRemoteAppEntryParameterTypes4);
+				_updateIFrameRemoteAppEntryParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, remoteAppEntryId, iFrameURL, nameMap);
@@ -276,14 +317,16 @@ public class RemoteAppEntryServiceHttp {
 		};
 	private static final Class<?>[] _addIFrameRemoteAppEntryParameterTypes1 =
 		new Class[] {String.class, java.util.Map.class};
-	private static final Class<?>[] _getRemoteAppEntryParameterTypes2 =
+	private static final Class<?>[] _deleteRemoteAppEntryParameterTypes2 =
+		new Class[] {long.class};
+	private static final Class<?>[] _getRemoteAppEntryParameterTypes3 =
 		new Class[] {long.class};
 	private static final Class<?>[]
-		_updateCustomElementRemoteAppEntryParameterTypes3 = new Class[] {
+		_updateCustomElementRemoteAppEntryParameterTypes4 = new Class[] {
 			long.class, String.class, String.class, String.class,
 			java.util.Map.class
 		};
-	private static final Class<?>[] _updateIFrameRemoteAppEntryParameterTypes4 =
+	private static final Class<?>[] _updateIFrameRemoteAppEntryParameterTypes5 =
 		new Class[] {long.class, String.class, java.util.Map.class};
 
 }

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/http/RemoteAppEntryServiceSoap.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/http/RemoteAppEntryServiceSoap.java
@@ -118,6 +118,25 @@ public class RemoteAppEntryServiceSoap {
 	}
 
 	public static com.liferay.remote.app.model.RemoteAppEntrySoap
+			deleteRemoteAppEntry(long remoteAppEntryId)
+		throws RemoteException {
+
+		try {
+			com.liferay.remote.app.model.RemoteAppEntry returnValue =
+				RemoteAppEntryServiceUtil.deleteRemoteAppEntry(
+					remoteAppEntryId);
+
+			return com.liferay.remote.app.model.RemoteAppEntrySoap.toSoapModel(
+				returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
+	public static com.liferay.remote.app.model.RemoteAppEntrySoap
 			getRemoteAppEntry(long remoteAppEntryId)
 		throws RemoteException {
 

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
@@ -32,6 +33,7 @@ import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -105,6 +107,8 @@ public class RemoteAppEntryLocalServiceImpl
 
 		remoteAppEntry = remoteAppEntryPersistence.update(remoteAppEntry);
 
+		_addRemoteAppEntryResources(remoteAppEntry);
+
 		remoteAppEntryLocalService.deployRemoteAppEntry(remoteAppEntry);
 
 		return remoteAppEntry;
@@ -135,6 +139,8 @@ public class RemoteAppEntryLocalServiceImpl
 
 		remoteAppEntry = remoteAppEntryPersistence.update(remoteAppEntry);
 
+		_addRemoteAppEntryResources(remoteAppEntry);
+
 		remoteAppEntryLocalService.deployRemoteAppEntry(remoteAppEntry);
 
 		return remoteAppEntry;
@@ -155,6 +161,11 @@ public class RemoteAppEntryLocalServiceImpl
 		throws PortalException {
 
 		remoteAppEntryPersistence.remove(remoteAppEntry);
+
+		_resourceLocalService.deleteResource(
+			remoteAppEntry.getCompanyId(), RemoteAppEntry.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			remoteAppEntry.getRemoteAppEntryId());
 
 		remoteAppEntryLocalService.undeployRemoteAppEntry(remoteAppEntry);
 
@@ -298,6 +309,15 @@ public class RemoteAppEntryLocalServiceImpl
 		_bundleContext = bundleContext;
 	}
 
+	private void _addRemoteAppEntryResources(RemoteAppEntry remoteAppEntry)
+		throws PortalException {
+
+		_resourceLocalService.addResources(
+			remoteAppEntry.getCompanyId(), 0, remoteAppEntry.getUserId(),
+			RemoteAppEntry.class.getName(),
+			remoteAppEntry.getRemoteAppEntryId(), false, true, true);
+	}
+
 	private SearchContext _buildSearchContext(
 		long companyId, String keywords, int start, int end, Sort sort) {
 
@@ -439,6 +459,9 @@ public class RemoteAppEntryLocalServiceImpl
 
 	@Reference
 	private RemoteAppEntryDeployer _remoteAppEntryDeployer;
+
+	@Reference
+	private ResourceLocalService _resourceLocalService;
 
 	private final Map<Long, List<ServiceRegistration<?>>>
 		_serviceRegistrationsMaps = new ConcurrentHashMap<>();

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryServiceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryServiceImpl.java
@@ -68,6 +68,17 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 	}
 
 	@Override
+	public RemoteAppEntry deleteRemoteAppEntry(long remoteAppEntryId)
+		throws PortalException {
+
+		_remoteAppEntryModelResourcePermission.check(
+			getPermissionChecker(), remoteAppEntryId, ActionKeys.DELETE);
+
+		return remoteAppEntryLocalService.deleteRemoteAppEntry(
+			remoteAppEntryId);
+	}
+
+	@Override
 	public RemoteAppEntry getRemoteAppEntry(long remoteAppEntryId)
 		throws PortalException {
 

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryServiceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryServiceImpl.java
@@ -16,6 +16,10 @@ package com.liferay.remote.app.service.impl;
 
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.remote.app.constants.RemoteAppConstants;
 import com.liferay.remote.app.model.RemoteAppEntry;
 import com.liferay.remote.app.service.base.RemoteAppEntryServiceBaseImpl;
 
@@ -23,6 +27,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Brian Wing Shun Chan
@@ -42,6 +47,9 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 			String customElementURLs, Map<Locale, String> nameMap)
 		throws PortalException {
 
+		_portletResourcePermission.check(
+			getPermissionChecker(), null, ActionKeys.ADD_ENTRY);
+
 		return remoteAppEntryLocalService.addCustomElementRemoteAppEntry(
 			getUserId(), customElementCSSURLs, customElementHTMLElementName,
 			customElementURLs, nameMap);
@@ -52,6 +60,9 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 			String iFrameURL, Map<Locale, String> nameMap)
 		throws PortalException {
 
+		_portletResourcePermission.check(
+			getPermissionChecker(), null, ActionKeys.ADD_ENTRY);
+
 		return remoteAppEntryLocalService.addIFrameRemoteAppEntry(
 			getUserId(), iFrameURL, nameMap);
 	}
@@ -59,6 +70,9 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 	@Override
 	public RemoteAppEntry getRemoteAppEntry(long remoteAppEntryId)
 		throws PortalException {
+
+		_remoteAppEntryModelResourcePermission.check(
+			getPermissionChecker(), remoteAppEntryId, ActionKeys.VIEW);
 
 		return remoteAppEntryLocalService.getRemoteAppEntry(remoteAppEntryId);
 	}
@@ -69,6 +83,9 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 			String customElementHTMLElementName, String customElementURLs,
 			Map<Locale, String> nameMap)
 		throws PortalException {
+
+		_remoteAppEntryModelResourcePermission.check(
+			getPermissionChecker(), remoteAppEntryId, ActionKeys.UPDATE);
 
 		return remoteAppEntryLocalService.updateCustomElementRemoteAppEntry(
 			remoteAppEntryId, customElementCSSURLs,
@@ -81,8 +98,22 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 			Map<Locale, String> nameMap)
 		throws PortalException {
 
+		_remoteAppEntryModelResourcePermission.check(
+			getPermissionChecker(), remoteAppEntryId, ActionKeys.UPDATE);
+
 		return remoteAppEntryLocalService.updateIFrameRemoteAppEntry(
 			remoteAppEntryId, iFrameURL, nameMap);
 	}
+
+	@Reference(
+		target = "(resource.name=" + RemoteAppConstants.RESOURCE_NAME + ")"
+	)
+	private PortletResourcePermission _portletResourcePermission;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.remote.app.model.RemoteAppEntry)"
+	)
+	private ModelResourcePermission<RemoteAppEntry>
+		_remoteAppEntryModelResourcePermission;
 
 }

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/persistence/impl/RemoteAppEntryPersistenceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/persistence/impl/RemoteAppEntryPersistenceImpl.java
@@ -22,11 +22,13 @@ import com.liferay.portal.kernel.dao.orm.FinderPath;
 import com.liferay.portal.kernel.dao.orm.Query;
 import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.SessionFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
@@ -548,6 +550,363 @@ public class RemoteAppEntryPersistenceImpl
 	}
 
 	/**
+	 * Returns all the remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @return the matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public List<RemoteAppEntry> filterFindByUuid(String uuid) {
+		return filterFindByUuid(
+			uuid, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public List<RemoteAppEntry> filterFindByUuid(
+		String uuid, int start, int end) {
+
+		return filterFindByUuid(uuid, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the remote app entries that the user has permissions to view where uuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public List<RemoteAppEntry> filterFindByUuid(
+		String uuid, int start, int end,
+		OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return findByUuid(uuid, start, end, orderByComparator);
+		}
+
+		uuid = Objects.toString(uuid, "");
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				3 + (orderByComparator.getOrderByFields().length * 2));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_REMOTEAPPENTRY_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		boolean bindUuid = false;
+
+		if (uuid.isEmpty()) {
+			sb.append(_FINDER_COLUMN_UUID_UUID_3_SQL);
+		}
+		else {
+			bindUuid = true;
+
+			sb.append(_FINDER_COLUMN_UUID_UUID_2_SQL);
+		}
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator, true);
+			}
+			else {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_TABLE, orderByComparator, true);
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), RemoteAppEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_ALIAS, RemoteAppEntryImpl.class);
+			}
+			else {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_TABLE, RemoteAppEntryImpl.class);
+			}
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			if (bindUuid) {
+				queryPos.add(uuid);
+			}
+
+			return (List<RemoteAppEntry>)QueryUtil.list(
+				sqlQuery, getDialect(), start, end);
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set of remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param uuid the uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	@Override
+	public RemoteAppEntry[] filterFindByUuid_PrevAndNext(
+			long remoteAppEntryId, String uuid,
+			OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws NoSuchRemoteAppEntryException {
+
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return findByUuid_PrevAndNext(
+				remoteAppEntryId, uuid, orderByComparator);
+		}
+
+		uuid = Objects.toString(uuid, "");
+
+		RemoteAppEntry remoteAppEntry = findByPrimaryKey(remoteAppEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			RemoteAppEntry[] array = new RemoteAppEntryImpl[3];
+
+			array[0] = filterGetByUuid_PrevAndNext(
+				session, remoteAppEntry, uuid, orderByComparator, true);
+
+			array[1] = remoteAppEntry;
+
+			array[2] = filterGetByUuid_PrevAndNext(
+				session, remoteAppEntry, uuid, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected RemoteAppEntry filterGetByUuid_PrevAndNext(
+		Session session, RemoteAppEntry remoteAppEntry, String uuid,
+		OrderByComparator<RemoteAppEntry> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_REMOTEAPPENTRY_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		boolean bindUuid = false;
+
+		if (uuid.isEmpty()) {
+			sb.append(_FINDER_COLUMN_UUID_UUID_3_SQL);
+		}
+		else {
+			bindUuid = true;
+
+			sb.append(_FINDER_COLUMN_UUID_UUID_2_SQL);
+		}
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByConditionFields[i],
+							true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByConditionFields[i],
+							true));
+				}
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByFields[i], true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByFields[i], true));
+				}
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), RemoteAppEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+		sqlQuery.setFirstResult(0);
+		sqlQuery.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, RemoteAppEntryImpl.class);
+		}
+		else {
+			sqlQuery.addEntity(_FILTER_ENTITY_TABLE, RemoteAppEntryImpl.class);
+		}
+
+		QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+		if (bindUuid) {
+			queryPos.add(uuid);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						remoteAppEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<RemoteAppEntry> list = sqlQuery.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
 	 * Removes all the remote app entries where uuid = &#63; from the database.
 	 *
 	 * @param uuid the uuid
@@ -623,11 +982,78 @@ public class RemoteAppEntryPersistenceImpl
 		return count.intValue();
 	}
 
+	/**
+	 * Returns the number of remote app entries that the user has permission to view where uuid = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @return the number of matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public int filterCountByUuid(String uuid) {
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return countByUuid(uuid);
+		}
+
+		uuid = Objects.toString(uuid, "");
+
+		StringBundler sb = new StringBundler(2);
+
+		sb.append(_FILTER_SQL_COUNT_REMOTEAPPENTRY_WHERE);
+
+		boolean bindUuid = false;
+
+		if (uuid.isEmpty()) {
+			sb.append(_FINDER_COLUMN_UUID_UUID_3_SQL);
+		}
+		else {
+			bindUuid = true;
+
+			sb.append(_FINDER_COLUMN_UUID_UUID_2_SQL);
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), RemoteAppEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addScalar(
+				COUNT_COLUMN_NAME, com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			if (bindUuid) {
+				queryPos.add(uuid);
+			}
+
+			Long count = (Long)sqlQuery.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
 	private static final String _FINDER_COLUMN_UUID_UUID_2 =
 		"remoteAppEntry.uuid = ?";
 
 	private static final String _FINDER_COLUMN_UUID_UUID_3 =
 		"(remoteAppEntry.uuid IS NULL OR remoteAppEntry.uuid = '')";
+
+	private static final String _FINDER_COLUMN_UUID_UUID_2_SQL =
+		"remoteAppEntry.uuid_ = ?";
+
+	private static final String _FINDER_COLUMN_UUID_UUID_3_SQL =
+		"(remoteAppEntry.uuid_ IS NULL OR remoteAppEntry.uuid_ = '')";
 
 	private FinderPath _finderPathWithPaginationFindByUuid_C;
 	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
@@ -1119,6 +1545,380 @@ public class RemoteAppEntryPersistenceImpl
 	}
 
 	/**
+	 * Returns all the remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @return the matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public List<RemoteAppEntry> filterFindByUuid_C(
+		String uuid, long companyId) {
+
+		return filterFindByUuid_C(
+			uuid, companyId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public List<RemoteAppEntry> filterFindByUuid_C(
+		String uuid, long companyId, int start, int end) {
+
+		return filterFindByUuid_C(uuid, companyId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the remote app entries that the user has permissions to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public List<RemoteAppEntry> filterFindByUuid_C(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		if (!InlineSQLHelperUtil.isEnabled(companyId, 0)) {
+			return findByUuid_C(uuid, companyId, start, end, orderByComparator);
+		}
+
+		uuid = Objects.toString(uuid, "");
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				4 + (orderByComparator.getOrderByFields().length * 2));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_REMOTEAPPENTRY_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		boolean bindUuid = false;
+
+		if (uuid.isEmpty()) {
+			sb.append(_FINDER_COLUMN_UUID_C_UUID_3_SQL);
+		}
+		else {
+			bindUuid = true;
+
+			sb.append(_FINDER_COLUMN_UUID_C_UUID_2_SQL);
+		}
+
+		sb.append(_FINDER_COLUMN_UUID_C_COMPANYID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator, true);
+			}
+			else {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_TABLE, orderByComparator, true);
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), RemoteAppEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_ALIAS, RemoteAppEntryImpl.class);
+			}
+			else {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_TABLE, RemoteAppEntryImpl.class);
+			}
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			if (bindUuid) {
+				queryPos.add(uuid);
+			}
+
+			queryPos.add(companyId);
+
+			return (List<RemoteAppEntry>)QueryUtil.list(
+				sqlQuery, getDialect(), start, end);
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set of remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	@Override
+	public RemoteAppEntry[] filterFindByUuid_C_PrevAndNext(
+			long remoteAppEntryId, String uuid, long companyId,
+			OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws NoSuchRemoteAppEntryException {
+
+		if (!InlineSQLHelperUtil.isEnabled(companyId, 0)) {
+			return findByUuid_C_PrevAndNext(
+				remoteAppEntryId, uuid, companyId, orderByComparator);
+		}
+
+		uuid = Objects.toString(uuid, "");
+
+		RemoteAppEntry remoteAppEntry = findByPrimaryKey(remoteAppEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			RemoteAppEntry[] array = new RemoteAppEntryImpl[3];
+
+			array[0] = filterGetByUuid_C_PrevAndNext(
+				session, remoteAppEntry, uuid, companyId, orderByComparator,
+				true);
+
+			array[1] = remoteAppEntry;
+
+			array[2] = filterGetByUuid_C_PrevAndNext(
+				session, remoteAppEntry, uuid, companyId, orderByComparator,
+				false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected RemoteAppEntry filterGetByUuid_C_PrevAndNext(
+		Session session, RemoteAppEntry remoteAppEntry, String uuid,
+		long companyId, OrderByComparator<RemoteAppEntry> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_REMOTEAPPENTRY_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		boolean bindUuid = false;
+
+		if (uuid.isEmpty()) {
+			sb.append(_FINDER_COLUMN_UUID_C_UUID_3_SQL);
+		}
+		else {
+			bindUuid = true;
+
+			sb.append(_FINDER_COLUMN_UUID_C_UUID_2_SQL);
+		}
+
+		sb.append(_FINDER_COLUMN_UUID_C_COMPANYID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByConditionFields[i],
+							true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByConditionFields[i],
+							true));
+				}
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByFields[i], true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByFields[i], true));
+				}
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), RemoteAppEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+		sqlQuery.setFirstResult(0);
+		sqlQuery.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, RemoteAppEntryImpl.class);
+		}
+		else {
+			sqlQuery.addEntity(_FILTER_ENTITY_TABLE, RemoteAppEntryImpl.class);
+		}
+
+		QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+		if (bindUuid) {
+			queryPos.add(uuid);
+		}
+
+		queryPos.add(companyId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						remoteAppEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<RemoteAppEntry> list = sqlQuery.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
 	 * Removes all the remote app entries where uuid = &#63; and companyId = &#63; from the database.
 	 *
 	 * @param uuid the uuid
@@ -1202,11 +2002,83 @@ public class RemoteAppEntryPersistenceImpl
 		return count.intValue();
 	}
 
+	/**
+	 * Returns the number of remote app entries that the user has permission to view where uuid = &#63; and companyId = &#63;.
+	 *
+	 * @param uuid the uuid
+	 * @param companyId the company ID
+	 * @return the number of matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public int filterCountByUuid_C(String uuid, long companyId) {
+		if (!InlineSQLHelperUtil.isEnabled(companyId, 0)) {
+			return countByUuid_C(uuid, companyId);
+		}
+
+		uuid = Objects.toString(uuid, "");
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(_FILTER_SQL_COUNT_REMOTEAPPENTRY_WHERE);
+
+		boolean bindUuid = false;
+
+		if (uuid.isEmpty()) {
+			sb.append(_FINDER_COLUMN_UUID_C_UUID_3_SQL);
+		}
+		else {
+			bindUuid = true;
+
+			sb.append(_FINDER_COLUMN_UUID_C_UUID_2_SQL);
+		}
+
+		sb.append(_FINDER_COLUMN_UUID_C_COMPANYID_2);
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), RemoteAppEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addScalar(
+				COUNT_COLUMN_NAME, com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			if (bindUuid) {
+				queryPos.add(uuid);
+			}
+
+			queryPos.add(companyId);
+
+			Long count = (Long)sqlQuery.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
 	private static final String _FINDER_COLUMN_UUID_C_UUID_2 =
 		"remoteAppEntry.uuid = ? AND ";
 
 	private static final String _FINDER_COLUMN_UUID_C_UUID_3 =
 		"(remoteAppEntry.uuid IS NULL OR remoteAppEntry.uuid = '') AND ";
+
+	private static final String _FINDER_COLUMN_UUID_C_UUID_2_SQL =
+		"remoteAppEntry.uuid_ = ? AND ";
+
+	private static final String _FINDER_COLUMN_UUID_C_UUID_3_SQL =
+		"(remoteAppEntry.uuid_ IS NULL OR remoteAppEntry.uuid_ = '') AND ";
 
 	private static final String _FINDER_COLUMN_UUID_C_COMPANYID_2 =
 		"remoteAppEntry.companyId = ?";
@@ -1864,7 +2736,30 @@ public class RemoteAppEntryPersistenceImpl
 	private static final String _SQL_COUNT_REMOTEAPPENTRY_WHERE =
 		"SELECT COUNT(remoteAppEntry) FROM RemoteAppEntry remoteAppEntry WHERE ";
 
+	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN =
+		"remoteAppEntry.remoteAppEntryId";
+
+	private static final String _FILTER_SQL_SELECT_REMOTEAPPENTRY_WHERE =
+		"SELECT DISTINCT {remoteAppEntry.*} FROM RemoteAppEntry remoteAppEntry WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_1 =
+			"SELECT {RemoteAppEntry.*} FROM (SELECT DISTINCT remoteAppEntry.remoteAppEntryId FROM RemoteAppEntry remoteAppEntry WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_2 =
+			") TEMP_TABLE INNER JOIN RemoteAppEntry ON TEMP_TABLE.remoteAppEntryId = RemoteAppEntry.remoteAppEntryId";
+
+	private static final String _FILTER_SQL_COUNT_REMOTEAPPENTRY_WHERE =
+		"SELECT COUNT(DISTINCT remoteAppEntry.remoteAppEntryId) AS COUNT_VALUE FROM RemoteAppEntry remoteAppEntry WHERE ";
+
+	private static final String _FILTER_ENTITY_ALIAS = "remoteAppEntry";
+
+	private static final String _FILTER_ENTITY_TABLE = "RemoteAppEntry";
+
 	private static final String _ORDER_BY_ENTITY_ALIAS = "remoteAppEntry.";
+
+	private static final String _ORDER_BY_ENTITY_TABLE = "RemoteAppEntry.";
 
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY =
 		"No RemoteAppEntry exists with the primary key ";

--- a/modules/apps/remote-app/remote-app-service/src/main/resources/portlet.properties
+++ b/modules/apps/remote-app/remote-app-service/src/main/resources/portlet.properties
@@ -1,0 +1,7 @@
+include-and-override=portlet-ext.properties
+
+#
+# Input a list of comma delimited resource action configurations that will be
+# read from the class path.
+#
+resource.actions.configs=resource-actions/default.xml

--- a/modules/apps/remote-app/remote-app-service/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/remote-app/remote-app-service/src/main/resources/resource-actions/default.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!DOCTYPE resource-action-mapping PUBLIC "-//Liferay//DTD Resource Action Mapping 7.4.0//EN" "http://www.liferay.com/dtd/liferay-resource-action-mapping_7_4_0.dtd">
+
+<resource-action-mapping>
+	<model-resource>
+		<model-name>com.liferay.remote.app.model</model-name>
+		<portlet-ref>
+			<portlet-name>com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet</portlet-name>
+		</portlet-ref>
+		<root>true</root>
+		<weight>1</weight>
+		<permissions>
+			<supports>
+				<action-key>ADD_ENTRY</action-key>
+				<action-key>PERMISSIONS</action-key>
+			</supports>
+			<guest-unsupported>
+				<action-key>ADD_ENTRY</action-key>
+				<action-key>PERMISSIONS</action-key>
+			</guest-unsupported>
+		</permissions>
+	</model-resource>
+	<model-resource>
+		<model-name>com.liferay.remote.app.model.RemoteAppEntry</model-name>
+		<portlet-ref>
+			<portlet-name>com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet</portlet-name>
+		</portlet-ref>
+		<weight>1</weight>
+		<permissions>
+			<supports>
+				<action-key>DELETE</action-key>
+				<action-key>PERMISSIONS</action-key>
+				<action-key>UPDATE</action-key>
+				<action-key>VIEW</action-key>
+			</supports>
+			<guest-defaults>
+				<action-key>VIEW</action-key>
+			</guest-defaults>
+			<guest-unsupported>
+				<action-key>DELETE</action-key>
+				<action-key>PERMISSIONS</action-key>
+				<action-key>UPDATE</action-key>
+			</guest-unsupported>
+		</permissions>
+	</model-resource>
+</resource-action-mapping>

--- a/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/portlet/action/DeleteRemoteAppEntryMVCActionCommand.java
+++ b/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/portlet/action/DeleteRemoteAppEntryMVCActionCommand.java
@@ -18,7 +18,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.remote.app.service.RemoteAppEntryLocalService;
+import com.liferay.remote.app.service.RemoteAppEntryService;
 import com.liferay.remote.app.web.internal.constants.RemoteAppAdminPortletKeys;
 
 import javax.portlet.ActionRequest;
@@ -48,7 +48,7 @@ public class DeleteRemoteAppEntryMVCActionCommand extends BaseMVCActionCommand {
 		long remoteAppEntryId = ParamUtil.getLong(
 			actionRequest, "remoteAppEntryId");
 
-		_remoteAppEntryLocalService.deleteRemoteAppEntry(remoteAppEntryId);
+		_remoteAppEntryService.deleteRemoteAppEntry(remoteAppEntryId);
 
 		String redirect = ParamUtil.getString(actionRequest, "redirect");
 
@@ -58,6 +58,6 @@ public class DeleteRemoteAppEntryMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	@Reference
-	private RemoteAppEntryLocalService _remoteAppEntryLocalService;
+	private RemoteAppEntryService _remoteAppEntryService;
 
 }


### PR DESCRIPTION
This PR adds the permissions to the RemoteAppEntry entity and RemoteAppAdmin portlet.

The first thing to review is if the defined permissions make sense in the context of the Remote Apps application and use cases. Check [first commit](https://github.com/liferay-frontend/liferay-portal/commit/31f16a16d0a48d5e1989f80813178c62065a8823)

Taking other entities as an example I defined the ADD_ENTRY and PERMISSIONS actions for the collection. Checking the frontend code I didn't see any place where the permissions could be changed, but I add the PERMISSIONS action in case it is interesting to add it in the future. If not, we can remove it.

From the entity level, the actions defined are DELETE, PERMISSIONS, UPDATE, and VIEW. The VIEW permission is given by a guest role.

I've modified the Service impl to check permissions before calling the local service to execute the desired action and the MVCAction commands to always use the service (and avoid using the local service which will avoid the permission checking).

I'm not adding any label to this PR although I think that s-dxp is the best fit. Please add it when you review the PR.
