### PR TITLE
LPS-140031 Add test that validates basic CKEditor toolbar is present on DM

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
@@ -103,6 +103,11 @@
 </tr>
 <!--TOOLBAR-->
 <tr>
+	<td>TOOLBAR</td>
+	<td>//span[contains(@class,'cke_toolbox') ]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>HYPERLINK_BROWSE_SRVR_BTN</td>
 	<td>//a[contains(@class,'cke_button') and contains(@title,'Browse Server')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -464,4 +464,56 @@ definition {
 		AssertElementPresent(locator1 = "//p[normalize-space(text())='sample text']");
 	}
 
+	@description = "Verify that basic CKEditor toolbar is present on DM"
+	@priority = "3"
+	test DMCanFormatTextWithEditorToolbar {
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "wysiwyg-site-name");
+
+		DMNavigator.gotoDocumentType();
+
+		DMDocumentType.add(
+			dmDocumentTypeDescription = "DM Document Type Description",
+			dmDocumentTypeFieldNames = "Rich Text",
+			dmDocumentTypeName = "DM Document Type Name");
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "wysiwyg-site-name");
+
+		DMDocument.addCP(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentFile = "Document_1.txt",
+			dmDocumentTitle = "DM Document Title");
+
+		DMDocument.editCP(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentFile = "Document_1.txt",
+			dmDocumentTitle = "DM Document Title",
+			dmDocumentTypeEdit = "DM Document Type Name");
+
+		LexiconEntry.gotoEntryMenuItem(
+			menuItem = "Edit",
+			rowEntry = "DM Document Title");
+
+		AssertElementPresent(locator1 = "CKEditor#TOOLBAR");
+
+		Click(locator1 = "CKEditor#TOOLBAR_SOURCE_BUTTON");
+
+		Click(locator1 = "CKEditor#TOOLBAR_PREVIEW_BUTTON");
+
+		Type.typeCodeMirrorEditorNoError(
+			locator1 = "CKEditor#SOURCE_CODE_DIALOG",
+			value1 = "<h1>Sample Header 1</h1><p>sample text</p>");
+
+		AssertTextEquals.assertPartialText(
+			locator1 = "CKEditor#SOURCE_CODE_DIALOG",
+			value1 = "<h1>Sample Header 1</h1>");
+
+		AssertTextEquals.assertPartialText(
+			locator1 = "CKEditor#SOURCE_CODE_DIALOG",
+			value1 = "<p>sample text</p>");
+
+		SelectFrame.selectFrameNoLoading(locator1 = "CKEditor#CODE_PREVIEW_IFRAME");
+
+	   }
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -466,8 +466,8 @@ definition {
 
 	@description = "Verify that basic CKEditor toolbar is present on DM"
 	@priority = "3"
+	@refactorneeded
 	test DMCanFormatTextWithEditorToolbar {
-
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "wysiwyg-site-name");
 
 		DMNavigator.gotoDocumentType();
@@ -512,8 +512,7 @@ definition {
 			locator1 = "CKEditor#SOURCE_CODE_DIALOG",
 			value1 = "<p>sample text</p>");
 
-		SelectFrame.selectFrameNoLoading(locator1 = "CKEditor#CODE_PREVIEW_IFRAME");
-
-	   }
+		takeScreenshot();
+	}
 
 }


### PR DESCRIPTION
Goal is to add usecase test coverage for CKeditor toolbar is missing from Web Content/DM/Forms LPS-130399.

Choosing DM since it is the most stable from the 3 affected components. We have a CKEditor portlet now, but it only has balloon toolbar and does not have a editor toolbar such as the one seen in Web Content/DM/Forms.

**WYSIWYGUsecase#DMCanFormatTextWithEditorToolbar**

Test Steps:

1. Navigate to DM
2. Add document type with rich text field
3. Add a document
4. Click Edit document
5. Change document type to created one
6. Assert CKEditor toolbar is present in rich text field
7. Assert able to modify text with one or two toolbar buttons. In this case, I use the two buttons related to *Source* and *Preview*. 