### PR TITLE
[LPS-138717,LPS-139643,LPS-139645,LPS-139789] Various Remote Apps Adjustments

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_dnd_table.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/_dnd_table.scss
@@ -136,7 +136,7 @@
 	color: $table-list-color;
 	display: table;
 	font-size: 0.875rem;
-	overflow-x: scroll;
+	overflow-x: auto;
 	transition: opacity 0.1s ease-in;
 	white-space: nowrap;
 	width: 100%;

--- a/modules/apps/remote-app/remote-app-client-js/bnd.bnd
+++ b/modules/apps/remote-app/remote-app-client-js/bnd.bnd
@@ -1,5 +1,4 @@
 Bundle-Name: Liferay Remote App Client JS
 Bundle-SymbolicName: com.liferay.remote.app.client.js
 Bundle-Version: 1.0.0
-Liferay-JS-Resources-Top-Head: /remote-app-client-js.js
 Web-ContextPath: /remote-app-client-js

--- a/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/deployer/RemoteAppEntryDeployerImpl.java
+++ b/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/deployer/RemoteAppEntryDeployerImpl.java
@@ -117,9 +117,16 @@ public class RemoteAppEntryDeployerImpl implements RemoteAppEntryDeployer {
 			String customElementCSSURLs =
 				remoteAppEntry.getCustomElementCSSURLs();
 
+			String[] customElementCSSURLsArray = null;
+
+			if (!customElementCSSURLs.isEmpty()) {
+				customElementCSSURLsArray = customElementCSSURLs.split(
+					StringPool.NEW_LINE);
+			}
+
 			dictionary.put(
 				"com.liferay.portlet.header-portlet-css",
-				customElementCSSURLs.split(StringPool.NEW_LINE));
+				customElementCSSURLsArray);
 		}
 		else if (Objects.equals(
 					remoteAppEntry.getType(), RemoteAppConstants.TYPE_IFRAME)) {

--- a/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/portlet/action/EditRemoteAppEntryMVCActionCommand.java
+++ b/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/portlet/action/EditRemoteAppEntryMVCActionCommand.java
@@ -96,11 +96,16 @@ public class EditRemoteAppEntryMVCActionCommand extends BaseMVCActionCommand {
 		String type = ParamUtil.getString(actionRequest, "type");
 
 		if (type.equals(RemoteAppConstants.TYPE_CUSTOM_ELEMENT)) {
+			String[] customElementCSSURLs = ParamUtil.getStringValues(
+				actionRequest, "customElementCSSURLs");
+			String[] customElementURLs = ParamUtil.getStringValues(
+				actionRequest, "customElementURLs");
+
 			_remoteAppEntryService.addCustomElementRemoteAppEntry(
-				ParamUtil.getString(actionRequest, "customElementCSSURLs"),
+				StringUtil.merge(customElementCSSURLs, StringPool.NEW_LINE),
 				ParamUtil.getString(
 					actionRequest, "customElementHTMLElementName"),
-				ParamUtil.getString(actionRequest, "customElementURLs"),
+				StringUtil.merge(customElementURLs, StringPool.NEW_LINE),
 				nameMap, portletCategoryName,
 				ParamUtil.getString(actionRequest, "properties"));
 		}


### PR DESCRIPTION
This is https://github.com/liferay-frontend/liferay-portal/pull/1488 minus [LPS-139629](https://issues.liferay.com/browse/LPS-139629) plus [LPS-139789](https://issues.liferay.com/browse/LPS-139789), so:
- [Custom elements add empty CSS resources that fail fetching](https://issues.liferay.com/browse/LPS-138717)
- [Remove unnecessary scroll from DatasetDisplay](https://issues.liferay.com/browse/LPS-139643)	
- [The remote-app-client SDK is being rendered unnecessarily](https://issues.liferay.com/browse/LPS-139645)
- [Can't add multiple URLs to Remote App Custom Element on first try](https://issues.liferay.com/browse/LPS-139789)

/cc @izaera @john-co, please see [LPS-139789](https://issues.liferay.com/browse/LPS-139789). This was caught manually by @kevenleone. Could we maybe add some automation for this?