### PR TITLE
LPS-142380 Wrong custom field language is shown when creating an asset

### DIFF
--- a/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
+++ b/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
@@ -647,6 +647,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 							<liferay-ui:input-localized
 								availableLocales="<%= availableLocales %>"
 								cssClass="lfr-input-text"
+								defaultLanguageId="<%= LocaleUtil.toLanguageId(locale) %>"
 								id="<%= randomNamespace + name %>"
 								name='<%= "ExpandoAttribute--" + name + "--" %>'
 								type='<%= (propertyHeight > 0) ? "textarea" : "input" %>'


### PR DESCRIPTION
Relevant issue: [LPS-142380](https://issues.liferay.com/browse/LPS-142380)

Commits:
- LPS-142380 use the current view language as the default language for rendering custom fields

## Steps to reproduce
1. Go to Global Menu > Control Panel tab > Sites session > Custom Fields item
1. Create a new Document custom field, choosing type Text Area
1. Mark the Make Field Localizable checkbox
1. In the localization button to the right of the Starting Value, choose es-ES as the locale
1. Fill the Starting Value box with value "in Spanish"
1. Field Name: CF1
1. Save
1. Go to side panel menu: Content & Data > Documents and Media
1. Add a new document by clicking on the + button > File Upload
1. Change the URL locale to Spanish by adding an /es after the hostname (between localhost:8080 and /group, for example)
1. Open the CUSTOM FIELDS collapsible section to show the custom fields

## Expected behavior
The custom field CF1 shows the Spanish starting value and the button has the es-ES locale chosen. If another valid locale is chosen instead of es-ES, the locale button will change accordingly

## Actual behavior
The custom field CF1 shows the _Spanish_ starting value and the button has the en-US locale chosen regardless of the locale chosen.