### PR TITLE
LPS-142500 Remove unrelated test batches from ci test frontend suite

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -3,8 +3,8 @@ definition {
 
 	property osgi.modules.includes = "frontend-js-a11y-sample-web,frontend-js-a11y-web";
 	property portal.release = "false";
-	property portal.upstream = "true";
-	property testray.component.names = "User Interface";
+	property portal.upstream = "quarantine";
+	property testray.component.names = "A11y Tool";
 	property testray.main.component.name = "User Interface";
 
 	setUp {

--- a/test.properties
+++ b/test.properties
@@ -6131,6 +6131,7 @@
         Web Form
 
     testray.team.frontend-infrastructure.component.names=\
+        A11y Tool,\
         AMD Loader,\
         AUI,\
         Clay,\

--- a/test.properties
+++ b/test.properties
@@ -2984,14 +2984,8 @@
     test.batch.dist.app.servers[frontend]=tomcat
 
     test.batch.names[frontend]=\
-        central-requirements-jdk8,\
         functional-tomcat90-mysql57-jdk8,\
-        js-unit-jdk8,\
-        modules-integration-mysql57-jdk8,\
-        modules-semantic-versioning-jdk8,\
-        modules-unit-jdk8,\
-        semantic-versioning-jdk8,\
-        unit-jdk8
+        js-unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][frontend]=\
         (portal.upstream == true) AND \

--- a/test.properties
+++ b/test.properties
@@ -2969,8 +2969,12 @@
 
     test.batch.class.names.includes[frontend]=\
         **/frontend-css/**/*Test.java,\
+        **/frontend-editor/**/*Test.java,\
         **/frontend-js/**/*Test.java,\
+        **/frontend-taglib/**/*Test.java,\
+        **/frontend-theme/**/*Test.java,\
         **/frontend-token/**/*Test.java,\
+        **/portal-portlet-bridge/**/*Test.java,\
         **/portal-template-react-renderer-api/**/*Test.java,\
         **/portal-template-react-renderer-impl/**/*Test.java,\
         **/portal-template-soy-context-contributor/**/*Test.java,\
@@ -2978,6 +2982,7 @@
         **/portal-template-soy-renderer-api/**/*Test.java,\
         **/portal-template-soy-renderer-impl/**/*Test.java,\
         **/portal-url-builder/**/*Test.java,\
+        **/remote-app/**/*Test.java,\
         /portal-web/docroot/html/**/*Test.java,\
         /util-taglib/**/*Test.java
 
@@ -2985,7 +2990,8 @@
 
     test.batch.names[frontend]=\
         functional-tomcat90-mysql57-jdk8,\
-        js-unit-jdk8
+        js-unit-jdk8,\
+        modules-unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][frontend]=\
         (portal.upstream == true) AND \


### PR DESCRIPTION
**Description**
Remove unrelated test batches from ci test frontend suite. Only need functional tests, modules-unit and js-unit tests. All other test batches are covered by `ci:test:relevant` and PR automation test strategy.

**Test Plan**
- [x] Remove all test batches except functional, modules-unit, and js unit from `ci:test:frontend`
- [x] Quarantine failing A11y tests

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-142500