### PR TITLE
LPS-139734 Add upgrade process to add RemoteAppEntry resource permission entries

### DIFF
--- a/modules/apps/remote-app/remote-app-service/bnd.bnd
+++ b/modules/apps/remote-app/remote-app-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Remote App Service
 Bundle-SymbolicName: com.liferay.remote.app.service
 Bundle-Version: 2.0.6
-Liferay-Require-SchemaVersion: 2.0.0
+Liferay-Require-SchemaVersion: 2.1.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/RemoteAppServiceUpgrade.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/RemoteAppServiceUpgrade.java
@@ -35,6 +35,11 @@ public class RemoteAppServiceUpgrade implements UpgradeStepRegistrator {
 			"1.0.1", "2.0.0",
 			new com.liferay.remote.app.internal.upgrade.v2_0_0.
 				RemoteAppEntryUpgradeProcess());
+
+		registry.register(
+			"2.0.0", "2.1.0",
+			new com.liferay.remote.app.internal.upgrade.v2_1_0.
+				ResourcePermissionsUpgradeProcess());
 	}
 
 }

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/v2_1_0/ResourcePermissionsUpgradeProcess.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/v2_1_0/ResourcePermissionsUpgradeProcess.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.remote.app.model.RemoteAppEntry;
 
 import java.sql.PreparedStatement;
@@ -72,7 +71,7 @@ public class ResourcePermissionsUpgradeProcess extends UpgradeProcess {
 				preparedStatement.setLong(
 					5, ResourceConstants.SCOPE_INDIVIDUAL);
 				preparedStatement.setString(
-					6, GetterUtil.getString(remoteAppEntryId));
+					6, String.valueOf(remoteAppEntryId));
 				preparedStatement.setLong(7, remoteAppEntryId);
 				preparedStatement.setLong(8, ownerRole.getRoleId());
 				preparedStatement.setLong(9, userId);
@@ -85,7 +84,7 @@ public class ResourcePermissionsUpgradeProcess extends UpgradeProcess {
 				preparedStatement.setLong(
 					16, ResourceConstants.SCOPE_INDIVIDUAL);
 				preparedStatement.setString(
-					17, GetterUtil.getString(remoteAppEntryId));
+					17, String.valueOf(remoteAppEntryId));
 				preparedStatement.setLong(18, remoteAppEntryId);
 				preparedStatement.setLong(19, guestRole.getRoleId());
 				preparedStatement.setLong(20, 0);

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/v2_1_0/ResourcePermissionsUpgradeProcess.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/v2_1_0/ResourcePermissionsUpgradeProcess.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.internal.upgrade.v2_1_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.remote.app.model.RemoteAppEntry;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/**
+ * @author Javier de Arcos
+ */
+public class ResourcePermissionsUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() {
+		_insertResourcePermissions();
+	}
+
+	private void _insertResourcePermissions() {
+		try (Statement s = connection.createStatement();
+			ResultSet resultSet = s.executeQuery(
+				"select mvccVersion, remoteAppEntryId, companyId, userId " +
+					"from RemoteAppEntry");
+			PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection.prepareStatement(
+						StringBundler.concat(
+							"insert into ResourcePermission (mvccVersion, ",
+							"resourcePermissionId, companyId, name, scope, ",
+							"primKey, primKeyId, roleId, ownerId, actionIds, ",
+							"viewActionId) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ",
+							"?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")))) {
+
+			while (resultSet.next()) {
+				long mvccVersion = resultSet.getLong("mvccVersion");
+				long remoteAppEntryId = resultSet.getLong("remoteAppEntryId");
+				long companyId = resultSet.getLong("companyId");
+				long userId = resultSet.getLong("userId");
+
+				Role ownerRole = RoleLocalServiceUtil.getRole(
+					companyId, "Owner");
+				Role guestRole = RoleLocalServiceUtil.getRole(
+					companyId, "Guest");
+
+				preparedStatement.setLong(1, mvccVersion);
+				preparedStatement.setLong(2, increment());
+				preparedStatement.setLong(3, companyId);
+				preparedStatement.setString(4, RemoteAppEntry.class.getName());
+				preparedStatement.setLong(
+					5, ResourceConstants.SCOPE_INDIVIDUAL);
+				preparedStatement.setString(
+					6, GetterUtil.getString(remoteAppEntryId));
+				preparedStatement.setLong(7, remoteAppEntryId);
+				preparedStatement.setLong(8, ownerRole.getRoleId());
+				preparedStatement.setLong(9, userId);
+				preparedStatement.setLong(10, 15);
+				preparedStatement.setLong(11, 1);
+				preparedStatement.setLong(12, mvccVersion);
+				preparedStatement.setLong(13, increment());
+				preparedStatement.setLong(14, companyId);
+				preparedStatement.setString(15, RemoteAppEntry.class.getName());
+				preparedStatement.setLong(
+					16, ResourceConstants.SCOPE_INDIVIDUAL);
+				preparedStatement.setString(
+					17, GetterUtil.getString(remoteAppEntryId));
+				preparedStatement.setLong(18, remoteAppEntryId);
+				preparedStatement.setLong(19, guestRole.getRoleId());
+				preparedStatement.setLong(20, 0);
+				preparedStatement.setLong(21, 1);
+				preparedStatement.setLong(22, 1);
+
+				preparedStatement.addBatch();
+			}
+
+			preparedStatement.executeBatch();
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ResourcePermissionsUpgradeProcess.class);
+
+}


### PR DESCRIPTION
Remote App edit page is not available after upgrading portal.

Permissions were added to RemoteAppEntries to check the permissions before executing an operation on a RemoteAppEntry [on this PR](https://github.com/liferay-frontend/liferay-portal/pull/1479). 

The upgrade process to add the resource permission entries in the database was missing and is added here.

Maybe it exists a more elegant query to create the entries... I've tried to test the upgrade updating from 7.3.0 to master but there were other upgrade unrelated errors. Anyway, the new entries were created correctly, but I wasn't able to check in the portal if the bug is fixed with the proposed solution.  

I will make another test tomorrow and if I'm not successful maybe I ask for help.

**Steps to Reproduce:**
1. Add a remote app to 7.3 portal
2. upgrade 7.3 to master
3. Navigate to Remote Apps admin
4. Click on remote app name to edit

**Expected Result:**
Fields were saved properly from upgrade and able to edit remote app fields

**Actual Result:**
Page does not render fields and error message present on the page: Portlet is temporarily unavailable.

After running the upgrade process with the new upgrade step the bug should be fixed.