### PR TITLE
LPS-139695 remove from bundle after moving the APIs to this folder

### DIFF
--- a/modules/apps/batch-planner/app.bnd
+++ b/modules/apps/batch-planner/app.bnd
@@ -1,15 +1,15 @@
 Liferay-Releng-App-Description:
 Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Batch Planner
-Liferay-Releng-Bundle: true
+Liferay-Releng-Bundle: false
 Liferay-Releng-Category: Utility
 Liferay-Releng-Demo-Url:
 Liferay-Releng-Deprecated: false
-Liferay-Releng-Fix-Delivery-Method: core
+Liferay-Releng-Fix-Delivery-Method:
 Liferay-Releng-Labs: false
 Liferay-Releng-Marketplace: true
-Liferay-Releng-Portal-Required: true
+Liferay-Releng-Portal-Required: false
 Liferay-Releng-Public: ${liferay.releng.public}
 Liferay-Releng-Restart-Required: true
-Liferay-Releng-Suite: foundation
+Liferay-Releng-Suite:
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}


### PR DESCRIPTION
I think* (no-one knows and if you know please speak up) that this removes all these modules from the release but does not ignore them to let the tests run in the CI. 

Let's see if this stupid change works and the CI is happy...

If anyone can read [this](https://github.com/liferay/liferay-portal/blob/master/modules/README.markdown) and let me know the right value that would also be nice.