### PR TITLE
LPS-139802 Make AutoFields add/remove buttons accessible

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -29,12 +29,16 @@ AUI.add(
 		];
 
 		var TPL_ADD_BUTTON =
-			'<button class="add-row btn btn-icon-only btn-monospaced btn-secondary toolbar-first toolbar-item" title="" type="button">' +
+			'<button class="add-row btn btn-icon-only btn-monospaced btn-secondary toolbar-first toolbar-item" title="' +
+			Liferay.Language.get('add') +
+			'" type="button">' +
 			Liferay.Util.getLexiconIconTpl('plus') +
 			'</button>';
 
 		var TPL_DELETE_BUTTON =
-			'<button class="btn btn-icon-only btn-monospaced btn-secondary delete-row toolbar-item toolbar-last" title="" type="button">' +
+			'<button class="btn btn-icon-only btn-monospaced btn-secondary delete-row toolbar-item toolbar-last" title="' +
+			Liferay.Language.get('remove') +
+			'" type="button">' +
 			Liferay.Util.getLexiconIconTpl('hr') +
 			'</button>';
 


### PR DESCRIPTION
### Issues

- [LPS-139802](https://issues.liferay.com/browse/LPS-139802)

### What is the goal?

Fix accesibility issue in AutoFields buttons

### A picture is worth a thousand words

![image](https://user-images.githubusercontent.com/6642927/136166768-63d55f2c-38d7-4a7d-8cad-666980ae5794.png)

https://user-images.githubusercontent.com/6642927/136169649-75eeedd5-e4de-489d-85c9-b1ebb95ce535.mov

### How to replicate

* Go to Applications Menu > Remote Apps
* Create a new Remote App
* Change type to Custom Element
* Inspect +/- buttons and check they now have a title attribute (and/or hold your mouse over the button and check that title appears as a tooltip)

### Checklist

- ~~[ ] I have made corresponding changes to the documentation~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked this works in the browser