### PR TITLE
LPS-139049 | FieldsSelectorDropdown redirects to blank page if Enter is pressed.

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/FieldsSelectorDropdown.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/views/table/FieldsSelectorDropdown.js
@@ -67,6 +67,7 @@ const FieldsSelectorDropdown = ({fields}) => {
 			}
 		>
 			<ClayDropDown.Search
+				formProps={{onSubmit: (event) => event.preventDefault()}}
 				onChange={(event) => setQuery(event.target.value)}
 				value={query}
 			/>


### PR DESCRIPTION
From @Odrakir1:

> When using the FieldsSelectorDropdown component, which uses ClayDropDown.Search, the user is redirected to a blank page inside the Portal he types _Enter_ inside the text area. Preventing the form from being submitted by passing a onForm event to the component solves the issue.

Steps to Reproduce:

1. Navigate to Remote Apps or Custom Elements
2. Add asset
3. Click on carrot at top of last column of asset list
4. Type any string in search bar
5. Hit Enter key

# What have been changed?

Now, a blank page won't shown up if the user hits _Enter_

# Why this fix was necessary?

The previous behavior was unintended and didn't make sense, if the user was being redirected to a blank page losing the progress what if he was doing, in this context, searching for a filter.

[Gif of the current behavior.](https://hnet.com/video-to-gif/viewimage/20210917-10-oMnfTaul1FXu6EuO-fqbyv8-hnet)

[You can find more details here: LPS-139049](https://issues.liferay.com/browse/LPS-139049)