### PR TITLE
LPS-142335 Establish z-index for input field in Modal for Chrome

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -24,6 +24,10 @@ html#{$cadmin-selector} {
 			}
 		}
 
+		input.form-control.form-control.input-group-inset.input-group-inset-after {
+			z-index: auto;
+		}
+
 		.lfr-ddm-field-group {
 			margin-bottom: 20px;
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-142335

This issue only relates to Chrome as it has a weird behavior with the input fields text being pushed back and not visible when clicked on. This only occurs when the input field is in a modal and not anywhere else in chrome. All the other browsers seem to behavior normally. 
A solution is to add `z-index: auto` to the input field so it would take the z-index of its parent element and remain on top. Including the z-index resolves the weird behavior that chrome has and will not affect any other browsers. This will be added to all inputs that are in a modal.

Let me know if there are any questions or comments about this.
Thank you.