### PR TITLE
LPS-135322 Create Frontend Data Set Sample

### DIFF
--- a/modules/.releng/apps/frontend-data-set/app.properties
+++ b/modules/.releng/apps/frontend-data-set/app.properties
@@ -1,0 +1,4 @@
+app.marketplace.id=
+app.marketplace.title=Liferay CE Frontend Data Set
+app.marketplace.version=1.0.0
+app.portal.build=7403

--- a/modules/.releng/dxp/apps/frontend-data-set/app.properties
+++ b/modules/.releng/dxp/apps/frontend-data-set/app.properties
@@ -1,0 +1,4 @@
+app.marketplace.id=
+app.marketplace.title=Liferay Frontend Data Set
+app.marketplace.version=1.0.0
+app.portal.build=7413

--- a/modules/apps/frontend-data-set/app.bnd
+++ b/modules/apps/frontend-data-set/app.bnd
@@ -1,0 +1,15 @@
+Liferay-Releng-App-Description:
+Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Frontend Data Set
+Liferay-Releng-Bundle: true
+Liferay-Releng-Category: Utility
+Liferay-Releng-Demo-Url:
+Liferay-Releng-Deprecated: false
+Liferay-Releng-Fix-Delivery-Method: core
+Liferay-Releng-Labs: false
+Liferay-Releng-Marketplace: true
+Liferay-Releng-Portal-Required: true
+Liferay-Releng-Public: ${liferay.releng.public}
+Liferay-Releng-Restart-Required: true
+Liferay-Releng-Suite: foundation
+Liferay-Releng-Support-Url: http://www.liferay.com
+Liferay-Releng-Supported: ${liferay.releng.supported}

