### PR TITLE
LPS-140256 Set position absolute in the loading indicator to avoid displacing the iframe content

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.scss
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.scss
@@ -1,46 +1,56 @@
-.liferay-modal .modal-dialog {
-	position: relative;
+@import 'cadmin-variables';
 
-	@media (max-width: 768px) {
-		width: 100%;
-	}
+.liferay-modal {
+	.modal-dialog {
+		position: relative;
 
-	&.modal-full-screen {
-		position: absolute;
+		@media (max-width: 768px) {
+			width: 100%;
+		}
 
-		.liferay-modal-body {
-			height: 100%;
+		&.modal-full-screen {
+			position: absolute;
 
-			.lfr-fullscreen-source-editor-content {
-				bottom: 0;
-				height: auto;
-				left: 24px;
-				position: absolute;
-				right: 24px;
-				top: 80px;
+			.liferay-modal-body {
+				height: 100%;
 
-				.source-panel {
-					float: left;
+				.lfr-fullscreen-source-editor-content {
+					bottom: 0;
+					height: auto;
+					left: 24px;
+					position: absolute;
+					right: 24px;
+					top: 80px;
 
-					.lfr-source-editor {
-						border-bottom-width: 0;
+					.source-panel {
+						float: left;
+
+						.lfr-source-editor {
+							border-bottom-width: 0;
+						}
 					}
-				}
 
-				.preview-panel {
-					float: right;
+					.preview-panel {
+						float: right;
+					}
 				}
 			}
 		}
-	}
 
-	.modal-body .loading-animation {
-		left: 0;
-		margin-bottom: 0;
-		margin-top: 0;
-		position: absolute;
-		right: 0;
-		top: 50%;
-		transform: translateY(-50%);
+		.modal-body .loading-animation {
+			left: 0;
+			margin-bottom: 0;
+			margin-top: 0;
+			position: absolute;
+			right: 0;
+			top: 50%;
+			transform: translateY(-50%);
+		}
+	}
+}
+
+html#{$cadmin-selector} {
+	.cadmin {
+		@extend .liferay-modal;
 	}
 }


### PR DESCRIPTION
Related ticket: https://issues.liferay.com/browse/LPS-140256

### Steps to reproduce:

1. Add a web content
2. Go to Display pages sidebar section
3. Select specific and click select

Before the PR: 
https://user-images.githubusercontent.com/11654230/135861477-b6ce8f9d-c9ef-47c0-874f-f31dfa593a48.mov

After the PR:
https://user-images.githubusercontent.com/11654230/135861723-de26f811-c9d2-44e9-914a-c24224acb866.mov



