### PR TITLE
LPS-130658 Add sample test for frontend js state

### DIFF
--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/A11y.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/A11y.d.ts
@@ -11,10 +11,6 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 /// <reference types="react" />
-
-import type {A11yCheckerOptions} from './A11yChecker';
-export declare function A11y(
-	props: Omit<A11yCheckerOptions, 'callback'>
-): JSX.Element | null;
+import type { A11yCheckerOptions } from './A11yChecker';
+export declare function A11y(props: Omit<A11yCheckerOptions, 'callback'>): JSX.Element | null;

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/A11yChecker.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/A11yChecker.d.ts
@@ -11,26 +11,19 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
-import {AxeResults, RunOptions} from 'axe-core';
+import { AxeResults, RunOptions } from 'axe-core';
 declare global {
-	interface Window {
-		requestIdleCallback(callback: Function): any;
-		cancelIdleCallback(handle: number): void;
-	}
+    interface Window {
+        requestIdleCallback(callback: Function): any;
+        cancelIdleCallback(handle: number): void;
+    }
 }
 declare type Task<T> = {
-	id: number;
-	callback: Function;
-	target: T;
+    id: number;
+    callback: Function;
+    target: T;
 };
-declare type Selector<T> = (
-	this: void,
-	value: T,
-	index: number,
-	object: Array<T>
-) => unknown;
-
+declare type Selector<T> = (this: void, value: T, index: number, object: Array<T>) => unknown;
 /**
  * Scheduler deals with scheduling a callback to A11y that runs axe-core at the
  * end, many of the logics and algorithms in the scheduler are restricted to
@@ -64,99 +57,84 @@ declare type Selector<T> = (
  * empty.
  */
 export declare class Scheduler<T> {
-	private taskIdCounter;
-	private readonly queue;
-	private currentTask;
-	private scheduledHostHandle;
-	private isCallbackScheduled;
-	private isPerformingWork;
-
-	/**
-	 * The frame phases can be recognized as lanes which are a space of time
-	 * where the scheduler yields up the main thread to the host in that time
-	 * interval before taking up again.
-	 */
-	private nextFramePhase;
-
-	/**
-	 * The yield interval is defined based on the RAIL model, this value is
-	 * static and means that we yield 100ms to the host and define the deadline
-	 * to maximize the chances of hitting 60 fps.
-	 */
-	private readonly yieldInterval;
-	deadline: number;
-	cancelHostCallback(): void;
-	hasCallback(selector: Selector<Task<T>>): Task<T> | undefined;
-	private flushWork;
-	private requestHostCallback;
-	private shouldYieldToHost;
-	private workLoop;
-	scheduleCallback(callback: Function, target: T): void;
+    private taskIdCounter;
+    private readonly queue;
+    private currentTask;
+    private scheduledHostHandle;
+    private isCallbackScheduled;
+    private isPerformingWork;
+    /**
+     * The frame phases can be recognized as lanes which are a space of time
+     * where the scheduler yields up the main thread to the host in that time
+     * interval before taking up again.
+     */
+    private nextFramePhase;
+    /**
+     * The yield interval is defined based on the RAIL model, this value is
+     * static and means that we yield 100ms to the host and define the deadline
+     * to maximize the chances of hitting 60 fps.
+     */
+    private readonly yieldInterval;
+    deadline: number;
+    cancelHostCallback(): void;
+    hasCallback(selector: Selector<Task<T>>): Task<T> | undefined;
+    private flushWork;
+    private requestHostCallback;
+    private shouldYieldToHost;
+    private workLoop;
+    scheduleCallback(callback: Function, target: T): void;
 }