--- a/modules/apps/frontend-data-set/build.gradle
+++ b/modules/apps/frontend-data-set/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: "com.liferay.app.defaults.plugin"

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Frontend Data Set Sample Web
+Bundle-SymbolicName: com.liferay.frontend.data.set.sample.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /frontend-data-set-sample-web

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/build.gradle
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:object:object-api")
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/package.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "@liferay/frontend-data-set-sample-web",
+	"private": true,
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "1.0.0"
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/FrontendDataSetSampleGenerator.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/FrontendDataSetSampleGenerator.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal;
+
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.util.LocalizedMapUtil;
+import com.liferay.object.util.ObjectFieldUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(service = FrontendDataSetSampleGenerator.class)
+public class FrontendDataSetSampleGenerator {
+
+	public void generateFrontendDataSetSample(long companyId) {
+		if (_isFrontendDataSetSampleGenerated(companyId)) {
+			return;
+		}
+
+		User user = _userLocalService.fetchUserByEmailAddress(
+			companyId, "test@liferay.com");
+
+		if (user == null) {
+			return;
+		}
+
+		try {
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.fetchObjectDefinition(
+					companyId, "C_FrontendDataSetSample");
+
+			if (objectDefinition == null) {
+				objectDefinition =
+					_objectDefinitionLocalService.addCustomObjectDefinition(
+						user.getUserId(),
+						LocalizedMapUtil.getLocalizedMap(
+							"Frontend Data Set Sample"),
+						"FrontendDataSetSample", "100", null,
+						LocalizedMapUtil.getLocalizedMap(
+							"Frontend Data Set Samples"),
+						ObjectDefinitionConstants.SCOPE_COMPANY,
+						Arrays.asList(
+							ObjectFieldUtil.createObjectField(
+								true, false, null, "Title", "title", false,
+								"String"),
+							ObjectFieldUtil.createObjectField(
+								true, false, null, "Description", "description",
+								false, "String"),
+							ObjectFieldUtil.createObjectField(
+								true, false, null, "Date", "date", false,
+								"Date")));
+
+				objectDefinition =
+					_objectDefinitionLocalService.publishCustomObjectDefinition(
+						user.getUserId(),
+						objectDefinition.getObjectDefinitionId());
+			}
+
+			for (int i = 1; i <= 100; i++) {
+				_objectEntryLocalService.addObjectEntry(
+					user.getUserId(), 0,
+					objectDefinition.getObjectDefinitionId(),
+					HashMapBuilder.<String, Serializable>put(
+						"date", new Date()
+					).put(
+						"description", "Description of the sample " + i
+					).put(
+						"title", "Sample" + i
+					).build(),
+					new ServiceContext());
+			}
+
+			_generated = true;
+		}
+		catch (Exception exception) {
+			_generated = null;
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Error generating Frontend Data Set sample", exception);
+			}
+		}
+	}
+
+	private boolean _isFrontendDataSetSampleGenerated(long companyId) {
+		if (_generated != null) {
+			return _generated;
+		}
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				companyId, "C_FrontendDataSetSample");
+
+		if (objectDefinition == null) {
+			_generated = false;
+
+			return false;
+		}
+
+		int samples = _objectEntryLocalService.getObjectEntriesCount(
+			0L, objectDefinition.getObjectDefinitionId());
+
+		_generated = samples > 0;
+
+		return _generated;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FrontendDataSetSampleGenerator.class);
+
+	private Boolean _generated;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FrontendDataSetSampleFrontendDataSetNames.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FrontendDataSetSampleFrontendDataSetNames.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.constants;
+
+/**
+ * @author Marko Cikos
+ */
+public class FrontendDataSetSampleFrontendDataSetNames {
+
+	public static final String HEADLESS_SAMPLE = "HEADLESS_SAMPLE";
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FrontendDataSetSamplePortletKeys.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FrontendDataSetSamplePortletKeys.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.constants;
+
+/**
+ * @author Marko Cikos
+ */
+public class FrontendDataSetSamplePortletKeys {
+
+	public static final String FRONTEND_DATA_SET_SAMPLE =
+		"com_liferay_frontend_data_set_sample_web_internal_portlet_" +
+			"FrontendDataSetSamplePortlet";
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FrontendDataSetSampleWebKeys.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FrontendDataSetSampleWebKeys.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.constants;
+
+/**
+ * @author Marko Cikos
+ */
+public class FrontendDataSetSampleWebKeys {
+
+	public static final String HEADLESS_SAMPLE_DISPLAY_CONTEXT =
+		"HEADLESS_SAMPLE_DISPLAY_CONTEXT";
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/HeadlessSampleDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/HeadlessSampleDisplayContext.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.display.context;
+
+import com.liferay.frontend.data.set.sample.web.internal.display.context.util.FrontendDataSetRequestHelper;
+import com.liferay.frontend.taglib.clay.data.set.servlet.taglib.util.ClayDataSetActionDropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.portal.kernel.portlet.PortletURLUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.portlet.PortletException;
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Javier Gamarra
+ * @author Javier de Arcos
+ */
+public class HeadlessSampleDisplayContext {
+
+	public HeadlessSampleDisplayContext(HttpServletRequest httpServletRequest) {
+		_frontendDataSetRequestHelper = new FrontendDataSetRequestHelper(
+			httpServletRequest);
+	}
+
+	public String getAPIURL() {
+		return "/o/c/datasetdisplaysamples";
+	}
+
+	public List<ClayDataSetActionDropdownItem>
+			getClayDataSetActionDropdownItems()
+		throws Exception {
+
+		return new ArrayList<>();
+	}
+
+	public CreationMenu getCreationMenu() throws Exception {
+		return new CreationMenu();
+	}
+
+	public PortletURL getPortletURL() throws PortletException {
+		return PortletURLUtil.clone(
+			PortletURLUtil.getCurrent(
+				_frontendDataSetRequestHelper.getLiferayPortletRequest(),
+				_frontendDataSetRequestHelper.getLiferayPortletResponse()),
+			_frontendDataSetRequestHelper.getLiferayPortletResponse());
+	}
+
+	private final FrontendDataSetRequestHelper _frontendDataSetRequestHelper;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/util/FrontendDataSetRequestHelper.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/util/FrontendDataSetRequestHelper.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.display.context.util;
+
+import com.liferay.portal.kernel.display.context.util.BaseRequestHelper;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Javier Gamarra
+ */
+public class FrontendDataSetRequestHelper extends BaseRequestHelper {
+
+	public FrontendDataSetRequestHelper(HttpServletRequest httpServletRequest) {
+		super(httpServletRequest);
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/DateRangeClayTableDataSetFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/DateRangeClayTableDataSetFilter.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.filter;
+
+import com.liferay.frontend.data.set.sample.web.internal.constants.FrontendDataSetSampleFrontendDataSetNames;
+import com.liferay.frontend.taglib.clay.data.set.filter.BaseDateRangeClayDataSetFilter;
+import com.liferay.frontend.taglib.clay.data.set.filter.ClayDataSetFilter;
+import com.liferay.frontend.taglib.clay.data.set.filter.DateClayDataSetFilterItem;
+
+import java.util.Calendar;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+	property = "clay.data.set.display.name=" + FrontendDataSetSampleFrontendDataSetNames.HEADLESS_SAMPLE,
+	service = ClayDataSetFilter.class
+)
+public class DateRangeClayTableDataSetFilter
+	extends BaseDateRangeClayDataSetFilter {
+
+	@Override
+	public String getId() {
+		return "date";
+	}
+
+	@Override
+	public String getLabel() {
+		return "Date Range";
+	}
+
+	public DateClayDataSetFilterItem getMaxDateClayDataSetFilterItem() {
+		Calendar calendar = Calendar.getInstance();
+
+		return new DateClayDataSetFilterItem(
+			calendar.get(Calendar.DAY_OF_MONTH),
+			calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.YEAR));
+	}
+
+	@Override
+	public DateClayDataSetFilterItem getMinDateClayDataSetFilterItem() {
+		return new DateClayDataSetFilterItem(0, 0, 0);
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/StatusCheckBoxClayDataSetFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/StatusCheckBoxClayDataSetFilter.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.filter;
+
+import com.liferay.frontend.data.set.sample.web.internal.constants.FrontendDataSetSampleFrontendDataSetNames;
+import com.liferay.frontend.taglib.clay.data.set.filter.BaseCheckBoxClayDataSetFilter;
+import com.liferay.frontend.taglib.clay.data.set.filter.CheckBoxClayDataSetFilterItem;
+import com.liferay.frontend.taglib.clay.data.set.filter.ClayDataSetFilter;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+	property = "clay.data.set.display.name=" + FrontendDataSetSampleFrontendDataSetNames.HEADLESS_SAMPLE,
+	service = ClayDataSetFilter.class
+)
+public class StatusCheckBoxClayDataSetFilter
+	extends BaseCheckBoxClayDataSetFilter {
+
+	@Override
+	public List<CheckBoxClayDataSetFilterItem>
+		getCheckBoxClayDataSetFilterItems(Locale locale) {
+
+		return ListUtil.fromArray(
+			new CheckBoxClayDataSetFilterItem(
+				WorkflowConstants.getStatusLabel(
+					WorkflowConstants.STATUS_APPROVED),
+				WorkflowConstants.STATUS_APPROVED),
+			new CheckBoxClayDataSetFilterItem(
+				WorkflowConstants.getStatusLabel(
+					WorkflowConstants.STATUS_DRAFT),
+				WorkflowConstants.STATUS_DRAFT),
+			new CheckBoxClayDataSetFilterItem(
+				WorkflowConstants.getStatusLabel(
+					WorkflowConstants.STATUS_PENDING),
+				WorkflowConstants.STATUS_PENDING));
+	}
+
+	@Override
+	public String getId() {
+		return "status";
+	}
+
+	@Override
+	public String getLabel() {
+		return "status";
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/portlet/FrontendDataSetSamplePortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/portlet/FrontendDataSetSamplePortlet.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.portlet;
+
+import com.liferay.frontend.data.set.sample.web.internal.FrontendDataSetSampleGenerator;
+import com.liferay.frontend.data.set.sample.web.internal.constants.FrontendDataSetSamplePortletKeys;
+import com.liferay.frontend.data.set.sample.web.internal.constants.FrontendDataSetSampleWebKeys;
+import com.liferay.frontend.data.set.sample.web.internal.display.context.HeadlessSampleDisplayContext;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.io.IOException;
+
+import java.util.concurrent.CompletableFuture;
+
+import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+	immediate = true,
+	property = {
+		"com.liferay.portlet.display-category=category.sample",
+		"com.liferay.portlet.instanceable=true",
+		"com.liferay.portlet.layout-cacheable=true",
+		"com.liferay.portlet.private-request-attributes=false",
+		"com.liferay.portlet.private-session-attributes=false",
+		"com.liferay.portlet.render-weight=50",
+		"com.liferay.portlet.use-default-template=true",
+		"javax.portlet.display-name=Frontend Data Set Sample",
+		"javax.portlet.expiration-cache=0",
+		"javax.portlet.init-param.template-path=/META-INF/resources/",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.name=" + FrontendDataSetSamplePortletKeys.FRONTEND_DATA_SET_SAMPLE,
+		"javax.portlet.resource-bundle=content.Language",
+		"javax.portlet.security-role-ref=power-user,user"
+	},
+	service = Portlet.class
+)
+public class FrontendDataSetSamplePortlet extends MVCPortlet {
+
+	@Override
+	public void doDispatch(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		CompletableFuture.runAsync(
+			() -> _frontendDataSetSampleGenerator.generateFrontendDataSetSample(
+				_portal.getCompanyId(renderRequest)));
+
+		renderRequest.setAttribute(
+			FrontendDataSetSampleWebKeys.HEADLESS_SAMPLE_DISPLAY_CONTEXT,
+			new HeadlessSampleDisplayContext(
+				_portal.getHttpServletRequest(renderRequest)));
+
+		super.doDispatch(renderRequest, renderResponse);
+	}
+
+	@Reference
+	private FrontendDataSetSampleGenerator _frontendDataSetSampleGenerator;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CardsClayDataSetDisplayView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CardsClayDataSetDisplayView.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.view;
+
+import com.liferay.frontend.data.set.sample.web.internal.constants.FrontendDataSetSampleFrontendDataSetNames;
+import com.liferay.frontend.taglib.clay.data.set.ClayDataSetDisplayView;
+import com.liferay.frontend.taglib.clay.data.set.view.cards.BaseCardsClayDataSetDisplayView;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+	enabled = false,
+	property = "clay.data.set.display.name=" + FrontendDataSetSampleFrontendDataSetNames.HEADLESS_SAMPLE,
+	service = ClayDataSetDisplayView.class
+)
+public class CardsClayDataSetDisplayView
+	extends BaseCardsClayDataSetDisplayView {
+
+	@Override
+	public String getDescription() {
+		return "description";
+	}
+
+	@Override
+	public String getTitle() {
+		return "title";
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/ListClayDataSetDisplayView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/ListClayDataSetDisplayView.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.view;
+
+import com.liferay.frontend.data.set.sample.web.internal.constants.FrontendDataSetSampleFrontendDataSetNames;
+import com.liferay.frontend.taglib.clay.data.set.ClayDataSetDisplayView;
+import com.liferay.frontend.taglib.clay.data.set.view.list.BaseListClayDataSetDisplayView;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+	enabled = false,
+	property = "clay.data.set.display.name=" + FrontendDataSetSampleFrontendDataSetNames.HEADLESS_SAMPLE,
+	service = ClayDataSetDisplayView.class
+)
+public class ListClayDataSetDisplayView extends BaseListClayDataSetDisplayView {
+
+	@Override
+	public String getDescription() {
+		return "description";
+	}
+
+	@Override
+	public String getTitle() {
+		return "title";
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/TableClayDataSetDisplayView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/TableClayDataSetDisplayView.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.view;
+
+import com.liferay.frontend.data.set.sample.web.internal.constants.FrontendDataSetSampleFrontendDataSetNames;
+import com.liferay.frontend.taglib.clay.data.set.ClayDataSetDisplayView;
+import com.liferay.frontend.taglib.clay.data.set.view.table.BaseTableClayDataSetDisplayView;
+import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchema;
+import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaBuilder;
+import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaBuilderFactory;
+import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaField;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Javier Gamarra
+ * @author Javier de Arcos
+ */
+@Component(
+	enabled = true,
+	property = "clay.data.set.display.name=" + FrontendDataSetSampleFrontendDataSetNames.HEADLESS_SAMPLE,
+	service = ClayDataSetDisplayView.class
+)
+public class TableClayDataSetDisplayView
+	extends BaseTableClayDataSetDisplayView {
+
+	@Override
+	public ClayTableSchema getClayTableSchema() {
+		ClayTableSchemaBuilder clayTableSchemaBuilder =
+			_clayTableSchemaBuilderFactory.create();
+
+		clayTableSchemaBuilder.addClayTableSchemaField("id", "id");
+
+		clayTableSchemaBuilder.addClayTableSchemaField("title", "Title");
+
+		clayTableSchemaBuilder.addClayTableSchemaField(
+			"description", "Description");
+
+		clayTableSchemaBuilder.addClayTableSchemaField("date", "Date");
+
+		ClayTableSchemaField statusClayTableSchemaField =
+			clayTableSchemaBuilder.addClayTableSchemaField("status", "status");
+
+		statusClayTableSchemaField.setContentRenderer("status");
+
+		clayTableSchemaBuilder.addClayTableSchemaField(
+			"creator.name", "author");
+
+		return clayTableSchemaBuilder.build();
+	}
+
+	@Reference
+	private ClayTableSchemaBuilderFactory _clayTableSchemaBuilderFactory;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/TimelineClayDataSetDisplayView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/TimelineClayDataSetDisplayView.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.view;
+
+import com.liferay.frontend.data.set.sample.web.internal.constants.FrontendDataSetSampleFrontendDataSetNames;
+import com.liferay.frontend.taglib.clay.data.set.ClayDataSetDisplayView;
+import com.liferay.frontend.taglib.clay.data.set.view.timeline.BaseTimelineClayDataSetDisplayView;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+	enabled = false,
+	property = "clay.data.set.display.name=" + FrontendDataSetSampleFrontendDataSetNames.HEADLESS_SAMPLE,
+	service = ClayDataSetDisplayView.class
+)
+public class TimelineClayDataSetDisplayView
+	extends BaseTimelineClayDataSetDisplayView {
+
+	@Override
+	public String getDate() {
+		return "date";
+	}
+
+	@Override
+	public String getDescription() {
+		return "description";
+	}
+
+	@Override
+	public String getTitle() {
+		return "title";
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,28 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+
+<%@ page import="com.liferay.frontend.data.set.sample.web.internal.constants.FrontendDataSetSampleFrontendDataSetNames" %><%@
+page import="com.liferay.frontend.data.set.sample.web.internal.constants.FrontendDataSetSampleWebKeys" %><%@
+page import="com.liferay.frontend.data.set.sample.web.internal.display.context.HeadlessSampleDisplayContext" %>
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,33 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+HeadlessSampleDisplayContext headlessSampleDisplayContext = (HeadlessSampleDisplayContext)request.getAttribute(FrontendDataSetSampleWebKeys.HEADLESS_SAMPLE_DISPLAY_CONTEXT);
+%>
+
+<clay:headless-data-set-display
+	apiURL="<%= headlessSampleDisplayContext.getAPIURL() %>"
+	clayDataSetActionDropdownItems="<%= headlessSampleDisplayContext.getClayDataSetActionDropdownItems() %>"
+	formId="fm"
+	id="<%= FrontendDataSetSampleFrontendDataSetNames.HEADLESS_SAMPLE %>"
+	itemsPerPage="<%= 20 %>"
+	namespace="<%= liferayPortletResponse.getNamespace() %>"
+	pageNumber="<%= 1 %>"
+	portletURL="<%= liferayPortletResponse.createRenderURL() %>"
+	style="fluid"
+/>


### PR DESCRIPTION
This is a followup on https://github.com/brianchandotcom/liferay-portal/pull/108368

JIRA: https://issues.liferay.com/browse/LPS-135322

This is the second part of [rebuilding Data Set Display as a DXP app](https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/1912931035/LPS-140691+-+Create+a+strategy+to+rebuild+Data+Set+Display+as+a+DXP+app).
- [x] frontend-data-set-web
- [x] frontend-data-set-sample-web
- [ ] frontend-data-set-taglib
- [ ] frontend-data-set-api

Changes from https://github.com/brianchandotcom/liferay-portal/pull/108368:
- A bunch of renaming. `*Filter` classes and service properties still have old naming pattern. These are part of public API, that we will migrate in an upcoming task.
- Constants are now in an internal package. They are split into three constants files, based on type of constants. We are no longer exposing this package.

@javierdearcos 

/cc @carloslancha @tinycarol @nhpatt 
