### PR TITLE
LPS-139800 Liferay.Session.extend() is registering the session banner many times

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -540,13 +540,11 @@ AUI.add(
 
 					const toastRootElement = toast?.parentElement;
 
-					instance._banner.destroy();
+					Liferay.destroyComponent(TOAST_ID);
 
 					if (toastRootElement) {
 						toastRootElement.remove();
 					}
-
-					Liferay.component(TOAST_ID, null);
 
 					instance._banner = false;
 				},


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-139800, and maybe https://issues.liferay.com/browse/LPS-137506

See steps to reproduce in the JIRA ticket. That case is also in gifs below. 

In addition, this PR fixes component and DOM cleanup in typical session toast scenarios. For easier testing:
- set `session.timeout=2` in portal-ext.properties
- set `session.timeout.warning=1` in portal-ext.properties

Now, warning toast appears after 1 min. The typical scenarios are:
1. Close warning with `Liferay.Session.extend()`.
2. Click on `Extend` in warning.
3. Click on (x) to close warning. Error toast opens on 2 mins.
4. Let warning timer expire. Error toast opens on 2 mins.

All above scenarios result in duplicate component warning and junk `<div>`s in DOM.

/cc @jbalsas @diegonvs 

Before PR:
![before](https://user-images.githubusercontent.com/5435511/135096170-942ff4fe-d64a-4867-b018-87b6127eec12.gif)

After PR:
![after](https://user-images.githubusercontent.com/5435511/135096163-20d34fe8-2a3e-48f2-adfe-e7ba774805a9.gif)



