### PR TITLE
LPS-138477 Ignore usages of A.Modal

### DIFF
--- a/modules/.eslintrc.js
+++ b/modules/.eslintrc.js
@@ -25,7 +25,7 @@ try {
 }
 catch (error) {
 	throw new Error(
-		'@liferay/npm-scripts is not installed; please run "ant setup-sdk"'
+		'@liferay/npm-scripts is not installed; please run "ant setup-sdk"',
 	);
 }
 
@@ -36,6 +36,17 @@ config = {
 		MODULE_PATH: true,
 	},
 	rules: {
+		'@liferay/aui/no-all': 'off',
+		'@liferay/aui/no-array': 'off',
+		'@liferay/aui/no-each': 'off',
+		'@liferay/aui/no-get-body': 'off',
+		'@liferay/aui/no-io': 'off',
+		'@liferay/aui/no-merge': 'off',
+		'@liferay/aui/no-modal': 'off',
+		'@liferay/aui/no-node': 'off',
+		'@liferay/aui/no-object': 'off',
+		'@liferay/aui/no-one': 'off',
+		'@liferay/empty-line-between-elements': 'off',
 		'no-empty': ['error', {allowEmptyCatch: true}],
 		'notice/notice': [
 			'error',

--- a/modules/.eslintrc.js
+++ b/modules/.eslintrc.js
@@ -25,7 +25,7 @@ try {
 }
 catch (error) {
 	throw new Error(
-		'@liferay/npm-scripts is not installed; please run "ant setup-sdk"',
+		'@liferay/npm-scripts is not installed; please run "ant setup-sdk"'
 	);
 }
 

--- a/modules/apps/commerce/commerce-frontend-js/dev/fakeServerUtilities.js
+++ b/modules/apps/commerce/commerce-frontend-js/dev/fakeServerUtilities.js
@@ -58,7 +58,7 @@ function defineServerResponses(app) {
 						},
 					],
 					id: 'asd',
-					// eslint-disable-next-line @liferay/liferay/no-abbreviations
+					// eslint-disable-next-line @liferay/no-abbreviations
 					img: {
 						src: '//via.placeholder.com/250x250',
 					},
@@ -114,7 +114,7 @@ function defineServerResponses(app) {
 								},
 							],
 							id: '111',
-							// eslint-disable-next-line @liferay/liferay/no-abbreviations
+							// eslint-disable-next-line @liferay/no-abbreviations
 							img: {
 								src: '//via.placeholder.com/250x250',
 							},
@@ -165,7 +165,7 @@ function defineServerResponses(app) {
 								},
 							],
 							id: '112',
-							// eslint-disable-next-line @liferay/liferay/no-abbreviations
+							// eslint-disable-next-line @liferay/no-abbreviations
 							img: {
 								src: '//via.placeholder.com/250x250',
 							},
