### PR TITLE
LPS-137759 Bring alert text formatting styles from AlloyEditor to Balloon Editor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/config/DefaultBalloonEditorConfiguration.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/config/DefaultBalloonEditorConfiguration.js
@@ -43,6 +43,27 @@ const DEFAULT_BALLOON_EDITOR_CONFIG = {
 			element: 'code',
 			name: Liferay.Language.get('computer-code'),
 		},
+		{
+			attributes: {
+				class: 'overflow-auto portlet-msg-info',
+			},
+			element: 'div',
+			name: Liferay.Language.get('info-message'),
+		},
+		{
+			attributes: {
+				class: 'overflow-auto portlet-msg-alert',
+			},
+			element: 'div',
+			name: Liferay.Language.get('alert-message'),
+		},
+		{
+			attributes: {
+				class: 'overflow-auto portlet-msg-error',
+			},
+			element: 'div',
+			name: Liferay.Language.get('error-message'),
+		},
 	],
 	title: false,
 	toolbarImage:


### PR DESCRIPTION
# How to test this change?

1. Deploy `frontend-editor-ckeditor-sample-web` module (gw clean deploy)
2. Place a ckeditor-sample module using Page Editor
3. Publish the page
4. Make a text selection and click in the text formatting combobox :)

# Result

See the following video:

https://user-images.githubusercontent.com/7663513/136078420-974f6031-a630-43f1-b674-c49502f1acb6.mov


