### PR TITLE
LPS-142737 Fix rendering issues in frontend-taglib-clay-sample-web

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/dropdowns.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/dropdowns.jsp
@@ -35,24 +35,6 @@
 	<clay:col
 		md="2"
 	>
-		<liferay-util:buffer
-			var="userSticker"
-		>
-			<clay:sticker
-				icon="picture"
-				shape="circle"
-			/>
-		</liferay-util:buffer>
-
-		<clay:dropdown-menu
-			dropdownItems="<%= dropdownsDisplayContext.getDefaultDropdownItems() %>"
-			label="<%= userSticker %>"
-		/>
-	</clay:col>
-
-	<clay:col
-		md="2"
-	>
 		<clay:dropdown-menu
 			dropdownItems="<%= dropdownsDisplayContext.getGroupDropdownItems() %>"
 			label="Dividers"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/stickers.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/stickers.jsp
@@ -75,7 +75,7 @@
 		md="2"
 	>
 		<div class="aspect-ratio">
-			<img class="aspect-ratio-item-fluid" src="https://claycss.com/images/thumbnail_hot_air_ballon.jpg" />
+			<img class="aspect-ratio-item-fluid" src="https://clayui.com/images/thumbnail_hot_air_ballon.jpg" />
 
 			<clay:sticker
 				displayType="danger"
@@ -89,7 +89,7 @@
 		md="2"
 	>
 		<div class="aspect-ratio">
-			<img class="aspect-ratio-item-fluid" src="https://claycss.com/images/thumbnail_hot_air_ballon.jpg" />
+			<img class="aspect-ratio-item-fluid" src="https://clayui.com/images/thumbnail_hot_air_ballon.jpg" />
 
 			<clay:sticker
 				displayType="danger"
@@ -103,7 +103,7 @@
 		md="2"
 	>
 		<div class="aspect-ratio">
-			<img class="aspect-ratio-item-fluid" src="https://claycss.com/images/thumbnail_hot_air_ballon.jpg" />
+			<img class="aspect-ratio-item-fluid" src="https://clayui.com/images/thumbnail_hot_air_ballon.jpg" />
 
 			<clay:sticker
 				displayType="danger"
@@ -117,7 +117,7 @@
 		md="2"
 	>
 		<div class="aspect-ratio">
-			<img class="aspect-ratio-item-fluid" src="https://claycss.com/images/thumbnail_hot_air_ballon.jpg" />
+			<img class="aspect-ratio-item-fluid" src="https://clayui.com/images/thumbnail_hot_air_ballon.jpg" />
 
 			<clay:sticker
 				displayType="danger"


### PR DESCRIPTION
The label attribute isn't supposed to be HTML in StickerTag, so
this example has been removed. The URL for the images in the sticker
sample has been fixed so that it doesn't trigger a 404 error.

**Test plan**
- Fetch this branch
- Deploy the `frontend-taglib-clay-sample-web` OSGi module
- Create a new (blank) page
- Add the "Clay Sample" widget
- Publish the page
- Assert that there are no rendering issues

**Before**
![](https://user-images.githubusercontent.com/5572/142441213-e0460c6f-a63c-4c40-be20-f2967c317845.png)

**After**
![](https://user-images.githubusercontent.com/5572/142441245-4ca03529-b3b3-49e9-a4f3-b18e2d849913.png)