-
 /**
  * Attributes are the attributes of a node. The array is considered a
  * conditional `or`, the same for the values of an attribute.
  */
 declare type Attributes = Record<string, Array<string>>;
 export interface A11yCheckerOptions {
-
-	/**
-	 * AxeOptions is the set of settings that are passed to axe-core.
-	 */
-	axeOptions?: RunOptions;
-
-	/**
-	 * Callback for when the analysis is finished.
-	 */
-	callback: (violations: AxeResults) => void;
-
-	/**
-	 * Denylist is an optional list with CSS selectors that will be excluded
-	 * from the analysis.
-	 */
-	denylist?: Array<string>;
-
-	/**
-	 * Mutation is an optional list of criteria on which a new analysis will be
-	 * ignored.
-	 */
-	mutations: Record<string, Attributes>;
-
-	/**
-	 * Targets is a list or element that represents the subtree(s) to be
-	 * analyzed.
-	 */
-	targets: Array<string>;
+    /**
+     * AxeOptions is the set of settings that are passed to axe-core.
+     */
+    axeOptions?: RunOptions;
+    /**
+     * Callback for when the analysis is finished.
+     */
+    callback: (violations: AxeResults) => void;
+    /**
+     * Denylist is an optional list with CSS selectors that will be excluded
+     * from the analysis.
+     */
+    denylist?: Array<string>;
+    /**
+     * Mutation is an optional list of criteria on which a new analysis will be
+     * ignored.
+     */
+    mutations: Record<string, Attributes>;
+    /**
+     * Targets is a list or element that represents the subtree(s) to be
+     * analyzed.
+     */
+    targets: Array<string>;
 }
 export declare class A11yChecker {
-	private callback;
-	private scheduler;
-	private observers;
-	private mutations;
-	readonly axeOptions: RunOptions;
-	readonly denylist?: Array<Array<string>>;
-	constructor({
-		axeOptions,
-		callback,
-		denylist,
-		mutations,
-		targets,
-	}: A11yCheckerOptions);
-	private run;
-	private recordCallback;
-
-	/**
-	 * Search for any iframe that is within the element to monitor mutations
-	 * within the iframe that may trigger further analysis.
-	 *
-	 * Searching for iframes when the checker is initialized is not good
-	 * because iframes can appear at any time on the page, like opening a
-	 * Modal, we need to monitor iframes as they appear during their lifecycle.
-	 */
-	private observeIframes;
-	private mutationCallback;
-	observe(): void;
-	unobserve(): void;
+    private callback;
+    private scheduler;
+    private observers;
+    private mutations;
+    readonly axeOptions: RunOptions;
+    readonly denylist?: Array<Array<string>>;
+    constructor({ axeOptions, callback, denylist, mutations, targets, }: A11yCheckerOptions);
+    private run;
+    private recordCallback;
+    /**
+     * Search for any iframe that is within the element to monitor mutations
+     * within the iframe that may trigger further analysis.
+     *
+     * Searching for iframes when the checker is initialized is not good
+     * because iframes can appear at any time on the page, like opening a
+     * Modal, we need to monitor iframes as they appear during their lifecycle.
+     */
+    private observeIframes;
+    private mutationCallback;
+    observe(): void;
+    unobserve(): void;
 }
 export {};

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/A11yIframe.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/A11yIframe.d.ts
@@ -11,7 +11,5 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 /// <reference types="react" />
-
 export declare function A11yIframe(): JSX.Element[];

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/SDK.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/SDK.d.ts
@@ -11,15 +11,13 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
-declare const PROTOCOL = 'com.liferay.frontend.js.a11y.protocol';
+declare const PROTOCOL = "com.liferay.frontend.js.a11y.protocol";
 export declare type ChannelEvent<T, K> = {
-	payload: T;
-	kind: K;
-	protocol: typeof PROTOCOL;
+    payload: T;
+    kind: K;
+    protocol: typeof PROTOCOL;
 };
 export declare type Recv<T, S> = (payload: T, kind?: S) => void;
-
 /**
  * The communication channel is responsible for implementing the tx and rx
  * methods, the channel is bidirectional so it will transmit (tx) and
@@ -27,34 +25,31 @@ export declare type Recv<T, S> = (payload: T, kind?: S) => void;
  * differentiate messages on the same channel.
  */
 declare class Channel<T, S> {
-	#private;
-	constructor(onRecv: Recv<T, S>, side: boolean);
-
-	/**
-	 * Transmit the event to the target following the communication protocol so
-	 * that the other side can accept. Kind is the type of event so it can be
-	 * differentiated in the receptor.
-	 */
-	tx<P, K>(target: Window, payload: P, kind?: K): void;
-
-	/**
-	 * Receive is not used directly but is used to verify the identity of
-	 * the protocol and attached to the window listener, if it satisfies
-	 * the condition it calls the callback.
-	 */
-	rx(event: MessageEvent<ChannelEvent<T, S>>): void;
+    #private;
+    constructor(onRecv: Recv<T, S>, side: boolean);
+    /**
+     * Transmit the event to the target following the communication protocol so
+     * that the other side can accept. Kind is the type of event so it can be
+     * differentiated in the receptor.
+     */
+    tx<P, K>(target: Window, payload: P, kind?: K): void;
+    /**
+     * Receive is not used directly but is used to verify the identity of
+     * the protocol and attached to the window listener, if it satisfies
+     * the condition it calls the callback.
+     */
+    rx(event: MessageEvent<ChannelEvent<T, S>>): void;
 }
