### PR TITLE
LPS-141380 LPS-139191 Translation manager bugs

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -119,13 +119,9 @@ const TranslationAdminContent = ({
 										<ClayDropDown.Item
 											key={availableLocale.label}
 											onClick={() => {
-												onAddLocale(
-													availableLocale.id
-												);
+												onAddLocale(availableLocale.id);
 											}}
-											symbolLeft={
-												availableLocale.symbol
-											}
+											symbolLeft={availableLocale.symbol}
 										>
 											{availableLocale.label}
 										</ClayDropDown.Item>
@@ -201,15 +197,19 @@ const TranslationAdminContent = ({
 
 									<ClayTable.Cell>
 										{!isDefaultLocale && (
-											<ClayIcon
-												className="inline-item"
+											<ClayButton
+												displayType="unstyled"
 												onClick={() =>
 													onRemoveLocale(
 														activeLocale.id
 													)
 												}
-												symbol="trash"
-											/>
+											>
+												<ClayIcon
+													className="inline-item"
+													symbol="trash"
+												/>
+											</ClayButton>
 										)}
 									</ClayTable.Cell>
 								</ClayTable.Row>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -76,11 +76,9 @@ const TranslationAdminContent = ({
 						<ClayInput
 							aria-label={Liferay.Language.get('search')}
 							insetAfter={true}
-							onChange={(event) => {
-								const {value} = event.target;
-
-								setSearchValue(value);
-							}}
+							onChange={(event) =>
+								setSearchValue(event.target.value)
+							}
 							placeholder={Liferay.Language.get('search')}
 							value={searchValue}
 						/>
@@ -197,19 +195,16 @@ const TranslationAdminContent = ({
 
 									<ClayTable.Cell>
 										{!isDefaultLocale && (
-											<ClayButton
+											<ClayButtonWithIcon
 												displayType="unstyled"
+												monospaced={false}
 												onClick={() =>
 													onRemoveLocale(
 														activeLocale.id
 													)
 												}
-											>
-												<ClayIcon
-													className="inline-item"
-													symbol="trash"
-												/>
-											</ClayButton>
+												symbol="trash"
+											/>
 										)}
 									</ClayTable.Cell>
 								</ClayTable.Row>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -71,72 +71,70 @@ const TranslationAdminContent = ({
 			</ClayModal.Header>
 
 			<ClayModal.Header withTitle={false}>
-				<ClayModal.Title>
-					<ClayInput.Group className="align-items-center">
-						<ClayInput.GroupItem>
-							<ClayInput
+				<ClayInput.Group className="align-items-center">
+					<ClayInput.GroupItem>
+						<ClayInput
+							aria-label={Liferay.Language.get('search')}
+							insetAfter={true}
+							onChange={(event) => {
+								const {value} = event.target;
+
+								setSearchValue(value);
+							}}
+							placeholder={Liferay.Language.get('search')}
+							value={searchValue}
+						/>
+
+						<ClayInput.GroupInsetItem after tag="span">
+							<ClayButtonWithIcon
 								aria-label={Liferay.Language.get('search')}
-								insetAfter={true}
-								onChange={(event) => {
-									const {value} = event.target;
-
-									setSearchValue(value);
+								displayType="unstyled"
+								onClick={() => {
+									setSearchValue('');
 								}}
-								placeholder={Liferay.Language.get('search')}
-								value={searchValue}
+								symbol={searchValue ? 'times' : 'search'}
 							/>
+						</ClayInput.GroupInsetItem>
+					</ClayInput.GroupItem>
 
-							<ClayInput.GroupInsetItem after tag="span">
+					<ClayInput.GroupItem shrink>
+						<ClayDropDown
+							active={
+								creationMenuActive &&
+								availableLocales.length > 0
+							}
+							hasLeftSymbols
+							onActiveChange={setCreationMenuActive}
+							trigger={
 								<ClayButtonWithIcon
-									aria-label={Liferay.Language.get('search')}
-									displayType="unstyled"
-									onClick={() => {
-										setSearchValue('');
-									}}
-									symbol={searchValue ? 'times' : 'search'}
+									disabled={availableLocales.length === 0}
+									small
+									symbol="plus"
 								/>
-							</ClayInput.GroupInsetItem>
-						</ClayInput.GroupItem>
-
-						<ClayInput.GroupItem shrink>
-							<ClayDropDown
-								active={
-									creationMenuActive &&
-									availableLocales.length > 0
-								}
-								hasLeftSymbols
-								onActiveChange={setCreationMenuActive}
-								trigger={
-									<ClayButtonWithIcon
-										disabled={availableLocales.length === 0}
-										small
-										symbol="plus"
-									/>
-								}
-							>
-								<ClayDropDown.ItemList>
-									{availableLocales.map((availableLocale) => {
-										return (
-											<ClayDropDown.Item
-												key={availableLocale.label}
-												onClick={() => {
-													onAddLocale(
-														availableLocale.id
-													);
-												}}
-												symbolLeft={
-													availableLocale.symbol
-												}
-											>
-												{availableLocale.label}
-											</ClayDropDown.Item>
-										);
-									})}
-								</ClayDropDown.ItemList>
-							</ClayDropDown>
-						</ClayInput.GroupItem>
-					</ClayInput.Group>
-				</ClayModal.Title>
+							}
+						>
+							<ClayDropDown.ItemList>
+								{availableLocales.map((availableLocale) => {
+									return (
+										<ClayDropDown.Item
+											key={availableLocale.label}
+											onClick={() => {
+												onAddLocale(
+													availableLocale.id
+												);
+											}}
+											symbolLeft={
+												availableLocale.symbol
+											}
+										>
+											{availableLocale.label}
+										</ClayDropDown.Item>
+									);
+								})}
+							</ClayDropDown.ItemList>
+						</ClayDropDown>
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
 			</ClayModal.Header>
 
 			<ClayModal.Body className="pb-0 pt-3" scrollable>


### PR DESCRIPTION
### References

- [LPS-141380](https://issues.liferay.com/browse/LPS-141380)
- [LPS-139191](https://issues.liferay.com/browse/LPS-139191)

### What is the goal?

* Fix add languages button focus outline being partially hidden
* Fix delete languages buttons not being keyboard-accessible

### A picture is worth a thousand words

#### Before PR

https://user-images.githubusercontent.com/6642927/139438678-faad1dcb-1ad5-489a-8b73-b786ac4202bb.mov

https://user-images.githubusercontent.com/6642927/139438693-dd605531-f06f-41c1-b132-957ba9363cab.mov


#### After PR


https://user-images.githubusercontent.com/6642927/139438734-08add1f3-59c4-4561-aedd-38ed559f78ca.mov


https://user-images.githubusercontent.com/6642927/139438737-5110e807-b392-457d-83b4-5f2a1d9d7a4d.mov



### How to replicate
* Go to Content & Data > Web Content
* Click on translations button
* Click on `Manage Translations`
* Click on `+` button, see that the focus outline is not cropped
* Click outside the dropdown so it will close
* Use the tab keyboard key to move around the modal, see that the trash buttons are now focusable

### Checklist

- ~~[ ] I have made corresponding changes to the documentation~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked this works in the corresponding browser