### PR TITLE
[TS] LPS-139565

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -152,8 +152,7 @@ name = HtmlUtil.escapeJS(name);
 			data =
 				'<%= (contents != null) ? HtmlUtil.escapeJS(contents) : StringPool.BLANK %>';
 		}
-
-		return data;
+		return Liferay.Util.transformInlineCSS(data);
 	};
 
 	var onLocaleChangedHandler = function (event) {
@@ -301,6 +300,8 @@ name = HtmlUtil.escapeJS(name);
 
 		setHTML: function (value) {
 			var ckEditorInstance = CKEDITOR.instances['<%= name %>'];
+
+			value = Liferay.Util.transformInlineCSS(value);
 
 			var win = window['<%= name %>'];
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
@@ -29,7 +29,12 @@ const Editor = React.forwardRef((props, ref) => {
 		});
 	}, []);
 
-	return <CKEditor ref={ref} {...props} />;
+	return (
+		<CKEditor
+			ref={ref}
+			{...Object.assign(props, {data: Liferay.Util.transformInlineCSS(props.data)})}
+		/>
+	);
 });
 
 CKEditor.editorUrl = `${BASEPATH}ckeditor.js`;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/InlineEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/InlineEditor.js
@@ -18,7 +18,12 @@ import React from 'react';
 const BASEPATH = '/o/frontend-editor-ckeditor-web/ckeditor/';
 
 const InlineEditor = (props) => {
-	return <CKEditor {...props} type="inline" />;
+	return (
+		<CKEditor
+			{...Object.assign(props, {data: Liferay.Util.transformInlineCSS(props.data)})}
+			type="inline"
+		/>
+	);
 };
 
 CKEditor.editorUrl = `${BASEPATH}ckeditor.js`;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -75,6 +75,7 @@ import createResourceURL from './util/portlet_url/create_resource_url.es';
 import {getSessionValue, setSessionValue} from './util/session.es';
 import toCharCode from './util/to_char_code.es';
 import toggleDisabled from './util/toggle_disabled';
+import transformInlineCSS from './util/transform_inline_css';
 
 Liferay = window.Liferay || {};
 
@@ -271,5 +272,6 @@ Liferay.Util.Session = {
 
 Liferay.Util.unescape = unescape;
 Liferay.Util.unescapeHTML = unescapeHTML;
+Liferay.Util.transformInlineCSS = transformInlineCSS;
 
 export {portlet};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/transform_inline_css.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/transform_inline_css.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function transformInlineCSS(data) {
+	const parser = new DOMParser();
+
+	const htmlDoc = parser.parseFromString(data, 'text/html');
+
+	const imageNodes = htmlDoc.getElementsByTagName('img');
+
+	for (let i = 0; i < imageNodes.length; i++) {
+		const imageNode = imageNodes[i];
+
+		if (
+			imageNode.getAttribute('width') !== null &&
+			imageNode.getAttribute('height') !== null
+		) {
+			continue;
+		}
+
+		const style = imageNode.getAttribute('style');
+
+		if (style === null || style === '') {
+			continue;
+		}
+
+		const styleHeight = imageNode.style.removeProperty('height');
+
+		if (styleHeight) {
+			imageNode.setAttribute('height', styleHeight.replace('px', ''));
+		}
+
+		const styleWidth = imageNode.style.removeProperty('width');
+
+		if (styleWidth) {
+			imageNode.setAttribute('width', styleWidth.replace('px', ''));
+		}
+	}
+
+	return htmlDoc.body.innerHTML;
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-139565

## Problem overview

In earlier versions of CKEditor, it set the height and width of a resized image as style properties. However, in later versions of CKEditor, it instead sets element attributes instead. As a result, any content created with the earlier version of CKEditor will run into issues in the newer versions of CKEditor.

## Steps to reproduce

1. Navigate to the screen to create a new web content
2. In the "content" field editor, switch to the source view, and set the following for the content to simulate the creation of legacy content (do not switch back to WYSIWYG view)
```html
<img src="" style="height:100px; width:100px" />
```
3. Publish the web content
4. Edit the web content that you created
5. In the "content" field editor, switch to the source view

Expected behavior is that reloading the content in WYSIWYG view will result in an image that can be resized. Actual behavior is that the inline styling makes it impossible to resize the image.