-
 /**
  * SDK is a simple abstraction to create side channels of communication between
  * the main window and the iframe the same happens inversely between the iframe
  * and the main window.
  */
 export declare class SDK<T, S> {
-	private channelRx;
-	channel: Channel<T, S>;
-	constructor(onRecv: Recv<T, S>, side: boolean);
-	observe(): void;
-	unobserve(): void;
+    private channelRx;
+    channel: Channel<T, S>;
+    constructor(onRecv: Recv<T, S>, side: boolean);
+    observe(): void;
+    unobserve(): void;
 }
 export {};

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/ErrorBoundary.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/ErrorBoundary.d.ts
@@ -11,22 +11,18 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 import React from 'react';
 declare type Props = {
-	fallback: React.ReactElement;
-	children: React.ReactElement;
+    fallback: React.ReactElement;
+    children: React.ReactElement;
 };
 declare type State = {
-	hasError: boolean;
+    hasError: boolean;
 };
 export declare class ErrorBoundary extends React.Component<Props, State> {
-	state: State;
-	static getDerivedStateFromError(_: Error): State;
-	componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void;
-	render(): React.ReactElement<
-		any,
-		string | React.JSXElementConstructor<any>
-	>;
+    state: State;
+    static getDerivedStateFromError(_: Error): State;
+    componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void;
+    render(): React.ReactElement<any, string | React.JSXElementConstructor<any>>;
 }
 export {};

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/NotFound.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/NotFound.d.ts
@@ -11,17 +11,11 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 /// <reference types="react" />
-
 declare type Props = {
-	description: string;
-	onClick: () => void;
-	title: string;
+    description: string;
+    onClick: () => void;
+    title: string;
 };
-export declare const NotFound: ({
-	description,
-	onClick,
-	title,
-}: Props) => JSX.Element;
+export declare const NotFound: ({ description, onClick, title }: Props) => JSX.Element;
 export {};

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/Occurrence.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/Occurrence.d.ts
@@ -11,24 +11,18 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 /// <reference types="react" />
-
 import './Occurrence.scss';
-import type {Violations} from '../hooks/useA11y';
+import type { Violations } from '../hooks/useA11y';
 declare type Params = {
-	name: string;
-	ruleId: string;
-	target: string;
+    name: string;
+    ruleId: string;
+    target: string;
 };
 declare type OccurrenceProps = {
-	params?: Params;
-	previous?: (state: Omit<Params, 'target'>) => void;
-	violations: Omit<Violations, 'iframes'>;
+    params?: Params;
+    previous?: (state: Omit<Params, 'target'>) => void;
+    violations: Omit<Violations, 'iframes'>;
 };
-declare function Occurrence({
-	params,
-	previous,
-	violations,
-}: OccurrenceProps): JSX.Element | null;
+declare function Occurrence({ params, previous, violations }: OccurrenceProps): JSX.Element | null;
 export default Occurrence;

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/PanelNavigator.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/PanelNavigator.d.ts
@@ -11,22 +11,15 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 import './PanelNavigator.scss';
 import React from 'react';
-import type {ImpactValue} from 'axe-core';
+import type { ImpactValue } from 'axe-core';
 declare type PanelNavigatorProps = {
-	helpUrl: string;
-	impact?: ImpactValue;
-	onBack: (event: React.MouseEvent<HTMLButtonElement>) => void;
-	title: string;
-	tags: Array<string>;
+    helpUrl: string;
+    impact?: ImpactValue;
+    onBack: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    title: string;
+    tags: Array<string>;
 };
-declare function PanelNavigator({
-	helpUrl,
-	impact,
-	onBack,
-	tags,
-	title,
-}: PanelNavigatorProps): JSX.Element;
+declare function PanelNavigator({ helpUrl, impact, onBack, tags, title, }: PanelNavigatorProps): JSX.Element;
 export default PanelNavigator;

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/Rule.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/Rule.d.ts
@@ -11,21 +11,14 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 import './Rule.scss';
 import React from 'react';
-import type {ImpactValue} from 'axe-core';
+import type { ImpactValue } from 'axe-core';
 interface IRule extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-	quantity?: number;
-	ruleSubtext?: ImpactValue;
-	ruleText?: React.ReactNode;
-	ruleTitle?: React.ReactNode;
+    quantity?: number;
+    ruleSubtext?: ImpactValue;
+    ruleText?: React.ReactNode;
+    ruleTitle?: React.ReactNode;
 }
-declare function Rule({
-	quantity,
-	ruleSubtext,
-	ruleText,
-	ruleTitle,
-	...otherProps
-}: IRule): JSX.Element;
+declare function Rule({ quantity, ruleSubtext, ruleText, ruleTitle, ...otherProps }: IRule): JSX.Element;
 export default Rule;

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/StackNavigator.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/StackNavigator.d.ts
@@ -11,23 +11,13 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 import React from 'react';
 declare type StackNavigatorProps<T> = {
-	activePage: number;
-	children: Array<React.ReactElement>;
-	onActiveChange: (index: number) => void;
-	onParamsChange: (payload: T) => void;
-	params: T | undefined;
+    activePage: number;
+    children: Array<React.ReactElement>;
+    onActiveChange: (index: number) => void;
+    onParamsChange: (payload: T) => void;
+    params: T | undefined;
 };
