### PR TITLE
LPS-141458 Inherited Roles UI getting distorted when roles list is long

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -212,6 +212,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 				%>
 
 				<liferay-ui:search-container-column-text
+					cssClass="table-cell-expand"
 					name="title"
 					value="<%= HtmlUtil.escape(ListUtil.toString(groupRoles, Role.NAME_ACCESSOR)) %>"
 				>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-141458

/cc @quanhuynhces

### Steps to reproduce (7.3.x only)

1. Navigate Control Panel -> User and Organizations -> Organizations -> Create Org (TestOrg)
2. Navigate Control Panel -> Roles (Regular Roles)
3. Create a regular role with a longer name (example: `RegularRoleOne_RegularRoleTwo_RegularRoleThree_RegularRoleFour_1`)
4. Once Role is created -> Goto Assignees Tab -> Associate Role with (TestOrg)
5. Repeat above Steps (2,3,4) for 2 more times (example: `RegularRoleOne_RegularRoleTwo_RegularRoleThree_RegularRoleFour_2` and `RegularRoleOne_RegularRoleTwo_RegularRoleThree_RegularRoleFour_3`)
6. Navigate to Control Panel -> User and Organizations -> Users -> Create User (TestUser)
7. Assign Organization (TestOrg) to user, it will automatically inherit the roles granted to (TestOrg)
8. Go to Roles tab.

**Expected behavior**: INHERITED REGULAR ROLES can be displayed correctly.
**Current behavior**: Inherited Roles UI getting distorted.

![](https://issues.liferay.com/secure/attachment/429980/inherited_roles_ui_getting_distorted.png)

### Notes about the solution

The issue only affects versions of Liferay that use an older version of clay-css, since the issue is resolved in master via an update to clay-css (3.22.0):

* https://github.com/liferay/clay/commit/6f7f2bf55a8820ac545a92cbfbd5eabf5ecee7b7
* https://github.com/liferay/clay/blob/master/packages/clay-css/CHANGELOG.md#3220-2020-12-16

We can fix the issue in those versions without an update to clay by adding the `table-cell-expand` class to the table cell that we need to have `word-wrap: break-word` applied. A lot of the other cells within the same .jsp already have this class, so updating this cell to match seemed like a sensible solution.