### PR TITLE
[TS] LPS-138791

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -273,7 +273,7 @@
 			for (Locale availableLocale : availableLocales) {
 			%>
 
-				available['<%= LocaleUtil.toLanguageId(availableLocale) %>'] = '<%= availableLocale.getDisplayName(locale) %>';
+				available['<%= LocaleUtil.toLanguageId(availableLocale) %>'] = '<%= HtmlUtil.escapeJS(availableLocale.getDisplayName(locale)) %>';
 
 			<%
 			}


### PR DESCRIPTION
Steps to reproduce:

In portal-ext.properties include fr_CI (Cote d'Ivoire language) in locales and locales.enabled properties.
Start the server.
Navigate, in the default language (en_US), to localhost:8080/web/guest
Expected result: no errors in console.

Current result: you can see a js error in the console: "Uncaught syntax error: Unexpected identifier".

It is caused by fr_CI English (and French) display name: French (Cote d'Ivoire), which is included with the unescaped apostrophe in top_js.jspf.

You can check the details in https://issues.liferay.com/browse/LPS-138791, and this is a related issue: https://issues.liferay.com/browse/LPS-131814

I've escaped again, this time in taglib `input_localized`, each available language displayName to avoid apostrophes, which may be frequently found in some languages names (especially french ones, L'Antartique also, for example), from being interpreted as closing quotes and provoque navigation errors.