### PR TITLE
LPS-139629 Generates predictable remote app portlet names and adds support for aliases

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_dnd_table.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_dnd_table.scss
@@ -136,7 +136,7 @@
 	color: $table-list-color;
 	display: table;
 	font-size: 0.875rem;
-	overflow-x: scroll;
+	overflow-x: auto;
 	transition: opacity 0.1s ease-in;
 	white-space: nowrap;
 	width: 100%;

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/model/RemoteAppEntryModel.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/model/RemoteAppEntryModel.java
@@ -370,6 +370,21 @@ public interface RemoteAppEntryModel
 	public void setNameMap(Map<Locale, String> nameMap, Locale defaultLocale);
 
 	/**
+	 * Returns the portlet alias of this remote app entry.
+	 *
+	 * @return the portlet alias of this remote app entry
+	 */
+	@AutoEscape
+	public String getPortletAlias();
+
+	/**
+	 * Sets the portlet alias of this remote app entry.
+	 *
+	 * @param portletAlias the portlet alias of this remote app entry
+	 */
+	public void setPortletAlias(String portletAlias);
+
+	/**
 	 * Returns the portlet category name of this remote app entry.
 	 *
 	 * @return the portlet category name of this remote app entry

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/model/RemoteAppEntrySoap.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/model/RemoteAppEntrySoap.java
@@ -47,6 +47,7 @@ public class RemoteAppEntrySoap implements Serializable {
 		soapModel.setCustomElementURLs(model.getCustomElementURLs());
 		soapModel.setIFrameURL(model.getIFrameURL());
 		soapModel.setName(model.getName());
+		soapModel.setPortletAlias(model.getPortletAlias());
 		soapModel.setPortletCategoryName(model.getPortletCategoryName());
 		soapModel.setProperties(model.getProperties());
 		soapModel.setType(model.getType());
@@ -214,6 +215,14 @@ public class RemoteAppEntrySoap implements Serializable {
 		_name = name;
 	}
 
+	public String getPortletAlias() {
+		return _portletAlias;
+	}
+
+	public void setPortletAlias(String portletAlias) {
+		_portletAlias = portletAlias;
+	}
+
 	public String getPortletCategoryName() {
 		return _portletCategoryName;
 	}
@@ -251,6 +260,7 @@ public class RemoteAppEntrySoap implements Serializable {
 	private String _customElementURLs;
 	private String _iFrameURL;
 	private String _name;
+	private String _portletAlias;
 	private String _portletCategoryName;
 	private String _properties;
 	private String _type;

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/model/RemoteAppEntryTable.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/model/RemoteAppEntryTable.java
@@ -66,6 +66,9 @@ public class RemoteAppEntryTable extends BaseTable<RemoteAppEntryTable> {
 		"iFrameURL", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<RemoteAppEntryTable, String> name = createColumn(
 		"name", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<RemoteAppEntryTable, String> portletAlias =
+		createColumn(
+			"portletAlias", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<RemoteAppEntryTable, String> portletCategoryName =
 		createColumn(
 			"portletCategoryName", String.class, Types.VARCHAR,

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/model/RemoteAppEntryWrapper.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/model/RemoteAppEntryWrapper.java
@@ -57,6 +57,7 @@ public class RemoteAppEntryWrapper
 		attributes.put("customElementURLs", getCustomElementURLs());
 		attributes.put("iFrameURL", getIFrameURL());
 		attributes.put("name", getName());
+		attributes.put("portletAlias", getPortletAlias());
 		attributes.put("portletCategoryName", getPortletCategoryName());
 		attributes.put("properties", getProperties());
 		attributes.put("type", getType());
@@ -144,6 +145,12 @@ public class RemoteAppEntryWrapper
 
 		if (name != null) {
 			setName(name);
+		}
+
+		String portletAlias = (String)attributes.get("portletAlias");
+
+		if (portletAlias != null) {
+			setPortletAlias(portletAlias);
 		}
 
 		String portletCategoryName = (String)attributes.get(
@@ -365,6 +372,16 @@ public class RemoteAppEntryWrapper
 	@Override
 	public long getParentContainerModelId() {
 		return model.getParentContainerModelId();
+	}
+
+	/**
+	 * Returns the portlet alias of this remote app entry.
+	 *
+	 * @return the portlet alias of this remote app entry
+	 */
+	@Override
+	public String getPortletAlias() {
+		return model.getPortletAlias();
 	}
 
 	/**
@@ -640,6 +657,16 @@ public class RemoteAppEntryWrapper
 	@Override
 	public void setParentContainerModelId(long parentContainerModelId) {
 		model.setParentContainerModelId(parentContainerModelId);
+	}
+
+	/**
+	 * Sets the portlet alias of this remote app entry.
+	 *
+	 * @param portletAlias the portlet alias of this remote app entry
+	 */
+	@Override
+	public void setPortletAlias(String portletAlias) {
+		model.setPortletAlias(portletAlias);
 	}
 
 	/**

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalService.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalService.java
@@ -71,14 +71,14 @@ public interface RemoteAppEntryLocalService
 	public RemoteAppEntry addCustomElementRemoteAppEntry(
 			long userId, String customElementCSSURLs,
 			String customElementHTMLElementName, String customElementURLs,
-			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException;
 
 	@Indexable(type = IndexableType.REINDEX)
 	public RemoteAppEntry addIFrameRemoteAppEntry(
 			long userId, String iFrameURL, Map<Locale, String> nameMap,
-			String portletCategoryName, String properties)
+			String portletAlias, String portletCategoryName, String properties)
 		throws PortalException;
 
 	/**
@@ -322,15 +322,15 @@ public interface RemoteAppEntryLocalService
 	public RemoteAppEntry updateCustomElementRemoteAppEntry(
 			long remoteAppEntryId, String customElementCSSURLs,
 			String customElementHTMLElementName, String customElementURLs,
-			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException;
 
 	@Indexable(type = IndexableType.REINDEX)
 	public RemoteAppEntry updateIFrameRemoteAppEntry(
 			long remoteAppEntryId, String iFrameURL,
-			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException;
 
 	/**

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceUtil.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceUtil.java
@@ -48,23 +48,25 @@ public class RemoteAppEntryLocalServiceUtil {
 	public static RemoteAppEntry addCustomElementRemoteAppEntry(
 			long userId, String customElementCSSURLs,
 			String customElementHTMLElementName, String customElementURLs,
-			Map<java.util.Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<java.util.Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException {
 
 		return getService().addCustomElementRemoteAppEntry(
 			userId, customElementCSSURLs, customElementHTMLElementName,
-			customElementURLs, nameMap, portletCategoryName, properties);
+			customElementURLs, nameMap, portletAlias, portletCategoryName,
+			properties);
 	}
 
 	public static RemoteAppEntry addIFrameRemoteAppEntry(
 			long userId, String iFrameURL,
-			Map<java.util.Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<java.util.Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException {
 
 		return getService().addIFrameRemoteAppEntry(
-			userId, iFrameURL, nameMap, portletCategoryName, properties);
+			userId, iFrameURL, nameMap, portletAlias, portletCategoryName,
+			properties);
 	}
 
 	/**
@@ -368,25 +370,25 @@ public class RemoteAppEntryLocalServiceUtil {
 	public static RemoteAppEntry updateCustomElementRemoteAppEntry(
 			long remoteAppEntryId, String customElementCSSURLs,
 			String customElementHTMLElementName, String customElementURLs,
-			Map<java.util.Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<java.util.Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException {
 
 		return getService().updateCustomElementRemoteAppEntry(
 			remoteAppEntryId, customElementCSSURLs,
 			customElementHTMLElementName, customElementURLs, nameMap,
-			portletCategoryName, properties);
+			portletAlias, portletCategoryName, properties);
 	}
 
 	public static RemoteAppEntry updateIFrameRemoteAppEntry(
 			long remoteAppEntryId, String iFrameURL,
-			Map<java.util.Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<java.util.Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException {
 
 		return getService().updateIFrameRemoteAppEntry(
-			remoteAppEntryId, iFrameURL, nameMap, portletCategoryName,
-			properties);
+			remoteAppEntryId, iFrameURL, nameMap, portletAlias,
+			portletCategoryName, properties);
 	}
 
 	/**

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceWrapper.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceWrapper.java
@@ -39,23 +39,26 @@ public class RemoteAppEntryLocalServiceWrapper
 				long userId, String customElementCSSURLs,
 				String customElementHTMLElementName, String customElementURLs,
 				java.util.Map<java.util.Locale, String> nameMap,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _remoteAppEntryLocalService.addCustomElementRemoteAppEntry(
 			userId, customElementCSSURLs, customElementHTMLElementName,
-			customElementURLs, nameMap, portletCategoryName, properties);
+			customElementURLs, nameMap, portletAlias, portletCategoryName,
+			properties);
 	}
 
 	@Override
 	public com.liferay.remote.app.model.RemoteAppEntry addIFrameRemoteAppEntry(
 			long userId, String iFrameURL,
 			java.util.Map<java.util.Locale, String> nameMap,
-			String portletCategoryName, String properties)
+			String portletAlias, String portletCategoryName, String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _remoteAppEntryLocalService.addIFrameRemoteAppEntry(
-			userId, iFrameURL, nameMap, portletCategoryName, properties);
+			userId, iFrameURL, nameMap, portletAlias, portletCategoryName,
+			properties);
 	}
 
 	/**
@@ -418,13 +421,14 @@ public class RemoteAppEntryLocalServiceWrapper
 				long remoteAppEntryId, String customElementCSSURLs,
 				String customElementHTMLElementName, String customElementURLs,
 				java.util.Map<java.util.Locale, String> nameMap,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _remoteAppEntryLocalService.updateCustomElementRemoteAppEntry(
 			remoteAppEntryId, customElementCSSURLs,
 			customElementHTMLElementName, customElementURLs, nameMap,
-			portletCategoryName, properties);
+			portletAlias, portletCategoryName, properties);
 	}
 
 	@Override
@@ -432,12 +436,13 @@ public class RemoteAppEntryLocalServiceWrapper
 			updateIFrameRemoteAppEntry(
 				long remoteAppEntryId, String iFrameURL,
 				java.util.Map<java.util.Locale, String> nameMap,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _remoteAppEntryLocalService.updateIFrameRemoteAppEntry(
-			remoteAppEntryId, iFrameURL, nameMap, portletCategoryName,
-			properties);
+			remoteAppEntryId, iFrameURL, nameMap, portletAlias,
+			portletCategoryName, properties);
 	}
 
 	/**

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryService.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryService.java
@@ -55,11 +55,11 @@ public interface RemoteAppEntryService extends BaseService {
 	public RemoteAppEntry addCustomElementRemoteAppEntry(
 			String customElementCSSURLs, String customElementHTMLElementName,
 			String customElementURLs, Map<Locale, String> nameMap,
-			String portletCategoryName, String properties)
+			String portletAlias, String portletCategoryName, String properties)
 		throws PortalException;
 
 	public RemoteAppEntry addIFrameRemoteAppEntry(
-			String iFrameURL, Map<Locale, String> nameMap,
+			String iFrameURL, Map<Locale, String> nameMap, String portletAlias,
 			String portletCategoryName, String properties)
 		throws PortalException;
 
@@ -80,14 +80,14 @@ public interface RemoteAppEntryService extends BaseService {
 	public RemoteAppEntry updateCustomElementRemoteAppEntry(
 			long remoteAppEntryId, String customElementCSSURLs,
 			String customElementHTMLElementName, String customElementURLs,
-			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException;
 
 	public RemoteAppEntry updateIFrameRemoteAppEntry(
 			long remoteAppEntryId, String iFrameURL,
-			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException;
 
 }

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryServiceUtil.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryServiceUtil.java
@@ -41,21 +41,22 @@ public class RemoteAppEntryServiceUtil {
 	public static RemoteAppEntry addCustomElementRemoteAppEntry(
 			String customElementCSSURLs, String customElementHTMLElementName,
 			String customElementURLs, Map<java.util.Locale, String> nameMap,
-			String portletCategoryName, String properties)
+			String portletAlias, String portletCategoryName, String properties)
 		throws PortalException {
 
 		return getService().addCustomElementRemoteAppEntry(
 			customElementCSSURLs, customElementHTMLElementName,
-			customElementURLs, nameMap, portletCategoryName, properties);
+			customElementURLs, nameMap, portletAlias, portletCategoryName,
+			properties);
 	}
 
 	public static RemoteAppEntry addIFrameRemoteAppEntry(
 			String iFrameURL, Map<java.util.Locale, String> nameMap,
-			String portletCategoryName, String properties)
+			String portletAlias, String portletCategoryName, String properties)
 		throws PortalException {
 
 		return getService().addIFrameRemoteAppEntry(
-			iFrameURL, nameMap, portletCategoryName, properties);
+			iFrameURL, nameMap, portletAlias, portletCategoryName, properties);
 	}
 
 	public static RemoteAppEntry deleteRemoteAppEntry(long remoteAppEntryId)
@@ -82,25 +83,25 @@ public class RemoteAppEntryServiceUtil {
 	public static RemoteAppEntry updateCustomElementRemoteAppEntry(
 			long remoteAppEntryId, String customElementCSSURLs,
 			String customElementHTMLElementName, String customElementURLs,
-			Map<java.util.Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<java.util.Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException {
 
 		return getService().updateCustomElementRemoteAppEntry(
 			remoteAppEntryId, customElementCSSURLs,
 			customElementHTMLElementName, customElementURLs, nameMap,
-			portletCategoryName, properties);
+			portletAlias, portletCategoryName, properties);
 	}
 
 	public static RemoteAppEntry updateIFrameRemoteAppEntry(
 			long remoteAppEntryId, String iFrameURL,
-			Map<java.util.Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<java.util.Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException {
 
 		return getService().updateIFrameRemoteAppEntry(
-			remoteAppEntryId, iFrameURL, nameMap, portletCategoryName,
-			properties);
+			remoteAppEntryId, iFrameURL, nameMap, portletAlias,
+			portletCategoryName, properties);
 	}
 
 	public static RemoteAppEntryService getService() {

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryServiceWrapper.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryServiceWrapper.java
@@ -38,22 +38,24 @@ public class RemoteAppEntryServiceWrapper
 				String customElementCSSURLs,
 				String customElementHTMLElementName, String customElementURLs,
 				java.util.Map<java.util.Locale, String> nameMap,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _remoteAppEntryService.addCustomElementRemoteAppEntry(
 			customElementCSSURLs, customElementHTMLElementName,
-			customElementURLs, nameMap, portletCategoryName, properties);
+			customElementURLs, nameMap, portletAlias, portletCategoryName,
+			properties);
 	}
 
 	@Override
 	public com.liferay.remote.app.model.RemoteAppEntry addIFrameRemoteAppEntry(
 			String iFrameURL, java.util.Map<java.util.Locale, String> nameMap,
-			String portletCategoryName, String properties)
+			String portletAlias, String portletCategoryName, String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _remoteAppEntryService.addIFrameRemoteAppEntry(
-			iFrameURL, nameMap, portletCategoryName, properties);
+			iFrameURL, nameMap, portletAlias, portletCategoryName, properties);
 	}
 
 	@Override
@@ -88,13 +90,14 @@ public class RemoteAppEntryServiceWrapper
 				long remoteAppEntryId, String customElementCSSURLs,
 				String customElementHTMLElementName, String customElementURLs,
 				java.util.Map<java.util.Locale, String> nameMap,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _remoteAppEntryService.updateCustomElementRemoteAppEntry(
 			remoteAppEntryId, customElementCSSURLs,
 			customElementHTMLElementName, customElementURLs, nameMap,
-			portletCategoryName, properties);
+			portletAlias, portletCategoryName, properties);
 	}
 
 	@Override
@@ -102,12 +105,13 @@ public class RemoteAppEntryServiceWrapper
 			updateIFrameRemoteAppEntry(
 				long remoteAppEntryId, String iFrameURL,
 				java.util.Map<java.util.Locale, String> nameMap,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _remoteAppEntryService.updateIFrameRemoteAppEntry(
-			remoteAppEntryId, iFrameURL, nameMap, portletCategoryName,
-			properties);
+			remoteAppEntryId, iFrameURL, nameMap, portletAlias,
+			portletCategoryName, properties);
 	}
 
 	@Override

--- a/modules/apps/remote-app/remote-app-client-js/bnd.bnd
+++ b/modules/apps/remote-app/remote-app-client-js/bnd.bnd
@@ -1,5 +1,4 @@
 Bundle-Name: Liferay Remote App Client JS
 Bundle-SymbolicName: com.liferay.remote.app.client.js
 Bundle-Version: 1.0.0
-Liferay-JS-Resources-Top-Head: /remote-app-client-js.js
 Web-ContextPath: /remote-app-client-js

--- a/modules/apps/remote-app/remote-app-service/service.xml
+++ b/modules/apps/remote-app/remote-app-service/service.xml
@@ -24,6 +24,7 @@
 		<column name="customElementURLs" type="String" />
 		<column method-name="IFrameURL" name="iFrameURL" type="String" />
 		<column localized="true" name="name" type="String" />
+		<column name="portletAlias" type="String" />
 		<column name="portletCategoryName" type="String" />
 		<column name="properties" type="String" />
 		<column name="type" type="String" />

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/v2_0_0/RemoteAppEntryUpgradeProcess.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/v2_0_0/RemoteAppEntryUpgradeProcess.java
@@ -49,6 +49,12 @@ public class RemoteAppEntryUpgradeProcess extends UpgradeProcess {
 			RemoteAppEntryTable.class,
 			new AlterColumnName("url", "iFrameURL STRING null"));
 
+		if (!hasColumn("RemoteAppEntry", "portletAlias")) {
+			alter(
+				RemoteAppEntryTable.class,
+				new AlterTableAddColumn("portletAlias", "VARCHAR(255)"));
+		}
+
 		if (!hasColumn("RemoteAppEntry", "portletCategoryName")) {
 			alter(
 				RemoteAppEntryTable.class,

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/model/impl/RemoteAppEntryCacheModel.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/model/impl/RemoteAppEntryCacheModel.java
@@ -77,7 +77,7 @@ public class RemoteAppEntryCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(33);
+		StringBundler sb = new StringBundler(35);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -105,6 +105,8 @@ public class RemoteAppEntryCacheModel
 		sb.append(iFrameURL);
 		sb.append(", name=");
 		sb.append(name);
+		sb.append(", portletAlias=");
+		sb.append(portletAlias);
 		sb.append(", portletCategoryName=");
 		sb.append(portletCategoryName);
 		sb.append(", properties=");
@@ -190,6 +192,13 @@ public class RemoteAppEntryCacheModel
 			remoteAppEntryImpl.setName(name);
 		}
 
+		if (portletAlias == null) {
+			remoteAppEntryImpl.setPortletAlias("");
+		}
+		else {
+			remoteAppEntryImpl.setPortletAlias(portletAlias);
+		}
+
 		if (portletCategoryName == null) {
 			remoteAppEntryImpl.setPortletCategoryName("");
 		}
@@ -236,6 +245,7 @@ public class RemoteAppEntryCacheModel
 		customElementURLs = (String)objectInput.readObject();
 		iFrameURL = objectInput.readUTF();
 		name = objectInput.readUTF();
+		portletAlias = objectInput.readUTF();
 		portletCategoryName = objectInput.readUTF();
 		properties = (String)objectInput.readObject();
 		type = objectInput.readUTF();
@@ -303,6 +313,13 @@ public class RemoteAppEntryCacheModel
 			objectOutput.writeUTF(name);
 		}
 
+		if (portletAlias == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(portletAlias);
+		}
+
 		if (portletCategoryName == null) {
 			objectOutput.writeUTF("");
 		}
@@ -338,6 +355,7 @@ public class RemoteAppEntryCacheModel
 	public String customElementURLs;
 	public String iFrameURL;
 	public String name;
+	public String portletAlias;
 	public String portletCategoryName;
 	public String properties;
 	public String type;

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/model/impl/RemoteAppEntryModelImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/model/impl/RemoteAppEntryModelImpl.java
@@ -91,8 +91,9 @@ public class RemoteAppEntryModelImpl
 		{"customElementCSSURLs", Types.CLOB},
 		{"customElementHTMLElementName", Types.VARCHAR},
 		{"customElementURLs", Types.CLOB}, {"iFrameURL", Types.VARCHAR},
-		{"name", Types.VARCHAR}, {"portletCategoryName", Types.VARCHAR},
-		{"properties", Types.CLOB}, {"type_", Types.VARCHAR}
+		{"name", Types.VARCHAR}, {"portletAlias", Types.VARCHAR},
+		{"portletCategoryName", Types.VARCHAR}, {"properties", Types.CLOB},
+		{"type_", Types.VARCHAR}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -112,13 +113,14 @@ public class RemoteAppEntryModelImpl
 		TABLE_COLUMNS_MAP.put("customElementURLs", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("iFrameURL", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("portletAlias", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("portletCategoryName", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("properties", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("type_", Types.VARCHAR);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table RemoteAppEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,remoteAppEntryId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,customElementCSSURLs TEXT null,customElementHTMLElementName VARCHAR(255) null,customElementURLs TEXT null,iFrameURL STRING null,name STRING null,portletCategoryName VARCHAR(75) null,properties TEXT null,type_ VARCHAR(75) null)";
+		"create table RemoteAppEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,remoteAppEntryId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,customElementCSSURLs TEXT null,customElementHTMLElementName VARCHAR(255) null,customElementURLs TEXT null,iFrameURL STRING null,name STRING null,portletAlias VARCHAR(75) null,portletCategoryName VARCHAR(75) null,properties TEXT null,type_ VARCHAR(75) null)";
 
 	public static final String TABLE_SQL_DROP = "drop table RemoteAppEntry";
 
@@ -196,6 +198,7 @@ public class RemoteAppEntryModelImpl
 		model.setCustomElementURLs(soapModel.getCustomElementURLs());
 		model.setIFrameURL(soapModel.getIFrameURL());
 		model.setName(soapModel.getName());
+		model.setPortletAlias(soapModel.getPortletAlias());
 		model.setPortletCategoryName(soapModel.getPortletCategoryName());
 		model.setProperties(soapModel.getProperties());
 		model.setType(soapModel.getType());
@@ -416,6 +419,12 @@ public class RemoteAppEntryModelImpl
 		attributeSetterBiConsumers.put(
 			"name",
 			(BiConsumer<RemoteAppEntry, String>)RemoteAppEntry::setName);
+		attributeGetterFunctions.put(
+			"portletAlias", RemoteAppEntry::getPortletAlias);
+		attributeSetterBiConsumers.put(
+			"portletAlias",
+			(BiConsumer<RemoteAppEntry, String>)
+				RemoteAppEntry::setPortletAlias);
 		attributeGetterFunctions.put(
 			"portletCategoryName", RemoteAppEntry::getPortletCategoryName);
 		attributeSetterBiConsumers.put(
@@ -800,6 +809,26 @@ public class RemoteAppEntryModelImpl
 
 	@JSON
 	@Override
+	public String getPortletAlias() {
+		if (_portletAlias == null) {
+			return "";
+		}
+		else {
+			return _portletAlias;
+		}
+	}
+
+	@Override
+	public void setPortletAlias(String portletAlias) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_portletAlias = portletAlias;
+	}
+
+	@JSON
+	@Override
 	public String getPortletCategoryName() {
 		if (_portletCategoryName == null) {
 			return "";
@@ -1024,6 +1053,7 @@ public class RemoteAppEntryModelImpl
 		remoteAppEntryImpl.setCustomElementURLs(getCustomElementURLs());
 		remoteAppEntryImpl.setIFrameURL(getIFrameURL());
 		remoteAppEntryImpl.setName(getName());
+		remoteAppEntryImpl.setPortletAlias(getPortletAlias());
 		remoteAppEntryImpl.setPortletCategoryName(getPortletCategoryName());
 		remoteAppEntryImpl.setProperties(getProperties());
 		remoteAppEntryImpl.setType(getType());
@@ -1063,6 +1093,8 @@ public class RemoteAppEntryModelImpl
 		remoteAppEntryImpl.setIFrameURL(
 			this.<String>getColumnOriginalValue("iFrameURL"));
 		remoteAppEntryImpl.setName(this.<String>getColumnOriginalValue("name"));
+		remoteAppEntryImpl.setPortletAlias(
+			this.<String>getColumnOriginalValue("portletAlias"));
 		remoteAppEntryImpl.setPortletCategoryName(
 			this.<String>getColumnOriginalValue("portletCategoryName"));
 		remoteAppEntryImpl.setProperties(
@@ -1237,6 +1269,14 @@ public class RemoteAppEntryModelImpl
 			remoteAppEntryCacheModel.name = null;
 		}
 
+		remoteAppEntryCacheModel.portletAlias = getPortletAlias();
+
+		String portletAlias = remoteAppEntryCacheModel.portletAlias;
+
+		if ((portletAlias != null) && (portletAlias.length() == 0)) {
+			remoteAppEntryCacheModel.portletAlias = null;
+		}
+
 		remoteAppEntryCacheModel.portletCategoryName = getPortletCategoryName();
 
 		String portletCategoryName =
@@ -1369,6 +1409,7 @@ public class RemoteAppEntryModelImpl
 	private String _iFrameURL;
 	private String _name;
 	private String _nameCurrentLanguageId;
+	private String _portletAlias;
 	private String _portletCategoryName;
 	private String _properties;
 	private String _type;
@@ -1417,6 +1458,7 @@ public class RemoteAppEntryModelImpl
 		_columnOriginalValues.put("customElementURLs", _customElementURLs);
 		_columnOriginalValues.put("iFrameURL", _iFrameURL);
 		_columnOriginalValues.put("name", _name);
+		_columnOriginalValues.put("portletAlias", _portletAlias);
 		_columnOriginalValues.put("portletCategoryName", _portletCategoryName);
 		_columnOriginalValues.put("properties", _properties);
 		_columnOriginalValues.put("type_", _type);
@@ -1470,11 +1512,13 @@ public class RemoteAppEntryModelImpl
 
 		columnBitmasks.put("name", 4096L);
 
-		columnBitmasks.put("portletCategoryName", 8192L);
+		columnBitmasks.put("portletAlias", 8192L);
 
-		columnBitmasks.put("properties", 16384L);
+		columnBitmasks.put("portletCategoryName", 16384L);
 
-		columnBitmasks.put("type_", 32768L);
+		columnBitmasks.put("properties", 32768L);
+
+		columnBitmasks.put("type_", 65536L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/http/RemoteAppEntryServiceHttp.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/http/RemoteAppEntryServiceHttp.java
@@ -56,7 +56,8 @@ public class RemoteAppEntryServiceHttp {
 				HttpPrincipal httpPrincipal, String customElementCSSURLs,
 				String customElementHTMLElementName, String customElementURLs,
 				java.util.Map<java.util.Locale, String> nameMap,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -67,7 +68,8 @@ public class RemoteAppEntryServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, customElementCSSURLs, customElementHTMLElementName,
-				customElementURLs, nameMap, portletCategoryName, properties);
+				customElementURLs, nameMap, portletAlias, portletCategoryName,
+				properties);
 
 			Object returnObj = null;
 
@@ -101,7 +103,8 @@ public class RemoteAppEntryServiceHttp {
 			addIFrameRemoteAppEntry(
 				HttpPrincipal httpPrincipal, String iFrameURL,
 				java.util.Map<java.util.Locale, String> nameMap,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -110,7 +113,8 @@ public class RemoteAppEntryServiceHttp {
 				_addIFrameRemoteAppEntryParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, iFrameURL, nameMap, portletCategoryName, properties);
+				methodKey, iFrameURL, nameMap, portletAlias,
+				portletCategoryName, properties);
 
 			Object returnObj = null;
 
@@ -227,7 +231,8 @@ public class RemoteAppEntryServiceHttp {
 				String customElementCSSURLs,
 				String customElementHTMLElementName, String customElementURLs,
 				java.util.Map<java.util.Locale, String> nameMap,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -239,7 +244,7 @@ public class RemoteAppEntryServiceHttp {
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, remoteAppEntryId, customElementCSSURLs,
 				customElementHTMLElementName, customElementURLs, nameMap,
-				portletCategoryName, properties);
+				portletAlias, portletCategoryName, properties);
 
 			Object returnObj = null;
 
@@ -274,7 +279,8 @@ public class RemoteAppEntryServiceHttp {
 				HttpPrincipal httpPrincipal, long remoteAppEntryId,
 				String iFrameURL,
 				java.util.Map<java.util.Locale, String> nameMap,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -283,7 +289,7 @@ public class RemoteAppEntryServiceHttp {
 				_updateIFrameRemoteAppEntryParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, remoteAppEntryId, iFrameURL, nameMap,
+				methodKey, remoteAppEntryId, iFrameURL, nameMap, portletAlias,
 				portletCategoryName, properties);
 
 			Object returnObj = null;
@@ -320,11 +326,12 @@ public class RemoteAppEntryServiceHttp {
 	private static final Class<?>[]
 		_addCustomElementRemoteAppEntryParameterTypes0 = new Class[] {
 			String.class, String.class, String.class, java.util.Map.class,
-			String.class, String.class
+			String.class, String.class, String.class
 		};
 	private static final Class<?>[] _addIFrameRemoteAppEntryParameterTypes1 =
 		new Class[] {
-			String.class, java.util.Map.class, String.class, String.class
+			String.class, java.util.Map.class, String.class, String.class,
+			String.class
 		};
 	private static final Class<?>[] _deleteRemoteAppEntryParameterTypes2 =
 		new Class[] {long.class};
@@ -333,12 +340,12 @@ public class RemoteAppEntryServiceHttp {
 	private static final Class<?>[]
 		_updateCustomElementRemoteAppEntryParameterTypes4 = new Class[] {
 			long.class, String.class, String.class, String.class,
-			java.util.Map.class, String.class, String.class
+			java.util.Map.class, String.class, String.class, String.class
 		};
 	private static final Class<?>[] _updateIFrameRemoteAppEntryParameterTypes5 =
 		new Class[] {
 			long.class, String.class, java.util.Map.class, String.class,
-			String.class
+			String.class, String.class
 		};
 
 }

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/http/RemoteAppEntryServiceSoap.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/http/RemoteAppEntryServiceSoap.java
@@ -72,7 +72,8 @@ public class RemoteAppEntryServiceSoap {
 				String customElementCSSURLs,
 				String customElementHTMLElementName, String customElementURLs,
 				String[] nameMapLanguageIds, String[] nameMapValues,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws RemoteException {
 
 		try {
@@ -82,8 +83,8 @@ public class RemoteAppEntryServiceSoap {
 			com.liferay.remote.app.model.RemoteAppEntry returnValue =
 				RemoteAppEntryServiceUtil.addCustomElementRemoteAppEntry(
 					customElementCSSURLs, customElementHTMLElementName,
-					customElementURLs, nameMap, portletCategoryName,
-					properties);
+					customElementURLs, nameMap, portletAlias,
+					portletCategoryName, properties);
 
 			return com.liferay.remote.app.model.RemoteAppEntrySoap.toSoapModel(
 				returnValue);
@@ -98,8 +99,8 @@ public class RemoteAppEntryServiceSoap {
 	public static com.liferay.remote.app.model.RemoteAppEntrySoap
 			addIFrameRemoteAppEntry(
 				String iFrameURL, String[] nameMapLanguageIds,
-				String[] nameMapValues, String portletCategoryName,
-				String properties)
+				String[] nameMapValues, String portletAlias,
+				String portletCategoryName, String properties)
 		throws RemoteException {
 
 		try {
@@ -108,7 +109,8 @@ public class RemoteAppEntryServiceSoap {
 
 			com.liferay.remote.app.model.RemoteAppEntry returnValue =
 				RemoteAppEntryServiceUtil.addIFrameRemoteAppEntry(
-					iFrameURL, nameMap, portletCategoryName, properties);
+					iFrameURL, nameMap, portletAlias, portletCategoryName,
+					properties);
 
 			return com.liferay.remote.app.model.RemoteAppEntrySoap.toSoapModel(
 				returnValue);
@@ -162,7 +164,8 @@ public class RemoteAppEntryServiceSoap {
 				long remoteAppEntryId, String customElementCSSURLs,
 				String customElementHTMLElementName, String customElementURLs,
 				String[] nameMapLanguageIds, String[] nameMapValues,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws RemoteException {
 
 		try {
@@ -173,7 +176,7 @@ public class RemoteAppEntryServiceSoap {
 				RemoteAppEntryServiceUtil.updateCustomElementRemoteAppEntry(
 					remoteAppEntryId, customElementCSSURLs,
 					customElementHTMLElementName, customElementURLs, nameMap,
-					portletCategoryName, properties);
+					portletAlias, portletCategoryName, properties);
 
 			return com.liferay.remote.app.model.RemoteAppEntrySoap.toSoapModel(
 				returnValue);
@@ -189,7 +192,8 @@ public class RemoteAppEntryServiceSoap {
 			updateIFrameRemoteAppEntry(
 				long remoteAppEntryId, String iFrameURL,
 				String[] nameMapLanguageIds, String[] nameMapValues,
-				String portletCategoryName, String properties)
+				String portletAlias, String portletCategoryName,
+				String properties)
 		throws RemoteException {
 
 		try {
@@ -198,8 +202,8 @@ public class RemoteAppEntryServiceSoap {
 
 			com.liferay.remote.app.model.RemoteAppEntry returnValue =
 				RemoteAppEntryServiceUtil.updateIFrameRemoteAppEntry(
-					remoteAppEntryId, iFrameURL, nameMap, portletCategoryName,
-					properties);
+					remoteAppEntryId, iFrameURL, nameMap, portletAlias,
+					portletCategoryName, properties);
 
 			return com.liferay.remote.app.model.RemoteAppEntrySoap.toSoapModel(
 				returnValue);

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
@@ -79,8 +79,8 @@ public class RemoteAppEntryLocalServiceImpl
 	public RemoteAppEntry addCustomElementRemoteAppEntry(
 			long userId, String customElementCSSURLs,
 			String customElementHTMLElementName, String customElementURLs,
-			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException {
 
 		customElementCSSURLs = StringUtil.trim(customElementCSSURLs);
@@ -106,6 +106,7 @@ public class RemoteAppEntryLocalServiceImpl
 			customElementHTMLElementName);
 		remoteAppEntry.setCustomElementURLs(customElementURLs);
 		remoteAppEntry.setNameMap(nameMap);
+		remoteAppEntry.setPortletAlias(portletAlias);
 		remoteAppEntry.setPortletCategoryName(portletCategoryName);
 		remoteAppEntry.setProperties(properties);
 		remoteAppEntry.setType(RemoteAppConstants.TYPE_CUSTOM_ELEMENT);
@@ -123,7 +124,7 @@ public class RemoteAppEntryLocalServiceImpl
 	@Override
 	public RemoteAppEntry addIFrameRemoteAppEntry(
 			long userId, String iFrameURL, Map<Locale, String> nameMap,
-			String portletCategoryName, String properties)
+			String portletAlias, String portletCategoryName, String properties)
 		throws PortalException {
 
 		iFrameURL = StringUtil.trim(iFrameURL);
@@ -141,6 +142,7 @@ public class RemoteAppEntryLocalServiceImpl
 
 		remoteAppEntry.setIFrameURL(iFrameURL);
 		remoteAppEntry.setNameMap(nameMap);
+		remoteAppEntry.setPortletAlias(portletAlias);
 		remoteAppEntry.setPortletCategoryName(portletCategoryName);
 		remoteAppEntry.setProperties(properties);
 		remoteAppEntry.setType(RemoteAppConstants.TYPE_IFRAME);
@@ -261,8 +263,8 @@ public class RemoteAppEntryLocalServiceImpl
 	public RemoteAppEntry updateCustomElementRemoteAppEntry(
 			long remoteAppEntryId, String customElementCSSURLs,
 			String customElementHTMLElementName, String customElementURLs,
-			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException {
 
 		customElementCSSURLs = StringUtil.trim(customElementCSSURLs);
@@ -282,6 +284,7 @@ public class RemoteAppEntryLocalServiceImpl
 			customElementHTMLElementName);
 		remoteAppEntry.setCustomElementURLs(customElementURLs);
 		remoteAppEntry.setNameMap(nameMap);
+		remoteAppEntry.setPortletAlias(portletAlias);
 		remoteAppEntry.setPortletCategoryName(portletCategoryName);
 		remoteAppEntry.setProperties(properties);
 
@@ -296,8 +299,8 @@ public class RemoteAppEntryLocalServiceImpl
 	@Override
 	public RemoteAppEntry updateIFrameRemoteAppEntry(
 			long remoteAppEntryId, String iFrameURL,
-			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException {
 
 		iFrameURL = StringUtil.trim(iFrameURL);
@@ -309,6 +312,7 @@ public class RemoteAppEntryLocalServiceImpl
 
 		remoteAppEntry.setIFrameURL(iFrameURL);
 		remoteAppEntry.setNameMap(nameMap);
+		remoteAppEntry.setPortletAlias(portletAlias);
 		remoteAppEntry.setPortletCategoryName(portletCategoryName);
 		remoteAppEntry.setProperties(properties);
 

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryServiceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryServiceImpl.java
@@ -45,7 +45,7 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 	public RemoteAppEntry addCustomElementRemoteAppEntry(
 			String customElementCSSURLs, String customElementHTMLElementName,
 			String customElementURLs, Map<Locale, String> nameMap,
-			String portletCategoryName, String properties)
+			String portletAlias, String portletCategoryName, String properties)
 		throws PortalException {
 
 		_portletResourcePermission.check(
@@ -53,12 +53,13 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 
 		return remoteAppEntryLocalService.addCustomElementRemoteAppEntry(
 			getUserId(), customElementCSSURLs, customElementHTMLElementName,
-			customElementURLs, nameMap, portletCategoryName, properties);
+			customElementURLs, nameMap, portletAlias, portletCategoryName,
+			properties);
 	}
 
 	@Override
 	public RemoteAppEntry addIFrameRemoteAppEntry(
-			String iFrameURL, Map<Locale, String> nameMap,
+			String iFrameURL, Map<Locale, String> nameMap, String portletAlias,
 			String portletCategoryName, String properties)
 		throws PortalException {
 
@@ -66,7 +67,8 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 			getPermissionChecker(), null, ActionKeys.ADD_ENTRY);
 
 		return remoteAppEntryLocalService.addIFrameRemoteAppEntry(
-			getUserId(), iFrameURL, nameMap, portletCategoryName, properties);
+			getUserId(), iFrameURL, nameMap, portletAlias, portletCategoryName,
+			properties);
 	}
 
 	@Override
@@ -94,8 +96,8 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 	public RemoteAppEntry updateCustomElementRemoteAppEntry(
 			long remoteAppEntryId, String customElementCSSURLs,
 			String customElementHTMLElementName, String customElementURLs,
-			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException {
 
 		_remoteAppEntryModelResourcePermission.check(
@@ -104,22 +106,22 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 		return remoteAppEntryLocalService.updateCustomElementRemoteAppEntry(
 			remoteAppEntryId, customElementCSSURLs,
 			customElementHTMLElementName, customElementURLs, nameMap,
-			portletCategoryName, properties);
+			portletAlias, portletCategoryName, properties);
 	}
 
 	@Override
 	public RemoteAppEntry updateIFrameRemoteAppEntry(
 			long remoteAppEntryId, String iFrameURL,
-			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties)
+			Map<Locale, String> nameMap, String portletAlias,
+			String portletCategoryName, String properties)
 		throws PortalException {
 
 		_remoteAppEntryModelResourcePermission.check(
 			getPermissionChecker(), remoteAppEntryId, ActionKeys.UPDATE);
 
 		return remoteAppEntryLocalService.updateIFrameRemoteAppEntry(
-			remoteAppEntryId, iFrameURL, nameMap, portletCategoryName,
-			properties);
+			remoteAppEntryId, iFrameURL, nameMap, portletAlias,
+			portletCategoryName, properties);
 	}
 
 	@Reference(

--- a/modules/apps/remote-app/remote-app-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/remote-app/remote-app-service/src/main/resources/META-INF/module-hbm.xml
@@ -19,6 +19,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="customElementURLs" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.CamelCasePropertyAccessor" name="iFrameURL" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="name" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="portletAlias" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="portletCategoryName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="properties" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" column="type_" name="type" type="com.liferay.portal.dao.orm.hibernate.StringType" />

--- a/modules/apps/remote-app/remote-app-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/remote-app/remote-app-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -24,6 +24,7 @@
 			<hint name="method-name">IFrameURL</hint>
 		</field>
 		<field localized="true" name="name" type="String" />
+		<field name="portletAlias" type="String" />
 		<field name="portletCategoryName" type="String" />
 		<field name="properties" type="String">
 			<hint-collection name="CLOB" />

--- a/modules/apps/remote-app/remote-app-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/remote-app/remote-app-service/src/main/resources/META-INF/sql/tables.sql
@@ -12,6 +12,7 @@ create table RemoteAppEntry (
 	customElementURLs TEXT null,
 	iFrameURL STRING null,
 	name STRING null,
+	portletAlias VARCHAR(75) null,
 	portletCategoryName VARCHAR(75) null,
 	properties TEXT null,
 	type_ VARCHAR(75) null

--- a/modules/apps/remote-app/remote-app-test/src/testIntegration/java/com/liferay/remote/app/service/persistence/test/RemoteAppEntryPersistenceTest.java
+++ b/modules/apps/remote-app/remote-app-test/src/testIntegration/java/com/liferay/remote/app/service/persistence/test/RemoteAppEntryPersistenceTest.java
@@ -148,6 +148,8 @@ public class RemoteAppEntryPersistenceTest {
 
 		newRemoteAppEntry.setName(RandomTestUtil.randomString());
 
+		newRemoteAppEntry.setPortletAlias(RandomTestUtil.randomString());
+
 		newRemoteAppEntry.setPortletCategoryName(RandomTestUtil.randomString());
 
 		newRemoteAppEntry.setProperties(RandomTestUtil.randomString());
@@ -195,6 +197,9 @@ public class RemoteAppEntryPersistenceTest {
 			newRemoteAppEntry.getIFrameURL());
 		Assert.assertEquals(
 			existingRemoteAppEntry.getName(), newRemoteAppEntry.getName());
+		Assert.assertEquals(
+			existingRemoteAppEntry.getPortletAlias(),
+			newRemoteAppEntry.getPortletAlias());
 		Assert.assertEquals(
 			existingRemoteAppEntry.getPortletCategoryName(),
 			newRemoteAppEntry.getPortletCategoryName());
@@ -252,7 +257,8 @@ public class RemoteAppEntryPersistenceTest {
 			"remoteAppEntryId", true, "companyId", true, "userId", true,
 			"userName", true, "createDate", true, "modifiedDate", true,
 			"customElementHTMLElementName", true, "iFrameURL", true, "name",
-			true, "portletCategoryName", true, "type", true);
+			true, "portletAlias", true, "portletCategoryName", true, "type",
+			true);
 	}
 
 	@Test
@@ -498,6 +504,8 @@ public class RemoteAppEntryPersistenceTest {
 		remoteAppEntry.setIFrameURL(RandomTestUtil.randomString());
 
 		remoteAppEntry.setName(RandomTestUtil.randomString());
+
+		remoteAppEntry.setPortletAlias(RandomTestUtil.randomString());
 
 		remoteAppEntry.setPortletCategoryName(RandomTestUtil.randomString());
 

--- a/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/deployer/RemoteAppEntryDeployerImpl.java
+++ b/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/deployer/RemoteAppEntryDeployerImpl.java
@@ -132,9 +132,16 @@ public class RemoteAppEntryDeployerImpl implements RemoteAppEntryDeployer {
 			String customElementCSSURLs =
 				remoteAppEntry.getCustomElementCSSURLs();
 
+			String[] customElementCSSURLsArray = null;
+
+			if (!customElementCSSURLs.isEmpty()) {
+				customElementCSSURLsArray = customElementCSSURLs.split(
+					StringPool.NEW_LINE);
+			}
+
 			dictionary.put(
 				"com.liferay.portlet.header-portlet-css",
-				customElementCSSURLs.split(StringPool.NEW_LINE));
+				customElementCSSURLsArray);
 		}
 		else if (Objects.equals(
 					remoteAppEntry.getType(), RemoteAppConstants.TYPE_IFRAME)) {

--- a/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/deployer/RemoteAppEntryDeployerImpl.java
+++ b/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/deployer/RemoteAppEntryDeployerImpl.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.remote.app.constants.RemoteAppConstants;
 import com.liferay.remote.app.deployer.RemoteAppEntryDeployer;
@@ -68,8 +69,22 @@ public class RemoteAppEntryDeployerImpl implements RemoteAppEntryDeployer {
 	}
 
 	private String _getPortletId(RemoteAppEntry remoteAppEntry) {
-		return "com_liferay_remote_app_web_internal_portlet_" +
-			"RemoteAppEntryPortlet_" + remoteAppEntry.getRemoteAppEntryId();
+		String portletId = remoteAppEntry.getPortletAlias();
+
+		if (Validator.isNull(portletId)) {
+			portletId = remoteAppEntry.getName(LocaleUtil.US);
+
+			if (Validator.isNull(portletId)) {
+				portletId = String.valueOf(
+					remoteAppEntry.getRemoteAppEntryId());
+			}
+
+			portletId =
+				"com_liferay_remote_app_web_internal_portlet_" +
+					"RemoteAppEntryPortlet_" + portletId;
+		}
+
+		return _portal.getJsSafePortletId(portletId);
 	}
 
 	private ServiceRegistration<ConfigurationAction>
@@ -143,5 +158,8 @@ public class RemoteAppEntryDeployerImpl implements RemoteAppEntryDeployer {
 
 	@Reference
 	private NPMResolver _npmResolver;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/portlet/action/EditRemoteAppEntryMVCActionCommand.java
+++ b/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/portlet/action/EditRemoteAppEntryMVCActionCommand.java
@@ -91,8 +91,11 @@ public class EditRemoteAppEntryMVCActionCommand extends BaseMVCActionCommand {
 	private void _add(ActionRequest actionRequest) throws PortalException {
 		Map<Locale, String> nameMap = LocalizationUtil.getLocalizationMap(
 			actionRequest, "name");
+		String portletAlias = ParamUtil.getString(
+			actionRequest, "portletAlias");
 		String portletCategoryName = ParamUtil.getString(
 			actionRequest, "portletCategoryName");
+		String properties = ParamUtil.getString(actionRequest, "properties");
 		String type = ParamUtil.getString(actionRequest, "type");
 
 		if (type.equals(RemoteAppConstants.TYPE_CUSTOM_ELEMENT)) {
@@ -101,14 +104,12 @@ public class EditRemoteAppEntryMVCActionCommand extends BaseMVCActionCommand {
 				ParamUtil.getString(
 					actionRequest, "customElementHTMLElementName"),
 				ParamUtil.getString(actionRequest, "customElementURLs"),
-				nameMap, portletCategoryName,
-				ParamUtil.getString(actionRequest, "properties"));
+				nameMap, portletAlias, portletCategoryName, properties);
 		}
 		else if (type.equals(RemoteAppConstants.TYPE_IFRAME)) {
 			_remoteAppEntryService.addIFrameRemoteAppEntry(
 				ParamUtil.getString(actionRequest, "iFrameURL"), nameMap,
-				portletCategoryName,
-				ParamUtil.getString(actionRequest, "properties"));
+				portletAlias, portletCategoryName, properties);
 		}
 	}
 
@@ -130,8 +131,11 @@ public class EditRemoteAppEntryMVCActionCommand extends BaseMVCActionCommand {
 
 		Map<Locale, String> nameMap = LocalizationUtil.getLocalizationMap(
 			actionRequest, "name");
+		String portletAlias = ParamUtil.getString(
+			actionRequest, "portletAlias");
 		String portletCategoryName = ParamUtil.getString(
 			actionRequest, "portletCategoryName");
+		String properties = ParamUtil.getString(actionRequest, "properties");
 
 		if (Objects.equals(
 				remoteAppEntry.getType(),
@@ -148,8 +152,7 @@ public class EditRemoteAppEntryMVCActionCommand extends BaseMVCActionCommand {
 				ParamUtil.getString(
 					actionRequest, "customElementHTMLElementName"),
 				StringUtil.merge(customElementURLs, StringPool.NEW_LINE),
-				nameMap, portletCategoryName,
-				ParamUtil.getString(actionRequest, "properties"));
+				nameMap, portletAlias, portletCategoryName, properties);
 		}
 		else if (Objects.equals(
 					remoteAppEntry.getType(), RemoteAppConstants.TYPE_IFRAME)) {
@@ -157,8 +160,7 @@ public class EditRemoteAppEntryMVCActionCommand extends BaseMVCActionCommand {
 			_remoteAppEntryService.updateIFrameRemoteAppEntry(
 				remoteAppEntry.getRemoteAppEntryId(),
 				ParamUtil.getString(actionRequest, "iFrameURL"), nameMap,
-				portletCategoryName,
-				ParamUtil.getString(actionRequest, "properties"));
+				portletAlias, portletCategoryName, properties);
 		}
 	}
 

--- a/modules/apps/remote-app/remote-app-web/src/main/resources/META-INF/resources/admin/edit_remote_app_entry.jsp
+++ b/modules/apps/remote-app/remote-app-web/src/main/resources/META-INF/resources/admin/edit_remote_app_entry.jsp
@@ -117,6 +117,8 @@ renderResponse.setTitle(editRemoteAppEntryDisplayContext.getTitle());
 				%>"
 			/>
 
+			<aui:input label="alias" name="portletAlias" />
+
 			<aui:input label="properties" name="properties" type="textarea" />
 		</liferay-frontend:fieldset-group>
 	</liferay-frontend:edit-form-body>


### PR DESCRIPTION
This adds the following to the existing remote apps infrastructure:
- Adds an extra `portletAlias` field to `RemoteApp` so admins could uniquely identify the generated apps
- When registering the remote app, follow a more predictable name scheme:
    - If an alias is passed, use it
    - If alias is null, use name (namespaced)
    - If name is null (I don't think it could be, but right now it's allowed), use id (namespaced)
    - In any case, sanitize the value following safe portlet id rules

The main use case for this is to allow programatic access without having to jump through too many hoops. For example, using a remote app widget in a fragment through a site initializer. Being able to predict the portlet name allows for an easy setup at the cost of a small coupling.

One alternative would be to add some placeholder tokens in the fragment definition and then have the site initializer replace those with the remote app name once created. This, however, might not be 100% straightforward depending on how the fragments are consumed (zippableResources).

/cc @izaera, @nhpatt, @dsanz, @kevenleone