### PR TITLE
LPS-140338 Set portal.acceptance property for all tests with environment.acceptance

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsAdmin.testcase
@@ -30,6 +30,7 @@ definition {
 		property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
 		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
 		property environment.acceptance = "true";
+		property portal.acceptance = "true";
 		property testray.component.names = "WYSIWYG";
 
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -417,6 +417,7 @@ definition {
 	@refactorneeded
 	test CanViewSourceCodeFormattedInTextView {
 		property environment.acceptance = "true";
+		property portal.acceptance = "true";
 
 		JSONWebcontent.addWebContent(
 			content = "WC WebContent Content",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/PGStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/PGStaging.testcase
@@ -35,6 +35,7 @@ definition {
 		property custom.properties = "tunneling.servlet.shared.secret=1234567890123456${line.separator}auth.verifier.TunnelAuthVerifier.hosts.allowed=";
 		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
 		property environment.acceptance = "true";
+		property portal.acceptance = "true";
 
 		Staging.remoteStagingSetUp(siteName = "Site Name");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecaseWithVersioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecaseWithVersioning.testcase
@@ -831,6 +831,7 @@ definition {
 		property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
 		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
 		property environment.acceptance = "true";
+		property portal.acceptance = "true";
 
 		Navigator.openSiteURL(siteName = "Site Name");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/structure/WebContentWithCustomStructures.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/structure/WebContentWithCustomStructures.testcase
@@ -585,6 +585,7 @@ definition {
 	@priority = "4"
 	test AddWebContentWithRepeatableRichTextField {
 		property environment.acceptance = "true";
+		property portal.acceptance = "true";
 
 		task ("Add a web content structure with a repeatable Rich Text field") {
 			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");


### PR DESCRIPTION
**Description**
Some relevant test suites are running non-acceptance tests causing unique comparison logic in PR tester to incorrectly fail ([example](https://github.com/john-co/liferay-portal/pull/428#issuecomment-934017655)). This is a quick patch to capture environment.acceptance tests.

**Test Plan**
- [x] Environment.acceptance tests also include portal.acceptance property

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-140338