### PR TITLE
LPS-140697 Fix testGetObjectDefinitionsPageWithSortString test

### DIFF
--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -67,6 +67,8 @@ public class ObjectDefinitionResourceTest
 	public void testGetObjectDefinitionsPageWithSortString() throws Exception {
 		ObjectDefinition objectDefinition1 = randomObjectDefinition();
 
+		objectDefinition1.setName("A" + objectDefinition1.getName());
+
 		objectDefinition1 = testGetObjectDefinitionsPage_addObjectDefinition(
 			objectDefinition1);
 
@@ -96,7 +98,7 @@ public class ObjectDefinitionResourceTest
 
 		assertEquals(
 			Arrays.asList(objectDefinition2, objectDefinition1),
-			items.subList(2, items.size()));
+			items.subList(items.size() - 2, items.size()));
 	}
 
 	@Ignore
@@ -122,11 +124,11 @@ public class ObjectDefinitionResourceTest
 		objectDefinition.setActive(false);
 		objectDefinition.setLabel(
 			Collections.singletonMap(
-				"en_US", "A" + objectDefinition.getName()));
-		objectDefinition.setName("A" + objectDefinition.getName());
+				"en_US", "O" + objectDefinition.getName()));
+		objectDefinition.setName("O" + objectDefinition.getName());
 		objectDefinition.setPluralLabel(
 			Collections.singletonMap(
-				"en_US", "A" + objectDefinition.getName()));
+				"en_US", "O" + objectDefinition.getName()));
 		objectDefinition.setObjectFields(
 			new ObjectField[] {
 				new ObjectField() {


### PR DESCRIPTION
The testGetObjectDefinitionsPageWithSortString test is failing checking the descendant behavior because it finds ObjectDefinitions created by other tests.

It is not possible to fix the test using the base implementation. System Object Definitions get in the way checking the ascendant or the descendant behavior. Also, Object API has many particularities and does not worth the effort to change everything to make it work.

Focus on solving the overridden test, this is the most effective solution that I found to fix it and avoid random errors in the future