### PR TITLE
LPS-141385 Change "untranslated" label to "not translated" in input localized

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -609,7 +609,7 @@ AUI.add(
 					);
 
 					var translationStatus = Liferay.Language.get(
-						'untranslated'
+						'not-translated'
 					);
 					var translationStatusCssClass = 'warning';
 

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsApplication.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsApplication.testcase
@@ -77,7 +77,7 @@ definition {
 		AssertTextEquals(
 			key_localizedLanguage = "es-ES",
 			locator1 = "Translation#TRANSLATION_STATUS_TITLE",
-			value1 = "Untranslated");
+			value1 = "Not Translated");
 	}
 
 	@description = "This ensures that The translation in the web content remains after deleting the translation in approved status from the app."

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsWorkflow.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsWorkflow.testcase
@@ -388,7 +388,7 @@ definition {
 		AssertTextEquals(
 			key_localizedLanguage = "es-ES",
 			locator1 = "Translation#TRANSLATION_STATUS_TITLE",
-			value1 = "Untranslated");
+			value1 = "Not Translated");
 	}
 
 	@description = "This ensures that an imported translation can be Rejected and Resubmited through the workflow."

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/paths/KaleoDesigner.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/paths/KaleoDesigner.path
@@ -37,7 +37,7 @@
 </tr>
 <tr>
 	<td>UNTRANSLATED_ICON_COUNTRY</td>
-	<td>//*[contains(@class,'lexicon-icon-${key_icon}')]/../../span//span[contains(text(),'Untranslated')]</td>
+	<td>//*[contains(@class,'lexicon-icon-${key_icon}')]/../../span//span[contains(text(),'Not Translated')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -179,7 +179,7 @@
 								"value", curLanguageId
 							).build();
 
-							String translationStatus = LanguageUtil.get(request, "untranslated");
+							String translationStatus = LanguageUtil.get(request, "not-translated");
 							String translationStatusCssClass = "warning";
 
 							if (languageIds.contains(curLanguageId)) {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgrade.testcase
@@ -349,7 +349,7 @@ definition {
 			AssertTextEquals(
 				key_localizedLanguage = "zh-CN",
 				locator1 = "Translation#TRANSLATION_STATUS_TITLE",
-				value1 = "Untranslated");
+				value1 = "Not Translated");
 		}
 
 		task ("View Translation while Editing article") {
@@ -778,7 +778,7 @@ definition {
 			AssertTextEquals(
 				key_localizedLanguage = "zh-CN",
 				locator1 = "Translation#TRANSLATION_STATUS_TITLE",
-				value1 = "Untranslated");
+				value1 = "Not Translated");
 		}
 
 		task ("View Translation while Editing article") {


### PR DESCRIPTION
Doing so to make it consistent with the label in the Translation modal, as explained here: https://issues.liferay.com/browse/LPS-141385?focusedCommentId=2553040&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2553040

I've also updated some poshi tests that were depending on that label