### PR TITLE
LPS-138181 Recover the select all files missing button on DM - multiple files uploader

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/upload.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/upload.js
@@ -154,7 +154,7 @@ AUI.add(
 			'<strong class="lead">{[ this.strings.warningTitle ]}</strong>{[ this.strings.pendingFileText ]}',
 			'</div>',
 
-			'<div class="hide manage-upload-target" id="{$ns}manageUploadTarget">',
+			'<div class="hide manage-upload-target clearfix" id="{$ns}manageUploadTarget">',
 			'<tpl if="multipleFiles">',
 			'<span class="field field-choice select-files">',
 			'<span class="field-content">',

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_uploader.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_uploader.scss
@@ -43,7 +43,7 @@
 		position: relative;
 
 		.select-files {
-			margin: 0 10px 10px;
+			margin: 0 1.125rem 1.125rem;
 		}
 	}
 


### PR DESCRIPTION
Dear @liferay-frontend friends,

With this PR I resurrect the `select all files checkbox` from the Multiple Files Upload (Documents and media).

I have a question, I have found the same CSS class of the uploader also repeated in [clay_admin.scs](https://github.com/liferay/liferay-portal/blob/47b47e63d3001a67aeef40172efc097b0e06fa7d/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss#L338) but only update the [_uploader.scss](https://github.com/boton/liferay-portal/blob/2cb1b827284f0f6a153826420b2c508140549438/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_uploader.scss#L46).
Do we need to update both?

🐛  https://issues.liferay.com/browse/LPS-138181

**How to reproduce**

1. Go to Content & Data > Documents and Media.
2. Click the plus icon, then select Multiple Files Upload.
3. Select some files.

**Before PR**

![image](https://user-images.githubusercontent.com/67901/135505065-5629f6ec-7ab6-4604-8cd2-31b39ea9820b.png)

---

**After PR**

![image](https://user-images.githubusercontent.com/67901/135505048-2163ae97-cfb0-4a0a-80be-f59eeddf6a77.png)



