### PR TITLE
LPS-137051 Restric use of .. in API explorer

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryAPIApplication.java
+++ b/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryAPIApplication.java
@@ -174,6 +174,12 @@ public class HeadlessDiscoveryAPIApplication extends Application {
 			@PathParam("parameter") String parameter)
 		throws Exception {
 
+		if (parameter.contains("..")) {
+			return Response.status(
+				Response.Status.FORBIDDEN
+			).build();
+		}
+
 		URL url = _getURL(parameter);
 
 		if (url == null) {


### PR DESCRIPTION
Related ticket -> [LPS-137051](https://issues.liferay.com/browse/LPS-137051)

The ticket describes that the method `_getURL` is potentially vulnerable to a `path transversal vulnerability` via the `parameter` parameter which can allow access to files outside of `/META-INF/resources` and potentially even outside of `com.liferay.headless.discovery.web` 

The last part, according to [this documentation](http://docs.osgi.org/javadoc/r4v41/org/osgi/framework/Bundle.html#getEntry(java.lang.String)), is not possible to access files outside the bundle and as everything in `com.liferay.headless.discovery.web` is public, so it does not look like an FP4.

Anyway, we decide to restrict the use and return a 403