### PR TITLE
[TS] LPS-141139 Remove content text from css styles (accessibility)

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -226,9 +226,10 @@ html#{$cadmin-selector} {
 	}
 
 	.edit-entry {
-		.alloy-editor-placeholder:before {
+		.alloy-editor.ae-placeholder ~ .alloy-editor-placeholder {
 			display: block;
 			text-align: inherit;
+			top: 0.75rem;
 			width: 100%;
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
@@ -222,14 +222,6 @@ td.lfr-name-column {
 
 .form-builder-sidebar,
 .portlet-forms {
-	.form-group
-		.alloy-editor-container.input-group
-		.alloy-editor-placeholder.ae-placeholder {
-		border-left: 0;
-		padding-left: 0;
-		width: inherit;
-	}
-
 	.forms-navigation-bar,
 	.navigation-bar-secondary,
 	.management-bar {
@@ -302,12 +294,6 @@ td.lfr-name-column {
 			margin: 0;
 		}
 
-		.ae-placeholder:empty:before {
-			content: attr(data-placeholder);
-		}
-
-		.alloy-editor-container
-			.alloy-editor.alloy-editor-placeholder.ae-placeholder:not(:focus):not(.form-control),
 		.ddm-form-name,
 		.ddm-form-description {
 			border-width: 0;
@@ -321,15 +307,6 @@ td.lfr-name-column {
 			p {
 				margin: 0;
 			}
-		}
-
-		.alloy-editor.alloy-editor-placeholder {
-			color: #000;
-			font-weight: 500;
-		}
-
-		.alloy-editor.alloy-editor-placeholder:empty:not(:focus) {
-			color: #c0ccd3;
 		}
 
 		.ddm-form-name {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
@@ -91,30 +91,6 @@
 		.h5 {
 			margin: 0;
 		}
-
-		.ae-placeholder:empty:before {
-			content: attr(data-placeholder);
-		}
-
-		.alloy-editor-container .alloy-editor.alloy-editor-placeholder,
-		.alloy-editor-container
-			.alloy-editor.alloy-editor-placeholder:empty:not(:focus) {
-			border-width: 0;
-			padding-left: 0;
-
-			.form-feedback-item {
-				top: -15px;
-			}
-
-			p {
-				margin: 0;
-			}
-		}
-
-		.alloy-editor-container
-			.alloy-editor.alloy-editor-placeholder:empty:not(:focus) {
-			color: $form-header-placeholder-color;
-		}
 	}
 
 	.form-builder-content {

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -81,7 +81,13 @@ if (editorOptions != null) {
 <liferay-util:buffer
 	var="alloyEditor"
 >
-	<div class="alloy-editor alloy-editor-placeholder <%= HtmlUtil.escapeAttribute(cssClass) %>" contenteditable="false" data-placeholder="<%= LanguageUtil.get(request, placeholder) %>" data-required="<%= required %>" id="<%= HtmlUtil.escapeAttribute(name) %>" name="<%= HtmlUtil.escapeAttribute(name) %>"></div>
+	<div class="alloy-editor <%= HtmlUtil.escapeAttribute(cssClass) %>" contenteditable="false" data-placeholder="<%= LanguageUtil.get(request, placeholder) %>" data-required="<%= required %>" id="<%= HtmlUtil.escapeAttribute(name) %>" name="<%= HtmlUtil.escapeAttribute(name) %>"></div>
+	<div class="alloy-editor-placeholder <%= HtmlUtil.escapeAttribute(cssClass) %>">
+		<%= LanguageUtil.get(request, placeholder) %>
+		<c:if test="<%= Boolean.parseBoolean(required) %>">
+			<span class="text-warning">*</span>
+		</c:if>
+	</div>
 
 	<aui:icon cssClass="alloy-editor-icon" image="text-editor" markupView="lexicon" />
 </liferay-util:buffer>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/a11yhelpbtn/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/a11yhelpbtn/plugin.js
@@ -17,10 +17,11 @@
 
 	CKEDITOR.plugins.add(pluginName, {
 		init(editor) {
+			var helpText = CKEDITOR.env.mac ? ' Option+0' : ' Alt+0';
 			if (editor.ui.addButton) {
 				editor.ui.addButton('A11YBtn', {
 					command: 'a11yHelp',
-					label: Liferay.Language.get('action.HELP'),
+					label: Liferay.Language.get('action.HELP') + helpText,
 				});
 			}
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -155,17 +155,6 @@
 
 			.cke_button__a11ybtn_label {
 				display: inline;
-
-				&:after {
-					border: 1px solid transparent;
-					content: 'Alt+0';
-					margin-left: 5px;
-					padding: 3px;
-				}
-
-				&.mac:after {
-					content: 'Option+0';
-				}
 			}
 		}
 	}

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_editor_alloy.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_editor_alloy.scss
@@ -25,6 +25,10 @@
 .alloy-editor-container {
 	position: relative;
 
+	.wrapper {
+		position: relative;
+	}
+
 	.alloy-editor-icon {
 		bottom: 8px;
 		color: #869cad;
@@ -43,26 +47,33 @@
 			left: 8px;
 		}
 
-		&.alloy-editor-placeholder {
-			color: #2b4259;
+		~ .alloy-editor-placeholder {
+			display: none;
+		}
 
-			&:before {
+		&.ae-placeholder {
+			~ .alloy-editor-placeholder {
+				background-color: transparent;
+				color: #2b4259;
+				display: block;
+				padding-left: 10px;
 				pointer-events: none;
+				position: absolute;
+				top: 0.25rem;
 			}
-
-			&.readonly {
+			&.readonly ~ .alloy-editor-placeholder {
 				color: #ccc;
 			}
-
-			&.ae-placeholder:empty {
+			&:empty {
 				min-height: 1.5em;
 			}
+			&:not(:focus) {
+				~ .alloy-editor-placeholder {
+					border-left-color: #dbdde1;
+					color: #b0b4bb;
+				}
 
-			&.ae-placeholder:not(:focus) {
-				border-left-color: #dbdde1;
-				color: #b0b4bb;
-
-				&:not(.form-control) {
+				&:not(.form-control) ~ .alloy-editor-placeholder {
 					border-left: 2px solid;
 					padding-left: 10px;
 				}
@@ -71,9 +82,14 @@
 					border-left-color: #c67;
 				}
 			}
-
-			&.ae-placeholder[data-required='true']:not(:focus):before {
-				content: attr(data-placeholder) ' *';
+			&:focus,
+			&.cke_focus {
+				~ .alloy-editor-placeholder {
+					display: none !important;
+				}
+			}
+			&:not(:focus):before {
+				content: '';
 			}
 		}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/HTMLProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/HTMLProcessor.js
@@ -83,8 +83,7 @@ function createEditor(element, changeCallback, destroyCallback) {
 					if (editorContainer) {
 						editor = new A.LiferayFullScreenSourceEditor({
 							boundingBox: editorContainer,
-							previewCssClass:
-								'alloy-editor alloy-editor-placeholder',
+							previewCssClass: 'alloy-editor',
 							value: element.innerHTML,
 						}).render();
 					}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/Editor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/Editor.js
@@ -114,7 +114,7 @@ export default function Editor({
 			id={`${config.portletNamespace}${id}`}
 		>
 			<div
-				className="alloy-editor alloy-editor-placeholder form-control form-control-sm page-editor__editor"
+				className="alloy-editor form-control form-control-sm page-editor__editor"
 				contentEditable={false}
 				data-placeholder={placeholder}
 				data-required={false}
@@ -122,6 +122,7 @@ export default function Editor({
 				name={id}
 				ref={wrapperRef}
 			/>
+			<div className="alloy-editor-placeholder">{placeholder}</div>
 		</div>
 	);
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support-test/src/testIntegration/resources/exploded-test-theme/css/application/_editor_alloy.scss
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support-test/src/testIntegration/resources/exploded-test-theme/css/application/_editor_alloy.scss
@@ -1,15 +1,15 @@
 .alloy-editor-container {
 	.alloy-editor {
-		&.alloy-editor-placeholder {
-			color: #2b4259;
-
-			&.ae-placeholder:not(:focus) {
-				background: transparent;
-				border-left-color: #dbdde1;
-				color: #b0b4bb;
+		&.ae-placeholder {
+			~ .alloy-editor-placeholder {
+				color: #2b4259;
+				&:not(:focus) {
+					background: transparent;
+					border-left-color: #dbdde1;
+					color: #b0b4bb;
+				}
 			}
-
-			&.readonly {
+			&.readonly ~ .alloy-editor-placeholder {
 				color: #ccc;
 			}
 		}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support-test/src/testIntegration/resources/exploded-test-theme/css/main.css
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support-test/src/testIntegration/resources/exploded-test-theme/css/main.css
@@ -1759,19 +1759,19 @@ a.taglib-icon.btn:focus .taglib-text, a.taglib-icon.btn:hover .taglib-text {
 
 .alloy-editor-container .alloy-editor {
   outline: 0; }
-  .alloy-editor-container .alloy-editor.alloy-editor-placeholder {
+  .alloy-editor-container .alloy-editor .alloy-editor-placeholder {
     color: #2B4259; }
-    .alloy-editor-container .alloy-editor.alloy-editor-placeholder.ae-placeholder:not(:focus) {
+    .alloy-editor-container .alloy-editor.ae-placeholder ~ .alloy-editor-placeholder:not(:focus) {
       background: transparent;
       border-left-color: #DBDDE1;
       color: #B0B4BB; }
-    .alloy-editor-container .alloy-editor.alloy-editor-placeholder.readonly {
+    .alloy-editor-container .alloy-editor.ae-placeholder.readonly ~ .alloy-editor-placeholder {
       color: #CCC; }
 
 .alloy-editor-container .alloy-editor-icon {
   color: #869CAD; }
 
-.has-error .alloy-editor-container .alloy-editor.alloy-editor-placeholder.ae-placeholder:not(:focus) {
+.has-error .alloy-editor-container .alloy-editor.ae-placeholder ~ .alloy-editor-placeholder:not(:focus) {
   border-left-color: #CC6677; }
 
 .cke_dialog .cke_dialog_ui_input_text {

--- a/modules/sdk/gradle-plugins-css-builder/src/gradleTest/compileClayCssWithRuby/src/main/resources/css/main.scss
+++ b/modules/sdk/gradle-plugins-css-builder/src/gradleTest/compileClayCssWithRuby/src/main/resources/css/main.scss
@@ -149,7 +149,7 @@
 	}
 
 	.edit-entry {
-		.alloy-editor-placeholder:before {
+		.alloy-editor.ae-placeholder ~ .alloy-editor-placeholder {
 			display: block;
 			text-align: inherit;
 			width: 100%;
@@ -171,7 +171,7 @@
 			padding-left: 0;
 			text-align: center;
 
-			&.alloy-editor-placeholder:empty:not(:focus) {
+			~ .alloy-editor-placeholder:empty:not(:focus) {
 				border-left-width: 0;
 			}
 		}
@@ -226,7 +226,7 @@
 			margin-right: 30px;
 			margin-top: 0;
 
-			.alloy-editor-placeholder p {
+			.alloy-editor.ae-placeholder p {
 				margin-bottom: 0;
 			}
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/test-theme.war/css/application/_editor_alloy.scss
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/test-theme.war/css/application/_editor_alloy.scss
@@ -1,14 +1,15 @@
 .alloy-editor-container {
 	.alloy-editor {
-		&.alloy-editor-placeholder {
-			color: #2B4259;
-
-			&.ae-placeholder:not(:focus) {
-				border-left-color: #DBDDE1;
-				color: #B0B4BB;
+		&.ae-placeholder {
+			~ .alloy-editor-placeholder {
+				color: #2B4259;
+				&:not(:focus) {
+					border-left-color: #DBDDE1;
+					color: #B0B4BB;
+				}
 			}
 
-			&.readonly {
+			&.readonly ~ .alloy-editor-placeholder {
 				color: #CCC;
 			}
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/test-theme.war/css/main.css
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/test-theme.war/css/main.css
@@ -1498,18 +1498,18 @@ a.taglib-icon.btn:focus .taglib-text, a.taglib-icon.btn:hover .taglib-text {
 
 .alloy-editor-container .alloy-editor {
   outline: 0; }
-  .alloy-editor-container .alloy-editor.alloy-editor-placeholder {
+  .alloy-editor-container .alloy-editor .alloy-editor-placeholder {
     color: #2B4259; }
-    .alloy-editor-container .alloy-editor.alloy-editor-placeholder.ae-placeholder:not(:focus) {
+    .alloy-editor-container .alloy-editor.ae-placeholder ~ .alloy-editor-placeholder:not(:focus) {
       border-left-color: #DBDDE1;
       color: #B0B4BB; }
-    .alloy-editor-container .alloy-editor.alloy-editor-placeholder.readonly {
+    .alloy-editor-container .alloy-editor.ae-placeholder.readonly ~ .alloy-editor-placeholder {
       color: #CCC; }
 
 .alloy-editor-container .alloy-editor-icon {
   color: #869CAD; }
 
-.has-error .alloy-editor-container .alloy-editor.alloy-editor-placeholder.ae-placeholder:not(:focus) {
+.has-error .alloy-editor-container .alloy-editor.ae-placeholder ~ .alloy-editor-placeholder:not(:focus) {
   border-left-color: #CC6677; }
 
 .cke_dialog .cke_dialog_ui_input_text {


### PR DESCRIPTION
LPS-141139 Remove content text from CSS styles as this is not recommended because this content is not accessible for screen readers tools. Check LPS-133314 for more reference.

As in master we don't use alloy editor in many places, I could not test all the styles changes, the only one I could test was on Blogs, where we still use this placeholder with content.

Also, not sure if it makes sense to remove this from alloy editor repo (see my comment below), for example we use this in https://github.com/liferay/alloy-editor/blob/3cbc0af0ef3bc21eda826796d0cce03bbdafa600/src/assets/sass/components/ae-placeholder/structure.scss#L2 

/cc @joseluisbango