-export declare function StackNavigator<T>({
-	activePage,
-	children,
-	onActiveChange,
-	onParamsChange,
-	params,
-}: StackNavigatorProps<T>): React.ReactElement<
-	any,
-	string | React.JSXElementConstructor<any>
->;
+export declare function StackNavigator<T>({ activePage, children, onActiveChange, onParamsChange, params, }: StackNavigatorProps<T>): React.ReactElement<any, string | React.JSXElementConstructor<any>>;
 export {};

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/Violation.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/Violation.d.ts
@@ -11,26 +11,19 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 /// <reference types="react" />
-
 import './Violation.scss';
-import type {Violations} from '../hooks/useA11y';
+import type { Violations } from '../hooks/useA11y';
 declare type Params = {
-	name: string;
-	ruleId: string;
-	target: string;
+    name: string;
+    ruleId: string;
+    target: string;
 };
 declare type ViolationProps = {
-	next?: (payload: Params) => void;
-	params?: Pick<Params, 'ruleId'>;
-	previous?: () => void;
-	violations: Omit<Violations, 'iframes'>;
+    next?: (payload: Params) => void;
+    params?: Pick<Params, 'ruleId'>;
+    previous?: () => void;
+    violations: Omit<Violations, 'iframes'>;
 };
-declare function Violation({
-	next,
-	params,
-	previous,
-	violations,
-}: ViolationProps): JSX.Element | null;
+declare function Violation({ next, params, previous, violations }: ViolationProps): JSX.Element | null;
 export default Violation;

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/ViolationPopover.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/ViolationPopover.d.ts
@@ -11,21 +11,14 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 /// <reference types="react" />
-
 import './ViolationPopover.scss';
-import type {RuleRaw} from '../hooks/useA11y';
+import type { RuleRaw } from '../hooks/useA11y';
 declare type ViolationProps = {
-	onClick: (target: string, id: string) => void;
-	rules: Record<string, RuleRaw>;
-	target: string;
-	violations: Array<string>;
+    onClick: (target: string, id: string) => void;
+    rules: Record<string, RuleRaw>;
+    target: string;
+    violations: Array<string>;
 };
-export declare function ViolationPopover({
-	onClick,
-	rules,
-	target,
-	violations,
-}: ViolationProps): JSX.Element | null;
+export declare function ViolationPopover({ onClick, rules, target, violations, }: ViolationProps): JSX.Element | null;
 export {};

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/Violations.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/components/Violations.d.ts
@@ -11,32 +11,22 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 /// <reference types="react" />
-
 import './Violations.scss';
-import {TYPES} from '../hooks/useFilterViolations';
-import type {RuleRaw, Violations} from '../hooks/useA11y';
+import { TYPES } from '../hooks/useFilterViolations';
+import type { RuleRaw, Violations } from '../hooks/useA11y';
 declare type TViolationNext = {
-	ruleId: string;
+    ruleId: string;
 };
-declare type onFilterChange = (
-	type: keyof typeof TYPES,
-	payload: {
-		value: string;
-		key: keyof RuleRaw;
-	}
-) => void;
+declare type onFilterChange = (type: keyof typeof TYPES, payload: {
+    value: string;
+    key: keyof RuleRaw;
+}) => void;
 declare type ViolationsPanelProps = {
-	filters: Record<keyof RuleRaw, Array<string>>;
-	next?: (payload: TViolationNext) => void;
-	onFilterChange: onFilterChange;
-	violations: Omit<Violations, 'iframes'>;
+    filters: Record<keyof RuleRaw, Array<string>>;
+    next?: (payload: TViolationNext) => void;
+    onFilterChange: onFilterChange;
+    violations: Omit<Violations, 'iframes'>;
 };
-export default function ViolationsPanel({
-	filters,
-	next,
-	onFilterChange,
-	violations,
-}: ViolationsPanelProps): JSX.Element;
+export default function ViolationsPanel({ filters, next, onFilterChange, violations, }: ViolationsPanelProps): JSX.Element;
 export {};

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/hooks/useA11y.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/hooks/useA11y.d.ts
@@ -11,22 +11,19 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
-import type {NodeResult, Result} from 'axe-core';
-import type {A11yCheckerOptions} from '../A11yChecker';
+import type { NodeResult, Result } from 'axe-core';
+import type { A11yCheckerOptions } from '../A11yChecker';
 declare type Target = string;
 declare type RuleId = string;
 declare type IframeId = string;
 export interface RuleRaw extends Omit<Result, 'nodes'> {
-	nodes: Array<Target>;
+    nodes: Array<Target>;
 }
 export declare type NodeViolations = Record<RuleId, NodeResult>;
 export declare type Violations = {
-	iframes: Record<IframeId, Array<Target>>;
-	nodes: Record<Target, NodeViolations>;
-	rules: Record<RuleId, RuleRaw>;
+    iframes: Record<IframeId, Array<Target>>;
+    nodes: Record<Target, NodeViolations>;
+    rules: Record<RuleId, RuleRaw>;
 };
