### PR TITLE
LPS-138109 Bump BalloonEditor's z-index

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,6 +1,6 @@
 .lfr-balloon-editor {
 	&.cke_balloon.cke_balloontoolbar {
-		z-index: 899;
+		z-index: 1100;
 	}
 
 	.cke_inner .cke_top {


### PR DESCRIPTION
# Motivation

This commit fixes a bug where [portlet-topper styles](https://github.com/liferay/liferay-portal/blob/34b48b84098dea7fc7552d2b7fb5a124c27e3c82/modules/apps/frontend-theme/frontend-theme-classic/src/css/portlet/_portlet.scss#L6) are overlapping the editor and We don't want it

# Result:

<img width="676" alt="Screen Shot 2021-10-05 at 16 21 22" src="https://user-images.githubusercontent.com/7663513/136089412-9291f566-1020-43b7-bc59-7fa41a60ecea.png">

You can find the old behaviour in the attached recording in Jira's [ticket](https://issues.liferay.com/browse/LPS-138109)
