### PR TITLE
LPS-140073 Remove alert message on Translation Admin modal

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -12,13 +12,11 @@
  * details.
  */
 
-import ClayAlert from '@clayui/alert';
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
-import ClayLink from '@clayui/link';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import ClayModal from '@clayui/modal';
 import ClayTable from '@clayui/table';
@@ -39,11 +37,8 @@ const TranslationAdminContent = ({
 	activeLanguageIds: initialActiveLanguageIds = emptyArray,
 	availableLocales: initialAvailableLocales = emptyArray,
 	defaultLanguageId,
-	lastDeletedLocaleId,
 	onAddLocale = noop,
-	onClearRestoreLocale = noop,
 	onRemoveLocale = noop,
-	onRestoreLocale = noop,
 	translations = {},
 }) => {
 	const [creationMenuActive, setCreationMenuActive] = useState(false);
@@ -144,25 +139,6 @@ const TranslationAdminContent = ({
 						</ClayDropDown>
 					</ClayManagementToolbar.ItemList>
 				</ClayManagementToolbar>
-
-				{lastDeletedLocaleId && (
-					<ClayAlert
-						displayType="success"
-						onClose={onClearRestoreLocale}
-						title={Liferay.Language.get('success')}
-					>
-						{Liferay.Util.sub(
-							Liferay.Language.get('translation-was-deleted'),
-							availableLocales.find(
-								(availableLocale) =>
-									availableLocale.id === lastDeletedLocaleId
-							).label
-						)}
-						<ClayLink onClick={onRestoreLocale}>
-							{Liferay.Language.get('undo')}
-						</ClayLink>
-					</ClayAlert>
-				)}
 
 				<ClayTable>
 					<ClayTable.Head>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminModal.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminModal.js
@@ -38,7 +38,6 @@ const TranslationAdminModal = ({
 	const [activeLanguageIds, setActiveLanguageIds] = useState(
 		initialActiveLanguageIds
 	);
-	const [lastDeletedLanguageId, setLastDeletedLanguageId] = useState(null);
 	const [visible, setVisible] = useState(initialVisible);
 
 	const {observer} = useModal({
@@ -50,23 +49,12 @@ const TranslationAdminModal = ({
 
 	const handleAddLocale = (localeId) => {
 		setActiveLanguageIds([...activeLanguageIds, localeId]);
-		setLastDeletedLanguageId(null);
-	};
-
-	const handleClearRestoreLocale = () => {
-		setLastDeletedLanguageId(null);
 	};
 
 	const handleRemoveLocale = (localeId) => {
 		const newActiveLanguageIds = [...activeLanguageIds];
 		newActiveLanguageIds.splice(activeLanguageIds.indexOf(localeId), 1);
 		setActiveLanguageIds(newActiveLanguageIds);
-		setLastDeletedLanguageId(localeId);
-	};
-
-	const handleRestoreLocale = () => {
-		handleAddLocale(lastDeletedLanguageId);
-		setLastDeletedLanguageId(null);
 	};
 
 	useEffect(() => {
@@ -86,11 +74,8 @@ const TranslationAdminModal = ({
 						ariaLabels={ariaLabels}
 						availableLocales={availableLocales}
 						defaultLanguageId={defaultLanguageId}
-						lastDeletedLanguageId={lastDeletedLanguageId}
 						onAddLocale={handleAddLocale}
-						onClearRestoreLocale={handleClearRestoreLocale}
 						onRemoveLocale={handleRemoveLocale}
-						onRestoreLocale={handleRestoreLocale}
 						translations={translations}
 					/>
 				</ClayModal>


### PR DESCRIPTION
### References

- [LPS-140073](https://issues.liferay.com/browse/LPS-140073)

### What is the goal?

Remove alert messages in Translation Admin modal

### A picture is worth a thousand words



https://user-images.githubusercontent.com/6642927/137129309-99e7e3bb-5024-4eeb-aa07-2cf2f405be16.mov




### How to replicate
* Go to Content & Data > Web Content
* Select Add button, choose Basic Web Content
* Click on select translation button (icon with a flag to the left of the title)
* Click on `Manage Translations`
* Click on `+` button, select any language
* Click on trash can next to the new language, check the alert message doesn't show anymore

### Checklist

- ~~[ ] I have made corresponding changes to the documentation~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked this works in the corresponding browser