### PR TITLE
LPS-141176 Reduce unneeded environment testing on frontend infrastructure functional tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/RightToLeftInfrastructure.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/RightToLeftInfrastructure.testcase
@@ -27,8 +27,8 @@ definition {
 	@priority = "5"
 	@refactorneeded
 	test RTLDirectionStyleAppliedToTextField {
-		property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
-		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
+		property app.server.types = "tomcat";
+		property database.types = "mysql";
 		property environment.acceptance = "true";
 		property portal.acceptance = "true";
 		property test.name.skip.portal.instance = "RightToLeftInfrastructure#RTLDirectionStyleAppliedToTextField";
@@ -57,8 +57,8 @@ definition {
 	@priority = "5"
 	@refactorneeded
 	test RTLStylesAppliedToPageLayout {
-		property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
-		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
+		property app.server.types = "tomcat";
+		property database.types = "mysql";
 		property environment.acceptance = "true";
 		property portal.acceptance = "true";
 		property test.name.skip.portal.instance = "RightToLeftInfrastructure#RTLStylesAppliedToPageLayout";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
@@ -29,8 +29,8 @@ definition {
 	@priority = "5"
 	@refactordone
 	test AdminPageCanDisplayStyleCorrectlyAfterPageRefresh {
-		property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
-		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
+		property app.server.types = "tomcat";
+		property database.types = "mysql";
 		property environment.acceptance = "true";
 		property portal.acceptance = "true";
 
@@ -86,8 +86,8 @@ definition {
 	@priority = "5"
 	@refactordone
 	test PortletBoundariesAreContained {
-		property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
-		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
+		property app.server.types = "tomcat";
+		property database.types = "mysql";
 		property environment.acceptance = "true";
 		property osgi.modules.includes = "frontend-taglib-clay-sample-web";
 		property portal.acceptance = "true";
@@ -238,8 +238,8 @@ definition {
 	@priority = "5"
 	@refactordone
 	test SitePageCanDisplayStyleCorrectlyAfterPageRefresh {
-		property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
-		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
+		property app.server.types = "tomcat";
+		property database.types = "mysql";
 		property environment.acceptance = "true";
 		property portal.acceptance = "true";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -218,8 +218,8 @@ definition {
 	@priority = "4"
 	@refactordone
 	test CanDisplayFormattedHTMLFromCopyPaste {
-		property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
-		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
+		property app.server.types = "tomcat";
+		property database.types = "mysql";
 		property environment.acceptance = "true";
 		property portal.acceptance = "true";
 
@@ -422,6 +422,8 @@ definition {
 	@priority = "4"
 	@refactordone
 	test CanViewSourceCodeFormattedInTextView {
+		property app.server.types = "tomcat";
+		property database.types = "mysql";
 		property environment.acceptance = "true";
 		property portal.acceptance = "true";
 


### PR DESCRIPTION
**Description**
Some FI tests have `environment.acceptance` property but since we don't have stable browser testing on CI besides Chrome, we should reduce the amount of environments to only mysql tomcat since we're not concerned about regressions on different app servers and databases for these tests.

**Test Plan**
- [x] FI owned tests with `environment.acceptance = "true"` are reduced to the following environment types
```
property app.server.types = "tomcat";
property database.types = "mysql";
```
*May have a couple FI owned tests still include all environments for smoke testing purposes on those environments.

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-141176