-export default function useA11y(
-	props: Omit<A11yCheckerOptions, 'callback'>
-): Violations;
+export default function useA11y(props: Omit<A11yCheckerOptions, 'callback'>): Violations;
 export {};

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/hooks/useFilterViolations.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/hooks/useFilterViolations.d.ts
@@ -11,31 +11,24 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 /// <reference types="react" />
-
-import type {NodeViolations, RuleRaw, Violations} from './useA11y';
+import type { NodeViolations, RuleRaw, Violations } from './useA11y';
 export declare const TYPES: {
-	readonly ADD_FILTER: 'ADD_FILTER';
-	readonly REMOVE_FILTER: 'REMOVE_FILTER';
+    readonly ADD_FILTER: "ADD_FILTER";
+    readonly REMOVE_FILTER: "REMOVE_FILTER";
 };
 declare type TAction = {
-	payload: {
-		key: keyof RuleRaw;
-		value: string;
-	};
-	type: keyof typeof TYPES;
+    payload: {
+        key: keyof RuleRaw;
+        value: string;
+    };
+    type: keyof typeof TYPES;
 };
-export declare function useFilterViolations(
-	value: Violations
-): readonly [
-	{
-		readonly filters: Record<keyof RuleRaw, string[]>;
-		readonly violations: {
-			readonly nodes: Record<string, NodeViolations>;
-			readonly rules: Record<string, RuleRaw>;
-		};
-	},
-	import('react').Dispatch<TAction>
-];
+export declare function useFilterViolations(value: Violations): readonly [{
+    readonly filters: Record<keyof RuleRaw, string[]>;
+    readonly violations: {
+        readonly nodes: Record<string, NodeViolations>;
+        readonly rules: Record<string, RuleRaw>;
+    };
+}, import("react").Dispatch<TAction>];
 export {};

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/hooks/useIframeA11yChannel.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/hooks/useIframeA11yChannel.d.ts
@@ -11,13 +11,8 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
-import type {Recv} from '../SDK';
-import type {Violations} from './useA11y';
+import type { Recv } from '../SDK';
+import type { Violations } from './useA11y';
 declare type FilteredViolations = Omit<Violations, 'iframes'>;
-export default function useIframeA11yChannel<T, K>(
-	iframes: Record<string, Array<string>>,
-	violations: FilteredViolations,
-	onMessage: Recv<T, K>
-): void;
+export default function useIframeA11yChannel<T, K>(iframes: Record<string, Array<string>>, violations: FilteredViolations, onMessage: Recv<T, K>): void;
 export {};

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/hooks/useIframeClient.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/hooks/useIframeClient.d.ts
@@ -11,10 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 export declare enum Kind {
-	Click = 'a11y:popover:click',
+    Click = "a11y:popover:click"
 }
-export default function useIframeClient<T>(
-	initialState: T
-): readonly [T, <P>(kind: Kind, payload: P) => void];
+export default function useIframeClient<T>(initialState: T): readonly [T, <P>(kind: Kind, payload: P) => void];

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/hooks/useObserveRect.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/hooks/useObserveRect.d.ts
@@ -11,8 +11,4 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
-export declare const useObserveRect: (
-	callback: (rect: DOMRect | undefined) => void,
-	node: Element | null
-) => void;
+export declare const useObserveRect: (callback: (rect: DOMRect | undefined) => void, node: Element | null) => void;

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/index.d.ts
@@ -11,25 +11,22 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
-import type {A11yCheckerOptions} from './A11yChecker';
+import type { A11yCheckerOptions } from './A11yChecker';
 declare global {
-	var Liferay: {
-		Language: {
-			get(value: string): string;
-		};
-		Util: {
-			sub(...value: string[]): string;
-		};
-	};
-	interface ThemeDisplay {
-		isStatePopUp(): boolean;
-	}
-	interface Window {
-		themeDisplay: ThemeDisplay;
-	}
+    var Liferay: {
+        Language: {
+            get(value: string): string;
+        };
+        Util: {
+            sub(...value: string[]): string;
+        };
+    };
+    interface ThemeDisplay {
+        isStatePopUp(): boolean;
+    }
+    interface Window {
+        themeDisplay: ThemeDisplay;
+    }
 }
