### PR TITLE
LPS-140075 Update translation status after languageIds change

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -521,6 +521,12 @@ AUI.add(
 
 					currentFlagsNode.innerHTML = newFlagsNode.innerHTML;
 
+					Object.entries(instance.get('availableLocales')).forEach(
+						([key]) => {
+							this._updateTranslationStatus(key);
+						}
+					);
+
 					var boundingBox = instance.get('boundingBox');
 					instance._flags = boundingBox.one('.palette-container');
 


### PR DESCRIPTION
### References

- [LPS-140075](https://issues.liferay.com/browse/LPS-140075)

### What is the goal?

Update languages translation status after languageIDs change

### A picture is worth a thousand words

#### Before PR 



https://user-images.githubusercontent.com/6642927/138067984-51b9454d-bf7c-4372-8e94-ae643e689c32.mov

#### After PR

https://user-images.githubusercontent.com/6642927/138067048-4b0df8df-05d8-4ca3-a8ee-d73db7dae2f7.mov






### How to replicate
* Go to Content & Data > Web Content
* Create a new Basic Web Content
* Open translation dropdown, click on `Manage translations`, add a new language, click on `Done`
* Open translation dropdown, select language you added, edit title
* Open translation dropdown, check language now appears as `translated`
* Click on publish
* Click on the same Web Content
* Open translation dropdown, check the language you added is now `translated`
* Click on `Manage translations`, delete that language, click on `Done` 
* Open translation dropdown, check the language isn't there anymore
* Click on `Manage translations`, re-add the language you deleted, check it now appears `untranslated`, click on `Done`
* Open translation dropdown, check the language now shows `untranslated`

### Checklist

- ~~[ ] I have made corresponding changes to the documentation~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked this works in the corresponding browser