### PR TITLE
LRQA-66550 | Add back WYSIWYG testray component names property

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBThread.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBThread.testcase
@@ -134,6 +134,7 @@ definition {
 	@refactorneeded
 	test CanAddLinkToPage {
 		property portal.acceptance = "true";
+		property testray.component.names = "WYSIWYG";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",


### PR DESCRIPTION
**Description**
Add usecase test coverage for CKEditor able to add link to page.

**Test Plan**
- [x] Check to see CanAddLinkToPage has WYSIWYG listed for  testray.component.names property

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-66550