### PR TITLE
LPS-141235 Add test that verifies remote app type IFrame can display property fields

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
@@ -20,16 +20,6 @@
 	<td>//input[contains(@id,'customElementURLs')]</td>
 	<td></td>
 </tr>
-<tr>
-	<td>HTML_ELEMENT_INPUT</td>
-	<td>//input[contains(@id,'customElementHTMLElementName')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>CSS_ELEMENT_INPUT</td>
-	<td>//input[contains(@id,'customElementCSSURLs')]</td>
-	<td></td>
-</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
@@ -20,6 +20,16 @@
 	<td>//input[contains(@id,'customElementURLs')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>HTML_ELEMENT_INPUT</td>
+	<td>//input[contains(@id,'customElementHTMLElementName')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>CSS_ELEMENT_INPUT</td>
+	<td>//input[contains(@id,'customElementCSSURLs')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -85,22 +85,35 @@ definition {
 		property portal.acceptance = "true";
 
 		var customElementType = "Custom Element";
+		var IFrameType = "IFrame";
 
 		RemoteApps.goToRemoteAppsPortlet();
 
 		LexiconEntry.gotoAdd();
 
-		AssertNotVisible(locator1 = "RemoteAppsEntry#HTML_ELEMENT_INPUT");
+		Select(
+			locator1 = "Select#TYPE",
+			value1 = "${IFrameType}");
 
-		AssertNotVisible(locator1 = "RemoteAppsEntry#CSS_ELEMENT_INPUT");
+		AssertNotVisible(
+			key_text = "HTML Element Name",
+			locator1 = "TextInput#ANY");
+
+		AssertNotVisible(
+			key_text = "CSS URL",
+			locator1 = "TextInput#ANY");
 
 		Select(
 			locator1 = "Select#TYPE",
 			value1 = "${customElementType}");
 
-		AssertVisible(locator1 = "RemoteAppsEntry#HTML_ELEMENT_INPUT");
+		AssertVisible(
+			key_text = "HTML Element Name",
+			locator1 = "TextInput#ANY");
 
-		AssertVisible(locator1 = "RemoteAppsEntry#CSS_ELEMENT_INPUT");
+		AssertVisible(
+			key_text = "CSS URL",
+			locator1 = "TextInput#ANY");
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -79,4 +79,28 @@ definition {
 			entryType = "${customElementType}");
 	}
 
+	@description = "Verify that remote app type IFrame can display property fields"
+	@priority = "4"
+	test IframeTypeCanDisplayProperFields {
+		property portal.acceptance = "true";
+
+		var customElementType = "Custom Element";
+
+		RemoteApps.goToRemoteAppsPortlet();
+
+		LexiconEntry.gotoAdd();
+
+		AssertNotVisible(locator1 = "RemoteAppsEntry#HTML_ELEMENT_INPUT");
+
+		AssertNotVisible(locator1 = "RemoteAppsEntry#CSS_ELEMENT_INPUT");
+
+		Select(
+			locator1 = "Select#TYPE",
+			value1 = "${customElementType}");
+
+		AssertVisible(locator1 = "RemoteAppsEntry#HTML_ELEMENT_INPUT");
+
+		AssertVisible(locator1 = "RemoteAppsEntry#CSS_ELEMENT_INPUT");
+	}
+
 }


### PR DESCRIPTION
**Test Name:**
RemoteApps#IframeTypeCanDisplayProperFields

**Description:**
Remote App type IFrame can display property fields.

**Test scenario:**
Given: **Remote Apps** Add page.
When: Type is **IFrame**.
Then: **HTML Element Name** and **CSS URL** fields are not present.
When: select type **Custom Element**.
Then: **HTML Element Name** and **CSS URL** fields are present.

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-141235