### PR TITLE
LPS-140327 Avoid ArrayIndexOutOfBoundsException in PaginationBarTag

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PaginationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PaginationBarTag.java
@@ -294,7 +294,7 @@ public class PaginationBarTag extends BaseContainerTag {
 			if (leftItems.length > 1) {
 				_processEllipsis(pageContext);
 			}
-			else {
+			else if (leftItems.length == 1) {
 				int leftItem = leftItems[0];
 
 				_processItem(pageContext, leftItem);


### PR DESCRIPTION
When we updated the PaginationBarTag in
[04292c613c775e1e249e3a224969c1d111ee9707](https://github.com/liferay/liferay-portal/commit/04292c613c775e1e249e3a224969c1d111ee9707),
we forgot to check that the `leftItems` array has elements,
just like we do for `rightItems`, and this was causing 
an `ArrayIndexOutOfBoundsException` to be thrown.

**Test plan**
- Fetch this branch
- Deploy the `frontend-taglib-clay` OSGi module
- Assert that [LPS-140327](https://issues.liferay.com/browse/LPS-140327) is fixed