### PR TITLE
LPS-141242 Use onInstanceReady with options in ClassicEditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -105,7 +105,6 @@ const ClassicEditor = React.forwardRef(
 						toolbar: initialToolbarSet,
 						...editorConfig,
 					}}
-					data={contents}
 					name={name}
 					onBeforeLoad={(CKEDITOR) => {
 						CKEDITOR.disableAutoInline = true;
@@ -136,6 +135,14 @@ const ClassicEditor = React.forwardRef(
 								return editor.pasteFilter.check(name);
 							}
 						}
+					}}
+					onInstanceReady={({editor}) => {
+						editor.setData(contents, {
+							callback: () => {
+								editor.resetUndo();
+							},
+							noSnapshot: true,
+						});
 					}}
 					ref={editorRefsCallback}
 					{...otherProps}


### PR DESCRIPTION
### References

- [LPS-141242](https://issues.liferay.com/browse/LPS-141242)

### What is the goal?

* Fix CKEditor allowing undo on first render and showing `undefined` after undo
   * Call `setData` in the `onInstanceReady` with the necessary options to avoid the history being modified

### A picture is worth a thousand words

#### Before PR

https://user-images.githubusercontent.com/6642927/140052841-71de72b8-6f45-42c6-972f-a91b2de2ea7f.mov

#### After PR

https://user-images.githubusercontent.com/6642927/140052876-508107a9-8d93-4ff5-9544-988933174e60.mov



### How to replicate
* Go to Content & Data > Web Content
* Wait for content editor to be ready
* See that the `undo` button is disabled and that clicking it does nothing
* Edit content
* See that the `undo` button is not disabled anymore and it works as expected 

### Notes
I found that we were using a similar approach before, which was changed to the `data={contents}` approach in #1133. 
The problem with that approach [as you can see in the ckeditor4-react code for v1.4.2](https://github.com/ckeditor/ckeditor4-react/blob/v1.4.2/src/ckeditor.jsx#L89-L95) is that what the library does is call `setData` without the options necessary to not modify the history of ckeditor, and so the `undo` button is active on first render and makes weird changes.  I have checked that the bug in #1133 doesn't happen after this change, as you can see in the following video.


https://user-images.githubusercontent.com/6642927/140053696-feca09c8-69eb-46c8-8728-c19e7c07b65b.mov



The bug with the `data` prop is fixed in later versions of `ckeditor4-react`, [as you can see here](https://github.com/ckeditor/ckeditor4-react/blob/3119c915200616b005d880582d448a2bb2f438e9/src/useCKEditor.ts#L187-L199). The fix is passing the same options as I'm passing in this PR. I tried to update the version and added some compatibility changes, but the latest version doesn't allow passing a `ref` to the component, which caused the `undo` button to break. That ref appears to be used in multiple places in DXP, so maybe we should dedicate some time to updating the library and our code.

Thanks @julien and @carloslancha  for all the help!

### Checklist

- ~~[ ] I have made corresponding changes to the documentation~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked this works in the corresponding browser