### PR TITLE
LPS-142333 | A11yTool - Asserts that filters reset to their default after page refresh

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/A11yTool.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/A11yTool.macro
@@ -68,16 +68,6 @@ definition {
 		}
 	}
 
-	macro setFilter {
-		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
-
-		Check.checkNotVisible(
-			key_filter = "${filterType}",
-			locator1 = "A11yTool#FILTER_CHECKBOX");
-
-		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
-	}
-
 	macro uncheckFilter {
 		Uncheck.uncheckNotVisible(
 			key_filter = "${filterType}",
@@ -122,13 +112,4 @@ definition {
 			locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
 	}
 
-	macro setFilter {
-		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
-
-		Check.checkNotVisible(
-			key_filter = "${filterType}",
-			locator1 = "A11yTool#FILTER_CHECKBOX");
-
-		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
-	}
 }

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/A11yTool.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/A11yTool.macro
@@ -68,6 +68,16 @@ definition {
 		}
 	}
 
+	macro setFilter {
+		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
+
+		Check.checkNotVisible(
+			key_filter = "${filterType}",
+			locator1 = "A11yTool#FILTER_CHECKBOX");
+
+		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
+	}
+
 	macro uncheckFilter {
 		Uncheck.uncheckNotVisible(
 			key_filter = "${filterType}",

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/A11yTool.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/A11yTool.macro
@@ -112,4 +112,13 @@ definition {
 			locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
 	}
 
+	macro setFilter {
+		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
+
+		Check.checkNotVisible(
+			key_filter = "${filterType}",
+			locator1 = "A11yTool#FILTER_CHECKBOX");
+
+		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
+	}
 }

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -50,41 +50,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-142333. To assert that filters reset to default after page refresh."
-	@priority = "2"
-	test FiltersAreResetToDefaultAfterPageRefresh {
-		property osgi.module.configuration.file.names = "com.liferay.frontend.js.a11y.web.internal.configuration.FFA11yConfiguration.config";
-		property osgi.module.configurations = "enable=B&quot;true&quot;";
-
-		// Workaround for side panel sometimes not displaying LPS-141442
-
-		while (IsElementNotPresent(locator1 = "A11yTool#VIOLATION_PANEL_HEADER")) {
-			Refresh();
-		}
-
-		task ("Set filters, open filter panel, and check the filter.") {
-			A11yTool.setFilter(filterType = "critical");
-
-			A11yTool.setFilter(filterType = "serious");
-
-			A11yTool.openFilterPanel();
-
-			A11yTool.checkFilter(filterType = "critical");
-
-			A11yTool.checkFilter(filterType = "serious");
-		}
-
-		task ("Refresh page and assert filters are default") {
-			Refresh();
-
-			FormFields.viewCheckboxNotChecked(
-				fieldName = "Critical");
-
-			FormFields.viewCheckboxNotChecked(
-				fieldName = "Serious");
-		}
-	}
-
 	@description = "LPS-142107. Verifies a11y tool can be disabled."
 	@priority = "5"
 	test CanBeDisabledWithDevelopment {

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -574,23 +574,27 @@ definition {
 		}
 
 		task ("Set filters, open filter panel, and check the filter.") {
-			A11yTool.setFilter(filterType = "critical");
-
-			A11yTool.setFilter(filterType = "serious");
-
 			A11yTool.openFilterPanel();
 
 			A11yTool.checkFilter(filterType = "critical");
 
 			A11yTool.checkFilter(filterType = "serious");
+
+			A11yTool.closeFilterPanel();
 		}
 
 		task ("Refresh page and assert filters are default") {
 			Refresh();
 
-			FormFields.viewCheckboxNotChecked(fieldName = "Critical");
+			A11yTool.openFilterPanel();
 
-			FormFields.viewCheckboxNotChecked(fieldName = "Serious");
+			AssertNotChecked.assertNotCheckedNotVisible(
+				key_filter = "critical",
+				locator1 = "A11yTool#FILTER_CHECKBOX");
+
+			AssertNotChecked.assertNotCheckedNotVisible(
+				key_filter = "serious",
+				locator1 = "A11yTool#FILTER_CHECKBOX");
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -596,6 +596,39 @@ definition {
 		takeScreenshot();
 	}
 
+	@description = "LPS-142333. To assert that filters reset to default after page refresh."
+	@priority = "2"
+	test FiltersAreResetToDefaultAfterPageRefresh {
+		property osgi.module.configuration.file.names = "com.liferay.frontend.js.a11y.web.internal.configuration.FFA11yConfiguration.config";
+		property osgi.module.configurations = "enable=B&quot;true&quot;";
+
+		// Workaround for side panel sometimes not displaying LPS-141442
+
+		while (IsElementNotPresent(locator1 = "A11yTool#VIOLATION_PANEL_HEADER")) {
+			Refresh();
+		}
+
+		task ("Set filters, open filter panel, and check the filter.") {
+			A11yTool.setFilter(filterType = "critical");
+
+			A11yTool.setFilter(filterType = "serious");
+
+			A11yTool.openFilterPanel();
+
+			A11yTool.checkFilter(filterType = "critical");
+
+			A11yTool.checkFilter(filterType = "serious");
+		}
+
+		task ("Refresh page and assert filters are default") {
+			Refresh();
+
+			FormFields.viewCheckboxNotChecked(fieldName = "Critical");
+
+			FormFields.viewCheckboxNotChecked(fieldName = "Serious");
+		}
+	}
+
 	@description = "LPS-142271. Verifies violations are sorted by descending impact."
 	@priority = "4"
 	test OrdersViolationsByDescendingImpact {

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -50,6 +50,41 @@ definition {
 		}
 	}
 
+	@description = "LPS-142333. To assert that filters reset to default after page refresh."
+	@priority = "2"
+	test FiltersAreResetToDefaultAfterPageRefresh {
+		property osgi.module.configuration.file.names = "com.liferay.frontend.js.a11y.web.internal.configuration.FFA11yConfiguration.config";
+		property osgi.module.configurations = "enable=B&quot;true&quot;";
+
+		// Workaround for side panel sometimes not displaying LPS-141442
+
+		while (IsElementNotPresent(locator1 = "A11yTool#VIOLATION_PANEL_HEADER")) {
+			Refresh();
+		}
+
+		task ("Set filters, open filter panel, and check the filter.") {
+			A11yTool.setFilter(filterType = "critical");
+
+			A11yTool.setFilter(filterType = "serious");
+
+			A11yTool.openFilterPanel();
+
+			A11yTool.checkFilter(filterType = "critical");
+
+			A11yTool.checkFilter(filterType = "serious");
+		}
+
+		task ("Refresh page and assert filters are default") {
+			Refresh();
+
+			FormFields.viewCheckboxNotChecked(
+				fieldName = "Critical");
+
+			FormFields.viewCheckboxNotChecked(
+				fieldName = "Serious");
+		}
+	}
+
 	@description = "LPS-142107. Verifies a11y tool can be disabled."
 	@priority = "5"
 	test CanBeDisabledWithDevelopment {


### PR DESCRIPTION
**Background**
Create automated tests for the A11y tool

**Test Plan**

- Set filter to critical and verify
- Refresh
- Assert critical element present
- Assert serious element present
- Assert moderate element present
- Assert minor element present

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-142333