### PR TITLE
LPS-142399 Remove a11y tool tests from release testing

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -2,7 +2,7 @@
 definition {
 
 	property osgi.modules.includes = "frontend-js-a11y-sample-web,frontend-js-a11y-web";
-	property portal.release = "true";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.component.names = "User Interface";
 	property testray.main.component.name = "User Interface";


### PR DESCRIPTION
**Description**
A11y tool is internal feature and not meant to be included in release bundles. No need to include the tests in release.

**Test Plan**
- [x] property portal.release = "false";

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-142399