-declare const _default: (
-	props: Omit<A11yCheckerOptions, 'callback' | 'targets'>
-) => void;
+declare const _default: (props: Omit<A11yCheckerOptions, 'callback' | 'targets'>) => void;
 export default _default;

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/test/js/A11yChecker.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/test/js/A11yChecker.d.ts
@@ -11,15 +11,14 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 declare global {
-	namespace NodeJS {
-		interface Performance {
-			now: () => number;
-		}
-		interface Global {
-			performance?: Performance;
-		}
-	}
+    namespace NodeJS {
+        interface Performance {
+            now: () => number;
+        }
+        interface Global {
+            performance?: Performance;
+        }
+    }
 }
 export {};

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/test/js/A11yPanel.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/test/js/A11yPanel.d.ts
@@ -11,5 +11,4 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
 import '@testing-library/jest-dom/extend-expect';

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/test/js/__fixtures__/violationsMock.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/test/js/__fixtures__/violationsMock.d.ts
@@ -11,7 +11,6 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
-import type {Violations} from '../../../src/main/resources/META-INF/resources/hooks/useA11y';
+import type { Violations } from '../../../src/main/resources/META-INF/resources/hooks/useA11y';
 declare const violations: Violations;
 export default violations;

--- a/modules/apps/frontend-js/frontend-js-sample-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-sample-web/.npmbundlerrc
@@ -1,0 +1,9 @@
+{
+	"config": {
+		"imports": {
+			"@liferay/frontend-js-state-web": {
+				"/": ">=1.0.0"
+			}
+		}
+	}
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-sample-web/.npmbundlerrc
@@ -1,9 +1,0 @@
-{
-	"config": {
-		"imports": {
-			"@liferay/frontend-js-state-web": {
-				"/": ">=1.0.0"
-			}
-		}
-	}
-}

--- a/modules/apps/frontend-js/frontend-js-sample-web/bnd.bnd
+++ b/modules/apps/frontend-js/frontend-js-sample-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Frontend JS Sample Web
+Bundle-SymbolicName: com.liferay.frontend.js.sample.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /frontend-js-sample-web

--- a/modules/apps/frontend-js/frontend-js-sample-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-sample-web/build.gradle
@@ -1,0 +1,20 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "jstl", name: "jstl", version: "1.2"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:asset:asset-taglib")
+	compileOnly project(":apps:comment:comment-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-dynamic-section")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-form-navigator")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-util")
+	compileOnly project(":apps:journal:journal-taglib")
+	compileOnly project(":apps:layout:layout-taglib")
+	compileOnly project(":apps:site:site-taglib")
+
+	cssBuilder project(":util:css-builder")
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/npmscripts.config.js
+++ b/modules/apps/frontend-js/frontend-js-sample-web/npmscripts.config.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+module.exports = {
+	build: {
+		bundler: {
+			config: {
+				imports: {
+					'@liferay/frontend-js-state-web': {
+						'/': '*',
+					},
+				},
+			},
+		},
+	},
+};

--- a/modules/apps/frontend-js/frontend-js-sample-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-sample-web/package.json
@@ -1,0 +1,19 @@
+{
+	"dependencies": {
+		"@clayui/alert": "3.26.0",
+		"@clayui/button": "3.6.0",
+		"@liferay/frontend-js-react-web": "*",
+		"@liferay/frontend-js-state-web": "*",
+		"frontend-js-web": "*",
+		"react": "16.12.0",
+		"react-dom": "16.12.0"
+	},
+	"main": "js/App.es",
+	"name": "@liferay/frontend-js-sample-web",
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "1.0.0"
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-sample-web/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
-		"@clayui/alert": "3.26.0",
-		"@clayui/button": "3.6.0",
+		"@clayui/alert": "3.32.0",
+		"@clayui/button": "3.32.0",
 		"@liferay/frontend-js-react-web": "*",
 		"@liferay/frontend-js-state-web": "*",
 		"frontend-js-web": "*",

--- a/modules/apps/frontend-js/frontend-js-sample-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-sample-web/package.json
@@ -8,7 +8,7 @@
 		"react": "16.12.0",
 		"react-dom": "16.12.0"
 	},