@@ -180,7 +180,7 @@ function defineServerResponses(app) {
 						},
 						{
 							id: '113',
-							// eslint-disable-next-line @liferay/liferay/no-abbreviations
+							// eslint-disable-next-line @liferay/no-abbreviations
 							img: {
 								src: '//via.placeholder.com/250x250',
 							},
@@ -195,7 +195,7 @@ function defineServerResponses(app) {
 						},
 						{
 							id: '114',
-							// eslint-disable-next-line @liferay/liferay/no-abbreviations
+							// eslint-disable-next-line @liferay/no-abbreviations
 							img: {
 								src: '//via.placeholder.com/250x250',
 							},
@@ -248,7 +248,7 @@ function defineServerResponses(app) {
 						},
 					],
 					id: 'sdf',
-					// eslint-disable-next-line @liferay/liferay/no-abbreviations
+					// eslint-disable-next-line @liferay/no-abbreviations
 					img: {
 						src: '//via.placeholder.com/500x500',
 					},

--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/item_finder/AddOrCreate.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/item_finder/AddOrCreate.js
@@ -134,7 +134,7 @@ class AddOrCreateBase extends Component {
 				</div>
 				{this.props.active &&
 					(this.props.inputSearchValue ||
-						(this.props.items && this.props.items.length)) && (
+						(this.props.items && !!this.props.items.length)) && (
 						<div className="card-body">
 							<ClayList>
 								{this.props.itemCreation &&
@@ -147,7 +147,7 @@ class AddOrCreateBase extends Component {
 												className={classNames(
 													'py-3',
 													this.props.items &&
-														this.props.items
+														!!this.props.items
 															.length &&
 														'border-bottom mb-3'
 												)}
@@ -189,7 +189,7 @@ class AddOrCreateBase extends Component {
 										</ClayList.Header>
 									)}
 							</ClayList>
-							{this.props.items && this.props.items.length ? (
+							{this.props.items && !!this.props.items.length ? (
 								<>
 									{this.props.itemCreation && (
 										<ClayList.Header className="px-0">

--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/mini_compare/MiniCompare.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/mini_compare/MiniCompare.js
@@ -119,7 +119,10 @@ function MiniCompare(props) {
 	return (
 		<ClayIconSpriteContext.Provider value={props.spritemap}>
 			<div
-				className={classnames('mini-compare', items.length && 'active')}
+				className={classnames(
+					'mini-compare',
+					!!items.length && 'active'
+				)}
 			>
 				{Array(props.itemsLimit)
 					.fill(null)

--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-impl/.eslintrc.js
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-impl/.eslintrc.js
@@ -13,5 +13,6 @@
  */
 
 module.exports = {
-	extends: ['@liferay/eslint-config/metal'],
+	extends: ['plugin:@liferay/metal'],
+	plugins: ['@liferay'],
 };

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
@@ -318,7 +318,7 @@ export default function AuditBarChart({namespace, rtl, vocabularies}) {
 							cursor={{fill: 'transparent'}}
 							tooltip={tooltip}
 						/>
-						{bars.length &&
+						{!!bars.length &&
 							bars.map((bar, index) => {
 								return (
 									<Bar

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/plugins/fields-sidebar/components/FieldsSidebarSettingsBody.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/plugins/fields-sidebar/components/FieldsSidebarSettingsBody.js
@@ -41,7 +41,7 @@ const getColumn = ({objectFields}) => ({children, column, index}) => {
 				// Avoid using repeatable and searchable fields when object storage type is selected
 
 				if (
-					objectFields.length &&
+					!!objectFields.length &&
 					(fieldName === 'repeatable' || fieldName === 'indexType')
 				) {
 					return <React.Fragment key={index} />;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/.eslintrc.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/.eslintrc.js
@@ -13,5 +13,6 @@
  */
 
 module.exports = {
-	extends: ['@liferay/eslint-config/metal'],
+	extends: ['plugin:@liferay/metal'],
+	plugins: ['@liferay'],
 };

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/share-form/Email.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/share-form/Email.es.js
@@ -95,7 +95,7 @@ const Email = ({
 										}
 
 										if (
-											newItems.length &&
+											!!newItems.length &&
 											isEmailAddressValid(
 												newItems[newItems.length - 1]
 													?.label

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/main.js
@@ -193,7 +193,7 @@ AUI.add(
 					value: {
 						strings: {
 							asc: Liferay.Language.get('ascending'),
-							// eslint-disable-next-line @liferay/liferay/no-abbreviations
+							// eslint-disable-next-line @liferay/no-abbreviations
 							desc: Liferay.Language.get('descending'),
 							propertyName: Liferay.Language.get('property-name'),
 							reverseSortBy: Lang.sub(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -163,7 +163,7 @@
 
 			const filter = new CKEDITOR.htmlParser.filter({
 				elements: {
-					// eslint-disable-next-line @liferay/liferay/no-abbreviations
+					// eslint-disable-next-line @liferay/no-abbreviations
 					img(element) {
 						if (image.src === instance._tempImage.src) {
 							element.attributes.src = image.src;
@@ -420,7 +420,7 @@
 
 							editor.fire('imageUploaded', {
 								editor,
-								// eslint-disable-next-line @liferay/liferay/no-abbreviations
+								// eslint-disable-next-line @liferay/no-abbreviations
 								el: image,
 								fileEntryId: data.file.fileEntryId,
 								uploadImageReturnType: '',

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/bbcode_data_processor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/bbcode_data_processor.js
@@ -34,7 +34,7 @@
 		em: '_handleEm',
 		font: '_handleFont',
 		i: '_handleEm',
-		// eslint-disable-next-line @liferay/liferay/no-abbreviations
+		// eslint-disable-next-line @liferay/no-abbreviations
 		img: '_handleImage',
 		li: '_handleListItem',
 		ol: '_handleOrderedList',

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/bbcode_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/bbcode_parser.js
@@ -86,7 +86,7 @@
 		color: 1,
 		font: 1,
 		i: 1,
-		// eslint-disable-next-line @liferay/liferay/no-abbreviations
+		// eslint-disable-next-line @liferay/no-abbreviations
 		img: 1,
 		s: 1,
 		size: 1,
@@ -343,7 +343,7 @@
 		email: '_handleEmail',
 		font: '_handleFont',
 		i: '_handleEm',
-		// eslint-disable-next-line @liferay/liferay/no-abbreviations
+		// eslint-disable-next-line @liferay/no-abbreviations
 		img: '_handleImage',
 		justify: '_handleTextAlign',
 		left: '_handleTextAlign',

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/converter.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/converter.js
@@ -42,7 +42,7 @@
 		email: '_handleEmail',
 		font: '_handleFont',
 		i: '_handleEm',
-		// eslint-disable-next-line @liferay/liferay/no-abbreviations
+		// eslint-disable-next-line @liferay/no-abbreviations
 		img: '_handleImage',
 		justify: '_handleTextAlign',
 		left: '_handleTextAlign',

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/parser.js
@@ -45,7 +45,7 @@
 		color: 1,
 		font: 1,
 		i: 1,
-		// eslint-disable-next-line @liferay/liferay/no-abbreviations
+		// eslint-disable-next-line @liferay/no-abbreviations
 		img: 1,
 		s: 1,
 		size: 1,

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
@@ -288,7 +288,7 @@
 			},
 
 			hr: {regex: /(^|\n)\s*----\s*(\n|$)/, tag: 'hr'},
-			// eslint-disable-next-line @liferay/liferay/no-abbreviations
+			// eslint-disable-next-line @liferay/no-abbreviations
 			img: {
 				build(node, r, options) {
 					var imagePath = r[1];

--- a/modules/apps/frontend-js/frontend-js-a11y-web/test/js/A11yChecker.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/test/js/A11yChecker.ts
@@ -51,6 +51,7 @@ let scheduler: Scheduler<string>;
  * time, pause... we assume control the browser APIs and decide when to call
  * them to simulate situations.
  */
+
 describe('A11yChecker', () => {
 	function installMockBrowserRuntime() {
 		let hasPendingCallback = false;
@@ -71,7 +72,7 @@ describe('A11yChecker', () => {
 		// A simplified mock for requestIdleCallback, this does not implement a queuing
 		// system but only simulates scheduling.
 
-		window.requestIdleCallback = (callbackFn: () => Promise<void>) => {
+		const customRequestIdleCallback = (callbackFn: () => Promise<void>) => {
 			if (hasPendingCallback) {
 				throw Error('Callback already scheduled');
 			}
@@ -81,6 +82,8 @@ describe('A11yChecker', () => {
 			callback = callbackFn;
 			hasPendingCallback = true;
 		};
+
+		window.requestIdleCallback = customRequestIdleCallback as any;
 
 		window.cancelIdleCallback = () => {
 			log('Cancel Callback');

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/preview.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/preview.js
@@ -73,6 +73,7 @@ AUI.add(
 		var Preview = A.Component.create({
 			ATTRS: {
 				actionContent: {
+					// eslint-disable-next-line @liferay/aui/no-one
 					setter: A.one,
 				},
 				activeThumb: {
@@ -86,9 +87,11 @@ AUI.add(
 					value: 0,
 				},
 				currentPreviewImage: {
+					// eslint-disable-next-line @liferay/aui/no-one
 					setter: A.one,
 				},
 				imageListContent: {
+					// eslint-disable-next-line @liferay/aui/no-one
 					setter: A.one,
 				},
 				maxIndex: {
@@ -96,9 +99,11 @@ AUI.add(
 					value: 0,
 				},
 				previewFileIndexNode: {
+					// eslint-disable-next-line @liferay/aui/no-one
 					setter: A.one,
 				},
 				toolbar: {
+					// eslint-disable-next-line @liferay/aui/no-one
 					setter: A.one,
 				},
 			},
@@ -122,6 +127,7 @@ AUI.add(
 					var loadingCountNode = instance._loadingCountNode;
 
 					if (!loadingCountNode) {
+						// eslint-disable-next-line @liferay/aui/no-node
 						loadingCountNode = A.Node.create(TPL_LOADING_COUNT);
 
 						instance._loadingCountNode = loadingCountNode;
@@ -136,6 +142,7 @@ AUI.add(
 					var loadingIndicator = instance._loadingIndicator;
 
 					if (!loadingIndicator) {
+						// eslint-disable-next-line @liferay/aui/no-node
 						loadingIndicator = A.Node.create(
 							A.Lang.sub(TPL_LOADING_INDICATOR, [
 								Liferay.Language.get('loading'),
@@ -157,13 +164,14 @@ AUI.add(
 				},
 
 				_getMaxOverlay() {
+					alert('_getMaxOverlay');
 					var instance = this;
 
 					var maxOverlay = instance._maxOverlay;
 
 					if (!maxOverlay) {
 						var maxOverlayMask = instance._getMaxOverlayMask();
-
+						// eslint-disable-next-line @liferay/aui/no-modal
 						maxOverlay = new A.Modal({
 							after: {
 								render() {
@@ -216,9 +224,12 @@ AUI.add(
 					var maxPreviewControls = instance._maxPreviewControls;
 
 					if (!maxPreviewControls) {
+						// eslint-disable-next-line @liferay/aui/no-node
 						var arrowLeft = A.Node.create(TPL_MAX_ARROW_LEFT);
+						// eslint-disable-next-line @liferay/aui/no-node
 						var arrowRight = A.Node.create(TPL_MAX_ARROW_RIGHT);
 
+						// eslint-disable-next-line @liferay/aui/no-node
 						maxPreviewControls = A.Node.create(TPL_MAX_CONTROLS);
 
 						maxPreviewControls.append(arrowLeft);

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -93,9 +93,9 @@ AUI.add(
 					},
 				},
 			},
-
+			// eslint-disable-next-line @liferay/aui/no-modal
 			EXTENDS: A.Modal,
-
+			// eslint-disable-next-line @liferay/aui/no-modal
 			NAME: A.Modal.NAME,
 
 			prototype: {},

--- a/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/State.d.ts
+++ b/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/State.d.ts
@@ -76,15 +76,15 @@ declare const State: {
 		atomOrSelector: Atom<unknown> | Selector<unknown>,
 		invalidated: Array<Selector<unknown>>
 	): void;
-	_notify<T_1>(callback: (value: T_1) => void, value: T_1): void;
-	_readSelector<T_2>(
+	_notify<T>(callback: (value: T) => void, value: T): void;
+	_readSelector<T_1>(
 		selector: {
-			readonly deriveValue: (get: Getter) => T_2;
+			readonly deriveValue: (get: Getter) => T_1;
 			readonly key: string;
 			readonly 'Liferay.State.SELECTOR': true;
 		},
 		seen: Set<Selector<unknown>>
-	): Immutable<T_2>;
+	): Immutable<T_1>;
 
 	/**
 	 * Register a unit of shared state called an "atom". Atoms have a unique
@@ -100,11 +100,11 @@ declare const State: {
 	 * - Subscribe to be notified of changes with `subscribe()`.
 	 * - In React components, the `useLiferayState()` hook does all the above.
 	 */
-	atom<T_3>(
+	atom<T_2>(
 		key: string,
-		value: T_3
+		value: T_2
 	): {
-		readonly default: Immutable<T_3>;
+		readonly default: Immutable<T_2>;
 		readonly key: string;
 		readonly 'Liferay.State.ATOM': true;
 	};
@@ -114,37 +114,37 @@ declare const State: {
 	 *
 	 * This is a convenience wrapper around `readAtom()` and `readSelector()`.
 	 */
-	read<T_4>(
+	read<T_3>(
 		atomOrSelector:
 			| {
-					readonly default: Immutable<T_4>;
+					readonly default: Immutable<T_3>;
 					readonly key: string;
 					readonly 'Liferay.State.ATOM': true;
 			  }
 			| {
-					readonly deriveValue: (get: Getter) => T_4;
+					readonly deriveValue: (get: Getter) => T_3;
 					readonly key: string;
 					readonly 'Liferay.State.SELECTOR': true;
 			  }
-	): Immutable<T_4>;
+	): Immutable<T_3>;
 
 	/**
 	 * Read the current value associated with the provided atom.
 	 */
-	readAtom<T_5>(atom: {
-		readonly default: Immutable<T_5>;
+	readAtom<T_4>(atom: {
+		readonly default: Immutable<T_4>;
 		readonly key: string;
 		readonly 'Liferay.State.ATOM': true;
-	}): Immutable<T_5>;
+	}): Immutable<T_4>;
 
 	/**
 	 * Read the current value associated with the provided selector.
 	 */
-	readSelector<T_6>(selector: {
-		readonly deriveValue: (get: Getter) => T_6;
+	readSelector<T_5>(selector: {
+		readonly deriveValue: (get: Getter) => T_5;
 		readonly key: string;
 		readonly 'Liferay.State.SELECTOR': true;
-	}): Immutable<T_6>;
+	}): Immutable<T_5>;
 
 	/**
 	 * Register a shared unit of derived state called a "selector", identified
@@ -165,12 +165,12 @@ declare const State: {
 	 * instead, you update them by changing their upstream atoms, which causes
 	 * the affected selectors to re-derive their updated values.
 	 */
-	selector<T_7>(
+	selector<T_6>(
 		key: string,
-		deriveValue: (get: Getter) => T_7
+		deriveValue: (get: Getter) => T_6
 	): {
 		readonly 'Liferay.State.SELECTOR': true;
-		readonly deriveValue: (get: Getter) => T_7;
+		readonly deriveValue: (get: Getter) => T_6;
 		readonly key: string;
 	};
 
@@ -185,19 +185,19 @@ declare const State: {
 	 * used to observe and trigger state changes in a way that is analagous to
 	 * the built-in `useState()` hook.
 	 */
-	subscribe<T_8 extends unknown>(
+	subscribe<T_7 extends unknown>(
 		atomOrSelector:
 			| {
-					readonly default: Immutable<T_8>;
+					readonly default: Immutable<T_7>;
 					readonly key: string;
 					readonly 'Liferay.State.ATOM': true;
 			  }
 			| {
-					readonly deriveValue: (get: Getter) => T_8;
+					readonly deriveValue: (get: Getter) => T_7;
 					readonly key: string;
 					readonly 'Liferay.State.SELECTOR': true;
 			  },
-		callback: (value: Immutable<T_8>) => void
+		callback: (value: Immutable<T_7>) => void
 	): {
 		dispose: () => void;
 	};
@@ -212,19 +212,19 @@ declare const State: {
 	 * direct update to a selector (instead, the upstream atoms that it depends
 	 * on should be updated).
 	 */
-	write<T_9>(
+	write<T_8>(
 		atomOrSelector:
 			| {
-					readonly default: Immutable<T_9>;
+					readonly default: Immutable<T_8>;
 					readonly key: string;
 					readonly 'Liferay.State.ATOM': true;
 			  }
 			| {
-					readonly deriveValue: (get: Getter) => T_9;
+					readonly deriveValue: (get: Getter) => T_8;
 					readonly key: string;
 					readonly 'Liferay.State.SELECTOR': true;
 			  },
-		value: T_9
+		value: T_8
 	): void;
 
 	/**
@@ -232,13 +232,13 @@ declare const State: {
 	 * downstream subscribers (of the atom itself, or selectors that depend on
 	 * it).
 	 */
-	writeAtom<T_10>(
+	writeAtom<T_9>(
 		atom: {
-			readonly default: Immutable<T_10>;
+			readonly default: Immutable<T_9>;
 			readonly key: string;
 			readonly 'Liferay.State.ATOM': true;
 		},
-		value: T_10
+		value: T_9
 	): void;
 };
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -523,7 +523,7 @@
 					var handle = portlet.on(events, () => {
 						Util.portletTitleEdit({
 							doAsUserId: themeDisplay.getDoAsUserIdEncoded(),
-							// eslint-disable-next-line @liferay/liferay/no-abbreviations
+							// eslint-disable-next-line @liferay/no-abbreviations
 							obj: portlet,
 							plid: themeDisplay.getPlid(),
 							portletId,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/TooltipSummaryRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/TooltipSummaryRenderer.js
@@ -83,7 +83,7 @@ function TooltipSummaryRenderer({itemData, options, value}) {
 	return (
 		<>
 			{value}
-			{tooltipTableRows.length && (
+			{!!tooltipTableRows.length && (
 				<span
 					className="tooltip-provider"
 					data-title-set-as-html

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/AutocompleteFilter.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/management_bar/components/filters/AutocompleteFilter.js
@@ -284,7 +284,7 @@ function AutocompleteFilter({
 			<ClayDropDown.Divider />
 			<ClayDropDown.Caption>
 				<div className="form-group">
-					{items && items.length ? (
+					{items && !!items.length ? (
 						<ul
 							className="inline-scroller mb-n2 mx-n2 px-2"
 							ref={setScrollingArea}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableHead.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/TableHead.js
@@ -51,7 +51,7 @@ function TableHead({
 						columnName="item-selector"
 						heading
 					>
-						{items.length && selectionType === 'multiple' ? (
+						{!!items.length && selectionType === 'multiple' ? (
 							<ClayCheckbox
 								checked={!!selectedItemsValue.length}
 								indeterminate={

--- a/modules/apps/frontend-theme/frontend-theme-admin/.eslintrc.js
+++ b/modules/apps/frontend-theme/frontend-theme-admin/.eslintrc.js
@@ -14,7 +14,7 @@
 
 module.exports = {
 	rules: {
-		'@liferay/liferay/no-arrow': 'error',
+		'@liferay/no-arrow': 'error',
 		'prefer-arrow-callback': 'off',
 	},
 };

--- a/modules/apps/frontend-theme/frontend-theme-classic/.eslintrc.js
+++ b/modules/apps/frontend-theme/frontend-theme-classic/.eslintrc.js
@@ -14,7 +14,7 @@
 
 module.exports = {
 	rules: {
-		'@liferay/liferay/no-arrow': 'error',
+		'@liferay/no-arrow': 'error',
 		'prefer-arrow-callback': 'off',
 	},
 };

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/.eslintrc.js
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/.eslintrc.js
@@ -14,7 +14,7 @@
 
 module.exports = {
 	rules: {
-		'@liferay/liferay/no-arrow': 'error',
+		'@liferay/no-arrow': 'error',
 		'prefer-arrow-callback': 'off',
 	},
 };

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/LinkField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/LinkField.js
@@ -167,7 +167,7 @@ export default function LinkField({field, onValueSelect, value}) {
 				<LayoutSelector
 					mappedLayout={nextValue?.layout}
 					onLayoutSelect={(layout) => {
-						if (layout && Object.keys(layout).length) {
+						if (layout && !!Object.keys(layout).length) {
 							handleChange({layout});
 						}
 						else {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
@@ -459,12 +459,12 @@ function MappingFieldSelect({fieldType, fields, onValueSelect, value}) {
 
 			<ClaySelect
 				aria-label={Liferay.Language.get('field')}
-				disabled={!(fields && fields.length)}
+				disabled={!(fields && !!fields.length)}
 				id={mappingSelectorFieldSelectId}
 				onChange={onValueSelect}
 				value={value}
 			>
-				{fields && fields.length && (
+				{fields && !!fields.length && (
 					<>
 						<ClaySelect.Option
 							label={UNMAPPED_OPTION.label}

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/layout/layout-screen/AddNewTabButton.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/layout/layout-screen/AddNewTabButton.d.ts
@@ -12,7 +12,5 @@
  * details.
  */
 
-/// <reference types="react" />
-
 declare const AddNewTabButton: () => JSX.Element;
 export default AddNewTabButton;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/layout/layout-screen/AddNewTabButton.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/layout/layout-screen/AddNewTabButton.d.ts
@@ -12,5 +12,7 @@
  * details.
  */
 
+/// <reference types="react" />
+
 declare const AddNewTabButton: () => JSX.Element;
 export default AddNewTabButton;

--- a/modules/apps/portal-search/portal-search-web/test/setup.js
+++ b/modules/apps/portal-search/portal-search-web/test/setup.js
@@ -58,7 +58,7 @@ beforeEach(() => {
 		'..'
 	);
 
-	// eslint-disable-next-line @liferay/liferay/no-dynamic-require
+	// eslint-disable-next-line @liferay/no-dynamic-require
 	walk(build, (source) => require(source));
 
 	global.Liferay = {

--- a/modules/apps/portal-workflow/portal-workflow-instance-tracker-web/src/main/resources/META-INF/resources/js/components/WorkflowInstanceTracker.js
+++ b/modules/apps/portal-workflow/portal-workflow-instance-tracker-web/src/main/resources/META-INF/resources/js/components/WorkflowInstanceTracker.js
@@ -137,7 +137,7 @@ export default function WorkflowInstanceTracker({workflowInstanceId}) {
 
 	return (
 		<div className="workflow-instance-tracker">
-			{layoutedElements.length && (
+			{!!layoutedElements.length && (
 				<ReactFlowProvider>
 					<ReactFlow
 						edgeTypes={edgeTypes}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionRow.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionRow.es.js
@@ -99,7 +99,7 @@ export default ({currentSection, items, question, showSectionLabel}) => {
 						/>
 					</li>
 
-					{items && items.length && (
+					{items && !!items.length && (
 						<li>
 							<ClayDropDownWithItems
 								className="c-py-1"

--- a/modules/apps/remote-app/remote-app-client-js/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/remote-app/remote-app-client-js/src/main/resources/META-INF/resources/js/index.ts
@@ -370,8 +370,8 @@ function serializeRequestInfo(resource: RequestInfo): StructuredClonable {
 	serialized.credentials = resource.credentials;
 	serialized.destination = resource.destination;
 	serialized.integrity = resource.integrity;
-	serialized.isHistoryNavigation = resource.isHistoryNavigation;
-	serialized.isReloadNavigation = resource.isReloadNavigation;
+	serialized.isHistoryNavigation = (resource as any).isHistoryNavigation;
+	serialized.isReloadNavigation = (resource as any).isReloadNavigation;
 	serialized.keepalive = resource.keepalive;
 	serialized.method = resource.method;
 	serialized.mode = resource.mode;

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/.eslintrc.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/.eslintrc.js
@@ -16,16 +16,17 @@ let config = {};
 
 try {
 	config = require('@liferay/npm-scripts/src/config/eslint.config');
-} catch (error) {
+}
+catch (error) {
 	throw new Error(
-		'@liferay/npm-scripts is not installed; please run "ant setup-sdk"'
+		'@liferay/npm-scripts is not installed; please run "ant setup-sdk"',
 	);
 }
 
 module.exports = {
 	...config,
 	rules: {
-		'@liferay/liferay/group-imports': 'off',
+		'@liferay/group-imports': 'off',
 		'@liferay/portal/no-loader-import-specifier': 'off',
 		'@liferay/portal/no-react-dom-render': 'off',
 		'no-case-declarations': 'off',

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Basics/BusinessInformation/Address.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Basics/BusinessInformation/Address.js
@@ -53,11 +53,13 @@ export const BusinessInformationAddress = () => {
 					name={setFormPath('address')}
 					rules={{required: 'Business address is required.'}}
 				/>
+
 				<Input
 					{...register(setFormPath('addressApt'))}
 					label="&nbsp;"
 					placeholder="Apt/Suite (optional)"
 				/>
+
 				<div
 					className="content-row"
 					style={{
@@ -81,6 +83,7 @@ export const BusinessInformationAddress = () => {
 						}}
 					/>
 				</div>
+
 				<div className="content-row">
 					<ZIPControlledInput
 						control={control}

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Basics/BusinessInformation/index.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Basics/BusinessInformation/index.js
@@ -75,6 +75,7 @@ export const FormBasicBusinessInformation = ({form}) => {
 							required: 'First name is required.',
 						}}
 					/>
+
 					<ControlledInput
 						control={control}
 						inputProps={{
@@ -87,6 +88,7 @@ export const FormBasicBusinessInformation = ({form}) => {
 						}}
 					/>
 				</div>
+
 				<EmailControlledInput
 					control={control}
 					label="Business Email"
@@ -95,6 +97,7 @@ export const FormBasicBusinessInformation = ({form}) => {
 						required: 'Email is required.',
 					}}
 				/>
+
 				<PhoneControlledInput
 					control={control}
 					label="Phone"
@@ -103,13 +106,16 @@ export const FormBasicBusinessInformation = ({form}) => {
 						required: 'Phone number is required.',
 					}}
 				/>
+
 				<WebsiteControlledInput
 					control={control}
 					label="Business Website (optional)"
 					name={setFormPath('business.website')}
 				/>
+
 				<BusinessInformationAddress />
 			</div>
+
 			<CardFormActionsWithSave
 				isValid={isValid}
 				onNext={onNext}

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Basics/BusinessType/Search.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Basics/BusinessType/Search.js
@@ -169,6 +169,7 @@ export const BusinessTypeSearch = ({form, setNewSelectedProduct}) => {
 						Search
 					</button>
 				</SearchInput>
+
 				<p className="paragraph">
 					i.e. Coffee shop, Plumber, Drop Shipping, Landscape, etc
 				</p>

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Basics/BusinessType/index.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Basics/BusinessType/index.js
@@ -42,6 +42,7 @@ export const FormBasicBusinessType = ({form}) => {
 					setNewSelectedProduct={setNewSelectedProduct}
 				/>
 			</div>
+
 			<CardFormActionsWithSave
 				isValid={!!form?.basics?.businessCategoryId}
 				onNext={goToNextForm}

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Basics/ProductQuote.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Basics/ProductQuote.js
@@ -27,6 +27,7 @@ export const FormBasicProductQuote = ({form}) => {
 			<div className="card-content">
 				<div className="content-column">
 					<label>Select a product to quote.</label>
+
 					<fieldset className="content-column" id="productQuote">
 						<Controller
 							control={control}
@@ -73,6 +74,7 @@ export const FormBasicProductQuote = ({form}) => {
 					</fieldset>
 				</div>
 			</div>
+
 			<CardFormActionsWithSave
 				isValid={!!form.basics.productQuote}
 				onNext={onNext}

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Business.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Business.js
@@ -75,18 +75,21 @@ export const FormBusiness = ({form}) => {
 						required: 'This field is required',
 					}}
 				/>
+
 				<ControlledSwitch
 					control={control}
 					label="Do you store personally identifiable information about your customers?"
 					name={setFormPath('hasStoredCustomerInformation')}
 					rules={{required: true}}
 				/>
+
 				<ControlledSwitch
 					control={control}
 					label="Do you have a Raylife Auto policy?"
 					name={setFormPath('hasAutoPolicy')}
 					rules={{required: true}}
 				/>
+
 				<LegalEntityControlledSelect
 					control={control}
 					label="Legal Entity"
@@ -147,6 +150,7 @@ export const FormBusiness = ({form}) => {
 					/>
 				)}
 			</div>
+
 			<CardFormActionsWithSave
 				isValid={isValid}
 				onNext={onNext}

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Employees.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Employees.js
@@ -66,6 +66,7 @@ export const FormEmployees = ({form}) => {
 					name={setFormPath('hasFein')}
 					rules={{required: true}}
 				/>
+
 				<FEINControlledInput
 					control={control}
 					label="Federal Employer Identification Number (FEIN)"
@@ -87,18 +88,21 @@ export const FormEmployees = ({form}) => {
 						required: 'FEIN is required.',
 					}}
 				/>
+
 				<YearControlledInput
 					control={control}
 					label="What year did you start your business?"
 					name={setFormPath('startBusinessAtYear')}
 					rules={{required: 'This field is required'}}
 				/>
+
 				<ControlledSwitch
 					control={control}
 					label="Does your business operate year round?"
 					name={setFormPath('businessOperatesYearRound')}
 					rules={{required: true}}
 				/>
+
 				<NumberControlledInput
 					control={control}
 					label="How many full or part time employees do you have?"
@@ -123,18 +127,21 @@ export const FormEmployees = ({form}) => {
 						required: 'This field is required',
 					}}
 				/>
+
 				<CurrencyControlledInput
 					control={control}
 					label="What is your estimated annual gross revenue for the next 12 months?"
 					name={setFormPath('estimatedAnnualGrossRevenue')}
 					rules={{required: 'This field is required'}}
 				/>
+
 				<CurrencyControlledInput
 					control={control}
 					label="What do you anticipate your annual payroll will be for all owner(s) over the next 12 months?"
 					name={setFormPath('annualPayrollForOwner')}
 					rules={{required: 'This field is required'}}
 				/>
+
 				<CurrencyControlledInput
 					control={control}
 					label="What do you anticipate your annual payroll will be for all employees over the next 12 months?"
@@ -142,6 +149,7 @@ export const FormEmployees = ({form}) => {
 					rules={{required: 'This field is required'}}
 				/>
 			</div>
+
 			<CardFormActionsWithSave
 				isValid={isValid}
 				onNext={onNext}

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Property.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Forms/Property.js
@@ -54,6 +54,7 @@ export const FormProperty = ({form}) => {
 					name={setFormPath('doOwnBuildingAtAddress')}
 					rules={{required: true}}
 				/>
+
 				<NumberControlledInput
 					control={control}
 					label="How many stories is this building?"
@@ -66,6 +67,7 @@ export const FormProperty = ({form}) => {
 						required: 'This field is required',
 					}}
 				/>
+
 				<SquareFeatControlledInput
 					control={control}
 					label="How many square feet of the building does your business occupy?"
@@ -92,6 +94,7 @@ export const FormProperty = ({form}) => {
 						required: 'This field is required',
 					}}
 				/>
+
 				<SquareFeatControlledInput
 					control={control}
 					label="How many total square feet is the building?"
@@ -100,6 +103,7 @@ export const FormProperty = ({form}) => {
 						required: 'This field is required',
 					}}
 				/>
+
 				<YearControlledInput
 					control={control}
 					label="What year was the building constructed?"
@@ -120,6 +124,7 @@ export const FormProperty = ({form}) => {
 						required: 'This field is required',
 					}}
 				/>
+
 				<ControlledSwitch
 					control={control}
 					label="Is this the primary location where you conduct business?"
@@ -179,6 +184,7 @@ export const FormProperty = ({form}) => {
 					/>
 				)}
 			</div>
+
 			<CardFormActionsWithSave
 				isValid={isValid}
 				onNext={onNext}

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Steps.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/components/containers/Steps.js
@@ -27,6 +27,7 @@ export const Steps = () => {
 			>
 				Basics
 			</StepItem>
+
 			<StepItem
 				onClick={() => setSection(AVAILABLE_STEPS.BUSINESS)}
 				percentage={
@@ -38,6 +39,7 @@ export const Steps = () => {
 			>
 				Business
 			</StepItem>
+
 			<StepItem
 				onClick={() => setSection(AVAILABLE_STEPS.EMPLOYEES)}
 				percentage={
@@ -49,6 +51,7 @@ export const Steps = () => {
 			>
 				Employees
 			</StepItem>
+
 			<StepItem
 				onClick={() => setSection(AVAILABLE_STEPS.PROPERTY)}
 				percentage={

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/pages/GetAQuote.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/get-a-quote/pages/GetAQuote.js
@@ -37,12 +37,15 @@ const QuoteApp = () => {
 	return (
 		<div className="form-area">
 			<Steps />
+
 			<div>
 				<h2 className="title title-area">
 					<FormTitle />
 				</h2>
+
 				<Forms form={form} />
 			</div>
+
 			<div className="info-area"></div>
 		</div>
 	);
@@ -51,6 +54,7 @@ const QuoteApp = () => {
 const GetAQuote = () => (
 	<Providers>
 		<style>{Style}</style>
+
 		<QuoteApp />
 	</Providers>
 );

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/quote-comparison/components/product-comparison/index.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/apps/quote-comparison/components/product-comparison/index.js
@@ -84,17 +84,21 @@ const ProductComparison = ({
 		<div className="quote-content">
 			<div className="quote-header">
 				<div className="title">{category}</div>
+
 				<div className="value">
 					&#36;{price}
 					<div>/yr</div>
 				</div>
+
 				<div className="subtitle">
 					Get covered for <span>&#36;{promo} today</span>
 				</div>
 			</div>
+
 			<div className="quote-body">
 				<ListItems {...otherValues} />
 			</div>
+
 			<div className="quote-footer">
 				<div className="d-flex justify-content-center">
 					<button
@@ -108,6 +112,7 @@ const ProductComparison = ({
 						PURCHASE THIS POLICY
 					</button>
 				</div>
+
 				<div className="d-flex justify-content-center">
 					<button id="details" type="button">
 						Policy Details

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/shared/components/fragments/Forms/Radio.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/shared/components/fragments/Forms/Radio.js
@@ -35,6 +35,7 @@ export const Radio = ({
 			type="radio"
 			value={value}
 		/>
+
 		<div className="content">
 			<div className="content-header">
 				<label htmlFor={name}>
@@ -43,6 +44,7 @@ export const Radio = ({
 				</label>
 				{renderActions}
 			</div>
+
 			<p>{description}</p>
 		</div>
 	</div>

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/shared/components/fragments/Forms/Select.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/shared/components/fragments/Forms/Select.js
@@ -25,6 +25,7 @@ export const Select = React.forwardRef(
 					</Label>
 				)}
 				<ClayIcon className="select-icon" symbol="caret-bottom" />
+
 				<select
 					{...props}
 					className="input"

--- a/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/shared/components/fragments/Forms/Switch.js
+++ b/modules/apps/site-initializer/site-initializer-raylife/extra/direct-to-customer/src/shared/components/fragments/Forms/Switch.js
@@ -34,6 +34,7 @@ export const Switch = React.forwardRef(
 					>
 						Yes
 					</button>
+
 					<button
 						className={`btn switch ${
 							value === 'false' && 'selected'
@@ -44,6 +45,7 @@ export const Switch = React.forwardRef(
 						No
 					</button>
 				</div>
+
 				<input
 					{...props}
 					className="hidden"

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -260,7 +260,7 @@ export default function Chart({
 
 	return (
 		<>
-			{timeSpanOptions.length && (
+			{!!timeSpanOptions.length && (
 				<div className="c-mb-3 c-mt-4">
 					<TimeSpanSelector
 						disabledNextTimeSpan={timeSpanOffset === 0}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -275,7 +275,12 @@ function TrafficSourcesCustomTooltip(props) {
 	return (
 		<div className="custom-tooltip">
 			<p className="mb-1 mt-0">
-				<b>{payload.length && payload[0].payload.title}</b>
+				<b>
+				{
+					// eslint-disable-next-line @liferay/no-length-jsx-expression
+					payload.length && payload[0].payload.title
+				}
+				</b>
 			</p>
 
 			<ul className="list-unstyled mb-0">

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -276,10 +276,10 @@ function TrafficSourcesCustomTooltip(props) {
 		<div className="custom-tooltip">
 			<p className="mb-1 mt-0">
 				<b>
-				{
-					// eslint-disable-next-line @liferay/no-length-jsx-expression
-					payload.length && payload[0].payload.title
-				}
+					{
+						// eslint-disable-next-line @liferay/no-length-jsx-expression
+						payload.length && payload[0].payload.title
+					}
 				</b>
 			</p>
 

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddAccountsModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddAccountsModal.js
@@ -222,7 +222,7 @@ export default function AddOrganizationModal({
 
 				{newAccountMode ? (
 					<ClayForm.Group
-						className={classNames(errors.length && 'has-error')}
+						className={classNames(!!errors.length && 'has-error')}
 					>
 						<label htmlFor="newAccountNameInput">
 							{Liferay.Language.get('name')}
@@ -240,7 +240,7 @@ export default function AddOrganizationModal({
 					</ClayForm.Group>
 				) : (
 					<ClayForm.Group
-						className={classNames(errors.length && 'has-error')}
+						className={classNames(!!errors.length && 'has-error')}
 					>
 						<label htmlFor="searchAccountInput">
 							{Liferay.Language.get('search-account')}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddOrganizationsModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddOrganizationsModal.js
@@ -115,7 +115,7 @@ export default function AddOrganizationModal({
 
 			<ClayModal.Body>
 				<ClayForm.Group
-					className={classNames(errors.length && 'has-error')}
+					className={classNames(!!errors.length && 'has-error')}
 				>
 					<label htmlFor="addNewOrganization">
 						{Liferay.Language.get('name') + ' '}

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/InviteUsersModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/InviteUsersModal.js
@@ -101,7 +101,7 @@ export default function InviteUserModal({closeModal, observer, parentData}) {
 
 			<ClayModal.Body>
 				<ClayForm.Group
-					className={classNames(errors.length && 'has-error')}
+					className={classNames(!!errors.length && 'has-error')}
 				>
 					<label htmlFor="inviteUsersEmailInput">
 						{Liferay.Language.get('emails')}
@@ -133,7 +133,7 @@ export default function InviteUserModal({closeModal, observer, parentData}) {
 				</ClayForm.Group>
 
 				<ClayForm.Group
-					className={classNames(errors.length && 'has-error')}
+					className={classNames(!!errors.length && 'has-error')}
 				>
 					<label htmlFor="inviteUsersRoleInput">
 						{Liferay.Language.get('roles')}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/setup.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/setup.js
@@ -55,7 +55,7 @@ beforeEach(() => {
 		'..'
 	);
 
-	// eslint-disable-next-line @liferay/liferay/no-dynamic-require
+	// eslint-disable-next-line @liferay/no-dynamic-require
 	walk(build, (source) => require(source));
 
 	global.Liferay = {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/form-page/hooks/useSLANodes.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/form-page/hooks/useSLANodes.es.js
@@ -26,7 +26,7 @@ const useSLANodes = (processId) => {
 			if (node.type === 'STATE') {
 				const newNode = {
 					...node,
-					// eslint-disable-next-line @liferay/liferay/no-abbreviations
+					// eslint-disable-next-line @liferay/no-abbreviations
 					desc: node.initial
 						? Liferay.Language.get('process-begins')
 						: `${Liferay.Language.get('process-ends')} ${
@@ -45,7 +45,7 @@ const useSLANodes = (processId) => {
 			else if (node.type === 'TASK') {
 				nodeEnters.push({
 					...node,
-					// eslint-disable-next-line @liferay/liferay/no-abbreviations
+					// eslint-disable-next-line @liferay/no-abbreviations
 					desc: `${Liferay.Language.get('enters-task')} ${
 						node.label
 					}`,
@@ -54,7 +54,7 @@ const useSLANodes = (processId) => {
 
 				nodeLeaves.push({
 					...node,
-					// eslint-disable-next-line @liferay/liferay/no-abbreviations
+					// eslint-disable-next-line @liferay/no-abbreviations
 					desc: `${Liferay.Language.get('leaves-task')} ${
 						node.label
 					}`,
@@ -104,7 +104,7 @@ const useSLANodes = (processId) => {
 			.map((node) => ({
 				...node,
 				compositeId: `${node.id}:on`,
-				// eslint-disable-next-line @liferay/liferay/no-abbreviations
+				// eslint-disable-next-line @liferay/no-abbreviations
 				desc: `${onTaskString} ${node.label}`,
 				executionType: 'on',
 			}));

--- a/modules/package.json
+++ b/modules/package.json
@@ -15,7 +15,8 @@
 	},
 	"scripts": {
 		"checkFormat": "liferay-npm-scripts check",
-		"format": "liferay-npm-scripts fix"
+		"format": "liferay-npm-scripts fix",
+		"types": "liferay-npm-scripts types"
 	},
 	"workspaces": {
 		"packages": [

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@liferay/npm-scripts": "46.1.0",
+		"@liferay/npm-scripts": "46.2.0",
 		"acorn": "7.1.0",
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",
@@ -11,7 +11,7 @@
 	},
 	"private": true,
 	"resolutions": {
-		"@liferay/eslint-config": "25.0.1"
+		"@liferay/eslint-plugin": "1.0.0"
 	},
 	"scripts": {
 		"checkFormat": "liferay-npm-scripts check",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1543,13 +1543,13 @@
   resolved "https://registry.yarnpkg.com/@liferay/amd-loader/-/amd-loader-4.3.1.tgz#35cde6128f6e2795b7e45378e8f115f596b6cdda"
   integrity sha512-95i+LRK3gPTiBc75lJsr9OwRNFdzaamSe3B5x+kHLHYr78qS/4WD5mkDJ+WYv3CY0jFFnROTNLl3x6zCRuDMxw==
 
-"@liferay/eslint-config@25.0.1":
-  version "25.0.1"
-  resolved "https://registry.yarnpkg.com/@liferay/eslint-config/-/eslint-config-25.0.1.tgz#b1ce8cdfe9816a76796b3536811239e17e12563d"
-  integrity sha512-8GQdxVAjv/CyKVWmerbCvlGMo96q4eX8LP12MgnXLQLxi+L/fgugCqriL3Mx+LoMsM28rY7OVpVzJAzd5Fvn/A==
+"@liferay/eslint-plugin@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@liferay/eslint-plugin/-/eslint-plugin-1.0.0.tgz#f25e539233d6ad74adf434c2391864e807e5b0b3"
+  integrity sha512-RvpUzzahePrN/l5zVJ6v1irl/q0ZjdYvMxdaw+yiPYO/fHMTnUMG57tnjS2Uohvy1Kz/U6i8o7c4jY+kwYVqyg==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "4.19.0"
-    "@typescript-eslint/parser" "4.19.0"
+    "@typescript-eslint/eslint-plugin" "4.30.0"
+    "@typescript-eslint/parser" "4.30.0"
     eslint-config-prettier "8.1.0"
     eslint-plugin-no-for-of-loops "^1.0.0"
     eslint-plugin-no-only-tests "^2.1.0"
@@ -1613,10 +1613,10 @@
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-"@liferay/npm-scripts@46.1.0":
-  version "46.1.0"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-46.1.0.tgz#5887188f2f0c77b353345feab2d9e3e1a7cb175b"
-  integrity sha512-AFiDQSqVql2Gb1Pl4tKxVtplHXgjpqUuPUXldZe5nEA/0PBs6yYkDYmYWoZs9HZXAvWEJPaR+8ap8+xOPaATzA==
+"@liferay/npm-scripts@46.2.0":
+  version "46.2.0"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-46.2.0.tgz#8225ce69668e8e3f719f19f8e3c684f33ddb3d38"
+  integrity sha512-/WuQdov/BDemWZmKUtTQPI9xof+82Knj2W4GNx97Bc/Gt7z7cQTonPziIv84JI1kGark9U8eVUyDz9lVTetMBw==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"
@@ -1628,7 +1628,7 @@
     "@babel/preset-env" "^7.4.2"
     "@babel/preset-react" "^7.8.3"
     "@babel/preset-typescript" "^7.10.4"
-    "@liferay/eslint-config" "25.0.1"
+    "@liferay/eslint-plugin" "1.0.0"
     "@liferay/jest-junit-reporter" "1.2.0"
     "@liferay/js-toolkit-core" "3.0.1"
     "@testing-library/dom" "^5.6.1"
@@ -1670,7 +1670,7 @@
     liferay-npm-bundler-plugin-namespace-packages "2.24.2"
     liferay-npm-bundler-plugin-replace-browser-modules "2.24.2"
     liferay-npm-bundler-plugin-resolve-linked-dependencies "2.24.2"
-    liferay-theme-tasks "10.5.1"
+    liferay-theme-tasks "10.5.2"
     metal-tools-soy "4.3.2"
     mini-css-extract-plugin "0.11.2"
     minimist "^1.2.0"
@@ -1690,7 +1690,7 @@
     stylelint "^13.2.0"
     terser "5.3.8"
     ts-loader "^8.0.4"
-    typescript "^4.2.3"
+    typescript "4.4.2"
     webpack "^5.11.1"
     webpack-cli "^4.2.0"
     webpack-dev-server "^3.11.0"
@@ -1928,10 +1928,15 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
+"@types/json-schema@*", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
+"@types/json-schema@^7.0.7":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -2092,74 +2097,73 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.19.0.tgz#56f8da9ee118fe9763af34d6a526967234f6a7f0"
-  integrity sha512-CRQNQ0mC2Pa7VLwKFbrGVTArfdVDdefS+gTw0oC98vSI98IX5A8EVH4BzJ2FOB0YlCmm8Im36Elad/Jgtvveaw==
+"@typescript-eslint/eslint-plugin@4.30.0":
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz#4a0c1ae96b953f4e67435e20248d812bfa55e4fb"
+  integrity sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.19.0"
-    "@typescript-eslint/scope-manager" "4.19.0"
-    debug "^4.1.1"
+    "@typescript-eslint/experimental-utils" "4.30.0"
+    "@typescript-eslint/scope-manager" "4.30.0"
+    debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
-    lodash "^4.17.15"
-    regexpp "^3.0.0"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.19.0.tgz#9ca379919906dc72cb0fcd817d6cb5aa2d2054c6"
-  integrity sha512-9/23F1nnyzbHKuoTqFN1iXwN3bvOm/PRIXSBR3qFAYotK/0LveEOHr5JT1WZSzcD6BESl8kPOG3OoDRKO84bHA==
+"@typescript-eslint/experimental-utils@4.30.0":
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz#9e49704fef568432ae16fc0d6685c13d67db0fd5"
+  integrity sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==
   dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.19.0"
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/typescript-estree" "4.19.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.30.0"
+    "@typescript-eslint/types" "4.30.0"
+    "@typescript-eslint/typescript-estree" "4.30.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.19.0.tgz#4ae77513b39f164f1751f21f348d2e6cb2d11128"
-  integrity sha512-/uabZjo2ZZhm66rdAu21HA8nQebl3lAIDcybUoOxoI7VbZBYavLIwtOOmykKCJy+Xq6Vw6ugkiwn8Js7D6wieA==
+"@typescript-eslint/parser@4.30.0":
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.30.0.tgz#6abd720f66bd790f3e0e80c3be77180c8fcb192d"
+  integrity sha512-HJ0XuluSZSxeboLU7Q2VQ6eLlCwXPBOGnA7CqgBnz2Db3JRQYyBDJgQnop6TZ+rsbSx5gEdWhw4rE4mDa1FnZg==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.19.0"
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/typescript-estree" "4.19.0"
-    debug "^4.1.1"
+    "@typescript-eslint/scope-manager" "4.30.0"
+    "@typescript-eslint/types" "4.30.0"
+    "@typescript-eslint/typescript-estree" "4.30.0"
+    debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.19.0.tgz#5e0b49eca4df7684205d957c9856f4e720717a4f"
-  integrity sha512-GGy4Ba/hLXwJXygkXqMzduqOMc+Na6LrJTZXJWVhRrSuZeXmu8TAnniQVKgj8uTRKe4igO2ysYzH+Np879G75g==
+"@typescript-eslint/scope-manager@4.30.0":
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz#1a3ffbb385b1a06be85cd5165a22324f069a85ee"
+  integrity sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==
   dependencies:
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/visitor-keys" "4.19.0"
+    "@typescript-eslint/types" "4.30.0"
+    "@typescript-eslint/visitor-keys" "4.30.0"
 
-"@typescript-eslint/types@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.19.0.tgz#5181d5d2afd02e5b8f149ebb37ffc8bd7b07a568"
-  integrity sha512-A4iAlexVvd4IBsSTNxdvdepW0D4uR/fwxDrKUa+iEY9UWvGREu2ZyB8ylTENM1SH8F7bVC9ac9+si3LWNxcBuA==
+"@typescript-eslint/types@4.30.0":
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.30.0.tgz#fb9d9b0358426f18687fba82eb0b0f869780204f"
+  integrity sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==
 
-"@typescript-eslint/typescript-estree@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.19.0.tgz#8a709ffa400284ab72df33376df085e2e2f61147"
-  integrity sha512-3xqArJ/A62smaQYRv2ZFyTA+XxGGWmlDYrsfZG68zJeNbeqRScnhf81rUVa6QG4UgzHnXw5VnMT5cg75dQGDkA==
+"@typescript-eslint/typescript-estree@4.30.0":
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz#ae57833da72a753f4846cd3053758c771670c2ac"
+  integrity sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==
   dependencies:
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/visitor-keys" "4.19.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
+    "@typescript-eslint/types" "4.30.0"
+    "@typescript-eslint/visitor-keys" "4.30.0"
+    debug "^4.3.1"
+    globby "^11.0.3"
     is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.19.0.tgz#cbea35109cbd9b26e597644556be4546465d8f7f"
-  integrity sha512-aGPS6kz//j7XLSlgpzU2SeTqHPsmRYxFztj2vPuMMFJXZudpRSehE3WCV+BaxwZFvfAqMoSd86TEuM0PQ59E/A==
+"@typescript-eslint/visitor-keys@4.30.0":
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz#a47c6272fc71b0c627d1691f68eaecf4ad71445e"
+  integrity sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==
   dependencies:
-    "@typescript-eslint/types" "4.19.0"
+    "@typescript-eslint/types" "4.30.0"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.11.0":
@@ -5315,6 +5319,13 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
 decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -5992,7 +6003,7 @@ eslint-plugin-sort-destructure-keys@^1.3.5:
   dependencies:
     natural-compare-lite "^1.4.0"
 
-eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -6000,12 +6011,19 @@ eslint-scope@^5.0.0, eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.0.0, eslint-utils@^2.1.0:
+eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
 
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
@@ -7187,6 +7205,18 @@ globby@^11.0.0, globby@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
   integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
+globby@^11.0.3:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -9781,10 +9811,10 @@ liferay-npm-bundler@2.24.2:
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-liferay-theme-tasks@10.5.1:
-  version "10.5.1"
-  resolved "https://registry.yarnpkg.com/liferay-theme-tasks/-/liferay-theme-tasks-10.5.1.tgz#4506d417c2b40fbd3125f8ba70ca956361f1500f"
-  integrity sha512-KBg59Z6ajKmxpqOJV9nYSM7bGKvyvqnEPGCzesfW2hZbMagjr8O4I5zoq/u1mstyBjCCMHswrP1y4bVcRGFr4w==
+liferay-theme-tasks@10.5.2:
+  version "10.5.2"
+  resolved "https://registry.yarnpkg.com/liferay-theme-tasks/-/liferay-theme-tasks-10.5.2.tgz#eaf7e13d5123031fbfe2a1fdce03df45628d6f30"
+  integrity sha512-RXe9WVhNnpq8gWWdr/MdoVvKxVAVwtgpUQvFJ+8Wjrvd1hpyoFuFSwku/mNuv5+Yz18DxHEu5vljBDsJLCRvdA==
   dependencies:
     ansi-colors "^4.1.1"
     async "^2.6.1"
@@ -10191,6 +10221,13 @@ lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.1.5:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 lru-queue@^0.1.0:
   version "0.1.0"
@@ -10962,6 +10999,11 @@ ms@2.1.1, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -13164,7 +13206,7 @@ regexp.prototype.flags@^1.3.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regexpp@^3.0.0, regexpp@^3.1.0:
+regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
@@ -13777,10 +13819,17 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.1, semver@^7.2.1, semver@^7.3.2:
+semver@^7.1.1, semver@^7.2.1:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -15250,10 +15299,10 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tsutils@^3.17.1:
-  version "3.17.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
-  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
 
@@ -15338,10 +15387,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+typescript@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 typical@^5.0.0, typical@^5.2.0:
   version "5.2.0"
@@ -16303,6 +16352,11 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.0"


### PR DESCRIPTION
This one's pretty simple as the usages are only found in 2 files, a deprecated one, and one that relies on `A.Modal` by extending it. I also took this opportunity to ignore other rules that I found inside the deprecated file, as it would have to be done eventually, so why not all at once in this simple PR.