### PR TITLE
LPS-140052 Fix error upgrading RemoteAppEntry table with SQL Server and Oracle

### DIFF
--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/v2_0_0/RemoteAppEntryUpgradeProcess.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/v2_0_0/RemoteAppEntryUpgradeProcess.java
@@ -54,7 +54,7 @@ public class RemoteAppEntryUpgradeProcess extends UpgradeProcess {
 				RemoteAppEntryTable.class,
 				new AlterTableAddColumn("instanceable", "BOOLEAN"));
 
-			runSQL("update RemoteAppEntry set instanceable = true");
+			runSQL("update RemoteAppEntry set instanceable = [$TRUE$]");
 		}
 
 		if (!hasColumn("RemoteAppEntry", "portletCategoryName")) {

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/v2_1_0/ResourcePermissionsUpgradeProcess.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/upgrade/v2_1_0/ResourcePermissionsUpgradeProcess.java
@@ -68,20 +68,20 @@ public class ResourcePermissionsUpgradeProcess extends UpgradeProcess {
 				preparedStatement.setLong(2, increment());
 				preparedStatement.setLong(3, companyId);
 				preparedStatement.setString(4, RemoteAppEntry.class.getName());
-				preparedStatement.setLong(
-					5, ResourceConstants.SCOPE_INDIVIDUAL);
+				preparedStatement.setInt(5, ResourceConstants.SCOPE_INDIVIDUAL);
 				preparedStatement.setString(
 					6, String.valueOf(remoteAppEntryId));
 				preparedStatement.setLong(7, remoteAppEntryId);
 				preparedStatement.setLong(8, ownerRole.getRoleId());
 				preparedStatement.setLong(9, userId);
 				preparedStatement.setLong(10, 15);
-				preparedStatement.setLong(11, 1);
+				preparedStatement.setBoolean(11, true);
+
 				preparedStatement.setLong(12, mvccVersion);
 				preparedStatement.setLong(13, increment());
 				preparedStatement.setLong(14, companyId);
 				preparedStatement.setString(15, RemoteAppEntry.class.getName());
-				preparedStatement.setLong(
+				preparedStatement.setInt(
 					16, ResourceConstants.SCOPE_INDIVIDUAL);
 				preparedStatement.setString(
 					17, String.valueOf(remoteAppEntryId));
@@ -89,7 +89,7 @@ public class ResourcePermissionsUpgradeProcess extends UpgradeProcess {
 				preparedStatement.setLong(19, guestRole.getRoleId());
 				preparedStatement.setLong(20, 0);
 				preparedStatement.setLong(21, 1);
-				preparedStatement.setLong(22, 1);
+				preparedStatement.setBoolean(22, true);
 
 				preparedStatement.addBatch();
 			}


### PR DESCRIPTION
The PR solves the issues with the RemotaAppEntry table upgrade process for SQL Server and Oracle databases (tested with SQL Server).

I've located the error on the 2.0.0 upgrade step that was using the true literal instead of the [$TRUE$] placeholder that is replaced with a valid value for each database vendor.

I've also made changes to specify the most restrictive data types in the 2.1.0 upgrade step

**Steps to Reproduce:**

1. Start from a SQL Server dump from 7.3.10. You can use the dump attached on the [Jira LPS ticket](https://issues.liferay.com/browse/LPS-140052)
2. Run upgrade to upgrade to master

**Expected Result:**
No error on upgrade.

**Old Result:**
com.liferay.remote.app.service upgrade fails

**After changes result:**
The com.liferay.remote.app.service upgrade succeeds, although other errors appear for other modules