### PR TITLE
LPS-141928 The user list cannot be displayed when mentioning user in some special places

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_input.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_input.js
@@ -284,7 +284,9 @@ AUI.add(
 					return item !== 'value';
 				});
 
-				instance._triggerConfigDefaults = TRIGGER_CONFIG_DEFAULTS;
+				// LPS-141928
+
+				instance._triggerConfigDefaults = {...TRIGGER_CONFIG_DEFAULTS};
 
 				A.mix(
 					instance._triggerConfigDefaults,


### PR DESCRIPTION
BUG 🐛 : https://issues.liferay.com/browse/LPS-141928

**Steps to Prepare:**
1. Login 
2. Add a new widget page with a blog/mb/dm/wiki widget
3. Go to the widget to add a new entry
4. Add comment to this entry

**Steps to Reproduce: (no reloads in the middle of the process)**

1. Logout
2. Login
3. Go to the new page with the blog/mb/dm/wiki widget
4. reply to a previous comment
5. Mention other users

---

At first, I tried to understand the bug but I was getting stuck in AUI :(

The next strategy is to use the RCA information and revert this commit bb2ad29705910473f7069b569067db4a6842a842, this fixed the problem.

I want to find the faulty change, at first, I discard this change because looks naif and test others but in the end, it is the cause.

If anyone understands the problem please I am all ears 👂 🥺 

**Before FIX**

https://user-images.githubusercontent.com/67901/140512575-e0c69ad3-3b08-4290-8b83-539f10713815.mp4


**After FIX**

https://user-images.githubusercontent.com/67901/140512424-b1ce6ff6-bb99-44ee-882f-513af833976f.mp4


