### PR TITLE
LPS-140498 Fix compatibility breaking change between REST Builder and Portal Vulcan

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.CamelCaseUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.StringUtil_IW;
 import com.liferay.portal.kernel.util.TextFormatter;
@@ -176,6 +177,8 @@ public class RESTBuilder {
 			"configYAML", _configYAML
 		).put(
 			"freeMarkerTool", freeMarkerTool
+		).put(
+			"portalBuildNumber", ReleaseInfo.getBuildNumber()
 		).put(
 			"stringUtil", StringUtil_IW.getInstance()
 		).put(

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -118,14 +118,18 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 	}
 
 	public static ${schemaName} unsafeToDTO(String json) {
-		${schemaName} ${schemaVarName} =
-			ObjectMapperUtil.readValue(${schemaName}.class, json);
+		<#if portalBuildNumber lt 7412>
+			${schemaName} ${schemaVarName} =
+				ObjectMapperUtil.readValue(${schemaName}.class, json);
 
-		if (${schemaVarName} == null) {
-			throw new RuntimeException("Error processing JSON " + json);
-		}
+			if (${schemaVarName} == null) {
+				throw new RuntimeException("Error processing JSON " + json);
+			}
 
-		return ${schemaVarName};
+			return ${schemaVarName};
+		<#else>
+			return ObjectMapperUtil.unsafeReadValue(${schemaName}.class, json);
+		</#if>
 	}
 
 	<#assign


### PR DESCRIPTION
Due to a recent change on the REST Builder generation logic, where a new method ObjectMapperUtil.unsafeReadValue is used, the compatibility between REST Builder and Vulcan has been broken in REST Builder version 1.0.214.

Different approaches have been tested:

1. Check class and method availability using reflection ❌

I like this one but when the class or methods were loaded, the class dependencies were resolved and could cause false negatives when the classloader doesn't find an imported class. For example, in the case of ObjectMapperUtil if fails trying to find jackson classes

The methods were something like
```
public boolean isClassAvailable(String className) {
    try {
        Class.forName(className);

	return true;
    }
    catch (Exception exception) {
        if (_log.isDebugEnabled()) {
            _log.debug(className + " not found", exception);
        }
    }

    return false;
}

public boolean isMethodAvailable(String className, String methodName) {
    try {
        Class<?> clazz = Class.forName(className, false, this.getClass().getClassLoader());

        Method[] methods = clazz.getDeclaredMethods();

        Stream<Method> stream = Arrays.stream(methods);

        return stream.anyMatch(
            method -> Objects.equals(methodName, method.getName()));
    }
    catch (Throwable throwable) {
        if (_log.isDebugEnabled()) {
            _log.debug(
                StringBundler.concat(
                    "Method ", methodName, " in class ", className,
                        " not found"),
                    throwable);
        }
    }

    return false;
}
```

2. Get Portal Vulcan package version to make conditional logic in the templates ❌

Trying this approach getting the package version using [Package.getSpecificationVersion](https://docs.oracle.com/javase/7/docs/api/java/lang/Package.html#getSpecificationVersion()) or [Package.getImplementationVersion](https://docs.oracle.com/javase/7/docs/api/java/lang/Package.html#getImplementationVersion()), but they always return null, I guess because of the gradle wrapper

3. Get Portal build number from ReleaseInfo class to make conditional logic ✅

This is the approach that I finally use. The portal version build number is added in the FreeMarker engine context to be used from the templates and avoid using new methods if the portal build number shows that they would not exist. I think it is a good option to give us flexibility and avoid compatibility issues between REST Builder and Vulcan in the future. A usage example is:
```
<#if portalBuildNumber lt 7412>
    ${schemaName} ${schemaVarName} =
        ObjectMapperUtil.readValue(${schemaName}.class, json);

    if (${schemaVarName} == null) {
        throw new RuntimeException("Error processing JSON " + json);
    }

    return ${schemaVarName};
<#else>
    return ObjectMapperUtil.unsafeReadValue(${schemaName}.class, json);
</#if>
```