### PR TITLE
PoC integration between browser and AMD modules

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/package.json
@@ -2,7 +2,6 @@
 	"name": "frontend-taglib-clay-sample-web",
 	"private": true,
 	"scripts": {
-		"build": "liferay-npm-scripts build",
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/_amd/react.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/_amd/react.js
@@ -1,0 +1,9 @@
+const promise = new Promise((resolve, reject) => {
+	Liferay.Loader.require(
+		'liferay!frontend-js-react-web$react@16.12.0/index',
+		resolve,
+		reject
+	);
+});
+
+export default await promise;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/index.js
@@ -1,0 +1,5 @@
+import holi from './js/holi.js';
+import react from './_amd/react.js';
+
+holi();
+document.getElementById('perico').innerHTML = `React instance: ${react}`;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/holi.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/holi.js
@@ -1,0 +1,3 @@
+export default function holi() {
+	alert('holi!');
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,25 +16,6 @@
 
 <%@ include file="/init.jsp" %>
 
-<liferay-ui:tabs
-	names="Alerts,Badges,Buttons,Cards,Dropdowns,Form Elements,Icons,Labels,Links,Management Toolbars,Navigation Bars,Pagination Bars,Progress Bars,Stickers"
-	refresh="<%= false %>"
->
+<div id="perico"></div>
 
-	<%
-	String[] sections = {"alerts", "badges", "buttons", "cards", "dropdowns", "form_elements", "icons", "labels", "links", "management_toolbars", "navigation_bars", "pagination_bars", "progress_bars", "stickers"};
-
-	for (int i = 0; i < sections.length; i++) {
-	%>
-
-		<liferay-ui:section>
-			<clay:container-fluid>
-				<liferay-util:include page='<%= "/partials/" + sections[i] + ".jsp" %>' servletContext="<%= application %>" />
-			</clay:container-fluid>
-		</liferay-ui:section>
-
-	<%
-	}
-	%>
-
-</liferay-ui:tabs>
+<script src="/o/frontend-taglib-clay-sample-web/index.js" type="module" />


### PR DESCRIPTION
This is a quick and dirty test to show how it is possible to interop browser and AMD modules.

I initially started it to decide if we should get rid of bundler 3, or keep it for further refinement, but given that this simple PoC can give rise to new ideas, I wanted to share it as a draft.

I explain in the comments what each thing does.

Note that I'm not proposing this as the final solution, but showing that we may be nearer to using browser modules than we think.

We would still need interoperation the other way round (use browser modules from AMD ones) but in case we decided to support that, it would be a matter of injecting the browser modules into the AMD loader (i.e: it would need a new AMD loader). In any case, another legitimate option would be not supporting it, I think (the same way we don't provide any too to loadAUI from AMD).

One last thing to note is that, in theory, we wouldn't need to rewrite any line of JS in portal to switch from AMD to browser modules, given that we are already using ES module syntax.