### PR TITLE
LPS-139979 Update ci relevant testing for frontend modules to only run tests if portal.acceptance and portal.upstream are also true

### DIFF
--- a/modules/apps/frontend-css/test.properties
+++ b/modules/apps/frontend-css/test.properties
@@ -15,8 +15,8 @@
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (environment.acceptance == true) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream != quarantine) AND \
+        (portal.acceptance == true) AND \
+        (portal.upstream == true) AND \
         (\
             (app.server.types == null) OR \
             (app.server.types ~ "tomcat")\

--- a/modules/apps/frontend-js/test.properties
+++ b/modules/apps/frontend-js/test.properties
@@ -19,8 +19,8 @@
             (testray.component.names ~ "AUI")\
         ) AND \
         (\
-            (portal.acceptance != quarantine) AND \
-            (portal.upstream != quarantine)\
+            (portal.acceptance == true) AND \
+            (portal.upstream == true)\
         ) AND \
         (\
             (app.server.types == null) OR \

--- a/modules/apps/frontend-taglib/test.properties
+++ b/modules/apps/frontend-taglib/test.properties
@@ -19,8 +19,8 @@
             (testray.component.names == "Clay")\
         ) AND \
         (\
-            (portal.acceptance != quarantine) AND \
-            (portal.upstream != quarantine) AND \
+            (portal.acceptance == true) AND \
+            (portal.upstream == true) AND \
             (\
                 (app.server.types == null) OR \
                 (app.server.types ~ "tomcat")\


### PR DESCRIPTION
**Description**
There's a possibility that PRs in FI team could be blocked in `ci:forward` by incorrectly marked unique test failures when `portal.acceptance` is set to false since we mainly run `environment.acceptance` tests. Therefore, to mitigate this situation, we can make relevant test filters to check that portal.acceptance and portal.upstream is set to true.

**Test Plan**
- [x] frontend relevant filters include `portal.acceptance == true`.

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-139979
