### PR TITLE
LPS-138610 Fix Sidebar spacing when A11y Panel is open

### DIFF
--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/components/Violations.scss
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/components/Violations.scss
@@ -3,18 +3,19 @@ $a11y-panel-width: 320px;
 .a11y-body {
 	padding-right: $a11y-panel-width;
 
+	.lfr-add-panel.sidenav-right,
 	.multi-panel-sidebar,
 	.page-editor__sidebar {
-		right: $a11y-panel-width;
+		right: $a11y-panel-width !important;
 	}
 
 	.multi-panel-sidebar-content,
 	.page-editor__sidebar__content {
-		right: $a11y-panel-width + 42px;
+		right: $a11y-panel-width + 42px !important;
 	}
 
 	.modal-dialog {
-		right: $a11y-panel-width + 45px;
+		right: $a11y-panel-width + 45px !important;
 	}
 
 	.applications-menu-modal {


### PR DESCRIPTION
This fixes the spacing of Sidebars that are fixed or absolutes when the a11y tool is enabled and the Panel is rendered, this is a solution that needs to be added in every sidebar that has in DXP that doesn't follow a specific markup.

I can't think of another way to be able to position the A11y Panel with CSS only and move away the other sidebars that are open on the same side in a less hardcoded way. I'm accepting any suggestion for this!

| Before | After |
|--------|------|
| ![image](https://user-images.githubusercontent.com/13750819/138515277-e76c9514-1762-459b-9e59-a66d9df9d518.png) | <img width="1680" alt="Screen Shot 2021-10-22 at 16 54 11" src="https://user-images.githubusercontent.com/13750819/138515211-5fee0687-ac87-4b5f-919a-443df2cf36e0.png"> |

### Steps to Reproduce:

- Add `nodejs.node.env=development` in `build.${computer.name}.properties`
Create a `com.liferay.frontend.js.a11y.web.internal.configuration.FFA11yConfiguration.config` file containing `enable=B"true"` in `osgi/configs`
- Sign in with test
- Navigate to Site Builder -> Pages -> create Public Widget Page
- Navigate to widget page 
- Click on "+" to add widgets