### PR TITLE
LPS-142086 Modification of RestBuilder to support new permissions method's names

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/rest-openapi.yaml
+++ b/modules/apps/bulk/bulk-rest-impl/rest-openapi.yaml
@@ -89,7 +89,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.bulk.rest.client', and version '3.0.8'."
+        'com.liferay.bulk.rest.client', and version '3.0.9'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.bulk.rest.client', and version '3.0.8'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.bulk.rest.client', and version '3.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-openapi.yaml
@@ -488,7 +488,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.8'."
+        artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.10'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.8'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Account API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Account API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
@@ -1510,7 +1510,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.10'."
+        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.12'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-openapi.yaml
@@ -104,7 +104,7 @@ components:
 info:
     description:
         "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.8'."
+        artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.9'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.8'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Channel API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Channel API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-openapi.yaml
@@ -144,7 +144,7 @@ info:
         name: "Commerce Team"
     description:
         "Liferay Commerce Admin Inventory API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.8'."
+        artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.10'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Inventory API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.8'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Inventory API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Inventory API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Inventory API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
@@ -1135,7 +1135,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.9'."
+        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.11'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
@@ -1467,7 +1467,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.9'."
+        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.11'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi.yaml
@@ -484,7 +484,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.9'."
+        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.11'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v2.0")
+	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v2.0")
 )
 @Path("/v2.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
@@ -277,7 +277,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID
-        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.9'."
+        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.10'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Admin Shipment API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Admin Shipment API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-openapi.yaml
@@ -315,7 +315,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Site Setting API. A Java client JAR is available for use with the group ID
-        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.8'."
+        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.10'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Site Setting API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.8'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Site Setting API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Site Setting API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Site Setting API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
@@ -502,7 +502,7 @@ components:
 info:
     description:
         "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.9'."
+        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.10'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
+	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
@@ -491,7 +491,7 @@ components:
 info:
     description:
         "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.11'."
+        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.12'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
+	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/data-engine/data-engine-rest-api/bnd.bnd
+++ b/modules/apps/data-engine/data-engine-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Data Engine REST API
 Bundle-SymbolicName: com.liferay.data.engine.rest.api
-Bundle-Version: 23.2.4
+Bundle-Version: 24.0.0
 Export-Package:\
 	com.liferay.data.engine.rest.dto.v2_0,\
 	com.liferay.data.engine.rest.dto.v2_0.util,\

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionFieldLinkResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionFieldLinkResource.java
@@ -56,7 +56,7 @@ public interface DataDefinitionFieldLinkResource {
 	}
 
 	public Page<DataDefinitionFieldLink>
-			getDataDefinitionDataDefinitionFieldLinkPage(
+			getDataDefinitionDataDefinitionFieldLinksPage(
 				Long dataDefinitionId, String fieldName)
 		throws Exception;
 

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionResource.java
@@ -95,7 +95,7 @@ public interface DataDefinitionResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDataDefinitionPermission(
+			putDataDefinitionPermissionsPage(
 				Long dataDefinitionId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataLayoutResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataLayoutResource.java
@@ -59,7 +59,7 @@ public interface DataLayoutResource {
 		return FactoryHolder.factory.create();
 	}
 
-	public void deleteDataLayoutsDataDefinition(Long dataDefinitionId)
+	public void deleteDataDefinitionDataLayout(Long dataDefinitionId)
 		throws Exception;
 
 	public Page<DataLayout> getDataDefinitionDataLayoutsPage(

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataListViewResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataListViewResource.java
@@ -58,7 +58,7 @@ public interface DataListViewResource {
 		return FactoryHolder.factory.create();
 	}
 
-	public void deleteDataListViewsDataDefinition(Long dataDefinitionId)
+	public void deleteDataDefinitionDataListView(Long dataDefinitionId)
 		throws Exception;
 
 	public Page<DataListView> getDataDefinitionDataListViewsPage(

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataRecordCollectionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataRecordCollectionResource.java
@@ -100,7 +100,7 @@ public interface DataRecordCollectionResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDataRecordCollectionPermission(
+			putDataRecordCollectionPermissionsPage(
 				Long dataRecordCollectionId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/resources/com/liferay/data/engine/rest/resource/v2_0/packageinfo
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/resources/com/liferay/data/engine/rest/resource/v2_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.0
+version 6.0.0

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionFieldLinkResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionFieldLinkResource.java
@@ -40,12 +40,12 @@ public interface DataDefinitionFieldLinkResource {
 	}
 
 	public Page<DataDefinitionFieldLink>
-			getDataDefinitionDataDefinitionFieldLinkPage(
+			getDataDefinitionDataDefinitionFieldLinksPage(
 				Long dataDefinitionId, String fieldName)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getDataDefinitionDataDefinitionFieldLinkPageHttpResponse(
+			getDataDefinitionDataDefinitionFieldLinksPageHttpResponse(
 				Long dataDefinitionId, String fieldName)
 		throws Exception;
 
@@ -122,12 +122,12 @@ public interface DataDefinitionFieldLinkResource {
 		implements DataDefinitionFieldLinkResource {
 
 		public Page<DataDefinitionFieldLink>
-				getDataDefinitionDataDefinitionFieldLinkPage(
+				getDataDefinitionDataDefinitionFieldLinksPage(
 					Long dataDefinitionId, String fieldName)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getDataDefinitionDataDefinitionFieldLinkPageHttpResponse(
+				getDataDefinitionDataDefinitionFieldLinksPageHttpResponse(
 					dataDefinitionId, fieldName);
 
 			String content = httpResponse.getContent();
@@ -168,7 +168,7 @@ public interface DataDefinitionFieldLinkResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getDataDefinitionDataDefinitionFieldLinkPageHttpResponse(
+				getDataDefinitionDataDefinitionFieldLinksPageHttpResponse(
 					Long dataDefinitionId, String fieldName)
 			throws Exception {
 

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionResource.java
@@ -121,12 +121,13 @@ public interface DataDefinitionResource {
 				Long dataDefinitionId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putDataDefinitionPermission(
+	public Page<Permission> putDataDefinitionPermissionsPage(
 			Long dataDefinitionId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putDataDefinitionPermissionHttpResponse(
-			Long dataDefinitionId, Permission[] permissions)
+	public HttpInvoker.HttpResponse
+			putDataDefinitionPermissionsPageHttpResponse(
+				Long dataDefinitionId, Permission[] permissions)
 		throws Exception;
 
 	public Page<DataDefinition>
@@ -1067,12 +1068,12 @@ public interface DataDefinitionResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putDataDefinitionPermission(
+		public Page<Permission> putDataDefinitionPermissionsPage(
 				Long dataDefinitionId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putDataDefinitionPermissionHttpResponse(
+				putDataDefinitionPermissionsPageHttpResponse(
 					dataDefinitionId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1112,8 +1113,9 @@ public interface DataDefinitionResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse putDataDefinitionPermissionHttpResponse(
-				Long dataDefinitionId, Permission[] permissions)
+		public HttpInvoker.HttpResponse
+				putDataDefinitionPermissionsPageHttpResponse(
+					Long dataDefinitionId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataLayoutResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataLayoutResource.java
@@ -41,10 +41,10 @@ public interface DataLayoutResource {
 		return new Builder();
 	}
 
-	public void deleteDataLayoutsDataDefinition(Long dataDefinitionId)
+	public void deleteDataDefinitionDataLayout(Long dataDefinitionId)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse deleteDataLayoutsDataDefinitionHttpResponse(
+	public HttpInvoker.HttpResponse deleteDataDefinitionDataLayoutHttpResponse(
 			Long dataDefinitionId)
 		throws Exception;
 
@@ -198,11 +198,11 @@ public interface DataLayoutResource {
 
 	public static class DataLayoutResourceImpl implements DataLayoutResource {
 
-		public void deleteDataLayoutsDataDefinition(Long dataDefinitionId)
+		public void deleteDataDefinitionDataLayout(Long dataDefinitionId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				deleteDataLayoutsDataDefinitionHttpResponse(dataDefinitionId);
+				deleteDataDefinitionDataLayoutHttpResponse(dataDefinitionId);
 
 			String content = httpResponse.getContent();
 
@@ -242,7 +242,7 @@ public interface DataLayoutResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				deleteDataLayoutsDataDefinitionHttpResponse(
+				deleteDataDefinitionDataLayoutHttpResponse(
 					Long dataDefinitionId)
 			throws Exception {
 

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataListViewResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataListViewResource.java
@@ -40,11 +40,11 @@ public interface DataListViewResource {
 		return new Builder();
 	}
 
-	public void deleteDataListViewsDataDefinition(Long dataDefinitionId)
+	public void deleteDataDefinitionDataListView(Long dataDefinitionId)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			deleteDataListViewsDataDefinitionHttpResponse(Long dataDefinitionId)
+			deleteDataDefinitionDataListViewHttpResponse(Long dataDefinitionId)
 		throws Exception;
 
 	public Page<DataListView> getDataDefinitionDataListViewsPage(
@@ -181,11 +181,11 @@ public interface DataListViewResource {
 	public static class DataListViewResourceImpl
 		implements DataListViewResource {
 
-		public void deleteDataListViewsDataDefinition(Long dataDefinitionId)
+		public void deleteDataDefinitionDataListView(Long dataDefinitionId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				deleteDataListViewsDataDefinitionHttpResponse(dataDefinitionId);
+				deleteDataDefinitionDataListViewHttpResponse(dataDefinitionId);
 
 			String content = httpResponse.getContent();
 
@@ -225,7 +225,7 @@ public interface DataListViewResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				deleteDataListViewsDataDefinitionHttpResponse(
+				deleteDataDefinitionDataListViewHttpResponse(
 					Long dataDefinitionId)
 			throws Exception {
 

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataRecordCollectionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataRecordCollectionResource.java
@@ -130,12 +130,12 @@ public interface DataRecordCollectionResource {
 				Long dataRecordCollectionId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putDataRecordCollectionPermission(
+	public Page<Permission> putDataRecordCollectionPermissionsPage(
 			Long dataRecordCollectionId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putDataRecordCollectionPermissionHttpResponse(
+			putDataRecordCollectionPermissionsPageHttpResponse(
 				Long dataRecordCollectionId, Permission[] permissions)
 		throws Exception;
 
@@ -1075,12 +1075,12 @@ public interface DataRecordCollectionResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putDataRecordCollectionPermission(
+		public Page<Permission> putDataRecordCollectionPermissionsPage(
 				Long dataRecordCollectionId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putDataRecordCollectionPermissionHttpResponse(
+				putDataRecordCollectionPermissionsPageHttpResponse(
 					dataRecordCollectionId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1121,7 +1121,7 @@ public interface DataRecordCollectionResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putDataRecordCollectionPermissionHttpResponse(
+				putDataRecordCollectionPermissionsPageHttpResponse(
 					Long dataRecordCollectionId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-config.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-config.yaml
@@ -6,4 +6,5 @@ application:
     name: "Liferay.Data.Engine.REST"
 author: "Jeyvison Nascimento"
 clientDir: "../data-engine-rest-client/src/main/java"
+forcePredictableOperationId: true
 testDir: "../data-engine-rest-test/src/testIntegration/java"

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
@@ -329,7 +329,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.data.engine.rest.client', and version '3.0.9'."
+        'com.liferay.data.engine.rest.client', and version '3.0.10'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
@@ -507,7 +507,7 @@ paths:
             tags: ["DataDefinition"]
     "/data-definitions/{dataDefinitionId}/data-definition-field-links":
         get:
-            operationId: getDataDefinitionDataDefinitionFieldLinkPage
+            operationId: getDataDefinitionDataDefinitionFieldLinksPage
             parameters:
                 - in: path
                   name: dataDefinitionId
@@ -535,7 +535,7 @@ paths:
             tags: ["DataDefinitionFieldLink"]
     "/data-definitions/{dataDefinitionId}/data-layouts":
         delete:
-            operationId: deleteDataLayoutsDataDefinition
+            operationId: deleteDataDefinitionDataLayout
             parameters:
                 - in: path
                   name: dataDefinitionId
@@ -618,7 +618,7 @@ paths:
             tags: ["DataLayout"]
     "/data-definitions/{dataDefinitionId}/data-list-views":
         delete:
-            operationId: deleteDataListViewsDataDefinition
+            operationId: deleteDataDefinitionDataListView
             parameters:
                 - in: path
                   name: dataDefinitionId
@@ -877,7 +877,7 @@ paths:
                         application/xml: {}
             tags: ["DataDefinition"]
         put:
-            operationId: putDataDefinitionPermission
+            operationId: putDataDefinitionPermissionsPage
             parameters:
                 - in: path
                   name: dataDefinitionId
@@ -1232,7 +1232,7 @@ paths:
                         application/xml: {}
             tags: ["DataRecordCollection"]
         put:
-            operationId: putDataRecordCollectionPermission
+            operationId: putDataRecordCollectionPermissionsPage
             parameters:
                 - in: path
                   name: dataRecordCollectionId

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/mutation/v2_0/Mutation.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/mutation/v2_0/Mutation.java
@@ -181,7 +181,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateDataDefinitionPermission(
+			updateDataDefinitionPermissionsPage(
 				@GraphQLName("dataDefinitionId") Long dataDefinitionId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -193,7 +193,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			dataDefinitionResource -> {
 				Page paginationPage =
-					dataDefinitionResource.putDataDefinitionPermission(
+					dataDefinitionResource.putDataDefinitionPermissionsPage(
 						dataDefinitionId, permissions);
 
 				return paginationPage.getItems();
@@ -216,7 +216,7 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean deleteDataLayoutsDataDefinition(
+	public boolean deleteDataDefinitionDataLayout(
 			@GraphQLName("dataDefinitionId") Long dataDefinitionId)
 		throws Exception {
 
@@ -224,7 +224,7 @@ public class Mutation {
 			_dataLayoutResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			dataLayoutResource ->
-				dataLayoutResource.deleteDataLayoutsDataDefinition(
+				dataLayoutResource.deleteDataDefinitionDataLayout(
 					dataDefinitionId));
 
 		return true;
@@ -327,7 +327,7 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public boolean deleteDataListViewsDataDefinition(
+	public boolean deleteDataDefinitionDataListView(
 			@GraphQLName("dataDefinitionId") Long dataDefinitionId)
 		throws Exception {
 
@@ -335,7 +335,7 @@ public class Mutation {
 			_dataListViewResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			dataListViewResource ->
-				dataListViewResource.deleteDataListViewsDataDefinition(
+				dataListViewResource.deleteDataDefinitionDataListView(
 					dataDefinitionId));
 
 		return true;
@@ -640,7 +640,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateDataRecordCollectionPermission(
+			updateDataRecordCollectionPermissionsPage(
 				@GraphQLName("dataRecordCollectionId") Long
 					dataRecordCollectionId,
 				@GraphQLName("permissions")
@@ -654,7 +654,7 @@ public class Mutation {
 			dataRecordCollectionResource -> {
 				Page paginationPage =
 					dataRecordCollectionResource.
-						putDataRecordCollectionPermission(
+						putDataRecordCollectionPermissionsPage(
 							dataRecordCollectionId, permissions);
 
 				return paginationPage.getItems();

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/query/v2_0/Query.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/query/v2_0/Query.java
@@ -239,10 +239,10 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {dataDefinitionDataDefinitionFieldLink(dataDefinitionId: ___, fieldName: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {dataDefinitionDataDefinitionFieldLinks(dataDefinitionId: ___, fieldName: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
-	public DataDefinitionFieldLinkPage dataDefinitionDataDefinitionFieldLink(
+	public DataDefinitionFieldLinkPage dataDefinitionDataDefinitionFieldLinks(
 			@GraphQLName("dataDefinitionId") Long dataDefinitionId,
 			@GraphQLName("fieldName") String fieldName)
 		throws Exception {
@@ -252,7 +252,7 @@ public class Query {
 			this::_populateResourceContext,
 			dataDefinitionFieldLinkResource -> new DataDefinitionFieldLinkPage(
 				dataDefinitionFieldLinkResource.
-					getDataDefinitionDataDefinitionFieldLinkPage(
+					getDataDefinitionDataDefinitionFieldLinksPage(
 						dataDefinitionId, fieldName)));
 	}
 
@@ -593,6 +593,34 @@ public class Query {
 	}
 
 	@GraphQLTypeExtension(DataDefinition.class)
+	public class GetDataDefinitionDataDefinitionFieldLinksPageTypeExtension {
+
+		public GetDataDefinitionDataDefinitionFieldLinksPageTypeExtension(
+			DataDefinition dataDefinition) {
+
+			_dataDefinition = dataDefinition;
+		}
+
+		@GraphQLField
+		public DataDefinitionFieldLinkPage dataDefinitionFieldLinks(
+				@GraphQLName("fieldName") String fieldName)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_dataDefinitionFieldLinkResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				dataDefinitionFieldLinkResource ->
+					new DataDefinitionFieldLinkPage(
+						dataDefinitionFieldLinkResource.
+							getDataDefinitionDataDefinitionFieldLinksPage(
+								_dataDefinition.getId(), fieldName)));
+		}
+
+		private DataDefinition _dataDefinition;
+
+	}
+
+	@GraphQLTypeExtension(DataDefinition.class)
 	public class GetDataDefinitionDataRecordCollectionTypeExtension {
 
 		public GetDataDefinitionDataRecordCollectionTypeExtension(
@@ -662,34 +690,6 @@ public class Query {
 		}
 
 		private DataRecordCollection _dataRecordCollection;
-
-	}
-
-	@GraphQLTypeExtension(DataDefinition.class)
-	public class GetDataDefinitionDataDefinitionFieldLinkPageTypeExtension {
-
-		public GetDataDefinitionDataDefinitionFieldLinkPageTypeExtension(
-			DataDefinition dataDefinition) {
-
-			_dataDefinition = dataDefinition;
-		}
-
-		@GraphQLField
-		public DataDefinitionFieldLinkPage dataDefinitionFieldLink(
-				@GraphQLName("fieldName") String fieldName)
-			throws Exception {
-
-			return _applyComponentServiceObjects(
-				_dataDefinitionFieldLinkResourceComponentServiceObjects,
-				Query.this::_populateResourceContext,
-				dataDefinitionFieldLinkResource ->
-					new DataDefinitionFieldLinkPage(
-						dataDefinitionFieldLinkResource.
-							getDataDefinitionDataDefinitionFieldLinkPage(
-								_dataDefinition.getId(), fieldName)));
-		}
-
-		private DataDefinition _dataDefinition;
 
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
@@ -97,7 +97,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
 	public Page<DataDefinitionFieldLink>
-			getDataDefinitionDataDefinitionFieldLinkPage(
+			getDataDefinitionDataDefinitionFieldLinksPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("dataDefinitionId")
@@ -148,7 +148,9 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		return getDataDefinitionDataDefinitionFieldLinksPage(
+			Long.parseLong((String)parameters.get("dataDefinitionId")),
+			(String)parameters.get("fieldName"));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -516,7 +516,7 @@ public abstract class BaseDataDefinitionResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putDataDefinitionPermission",
+					ActionKeys.PERMISSIONS, "putDataDefinitionPermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
@@ -545,7 +545,7 @@ public abstract class BaseDataDefinitionResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDataDefinitionPermission(
+			putDataDefinitionPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("dataDefinitionId")
@@ -579,7 +579,7 @@ public abstract class BaseDataDefinitionResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putDataDefinitionPermission",
+					ActionKeys.PERMISSIONS, "putDataDefinitionPermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, null);

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
@@ -89,7 +89,7 @@ public abstract class BaseDataLayoutResourceImpl
 	@javax.ws.rs.Path("/data-definitions/{dataDefinitionId}/data-layouts")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public void deleteDataLayoutsDataDefinition(
+	public void deleteDataDefinitionDataLayout(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("dataDefinitionId")

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
@@ -88,7 +88,7 @@ public abstract class BaseDataListViewResourceImpl
 	@javax.ws.rs.Path("/data-definitions/{dataDefinitionId}/data-list-views")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public void deleteDataListViewsDataDefinition(
+	public void deleteDataDefinitionDataListView(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("dataDefinitionId")

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -520,8 +520,9 @@ public abstract class BaseDataRecordCollectionResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putDataRecordCollectionPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putDataRecordCollectionPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
 	}
@@ -553,7 +554,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDataRecordCollectionPermission(
+			putDataRecordCollectionPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("dataRecordCollectionId")
@@ -589,8 +590,9 @@ public abstract class BaseDataRecordCollectionResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putDataRecordCollectionPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putDataRecordCollectionPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, null);
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionFieldLinkResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionFieldLinkResourceImpl.java
@@ -59,7 +59,7 @@ public class DataDefinitionFieldLinkResourceImpl
 
 	@Override
 	public Page<DataDefinitionFieldLink>
-			getDataDefinitionDataDefinitionFieldLinkPage(
+			getDataDefinitionDataDefinitionFieldLinksPage(
 				Long dataDefinitionId, String fieldName)
 		throws Exception {
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
@@ -195,7 +195,7 @@ public class DataDefinitionResourceImpl
 
 		DataLayoutResource dataLayoutResource = _getDataLayoutResource(false);
 
-		dataLayoutResource.deleteDataLayoutsDataDefinition(dataDefinitionId);
+		dataLayoutResource.deleteDataDefinitionDataLayout(dataDefinitionId);
 
 		DataListViewResource.Builder dataListViewResourceBuilder =
 			_dataListViewResourceFactory.create();
@@ -207,8 +207,7 @@ public class DataDefinitionResourceImpl
 				contextUser
 			).build();
 
-		dataListViewResource.deleteDataListViewsDataDefinition(
-			dataDefinitionId);
+		dataListViewResource.deleteDataDefinitionDataListView(dataDefinitionId);
 
 		_ddlRecordSetLocalService.deleteDDMStructureRecordSets(
 			dataDefinitionId);

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataLayoutResourceImpl.java
@@ -110,21 +110,7 @@ public class DataLayoutResourceImpl
 	extends BaseDataLayoutResourceImpl implements EntityModelResource {
 
 	@Override
-	public void deleteDataLayout(Long dataLayoutId) throws Exception {
-		DDMStructureLayout ddmStructureLayout =
-			_ddmStructureLayoutLocalService.getStructureLayout(dataLayoutId);
-
-		DDMStructure ddmStructure = ddmStructureLayout.getDDMStructure();
-
-		_dataDefinitionModelResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(),
-			ddmStructure.getStructureId(), ActionKeys.DELETE);
-
-		_deleteDataLayout(dataLayoutId);
-	}
-
-	@Override
-	public void deleteDataLayoutsDataDefinition(Long dataDefinitionId)
+	public void deleteDataDefinitionDataLayout(Long dataDefinitionId)
 		throws Exception {
 
 		DDMStructure ddmStructure = _ddmStructureLocalService.getDDMStructure(
@@ -144,6 +130,20 @@ public class DataLayoutResourceImpl
 				_deleteDataLayout(ddmStructureLayout.getStructureLayoutId());
 			}
 		}
+	}
+
+	@Override
+	public void deleteDataLayout(Long dataLayoutId) throws Exception {
+		DDMStructureLayout ddmStructureLayout =
+			_ddmStructureLayoutLocalService.getStructureLayout(dataLayoutId);
+
+		DDMStructure ddmStructure = ddmStructureLayout.getDDMStructure();
+
+		_dataDefinitionModelResourcePermission.check(
+			PermissionThreadLocal.getPermissionChecker(),
+			ddmStructure.getStructureId(), ActionKeys.DELETE);
+
+		_deleteDataLayout(dataLayoutId);
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataListViewResourceImpl.java
@@ -85,18 +85,7 @@ public class DataListViewResourceImpl
 	extends BaseDataListViewResourceImpl implements EntityModelResource {
 
 	@Override
-	public void deleteDataListView(Long dataListViewId) throws Exception {
-		_dataDefinitionModelResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(),
-			_getDDMStructureId(
-				_deDataListViewLocalService.getDEDataListView(dataListViewId)),
-			ActionKeys.DELETE);
-
-		_deleteDataListView(dataListViewId);
-	}
-
-	@Override
-	public void deleteDataListViewsDataDefinition(Long dataDefinitionId)
+	public void deleteDataDefinitionDataListView(Long dataDefinitionId)
 		throws Exception {
 
 		for (DEDataListView deDataListView :
@@ -105,6 +94,17 @@ public class DataListViewResourceImpl
 
 			_deleteDataListView(deDataListView.getDeDataListViewId());
 		}
+	}
+
+	@Override
+	public void deleteDataListView(Long dataListViewId) throws Exception {
+		_dataDefinitionModelResourcePermission.check(
+			PermissionThreadLocal.getPermissionChecker(),
+			_getDDMStructureId(
+				_deDataListViewLocalService.getDEDataListView(dataListViewId)),
+			ActionKeys.DELETE);
+
+		_deleteDataListView(dataListViewId);
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/OpenAPIResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.data.engine.rest.client', and version '3.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Data Engine", version = "v2.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.data.engine.rest.client', and version '3.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Data Engine", version = "v2.0")
 )
 @Path("/v2.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionFieldLinkResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionFieldLinkResourceTestCase.java
@@ -192,30 +192,30 @@ public abstract class BaseDataDefinitionFieldLinkResourceTestCase {
 	}
 
 	@Test
-	public void testGetDataDefinitionDataDefinitionFieldLinkPage()
+	public void testGetDataDefinitionDataDefinitionFieldLinksPage()
 		throws Exception {
 
 		Long dataDefinitionId =
-			testGetDataDefinitionDataDefinitionFieldLinkPage_getDataDefinitionId();
+			testGetDataDefinitionDataDefinitionFieldLinksPage_getDataDefinitionId();
 		Long irrelevantDataDefinitionId =
-			testGetDataDefinitionDataDefinitionFieldLinkPage_getIrrelevantDataDefinitionId();
+			testGetDataDefinitionDataDefinitionFieldLinksPage_getIrrelevantDataDefinitionId();
 
 		Page<DataDefinitionFieldLink> page =
 			dataDefinitionFieldLinkResource.
-				getDataDefinitionDataDefinitionFieldLinkPage(
+				getDataDefinitionDataDefinitionFieldLinksPage(
 					dataDefinitionId, RandomTestUtil.randomString());
 
 		Assert.assertEquals(0, page.getTotalCount());
 
 		if (irrelevantDataDefinitionId != null) {
 			DataDefinitionFieldLink irrelevantDataDefinitionFieldLink =
-				testGetDataDefinitionDataDefinitionFieldLinkPage_addDataDefinitionFieldLink(
+				testGetDataDefinitionDataDefinitionFieldLinksPage_addDataDefinitionFieldLink(
 					irrelevantDataDefinitionId,
 					randomIrrelevantDataDefinitionFieldLink());
 
 			page =
 				dataDefinitionFieldLinkResource.
-					getDataDefinitionDataDefinitionFieldLinkPage(
+					getDataDefinitionDataDefinitionFieldLinksPage(
 						irrelevantDataDefinitionId, null);
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -227,16 +227,16 @@ public abstract class BaseDataDefinitionFieldLinkResourceTestCase {
 		}
 
 		DataDefinitionFieldLink dataDefinitionFieldLink1 =
-			testGetDataDefinitionDataDefinitionFieldLinkPage_addDataDefinitionFieldLink(
+			testGetDataDefinitionDataDefinitionFieldLinksPage_addDataDefinitionFieldLink(
 				dataDefinitionId, randomDataDefinitionFieldLink());
 
 		DataDefinitionFieldLink dataDefinitionFieldLink2 =
-			testGetDataDefinitionDataDefinitionFieldLinkPage_addDataDefinitionFieldLink(
+			testGetDataDefinitionDataDefinitionFieldLinksPage_addDataDefinitionFieldLink(
 				dataDefinitionId, randomDataDefinitionFieldLink());
 
 		page =
 			dataDefinitionFieldLinkResource.
-				getDataDefinitionDataDefinitionFieldLinkPage(
+				getDataDefinitionDataDefinitionFieldLinksPage(
 					dataDefinitionId, null);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -248,7 +248,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceTestCase {
 	}
 
 	protected DataDefinitionFieldLink
-			testGetDataDefinitionDataDefinitionFieldLinkPage_addDataDefinitionFieldLink(
+			testGetDataDefinitionDataDefinitionFieldLinksPage_addDataDefinitionFieldLink(
 				Long dataDefinitionId,
 				DataDefinitionFieldLink dataDefinitionFieldLink)
 		throws Exception {
@@ -258,7 +258,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceTestCase {
 	}
 
 	protected Long
-			testGetDataDefinitionDataDefinitionFieldLinkPage_getDataDefinitionId()
+			testGetDataDefinitionDataDefinitionFieldLinksPage_getDataDefinitionId()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -266,7 +266,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceTestCase {
 	}
 
 	protected Long
-			testGetDataDefinitionDataDefinitionFieldLinkPage_getIrrelevantDataDefinitionId()
+			testGetDataDefinitionDataDefinitionFieldLinksPage_getIrrelevantDataDefinitionId()
 		throws Exception {
 
 		return null;

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
@@ -711,10 +711,10 @@ public abstract class BaseDataDefinitionResourceTestCase {
 	}
 
 	@Test
-	public void testPutDataDefinitionPermission() throws Exception {
+	public void testPutDataDefinitionPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DataDefinition dataDefinition =
-			testPutDataDefinitionPermission_addDataDefinition();
+			testPutDataDefinitionPermissionsPage_addDataDefinition();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -722,7 +722,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			dataDefinitionResource.putDataDefinitionPermissionHttpResponse(
+			dataDefinitionResource.putDataDefinitionPermissionsPageHttpResponse(
 				dataDefinition.getId(),
 				new Permission[] {
 					new Permission() {
@@ -735,7 +735,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404,
-			dataDefinitionResource.putDataDefinitionPermissionHttpResponse(
+			dataDefinitionResource.putDataDefinitionPermissionsPageHttpResponse(
 				0L,
 				new Permission[] {
 					new Permission() {
@@ -747,7 +747,8 @@ public abstract class BaseDataDefinitionResourceTestCase {
 				}));
 	}
 
-	protected DataDefinition testPutDataDefinitionPermission_addDataDefinition()
+	protected DataDefinition
+			testPutDataDefinitionPermissionsPage_addDataDefinition()
 		throws Exception {
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
@@ -200,18 +200,18 @@ public abstract class BaseDataLayoutResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteDataLayoutsDataDefinition() throws Exception {
+	public void testDeleteDataDefinitionDataLayout() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DataLayout dataLayout =
-			testDeleteDataLayoutsDataDefinition_addDataLayout();
+			testDeleteDataDefinitionDataLayout_addDataLayout();
 
 		assertHttpResponseStatusCode(
 			204,
-			dataLayoutResource.deleteDataLayoutsDataDefinitionHttpResponse(
+			dataLayoutResource.deleteDataDefinitionDataLayoutHttpResponse(
 				dataLayout.getDataDefinitionId()));
 	}
 
-	protected DataLayout testDeleteDataLayoutsDataDefinition_addDataLayout()
+	protected DataLayout testDeleteDataDefinitionDataLayout_addDataLayout()
 		throws Exception {
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
@@ -196,19 +196,19 @@ public abstract class BaseDataListViewResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteDataListViewsDataDefinition() throws Exception {
+	public void testDeleteDataDefinitionDataListView() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DataListView dataListView =
-			testDeleteDataListViewsDataDefinition_addDataListView();
+			testDeleteDataDefinitionDataListView_addDataListView();
 
 		assertHttpResponseStatusCode(
 			204,
-			dataListViewResource.deleteDataListViewsDataDefinitionHttpResponse(
+			dataListViewResource.deleteDataDefinitionDataListViewHttpResponse(
 				dataListView.getDataDefinitionId()));
 	}
 
 	protected DataListView
-			testDeleteDataListViewsDataDefinition_addDataListView()
+			testDeleteDataDefinitionDataListView_addDataListView()
 		throws Exception {
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
@@ -627,10 +627,10 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 	}
 
 	@Test
-	public void testPutDataRecordCollectionPermission() throws Exception {
+	public void testPutDataRecordCollectionPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DataRecordCollection dataRecordCollection =
-			testPutDataRecordCollectionPermission_addDataRecordCollection();
+			testPutDataRecordCollectionPermissionsPage_addDataRecordCollection();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -639,7 +639,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			dataRecordCollectionResource.
-				putDataRecordCollectionPermissionHttpResponse(
+				putDataRecordCollectionPermissionsPageHttpResponse(
 					dataRecordCollection.getId(),
 					new Permission[] {
 						new Permission() {
@@ -653,7 +653,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			dataRecordCollectionResource.
-				putDataRecordCollectionPermissionHttpResponse(
+				putDataRecordCollectionPermissionsPageHttpResponse(
 					0L,
 					new Permission[] {
 						new Permission() {
@@ -666,7 +666,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 	}
 
 	protected DataRecordCollection
-			testPutDataRecordCollectionPermission_addDataRecordCollection()
+			testPutDataRecordCollectionPermissionsPage_addDataRecordCollection()
 		throws Exception {
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataDefinitionFieldLinkResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataDefinitionFieldLinkResourceTest.java
@@ -87,7 +87,7 @@ public class DataDefinitionFieldLinkResourceTest
 
 	@Override
 	protected DataDefinitionFieldLink
-			testGetDataDefinitionDataDefinitionFieldLinkPage_addDataDefinitionFieldLink(
+			testGetDataDefinitionDataDefinitionFieldLinksPage_addDataDefinitionFieldLink(
 				Long dataDefinitionId,
 				DataDefinitionFieldLink dataDefinitionFieldLink)
 		throws Exception {
@@ -100,7 +100,7 @@ public class DataDefinitionFieldLinkResourceTest
 
 	@Override
 	protected Long
-			testGetDataDefinitionDataDefinitionFieldLinkPage_getDataDefinitionId()
+			testGetDataDefinitionDataDefinitionFieldLinksPage_getDataDefinitionId()
 		throws Exception {
 
 		return _dataDefinition.getId();

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataDefinitionResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataDefinitionResourceTest.java
@@ -736,7 +736,8 @@ public class DataDefinitionResourceTest
 	}
 
 	@Override
-	protected DataDefinition testPutDataDefinitionPermission_addDataDefinition()
+	protected DataDefinition
+			testPutDataDefinitionPermissionsPage_addDataDefinition()
 		throws Exception {
 
 		return dataDefinitionResource.postSiteDataDefinitionByContentType(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataLayoutResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataLayoutResourceTest.java
@@ -412,15 +412,15 @@ public class DataLayoutResourceTest extends BaseDataLayoutResourceTestCase {
 	}
 
 	@Override
-	protected DataLayout testDeleteDataLayout_addDataLayout() throws Exception {
+	protected DataLayout testDeleteDataDefinitionDataLayout_addDataLayout()
+		throws Exception {
+
 		return dataLayoutResource.postDataDefinitionDataLayout(
 			_dataDefinition.getId(), randomDataLayout());
 	}
 
 	@Override
-	protected DataLayout testDeleteDataLayoutsDataDefinition_addDataLayout()
-		throws Exception {
-
+	protected DataLayout testDeleteDataLayout_addDataLayout() throws Exception {
 		return dataLayoutResource.postDataDefinitionDataLayout(
 			_dataDefinition.getId(), randomDataLayout());
 	}

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataListViewResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataListViewResourceTest.java
@@ -94,7 +94,8 @@ public class DataListViewResourceTest extends BaseDataListViewResourceTestCase {
 	}
 
 	@Override
-	protected DataListView testDeleteDataListView_addDataListView()
+	protected DataListView
+			testDeleteDataDefinitionDataListView_addDataListView()
 		throws Exception {
 
 		return dataListViewResource.postDataDefinitionDataListView(
@@ -102,8 +103,7 @@ public class DataListViewResourceTest extends BaseDataListViewResourceTestCase {
 	}
 
 	@Override
-	protected DataListView
-			testDeleteDataListViewsDataDefinition_addDataListView()
+	protected DataListView testDeleteDataListView_addDataListView()
 		throws Exception {
 
 		return dataListViewResource.postDataDefinitionDataListView(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataRecordCollectionResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataRecordCollectionResourceTest.java
@@ -319,7 +319,7 @@ public class DataRecordCollectionResourceTest
 
 	@Override
 	protected DataRecordCollection
-			testPutDataRecordCollectionPermission_addDataRecordCollection()
+			testPutDataRecordCollectionPermissionsPage_addDataRecordCollection()
 		throws Exception {
 
 		return dataRecordCollectionResource.

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -186,7 +186,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.content.client', and version '2.0.10'."
+        'com.liferay.headless.admin.content.client', and version '2.0.11'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-openapi.yaml
@@ -68,7 +68,7 @@ info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
         'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with
-        the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.3'."
+        the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.5'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.3'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "List Type", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.5'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "List Type", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin Taxonomy API
 Bundle-SymbolicName: com.liferay.headless.admin.taxonomy.api
-Bundle-Version: 7.0.2
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.headless.admin.taxonomy.dto.v1_0,\
 	com.liferay.headless.admin.taxonomy.resource.v1_0

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
@@ -76,7 +76,9 @@ public interface KeywordResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryKeywordPermissionsPage(Long assetLibraryId)
+			putAssetLibraryKeywordPermissionsPage(
+				Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<Keyword> getKeywordsRankedPage(
@@ -116,7 +118,9 @@ public interface KeywordResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteKeywordPermissionsPage(Long siteId)
+			putSiteKeywordPermissionsPage(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
@@ -98,7 +98,9 @@ public interface TaxonomyCategoryResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putTaxonomyCategoryPermissionsPage(String taxonomyCategoryId)
+			putTaxonomyCategoryPermissionsPage(
+				String taxonomyCategoryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<TaxonomyCategory> getTaxonomyVocabularyTaxonomyCategoriesPage(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
@@ -78,7 +78,8 @@ public interface TaxonomyVocabularyResource {
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
 			putAssetLibraryTaxonomyVocabularyPermissionsPage(
-				Long assetLibraryId)
+				Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<TaxonomyVocabulary> getSiteTaxonomyVocabulariesPage(
@@ -113,7 +114,9 @@ public interface TaxonomyVocabularyResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteTaxonomyVocabularyPermissionsPage(Long siteId)
+			putSiteTaxonomyVocabularyPermissionsPage(
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public void deleteTaxonomyVocabulary(Long taxonomyVocabularyId)
@@ -144,7 +147,9 @@ public interface TaxonomyVocabularyResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putTaxonomyVocabularyPermissionsPage(Long taxonomyVocabularyId)
+			putTaxonomyVocabularyPermissionsPage(
+				Long taxonomyVocabularyId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/KeywordResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/KeywordResource.java
@@ -27,6 +27,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Generated;
 
@@ -76,12 +78,12 @@ public interface KeywordResource {
 		throws Exception;
 
 	public Page<Permission> putAssetLibraryKeywordPermissionsPage(
-			Long assetLibraryId)
+			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			putAssetLibraryKeywordPermissionsPageHttpResponse(
-				Long assetLibraryId)
+				Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
 	public Page<Keyword> getKeywordsRankedPage(
@@ -167,11 +169,12 @@ public interface KeywordResource {
 			Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteKeywordPermissionsPage(Long siteId)
+	public Page<Permission> putSiteKeywordPermissionsPage(
+			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse putSiteKeywordPermissionsPageHttpResponse(
-			Long siteId)
+			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public static class Builder {
@@ -603,12 +606,12 @@ public interface KeywordResource {
 		}
 
 		public Page<Permission> putAssetLibraryKeywordPermissionsPage(
-				Long assetLibraryId)
+				Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				putAssetLibraryKeywordPermissionsPageHttpResponse(
-					assetLibraryId);
+					assetLibraryId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -649,10 +652,20 @@ public interface KeywordResource {
 
 		public HttpInvoker.HttpResponse
 				putAssetLibraryKeywordPermissionsPageHttpResponse(
-					Long assetLibraryId)
+					Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				Stream.of(
+					permissions
+				).map(
+					value -> String.valueOf(value)
+				).collect(
+					Collectors.toList()
+				).toString(),
+				"application/json");
 
 			if (_builder._locale != null) {
 				httpInvoker.header(
@@ -1681,11 +1694,12 @@ public interface KeywordResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteKeywordPermissionsPage(Long siteId)
+		public Page<Permission> putSiteKeywordPermissionsPage(
+				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteKeywordPermissionsPageHttpResponse(siteId);
+				putSiteKeywordPermissionsPageHttpResponse(siteId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -1725,10 +1739,21 @@ public interface KeywordResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteKeywordPermissionsPageHttpResponse(Long siteId)
+				putSiteKeywordPermissionsPageHttpResponse(
+					Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				Stream.of(
+					permissions
+				).map(
+					value -> String.valueOf(value)
+				).collect(
+					Collectors.toList()
+				).toString(),
+				"application/json");
 
 			if (_builder._locale != null) {
 				httpInvoker.header(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyCategoryResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyCategoryResource.java
@@ -27,6 +27,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Generated;
 
@@ -124,12 +126,12 @@ public interface TaxonomyCategoryResource {
 		throws Exception;
 
 	public Page<Permission> putTaxonomyCategoryPermissionsPage(
-			String taxonomyCategoryId)
+			String taxonomyCategoryId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			putTaxonomyCategoryPermissionsPageHttpResponse(
-				String taxonomyCategoryId)
+				String taxonomyCategoryId, Permission[] permissions)
 		throws Exception;
 
 	public Page<TaxonomyCategory> getTaxonomyVocabularyTaxonomyCategoriesPage(
@@ -1125,12 +1127,12 @@ public interface TaxonomyCategoryResource {
 		}
 
 		public Page<Permission> putTaxonomyCategoryPermissionsPage(
-				String taxonomyCategoryId)
+				String taxonomyCategoryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				putTaxonomyCategoryPermissionsPageHttpResponse(
-					taxonomyCategoryId);
+					taxonomyCategoryId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -1171,10 +1173,20 @@ public interface TaxonomyCategoryResource {
 
 		public HttpInvoker.HttpResponse
 				putTaxonomyCategoryPermissionsPageHttpResponse(
-					String taxonomyCategoryId)
+					String taxonomyCategoryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				Stream.of(
+					permissions
+				).map(
+					value -> String.valueOf(value)
+				).collect(
+					Collectors.toList()
+				).toString(),
+				"application/json");
 
 			if (_builder._locale != null) {
 				httpInvoker.header(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyVocabularyResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyVocabularyResource.java
@@ -27,6 +27,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Generated;
 
@@ -80,12 +82,12 @@ public interface TaxonomyVocabularyResource {
 		throws Exception;
 
 	public Page<Permission> putAssetLibraryTaxonomyVocabularyPermissionsPage(
-			Long assetLibraryId)
+			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			putAssetLibraryTaxonomyVocabularyPermissionsPageHttpResponse(
-				Long assetLibraryId)
+				Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
 	public Page<TaxonomyVocabulary> getSiteTaxonomyVocabulariesPage(
@@ -153,11 +155,12 @@ public interface TaxonomyVocabularyResource {
 		throws Exception;
 
 	public Page<Permission> putSiteTaxonomyVocabularyPermissionsPage(
-			Long siteId)
+			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putSiteTaxonomyVocabularyPermissionsPageHttpResponse(Long siteId)
+			putSiteTaxonomyVocabularyPermissionsPageHttpResponse(
+				Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public void deleteTaxonomyVocabulary(Long taxonomyVocabularyId)
@@ -214,12 +217,12 @@ public interface TaxonomyVocabularyResource {
 		throws Exception;
 
 	public Page<Permission> putTaxonomyVocabularyPermissionsPage(
-			Long taxonomyVocabularyId)
+			Long taxonomyVocabularyId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			putTaxonomyVocabularyPermissionsPageHttpResponse(
-				Long taxonomyVocabularyId)
+				Long taxonomyVocabularyId, Permission[] permissions)
 		throws Exception;
 
 	public static class Builder {
@@ -657,12 +660,12 @@ public interface TaxonomyVocabularyResource {
 
 		public Page<Permission>
 				putAssetLibraryTaxonomyVocabularyPermissionsPage(
-					Long assetLibraryId)
+					Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				putAssetLibraryTaxonomyVocabularyPermissionsPageHttpResponse(
-					assetLibraryId);
+					assetLibraryId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -703,10 +706,20 @@ public interface TaxonomyVocabularyResource {
 
 		public HttpInvoker.HttpResponse
 				putAssetLibraryTaxonomyVocabularyPermissionsPageHttpResponse(
-					Long assetLibraryId)
+					Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				Stream.of(
+					permissions
+				).map(
+					value -> String.valueOf(value)
+				).collect(
+					Collectors.toList()
+				).toString(),
+				"application/json");
 
 			if (_builder._locale != null) {
 				httpInvoker.header(
@@ -1360,11 +1373,12 @@ public interface TaxonomyVocabularyResource {
 		}
 
 		public Page<Permission> putSiteTaxonomyVocabularyPermissionsPage(
-				Long siteId)
+				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteTaxonomyVocabularyPermissionsPageHttpResponse(siteId);
+				putSiteTaxonomyVocabularyPermissionsPageHttpResponse(
+					siteId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -1405,10 +1419,20 @@ public interface TaxonomyVocabularyResource {
 
 		public HttpInvoker.HttpResponse
 				putSiteTaxonomyVocabularyPermissionsPageHttpResponse(
-					Long siteId)
+					Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				Stream.of(
+					permissions
+				).map(
+					value -> String.valueOf(value)
+				).collect(
+					Collectors.toList()
+				).toString(),
+				"application/json");
 
 			if (_builder._locale != null) {
 				httpInvoker.header(
@@ -2021,12 +2045,12 @@ public interface TaxonomyVocabularyResource {
 		}
 
 		public Page<Permission> putTaxonomyVocabularyPermissionsPage(
-				Long taxonomyVocabularyId)
+				Long taxonomyVocabularyId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				putTaxonomyVocabularyPermissionsPageHttpResponse(
-					taxonomyVocabularyId);
+					taxonomyVocabularyId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -2067,10 +2091,20 @@ public interface TaxonomyVocabularyResource {
 
 		public HttpInvoker.HttpResponse
 				putTaxonomyVocabularyPermissionsPageHttpResponse(
-					Long taxonomyVocabularyId)
+					Long taxonomyVocabularyId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				Stream.of(
+					permissions
+				).map(
+					value -> String.valueOf(value)
+				).collect(
+					Collectors.toList()
+				).toString(),
+				"application/json");
 
 			if (_builder._locale != null) {
 				httpInvoker.header(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -363,7 +363,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.taxonomy.client', and version '4.0.9'."
+        'com.liferay.headless.admin.taxonomy.client', and version '4.0.11'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/mutation/v1_0/Mutation.java
@@ -105,7 +105,10 @@ public class Mutation {
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
 			updateAssetLibraryKeywordPermissionsPage(
-				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId)
+				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -114,7 +117,7 @@ public class Mutation {
 			keywordResource -> {
 				Page paginationPage =
 					keywordResource.putAssetLibraryKeywordPermissionsPage(
-						Long.valueOf(assetLibraryId));
+						Long.valueOf(assetLibraryId), permissions);
 
 				return paginationPage.getItems();
 			});
@@ -231,7 +234,10 @@ public class Mutation {
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
 			updateSiteKeywordPermissionsPage(
-				@GraphQLName("siteKey") @NotEmpty String siteKey)
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -240,7 +246,7 @@ public class Mutation {
 			keywordResource -> {
 				Page paginationPage =
 					keywordResource.putSiteKeywordPermissionsPage(
-						Long.valueOf(siteKey));
+						Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
 			});
@@ -341,7 +347,10 @@ public class Mutation {
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
 			updateTaxonomyCategoryPermissionsPage(
-				@GraphQLName("taxonomyCategoryId") String taxonomyCategoryId)
+				@GraphQLName("taxonomyCategoryId") String taxonomyCategoryId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -350,7 +359,7 @@ public class Mutation {
 			taxonomyCategoryResource -> {
 				Page paginationPage =
 					taxonomyCategoryResource.putTaxonomyCategoryPermissionsPage(
-						taxonomyCategoryId);
+						taxonomyCategoryId, permissions);
 
 				return paginationPage.getItems();
 			});
@@ -465,7 +474,10 @@ public class Mutation {
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
 			updateAssetLibraryTaxonomyVocabularyPermissionsPage(
-				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId)
+				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -475,7 +487,7 @@ public class Mutation {
 				Page paginationPage =
 					taxonomyVocabularyResource.
 						putAssetLibraryTaxonomyVocabularyPermissionsPage(
-							Long.valueOf(assetLibraryId));
+							Long.valueOf(assetLibraryId), permissions);
 
 				return paginationPage.getItems();
 			});
@@ -555,7 +567,10 @@ public class Mutation {
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
 			updateSiteTaxonomyVocabularyPermissionsPage(
-				@GraphQLName("siteKey") @NotEmpty String siteKey)
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -565,7 +580,7 @@ public class Mutation {
 				Page paginationPage =
 					taxonomyVocabularyResource.
 						putSiteTaxonomyVocabularyPermissionsPage(
-							Long.valueOf(siteKey));
+							Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
 			});
@@ -653,7 +668,10 @@ public class Mutation {
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
 			updateTaxonomyVocabularyPermissionsPage(
-				@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId)
+				@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -663,7 +681,7 @@ public class Mutation {
 				Page paginationPage =
 					taxonomyVocabularyResource.
 						putTaxonomyVocabularyPermissionsPage(
-							taxonomyVocabularyId);
+							taxonomyVocabularyId, permissions);
 
 				return paginationPage.getItems();
 			});

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -266,8 +267,9 @@ public abstract class BaseKeywordResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putAssetLibraryKeywordPermission",
-					portletName, assetLibraryId)
+					ActionKeys.PERMISSIONS,
+					"putAssetLibraryKeywordPermissionsPage", portletName,
+					assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, roleNames);
 	}
@@ -297,10 +299,39 @@ public abstract class BaseKeywordResourceImpl
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId)
+				Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		String portletName = getPermissionCheckerPortletName(assetLibraryId);
+
+		PermissionUtil.checkPermission(
+			ActionKeys.PERMISSIONS, groupLocalService, portletName,
+			assetLibraryId, assetLibraryId);
+
+		resourcePermissionLocalService.updateResourcePermissions(
+			contextCompany.getCompanyId(), assetLibraryId, portletName,
+			String.valueOf(assetLibraryId),
+			ModelPermissionsUtil.toModelPermissions(
+				contextCompany.getCompanyId(), permissions, assetLibraryId,
+				portletName, resourceActionLocalService,
+				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS,
+					"getAssetLibraryKeywordPermissionsPage", portletName,
+					assetLibraryId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS,
+					"putAssetLibraryKeywordPermissionsPage", portletName,
+					assetLibraryId)
+			).build(),
+			assetLibraryId, portletName, null);
 	}
 
 	/**
@@ -787,7 +818,7 @@ public abstract class BaseKeywordResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteKeywordPermission",
+					ActionKeys.PERMISSIONS, "putSiteKeywordPermissionsPage",
 					portletName, siteId)
 			).build(),
 			siteId, portletName, roleNames);
@@ -818,10 +849,37 @@ public abstract class BaseKeywordResourceImpl
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
-				Long siteId)
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		String portletName = getPermissionCheckerPortletName(siteId);
+
+		PermissionUtil.checkPermission(
+			ActionKeys.PERMISSIONS, groupLocalService, portletName, siteId,
+			siteId);
+
+		resourcePermissionLocalService.updateResourcePermissions(
+			contextCompany.getCompanyId(), siteId, portletName,
+			String.valueOf(siteId),
+			ModelPermissionsUtil.toModelPermissions(
+				contextCompany.getCompanyId(), permissions, siteId, portletName,
+				resourceActionLocalService, resourcePermissionLocalService,
+				roleLocalService));
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS, "getSiteKeywordPermissionsPage",
+					portletName, siteId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS, "putSiteKeywordPermissionsPage",
+					portletName, siteId)
+			).build(),
+			siteId, portletName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -579,8 +580,9 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putTaxonomyCategoryPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putTaxonomyCategoryPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
 	}
@@ -612,10 +614,42 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("taxonomyCategoryId")
-				String taxonomyCategoryId)
+				String taxonomyCategoryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		String resourceName = getPermissionCheckerResourceName(
+			taxonomyCategoryId);
+		Long resourceId = getPermissionCheckerResourceId(taxonomyCategoryId);
+
+		PermissionUtil.checkPermission(
+			ActionKeys.PERMISSIONS, groupLocalService, resourceName, resourceId,
+			getPermissionCheckerGroupId(taxonomyCategoryId));
+
+		resourcePermissionLocalService.updateResourcePermissions(
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(taxonomyCategoryId), resourceName,
+			String.valueOf(resourceId),
+			ModelPermissionsUtil.toModelPermissions(
+				contextCompany.getCompanyId(), permissions, resourceId,
+				resourceName, resourceActionLocalService,
+				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS,
+					"getTaxonomyCategoryPermissionsPage", resourceName,
+					resourceId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS,
+					"putTaxonomyCategoryPermissionsPage", resourceName,
+					resourceId)
+			).build(),
+			resourceId, resourceName, null);
 	}
 
 	/**

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -279,8 +280,8 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putAssetLibraryTaxonomyVocabularyPermission", portletName,
-					assetLibraryId)
+					"putAssetLibraryTaxonomyVocabularyPermissionsPage",
+					portletName, assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, roleNames);
 	}
@@ -314,10 +315,39 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId)
+				Long assetLibraryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		String portletName = getPermissionCheckerPortletName(assetLibraryId);
+
+		PermissionUtil.checkPermission(
+			ActionKeys.PERMISSIONS, groupLocalService, portletName,
+			assetLibraryId, assetLibraryId);
+
+		resourcePermissionLocalService.updateResourcePermissions(
+			contextCompany.getCompanyId(), assetLibraryId, portletName,
+			String.valueOf(assetLibraryId),
+			ModelPermissionsUtil.toModelPermissions(
+				contextCompany.getCompanyId(), permissions, assetLibraryId,
+				portletName, resourceActionLocalService,
+				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS,
+					"getAssetLibraryTaxonomyVocabularyPermissionsPage",
+					portletName, assetLibraryId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS,
+					"putAssetLibraryTaxonomyVocabularyPermissionsPage",
+					portletName, assetLibraryId)
+			).build(),
+			assetLibraryId, portletName, null);
 	}
 
 	/**
@@ -661,7 +691,8 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteTaxonomyVocabularyPermission", portletName, siteId)
+					"putSiteTaxonomyVocabularyPermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, roleNames);
 	}
@@ -693,10 +724,39 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
-				Long siteId)
+				Long siteId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		String portletName = getPermissionCheckerPortletName(siteId);
+
+		PermissionUtil.checkPermission(
+			ActionKeys.PERMISSIONS, groupLocalService, portletName, siteId,
+			siteId);
+
+		resourcePermissionLocalService.updateResourcePermissions(
+			contextCompany.getCompanyId(), siteId, portletName,
+			String.valueOf(siteId),
+			ModelPermissionsUtil.toModelPermissions(
+				contextCompany.getCompanyId(), permissions, siteId, portletName,
+				resourceActionLocalService, resourcePermissionLocalService,
+				roleLocalService));
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS,
+					"getSiteTaxonomyVocabularyPermissionsPage", portletName,
+					siteId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS,
+					"putSiteTaxonomyVocabularyPermissionsPage", portletName,
+					siteId)
+			).build(),
+			siteId, portletName, null);
 	}
 
 	/**
@@ -1060,8 +1120,9 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putTaxonomyVocabularyPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putTaxonomyVocabularyPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
 	}
@@ -1095,10 +1156,42 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("taxonomyVocabularyId")
-				Long taxonomyVocabularyId)
+				Long taxonomyVocabularyId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		String resourceName = getPermissionCheckerResourceName(
+			taxonomyVocabularyId);
+		Long resourceId = getPermissionCheckerResourceId(taxonomyVocabularyId);
+
+		PermissionUtil.checkPermission(
+			ActionKeys.PERMISSIONS, groupLocalService, resourceName, resourceId,
+			getPermissionCheckerGroupId(taxonomyVocabularyId));
+
+		resourcePermissionLocalService.updateResourcePermissions(
+			contextCompany.getCompanyId(),
+			getPermissionCheckerGroupId(taxonomyVocabularyId), resourceName,
+			String.valueOf(resourceId),
+			ModelPermissionsUtil.toModelPermissions(
+				contextCompany.getCompanyId(), permissions, resourceId,
+				resourceName, resourceActionLocalService,
+				resourcePermissionLocalService, roleLocalService));
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS,
+					"getTaxonomyVocabularyPermissionsPage", resourceName,
+					resourceId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS,
+					"putTaxonomyVocabularyPermissionsPage", resourceName,
+					resourceId)
+			).build(),
+			resourceId, resourceName, null);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.taxonomy.client', and version '4.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Taxonomy", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.taxonomy.client', and version '4.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Taxonomy", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -562,12 +562,28 @@ public abstract class BaseKeywordResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			keywordResource.putAssetLibraryKeywordPermissionsPageHttpResponse(
-				testDepotEntry.getDepotEntryId()));
+				testDepotEntry.getDepotEntryId(),
+				new Permission[] {
+					new Permission() {
+						{
+							setActionIds(new String[] {"PERMISSIONS"});
+							setRoleName(role.getName());
+						}
+					}
+				}));
 
 		assertHttpResponseStatusCode(
 			404,
 			keywordResource.putAssetLibraryKeywordPermissionsPageHttpResponse(
-				testDepotEntry.getDepotEntryId()));
+				testDepotEntry.getDepotEntryId(),
+				new Permission[] {
+					new Permission() {
+						{
+							setActionIds(new String[] {"-"});
+							setRoleName("-");
+						}
+					}
+				}));
 	}
 
 	protected Keyword testPutAssetLibraryKeywordPermissionsPage_addKeyword()
@@ -1182,12 +1198,28 @@ public abstract class BaseKeywordResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			keywordResource.putSiteKeywordPermissionsPageHttpResponse(
-				keyword.getSiteId()));
+				keyword.getSiteId(),
+				new Permission[] {
+					new Permission() {
+						{
+							setActionIds(new String[] {"PERMISSIONS"});
+							setRoleName(role.getName());
+						}
+					}
+				}));
 
 		assertHttpResponseStatusCode(
 			404,
 			keywordResource.putSiteKeywordPermissionsPageHttpResponse(
-				keyword.getSiteId()));
+				keyword.getSiteId(),
+				new Permission[] {
+					new Permission() {
+						{
+							setActionIds(new String[] {"-"});
+							setRoleName("-");
+						}
+					}
+				}));
 	}
 
 	protected Keyword testPutSiteKeywordPermissionsPage_addKeyword()

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -906,12 +906,29 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			200,
 			taxonomyCategoryResource.
 				putTaxonomyCategoryPermissionsPageHttpResponse(
-					taxonomyCategory.getId()));
+					taxonomyCategory.getId(),
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"VIEW"});
+								setRoleName(role.getName());
+							}
+						}
+					}));
 
 		assertHttpResponseStatusCode(
 			404,
 			taxonomyCategoryResource.
-				putTaxonomyCategoryPermissionsPageHttpResponse("-"));
+				putTaxonomyCategoryPermissionsPageHttpResponse(
+					"-",
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"-"});
+								setRoleName("-");
+							}
+						}
+					}));
 	}
 
 	protected TaxonomyCategory

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -623,13 +623,29 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			200,
 			taxonomyVocabularyResource.
 				putAssetLibraryTaxonomyVocabularyPermissionsPageHttpResponse(
-					testDepotEntry.getDepotEntryId()));
+					testDepotEntry.getDepotEntryId(),
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"PERMISSIONS"});
+								setRoleName(role.getName());
+							}
+						}
+					}));
 
 		assertHttpResponseStatusCode(
 			404,
 			taxonomyVocabularyResource.
 				putAssetLibraryTaxonomyVocabularyPermissionsPageHttpResponse(
-					testDepotEntry.getDepotEntryId()));
+					testDepotEntry.getDepotEntryId(),
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"-"});
+								setRoleName("-");
+							}
+						}
+					}));
 	}
 
 	protected TaxonomyVocabulary
@@ -1274,13 +1290,29 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			200,
 			taxonomyVocabularyResource.
 				putSiteTaxonomyVocabularyPermissionsPageHttpResponse(
-					taxonomyVocabulary.getSiteId()));
+					taxonomyVocabulary.getSiteId(),
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"PERMISSIONS"});
+								setRoleName(role.getName());
+							}
+						}
+					}));
 
 		assertHttpResponseStatusCode(
 			404,
 			taxonomyVocabularyResource.
 				putSiteTaxonomyVocabularyPermissionsPageHttpResponse(
-					taxonomyVocabulary.getSiteId()));
+					taxonomyVocabulary.getSiteId(),
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"-"});
+								setRoleName("-");
+							}
+						}
+					}));
 	}
 
 	protected TaxonomyVocabulary
@@ -1523,12 +1555,29 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			200,
 			taxonomyVocabularyResource.
 				putTaxonomyVocabularyPermissionsPageHttpResponse(
-					taxonomyVocabulary.getId()));
+					taxonomyVocabulary.getId(),
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"VIEW"});
+								setRoleName(role.getName());
+							}
+						}
+					}));
 
 		assertHttpResponseStatusCode(
 			404,
 			taxonomyVocabularyResource.
-				putTaxonomyVocabularyPermissionsPageHttpResponse(0L));
+				putTaxonomyVocabularyPermissionsPageHttpResponse(
+					0L,
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"-"});
+								setRoleName("-");
+							}
+						}
+					}));
 	}
 
 	protected TaxonomyVocabulary

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -988,7 +988,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.user.client', and version '4.0.10'."
+        'com.liferay.headless.admin.user.client', and version '4.0.11'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
@@ -616,7 +616,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.workflow.client', and version '4.0.8'."
+        'com.liferay.headless.admin.workflow.client', and version '4.0.9'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.workflow.client', and version '4.0.8'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Workflow", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.workflow.client', and version '4.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Workflow", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 32.2.2
+Bundle-Version: 33.0.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
@@ -92,7 +92,7 @@ public interface BlogPostingResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putBlogPostingPermission(
+			putBlogPostingPermissionsPage(
 				Long blogPostingId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -131,7 +131,7 @@ public interface BlogPostingResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteBlogPostingPermission(
+			putSiteBlogPostingPermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentStructureResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentStructureResource.java
@@ -69,7 +69,7 @@ public interface ContentStructureResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryContentStructurePermission(
+			putAssetLibraryContentStructurePermissionsPage(
 				Long assetLibraryId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -83,7 +83,7 @@ public interface ContentStructureResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putContentStructurePermission(
+			putContentStructurePermissionsPage(
 				Long contentStructureId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -100,7 +100,7 @@ public interface ContentStructureResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteContentStructurePermission(
+			putSiteContentStructurePermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentTemplateResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentTemplateResource.java
@@ -69,7 +69,7 @@ public interface ContentTemplateResource {
 			Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception;
 
-	public ContentTemplate getContentTemplate(
+	public ContentTemplate getSiteContentTemplate(
 			Long siteId, String contentTemplateId)
 		throws Exception;
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
@@ -78,7 +78,7 @@ public interface DocumentFolderResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryDocumentFolderPermission(
+			putAssetLibraryDocumentFolderPermissionsPage(
 				Long assetLibraryId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -108,7 +108,7 @@ public interface DocumentFolderResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDocumentFolderPermission(
+			putDocumentFolderPermissionsPage(
 				Long documentFolderId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -148,7 +148,7 @@ public interface DocumentFolderResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteDocumentFolderPermission(
+			putSiteDocumentFolderPermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentResource.java
@@ -81,7 +81,7 @@ public interface DocumentResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryDocumentPermission(
+			putAssetLibraryDocumentPermissionsPage(
 				Long assetLibraryId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -133,7 +133,7 @@ public interface DocumentResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDocumentPermission(
+			putDocumentPermissionsPage(
 				Long documentId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -174,7 +174,7 @@ public interface DocumentResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteDocumentPermission(
+			putSiteDocumentPermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseArticleResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseArticleResource.java
@@ -104,7 +104,7 @@ public interface KnowledgeBaseArticleResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putKnowledgeBaseArticlePermission(
+			putKnowledgeBaseArticlePermissionsPage(
 				Long knowledgeBaseArticleId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -179,7 +179,7 @@ public interface KnowledgeBaseArticleResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteKnowledgeBaseArticlePermission(
+			putSiteKnowledgeBaseArticlePermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseFolderResource.java
@@ -86,7 +86,7 @@ public interface KnowledgeBaseFolderResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putKnowledgeBaseFolderPermission(
+			putKnowledgeBaseFolderPermissionsPage(
 				Long knowledgeBaseFolderId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -134,7 +134,7 @@ public interface KnowledgeBaseFolderResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteKnowledgeBaseFolderPermission(
+			putSiteKnowledgeBaseFolderPermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
@@ -102,7 +102,7 @@ public interface MessageBoardMessageResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putMessageBoardMessagePermission(
+			putMessageBoardMessagePermissionsPage(
 				Long messageBoardMessageId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -172,7 +172,7 @@ public interface MessageBoardMessageResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteMessageBoardMessagePermission(
+			putSiteMessageBoardMessagePermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardSectionResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardSectionResource.java
@@ -87,7 +87,7 @@ public interface MessageBoardSectionResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putMessageBoardSectionPermission(
+			putMessageBoardSectionPermissionsPage(
 				Long messageBoardSectionId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -130,7 +130,7 @@ public interface MessageBoardSectionResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteMessageBoardSectionPermission(
+			putSiteMessageBoardSectionPermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardThreadResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardThreadResource.java
@@ -122,7 +122,7 @@ public interface MessageBoardThreadResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putMessageBoardThreadPermission(
+			putMessageBoardThreadPermissionsPage(
 				Long messageBoardThreadId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -157,7 +157,7 @@ public interface MessageBoardThreadResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteMessageBoardThreadPermission(
+			putSiteMessageBoardThreadPermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/NavigationMenuResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/NavigationMenuResource.java
@@ -78,7 +78,7 @@ public interface NavigationMenuResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putNavigationMenuPermission(
+			putNavigationMenuPermissionsPage(
 				Long navigationMenuId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -100,7 +100,7 @@ public interface NavigationMenuResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteNavigationMenuPermission(
+			putSiteNavigationMenuPermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/SitePageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/SitePageResource.java
@@ -66,7 +66,7 @@ public interface SitePageResource {
 	public SitePage getSiteSitePage(Long siteId, String friendlyUrlPath)
 		throws Exception;
 
-	public Page<SitePage> getSiteSitePageFriendlyUrlPathExperiencesPage(
+	public Page<SitePage> getSiteSitePagesExperiencesPage(
 			Long siteId, String friendlyUrlPath)
 		throws Exception;
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentFolderResource.java
@@ -80,7 +80,7 @@ public interface StructuredContentFolderResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryStructuredContentFolderPermission(
+			putAssetLibraryStructuredContentFolderPermissionsPage(
 				Long assetLibraryId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -105,7 +105,7 @@ public interface StructuredContentFolderResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteStructuredContentFolderPermission(
+			putSiteStructuredContentFolderPermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -116,7 +116,7 @@ public interface StructuredContentFolderResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putStructuredContentFolderPermission(
+			putStructuredContentFolderPermissionsPage(
 				Long structuredContentFolderId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentResource.java
@@ -79,7 +79,7 @@ public interface StructuredContentResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryStructuredContentPermission(
+			putAssetLibraryStructuredContentPermissionsPage(
 				Long assetLibraryId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -131,7 +131,7 @@ public interface StructuredContentResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteStructuredContentPermission(
+			putSiteStructuredContentPermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -192,7 +192,7 @@ public interface StructuredContentResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putStructuredContentPermission(
+			putStructuredContentPermissionsPage(
 				Long structuredContentId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -202,7 +202,7 @@ public interface StructuredContentResource {
 				Long structuredContentId, String displayPageKey)
 		throws Exception;
 
-	public String getStructuredContentRenderedContentTemplate(
+	public String getStructuredContentRenderedContentContentTemplate(
 			Long structuredContentId, String contentTemplateId)
 		throws Exception;
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiNodeResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiNodeResource.java
@@ -88,7 +88,7 @@ public interface WikiNodeResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteWikiNodePermission(
+			putSiteWikiNodePermissionsPage(
 				Long siteId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
@@ -111,7 +111,7 @@ public interface WikiNodeResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putWikiNodePermission(
+			putWikiNodePermissionsPage(
 				Long wikiNodeId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageResource.java
@@ -108,7 +108,7 @@ public interface WikiPageResource {
 		throws Exception;
 
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putWikiPagePermission(
+			putWikiPagePermissionsPage(
 				Long wikiPageId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 11.5.0
+version 12.0.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingResource.java
@@ -122,11 +122,11 @@ public interface BlogPostingResource {
 			Long blogPostingId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putBlogPostingPermission(
+	public Page<Permission> putBlogPostingPermissionsPage(
 			Long blogPostingId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putBlogPostingPermissionHttpResponse(
+	public HttpInvoker.HttpResponse putBlogPostingPermissionsPageHttpResponse(
 			Long blogPostingId, Permission[] permissions)
 		throws Exception;
 
@@ -201,12 +201,13 @@ public interface BlogPostingResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteBlogPostingPermission(
+	public Page<Permission> putSiteBlogPostingPermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putSiteBlogPostingPermissionHttpResponse(
-			Long siteId, Permission[] permissions)
+	public HttpInvoker.HttpResponse
+			putSiteBlogPostingPermissionsPageHttpResponse(
+				Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public void putSiteBlogPostingSubscribe(Long siteId) throws Exception;
@@ -1184,12 +1185,12 @@ public interface BlogPostingResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putBlogPostingPermission(
+		public Page<Permission> putBlogPostingPermissionsPage(
 				Long blogPostingId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putBlogPostingPermissionHttpResponse(
+				putBlogPostingPermissionsPageHttpResponse(
 					blogPostingId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1229,8 +1230,9 @@ public interface BlogPostingResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse putBlogPostingPermissionHttpResponse(
-				Long blogPostingId, Permission[] permissions)
+		public HttpInvoker.HttpResponse
+				putBlogPostingPermissionsPageHttpResponse(
+					Long blogPostingId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1977,12 +1979,13 @@ public interface BlogPostingResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteBlogPostingPermission(
+		public Page<Permission> putSiteBlogPostingPermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteBlogPostingPermissionHttpResponse(siteId, permissions);
+				putSiteBlogPostingPermissionsPageHttpResponse(
+					siteId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -2022,7 +2025,7 @@ public interface BlogPostingResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteBlogPostingPermissionHttpResponse(
+				putSiteBlogPostingPermissionsPageHttpResponse(
 					Long siteId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentStructureResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentStructureResource.java
@@ -64,12 +64,12 @@ public interface ContentStructureResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putAssetLibraryContentStructurePermission(
+	public Page<Permission> putAssetLibraryContentStructurePermissionsPage(
 			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putAssetLibraryContentStructurePermissionHttpResponse(
+			putAssetLibraryContentStructurePermissionsPageHttpResponse(
 				Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -89,12 +89,13 @@ public interface ContentStructureResource {
 				Long contentStructureId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putContentStructurePermission(
+	public Page<Permission> putContentStructurePermissionsPage(
 			Long contentStructureId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putContentStructurePermissionHttpResponse(
-			Long contentStructureId, Permission[] permissions)
+	public HttpInvoker.HttpResponse
+			putContentStructurePermissionsPageHttpResponse(
+				Long contentStructureId, Permission[] permissions)
 		throws Exception;
 
 	public Page<ContentStructure> getSiteContentStructuresPage(
@@ -116,12 +117,12 @@ public interface ContentStructureResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteContentStructurePermission(
+	public Page<Permission> putSiteContentStructurePermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putSiteContentStructurePermissionHttpResponse(
+			putSiteContentStructurePermissionsPageHttpResponse(
 				Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -392,12 +393,12 @@ public interface ContentStructureResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putAssetLibraryContentStructurePermission(
+		public Page<Permission> putAssetLibraryContentStructurePermissionsPage(
 				Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putAssetLibraryContentStructurePermissionHttpResponse(
+				putAssetLibraryContentStructurePermissionsPageHttpResponse(
 					assetLibraryId, permissions);
 
 			String content = httpResponse.getContent();
@@ -438,7 +439,7 @@ public interface ContentStructureResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putAssetLibraryContentStructurePermissionHttpResponse(
+				putAssetLibraryContentStructurePermissionsPageHttpResponse(
 					Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
@@ -655,12 +656,12 @@ public interface ContentStructureResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putContentStructurePermission(
+		public Page<Permission> putContentStructurePermissionsPage(
 				Long contentStructureId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putContentStructurePermissionHttpResponse(
+				putContentStructurePermissionsPageHttpResponse(
 					contentStructureId, permissions);
 
 			String content = httpResponse.getContent();
@@ -701,7 +702,7 @@ public interface ContentStructureResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putContentStructurePermissionHttpResponse(
+				putContentStructurePermissionsPageHttpResponse(
 					Long contentStructureId, Permission[] permissions)
 			throws Exception {
 
@@ -944,12 +945,12 @@ public interface ContentStructureResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteContentStructurePermission(
+		public Page<Permission> putSiteContentStructurePermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteContentStructurePermissionHttpResponse(
+				putSiteContentStructurePermissionsPageHttpResponse(
 					siteId, permissions);
 
 			String content = httpResponse.getContent();
@@ -990,7 +991,7 @@ public interface ContentStructureResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteContentStructurePermissionHttpResponse(
+				putSiteContentStructurePermissionsPageHttpResponse(
 					Long siteId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentTemplateResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentTemplateResource.java
@@ -62,11 +62,11 @@ public interface ContentTemplateResource {
 			String filterString, Pagination pagination, String sortString)
 		throws Exception;
 
-	public ContentTemplate getContentTemplate(
+	public ContentTemplate getSiteContentTemplate(
 			Long siteId, String contentTemplateId)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse getContentTemplateHttpResponse(
+	public HttpInvoker.HttpResponse getSiteContentTemplateHttpResponse(
 			Long siteId, String contentTemplateId)
 		throws Exception;
 
@@ -354,12 +354,12 @@ public interface ContentTemplateResource {
 			return httpInvoker.invoke();
 		}
 
-		public ContentTemplate getContentTemplate(
+		public ContentTemplate getSiteContentTemplate(
 				Long siteId, String contentTemplateId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getContentTemplateHttpResponse(siteId, contentTemplateId);
+				getSiteContentTemplateHttpResponse(siteId, contentTemplateId);
 
 			String content = httpResponse.getContent();
 
@@ -398,7 +398,7 @@ public interface ContentTemplateResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse getContentTemplateHttpResponse(
+		public HttpInvoker.HttpResponse getSiteContentTemplateHttpResponse(
 				Long siteId, String contentTemplateId)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentFolderResource.java
@@ -83,12 +83,12 @@ public interface DocumentFolderResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putAssetLibraryDocumentFolderPermission(
+	public Page<Permission> putAssetLibraryDocumentFolderPermissionsPage(
 			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putAssetLibraryDocumentFolderPermissionHttpResponse(
+			putAssetLibraryDocumentFolderPermissionsPageHttpResponse(
 				Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -144,12 +144,13 @@ public interface DocumentFolderResource {
 				Long documentFolderId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putDocumentFolderPermission(
+	public Page<Permission> putDocumentFolderPermissionsPage(
 			Long documentFolderId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putDocumentFolderPermissionHttpResponse(
-			Long documentFolderId, Permission[] permissions)
+	public HttpInvoker.HttpResponse
+			putDocumentFolderPermissionsPageHttpResponse(
+				Long documentFolderId, Permission[] permissions)
 		throws Exception;
 
 	public void putDocumentFolderSubscribe(Long documentFolderId)
@@ -225,12 +226,13 @@ public interface DocumentFolderResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteDocumentFolderPermission(
+	public Page<Permission> putSiteDocumentFolderPermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putSiteDocumentFolderPermissionHttpResponse(
-			Long siteId, Permission[] permissions)
+	public HttpInvoker.HttpResponse
+			putSiteDocumentFolderPermissionsPageHttpResponse(
+				Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public static class Builder {
@@ -671,12 +673,12 @@ public interface DocumentFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putAssetLibraryDocumentFolderPermission(
+		public Page<Permission> putAssetLibraryDocumentFolderPermissionsPage(
 				Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putAssetLibraryDocumentFolderPermissionHttpResponse(
+				putAssetLibraryDocumentFolderPermissionsPageHttpResponse(
 					assetLibraryId, permissions);
 
 			String content = httpResponse.getContent();
@@ -717,7 +719,7 @@ public interface DocumentFolderResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putAssetLibraryDocumentFolderPermissionHttpResponse(
+				putAssetLibraryDocumentFolderPermissionsPageHttpResponse(
 					Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
@@ -1334,12 +1336,12 @@ public interface DocumentFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putDocumentFolderPermission(
+		public Page<Permission> putDocumentFolderPermissionsPage(
 				Long documentFolderId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putDocumentFolderPermissionHttpResponse(
+				putDocumentFolderPermissionsPageHttpResponse(
 					documentFolderId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1379,8 +1381,9 @@ public interface DocumentFolderResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse putDocumentFolderPermissionHttpResponse(
-				Long documentFolderId, Permission[] permissions)
+		public HttpInvoker.HttpResponse
+				putDocumentFolderPermissionsPageHttpResponse(
+					Long documentFolderId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -2149,12 +2152,12 @@ public interface DocumentFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteDocumentFolderPermission(
+		public Page<Permission> putSiteDocumentFolderPermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteDocumentFolderPermissionHttpResponse(
+				putSiteDocumentFolderPermissionsPageHttpResponse(
 					siteId, permissions);
 
 			String content = httpResponse.getContent();
@@ -2195,7 +2198,7 @@ public interface DocumentFolderResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteDocumentFolderPermissionHttpResponse(
+				putSiteDocumentFolderPermissionsPageHttpResponse(
 					Long siteId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentResource.java
@@ -89,12 +89,12 @@ public interface DocumentResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putAssetLibraryDocumentPermission(
+	public Page<Permission> putAssetLibraryDocumentPermissionsPage(
 			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putAssetLibraryDocumentPermissionHttpResponse(
+			putAssetLibraryDocumentPermissionsPageHttpResponse(
 				Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -211,11 +211,11 @@ public interface DocumentResource {
 			Long documentId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putDocumentPermission(
+	public Page<Permission> putDocumentPermissionsPage(
 			Long documentId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putDocumentPermissionHttpResponse(
+	public HttpInvoker.HttpResponse putDocumentPermissionsPageHttpResponse(
 			Long documentId, Permission[] permissions)
 		throws Exception;
 
@@ -295,11 +295,11 @@ public interface DocumentResource {
 			Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteDocumentPermission(
+	public Page<Permission> putSiteDocumentPermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putSiteDocumentPermissionHttpResponse(
+	public HttpInvoker.HttpResponse putSiteDocumentPermissionsPageHttpResponse(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -752,12 +752,12 @@ public interface DocumentResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putAssetLibraryDocumentPermission(
+		public Page<Permission> putAssetLibraryDocumentPermissionsPage(
 				Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putAssetLibraryDocumentPermissionHttpResponse(
+				putAssetLibraryDocumentPermissionsPageHttpResponse(
 					assetLibraryId, permissions);
 
 			String content = httpResponse.getContent();
@@ -798,7 +798,7 @@ public interface DocumentResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putAssetLibraryDocumentPermissionHttpResponse(
+				putAssetLibraryDocumentPermissionsPageHttpResponse(
 					Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
@@ -2041,12 +2041,12 @@ public interface DocumentResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putDocumentPermission(
+		public Page<Permission> putDocumentPermissionsPage(
 				Long documentId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putDocumentPermissionHttpResponse(documentId, permissions);
+				putDocumentPermissionsPageHttpResponse(documentId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -2085,7 +2085,7 @@ public interface DocumentResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse putDocumentPermissionHttpResponse(
+		public HttpInvoker.HttpResponse putDocumentPermissionsPageHttpResponse(
 				Long documentId, Permission[] permissions)
 			throws Exception {
 
@@ -2856,12 +2856,12 @@ public interface DocumentResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteDocumentPermission(
+		public Page<Permission> putSiteDocumentPermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteDocumentPermissionHttpResponse(siteId, permissions);
+				putSiteDocumentPermissionsPageHttpResponse(siteId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -2900,8 +2900,9 @@ public interface DocumentResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse putSiteDocumentPermissionHttpResponse(
-				Long siteId, Permission[] permissions)
+		public HttpInvoker.HttpResponse
+				putSiteDocumentPermissionsPageHttpResponse(
+					Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseArticleResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseArticleResource.java
@@ -137,12 +137,12 @@ public interface KnowledgeBaseArticleResource {
 				Long knowledgeBaseArticleId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putKnowledgeBaseArticlePermission(
+	public Page<Permission> putKnowledgeBaseArticlePermissionsPage(
 			Long knowledgeBaseArticleId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putKnowledgeBaseArticlePermissionHttpResponse(
+			putKnowledgeBaseArticlePermissionsPageHttpResponse(
 				Long knowledgeBaseArticleId, Permission[] permissions)
 		throws Exception;
 
@@ -291,12 +291,12 @@ public interface KnowledgeBaseArticleResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteKnowledgeBaseArticlePermission(
+	public Page<Permission> putSiteKnowledgeBaseArticlePermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putSiteKnowledgeBaseArticlePermissionHttpResponse(
+			putSiteKnowledgeBaseArticlePermissionsPageHttpResponse(
 				Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -1308,12 +1308,12 @@ public interface KnowledgeBaseArticleResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putKnowledgeBaseArticlePermission(
+		public Page<Permission> putKnowledgeBaseArticlePermissionsPage(
 				Long knowledgeBaseArticleId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putKnowledgeBaseArticlePermissionHttpResponse(
+				putKnowledgeBaseArticlePermissionsPageHttpResponse(
 					knowledgeBaseArticleId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1354,7 +1354,7 @@ public interface KnowledgeBaseArticleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putKnowledgeBaseArticlePermissionHttpResponse(
+				putKnowledgeBaseArticlePermissionsPageHttpResponse(
 					Long knowledgeBaseArticleId, Permission[] permissions)
 			throws Exception {
 
@@ -2689,12 +2689,12 @@ public interface KnowledgeBaseArticleResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteKnowledgeBaseArticlePermission(
+		public Page<Permission> putSiteKnowledgeBaseArticlePermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteKnowledgeBaseArticlePermissionHttpResponse(
+				putSiteKnowledgeBaseArticlePermissionsPageHttpResponse(
 					siteId, permissions);
 
 			String content = httpResponse.getContent();
@@ -2735,7 +2735,7 @@ public interface KnowledgeBaseArticleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteKnowledgeBaseArticlePermissionHttpResponse(
+				putSiteKnowledgeBaseArticlePermissionsPageHttpResponse(
 					Long siteId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseFolderResource.java
@@ -98,12 +98,12 @@ public interface KnowledgeBaseFolderResource {
 				Long knowledgeBaseFolderId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putKnowledgeBaseFolderPermission(
+	public Page<Permission> putKnowledgeBaseFolderPermissionsPage(
 			Long knowledgeBaseFolderId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putKnowledgeBaseFolderPermissionHttpResponse(
+			putKnowledgeBaseFolderPermissionsPageHttpResponse(
 				Long knowledgeBaseFolderId, Permission[] permissions)
 		throws Exception;
 
@@ -193,12 +193,12 @@ public interface KnowledgeBaseFolderResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteKnowledgeBaseFolderPermission(
+	public Page<Permission> putSiteKnowledgeBaseFolderPermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putSiteKnowledgeBaseFolderPermissionHttpResponse(
+			putSiteKnowledgeBaseFolderPermissionsPageHttpResponse(
 				Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -854,12 +854,12 @@ public interface KnowledgeBaseFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putKnowledgeBaseFolderPermission(
+		public Page<Permission> putKnowledgeBaseFolderPermissionsPage(
 				Long knowledgeBaseFolderId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putKnowledgeBaseFolderPermissionHttpResponse(
+				putKnowledgeBaseFolderPermissionsPageHttpResponse(
 					knowledgeBaseFolderId, permissions);
 
 			String content = httpResponse.getContent();
@@ -900,7 +900,7 @@ public interface KnowledgeBaseFolderResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putKnowledgeBaseFolderPermissionHttpResponse(
+				putKnowledgeBaseFolderPermissionsPageHttpResponse(
 					Long knowledgeBaseFolderId, Permission[] permissions)
 			throws Exception {
 
@@ -1737,12 +1737,12 @@ public interface KnowledgeBaseFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteKnowledgeBaseFolderPermission(
+		public Page<Permission> putSiteKnowledgeBaseFolderPermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteKnowledgeBaseFolderPermissionHttpResponse(
+				putSiteKnowledgeBaseFolderPermissionsPageHttpResponse(
 					siteId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1783,7 +1783,7 @@ public interface KnowledgeBaseFolderResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteKnowledgeBaseFolderPermissionHttpResponse(
+				putSiteKnowledgeBaseFolderPermissionsPageHttpResponse(
 					Long siteId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardMessageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardMessageResource.java
@@ -132,12 +132,12 @@ public interface MessageBoardMessageResource {
 				Long messageBoardMessageId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putMessageBoardMessagePermission(
+	public Page<Permission> putMessageBoardMessagePermissionsPage(
 			Long messageBoardMessageId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putMessageBoardMessagePermissionHttpResponse(
+			putMessageBoardMessagePermissionsPageHttpResponse(
 				Long messageBoardMessageId, Permission[] permissions)
 		throws Exception;
 
@@ -275,12 +275,12 @@ public interface MessageBoardMessageResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteMessageBoardMessagePermission(
+	public Page<Permission> putSiteMessageBoardMessagePermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putSiteMessageBoardMessagePermissionHttpResponse(
+			putSiteMessageBoardMessagePermissionsPageHttpResponse(
 				Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -1275,12 +1275,12 @@ public interface MessageBoardMessageResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putMessageBoardMessagePermission(
+		public Page<Permission> putMessageBoardMessagePermissionsPage(
 				Long messageBoardMessageId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putMessageBoardMessagePermissionHttpResponse(
+				putMessageBoardMessagePermissionsPageHttpResponse(
 					messageBoardMessageId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1321,7 +1321,7 @@ public interface MessageBoardMessageResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putMessageBoardMessagePermissionHttpResponse(
+				putMessageBoardMessagePermissionsPageHttpResponse(
 					Long messageBoardMessageId, Permission[] permissions)
 			throws Exception {
 
@@ -2568,12 +2568,12 @@ public interface MessageBoardMessageResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteMessageBoardMessagePermission(
+		public Page<Permission> putSiteMessageBoardMessagePermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteMessageBoardMessagePermissionHttpResponse(
+				putSiteMessageBoardMessagePermissionsPageHttpResponse(
 					siteId, permissions);
 
 			String content = httpResponse.getContent();
@@ -2614,7 +2614,7 @@ public interface MessageBoardMessageResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteMessageBoardMessagePermissionHttpResponse(
+				putSiteMessageBoardMessagePermissionsPageHttpResponse(
 					Long siteId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardSectionResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardSectionResource.java
@@ -99,12 +99,12 @@ public interface MessageBoardSectionResource {
 				Long messageBoardSectionId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putMessageBoardSectionPermission(
+	public Page<Permission> putMessageBoardSectionPermissionsPage(
 			Long messageBoardSectionId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putMessageBoardSectionPermissionHttpResponse(
+			putMessageBoardSectionPermissionsPageHttpResponse(
 				Long messageBoardSectionId, Permission[] permissions)
 		throws Exception;
 
@@ -186,12 +186,12 @@ public interface MessageBoardSectionResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteMessageBoardSectionPermission(
+	public Page<Permission> putSiteMessageBoardSectionPermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putSiteMessageBoardSectionPermissionHttpResponse(
+			putSiteMessageBoardSectionPermissionsPageHttpResponse(
 				Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -847,12 +847,12 @@ public interface MessageBoardSectionResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putMessageBoardSectionPermission(
+		public Page<Permission> putMessageBoardSectionPermissionsPage(
 				Long messageBoardSectionId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putMessageBoardSectionPermissionHttpResponse(
+				putMessageBoardSectionPermissionsPageHttpResponse(
 					messageBoardSectionId, permissions);
 
 			String content = httpResponse.getContent();
@@ -893,7 +893,7 @@ public interface MessageBoardSectionResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putMessageBoardSectionPermissionHttpResponse(
+				putMessageBoardSectionPermissionsPageHttpResponse(
 					Long messageBoardSectionId, Permission[] permissions)
 			throws Exception {
 
@@ -1674,12 +1674,12 @@ public interface MessageBoardSectionResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteMessageBoardSectionPermission(
+		public Page<Permission> putSiteMessageBoardSectionPermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteMessageBoardSectionPermissionHttpResponse(
+				putSiteMessageBoardSectionPermissionsPageHttpResponse(
 					siteId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1720,7 +1720,7 @@ public interface MessageBoardSectionResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteMessageBoardSectionPermissionHttpResponse(
+				putSiteMessageBoardSectionPermissionsPageHttpResponse(
 					Long siteId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardThreadResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardThreadResource.java
@@ -179,12 +179,13 @@ public interface MessageBoardThreadResource {
 				Long messageBoardThreadId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putMessageBoardThreadPermission(
+	public Page<Permission> putMessageBoardThreadPermissionsPage(
 			Long messageBoardThreadId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putMessageBoardThreadPermissionHttpResponse(
-			Long messageBoardThreadId, Permission[] permissions)
+	public HttpInvoker.HttpResponse
+			putMessageBoardThreadPermissionsPageHttpResponse(
+				Long messageBoardThreadId, Permission[] permissions)
 		throws Exception;
 
 	public void putMessageBoardThreadSubscribe(Long messageBoardThreadId)
@@ -248,12 +249,12 @@ public interface MessageBoardThreadResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteMessageBoardThreadPermission(
+	public Page<Permission> putSiteMessageBoardThreadPermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putSiteMessageBoardThreadPermissionHttpResponse(
+			putSiteMessageBoardThreadPermissionsPageHttpResponse(
 				Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -1640,12 +1641,12 @@ public interface MessageBoardThreadResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putMessageBoardThreadPermission(
+		public Page<Permission> putMessageBoardThreadPermissionsPage(
 				Long messageBoardThreadId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putMessageBoardThreadPermissionHttpResponse(
+				putMessageBoardThreadPermissionsPageHttpResponse(
 					messageBoardThreadId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1686,7 +1687,7 @@ public interface MessageBoardThreadResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putMessageBoardThreadPermissionHttpResponse(
+				putMessageBoardThreadPermissionsPageHttpResponse(
 					Long messageBoardThreadId, Permission[] permissions)
 			throws Exception {
 
@@ -2350,12 +2351,12 @@ public interface MessageBoardThreadResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteMessageBoardThreadPermission(
+		public Page<Permission> putSiteMessageBoardThreadPermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteMessageBoardThreadPermissionHttpResponse(
+				putSiteMessageBoardThreadPermissionsPageHttpResponse(
 					siteId, permissions);
 
 			String content = httpResponse.getContent();
@@ -2396,7 +2397,7 @@ public interface MessageBoardThreadResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteMessageBoardThreadPermissionHttpResponse(
+				putSiteMessageBoardThreadPermissionsPageHttpResponse(
 					Long siteId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/NavigationMenuResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/NavigationMenuResource.java
@@ -87,12 +87,13 @@ public interface NavigationMenuResource {
 				Long navigationMenuId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putNavigationMenuPermission(
+	public Page<Permission> putNavigationMenuPermissionsPage(
 			Long navigationMenuId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putNavigationMenuPermissionHttpResponse(
-			Long navigationMenuId, Permission[] permissions)
+	public HttpInvoker.HttpResponse
+			putNavigationMenuPermissionsPageHttpResponse(
+				Long navigationMenuId, Permission[] permissions)
 		throws Exception;
 
 	public Page<NavigationMenu> getSiteNavigationMenusPage(
@@ -128,12 +129,13 @@ public interface NavigationMenuResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteNavigationMenuPermission(
+	public Page<Permission> putSiteNavigationMenuPermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putSiteNavigationMenuPermissionHttpResponse(
-			Long siteId, Permission[] permissions)
+	public HttpInvoker.HttpResponse
+			putSiteNavigationMenuPermissionsPageHttpResponse(
+				Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public static class Builder {
@@ -692,12 +694,12 @@ public interface NavigationMenuResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putNavigationMenuPermission(
+		public Page<Permission> putNavigationMenuPermissionsPage(
 				Long navigationMenuId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putNavigationMenuPermissionHttpResponse(
+				putNavigationMenuPermissionsPageHttpResponse(
 					navigationMenuId, permissions);
 
 			String content = httpResponse.getContent();
@@ -737,8 +739,9 @@ public interface NavigationMenuResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse putNavigationMenuPermissionHttpResponse(
-				Long navigationMenuId, Permission[] permissions)
+		public HttpInvoker.HttpResponse
+				putNavigationMenuPermissionsPageHttpResponse(
+					Long navigationMenuId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1125,12 +1128,12 @@ public interface NavigationMenuResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteNavigationMenuPermission(
+		public Page<Permission> putSiteNavigationMenuPermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteNavigationMenuPermissionHttpResponse(
+				putSiteNavigationMenuPermissionsPageHttpResponse(
 					siteId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1171,7 +1174,7 @@ public interface NavigationMenuResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteNavigationMenuPermissionHttpResponse(
+				putSiteNavigationMenuPermissionsPageHttpResponse(
 					Long siteId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/SitePageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/SitePageResource.java
@@ -58,13 +58,12 @@ public interface SitePageResource {
 			Long siteId, String friendlyUrlPath)
 		throws Exception;
 
-	public Page<SitePage> getSiteSitePageFriendlyUrlPathExperiencesPage(
+	public Page<SitePage> getSiteSitePagesExperiencesPage(
 			Long siteId, String friendlyUrlPath)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse
-			getSiteSitePageFriendlyUrlPathExperiencesPageHttpResponse(
-				Long siteId, String friendlyUrlPath)
+	public HttpInvoker.HttpResponse getSiteSitePagesExperiencesPageHttpResponse(
+			Long siteId, String friendlyUrlPath)
 		throws Exception;
 
 	public SitePage getSiteSitePageExperienceExperienceKey(
@@ -351,12 +350,12 @@ public interface SitePageResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<SitePage> getSiteSitePageFriendlyUrlPathExperiencesPage(
+		public Page<SitePage> getSiteSitePagesExperiencesPage(
 				Long siteId, String friendlyUrlPath)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getSiteSitePageFriendlyUrlPathExperiencesPageHttpResponse(
+				getSiteSitePagesExperiencesPageHttpResponse(
 					siteId, friendlyUrlPath);
 
 			String content = httpResponse.getContent();
@@ -397,7 +396,7 @@ public interface SitePageResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getSiteSitePageFriendlyUrlPathExperiencesPageHttpResponse(
+				getSiteSitePagesExperiencesPageHttpResponse(
 					Long siteId, String friendlyUrlPath)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentFolderResource.java
@@ -88,12 +88,13 @@ public interface StructuredContentFolderResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putAssetLibraryStructuredContentFolderPermission(
-			Long assetLibraryId, Permission[] permissions)
+	public Page<Permission>
+			putAssetLibraryStructuredContentFolderPermissionsPage(
+				Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putAssetLibraryStructuredContentFolderPermissionHttpResponse(
+			putAssetLibraryStructuredContentFolderPermissionsPageHttpResponse(
 				Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -136,12 +137,12 @@ public interface StructuredContentFolderResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteStructuredContentFolderPermission(
+	public Page<Permission> putSiteStructuredContentFolderPermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putSiteStructuredContentFolderPermissionHttpResponse(
+			putSiteStructuredContentFolderPermissionsPageHttpResponse(
 				Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -154,12 +155,12 @@ public interface StructuredContentFolderResource {
 				Long structuredContentFolderId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putStructuredContentFolderPermission(
+	public Page<Permission> putStructuredContentFolderPermissionsPage(
 			Long structuredContentFolderId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putStructuredContentFolderPermissionHttpResponse(
+			putStructuredContentFolderPermissionsPageHttpResponse(
 				Long structuredContentFolderId, Permission[] permissions)
 		throws Exception;
 
@@ -703,12 +704,12 @@ public interface StructuredContentFolderResource {
 		}
 
 		public Page<Permission>
-				putAssetLibraryStructuredContentFolderPermission(
+				putAssetLibraryStructuredContentFolderPermissionsPage(
 					Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putAssetLibraryStructuredContentFolderPermissionHttpResponse(
+				putAssetLibraryStructuredContentFolderPermissionsPageHttpResponse(
 					assetLibraryId, permissions);
 
 			String content = httpResponse.getContent();
@@ -749,7 +750,7 @@ public interface StructuredContentFolderResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putAssetLibraryStructuredContentFolderPermissionHttpResponse(
+				putAssetLibraryStructuredContentFolderPermissionsPageHttpResponse(
 					Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
@@ -1166,12 +1167,12 @@ public interface StructuredContentFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteStructuredContentFolderPermission(
+		public Page<Permission> putSiteStructuredContentFolderPermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteStructuredContentFolderPermissionHttpResponse(
+				putSiteStructuredContentFolderPermissionsPageHttpResponse(
 					siteId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1212,7 +1213,7 @@ public interface StructuredContentFolderResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteStructuredContentFolderPermissionHttpResponse(
+				putSiteStructuredContentFolderPermissionsPageHttpResponse(
 					Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -1349,12 +1350,12 @@ public interface StructuredContentFolderResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putStructuredContentFolderPermission(
+		public Page<Permission> putStructuredContentFolderPermissionsPage(
 				Long structuredContentFolderId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putStructuredContentFolderPermissionHttpResponse(
+				putStructuredContentFolderPermissionsPageHttpResponse(
 					structuredContentFolderId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1395,7 +1396,7 @@ public interface StructuredContentFolderResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putStructuredContentFolderPermissionHttpResponse(
+				putStructuredContentFolderPermissionsPageHttpResponse(
 					Long structuredContentFolderId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentResource.java
@@ -86,12 +86,12 @@ public interface StructuredContentResource {
 				Long assetLibraryId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putAssetLibraryStructuredContentPermission(
+	public Page<Permission> putAssetLibraryStructuredContentPermissionsPage(
 			Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putAssetLibraryStructuredContentPermissionHttpResponse(
+			putAssetLibraryStructuredContentPermissionsPageHttpResponse(
 				Long assetLibraryId, Permission[] permissions)
 		throws Exception;
 
@@ -189,12 +189,12 @@ public interface StructuredContentResource {
 				Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteStructuredContentPermission(
+	public Page<Permission> putSiteStructuredContentPermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putSiteStructuredContentPermissionHttpResponse(
+			putSiteStructuredContentPermissionsPageHttpResponse(
 				Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -315,12 +315,13 @@ public interface StructuredContentResource {
 				Long structuredContentId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putStructuredContentPermission(
+	public Page<Permission> putStructuredContentPermissionsPage(
 			Long structuredContentId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putStructuredContentPermissionHttpResponse(
-			Long structuredContentId, Permission[] permissions)
+	public HttpInvoker.HttpResponse
+			putStructuredContentPermissionsPageHttpResponse(
+				Long structuredContentId, Permission[] permissions)
 		throws Exception;
 
 	public String
@@ -333,12 +334,12 @@ public interface StructuredContentResource {
 				Long structuredContentId, String displayPageKey)
 		throws Exception;
 
-	public String getStructuredContentRenderedContentTemplate(
+	public String getStructuredContentRenderedContentContentTemplate(
 			Long structuredContentId, String contentTemplateId)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getStructuredContentRenderedContentTemplateHttpResponse(
+			getStructuredContentRenderedContentContentTemplateHttpResponse(
 				Long structuredContentId, String contentTemplateId)
 		throws Exception;
 
@@ -794,12 +795,12 @@ public interface StructuredContentResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putAssetLibraryStructuredContentPermission(
+		public Page<Permission> putAssetLibraryStructuredContentPermissionsPage(
 				Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putAssetLibraryStructuredContentPermissionHttpResponse(
+				putAssetLibraryStructuredContentPermissionsPageHttpResponse(
 					assetLibraryId, permissions);
 
 			String content = httpResponse.getContent();
@@ -840,7 +841,7 @@ public interface StructuredContentResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putAssetLibraryStructuredContentPermissionHttpResponse(
+				putAssetLibraryStructuredContentPermissionsPageHttpResponse(
 					Long assetLibraryId, Permission[] permissions)
 			throws Exception {
 
@@ -1791,12 +1792,12 @@ public interface StructuredContentResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteStructuredContentPermission(
+		public Page<Permission> putSiteStructuredContentPermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteStructuredContentPermissionHttpResponse(
+				putSiteStructuredContentPermissionsPageHttpResponse(
 					siteId, permissions);
 
 			String content = httpResponse.getContent();
@@ -1837,7 +1838,7 @@ public interface StructuredContentResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putSiteStructuredContentPermissionHttpResponse(
+				putSiteStructuredContentPermissionsPageHttpResponse(
 					Long siteId, Permission[] permissions)
 			throws Exception {
 
@@ -3082,12 +3083,12 @@ public interface StructuredContentResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putStructuredContentPermission(
+		public Page<Permission> putStructuredContentPermissionsPage(
 				Long structuredContentId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putStructuredContentPermissionHttpResponse(
+				putStructuredContentPermissionsPageHttpResponse(
 					structuredContentId, permissions);
 
 			String content = httpResponse.getContent();
@@ -3128,7 +3129,7 @@ public interface StructuredContentResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putStructuredContentPermissionHttpResponse(
+				putStructuredContentPermissionsPageHttpResponse(
 					Long structuredContentId, Permission[] permissions)
 			throws Exception {
 
@@ -3262,12 +3263,12 @@ public interface StructuredContentResource {
 			return httpInvoker.invoke();
 		}
 
-		public String getStructuredContentRenderedContentTemplate(
+		public String getStructuredContentRenderedContentContentTemplate(
 				Long structuredContentId, String contentTemplateId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getStructuredContentRenderedContentTemplateHttpResponse(
+				getStructuredContentRenderedContentContentTemplateHttpResponse(
 					structuredContentId, contentTemplateId);
 
 			String content = httpResponse.getContent();
@@ -3308,7 +3309,7 @@ public interface StructuredContentResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getStructuredContentRenderedContentTemplateHttpResponse(
+				getStructuredContentRenderedContentContentTemplateHttpResponse(
 					Long structuredContentId, String contentTemplateId)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiNodeResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiNodeResource.java
@@ -104,11 +104,11 @@ public interface WikiNodeResource {
 			Long siteId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putSiteWikiNodePermission(
+	public Page<Permission> putSiteWikiNodePermissionsPage(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putSiteWikiNodePermissionHttpResponse(
+	public HttpInvoker.HttpResponse putSiteWikiNodePermissionsPageHttpResponse(
 			Long siteId, Permission[] permissions)
 		throws Exception;
 
@@ -151,11 +151,11 @@ public interface WikiNodeResource {
 			Long wikiNodeId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putWikiNodePermission(
+	public Page<Permission> putWikiNodePermissionsPage(
 			Long wikiNodeId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putWikiNodePermissionHttpResponse(
+	public HttpInvoker.HttpResponse putWikiNodePermissionsPageHttpResponse(
 			Long wikiNodeId, Permission[] permissions)
 		throws Exception;
 
@@ -853,12 +853,12 @@ public interface WikiNodeResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putSiteWikiNodePermission(
+		public Page<Permission> putSiteWikiNodePermissionsPage(
 				Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteWikiNodePermissionHttpResponse(siteId, permissions);
+				putSiteWikiNodePermissionsPageHttpResponse(siteId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -897,8 +897,9 @@ public interface WikiNodeResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse putSiteWikiNodePermissionHttpResponse(
-				Long siteId, Permission[] permissions)
+		public HttpInvoker.HttpResponse
+				putSiteWikiNodePermissionsPageHttpResponse(
+					Long siteId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1421,12 +1422,12 @@ public interface WikiNodeResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putWikiNodePermission(
+		public Page<Permission> putWikiNodePermissionsPage(
 				Long wikiNodeId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putWikiNodePermissionHttpResponse(wikiNodeId, permissions);
+				putWikiNodePermissionsPageHttpResponse(wikiNodeId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -1465,7 +1466,7 @@ public interface WikiNodeResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse putWikiNodePermissionHttpResponse(
+		public HttpInvoker.HttpResponse putWikiNodePermissionsPageHttpResponse(
 				Long wikiNodeId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiPageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiPageResource.java
@@ -150,11 +150,11 @@ public interface WikiPageResource {
 			Long wikiPageId, String roleNames)
 		throws Exception;
 
-	public Page<Permission> putWikiPagePermission(
+	public Page<Permission> putWikiPagePermissionsPage(
 			Long wikiPageId, Permission[] permissions)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse putWikiPagePermissionHttpResponse(
+	public HttpInvoker.HttpResponse putWikiPagePermissionsPageHttpResponse(
 			Long wikiPageId, Permission[] permissions)
 		throws Exception;
 
@@ -1407,12 +1407,12 @@ public interface WikiPageResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<Permission> putWikiPagePermission(
+		public Page<Permission> putWikiPagePermissionsPage(
 				Long wikiPageId, Permission[] permissions)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putWikiPagePermissionHttpResponse(wikiPageId, permissions);
+				putWikiPagePermissionsPageHttpResponse(wikiPageId, permissions);
 
 			String content = httpResponse.getContent();
 
@@ -1451,7 +1451,7 @@ public interface WikiPageResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse putWikiPagePermissionHttpResponse(
+		public HttpInvoker.HttpResponse putWikiPagePermissionsPageHttpResponse(
 				Long wikiPageId, Permission[] permissions)
 			throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-config.yaml
@@ -6,4 +6,5 @@ application:
     name: "Liferay.Headless.Delivery"
 author: "Javier Gamarra"
 clientDir: "../headless-delivery-client/src/main/java"
+forcePredictableOperationId: true
 testDir: "../headless-delivery-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -4783,7 +4783,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.13'."
+        'com.liferay.headless.delivery.client', and version '4.0.14'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
@@ -4986,7 +4986,7 @@ paths:
                         application/xml: {}
             tags: ["ContentStructure"]
         put:
-            operationId: putAssetLibraryContentStructurePermission
+            operationId: putAssetLibraryContentStructurePermissionsPage
             parameters:
                 - in: path
                   name: assetLibraryId
@@ -5152,7 +5152,7 @@ paths:
                         application/xml: {}
             tags: ["DocumentFolder"]
         put:
-            operationId: putAssetLibraryDocumentFolderPermission
+            operationId: putAssetLibraryDocumentFolderPermissionsPage
             parameters:
                 - in: path
                   name: assetLibraryId
@@ -5271,7 +5271,7 @@ paths:
                         application/xml: {}
             tags: ["Document"]
         put:
-            operationId: putAssetLibraryDocumentPermission
+            operationId: putAssetLibraryDocumentPermissionsPage
             parameters:
                 - in: path
                   name: assetLibraryId
@@ -5414,7 +5414,7 @@ paths:
                         application/xml: {}
             tags: ["StructuredContentFolder"]
         put:
-            operationId: putAssetLibraryStructuredContentFolderPermission
+            operationId: putAssetLibraryStructuredContentFolderPermissionsPage
             parameters:
                 - in: path
                   name: assetLibraryId
@@ -5538,7 +5538,7 @@ paths:
                         application/xml: {}
             tags: ["StructuredContent"]
         put:
-            operationId: putAssetLibraryStructuredContentPermission
+            operationId: putAssetLibraryStructuredContentPermissionsPage
             parameters:
                 - in: path
                   name: assetLibraryId
@@ -5889,7 +5889,7 @@ paths:
                         application/xml: {}
             tags: ["BlogPosting"]
         put:
-            operationId: putBlogPostingPermission
+            operationId: putBlogPostingPermissionsPage
             parameters:
                 - in: path
                   name: blogPostingId
@@ -6160,7 +6160,7 @@ paths:
                         application/xml: {}
             tags: ["ContentStructure"]
         put:
-            operationId: putContentStructurePermission
+            operationId: putContentStructurePermissionsPage
             parameters:
                 - in: path
                   name: contentStructureId
@@ -6440,7 +6440,7 @@ paths:
                         application/xml: {}
             tags: ["DocumentFolder"]
         put:
-            operationId: putDocumentFolderPermission
+            operationId: putDocumentFolderPermissionsPage
             parameters:
                 - in: path
                   name: documentFolderId
@@ -6878,7 +6878,7 @@ paths:
                         application/xml: {}
             tags: ["Document"]
         put:
-            operationId: putDocumentPermission
+            operationId: putDocumentPermissionsPage
             parameters:
                 - in: path
                   name: documentId
@@ -7193,7 +7193,7 @@ paths:
                         application/xml: {}
             tags: ["KnowledgeBaseArticle"]
         put:
-            operationId: putKnowledgeBaseArticlePermission
+            operationId: putKnowledgeBaseArticlePermissionsPage
             parameters:
                 - in: path
                   name: knowledgeBaseArticleId
@@ -7570,7 +7570,7 @@ paths:
                         application/xml: {}
             tags: ["KnowledgeBaseFolder"]
         put:
-            operationId: putKnowledgeBaseFolderPermission
+            operationId: putKnowledgeBaseFolderPermissionsPage
             parameters:
                 - in: path
                   name: knowledgeBaseFolderId
@@ -7963,7 +7963,7 @@ paths:
                         application/xml: {}
             tags: ["MessageBoardMessage"]
         put:
-            operationId: putMessageBoardMessagePermission
+            operationId: putMessageBoardMessagePermissionsPage
             parameters:
                 - in: path
                   name: messageBoardMessageId
@@ -8295,7 +8295,7 @@ paths:
                         application/xml: {}
             tags: ["MessageBoardSection"]
         put:
-            operationId: putMessageBoardSectionPermission
+            operationId: putMessageBoardSectionPermissionsPage
             parameters:
                 - in: path
                   name: messageBoardSectionId
@@ -8826,7 +8826,7 @@ paths:
                         application/xml: {}
             tags: ["MessageBoardThread"]
         put:
-            operationId: putMessageBoardThreadPermission
+            operationId: putMessageBoardThreadPermissionsPage
             parameters:
                 - in: path
                   name: messageBoardThreadId
@@ -8962,7 +8962,7 @@ paths:
                         application/xml: {}
             tags: ["NavigationMenu"]
         put:
-            operationId: putNavigationMenuPermission
+            operationId: putNavigationMenuPermissionsPage
             parameters:
                 - in: path
                   name: navigationMenuId
@@ -9249,7 +9249,7 @@ paths:
                         application/xml: {}
             tags: ["BlogPosting"]
         put:
-            operationId: putSiteBlogPostingPermission
+            operationId: putSiteBlogPostingPermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -9496,7 +9496,7 @@ paths:
                         application/xml: {}
             tags: ["ContentStructure"]
         put:
-            operationId: putSiteContentStructurePermission
+            operationId: putSiteContentStructurePermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -9562,7 +9562,7 @@ paths:
             tags: ["ContentTemplate"]
     "/sites/{siteId}/content-templates/{contentTemplateId}":
         get:
-            operationId: getContentTemplate
+            operationId: getSiteContentTemplate
             parameters:
                 - in: path
                   name: siteId
@@ -9692,7 +9692,7 @@ paths:
                         application/xml: {}
             tags: ["DocumentFolder"]
         put:
-            operationId: putSiteDocumentFolderPermission
+            operationId: putSiteDocumentFolderPermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -9909,7 +9909,7 @@ paths:
                         application/xml: {}
             tags: ["Document"]
         put:
-            operationId: putSiteDocumentPermission
+            operationId: putSiteDocumentPermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -10117,7 +10117,7 @@ paths:
                         application/xml: {}
             tags: ["KnowledgeBaseArticle"]
         put:
-            operationId: putSiteKnowledgeBaseArticlePermission
+            operationId: putSiteKnowledgeBaseArticlePermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -10334,7 +10334,7 @@ paths:
                         application/xml: {}
             tags: ["KnowledgeBaseFolder"]
         put:
-            operationId: putSiteKnowledgeBaseFolderPermission
+            operationId: putSiteKnowledgeBaseFolderPermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -10569,7 +10569,7 @@ paths:
                         application/xml: {}
             tags: ["MessageBoardMessage"]
         put:
-            operationId: putSiteMessageBoardMessagePermission
+            operationId: putSiteMessageBoardMessagePermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -10690,7 +10690,7 @@ paths:
                         application/xml: {}
             tags: ["MessageBoardSection"]
         put:
-            operationId: putSiteMessageBoardSectionPermission
+            operationId: putSiteMessageBoardSectionPermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -10840,7 +10840,7 @@ paths:
                         application/xml: {}
             tags: ["MessageBoardThread"]
         put:
-            operationId: putSiteMessageBoardThreadPermission
+            operationId: putSiteMessageBoardThreadPermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -10937,7 +10937,7 @@ paths:
                         application/xml: {}
             tags: ["NavigationMenu"]
         put:
-            operationId: putSiteNavigationMenuPermission
+            operationId: putSiteNavigationMenuPermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -11041,7 +11041,7 @@ paths:
             # @review
             description:
                 Retrieves the experiences of a given Page
-            operationId: getSiteSitePageFriendlyUrlPathExperiencesPage
+            operationId: getSiteSitePagesExperiencesPage
             parameters:
                 - in: path
                   name: siteId
@@ -11269,7 +11269,7 @@ paths:
                         application/xml: {}
             tags: ["StructuredContentFolder"]
         put:
-            operationId: putSiteStructuredContentFolderPermission
+            operationId: putSiteStructuredContentFolderPermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -11547,7 +11547,7 @@ paths:
                         application/xml: {}
             tags: ["StructuredContent"]
         put:
-            operationId: putSiteStructuredContentPermission
+            operationId: putSiteStructuredContentPermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -11748,7 +11748,7 @@ paths:
                         application/xml: {}
             tags: ["WikiNode"]
         put:
-            operationId: putSiteWikiNodePermission
+            operationId: putSiteWikiNodePermissionsPage
             parameters:
                 - in: path
                   name: siteId
@@ -11869,7 +11869,7 @@ paths:
                         application/xml: {}
             tags: ["StructuredContentFolder"]
         put:
-            operationId: putStructuredContentFolderPermission
+            operationId: putStructuredContentFolderPermissionsPage
             parameters:
                 - in: path
                   name: structuredContentFolderId
@@ -12498,7 +12498,7 @@ paths:
                         application/xml: {}
             tags: ["StructuredContent"]
         put:
-            operationId: putStructuredContentPermission
+            operationId: putStructuredContentPermissionsPage
             parameters:
                 - in: path
                   name: structuredContentId
@@ -12541,7 +12541,7 @@ paths:
             description:
                 Retrieves the structured content's rendered template (the result of applying the structure's values to a
                 template).
-            operationId: getStructuredContentRenderedContentTemplate
+            operationId: getStructuredContentRenderedContentContentTemplate
             parameters:
                 - in: path
                   name: structuredContentId
@@ -12684,7 +12684,7 @@ paths:
                         application/xml: {}
             tags: ["WikiNode"]
         put:
-            operationId: putWikiNodePermission
+            operationId: putWikiNodePermissionsPage
             parameters:
                 - in: path
                   name: wikiNodeId
@@ -12995,7 +12995,7 @@ paths:
                         application/xml: {}
             tags: ["WikiPage"]
         put:
-            operationId: putWikiPagePermission
+            operationId: putWikiPagePermissionsPage
             parameters:
                 - in: path
                   name: wikiPageId

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentDTOConverter.java
@@ -267,8 +267,8 @@ public class StructuredContentDTOConverter
 					renderedContentURL = JaxRsLinkUtil.getJaxRsLink(
 						"headless-delivery",
 						BaseStructuredContentResourceImpl.class,
-						"getStructuredContentRenderedContentTemplate", uriInfo,
-						journalArticle.getResourcePrimKey(),
+						"getStructuredContentRenderedContentContentTemplate",
+						uriInfo, journalArticle.getResourcePrimKey(),
 						ddmTemplate.getTemplateKey());
 
 					setMarkedAsDefault(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -358,7 +358,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateBlogPostingPermission(
+			updateBlogPostingPermissionsPage(
 				@GraphQLName("blogPostingId") Long blogPostingId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -370,7 +370,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			blogPostingResource -> {
 				Page paginationPage =
-					blogPostingResource.putBlogPostingPermission(
+					blogPostingResource.putBlogPostingPermissionsPage(
 						blogPostingId, permissions);
 
 				return paginationPage.getItems();
@@ -442,7 +442,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteBlogPostingPermission(
+			updateSiteBlogPostingPermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -454,7 +454,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			blogPostingResource -> {
 				Page paginationPage =
-					blogPostingResource.putSiteBlogPostingPermission(
+					blogPostingResource.putSiteBlogPostingPermissionsPage(
 						Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -711,7 +711,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateAssetLibraryContentStructurePermission(
+			updateAssetLibraryContentStructurePermissionsPage(
 				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -724,7 +724,7 @@ public class Mutation {
 			contentStructureResource -> {
 				Page paginationPage =
 					contentStructureResource.
-						putAssetLibraryContentStructurePermission(
+						putAssetLibraryContentStructurePermissionsPage(
 							Long.valueOf(assetLibraryId), permissions);
 
 				return paginationPage.getItems();
@@ -733,7 +733,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateContentStructurePermission(
+			updateContentStructurePermissionsPage(
 				@GraphQLName("contentStructureId") Long contentStructureId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -745,7 +745,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			contentStructureResource -> {
 				Page paginationPage =
-					contentStructureResource.putContentStructurePermission(
+					contentStructureResource.putContentStructurePermissionsPage(
 						contentStructureId, permissions);
 
 				return paginationPage.getItems();
@@ -754,7 +754,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteContentStructurePermission(
+			updateSiteContentStructurePermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -766,8 +766,9 @@ public class Mutation {
 			this::_populateResourceContext,
 			contentStructureResource -> {
 				Page paginationPage =
-					contentStructureResource.putSiteContentStructurePermission(
-						Long.valueOf(siteKey), permissions);
+					contentStructureResource.
+						putSiteContentStructurePermissionsPage(
+							Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
 			});
@@ -808,7 +809,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateAssetLibraryDocumentPermission(
+			updateAssetLibraryDocumentPermissionsPage(
 				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -820,7 +821,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			documentResource -> {
 				Page paginationPage =
-					documentResource.putAssetLibraryDocumentPermission(
+					documentResource.putAssetLibraryDocumentPermissionsPage(
 						Long.valueOf(assetLibraryId), permissions);
 
 				return paginationPage.getItems();
@@ -989,7 +990,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateDocumentPermission(
+			updateDocumentPermissionsPage(
 				@GraphQLName("documentId") Long documentId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -1000,8 +1001,9 @@ public class Mutation {
 			_documentResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			documentResource -> {
-				Page paginationPage = documentResource.putDocumentPermission(
-					documentId, permissions);
+				Page paginationPage =
+					documentResource.putDocumentPermissionsPage(
+						documentId, permissions);
 
 				return paginationPage.getItems();
 			});
@@ -1083,7 +1085,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteDocumentPermission(
+			updateSiteDocumentPermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -1095,7 +1097,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			documentResource -> {
 				Page paginationPage =
-					documentResource.putSiteDocumentPermission(
+					documentResource.putSiteDocumentPermissionsPage(
 						Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -1133,7 +1135,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateAssetLibraryDocumentFolderPermission(
+			updateAssetLibraryDocumentFolderPermissionsPage(
 				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -1146,7 +1148,7 @@ public class Mutation {
 			documentFolderResource -> {
 				Page paginationPage =
 					documentFolderResource.
-						putAssetLibraryDocumentFolderPermission(
+						putAssetLibraryDocumentFolderPermissionsPage(
 							Long.valueOf(assetLibraryId), permissions);
 
 				return paginationPage.getItems();
@@ -1230,7 +1232,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateDocumentFolderPermission(
+			updateDocumentFolderPermissionsPage(
 				@GraphQLName("documentFolderId") Long documentFolderId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -1242,7 +1244,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			documentFolderResource -> {
 				Page paginationPage =
-					documentFolderResource.putDocumentFolderPermission(
+					documentFolderResource.putDocumentFolderPermissionsPage(
 						documentFolderId, permissions);
 
 				return paginationPage.getItems();
@@ -1326,7 +1328,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteDocumentFolderPermission(
+			updateSiteDocumentFolderPermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -1338,7 +1340,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			documentFolderResource -> {
 				Page paginationPage =
-					documentFolderResource.putSiteDocumentFolderPermission(
+					documentFolderResource.putSiteDocumentFolderPermissionsPage(
 						Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -1475,7 +1477,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateKnowledgeBaseArticlePermission(
+			updateKnowledgeBaseArticlePermissionsPage(
 				@GraphQLName("knowledgeBaseArticleId") Long
 					knowledgeBaseArticleId,
 				@GraphQLName("permissions")
@@ -1489,7 +1491,7 @@ public class Mutation {
 			knowledgeBaseArticleResource -> {
 				Page paginationPage =
 					knowledgeBaseArticleResource.
-						putKnowledgeBaseArticlePermission(
+						putKnowledgeBaseArticlePermissionsPage(
 							knowledgeBaseArticleId, permissions);
 
 				return paginationPage.getItems();
@@ -1652,7 +1654,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteKnowledgeBaseArticlePermission(
+			updateSiteKnowledgeBaseArticlePermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -1665,7 +1667,7 @@ public class Mutation {
 			knowledgeBaseArticleResource -> {
 				Page paginationPage =
 					knowledgeBaseArticleResource.
-						putSiteKnowledgeBaseArticlePermission(
+						putSiteKnowledgeBaseArticlePermissionsPage(
 							Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -1858,7 +1860,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateKnowledgeBaseFolderPermission(
+			updateKnowledgeBaseFolderPermissionsPage(
 				@GraphQLName("knowledgeBaseFolderId") Long
 					knowledgeBaseFolderId,
 				@GraphQLName("permissions")
@@ -1872,7 +1874,7 @@ public class Mutation {
 			knowledgeBaseFolderResource -> {
 				Page paginationPage =
 					knowledgeBaseFolderResource.
-						putKnowledgeBaseFolderPermission(
+						putKnowledgeBaseFolderPermissionsPage(
 							knowledgeBaseFolderId, permissions);
 
 				return paginationPage.getItems();
@@ -1971,7 +1973,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteKnowledgeBaseFolderPermission(
+			updateSiteKnowledgeBaseFolderPermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -1984,7 +1986,7 @@ public class Mutation {
 			knowledgeBaseFolderResource -> {
 				Page paginationPage =
 					knowledgeBaseFolderResource.
-						putSiteKnowledgeBaseFolderPermission(
+						putSiteKnowledgeBaseFolderPermissionsPage(
 							Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -2234,7 +2236,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateMessageBoardMessagePermission(
+			updateMessageBoardMessagePermissionsPage(
 				@GraphQLName("messageBoardMessageId") Long
 					messageBoardMessageId,
 				@GraphQLName("permissions")
@@ -2248,7 +2250,7 @@ public class Mutation {
 			messageBoardMessageResource -> {
 				Page paginationPage =
 					messageBoardMessageResource.
-						putMessageBoardMessagePermission(
+						putMessageBoardMessagePermissionsPage(
 							messageBoardMessageId, permissions);
 
 				return paginationPage.getItems();
@@ -2381,7 +2383,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteMessageBoardMessagePermission(
+			updateSiteMessageBoardMessagePermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -2394,7 +2396,7 @@ public class Mutation {
 			messageBoardMessageResource -> {
 				Page paginationPage =
 					messageBoardMessageResource.
-						putSiteMessageBoardMessagePermission(
+						putSiteMessageBoardMessagePermissionsPage(
 							Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -2482,7 +2484,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateMessageBoardSectionPermission(
+			updateMessageBoardSectionPermissionsPage(
 				@GraphQLName("messageBoardSectionId") Long
 					messageBoardSectionId,
 				@GraphQLName("permissions")
@@ -2496,7 +2498,7 @@ public class Mutation {
 			messageBoardSectionResource -> {
 				Page paginationPage =
 					messageBoardSectionResource.
-						putMessageBoardSectionPermission(
+						putMessageBoardSectionPermissionsPage(
 							messageBoardSectionId, permissions);
 
 				return paginationPage.getItems();
@@ -2584,7 +2586,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteMessageBoardSectionPermission(
+			updateSiteMessageBoardSectionPermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -2597,7 +2599,7 @@ public class Mutation {
 			messageBoardSectionResource -> {
 				Page paginationPage =
 					messageBoardSectionResource.
-						putSiteMessageBoardSectionPermission(
+						putSiteMessageBoardSectionPermissionsPage(
 							Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -2766,7 +2768,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateMessageBoardThreadPermission(
+			updateMessageBoardThreadPermissionsPage(
 				@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -2778,8 +2780,9 @@ public class Mutation {
 			this::_populateResourceContext,
 			messageBoardThreadResource -> {
 				Page paginationPage =
-					messageBoardThreadResource.putMessageBoardThreadPermission(
-						messageBoardThreadId, permissions);
+					messageBoardThreadResource.
+						putMessageBoardThreadPermissionsPage(
+							messageBoardThreadId, permissions);
 
 				return paginationPage.getItems();
 			});
@@ -2847,7 +2850,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteMessageBoardThreadPermission(
+			updateSiteMessageBoardThreadPermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -2860,7 +2863,7 @@ public class Mutation {
 			messageBoardThreadResource -> {
 				Page paginationPage =
 					messageBoardThreadResource.
-						putSiteMessageBoardThreadPermission(
+						putSiteMessageBoardThreadPermissionsPage(
 							Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -2928,7 +2931,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateNavigationMenuPermission(
+			updateNavigationMenuPermissionsPage(
 				@GraphQLName("navigationMenuId") Long navigationMenuId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -2940,7 +2943,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			navigationMenuResource -> {
 				Page paginationPage =
-					navigationMenuResource.putNavigationMenuPermission(
+					navigationMenuResource.putNavigationMenuPermissionsPage(
 						navigationMenuId, permissions);
 
 				return paginationPage.getItems();
@@ -2978,7 +2981,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteNavigationMenuPermission(
+			updateSiteNavigationMenuPermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -2990,7 +2993,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			navigationMenuResource -> {
 				Page paginationPage =
-					navigationMenuResource.putSiteNavigationMenuPermission(
+					navigationMenuResource.putSiteNavigationMenuPermissionsPage(
 						Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -3030,7 +3033,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateAssetLibraryStructuredContentPermission(
+			updateAssetLibraryStructuredContentPermissionsPage(
 				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -3043,7 +3046,7 @@ public class Mutation {
 			structuredContentResource -> {
 				Page paginationPage =
 					structuredContentResource.
-						putAssetLibraryStructuredContentPermission(
+						putAssetLibraryStructuredContentPermissionsPage(
 							Long.valueOf(assetLibraryId), permissions);
 
 				return paginationPage.getItems();
@@ -3121,7 +3124,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteStructuredContentPermission(
+			updateSiteStructuredContentPermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -3134,7 +3137,7 @@ public class Mutation {
 			structuredContentResource -> {
 				Page paginationPage =
 					structuredContentResource.
-						putSiteStructuredContentPermission(
+						putSiteStructuredContentPermissionsPage(
 							Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -3305,7 +3308,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateStructuredContentPermission(
+			updateStructuredContentPermissionsPage(
 				@GraphQLName("structuredContentId") Long structuredContentId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -3317,8 +3320,9 @@ public class Mutation {
 			this::_populateResourceContext,
 			structuredContentResource -> {
 				Page paginationPage =
-					structuredContentResource.putStructuredContentPermission(
-						structuredContentId, permissions);
+					structuredContentResource.
+						putStructuredContentPermissionsPage(
+							structuredContentId, permissions);
 
 				return paginationPage.getItems();
 			});
@@ -3388,7 +3392,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateAssetLibraryStructuredContentFolderPermission(
+			updateAssetLibraryStructuredContentFolderPermissionsPage(
 				@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -3401,7 +3405,7 @@ public class Mutation {
 			structuredContentFolderResource -> {
 				Page paginationPage =
 					structuredContentFolderResource.
-						putAssetLibraryStructuredContentFolderPermission(
+						putAssetLibraryStructuredContentFolderPermissionsPage(
 							Long.valueOf(assetLibraryId), permissions);
 
 				return paginationPage.getItems();
@@ -3441,7 +3445,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteStructuredContentFolderPermission(
+			updateSiteStructuredContentFolderPermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -3454,7 +3458,7 @@ public class Mutation {
 			structuredContentFolderResource -> {
 				Page paginationPage =
 					structuredContentFolderResource.
-						putSiteStructuredContentFolderPermission(
+						putSiteStructuredContentFolderPermissionsPage(
 							Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -3463,7 +3467,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateStructuredContentFolderPermission(
+			updateStructuredContentFolderPermissionsPage(
 				@GraphQLName("structuredContentFolderId") Long
 					structuredContentFolderId,
 				@GraphQLName("permissions")
@@ -3477,7 +3481,7 @@ public class Mutation {
 			structuredContentFolderResource -> {
 				Page paginationPage =
 					structuredContentFolderResource.
-						putStructuredContentFolderPermission(
+						putStructuredContentFolderPermissionsPage(
 							structuredContentFolderId, permissions);
 
 				return paginationPage.getItems();
@@ -3685,7 +3689,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateSiteWikiNodePermission(
+			updateSiteWikiNodePermissionsPage(
 				@GraphQLName("siteKey") @NotEmpty String siteKey,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -3697,7 +3701,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			wikiNodeResource -> {
 				Page paginationPage =
-					wikiNodeResource.putSiteWikiNodePermission(
+					wikiNodeResource.putSiteWikiNodePermissionsPage(
 						Long.valueOf(siteKey), permissions);
 
 				return paginationPage.getItems();
@@ -3761,7 +3765,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateWikiNodePermission(
+			updateWikiNodePermissionsPage(
 				@GraphQLName("wikiNodeId") Long wikiNodeId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -3772,8 +3776,9 @@ public class Mutation {
 			_wikiNodeResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			wikiNodeResource -> {
-				Page paginationPage = wikiNodeResource.putWikiNodePermission(
-					wikiNodeId, permissions);
+				Page paginationPage =
+					wikiNodeResource.putWikiNodePermissionsPage(
+						wikiNodeId, permissions);
 
 				return paginationPage.getItems();
 			});
@@ -3941,7 +3946,7 @@ public class Mutation {
 
 	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
-			updateWikiPagePermission(
+			updateWikiPagePermissionsPage(
 				@GraphQLName("wikiPageId") Long wikiPageId,
 				@GraphQLName("permissions")
 					com.liferay.portal.vulcan.permission.Permission[]
@@ -3952,8 +3957,9 @@ public class Mutation {
 			_wikiPageResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			wikiPageResource -> {
-				Page paginationPage = wikiPageResource.putWikiPagePermission(
-					wikiPageId, permissions);
+				Page paginationPage =
+					wikiPageResource.putWikiPagePermissionsPage(
+						wikiPageId, permissions);
 
 				return paginationPage.getItems();
 			});

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -1029,7 +1029,7 @@ public class Query {
 			_contentTemplateResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			contentTemplateResource ->
-				contentTemplateResource.getContentTemplate(
+				contentTemplateResource.getSiteContentTemplate(
 					Long.valueOf(siteKey), contentTemplateId));
 	}
 
@@ -2566,10 +2566,10 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sitePageFriendlyUrlPathExperiences(friendlyUrlPath: ___, siteKey: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sitePagesExperiences(friendlyUrlPath: ___, siteKey: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the experiences of a given Page")
-	public SitePagePage sitePageFriendlyUrlPathExperiences(
+	public SitePagePage sitePagesExperiences(
 			@GraphQLName("siteKey") @NotEmpty String siteKey,
 			@GraphQLName("friendlyUrlPath") String friendlyUrlPath)
 		throws Exception {
@@ -2578,7 +2578,7 @@ public class Query {
 			_sitePageResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			sitePageResource -> new SitePagePage(
-				sitePageResource.getSiteSitePageFriendlyUrlPathExperiencesPage(
+				sitePageResource.getSiteSitePagesExperiencesPage(
 					Long.valueOf(siteKey), friendlyUrlPath)));
 	}
 
@@ -2965,12 +2965,12 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {structuredContentRenderedContentTemplate(contentTemplateId: ___, structuredContentId: ___){}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {structuredContentRenderedContentContentTemplate(contentTemplateId: ___, structuredContentId: ___){}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the structured content's rendered template (the result of applying the structure's values to a template)."
 	)
-	public String structuredContentRenderedContentTemplate(
+	public String structuredContentRenderedContentContentTemplate(
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("contentTemplateId") String contentTemplateId)
 		throws Exception {
@@ -2980,7 +2980,7 @@ public class Query {
 			this::_populateResourceContext,
 			structuredContentResource ->
 				structuredContentResource.
-					getStructuredContentRenderedContentTemplate(
+					getStructuredContentRenderedContentContentTemplate(
 						structuredContentId, contentTemplateId));
 	}
 
@@ -3624,6 +3624,36 @@ public class Query {
 
 	}
 
+	@GraphQLTypeExtension(StructuredContent.class)
+	public class
+		GetStructuredContentRenderedContentContentTemplateTypeExtension {
+
+		public GetStructuredContentRenderedContentContentTemplateTypeExtension(
+			StructuredContent structuredContent) {
+
+			_structuredContent = structuredContent;
+		}
+
+		@GraphQLField(
+			description = "Retrieves the structured content's rendered template (the result of applying the structure's values to a template)."
+		)
+		public String renderedContentContentTemplate(
+				@GraphQLName("contentTemplateId") String contentTemplateId)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_structuredContentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				structuredContentResource ->
+					structuredContentResource.
+						getStructuredContentRenderedContentContentTemplate(
+							_structuredContent.getId(), contentTemplateId));
+		}
+
+		private StructuredContent _structuredContent;
+
+	}
+
 	@GraphQLTypeExtension(WikiNode.class)
 	public class GetWikiNodeWikiPagesPageTypeExtension {
 
@@ -4187,35 +4217,6 @@ public class Query {
 		}
 
 		private NavigationMenu _navigationMenu;
-
-	}
-
-	@GraphQLTypeExtension(StructuredContent.class)
-	public class GetStructuredContentRenderedContentTemplateTypeExtension {
-
-		public GetStructuredContentRenderedContentTemplateTypeExtension(
-			StructuredContent structuredContent) {
-
-			_structuredContent = structuredContent;
-		}
-
-		@GraphQLField(
-			description = "Retrieves the structured content's rendered template (the result of applying the structure's values to a template)."
-		)
-		public String renderedContentTemplate(
-				@GraphQLName("contentTemplateId") String contentTemplateId)
-			throws Exception {
-
-			return _applyComponentServiceObjects(
-				_structuredContentResourceComponentServiceObjects,
-				Query.this::_populateResourceContext,
-				structuredContentResource ->
-					structuredContentResource.
-						getStructuredContentRenderedContentTemplate(
-							_structuredContent.getId(), contentTemplateId));
-		}
-
-		private StructuredContent _structuredContent;
 
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -560,7 +560,7 @@ public abstract class BaseBlogPostingResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putBlogPostingPermission",
+					ActionKeys.PERMISSIONS, "putBlogPostingPermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
@@ -587,7 +587,7 @@ public abstract class BaseBlogPostingResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putBlogPostingPermission(
+			putBlogPostingPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("blogPostingId")
@@ -620,7 +620,7 @@ public abstract class BaseBlogPostingResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putBlogPostingPermission",
+					ActionKeys.PERMISSIONS, "putBlogPostingPermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, null);
@@ -996,7 +996,7 @@ public abstract class BaseBlogPostingResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteBlogPostingPermission",
+					ActionKeys.PERMISSIONS, "putSiteBlogPostingPermissionsPage",
 					portletName, siteId)
 			).build(),
 			siteId, portletName, roleNames);
@@ -1023,7 +1023,7 @@ public abstract class BaseBlogPostingResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteBlogPostingPermission(
+			putSiteBlogPostingPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -1054,7 +1054,7 @@ public abstract class BaseBlogPostingResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteBlogPostingPermission",
+					ActionKeys.PERMISSIONS, "putSiteBlogPostingPermissionsPage",
 					portletName, siteId)
 			).build(),
 			siteId, portletName, null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -190,8 +190,8 @@ public abstract class BaseContentStructureResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putAssetLibraryContentStructurePermission", portletName,
-					assetLibraryId)
+					"putAssetLibraryContentStructurePermissionsPage",
+					portletName, assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, roleNames);
 	}
@@ -221,7 +221,7 @@ public abstract class BaseContentStructureResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryContentStructurePermission(
+			putAssetLibraryContentStructurePermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("assetLibraryId")
@@ -254,8 +254,8 @@ public abstract class BaseContentStructureResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putAssetLibraryContentStructurePermission", portletName,
-					assetLibraryId)
+					"putAssetLibraryContentStructurePermissionsPage",
+					portletName, assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, null);
 	}
@@ -350,8 +350,9 @@ public abstract class BaseContentStructureResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putContentStructurePermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putContentStructurePermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
 	}
@@ -379,7 +380,7 @@ public abstract class BaseContentStructureResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putContentStructurePermission(
+			putContentStructurePermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("contentStructureId")
@@ -414,8 +415,9 @@ public abstract class BaseContentStructureResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putContentStructurePermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putContentStructurePermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, null);
 	}
@@ -536,8 +538,9 @@ public abstract class BaseContentStructureResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteContentStructurePermission",
-					portletName, siteId)
+					ActionKeys.PERMISSIONS,
+					"putSiteContentStructurePermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, roleNames);
 	}
@@ -565,7 +568,7 @@ public abstract class BaseContentStructureResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteContentStructurePermission(
+			putSiteContentStructurePermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -597,8 +600,9 @@ public abstract class BaseContentStructureResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteContentStructurePermission",
-					portletName, siteId)
+					ActionKeys.PERMISSIONS,
+					"putSiteContentStructurePermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, null);
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
@@ -212,7 +212,7 @@ public abstract class BaseContentTemplateResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/content-templates/{contentTemplateId}")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public ContentTemplate getContentTemplate(
+	public ContentTemplate getSiteContentTemplate(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("siteId")

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -289,7 +289,7 @@ public abstract class BaseDocumentFolderResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putAssetLibraryDocumentFolderPermission", portletName,
+					"putAssetLibraryDocumentFolderPermissionsPage", portletName,
 					assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, roleNames);
@@ -320,7 +320,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryDocumentFolderPermission(
+			putAssetLibraryDocumentFolderPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("assetLibraryId")
@@ -353,7 +353,7 @@ public abstract class BaseDocumentFolderResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putAssetLibraryDocumentFolderPermission", portletName,
+					"putAssetLibraryDocumentFolderPermissionsPage", portletName,
 					assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, null);
@@ -709,7 +709,7 @@ public abstract class BaseDocumentFolderResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putDocumentFolderPermission",
+					ActionKeys.PERMISSIONS, "putDocumentFolderPermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
@@ -738,7 +738,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDocumentFolderPermission(
+			putDocumentFolderPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("documentFolderId")
@@ -772,7 +772,7 @@ public abstract class BaseDocumentFolderResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putDocumentFolderPermission",
+					ActionKeys.PERMISSIONS, "putDocumentFolderPermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, null);
@@ -1162,8 +1162,8 @@ public abstract class BaseDocumentFolderResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteDocumentFolderPermission",
-					portletName, siteId)
+					ActionKeys.PERMISSIONS,
+					"putSiteDocumentFolderPermissionsPage", portletName, siteId)
 			).build(),
 			siteId, portletName, roleNames);
 	}
@@ -1191,7 +1191,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteDocumentFolderPermission(
+			putSiteDocumentFolderPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -1222,8 +1222,8 @@ public abstract class BaseDocumentFolderResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteDocumentFolderPermission",
-					portletName, siteId)
+					ActionKeys.PERMISSIONS,
+					"putSiteDocumentFolderPermissionsPage", portletName, siteId)
 			).build(),
 			siteId, portletName, null);
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -280,8 +280,9 @@ public abstract class BaseDocumentResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putAssetLibraryDocumentPermission",
-					portletName, assetLibraryId)
+					ActionKeys.PERMISSIONS,
+					"putAssetLibraryDocumentPermissionsPage", portletName,
+					assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, roleNames);
 	}
@@ -307,7 +308,7 @@ public abstract class BaseDocumentResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryDocumentPermission(
+			putAssetLibraryDocumentPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("assetLibraryId")
@@ -339,8 +340,9 @@ public abstract class BaseDocumentResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putAssetLibraryDocumentPermission",
-					portletName, assetLibraryId)
+					ActionKeys.PERMISSIONS,
+					"putAssetLibraryDocumentPermissionsPage", portletName,
+					assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, null);
 	}
@@ -909,7 +911,7 @@ public abstract class BaseDocumentResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putDocumentPermission",
+					ActionKeys.PERMISSIONS, "putDocumentPermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
@@ -936,7 +938,7 @@ public abstract class BaseDocumentResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDocumentPermission(
+			putDocumentPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("documentId")
@@ -969,7 +971,7 @@ public abstract class BaseDocumentResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putDocumentPermission",
+					ActionKeys.PERMISSIONS, "putDocumentPermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, null);
@@ -1353,7 +1355,7 @@ public abstract class BaseDocumentResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteDocumentPermission",
+					ActionKeys.PERMISSIONS, "putSiteDocumentPermissionsPage",
 					portletName, siteId)
 			).build(),
 			siteId, portletName, roleNames);
@@ -1380,7 +1382,7 @@ public abstract class BaseDocumentResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteDocumentPermission(
+			putSiteDocumentPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -1411,7 +1413,7 @@ public abstract class BaseDocumentResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteDocumentPermission",
+					ActionKeys.PERMISSIONS, "putSiteDocumentPermissionsPage",
 					portletName, siteId)
 			).build(),
 			siteId, portletName, null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -637,8 +637,9 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putKnowledgeBaseArticlePermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putKnowledgeBaseArticlePermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
 	}
@@ -670,7 +671,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putKnowledgeBaseArticlePermission(
+			putKnowledgeBaseArticlePermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("knowledgeBaseArticleId")
@@ -706,8 +707,9 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putKnowledgeBaseArticlePermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putKnowledgeBaseArticlePermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, null);
 	}
@@ -1438,7 +1440,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteKnowledgeBaseArticlePermission", portletName,
+					"putSiteKnowledgeBaseArticlePermissionsPage", portletName,
 					siteId)
 			).build(),
 			siteId, portletName, roleNames);
@@ -1469,7 +1471,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteKnowledgeBaseArticlePermission(
+			putSiteKnowledgeBaseArticlePermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -1502,7 +1504,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteKnowledgeBaseArticlePermission", portletName,
+					"putSiteKnowledgeBaseArticlePermissionsPage", portletName,
 					siteId)
 			).build(),
 			siteId, portletName, null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -441,8 +441,9 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putKnowledgeBaseFolderPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putKnowledgeBaseFolderPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
 	}
@@ -474,7 +475,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putKnowledgeBaseFolderPermission(
+			putKnowledgeBaseFolderPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("knowledgeBaseFolderId")
@@ -509,8 +510,9 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putKnowledgeBaseFolderPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putKnowledgeBaseFolderPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, null);
 	}
@@ -945,7 +947,8 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteKnowledgeBaseFolderPermission", portletName, siteId)
+					"putSiteKnowledgeBaseFolderPermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, roleNames);
 	}
@@ -975,7 +978,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteKnowledgeBaseFolderPermission(
+			putSiteKnowledgeBaseFolderPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -1008,7 +1011,8 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteKnowledgeBaseFolderPermission", portletName, siteId)
+					"putSiteKnowledgeBaseFolderPermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, null);
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -646,8 +646,9 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putMessageBoardMessagePermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putMessageBoardMessagePermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
 	}
@@ -679,7 +680,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putMessageBoardMessagePermission(
+			putMessageBoardMessagePermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("messageBoardMessageId")
@@ -714,8 +715,9 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putMessageBoardMessagePermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putMessageBoardMessagePermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, null);
 	}
@@ -1388,7 +1390,8 @@ public abstract class BaseMessageBoardMessageResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteMessageBoardMessagePermission", portletName, siteId)
+					"putSiteMessageBoardMessagePermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, roleNames);
 	}
@@ -1418,7 +1421,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteMessageBoardMessagePermission(
+			putSiteMessageBoardMessagePermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -1451,7 +1454,8 @@ public abstract class BaseMessageBoardMessageResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteMessageBoardMessagePermission", portletName, siteId)
+					"putSiteMessageBoardMessagePermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, null);
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -442,8 +442,9 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putMessageBoardSectionPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putMessageBoardSectionPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
 	}
@@ -475,7 +476,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putMessageBoardSectionPermission(
+			putMessageBoardSectionPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("messageBoardSectionId")
@@ -510,8 +511,9 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putMessageBoardSectionPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putMessageBoardSectionPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, null);
 	}
@@ -917,7 +919,8 @@ public abstract class BaseMessageBoardSectionResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteMessageBoardSectionPermission", portletName, siteId)
+					"putSiteMessageBoardSectionPermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, roleNames);
 	}
@@ -947,7 +950,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteMessageBoardSectionPermission(
+			putSiteMessageBoardSectionPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -980,7 +983,8 @@ public abstract class BaseMessageBoardSectionResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteMessageBoardSectionPermission", portletName, siteId)
+					"putSiteMessageBoardSectionPermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, null);
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -846,8 +846,9 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putMessageBoardThreadPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putMessageBoardThreadPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
 	}
@@ -877,7 +878,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putMessageBoardThreadPermission(
+			putMessageBoardThreadPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("messageBoardThreadId")
@@ -912,8 +913,9 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putMessageBoardThreadPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putMessageBoardThreadPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, null);
 	}
@@ -1237,7 +1239,8 @@ public abstract class BaseMessageBoardThreadResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteMessageBoardThreadPermission", portletName, siteId)
+					"putSiteMessageBoardThreadPermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, roleNames);
 	}
@@ -1265,7 +1268,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteMessageBoardThreadPermission(
+			putSiteMessageBoardThreadPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -1298,7 +1301,8 @@ public abstract class BaseMessageBoardThreadResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteMessageBoardThreadPermission", portletName, siteId)
+					"putSiteMessageBoardThreadPermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, null);
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -324,7 +324,7 @@ public abstract class BaseNavigationMenuResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putNavigationMenuPermission",
+					ActionKeys.PERMISSIONS, "putNavigationMenuPermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
@@ -353,7 +353,7 @@ public abstract class BaseNavigationMenuResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putNavigationMenuPermission(
+			putNavigationMenuPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("navigationMenuId")
@@ -387,7 +387,7 @@ public abstract class BaseNavigationMenuResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putNavigationMenuPermission",
+					ActionKeys.PERMISSIONS, "putNavigationMenuPermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, null);
@@ -577,8 +577,8 @@ public abstract class BaseNavigationMenuResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteNavigationMenuPermission",
-					portletName, siteId)
+					ActionKeys.PERMISSIONS,
+					"putSiteNavigationMenuPermissionsPage", portletName, siteId)
 			).build(),
 			siteId, portletName, roleNames);
 	}
@@ -606,7 +606,7 @@ public abstract class BaseNavigationMenuResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteNavigationMenuPermission(
+			putSiteNavigationMenuPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -637,8 +637,8 @@ public abstract class BaseNavigationMenuResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteNavigationMenuPermission",
-					portletName, siteId)
+					ActionKeys.PERMISSIONS,
+					"putSiteNavigationMenuPermissionsPage", portletName, siteId)
 			).build(),
 			siteId, portletName, null);
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -198,7 +198,7 @@ public abstract class BaseSitePageResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<SitePage> getSiteSitePageFriendlyUrlPathExperiencesPage(
+	public Page<SitePage> getSiteSitePagesExperiencesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("siteId")

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -304,7 +304,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putAssetLibraryStructuredContentFolderPermission",
+					"putAssetLibraryStructuredContentFolderPermissionsPage",
 					portletName, assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, roleNames);
@@ -337,7 +337,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryStructuredContentFolderPermission(
+			putAssetLibraryStructuredContentFolderPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("assetLibraryId")
@@ -370,7 +370,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putAssetLibraryStructuredContentFolderPermission",
+					"putAssetLibraryStructuredContentFolderPermissionsPage",
 					portletName, assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, null);
@@ -600,8 +600,8 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteStructuredContentFolderPermission", portletName,
-					siteId)
+					"putSiteStructuredContentFolderPermissionsPage",
+					portletName, siteId)
 			).build(),
 			siteId, portletName, roleNames);
 	}
@@ -631,7 +631,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteStructuredContentFolderPermission(
+			putSiteStructuredContentFolderPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -664,8 +664,8 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteStructuredContentFolderPermission", portletName,
-					siteId)
+					"putSiteStructuredContentFolderPermissionsPage",
+					portletName, siteId)
 			).build(),
 			siteId, portletName, null);
 	}
@@ -731,7 +731,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putStructuredContentFolderPermission", resourceName,
+					"putStructuredContentFolderPermissionsPage", resourceName,
 					resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
@@ -764,7 +764,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putStructuredContentFolderPermission(
+			putStructuredContentFolderPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("structuredContentFolderId")
@@ -801,7 +801,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putStructuredContentFolderPermission", resourceName,
+					"putStructuredContentFolderPermissionsPage", resourceName,
 					resourceId)
 			).build(),
 			resourceId, resourceName, null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -291,8 +291,8 @@ public abstract class BaseStructuredContentResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putAssetLibraryStructuredContentPermission", portletName,
-					assetLibraryId)
+					"putAssetLibraryStructuredContentPermissionsPage",
+					portletName, assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, roleNames);
 	}
@@ -322,7 +322,7 @@ public abstract class BaseStructuredContentResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryStructuredContentPermission(
+			putAssetLibraryStructuredContentPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("assetLibraryId")
@@ -355,8 +355,8 @@ public abstract class BaseStructuredContentResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putAssetLibraryStructuredContentPermission", portletName,
-					assetLibraryId)
+					"putAssetLibraryStructuredContentPermissionsPage",
+					portletName, assetLibraryId)
 			).build(),
 			assetLibraryId, portletName, null);
 	}
@@ -860,7 +860,8 @@ public abstract class BaseStructuredContentResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteStructuredContentPermission", portletName, siteId)
+					"putSiteStructuredContentPermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, roleNames);
 	}
@@ -888,7 +889,7 @@ public abstract class BaseStructuredContentResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteStructuredContentPermission(
+			putSiteStructuredContentPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -921,7 +922,8 @@ public abstract class BaseStructuredContentResourceImpl
 				"replace",
 				addAction(
 					ActionKeys.PERMISSIONS,
-					"putSiteStructuredContentPermission", portletName, siteId)
+					"putSiteStructuredContentPermissionsPage", portletName,
+					siteId)
 			).build(),
 			siteId, portletName, null);
 	}
@@ -1638,8 +1640,9 @@ public abstract class BaseStructuredContentResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putStructuredContentPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putStructuredContentPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
 	}
@@ -1667,7 +1670,7 @@ public abstract class BaseStructuredContentResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putStructuredContentPermission(
+			putStructuredContentPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("structuredContentId")
@@ -1702,8 +1705,9 @@ public abstract class BaseStructuredContentResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putStructuredContentPermission",
-					resourceName, resourceId)
+					ActionKeys.PERMISSIONS,
+					"putStructuredContentPermissionsPage", resourceName,
+					resourceId)
 			).build(),
 			resourceId, resourceName, null);
 	}
@@ -1785,7 +1789,7 @@ public abstract class BaseStructuredContentResourceImpl
 	)
 	@javax.ws.rs.Produces("text/html")
 	@Override
-	public String getStructuredContentRenderedContentTemplate(
+	public String getStructuredContentRenderedContentContentTemplate(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("structuredContentId")

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -403,7 +403,7 @@ public abstract class BaseWikiNodeResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteWikiNodePermission",
+					ActionKeys.PERMISSIONS, "putSiteWikiNodePermissionsPage",
 					portletName, siteId)
 			).build(),
 			siteId, portletName, roleNames);
@@ -430,7 +430,7 @@ public abstract class BaseWikiNodeResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteWikiNodePermission(
+			putSiteWikiNodePermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("siteId")
@@ -461,7 +461,7 @@ public abstract class BaseWikiNodeResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putSiteWikiNodePermission",
+					ActionKeys.PERMISSIONS, "putSiteWikiNodePermissionsPage",
 					portletName, siteId)
 			).build(),
 			siteId, portletName, null);
@@ -705,7 +705,7 @@ public abstract class BaseWikiNodeResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putWikiNodePermission",
+					ActionKeys.PERMISSIONS, "putWikiNodePermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
@@ -732,7 +732,7 @@ public abstract class BaseWikiNodeResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putWikiNodePermission(
+			putWikiNodePermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("wikiNodeId")
@@ -765,7 +765,7 @@ public abstract class BaseWikiNodeResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putWikiNodePermission",
+					ActionKeys.PERMISSIONS, "putWikiNodePermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -659,7 +659,7 @@ public abstract class BaseWikiPageResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putWikiPagePermission",
+					ActionKeys.PERMISSIONS, "putWikiPagePermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, roleNames);
@@ -686,7 +686,7 @@ public abstract class BaseWikiPageResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putWikiPagePermission(
+			putWikiPagePermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("wikiPageId")
@@ -719,7 +719,7 @@ public abstract class BaseWikiPageResourceImpl
 			).put(
 				"replace",
 				addAction(
-					ActionKeys.PERMISSIONS, "putWikiPagePermission",
+					ActionKeys.PERMISSIONS, "putWikiPagePermissionsPage",
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentTemplateResourceImpl.java
@@ -68,7 +68,12 @@ public class ContentTemplateResourceImpl
 	}
 
 	@Override
-	public ContentTemplate getContentTemplate(
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _entityModel;
+	}
+
+	@Override
+	public ContentTemplate getSiteContentTemplate(
 			Long siteId, String contentTemplateId)
 		throws Exception {
 
@@ -79,11 +84,6 @@ public class ContentTemplateResourceImpl
 		return ContentTemplateUtil.toContentTemplate(
 			ddmTemplate, _getDtoConverterContext(ddmTemplate),
 			groupLocalService, _portal, _userLocalService);
-	}
-
-	@Override
-	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
-		return _entityModel;
 	}
 
 	@Override
@@ -134,7 +134,7 @@ public class ContentTemplateResourceImpl
 				"get",
 				addAction(
 					ActionKeys.VIEW, ddmTemplate.getTemplateId(),
-					"getContentTemplate", ddmTemplate.getUserId(),
+					"getSiteContentTemplate", ddmTemplate.getUserId(),
 					DDMTemplate.class.getName() + "-" +
 						JournalArticle.class.getName(),
 					ddmTemplate.getGroupId())),

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.13'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -125,7 +125,15 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 	}
 
 	@Override
-	public Page<SitePage> getSiteSitePageFriendlyUrlPathExperiencesPage(
+	public String getSiteSitePageRenderedPage(
+			Long siteId, String friendlyUrlPath)
+		throws Exception {
+
+		return _toHTML(friendlyUrlPath, siteId, null);
+	}
+
+	@Override
+	public Page<SitePage> getSiteSitePagesExperiencesPage(
 			Long siteId, String friendlyUrlPath)
 		throws Exception {
 
@@ -137,14 +145,6 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 				segmentsExperience -> _toSitePage(
 					_isEmbeddedPageDefinition(), layout,
 					segmentsExperience.getSegmentsExperienceKey())));
-	}
-
-	@Override
-	public String getSiteSitePageRenderedPage(
-			Long siteId, String friendlyUrlPath)
-		throws Exception {
-
-		return _toHTML(friendlyUrlPath, siteId, null);
 	}
 
 	@Override
@@ -221,8 +221,7 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 				}
 
 				return addAction(
-					ActionKeys.VIEW,
-					"getSiteSitePageFriendlyUrlPathExperiencesPage",
+					ActionKeys.VIEW, "getSiteSitePagesExperiencesPage",
 					Group.class.getName(), layout.getGroupId());
 			}
 		).put(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -400,7 +400,7 @@ public class StructuredContentResourceImpl
 	}
 
 	@Override
-	public String getStructuredContentRenderedContentTemplate(
+	public String getStructuredContentRenderedContentContentTemplate(
 			Long structuredContentId, String templateId)
 		throws Exception {
 
@@ -971,7 +971,7 @@ public class StructuredContentResourceImpl
 					"get-rendered-content",
 					addAction(
 						ActionKeys.VIEW, journalArticle.getResourcePrimKey(),
-						"getStructuredContentRenderedContentTemplate",
+						"getStructuredContentRenderedContentContentTemplate",
 						journalArticle.getUserId(),
 						JournalArticle.class.getName(),
 						journalArticle.getGroupId())

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -428,9 +428,10 @@ public abstract class BaseBlogPostingResourceTestCase {
 	}
 
 	@Test
-	public void testPutBlogPostingPermission() throws Exception {
+	public void testPutBlogPostingPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
-		BlogPosting blogPosting = testPutBlogPostingPermission_addBlogPosting();
+		BlogPosting blogPosting =
+			testPutBlogPostingPermissionsPage_addBlogPosting();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -438,7 +439,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			blogPostingResource.putBlogPostingPermissionHttpResponse(
+			blogPostingResource.putBlogPostingPermissionsPageHttpResponse(
 				blogPosting.getId(),
 				new Permission[] {
 					new Permission() {
@@ -451,7 +452,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404,
-			blogPostingResource.putBlogPostingPermissionHttpResponse(
+			blogPostingResource.putBlogPostingPermissionsPageHttpResponse(
 				0L,
 				new Permission[] {
 					new Permission() {
@@ -463,7 +464,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 				}));
 	}
 
-	protected BlogPosting testPutBlogPostingPermission_addBlogPosting()
+	protected BlogPosting testPutBlogPostingPermissionsPage_addBlogPosting()
 		throws Exception {
 
 		return blogPostingResource.postSiteBlogPosting(
@@ -1033,10 +1034,10 @@ public abstract class BaseBlogPostingResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteBlogPostingPermission() throws Exception {
+	public void testPutSiteBlogPostingPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		BlogPosting blogPosting =
-			testPutSiteBlogPostingPermission_addBlogPosting();
+			testPutSiteBlogPostingPermissionsPage_addBlogPosting();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1044,7 +1045,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			blogPostingResource.putSiteBlogPostingPermissionHttpResponse(
+			blogPostingResource.putSiteBlogPostingPermissionsPageHttpResponse(
 				blogPosting.getSiteId(),
 				new Permission[] {
 					new Permission() {
@@ -1057,7 +1058,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404,
-			blogPostingResource.putSiteBlogPostingPermissionHttpResponse(
+			blogPostingResource.putSiteBlogPostingPermissionsPageHttpResponse(
 				blogPosting.getSiteId(),
 				new Permission[] {
 					new Permission() {
@@ -1069,7 +1070,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 				}));
 	}
 
-	protected BlogPosting testPutSiteBlogPostingPermission_addBlogPosting()
+	protected BlogPosting testPutSiteBlogPostingPermissionsPage_addBlogPosting()
 		throws Exception {
 
 		return blogPostingResource.postSiteBlogPosting(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -565,12 +565,12 @@ public abstract class BaseContentStructureResourceTestCase {
 	}
 
 	@Test
-	public void testPutAssetLibraryContentStructurePermission()
+	public void testPutAssetLibraryContentStructurePermissionsPage()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ContentStructure contentStructure =
-			testPutAssetLibraryContentStructurePermission_addContentStructure();
+			testPutAssetLibraryContentStructurePermissionsPage_addContentStructure();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -579,7 +579,7 @@ public abstract class BaseContentStructureResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			contentStructureResource.
-				putAssetLibraryContentStructurePermissionHttpResponse(
+				putAssetLibraryContentStructurePermissionsPageHttpResponse(
 					testDepotEntry.getDepotEntryId(),
 					new Permission[] {
 						new Permission() {
@@ -593,7 +593,7 @@ public abstract class BaseContentStructureResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			contentStructureResource.
-				putAssetLibraryContentStructurePermissionHttpResponse(
+				putAssetLibraryContentStructurePermissionsPageHttpResponse(
 					testDepotEntry.getDepotEntryId(),
 					new Permission[] {
 						new Permission() {
@@ -606,7 +606,7 @@ public abstract class BaseContentStructureResourceTestCase {
 	}
 
 	protected ContentStructure
-			testPutAssetLibraryContentStructurePermission_addContentStructure()
+			testPutAssetLibraryContentStructurePermissionsPage_addContentStructure()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -700,10 +700,10 @@ public abstract class BaseContentStructureResourceTestCase {
 	}
 
 	@Test
-	public void testPutContentStructurePermission() throws Exception {
+	public void testPutContentStructurePermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ContentStructure contentStructure =
-			testPutContentStructurePermission_addContentStructure();
+			testPutContentStructurePermissionsPage_addContentStructure();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -711,33 +711,35 @@ public abstract class BaseContentStructureResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			contentStructureResource.putContentStructurePermissionHttpResponse(
-				contentStructure.getId(),
-				new Permission[] {
-					new Permission() {
-						{
-							setActionIds(new String[] {"VIEW"});
-							setRoleName(role.getName());
+			contentStructureResource.
+				putContentStructurePermissionsPageHttpResponse(
+					contentStructure.getId(),
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"VIEW"});
+								setRoleName(role.getName());
+							}
 						}
-					}
-				}));
+					}));
 
 		assertHttpResponseStatusCode(
 			404,
-			contentStructureResource.putContentStructurePermissionHttpResponse(
-				0L,
-				new Permission[] {
-					new Permission() {
-						{
-							setActionIds(new String[] {"-"});
-							setRoleName("-");
+			contentStructureResource.
+				putContentStructurePermissionsPageHttpResponse(
+					0L,
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"-"});
+								setRoleName("-");
+							}
 						}
-					}
-				}));
+					}));
 	}
 
 	protected ContentStructure
-			testPutContentStructurePermission_addContentStructure()
+			testPutContentStructurePermissionsPage_addContentStructure()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -1121,10 +1123,10 @@ public abstract class BaseContentStructureResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteContentStructurePermission() throws Exception {
+	public void testPutSiteContentStructurePermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ContentStructure contentStructure =
-			testPutSiteContentStructurePermission_addContentStructure();
+			testPutSiteContentStructurePermissionsPage_addContentStructure();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1133,7 +1135,7 @@ public abstract class BaseContentStructureResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			contentStructureResource.
-				putSiteContentStructurePermissionHttpResponse(
+				putSiteContentStructurePermissionsPageHttpResponse(
 					contentStructure.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1147,7 +1149,7 @@ public abstract class BaseContentStructureResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			contentStructureResource.
-				putSiteContentStructurePermissionHttpResponse(
+				putSiteContentStructurePermissionsPageHttpResponse(
 					contentStructure.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1160,7 +1162,7 @@ public abstract class BaseContentStructureResourceTestCase {
 	}
 
 	protected ContentStructure
-			testPutSiteContentStructurePermission_addContentStructure()
+			testPutSiteContentStructurePermissionsPage_addContentStructure()
 		throws Exception {
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
@@ -901,19 +901,19 @@ public abstract class BaseContentTemplateResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentTemplate() throws Exception {
+	public void testGetSiteContentTemplate() throws Exception {
 		ContentTemplate postContentTemplate =
-			testGetContentTemplate_addContentTemplate();
+			testGetSiteContentTemplate_addContentTemplate();
 
 		ContentTemplate getContentTemplate =
-			contentTemplateResource.getContentTemplate(
+			contentTemplateResource.getSiteContentTemplate(
 				postContentTemplate.getSiteId(), postContentTemplate.getId());
 
 		assertEquals(postContentTemplate, getContentTemplate);
 		assertValid(getContentTemplate);
 	}
 
-	protected ContentTemplate testGetContentTemplate_addContentTemplate()
+	protected ContentTemplate testGetSiteContentTemplate_addContentTemplate()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -921,7 +921,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 	}
 
 	@Test
-	public void testGraphQLGetContentTemplate() throws Exception {
+	public void testGraphQLGetSiteContentTemplate() throws Exception {
 		ContentTemplate contentTemplate =
 			testGraphQLContentTemplate_addContentTemplate();
 
@@ -950,7 +950,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 	}
 
 	@Test
-	public void testGraphQLGetContentTemplateNotFound() throws Exception {
+	public void testGraphQLGetSiteContentTemplateNotFound() throws Exception {
 		String irrelevantContentTemplateId =
 			"\"" + RandomTestUtil.randomString() + "\"";
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -593,10 +593,12 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	}
 
 	@Test
-	public void testPutAssetLibraryDocumentFolderPermission() throws Exception {
+	public void testPutAssetLibraryDocumentFolderPermissionsPage()
+		throws Exception {
+
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DocumentFolder documentFolder =
-			testPutAssetLibraryDocumentFolderPermission_addDocumentFolder();
+			testPutAssetLibraryDocumentFolderPermissionsPage_addDocumentFolder();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -605,7 +607,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			documentFolderResource.
-				putAssetLibraryDocumentFolderPermissionHttpResponse(
+				putAssetLibraryDocumentFolderPermissionsPageHttpResponse(
 					testDepotEntry.getDepotEntryId(),
 					new Permission[] {
 						new Permission() {
@@ -619,7 +621,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			documentFolderResource.
-				putAssetLibraryDocumentFolderPermissionHttpResponse(
+				putAssetLibraryDocumentFolderPermissionsPageHttpResponse(
 					testDepotEntry.getDepotEntryId(),
 					new Permission[] {
 						new Permission() {
@@ -632,7 +634,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	}
 
 	protected DocumentFolder
-			testPutAssetLibraryDocumentFolderPermission_addDocumentFolder()
+			testPutAssetLibraryDocumentFolderPermissionsPage_addDocumentFolder()
 		throws Exception {
 
 		return documentFolderResource.postAssetLibraryDocumentFolder(
@@ -845,10 +847,10 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	}
 
 	@Test
-	public void testPutDocumentFolderPermission() throws Exception {
+	public void testPutDocumentFolderPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DocumentFolder documentFolder =
-			testPutDocumentFolderPermission_addDocumentFolder();
+			testPutDocumentFolderPermissionsPage_addDocumentFolder();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -856,7 +858,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			documentFolderResource.putDocumentFolderPermissionHttpResponse(
+			documentFolderResource.putDocumentFolderPermissionsPageHttpResponse(
 				documentFolder.getId(),
 				new Permission[] {
 					new Permission() {
@@ -869,7 +871,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404,
-			documentFolderResource.putDocumentFolderPermissionHttpResponse(
+			documentFolderResource.putDocumentFolderPermissionsPageHttpResponse(
 				0L,
 				new Permission[] {
 					new Permission() {
@@ -881,7 +883,8 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				}));
 	}
 
-	protected DocumentFolder testPutDocumentFolderPermission_addDocumentFolder()
+	protected DocumentFolder
+			testPutDocumentFolderPermissionsPage_addDocumentFolder()
 		throws Exception {
 
 		return documentFolderResource.postSiteDocumentFolder(
@@ -1696,10 +1699,10 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteDocumentFolderPermission() throws Exception {
+	public void testPutSiteDocumentFolderPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DocumentFolder documentFolder =
-			testPutSiteDocumentFolderPermission_addDocumentFolder();
+			testPutSiteDocumentFolderPermissionsPage_addDocumentFolder();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1707,33 +1710,35 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			documentFolderResource.putSiteDocumentFolderPermissionHttpResponse(
-				documentFolder.getSiteId(),
-				new Permission[] {
-					new Permission() {
-						{
-							setActionIds(new String[] {"PERMISSIONS"});
-							setRoleName(role.getName());
+			documentFolderResource.
+				putSiteDocumentFolderPermissionsPageHttpResponse(
+					documentFolder.getSiteId(),
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"PERMISSIONS"});
+								setRoleName(role.getName());
+							}
 						}
-					}
-				}));
+					}));
 
 		assertHttpResponseStatusCode(
 			404,
-			documentFolderResource.putSiteDocumentFolderPermissionHttpResponse(
-				documentFolder.getSiteId(),
-				new Permission[] {
-					new Permission() {
-						{
-							setActionIds(new String[] {"-"});
-							setRoleName("-");
+			documentFolderResource.
+				putSiteDocumentFolderPermissionsPageHttpResponse(
+					documentFolder.getSiteId(),
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"-"});
+								setRoleName("-");
+							}
 						}
-					}
-				}));
+					}));
 	}
 
 	protected DocumentFolder
-			testPutSiteDocumentFolderPermission_addDocumentFolder()
+			testPutSiteDocumentFolderPermissionsPage_addDocumentFolder()
 		throws Exception {
 
 		return documentFolderResource.postSiteDocumentFolder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -575,9 +575,10 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testPutAssetLibraryDocumentPermission() throws Exception {
+	public void testPutAssetLibraryDocumentPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
-		Document document = testPutAssetLibraryDocumentPermission_addDocument();
+		Document document =
+			testPutAssetLibraryDocumentPermissionsPage_addDocument();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -585,7 +586,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			documentResource.putAssetLibraryDocumentPermissionHttpResponse(
+			documentResource.putAssetLibraryDocumentPermissionsPageHttpResponse(
 				testDepotEntry.getDepotEntryId(),
 				new Permission[] {
 					new Permission() {
@@ -598,7 +599,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404,
-			documentResource.putAssetLibraryDocumentPermissionHttpResponse(
+			documentResource.putAssetLibraryDocumentPermissionsPageHttpResponse(
 				testDepotEntry.getDepotEntryId(),
 				new Permission[] {
 					new Permission() {
@@ -610,7 +611,7 @@ public abstract class BaseDocumentResourceTestCase {
 				}));
 	}
 
-	protected Document testPutAssetLibraryDocumentPermission_addDocument()
+	protected Document testPutAssetLibraryDocumentPermissionsPage_addDocument()
 		throws Exception {
 
 		return documentResource.postAssetLibraryDocument(
@@ -1162,9 +1163,9 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testPutDocumentPermission() throws Exception {
+	public void testPutDocumentPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
-		Document document = testPutDocumentPermission_addDocument();
+		Document document = testPutDocumentPermissionsPage_addDocument();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1172,7 +1173,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			documentResource.putDocumentPermissionHttpResponse(
+			documentResource.putDocumentPermissionsPageHttpResponse(
 				document.getId(),
 				new Permission[] {
 					new Permission() {
@@ -1185,7 +1186,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404,
-			documentResource.putDocumentPermissionHttpResponse(
+			documentResource.putDocumentPermissionsPageHttpResponse(
 				0L,
 				new Permission[] {
 					new Permission() {
@@ -1197,7 +1198,7 @@ public abstract class BaseDocumentResourceTestCase {
 				}));
 	}
 
-	protected Document testPutDocumentPermission_addDocument()
+	protected Document testPutDocumentPermissionsPage_addDocument()
 		throws Exception {
 
 		return documentResource.postSiteDocument(
@@ -1743,9 +1744,9 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteDocumentPermission() throws Exception {
+	public void testPutSiteDocumentPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
-		Document document = testPutSiteDocumentPermission_addDocument();
+		Document document = testPutSiteDocumentPermissionsPage_addDocument();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1753,7 +1754,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			documentResource.putSiteDocumentPermissionHttpResponse(
+			documentResource.putSiteDocumentPermissionsPageHttpResponse(
 				document.getSiteId(),
 				new Permission[] {
 					new Permission() {
@@ -1766,7 +1767,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404,
-			documentResource.putSiteDocumentPermissionHttpResponse(
+			documentResource.putSiteDocumentPermissionsPageHttpResponse(
 				document.getSiteId(),
 				new Permission[] {
 					new Permission() {
@@ -1778,7 +1779,7 @@ public abstract class BaseDocumentResourceTestCase {
 				}));
 	}
 
-	protected Document testPutSiteDocumentPermission_addDocument()
+	protected Document testPutSiteDocumentPermissionsPage_addDocument()
 		throws Exception {
 
 		return documentResource.postSiteDocument(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -471,10 +471,10 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	}
 
 	@Test
-	public void testPutKnowledgeBaseArticlePermission() throws Exception {
+	public void testPutKnowledgeBaseArticlePermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		KnowledgeBaseArticle knowledgeBaseArticle =
-			testPutKnowledgeBaseArticlePermission_addKnowledgeBaseArticle();
+			testPutKnowledgeBaseArticlePermissionsPage_addKnowledgeBaseArticle();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -483,7 +483,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			knowledgeBaseArticleResource.
-				putKnowledgeBaseArticlePermissionHttpResponse(
+				putKnowledgeBaseArticlePermissionsPageHttpResponse(
 					knowledgeBaseArticle.getId(),
 					new Permission[] {
 						new Permission() {
@@ -497,7 +497,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			knowledgeBaseArticleResource.
-				putKnowledgeBaseArticlePermissionHttpResponse(
+				putKnowledgeBaseArticlePermissionsPageHttpResponse(
 					0L,
 					new Permission[] {
 						new Permission() {
@@ -510,7 +510,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	}
 
 	protected KnowledgeBaseArticle
-			testPutKnowledgeBaseArticlePermission_addKnowledgeBaseArticle()
+			testPutKnowledgeBaseArticlePermissionsPage_addKnowledgeBaseArticle()
 		throws Exception {
 
 		return knowledgeBaseArticleResource.postSiteKnowledgeBaseArticle(
@@ -1974,10 +1974,12 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteKnowledgeBaseArticlePermission() throws Exception {
+	public void testPutSiteKnowledgeBaseArticlePermissionsPage()
+		throws Exception {
+
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		KnowledgeBaseArticle knowledgeBaseArticle =
-			testPutSiteKnowledgeBaseArticlePermission_addKnowledgeBaseArticle();
+			testPutSiteKnowledgeBaseArticlePermissionsPage_addKnowledgeBaseArticle();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1986,7 +1988,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			knowledgeBaseArticleResource.
-				putSiteKnowledgeBaseArticlePermissionHttpResponse(
+				putSiteKnowledgeBaseArticlePermissionsPageHttpResponse(
 					knowledgeBaseArticle.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -2000,7 +2002,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			knowledgeBaseArticleResource.
-				putSiteKnowledgeBaseArticlePermissionHttpResponse(
+				putSiteKnowledgeBaseArticlePermissionsPageHttpResponse(
 					knowledgeBaseArticle.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -2013,7 +2015,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	}
 
 	protected KnowledgeBaseArticle
-			testPutSiteKnowledgeBaseArticlePermission_addKnowledgeBaseArticle()
+			testPutSiteKnowledgeBaseArticlePermissionsPage_addKnowledgeBaseArticle()
 		throws Exception {
 
 		return knowledgeBaseArticleResource.postSiteKnowledgeBaseArticle(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -422,10 +422,10 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testPutKnowledgeBaseFolderPermission() throws Exception {
+	public void testPutKnowledgeBaseFolderPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		KnowledgeBaseFolder knowledgeBaseFolder =
-			testPutKnowledgeBaseFolderPermission_addKnowledgeBaseFolder();
+			testPutKnowledgeBaseFolderPermissionsPage_addKnowledgeBaseFolder();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -434,7 +434,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			knowledgeBaseFolderResource.
-				putKnowledgeBaseFolderPermissionHttpResponse(
+				putKnowledgeBaseFolderPermissionsPageHttpResponse(
 					knowledgeBaseFolder.getId(),
 					new Permission[] {
 						new Permission() {
@@ -448,7 +448,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			knowledgeBaseFolderResource.
-				putKnowledgeBaseFolderPermissionHttpResponse(
+				putKnowledgeBaseFolderPermissionsPageHttpResponse(
 					0L,
 					new Permission[] {
 						new Permission() {
@@ -461,7 +461,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	}
 
 	protected KnowledgeBaseFolder
-			testPutKnowledgeBaseFolderPermission_addKnowledgeBaseFolder()
+			testPutKnowledgeBaseFolderPermissionsPage_addKnowledgeBaseFolder()
 		throws Exception {
 
 		return knowledgeBaseFolderResource.postSiteKnowledgeBaseFolder(
@@ -1060,10 +1060,12 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteKnowledgeBaseFolderPermission() throws Exception {
+	public void testPutSiteKnowledgeBaseFolderPermissionsPage()
+		throws Exception {
+
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		KnowledgeBaseFolder knowledgeBaseFolder =
-			testPutSiteKnowledgeBaseFolderPermission_addKnowledgeBaseFolder();
+			testPutSiteKnowledgeBaseFolderPermissionsPage_addKnowledgeBaseFolder();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1072,7 +1074,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			knowledgeBaseFolderResource.
-				putSiteKnowledgeBaseFolderPermissionHttpResponse(
+				putSiteKnowledgeBaseFolderPermissionsPageHttpResponse(
 					knowledgeBaseFolder.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1086,7 +1088,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			knowledgeBaseFolderResource.
-				putSiteKnowledgeBaseFolderPermissionHttpResponse(
+				putSiteKnowledgeBaseFolderPermissionsPageHttpResponse(
 					knowledgeBaseFolder.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1099,7 +1101,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	}
 
 	protected KnowledgeBaseFolder
-			testPutSiteKnowledgeBaseFolderPermission_addKnowledgeBaseFolder()
+			testPutSiteKnowledgeBaseFolderPermissionsPage_addKnowledgeBaseFolder()
 		throws Exception {
 
 		return knowledgeBaseFolderResource.postSiteKnowledgeBaseFolder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -465,10 +465,10 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	}
 
 	@Test
-	public void testPutMessageBoardMessagePermission() throws Exception {
+	public void testPutMessageBoardMessagePermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		MessageBoardMessage messageBoardMessage =
-			testPutMessageBoardMessagePermission_addMessageBoardMessage();
+			testPutMessageBoardMessagePermissionsPage_addMessageBoardMessage();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -477,7 +477,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			messageBoardMessageResource.
-				putMessageBoardMessagePermissionHttpResponse(
+				putMessageBoardMessagePermissionsPageHttpResponse(
 					messageBoardMessage.getId(),
 					new Permission[] {
 						new Permission() {
@@ -491,7 +491,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			messageBoardMessageResource.
-				putMessageBoardMessagePermissionHttpResponse(
+				putMessageBoardMessagePermissionsPageHttpResponse(
 					0L,
 					new Permission[] {
 						new Permission() {
@@ -504,7 +504,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	}
 
 	protected MessageBoardMessage
-			testPutMessageBoardMessagePermission_addMessageBoardMessage()
+			testPutMessageBoardMessagePermissionsPage_addMessageBoardMessage()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -2004,10 +2004,12 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteMessageBoardMessagePermission() throws Exception {
+	public void testPutSiteMessageBoardMessagePermissionsPage()
+		throws Exception {
+
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		MessageBoardMessage messageBoardMessage =
-			testPutSiteMessageBoardMessagePermission_addMessageBoardMessage();
+			testPutSiteMessageBoardMessagePermissionsPage_addMessageBoardMessage();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -2016,7 +2018,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			messageBoardMessageResource.
-				putSiteMessageBoardMessagePermissionHttpResponse(
+				putSiteMessageBoardMessagePermissionsPageHttpResponse(
 					messageBoardMessage.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -2030,7 +2032,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			messageBoardMessageResource.
-				putSiteMessageBoardMessagePermissionHttpResponse(
+				putSiteMessageBoardMessagePermissionsPageHttpResponse(
 					messageBoardMessage.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -2043,7 +2045,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	}
 
 	protected MessageBoardMessage
-			testPutSiteMessageBoardMessagePermission_addMessageBoardMessage()
+			testPutSiteMessageBoardMessagePermissionsPage_addMessageBoardMessage()
 		throws Exception {
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -424,10 +424,10 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	}
 
 	@Test
-	public void testPutMessageBoardSectionPermission() throws Exception {
+	public void testPutMessageBoardSectionPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		MessageBoardSection messageBoardSection =
-			testPutMessageBoardSectionPermission_addMessageBoardSection();
+			testPutMessageBoardSectionPermissionsPage_addMessageBoardSection();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -436,7 +436,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			messageBoardSectionResource.
-				putMessageBoardSectionPermissionHttpResponse(
+				putMessageBoardSectionPermissionsPageHttpResponse(
 					messageBoardSection.getId(),
 					new Permission[] {
 						new Permission() {
@@ -450,7 +450,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			messageBoardSectionResource.
-				putMessageBoardSectionPermissionHttpResponse(
+				putMessageBoardSectionPermissionsPageHttpResponse(
 					0L,
 					new Permission[] {
 						new Permission() {
@@ -463,7 +463,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	}
 
 	protected MessageBoardSection
-			testPutMessageBoardSectionPermission_addMessageBoardSection()
+			testPutMessageBoardSectionPermissionsPage_addMessageBoardSection()
 		throws Exception {
 
 		return messageBoardSectionResource.postSiteMessageBoardSection(
@@ -1332,10 +1332,12 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteMessageBoardSectionPermission() throws Exception {
+	public void testPutSiteMessageBoardSectionPermissionsPage()
+		throws Exception {
+
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		MessageBoardSection messageBoardSection =
-			testPutSiteMessageBoardSectionPermission_addMessageBoardSection();
+			testPutSiteMessageBoardSectionPermissionsPage_addMessageBoardSection();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1344,7 +1346,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			messageBoardSectionResource.
-				putSiteMessageBoardSectionPermissionHttpResponse(
+				putSiteMessageBoardSectionPermissionsPageHttpResponse(
 					messageBoardSection.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1358,7 +1360,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			messageBoardSectionResource.
-				putSiteMessageBoardSectionPermissionHttpResponse(
+				putSiteMessageBoardSectionPermissionsPageHttpResponse(
 					messageBoardSection.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1371,7 +1373,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	}
 
 	protected MessageBoardSection
-			testPutSiteMessageBoardSectionPermission_addMessageBoardSection()
+			testPutSiteMessageBoardSectionPermissionsPage_addMessageBoardSection()
 		throws Exception {
 
 		return messageBoardSectionResource.postSiteMessageBoardSection(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -1077,10 +1077,10 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	}
 
 	@Test
-	public void testPutMessageBoardThreadPermission() throws Exception {
+	public void testPutMessageBoardThreadPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		MessageBoardThread messageBoardThread =
-			testPutMessageBoardThreadPermission_addMessageBoardThread();
+			testPutMessageBoardThreadPermissionsPage_addMessageBoardThread();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1089,7 +1089,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			messageBoardThreadResource.
-				putMessageBoardThreadPermissionHttpResponse(
+				putMessageBoardThreadPermissionsPageHttpResponse(
 					messageBoardThread.getId(),
 					new Permission[] {
 						new Permission() {
@@ -1103,7 +1103,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			messageBoardThreadResource.
-				putMessageBoardThreadPermissionHttpResponse(
+				putMessageBoardThreadPermissionsPageHttpResponse(
 					0L,
 					new Permission[] {
 						new Permission() {
@@ -1116,7 +1116,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	}
 
 	protected MessageBoardThread
-			testPutMessageBoardThreadPermission_addMessageBoardThread()
+			testPutMessageBoardThreadPermissionsPage_addMessageBoardThread()
 		throws Exception {
 
 		return messageBoardThreadResource.postSiteMessageBoardThread(
@@ -1685,10 +1685,12 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteMessageBoardThreadPermission() throws Exception {
+	public void testPutSiteMessageBoardThreadPermissionsPage()
+		throws Exception {
+
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		MessageBoardThread messageBoardThread =
-			testPutSiteMessageBoardThreadPermission_addMessageBoardThread();
+			testPutSiteMessageBoardThreadPermissionsPage_addMessageBoardThread();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1697,7 +1699,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			messageBoardThreadResource.
-				putSiteMessageBoardThreadPermissionHttpResponse(
+				putSiteMessageBoardThreadPermissionsPageHttpResponse(
 					messageBoardThread.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1711,7 +1713,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			messageBoardThreadResource.
-				putSiteMessageBoardThreadPermissionHttpResponse(
+				putSiteMessageBoardThreadPermissionsPageHttpResponse(
 					messageBoardThread.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1724,7 +1726,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	}
 
 	protected MessageBoardThread
-			testPutSiteMessageBoardThreadPermission_addMessageBoardThread()
+			testPutSiteMessageBoardThreadPermissionsPage_addMessageBoardThread()
 		throws Exception {
 
 		return messageBoardThreadResource.postSiteMessageBoardThread(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -370,10 +370,10 @@ public abstract class BaseNavigationMenuResourceTestCase {
 	}
 
 	@Test
-	public void testPutNavigationMenuPermission() throws Exception {
+	public void testPutNavigationMenuPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		NavigationMenu navigationMenu =
-			testPutNavigationMenuPermission_addNavigationMenu();
+			testPutNavigationMenuPermissionsPage_addNavigationMenu();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -381,7 +381,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			navigationMenuResource.putNavigationMenuPermissionHttpResponse(
+			navigationMenuResource.putNavigationMenuPermissionsPageHttpResponse(
 				navigationMenu.getId(),
 				new Permission[] {
 					new Permission() {
@@ -394,7 +394,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404,
-			navigationMenuResource.putNavigationMenuPermissionHttpResponse(
+			navigationMenuResource.putNavigationMenuPermissionsPageHttpResponse(
 				0L,
 				new Permission[] {
 					new Permission() {
@@ -406,7 +406,8 @@ public abstract class BaseNavigationMenuResourceTestCase {
 				}));
 	}
 
-	protected NavigationMenu testPutNavigationMenuPermission_addNavigationMenu()
+	protected NavigationMenu
+			testPutNavigationMenuPermissionsPage_addNavigationMenu()
 		throws Exception {
 
 		return navigationMenuResource.postSiteNavigationMenu(
@@ -619,10 +620,10 @@ public abstract class BaseNavigationMenuResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteNavigationMenuPermission() throws Exception {
+	public void testPutSiteNavigationMenuPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		NavigationMenu navigationMenu =
-			testPutSiteNavigationMenuPermission_addNavigationMenu();
+			testPutSiteNavigationMenuPermissionsPage_addNavigationMenu();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -630,33 +631,35 @@ public abstract class BaseNavigationMenuResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			navigationMenuResource.putSiteNavigationMenuPermissionHttpResponse(
-				navigationMenu.getSiteId(),
-				new Permission[] {
-					new Permission() {
-						{
-							setActionIds(new String[] {"PERMISSIONS"});
-							setRoleName(role.getName());
+			navigationMenuResource.
+				putSiteNavigationMenuPermissionsPageHttpResponse(
+					navigationMenu.getSiteId(),
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"PERMISSIONS"});
+								setRoleName(role.getName());
+							}
 						}
-					}
-				}));
+					}));
 
 		assertHttpResponseStatusCode(
 			404,
-			navigationMenuResource.putSiteNavigationMenuPermissionHttpResponse(
-				navigationMenu.getSiteId(),
-				new Permission[] {
-					new Permission() {
-						{
-							setActionIds(new String[] {"-"});
-							setRoleName("-");
+			navigationMenuResource.
+				putSiteNavigationMenuPermissionsPageHttpResponse(
+					navigationMenu.getSiteId(),
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"-"});
+								setRoleName("-");
+							}
 						}
-					}
-				}));
+					}));
 	}
 
 	protected NavigationMenu
-			testPutSiteNavigationMenuPermission_addNavigationMenu()
+			testPutSiteNavigationMenuPermissionsPage_addNavigationMenu()
 		throws Exception {
 
 		return navigationMenuResource.postSiteNavigationMenu(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -496,33 +496,28 @@ public abstract class BaseSitePageResourceTestCase {
 	}
 
 	@Test
-	public void testGetSiteSitePageFriendlyUrlPathExperiencesPage()
-		throws Exception {
-
-		Long siteId =
-			testGetSiteSitePageFriendlyUrlPathExperiencesPage_getSiteId();
+	public void testGetSiteSitePagesExperiencesPage() throws Exception {
+		Long siteId = testGetSiteSitePagesExperiencesPage_getSiteId();
 		Long irrelevantSiteId =
-			testGetSiteSitePageFriendlyUrlPathExperiencesPage_getIrrelevantSiteId();
+			testGetSiteSitePagesExperiencesPage_getIrrelevantSiteId();
 		String friendlyUrlPath =
-			testGetSiteSitePageFriendlyUrlPathExperiencesPage_getFriendlyUrlPath();
+			testGetSiteSitePagesExperiencesPage_getFriendlyUrlPath();
 		String irrelevantFriendlyUrlPath =
-			testGetSiteSitePageFriendlyUrlPathExperiencesPage_getIrrelevantFriendlyUrlPath();
+			testGetSiteSitePagesExperiencesPage_getIrrelevantFriendlyUrlPath();
 
-		Page<SitePage> page =
-			sitePageResource.getSiteSitePageFriendlyUrlPathExperiencesPage(
-				siteId, friendlyUrlPath);
+		Page<SitePage> page = sitePageResource.getSiteSitePagesExperiencesPage(
+			siteId, friendlyUrlPath);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantSiteId != null) && (irrelevantFriendlyUrlPath != null)) {
 			SitePage irrelevantSitePage =
-				testGetSiteSitePageFriendlyUrlPathExperiencesPage_addSitePage(
+				testGetSiteSitePagesExperiencesPage_addSitePage(
 					irrelevantSiteId, irrelevantFriendlyUrlPath,
 					randomIrrelevantSitePage());
 
-			page =
-				sitePageResource.getSiteSitePageFriendlyUrlPathExperiencesPage(
-					irrelevantSiteId, irrelevantFriendlyUrlPath);
+			page = sitePageResource.getSiteSitePagesExperiencesPage(
+				irrelevantSiteId, irrelevantFriendlyUrlPath);
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -532,15 +527,13 @@ public abstract class BaseSitePageResourceTestCase {
 			assertValid(page);
 		}
 
-		SitePage sitePage1 =
-			testGetSiteSitePageFriendlyUrlPathExperiencesPage_addSitePage(
-				siteId, friendlyUrlPath, randomSitePage());
+		SitePage sitePage1 = testGetSiteSitePagesExperiencesPage_addSitePage(
+			siteId, friendlyUrlPath, randomSitePage());
 
-		SitePage sitePage2 =
-			testGetSiteSitePageFriendlyUrlPathExperiencesPage_addSitePage(
-				siteId, friendlyUrlPath, randomSitePage());
+		SitePage sitePage2 = testGetSiteSitePagesExperiencesPage_addSitePage(
+			siteId, friendlyUrlPath, randomSitePage());
 
-		page = sitePageResource.getSiteSitePageFriendlyUrlPathExperiencesPage(
+		page = sitePageResource.getSiteSitePagesExperiencesPage(
 			siteId, friendlyUrlPath);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -551,30 +544,27 @@ public abstract class BaseSitePageResourceTestCase {
 		assertValid(page);
 	}
 
-	protected SitePage
-			testGetSiteSitePageFriendlyUrlPathExperiencesPage_addSitePage(
-				Long siteId, String friendlyUrlPath, SitePage sitePage)
+	protected SitePage testGetSiteSitePagesExperiencesPage_addSitePage(
+			Long siteId, String friendlyUrlPath, SitePage sitePage)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}
 
-	protected Long testGetSiteSitePageFriendlyUrlPathExperiencesPage_getSiteId()
+	protected Long testGetSiteSitePagesExperiencesPage_getSiteId()
 		throws Exception {
 
 		return testGroup.getGroupId();
 	}
 
-	protected Long
-			testGetSiteSitePageFriendlyUrlPathExperiencesPage_getIrrelevantSiteId()
+	protected Long testGetSiteSitePagesExperiencesPage_getIrrelevantSiteId()
 		throws Exception {
 
 		return irrelevantGroup.getGroupId();
 	}
 
-	protected String
-			testGetSiteSitePageFriendlyUrlPathExperiencesPage_getFriendlyUrlPath()
+	protected String testGetSiteSitePagesExperiencesPage_getFriendlyUrlPath()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -582,7 +572,7 @@ public abstract class BaseSitePageResourceTestCase {
 	}
 
 	protected String
-			testGetSiteSitePageFriendlyUrlPathExperiencesPage_getIrrelevantFriendlyUrlPath()
+			testGetSiteSitePagesExperiencesPage_getIrrelevantFriendlyUrlPath()
 		throws Exception {
 
 		return null;

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -638,12 +638,12 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	}
 
 	@Test
-	public void testPutAssetLibraryStructuredContentFolderPermission()
+	public void testPutAssetLibraryStructuredContentFolderPermissionsPage()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		StructuredContentFolder structuredContentFolder =
-			testPutAssetLibraryStructuredContentFolderPermission_addStructuredContentFolder();
+			testPutAssetLibraryStructuredContentFolderPermissionsPage_addStructuredContentFolder();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -652,7 +652,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			structuredContentFolderResource.
-				putAssetLibraryStructuredContentFolderPermissionHttpResponse(
+				putAssetLibraryStructuredContentFolderPermissionsPageHttpResponse(
 					testDepotEntry.getDepotEntryId(),
 					new Permission[] {
 						new Permission() {
@@ -666,7 +666,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentFolderResource.
-				putAssetLibraryStructuredContentFolderPermissionHttpResponse(
+				putAssetLibraryStructuredContentFolderPermissionsPageHttpResponse(
 					testDepotEntry.getDepotEntryId(),
 					new Permission[] {
 						new Permission() {
@@ -679,7 +679,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	}
 
 	protected StructuredContentFolder
-			testPutAssetLibraryStructuredContentFolderPermission_addStructuredContentFolder()
+			testPutAssetLibraryStructuredContentFolderPermissionsPage_addStructuredContentFolder()
 		throws Exception {
 
 		return structuredContentFolderResource.
@@ -1135,12 +1135,12 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteStructuredContentFolderPermission()
+	public void testPutSiteStructuredContentFolderPermissionsPage()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		StructuredContentFolder structuredContentFolder =
-			testPutSiteStructuredContentFolderPermission_addStructuredContentFolder();
+			testPutSiteStructuredContentFolderPermissionsPage_addStructuredContentFolder();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1149,7 +1149,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			structuredContentFolderResource.
-				putSiteStructuredContentFolderPermissionHttpResponse(
+				putSiteStructuredContentFolderPermissionsPageHttpResponse(
 					structuredContentFolder.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1163,7 +1163,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentFolderResource.
-				putSiteStructuredContentFolderPermissionHttpResponse(
+				putSiteStructuredContentFolderPermissionsPageHttpResponse(
 					structuredContentFolder.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1176,7 +1176,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	}
 
 	protected StructuredContentFolder
-			testPutSiteStructuredContentFolderPermission_addStructuredContentFolder()
+			testPutSiteStructuredContentFolderPermissionsPage_addStructuredContentFolder()
 		throws Exception {
 
 		return structuredContentFolderResource.postSiteStructuredContentFolder(
@@ -1207,10 +1207,12 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	}
 
 	@Test
-	public void testPutStructuredContentFolderPermission() throws Exception {
+	public void testPutStructuredContentFolderPermissionsPage()
+		throws Exception {
+
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		StructuredContentFolder structuredContentFolder =
-			testPutStructuredContentFolderPermission_addStructuredContentFolder();
+			testPutStructuredContentFolderPermissionsPage_addStructuredContentFolder();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1219,7 +1221,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			structuredContentFolderResource.
-				putStructuredContentFolderPermissionHttpResponse(
+				putStructuredContentFolderPermissionsPageHttpResponse(
 					structuredContentFolder.getId(),
 					new Permission[] {
 						new Permission() {
@@ -1233,7 +1235,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentFolderResource.
-				putStructuredContentFolderPermissionHttpResponse(
+				putStructuredContentFolderPermissionsPageHttpResponse(
 					0L,
 					new Permission[] {
 						new Permission() {
@@ -1246,7 +1248,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	}
 
 	protected StructuredContentFolder
-			testPutStructuredContentFolderPermission_addStructuredContentFolder()
+			testPutStructuredContentFolderPermissionsPage_addStructuredContentFolder()
 		throws Exception {
 
 		return structuredContentFolderResource.postSiteStructuredContentFolder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -610,12 +610,12 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
-	public void testPutAssetLibraryStructuredContentPermission()
+	public void testPutAssetLibraryStructuredContentPermissionsPage()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		StructuredContent structuredContent =
-			testPutAssetLibraryStructuredContentPermission_addStructuredContent();
+			testPutAssetLibraryStructuredContentPermissionsPage_addStructuredContent();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -624,7 +624,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			structuredContentResource.
-				putAssetLibraryStructuredContentPermissionHttpResponse(
+				putAssetLibraryStructuredContentPermissionsPageHttpResponse(
 					testDepotEntry.getDepotEntryId(),
 					new Permission[] {
 						new Permission() {
@@ -638,7 +638,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentResource.
-				putAssetLibraryStructuredContentPermissionHttpResponse(
+				putAssetLibraryStructuredContentPermissionsPageHttpResponse(
 					testDepotEntry.getDepotEntryId(),
 					new Permission[] {
 						new Permission() {
@@ -651,7 +651,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	protected StructuredContent
-			testPutAssetLibraryStructuredContentPermission_addStructuredContent()
+			testPutAssetLibraryStructuredContentPermissionsPage_addStructuredContent()
 		throws Exception {
 
 		return structuredContentResource.postAssetLibraryStructuredContent(
@@ -1771,10 +1771,10 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteStructuredContentPermission() throws Exception {
+	public void testPutSiteStructuredContentPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		StructuredContent structuredContent =
-			testPutSiteStructuredContentPermission_addStructuredContent();
+			testPutSiteStructuredContentPermissionsPage_addStructuredContent();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -1783,7 +1783,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			structuredContentResource.
-				putSiteStructuredContentPermissionHttpResponse(
+				putSiteStructuredContentPermissionsPageHttpResponse(
 					structuredContent.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1797,7 +1797,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentResource.
-				putSiteStructuredContentPermissionHttpResponse(
+				putSiteStructuredContentPermissionsPageHttpResponse(
 					structuredContent.getSiteId(),
 					new Permission[] {
 						new Permission() {
@@ -1810,7 +1810,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	protected StructuredContent
-			testPutSiteStructuredContentPermission_addStructuredContent()
+			testPutSiteStructuredContentPermissionsPage_addStructuredContent()
 		throws Exception {
 
 		return structuredContentResource.postSiteStructuredContent(
@@ -2444,10 +2444,10 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
-	public void testPutStructuredContentPermission() throws Exception {
+	public void testPutStructuredContentPermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		StructuredContent structuredContent =
-			testPutStructuredContentPermission_addStructuredContent();
+			testPutStructuredContentPermissionsPage_addStructuredContent();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -2456,7 +2456,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		assertHttpResponseStatusCode(
 			200,
 			structuredContentResource.
-				putStructuredContentPermissionHttpResponse(
+				putStructuredContentPermissionsPageHttpResponse(
 					structuredContent.getId(),
 					new Permission[] {
 						new Permission() {
@@ -2470,7 +2470,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentResource.
-				putStructuredContentPermissionHttpResponse(
+				putStructuredContentPermissionsPageHttpResponse(
 					0L,
 					new Permission[] {
 						new Permission() {
@@ -2483,7 +2483,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	protected StructuredContent
-			testPutStructuredContentPermission_addStructuredContent()
+			testPutStructuredContentPermissionsPage_addStructuredContent()
 		throws Exception {
 
 		return structuredContentResource.postSiteStructuredContent(
@@ -2498,7 +2498,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
-	public void testGetStructuredContentRenderedContentTemplate()
+	public void testGetStructuredContentRenderedContentContentTemplate()
 		throws Exception {
 
 		Assert.assertTrue(false);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -732,9 +732,9 @@ public abstract class BaseWikiNodeResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteWikiNodePermission() throws Exception {
+	public void testPutSiteWikiNodePermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
-		WikiNode wikiNode = testPutSiteWikiNodePermission_addWikiNode();
+		WikiNode wikiNode = testPutSiteWikiNodePermissionsPage_addWikiNode();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -742,7 +742,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			wikiNodeResource.putSiteWikiNodePermissionHttpResponse(
+			wikiNodeResource.putSiteWikiNodePermissionsPageHttpResponse(
 				wikiNode.getSiteId(),
 				new Permission[] {
 					new Permission() {
@@ -755,7 +755,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404,
-			wikiNodeResource.putSiteWikiNodePermissionHttpResponse(
+			wikiNodeResource.putSiteWikiNodePermissionsPageHttpResponse(
 				wikiNode.getSiteId(),
 				new Permission[] {
 					new Permission() {
@@ -767,7 +767,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 				}));
 	}
 
-	protected WikiNode testPutSiteWikiNodePermission_addWikiNode()
+	protected WikiNode testPutSiteWikiNodePermissionsPage_addWikiNode()
 		throws Exception {
 
 		return wikiNodeResource.postSiteWikiNode(
@@ -923,9 +923,9 @@ public abstract class BaseWikiNodeResourceTestCase {
 	}
 
 	@Test
-	public void testPutWikiNodePermission() throws Exception {
+	public void testPutWikiNodePermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
-		WikiNode wikiNode = testPutWikiNodePermission_addWikiNode();
+		WikiNode wikiNode = testPutWikiNodePermissionsPage_addWikiNode();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -933,7 +933,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			wikiNodeResource.putWikiNodePermissionHttpResponse(
+			wikiNodeResource.putWikiNodePermissionsPageHttpResponse(
 				wikiNode.getId(),
 				new Permission[] {
 					new Permission() {
@@ -946,7 +946,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404,
-			wikiNodeResource.putWikiNodePermissionHttpResponse(
+			wikiNodeResource.putWikiNodePermissionsPageHttpResponse(
 				0L,
 				new Permission[] {
 					new Permission() {
@@ -958,7 +958,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 				}));
 	}
 
-	protected WikiNode testPutWikiNodePermission_addWikiNode()
+	protected WikiNode testPutWikiNodePermissionsPage_addWikiNode()
 		throws Exception {
 
 		return wikiNodeResource.postSiteWikiNode(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -920,9 +920,9 @@ public abstract class BaseWikiPageResourceTestCase {
 	}
 
 	@Test
-	public void testPutWikiPagePermission() throws Exception {
+	public void testPutWikiPagePermissionsPage() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
-		WikiPage wikiPage = testPutWikiPagePermission_addWikiPage();
+		WikiPage wikiPage = testPutWikiPagePermissionsPage_addWikiPage();
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
@@ -930,7 +930,7 @@ public abstract class BaseWikiPageResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			200,
-			wikiPageResource.putWikiPagePermissionHttpResponse(
+			wikiPageResource.putWikiPagePermissionsPageHttpResponse(
 				wikiPage.getId(),
 				new Permission[] {
 					new Permission() {
@@ -943,7 +943,7 @@ public abstract class BaseWikiPageResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404,
-			wikiPageResource.putWikiPagePermissionHttpResponse(
+			wikiPageResource.putWikiPagePermissionsPageHttpResponse(
 				0L,
 				new Permission[] {
 					new Permission() {
@@ -955,7 +955,7 @@ public abstract class BaseWikiPageResourceTestCase {
 				}));
 	}
 
-	protected WikiPage testPutWikiPagePermission_addWikiPage()
+	protected WikiPage testPutWikiPagePermissionsPage_addWikiPage()
 		throws Exception {
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentStructureResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentStructureResourceTest.java
@@ -113,7 +113,7 @@ public class ContentStructureResourceTest
 
 	@Override
 	protected ContentStructure
-			testPutAssetLibraryContentStructurePermission_addContentStructure()
+			testPutAssetLibraryContentStructurePermissionsPage_addContentStructure()
 		throws Exception {
 
 		return testGetContentStructure_addContentStructure();
@@ -121,7 +121,7 @@ public class ContentStructureResourceTest
 
 	@Override
 	protected ContentStructure
-			testPutContentStructurePermission_addContentStructure()
+			testPutContentStructurePermissionsPage_addContentStructure()
 		throws Exception {
 
 		return testGetContentStructure_addContentStructure();
@@ -129,7 +129,7 @@ public class ContentStructureResourceTest
 
 	@Override
 	protected ContentStructure
-			testPutSiteContentStructurePermission_addContentStructure()
+			testPutSiteContentStructurePermissionsPage_addContentStructure()
 		throws Exception {
 
 		return testGetContentStructure_addContentStructure();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentTemplateResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentTemplateResourceTest.java
@@ -76,7 +76,7 @@ public class ContentTemplateResourceTest
 	}
 
 	@Override
-	protected ContentTemplate testGetContentTemplate_addContentTemplate()
+	protected ContentTemplate testGetSiteContentTemplate_addContentTemplate()
 		throws Exception {
 
 		return _getContentTemplate(testGroup);
@@ -95,7 +95,7 @@ public class ContentTemplateResourceTest
 	protected ContentTemplate testGraphQLContentTemplate_addContentTemplate()
 		throws Exception {
 
-		return testGetContentTemplate_addContentTemplate();
+		return testGetSiteContentTemplate_addContentTemplate();
 	}
 
 	private DDMForm _deserialize(String content) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardMessageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardMessageResourceTest.java
@@ -218,7 +218,7 @@ public class MessageBoardMessageResourceTest
 
 	@Override
 	protected MessageBoardMessage
-			testPutMessageBoardMessagePermission_addMessageBoardMessage()
+			testPutMessageBoardMessagePermissionsPage_addMessageBoardMessage()
 		throws Exception {
 
 		return _addMessageBoardMessage();
@@ -265,7 +265,7 @@ public class MessageBoardMessageResourceTest
 
 	@Override
 	protected MessageBoardMessage
-			testPutSiteMessageBoardMessagePermission_addMessageBoardMessage()
+			testPutSiteMessageBoardMessagePermissionsPage_addMessageBoardMessage()
 		throws Exception {
 
 		return _addMessageBoardMessage();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
@@ -115,32 +115,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		Assert.assertNotNull(siteSitePageExperienceExperienceKeyRenderedPage);
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testGetSiteSitePageFriendlyUrlPathExperiencesPage()
-		throws Exception {
-
-		Layout layout = _addLayout(testGroup.getGroupId());
-
-		String friendlyURL = layout.getFriendlyURL();
-
-		Page<SitePage> page =
-			sitePageResource.getSiteSitePageFriendlyUrlPathExperiencesPage(
-				testGroup.getGroupId(), friendlyURL.substring(1));
-
-		long originalPageCount = page.getTotalCount();
-
-		_addSegmentsExperience(
-			layout,
-			ServiceContextTestUtil.getServiceContext(testGroup.getGroupId()));
-
-		page = sitePageResource.getSiteSitePageFriendlyUrlPathExperiencesPage(
-			testGroup.getGroupId(), friendlyURL.substring(1));
-
-		Assert.assertEquals(originalPageCount + 1, page.getTotalCount());
-	}
-
 	@Override
 	@Test
 	public void testGetSiteSitePageRenderedPage() throws Exception {
@@ -153,6 +127,29 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				testGroup.getGroupId(), friendlyURL.substring(1));
 
 		Assert.assertNotNull(siteSitePageRenderedPage);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSitePagesExperiencesPage() throws Exception {
+		Layout layout = _addLayout(testGroup.getGroupId());
+
+		String friendlyURL = layout.getFriendlyURL();
+
+		Page<SitePage> page = sitePageResource.getSiteSitePagesExperiencesPage(
+			testGroup.getGroupId(), friendlyURL.substring(1));
+
+		long originalPageCount = page.getTotalCount();
+
+		_addSegmentsExperience(
+			layout,
+			ServiceContextTestUtil.getServiceContext(testGroup.getGroupId()));
+
+		page = sitePageResource.getSiteSitePagesExperiencesPage(
+			testGroup.getGroupId(), friendlyURL.substring(1));
+
+		Assert.assertEquals(originalPageCount + 1, page.getTotalCount());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -402,7 +402,7 @@ public class StructuredContentResourceTest
 
 	@Override
 	@Test
-	public void testGetStructuredContentRenderedContentTemplate()
+	public void testGetStructuredContentRenderedContentContentTemplate()
 		throws Exception {
 
 		StructuredContent structuredContent =
@@ -416,7 +416,7 @@ public class StructuredContentResourceTest
 		Assert.assertEquals(
 			"<div>" + contentFieldValue.getData() + "</div>",
 			structuredContentResource.
-				getStructuredContentRenderedContentTemplate(
+				getStructuredContentRenderedContentContentTemplate(
 					structuredContent.getId(), _ddmTemplate.getTemplateKey()));
 	}
 
@@ -588,7 +588,7 @@ public class StructuredContentResourceTest
 
 	@Override
 	protected StructuredContent
-			testPutAssetLibraryStructuredContentPermission_addStructuredContent()
+			testPutAssetLibraryStructuredContentPermissionsPage_addStructuredContent()
 		throws Exception {
 
 		StructuredContent structuredContent = randomStructuredContent();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageResourceTest.java
@@ -169,7 +169,7 @@ public class WikiPageResourceTest extends BaseWikiPageResourceTestCase {
 	}
 
 	@Override
-	protected WikiPage testPutWikiPagePermission_addWikiPage()
+	protected WikiPage testPutWikiPagePermissionsPage_addWikiPage()
 		throws Exception {
 
 		return _addWikiPage(testGetWikiNodeWikiPagesPage_getWikiNodeId());

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
@@ -432,7 +432,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.form.client', and version '4.0.8'."
+        'com.liferay.headless.form.client', and version '4.0.9'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.form.client', and version '4.0.8'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Form", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.form.client', and version '4.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Form", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
@@ -28,7 +28,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.portal.instances.client', and version '1.0.3'."
+        'com.liferay.headless.portal.instances.client', and version '1.0.4'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.portal.instances.client', and version '1.0.3'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Portal Instances Headless API", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.portal.instances.client', and version '1.0.4'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Portal Instances Headless API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -273,7 +273,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.object.admin.rest.client', and version '1.0.5'."
+        'com.liferay.object.admin.rest.client', and version '1.0.6'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.5'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.6'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -515,7 +515,7 @@ public class ResourceOpenAPIParser {
 
 		String operationId = operation.getOperationId();
 
-		if ((operationId != null) && operationId.endsWith("Permission") &&
+		if ((operationId != null) && operationId.endsWith("PermissionsPage") &&
 			operationId.startsWith("put") && requestBodyMediaTypes.isEmpty()) {
 
 			javaMethodParameters.add(

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -214,7 +214,7 @@ public abstract class Base${schemaName}ResourceImpl
 						source="Site" + schemaName
 					/>,
 					siteId, portletName, roleNames);
-			<#elseif stringUtil.equals(javaMethodSignature.methodName, "put" + schemaName + "Permission")>
+			<#elseif stringUtil.equals(javaMethodSignature.methodName, "put" + schemaName + "PermissionsPage")>
 				<#if freeMarkerTool.hasParameter(javaMethodSignature, schemaVarName + "Id")>
 					<#assign generateGetPermissionCheckerMethods = true />
 
@@ -235,7 +235,7 @@ public abstract class Base${schemaName}ResourceImpl
 				<#else>
 					throw new UnsupportedOperationException("This method needs to be implemented");
 				</#if>
-			<#elseif stringUtil.equals(javaMethodSignature.methodName, "putAssetLibrary" + schemaName + "Permission")>
+			<#elseif stringUtil.equals(javaMethodSignature.methodName, "putAssetLibrary" + schemaName + "PermissionsPage")>
 				<#assign generateGetPermissionCheckerMethods = true />
 
 				String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -251,7 +251,7 @@ public abstract class Base${schemaName}ResourceImpl
 						source="AssetLibrary" + schemaName
 					/>
 				</@updateResourcePermissions>
-			<#elseif stringUtil.equals(javaMethodSignature.methodName, "putSite" + schemaName + "Permission")>
+			<#elseif stringUtil.equals(javaMethodSignature.methodName, "putSite" + schemaName + "PermissionsPage")>
 				<#assign generateGetPermissionCheckerMethods = true />
 
 				String portletName = getPermissionCheckerPortletName(siteId);
@@ -731,7 +731,7 @@ public abstract class Base${schemaName}ResourceImpl
 	HashMapBuilder.put(
 		"get", addAction(ActionKeys.PERMISSIONS, "get${source}PermissionsPage", ${resourceName}, ${resourceId})
 	).put(
-		"replace", addAction(ActionKeys.PERMISSIONS, "put${source}Permission", ${resourceName}, ${resourceId})
+		"replace", addAction(ActionKeys.PERMISSIONS, "put${source}PermissionsPage", ${resourceName}, ${resourceId})
 	).build()
 </#macro>
 


### PR DESCRIPTION
Related ticket -> [LPS-142086](https://issues.liferay.com/browse/LPS-142086)

There are some tests that are failing in headless taxonomy. This is because of a rename of some `operationsIds` in [this commit](https://github.com/brianchandotcom/liferay-portal/commit/14f9546e3811c8b9e811436ee99e3b01fd6dcc5e) and [this commit](https://github.com/brianchandotcom/liferay-portal/commit/df5eb7a272d17ff27bce20ca7dfef44a82731836) that was merged directly.

As we want to support these new names, I made the changes to create the methods with the proper names.

I've also made changes in Data Engine APIs to support the same convention of names, so I've also updated some code to the new names.

I hope everything is OK with the changes in the rest builder.