### PR TITLE
LPS-142717 Add tooltip for the add and delete buttons

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -105,9 +105,11 @@ const TranslationAdminContent = ({
 							onActiveChange={setCreationMenuActive}
 							trigger={
 								<ClayButtonWithIcon
+									className="lfr-portal-tooltip"
 									disabled={availableLocales.length === 0}
 									small
 									symbol="plus"
+									title={Liferay.Language.get('add')}
 								/>
 							}
 						>
@@ -196,6 +198,7 @@ const TranslationAdminContent = ({
 									<ClayTable.Cell>
 										{!isDefaultLocale && (
 											<ClayButtonWithIcon
+												className="lfr-portal-tooltip"
 												displayType="unstyled"
 												monospaced={false}
 												onClick={() =>
@@ -204,6 +207,9 @@ const TranslationAdminContent = ({
 													)
 												}
 												symbol="trash"
+												title={Liferay.Language.get(
+													'delete'
+												)}
 											/>
 										)}
 									</ClayTable.Cell>


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-142717

The translation manager modal is missing the tooltip for the add and delete buttons (the related issue only mention delete but I've added the add also)

Steps to reproduce:

1. Web Content > Structures
2. Create a structure
3. Click on the lang button next to title
4. Click on manage translations
5. Add a language
6. Hover the trash button
7. Tooltip is missing