-	"main": "js/App.es",
+	"main": "js/index.js",
 	"name": "@liferay/frontend-js-sample-web",
 	"scripts": {
 		"build": "liferay-npm-scripts build",

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/java/com/liferay/frontend/js/sample/web/internal/constants/JavaScriptSamplePortletKeys.java
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/java/com/liferay/frontend/js/sample/web/internal/constants/JavaScriptSamplePortletKeys.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.sample.web.internal.constants;
+
+/**
+ * @author John Co
+ */
+public class JavaScriptSamplePortletKeys {
+
+	public static final String JAVASCRIPT_SAMPLE =
+		"com_liferay_frontend_js_sample_web_internal_portlet_" +
+			"JavaScriptSamplePortlet";
+
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/java/com/liferay/frontend/js/sample/web/internal/portlet/JavaScriptSamplePortlet.java
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/java/com/liferay/frontend/js/sample/web/internal/portlet/JavaScriptSamplePortlet.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.sample.web.internal.portlet;
+
+import com.liferay.frontend.js.sample.web.internal.constants.JavaScriptSamplePortletKeys;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+
+import javax.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author John Co
+ */
+@Component(
+	immediate = true,
+	property = {
+		"com.liferay.portlet.display-category=category.sample",
+		"com.liferay.portlet.instanceable=true",
+		"javax.portlet.display-name=JS Sample",
+		"javax.portlet.init-param.template-path=/META-INF/resources/",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.name=" + JavaScriptSamplePortletKeys.JAVASCRIPT_SAMPLE,
+		"javax.portlet.resource-bundle=content.Language",
+		"javax.portlet.security-role-ref=power-user,user"
+	},
+	service = Portlet.class
+)
+public class JavaScriptSamplePortlet extends MVCPortlet {
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,24 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,7 +17,10 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+
+<liferay-frontend:defineObjects />
 
 <liferay-theme:defineObjects />
 

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/js/App.js
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/js/App.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayCard from '@clayui/card';
+import ClayForm, {ClayInput} from '@clayui/form';
+import {useLiferayState} from '@liferay/frontend-js-react-web';
+import React from 'react';
+
+import {counterAtomReact, userAtom, userSelector} from './sharedState';
+
+// Components that access that shared state:
+
+function Name() {
+	const [userNameAndLength] = useLiferayState(userSelector);
+
+	return (
+		<ClayCard>
+			<ClayCard.Body>
+				<ClayCard.Description displayType="title">
+					{Liferay.Language.get('name')}
+				</ClayCard.Description>
+				<ClayCard.Description displayType="text" truncate={false}>
+					{userNameAndLength}
+				</ClayCard.Description>
+			</ClayCard.Body>
+		</ClayCard>
+	);
+}
+
+function NameUpdater(portletId) {
+	const id = `${portletId}_form`;
+	const [user, setUser] = useLiferayState(userAtom);
+
+	return (
+		<ClayForm.Group>
+			<label htmlFor={id}>Name</label>
+			<ClayInput
+				id={id}
+				onChange={(event) => {
+					setUser({
+						...user,
+						name: event.target.value,
+					});
+				}}
+				type="text"
+				value={user.name}
+			/>
+		</ClayForm.Group>
+	);
+}
+
+function ButtonCounter() {
+	const [count] = useLiferayState(counterAtomReact);
+
+	return (
+		<h3>
+			React Counter: <span id="test-counter-react">{count}</span>
+		</h3>
+	);
+}
+
+export default ({portletId}) => {
+	return (
+		<div className="col-md-6">
+			<NameUpdater portletId={portletId} />
+			<Name />
+			<ButtonCounter />
+		</div>
+	);
+};

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/js/index.js
@@ -1,0 +1,33 @@
+import {State} from '@liferay/frontend-js-state-web/index';
+
+import {counterAtomReact, userAtom} from './sharedState';
+
+const buttonElementJSP = document.getElementById('test-button-jsp');
+const buttonElementReact = document.getElementById('test-button-react');
+const counterElement = document.getElementById('test-counter-jsp');
+const nameElement = document.getElementById('test-name');
+
+const counterAtom = State.atom('test-counter-jsp', 0);
+
+State.subscribe(counterAtom, (newVal) => {
+	counterElement.innerText = newVal;
+});
+
+State.subscribe(userAtom, (event) => {
+	nameElement.innerText = event.name;
+});
+
+if (buttonElementJSP) {
+	buttonElementJSP.addEventListener('click', () => {
+		State.write(counterAtom, State.read(counterAtom) + 1);
+	});
+}
+
+if (buttonElementReact) {
+	buttonElementReact.addEventListener('click', () => {
+		State.write(
+			counterAtomReact,
+			State.read(counterAtomReact) + 1
+		);
+	});
+}

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/js/sharedState.js
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/js/sharedState.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {State} from '@liferay/frontend-js-state-web';
+
+// Shared state (atoms and selectors);
+
+export const userAtom = State.atom('clay-sample-atom', {
+	name: Liferay.ThemeDisplay.getUserName(),
+});
+
+export const userSelector = State.selector('clay-sample-selector', (get) => {
+	const user = get(userAtom);
+
+	return `${user.name} (${user.name.length})`;
+});
+
+export const counterAtomReact = State.atom('sample-counter', 0);

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,71 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %>
+
+<div class="row">
+	<div class="col">
+		<react:component
+			module="js/App"
+		/>
+	</div>
+
+	<div class="col">
+		<button id="test-button-jsp">Increment jsp</button>
+
+		<h3>JSP Counter: <span id="test-counter-jsp">0</span></h3>
+
+		<h3>Name: <span id="test-name">Initial Name</span></h3>
+
+		<button id="test-button-react">Increment react</button>
+
+		<aui:script require="@liferay/frontend-js-state-web@1.0.3/index as StateModule, @liferay/frontend-js-sample-web@1.0.0/js/sharedState as SharedState">
+			const buttonElementJSP = document.getElementById('test-button-jsp');
+			const buttonElementReact = document.getElementById('test-button-react');
+			const counterElement = document.getElementById('test-counter-jsp');
+			const nameElement = document.getElementById('test-name');
+
+			const State = StateModule.State;
+
+			const counterAtom = State.atom('test-counter-jsp', 0);
+
+			State.subscribe(counterAtom, (newVal) => {
+				counterElement.innerText = newVal;
+			});
+
+			State.subscribe(SharedState.userAtom, (event) => {
+				nameElement.innerText = event.name;
+			});
+
+			if (buttonElementJSP) {
+				buttonElementJSP.addEventListener('click', () => {
+					State.write(counterAtom, State.read(counterAtom) + 1);
+				});
+			}
+
+			if (buttonElementReact) {
+				buttonElementReact.addEventListener('click', () => {
+					State.write(
+						SharedState.counterAtomReact,
+						State.read(SharedState.counterAtomReact) + 1
+					);
+				});
+			}
+		</aui:script>
+	</div>
+</div>

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -34,7 +34,7 @@
 
 		<button id="test-button-react">Increment react</button>
 
-		<aui:script require="@liferay/frontend-js-state-web@1.0.3/index as StateModule, @liferay/frontend-js-sample-web@1.0.0/js/sharedState as SharedState">
+		<aui:script require="@liferay/frontend-js-state-web@1.0.6/index as StateModule, @liferay/frontend-js-sample-web@1.0.0/js/sharedState as SharedState">
 			const buttonElementJSP = document.getElementById('test-button-jsp');
 			const buttonElementReact = document.getElementById('test-button-react');
 			const counterElement = document.getElementById('test-counter-jsp');

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -34,7 +34,7 @@
 
 		<button id="test-button-react">Increment react</button>
 
-		<aui:script require="@liferay/frontend-js-state-web@1.0.6/index as StateModule, @liferay/frontend-js-sample-web@1.0.0/js/sharedState as SharedState">
+		<aui:script require="@liferay/frontend-js-state-web/index as StateModule, @liferay/frontend-js-sample-web/js/sharedState as SharedState">
 			const buttonElementJSP = document.getElementById('test-button-jsp');
 			const buttonElementReact = document.getElementById('test-button-react');
 			const counterElement = document.getElementById('test-counter-jsp');

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -34,38 +34,6 @@
 
 		<button id="test-button-react">Increment react</button>
 
-		<aui:script require="@liferay/frontend-js-state-web/index as StateModule, @liferay/frontend-js-sample-web/js/sharedState as SharedState">
-			const buttonElementJSP = document.getElementById('test-button-jsp');
-			const buttonElementReact = document.getElementById('test-button-react');
-			const counterElement = document.getElementById('test-counter-jsp');
-			const nameElement = document.getElementById('test-name');
-
-			const State = StateModule.State;
-
-			const counterAtom = State.atom('test-counter-jsp', 0);
-
-			State.subscribe(counterAtom, (newVal) => {
-				counterElement.innerText = newVal;
-			});
-
-			State.subscribe(SharedState.userAtom, (event) => {
-				nameElement.innerText = event.name;
-			});
-
-			if (buttonElementJSP) {
-				buttonElementJSP.addEventListener('click', () => {
-					State.write(counterAtom, State.read(counterAtom) + 1);
-				});
-			}
-
-			if (buttonElementReact) {
-				buttonElementReact.addEventListener('click', () => {
-					State.write(
-						SharedState.counterAtomReact,
-						State.read(SharedState.counterAtomReact) + 1
-					);
-				});
-			}
-		</aui:script>
+		<aui:script require="<%= npmResolvedPackageName %>" />
 	</div>
 </div>

--- a/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/content/Language.properties
+++ b/modules/apps/frontend-js/frontend-js-sample-web/src/main/resources/content/Language.properties
@@ -1,0 +1,1 @@
+javax.portlet.title.com_liferay_frontend_js_sample_web_internal_portlet_JavaScriptSamplePortlet=JavaScript Sample


### PR DESCRIPTION
Continuation of https://github.com/liferay-frontend/liferay-portal/pull/1099

@john-co I've fixed the problem you had. I thought we could use `<aui:script require="..." />` without version numbers and it was failing. But it turned out that it was a limitation we imposed long ago to avoid making the architecture more complex and force people to put JS code inside .js files instead of .jsp ones.

I'm sending this to `liferay-frontend` user so that the review of the [original PR](https://github.com/liferay-frontend/liferay-portal/pull/1099) may continue.