### PR TITLE
LPS-141031 Avoid exceptions in PaginationBarTag

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PaginationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PaginationBarTag.java
@@ -288,9 +288,12 @@ public class PaginationBarTag extends BaseContainerTag {
 
 			int leftIndex = activeIndex - _ellipsisBuffer;
 
-			try {
+			int leftItemsStartIndex = 1;
+			int leftItemsEndIndex = Math.max(leftIndex, 1);
+
+			if (leftItemsStartIndex < leftItemsEndIndex) {
 				int[] leftItems = Arrays.copyOfRange(
-					pageNumberItems, 1, Math.max(leftIndex, 1));
+					pageNumberItems, leftItemsStartIndex, leftItemsEndIndex);
 
 				if (leftItems.length > 1) {
 					_processEllipsis(pageContext);
@@ -301,33 +304,35 @@ public class PaginationBarTag extends BaseContainerTag {
 					_processItem(pageContext, leftItem);
 				}
 			}
-			catch (Exception exception) {
-			}
 
 			int lastIndex = pageNumberItems.length - 1;
 
-			try {
+			int centerItemsStartIndex = Math.max(
+				activeIndex - _ellipsisBuffer, 1);
+			int centerItemsEndIndex = Math.min(
+				activeIndex + _ellipsisBuffer + 1, lastIndex);
+
+			if (centerItemsStartIndex < centerItemsEndIndex) {
 				int[] centerItems = Arrays.copyOfRange(
-					pageNumberItems, Math.max(activeIndex - _ellipsisBuffer, 1),
-					Math.min(activeIndex + _ellipsisBuffer + 1, lastIndex));
+					pageNumberItems, centerItemsStartIndex,
+					centerItemsEndIndex);
 
 				for (int centerItem : centerItems) {
 					_processItem(pageContext, centerItem);
 				}
 			}
-			catch (Exception exception) {
+
+			int rightItemsStartIndex = activeIndex + _ellipsisBuffer + 1;
+
+			if (rightItemsStartIndex > lastIndex) {
+				rightItemsStartIndex = lastIndex;
 			}
 
-			int rightIndex = activeIndex + _ellipsisBuffer + 1;
+			int rightItemsEndIndex = Math.max(lastIndex, rightItemsStartIndex);
 
-			if (rightIndex > lastIndex) {
-				rightIndex = lastIndex;
-			}
-
-			try {
+			if (rightItemsStartIndex < rightItemsEndIndex) {
 				int[] rightItems = Arrays.copyOfRange(
-					pageNumberItems, rightIndex,
-					Math.max(lastIndex, rightIndex));
+					pageNumberItems, rightItemsStartIndex, rightItemsEndIndex);
 
 				if (rightItems.length > 1) {
 					_processEllipsis(pageContext);
@@ -337,8 +342,6 @@ public class PaginationBarTag extends BaseContainerTag {
 
 					_processItem(pageContext, rightItem);
 				}
-			}
-			catch (Exception exception) {
 			}
 
 			if (totalPages > 1) {


### PR DESCRIPTION
Since Arrays.copyOfRange can throw exceptions if the
second argument is greater than the third argument,
we're putting these calls in try/catch blocks

**Test plan**
- Add 6 or more documents to a site.
- Create a new content page.
- Add the collection display fragment to the page.
-  Select the "highest rated assets" collection.
- Select Numeric Pagination.
- Verify Maximum Number of Items=5 and Maximum Number of Items per Page=5.
- Add a heading fragment to the collection display and map the title to the fragment.
-  Publish the page and navigate to it.
- Assert that the page is displayed correctly

**Before**

![](https://user-images.githubusercontent.com/5572/138720841-39566e5f-5250-4948-94fa-2cca03cc615e.png)

**After**
![](https://user-images.githubusercontent.com/5572/138720074-8c961993-9286-4c58-a645-b3f13f9b252b.png)
