### PR TITLE
LPS-140242 use full name, as we are loading a commerce module first

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIGUI.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIGUI.js
@@ -301,7 +301,9 @@ const APIGUI = () => {
 						tryItOutEnabled={true}
 						url={
 							endpoint ||
-							endpoints.find((url) => url.includes('delivery'))
+							endpoints.find((url) =>
+								url.includes('headless-delivery')
+							)
 						}
 					/>
 				)}


### PR DESCRIPTION
We were loading a delivery module from commerce first in /o/api and we wanted to load headless-delivery. Just using the full name.

Before:
<img width="1298" alt="Screenshot 2021-10-03 at 10 46 46" src="https://user-images.githubusercontent.com/340653/135746451-9ceccad5-9f38-4924-9834-f2123d402387.png">

After:
<img width="1255" alt="Screenshot 2021-10-03 at 10 46 56" src="https://user-images.githubusercontent.com/340653/135746457-4a692eab-bef9-4dea-b97f-14a456a98628.png">


