### PR TITLE
LPS-141734 | A11yTool - Verifies impact and category filter toggles are available

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/A11yTool.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/A11yTool.path
@@ -35,6 +35,27 @@
 	<td>//*[contains(@class,'a11y-overlay')]//*[*[name()='svg'][contains(@class,'info-circle')]]</td>
 	<td></td>
 </tr>
+<!--FILTER-->
+<tr>
+	<td>FILTER_ELEMENT_ICON</td>
+	<td>//*[contains(@class,'a11y-panel') and contains(@class,'violations-header')]//*[*[name()='svg'][contains(@class,'lexicon-icon-filter')]]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FILTER_BY_IMPACT_HEADER</td>
+	<td>//*[contains(@class,'a11y-dropdown show')]//*[contains(@class, 'dropdown-subheader') and contains(., 'Filter by Impact')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FILTER_BY_CATEGORY_HEADER</td>
+	<td>//*[contains(@class,'a11y-dropdown show')]//*[contains(@class, 'dropdown-subheader') and contains(., 'Filter by Category')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FILTER_LIST_ITEM</td>
+	<td>//*[contains(@class,'a11y-dropdown show')]//li//*[contains(@class,'dropdown-section') and contains(.,'${key_text}')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -93,6 +93,31 @@ definition {
 		takeScreenshot();
 	}
 
+	@description = "LPS-141734. Verifies impact and category filters are available."
+	@priority = "5"
+	test CanFilterViolationsByImpactAndCategory {
+		property osgi.module.configuration.file.names = "com.liferay.frontend.js.a11y.web.internal.configuration.FFA11yConfiguration.config";
+		property osgi.module.configurations = "enable=B&quot;true&quot;";
+
+		// Workaround for side panel sometimes not displaying LPS-141442
+
+		while (IsElementNotPresent(locator1 = "A11yTool#VIOLATION_PANEL_HEADER")) {
+			Refresh();
+		}
+
+		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
+
+		AssertElementPresent(locator1 = "A11yTool#FILTER_BY_IMPACT_HEADER");
+
+		AssertElementPresent(locator1 = "A11yTool#FILTER_BY_CATEGORY_HEADER");
+
+		AssertElementPresent(
+			key_text = "",
+			locator1 = "A11yTool#FILTER_LIST_ITEM");
+
+		takeScreenshot();
+	}
+
 	@description = "LPS-141455. Verifies the side panel appears with violation(s)."
 	@priority = "5"
 	test ShowsSidePanelWithViolation {


### PR DESCRIPTION
**Background**
Create automated tests for the A11y tool

**Test Plan**
- Verify the side panel appears with violations listed
- Click on the filter button
- Verify filtering by impact and category toggles are listed

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-141734