### PR TITLE
LPS-139942 Insert button only appears in one instance of Balloon Editor when more than one on the screen

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/insertbutton/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/insertbutton/plugin.js
@@ -26,9 +26,110 @@
 	);
 
 	CKEDITOR.plugins.add(pluginName, {
-		_createTable() {
-			const editor = this.editor;
+		_createInsertTableToolbar({editor}) {
+			const instance = this;
 
+			const tableToolbar = new CKEDITOR.ui.balloonToolbar(editor);
+
+			const tableData = {
+				columns: 3,
+				rows: 3,
+			};
+
+			const rowsInput = new CKEDITOR.ui.balloonToolbarNumberInput({
+				change(value) {
+					tableData.rows = value;
+				},
+				label: editor.lang.table.rows,
+				min: 1,
+				step: 1,
+				value: tableData.rows,
+			});
+
+			tableToolbar.addItem('rowsInput', rowsInput);
+
+			const columnsInput = new CKEDITOR.ui.balloonToolbarNumberInput({
+				change(value) {
+					tableData.columns = value;
+				},
+				label: editor.lang.table.columns,
+				min: 1,
+				step: 1,
+				value: tableData.columns,
+			});
+
+			tableToolbar.addItem('columnsInput', columnsInput);
+
+			const okButton = new CKEDITOR.ui.balloonToolbarButton({
+				click() {
+					instance._createTable({editor, tableData, tableToolbar});
+				},
+				icon: 'check',
+				title: editor.lang.common.ok,
+			});
+
+			tableToolbar.addItem('okButton', okButton);
+
+			return tableToolbar;
+		},
+
+		_createInsertToolbar({editor}) {
+			const instance = this;
+
+			const toolbar = new CKEDITOR.ui.balloonToolbar(editor);
+
+			toolbar.addItem(
+				'image',
+				new CKEDITOR.ui.balloonToolbarButton({
+					command: 'imageselector',
+					icon: 'image',
+					title: CKEDITOR.tools.capitalize(
+						editor.lang.image2.pathName
+					),
+				})
+			);
+
+			toolbar.addItem(
+				'video',
+				new CKEDITOR.ui.balloonToolbarButton({
+					command: 'videoselector',
+					icon: 'videoselector',
+					title: 'Video',
+				})
+			);
+
+			toolbar.addItem(
+				'table',
+				new CKEDITOR.ui.balloonToolbarButton({
+					click: () => {
+						toolbar.hide();
+
+						const tableToolbar = instance._getInsertTableToolbar({
+							editor,
+						});
+
+						tableToolbar.attach(editor.getSelection());
+
+						editor.focusManager.focus(tableToolbar);
+					},
+					icon: 'table',
+					title: editor.lang.table.toolbar,
+				})
+			);
+
+			toolbar.addItem(
+				'horizontalrule',
+				new CKEDITOR.ui.balloonToolbarButton({
+					command: 'horizontalrule',
+					icon: 'horizontalrule',
+					title: editor.lang.horizontalrule.toolbar,
+				})
+			);
+
+			return toolbar;
+		},
+
+		_createTable({editor, tableData, tableToolbar}) {
 			const tableElement = new CKEDITOR.dom.element('table');
 
 			tableElement.setAttributes({
@@ -43,8 +144,8 @@
 
 			tableElement.append(tbodyElement);
 
-			const columns = this._tableData.columns;
-			const rows = this._tableData.rows;
+			const columns = tableData.columns;
+			const rows = tableData.rows;
 
 			for (let i = 0; i < rows; i++) {
 				const tableRowElement = new CKEDITOR.dom.element('tr');
@@ -63,8 +164,7 @@
 
 			editor.insertElement(tableElement);
 
-			this._tableToolbar.destroy();
-			this._tableToolbar = null;
+			tableToolbar.hide();
 
 			setTimeout(() => {
 				const range = editor.createRange();
@@ -75,177 +175,46 @@
 			}, 0);
 		},
 
-		_createTableToolbar() {
+		_focusedEditorName: null,
+
+		_getInsertTableToolbar({editor}) {
 			const instance = this;
 
-			if (instance._tableToolbar) {
-				return instance._tableToolbar;
+			let toolbar = editor.liferayToolbars.insertTableToolbar;
+
+			if (toolbar) {
+				return toolbar;
 			}
 
-			const editor = instance.editor;
+			toolbar = instance._createInsertTableToolbar({editor});
 
-			instance._tableToolbar = new CKEDITOR.ui.balloonToolbar(editor);
+			editor.liferayToolbars.insertTableToolbar = toolbar;
 
-			const rowsInput = new CKEDITOR.ui.balloonToolbarNumberInput({
-				change(value) {
-					instance._tableData.rows = value;
-				},
-				label: editor.lang.table.rows,
-				min: 1,
-				step: 1,
-				value: this._tableData.rows,
-			});
-
-			instance._tableToolbar.addItem('rowsInput', rowsInput);
-
-			const columnsInput = new CKEDITOR.ui.balloonToolbarNumberInput({
-				change(value) {
-					instance._tableData.columns = value;
-				},
-				label: editor.lang.table.columns,
-				min: 1,
-				step: 1,
-				value: this._tableData.columns,
-			});
-
-			instance._tableToolbar.addItem('columnsInput', columnsInput);
-
-			const okButton = new CKEDITOR.ui.balloonToolbarButton({
-				click: instance._createTable.bind(instance),
-				icon: 'check',
-				title: editor.lang.common.ok,
-			});
-
-			instance._tableToolbar.addItem('okButton', okButton);
-
-			return instance._tableToolbar;
+			return toolbar;
 		},
 
-		_createToolbar() {
-			if (this._toolbar) {
-				return;
-			}
-
+		_getInsertToolbar({editor}) {
 			const instance = this;
 
-			const editor = instance.editor;
+			let toolbar = editor.liferayToolbars.insertToolbar;
 
-			instance._toolbar = new CKEDITOR.ui.balloonToolbar(editor);
-
-			instance._toolbar.addItem(
-				'image',
-				new CKEDITOR.ui.balloonToolbarButton({
-					command: 'imageselector',
-					icon: 'image',
-					title: CKEDITOR.tools.capitalize(
-						editor.lang.image2.pathName
-					),
-				})
-			);
-
-			instance._toolbar.addItem(
-				'video',
-				new CKEDITOR.ui.balloonToolbarButton({
-					command: 'videoselector',
-					icon: 'videoselector',
-					title: 'Video',
-				})
-			);
-
-			instance._toolbar.addItem(
-				'table',
-				new CKEDITOR.ui.balloonToolbarButton({
-					click() {
-						instance._toolbar.hide();
-
-						const tableToolbar = instance._createTableToolbar();
-
-						tableToolbar.attach(editor.getSelection());
-					},
-					icon: 'table',
-					title: editor.lang.table.toolbar,
-				})
-			);
-
-			instance._toolbar.addItem(
-				'horizontalrule',
-				new CKEDITOR.ui.balloonToolbarButton({
-					command: 'horizontalrule',
-					icon: 'horizontalrule',
-					title: editor.lang.horizontalrule.toolbar,
-				})
-			);
-		},
-
-		_eventListeners: [],
-
-		_onAfterCommandExec() {
-			this.hide();
-		},
-
-		_onBlur() {
-			if (!this._toolbarVisible) {
-				this.hide();
+			if (toolbar) {
+				return toolbar;
 			}
+
+			toolbar = instance._createInsertToolbar({editor});
+
+			editor.liferayToolbars.insertToolbar = toolbar;
+
+			return toolbar;
 		},
 
-		_onButtonClick(event) {
-			event.cancel();
-
-			this._createToolbar();
-			this._toolbarVisible = true;
-			this._toolbar.attach(this.editor.getSelection());
-		},
-
-		_onChange() {
-			this.hide();
-		},
-
-		_onContentDom() {
-			this.documentBody = this.editor.document.getBody();
-
-			if (!this.documentBody.contains(this._button)) {
-				this.documentBody.append(this._button);
-			}
-		},
-
-		_onDestroy() {
-			CKEDITOR.tools.array.forEach(this._eventListeners, (listener) => {
-				listener.removeListener();
-			});
-
-			this._eventListeners = [];
-		},
-
-		_onSelectionChange() {
-			const selection = this.editor.getSelection();
-
-			const type = selection.getType();
-
-			const startElement = selection.getStartElement();
-
-			if (
-				type === CKEDITOR.SELECTION_TEXT &&
-				selection.getSelectedText() === '' &&
-				startElement.getText() === '\n'
-			) {
-				this._positionButton();
-
-				this.show();
-			}
-			else {
-				this.hide();
-			}
-		},
-
-		_positionButton() {
-			const selection = this.editor.getSelection();
+		_positionButton({button, editor}) {
+			const selection = editor.getSelection();
 
 			const startElement = selection.getStartElement();
 
 			const selectionClientRect = startElement.getClientRect();
-
-			const button = this._button;
 
 			const buttonStyles = window.getComputedStyle(button.$);
 
@@ -253,7 +222,7 @@
 
 			let sideOffset = selectionClientRect.x + BUTTON_SIDE_OFFSET;
 
-			if (this.editor.config.contentsLangDirection === 'rtl') {
+			if (editor.config.contentsLangDirection === 'rtl') {
 				const buttonWidth = parseInt(buttonStyles.width, 10);
 
 				sideOffset =
@@ -267,69 +236,98 @@
 				left: `${sideOffset}px`,
 				top: `${
 					selectionClientRect.y +
+					document.defaultView.pageYOffset +
 					(selectionClientRect.height - buttonHeight) / 2
 				}px`,
 			});
 		},
 
-		_tableData: {
-			columns: 3,
-			rows: 3,
-		},
-
-		_tableToolbar: null,
-
-		_toolbarVisible: false,
-
-		hide() {
-			if (this._button.getStyle('display') !== 'none') {
-				this._button.setStyle('display', 'none');
-			}
-			if (this._toolbar) {
-				this._toolbar.hide();
-			}
-			if (this._tableToolbar) {
-				this._tableToolbar.destroy();
-			}
-		},
-
 		init(editor) {
-			this.editor = editor;
+			editor.liferayToolbars = editor.liferayToolbars ?? {};
 
-			this._eventListeners.push(
-				this.editor.on(
-					'afterCommandExec',
-					this._onAfterCommandExec.bind(this)
-				),
-				this.editor.on('blur', this._onBlur.bind(this)),
-				this.editor.on('change', this._onChange.bind(this)),
-				this.editor.on('contentDom', this._onContentDom.bind(this)),
-				this.editor.on('destroy', this._onDestroy.bind(this)),
-				this.editor.on('paste', this._onChange.bind(this)),
-				this.editor.on(
-					'selectionChange',
-					this._onSelectionChange.bind(this)
-				)
-			);
+			const button = CKEDITOR.dom.element.createFromHtml(template.source);
 
-			this._button = CKEDITOR.dom.element.createFromHtml(template.source);
+			const hide = () => {
+				button.addClass('hide');
 
-			this._button.setStyles({
-				display: 'none',
-				position: 'absolute',
-			});
+				editor.liferayToolbars.insertTableToolbar?.hide();
+				editor.liferayToolbars.insertToolbar?.hide();
+			};
 
-			this._eventListeners.push(
-				this._button.on('click', this._onButtonClick.bind(this))
+			const onFocusLoss = () => {
+				setTimeout(() => {
+					if (this._focusedEditorName !== editor.name) {
+						hide();
+					}
+				});
+			};
+
+			const eventListeners = [];
+
+			eventListeners.push(
+				button.on('blur', onFocusLoss),
+				editor.on('blur', onFocusLoss),
+
+				button.on('click', (event) => {
+					event.cancel();
+
+					editor.liferayToolbars.insertTableToolbar?.hide();
+
+					const toolbar = this._getInsertToolbar({
+						editor,
+						eventListeners,
+					});
+
+					toolbar.attach(editor.getSelection());
+				}),
+
+				editor.on('afterCommandExec', hide),
+
+				editor.on('focus', () => {
+					this._focusedEditorName = editor.name;
+				}),
+
+				editor.on('change', hide),
+
+				editor.on('contentDom', () => {
+					const body = editor.document.getBody();
+
+					if (!body.contains(button)) {
+						body.append(button);
+					}
+				}),
+
+				editor.on('destroy', () => {
+					eventListeners.forEach((listener) => {
+						listener.removeListener();
+					});
+				}),
+
+				editor.on('paste', hide),
+
+				editor.on('selectionChange', () => {
+					const selection = editor.getSelection();
+
+					const type = selection.getType();
+
+					const startElement = selection.getStartElement();
+
+					if (
+						type === CKEDITOR.SELECTION_TEXT &&
+						selection.getSelectedText() === '' &&
+						startElement.getText() === '\n'
+					) {
+						this._positionButton({button, editor});
+
+						button.removeClass('hide');
+					}
+					else {
+						hide();
+					}
+				})
 			);
 		},
 
 		requires: ['balloontoolbar', 'uibutton', 'uinumberinput'],
-
-		show() {
-			if (this._button.getStyle('display') !== '') {
-				this._button.setStyle('display', '');
-			}
-		},
 	});
 })();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,3 +1,5 @@
+@import 'atlas-variables';
+
 .lfr-balloon-editor {
 	&.cke_balloon.cke_balloontoolbar {
 		background: white;
@@ -126,10 +128,11 @@
 .lfr-balloon-editor-insert-button {
 	align-items: center;
 	background: white;
-	border: 0.75px solid #0b5fff;
+	border: 0.75px solid $primary;
 	border-radius: 2px;
-	color: #0b5fff;
+	color: $primary;
 	height: 24px;
+	position: absolute;
 	width: 24px;
 }
 


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-139942

This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/1514. See steps to reproduce and discussions there.

In this PR, we are rewriting most of the plugin to support multiple CKEditor instances. The whole plugin was fundamentally not built correctly. It was built with structure that assumes it will be instantiated somewhere, with something like `new InsertButton()`. But it is not used that way, it is a IIFE that initializes once and that's it. `this` refers to plugin, not the instance of button. This structure works with others plugins, like `uibutton`, but not with this one. We may have the same issue with other plugins.

Since this is a quite large overhaul, it was much easier for me to squash everything, to keep track of changes. Sorry for squashing in your commit @diegonvs !

After PR:
![after](https://user-images.githubusercontent.com/5435511/137353700-d9e6ff5f-f6f5-48df-944e-800be19d90f7.gif)

