### PR TITLE
LPS-140250 default to not use wrapper in XMLs

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/XmlMapperContextResolver.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/XmlMapperContextResolver.java
@@ -38,7 +38,9 @@ public class XmlMapperContextResolver implements ContextResolver<XmlMapper> {
 		private static final XmlMapper _XML_MAPPER = new XmlMapper() {
 			{
 				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+
 				setDateFormat(new ISO8601DateFormat());
+				setDefaultUseWrapper(false);
 				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 			}
 		};


### PR DESCRIPTION
In [this support ticket](https://issues.liferay.com/browse/LPP-42770) the user want to send this:

```
<TestObject>
  <arrayObjects>
     <title>string</title>
  </arrayObjects>
  <arrayObjects>
    <title>other string</title>
  </arrayObjects>
</TestObject>'
```

instead of this:

```
<TestObject>
  <arrayObjects>
     <any_value_is_ok_here>
       <title>string</title>
    </any_value_is_ok_here>
    <any_value_is_ok_here>
      <title>other string</title>
    </any_value_is_ok_here>
  </arrayObjects>
</TestObject>
```

I think the client is *wrong* and what we should want is this (and this is what /o/api suggests, note the uppercase and the missing plural):

```
<TestObject>
  <ArrayObject>
       <title>string</title>
  </ArrayObject>
  <ArrayObject>
      <title>other string</title>
  </ArrayObject>
</TestObject>
```

This is the "wrapping" behaviour in arrays for XMLs and the default should be false.

Ideally we should enable or disable it based on the `wrapped: false` in REST Builder. It should be controlled by this [annotation](http://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.2.0/com/fasterxml/jackson/dataformat/xml/annotation/JacksonXmlElementWrapper.html) (_useWrapping_ to false) and we could even use one name for XML and another different one for JSON with [JacksonXmlProperty](http://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.2.0/com/fasterxml/jackson/dataformat/xml/annotation/JacksonXmlProperty.html). And the ideal way would be generating the annotation based on this.

But I can't make it work. I don't know what is the exact problem that is preventing the annotation to work, I've tried different things:
* When I remove @JSONProperty, deserializing (POST) works but serializing doesn't. And removing @JSONProperty won't be valid when we have a field READ/WRITE_ONLY, as we couldn't specify it.
* We are mixing JAXB and JACKSON annotations. It should work fine. I've tried with JAXB annotations and they don't work either.
* I've update to the last jackson versions (2.13.0) as they mention a bug serializing wrappers with 2.12.x branch. It didn't work. Updating the version takes hours, as it's being provided globally by the static dependencies mechanism.
* I've tried providing the annotation XML library as an OSGi module, as right now it's being used with compileInclude and we could have classloading issues. Even providing it everywhere and deploying it in the portal it didn't work either.
* I've tried adding an XML module (always or optionally) that changes the behaviour. Also changing the flag directly in the ObjectMapper.
* Tried removing JAXB annotations (XMLRootElement) and use only jackson
* Read tens of post about it... it seems other people have found this problem too, mixing JSON and XML serialization is tricky and stops working in some versions, works again, etc.

I haven't tried writing a custom serializer. This would obviously work but it's annoying and error-prone. We used to had one for XML and Page that I removed last month. I thought it was not needed anymore but it was, it was fixing some version of these problem (that the XML name annotation is ignored) and we are returning these:

```
<items>
<items>
asdasd
```

instead of

```
<items>
<item>
```

So... what can we do?

We can disable directly but:
* This is a breaking change. If there were some XML users of the API, they were definitely relying on the wrapper. I don't think there are many (if any) users of the XML API though.
* We can't still rename, as the name annotation does not work. So users will have to provide several `arrayObjects` instead of `ArrayObject`. But in this case it is what the client wants...
* This won't let us support `wrapped` in OpenAPI. Note that we never wanted to support it.

What do you think? Do you want to check it @javierdearcos? Maybe you find a way or why the annotation is not working (I didn't dive into debugging how the annotations were being applied) but we should finish 1) Brian request about workflow in Object first 2) Marco&Brian request about nested fields in relationships first... so next week at the earliest. Or we just change this, see if the customer likes it and move on as no-one should be using the XML version of the APIs either way.
