### PR TITLE
LPS-141388 Fix languages order in TranslationManager Modal. the default language should be the first one always

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -391,17 +391,16 @@ AUI.add(
 						document.body.appendChild(modalContainer);
 					}
 
-					var availableLocales = Object.entries(
-						instance.get('availableLocales')
-					).map((entry) => {
-						var key = entry[0];
-						var value = entry[1];
+					var availableLocales = instance.get('availableLocales');
 
-						var label = key.replace(/_/, '-');
+					var locales = instance.get('items').map((languageId) => {
+						var displayName = availableLocales[languageId];
+
+						var label = languageId.replace(/_/, '-');
 
 						return {
-							displayName: value,
-							id: key,
+							displayName,
+							id: languageId,
 							label,
 							symbol: label.toLowerCase(),
 						};
@@ -422,7 +421,7 @@ AUI.add(
 
 					var props = {
 						activeLanguageIds: instance.get('activeLanguageIds'),
-						availableLocales,
+						availableLocales: locales,
 						defaultLanguageId: instance.get('defaultLanguageId'),
 						onClose(newActiveLanguageIds) {
 							instance._State.writeAtom(


### PR DESCRIPTION
This fixes: https://issues.liferay.com/browse/LPS-141388

AvailableLanguages property from inputLocalized component is not correctly ordered. In this PR I've changed to create the prop for the TranslationManager from the items property which reflect the correct order.

### How to test this
- Place [com.liferay.journal.web.internal.configuration.FFTranslationManagerAdminMode.config](https://issues.liferay.com/secure/attachment/429077/com.liferay.journal.web.internal.configuration.FFTranslationManagerAdminMode.config) file in bundles/osgi/configs 
- Change the default language to spanish in site settings
- Go to Web Content -> Structures -> Create new structure
- In the translation button, click Manage translation
- Add english translation

Before this pr the english translation was place above the default option (spanish), with this pr the option is placed below

