### PR TITLE
LPS-142702 Fix bug with duplicate externalReferenceCode in APIs returning 500 instead of 400 Bad Request

### DIFF
--- a/modules/apps/account/account-api/bnd.bnd
+++ b/modules/apps/account/account-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Account API
 Bundle-SymbolicName: com.liferay.account.api
-Bundle-Version: 5.2.1
+Bundle-Version: 6.0.0
 Export-Package:\
 	com.liferay.account.configuration,\
 	com.liferay.account.constants,\

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/exception/DuplicateAccountEntryExternalReferenceCodeException.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/exception/DuplicateAccountEntryExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.account.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateAccountEntryExternalReferenceCodeException
-	extends PortalException {
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicateAccountEntryExternalReferenceCodeException() {
 	}

--- a/modules/apps/account/account-api/src/main/resources/com/liferay/account/exception/packageinfo
+++ b/modules/apps/account/account-api/src/main/resources/com/liferay/account/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0

--- a/modules/apps/blogs/blogs-api/bnd.bnd
+++ b/modules/apps/blogs/blogs-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Blogs API
 Bundle-SymbolicName: com.liferay.blogs.api
-Bundle-Version: 9.1.1
+Bundle-Version: 10.0.0
 Export-Package:\
 	com.liferay.blogs.configuration,\
 	com.liferay.blogs.configuration.definition,\

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/exception/DuplicateEntryExternalReferenceCodeException.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/exception/DuplicateEntryExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.blogs.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateEntryExternalReferenceCodeException
-	extends PortalException {
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicateEntryExternalReferenceCodeException() {
 	}

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/exception/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/journal/journal-api/bnd.bnd
+++ b/modules/apps/journal/journal-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal API
 Bundle-SymbolicName: com.liferay.journal.api
-Bundle-Version: 9.0.5
+Bundle-Version: 10.0.0
 Export-Package:\
 	com.liferay.journal.configuration,\
 	com.liferay.journal.constants,\

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/DuplicateArticleExternalReferenceCodeException.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/DuplicateArticleExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.journal.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateArticleExternalReferenceCodeException
-	extends PortalException {
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicateArticleExternalReferenceCodeException() {
 	}

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/exception/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 3.0.0

--- a/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base API
 Bundle-SymbolicName: com.liferay.knowledge.base.api
-Bundle-Version: 10.0.6
+Bundle-Version: 11.0.0
 Export-Package:\
 	com.liferay.knowledge.base.configuration,\
 	com.liferay.knowledge.base.constants,\

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBArticleExternalReferenceCodeException.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBArticleExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.knowledge.base.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateKBArticleExternalReferenceCodeException
-	extends PortalException {
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicateKBArticleExternalReferenceCodeException() {
 	}

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBFolderExternalReferenceCodeException.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBFolderExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.knowledge.base.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateKBFolderExternalReferenceCodeException
-	extends PortalException {
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicateKBFolderExternalReferenceCodeException() {
 	}

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/exception/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 2.0.0

--- a/modules/apps/message-boards/message-boards-api/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Message Boards API
 Bundle-SymbolicName: com.liferay.message.boards.api
-Bundle-Version: 11.0.6
+Bundle-Version: 12.0.0
 Export-Package:\
 	com.liferay.message.boards.configuration,\
 	com.liferay.message.boards.constants,\

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/exception/DuplicateMessageExternalReferenceCodeException.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/exception/DuplicateMessageExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.message.boards.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateMessageExternalReferenceCodeException
-	extends PortalException {
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicateMessageExternalReferenceCodeException() {
 	}

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/exception/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/DuplicateExternalReferenceCodeExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/DuplicateExternalReferenceCodeExceptionMapper.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Converts any {@code DuplicateExternalReferenceCode} to a {@code 400} error.
+ *
+ * @author Javier de Arcos
+ */
+public class DuplicateExternalReferenceCodeExceptionMapper
+	extends BaseExceptionMapper<DuplicateExternalReferenceCodeException> {
+
+	@Override
+	protected Problem getProblem(
+		DuplicateExternalReferenceCodeException
+			duplicateExternalReferenceCodeException) {
+
+		return new Problem(
+			Response.Status.BAD_REQUEST,
+			duplicateExternalReferenceCodeException.getMessage());
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.jaxrs.xml.JacksonXMLProvider;
 
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.util.DLValidator;
-import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -107,7 +106,8 @@ public class VulcanFeature implements Feature {
 		featureContext.register(BeanValidationInterceptor.class);
 		featureContext.register(CTContainerRequestFilter.class);
 		featureContext.register(DateParamConverterProvider.class);
-		featureContext.register(DuplicateExternalReferenceCodeExceptionMapper.class);
+		featureContext.register(
+			DuplicateExternalReferenceCodeExceptionMapper.class);
 		featureContext.register(EntityExtensionWriterInterceptor.class);
 		featureContext.register(ExceptionMapper.class);
 		featureContext.register(FieldsQueryParamContextProvider.class);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.jaxrs.xml.JacksonXMLProvider;
 
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.util.DLValidator;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -47,6 +48,7 @@ import com.liferay.portal.vulcan.internal.jaxrs.context.provider.UserContextProv
 import com.liferay.portal.vulcan.internal.jaxrs.context.resolver.ObjectMapperContextResolver;
 import com.liferay.portal.vulcan.internal.jaxrs.context.resolver.XmlMapperContextResolver;
 import com.liferay.portal.vulcan.internal.jaxrs.dynamic.feature.StatusDynamicFeature;
+import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.DuplicateExternalReferenceCodeExceptionMapper;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.ExceptionMapper;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.InvalidFilterExceptionMapper;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.InvalidFormatExceptionMapper;
@@ -105,6 +107,7 @@ public class VulcanFeature implements Feature {
 		featureContext.register(BeanValidationInterceptor.class);
 		featureContext.register(CTContainerRequestFilter.class);
 		featureContext.register(DateParamConverterProvider.class);
+		featureContext.register(DuplicateExternalReferenceCodeExceptionMapper.class);
 		featureContext.register(EntityExtensionWriterInterceptor.class);
 		featureContext.register(ExceptionMapper.class);
 		featureContext.register(FieldsQueryParamContextProvider.class);

--- a/modules/apps/wiki/wiki-api/bnd.bnd
+++ b/modules/apps/wiki/wiki-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Wiki API
 Bundle-SymbolicName: com.liferay.wiki.api
-Bundle-Version: 7.2.5
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.wiki.configuration,\
 	com.liferay.wiki.configuration.definition,\

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicateNodeExternalReferenceCodeException.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicateNodeExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.wiki.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateNodeExternalReferenceCodeException
-	extends PortalException {
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicateNodeExternalReferenceCodeException() {
 	}

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicatePageExternalReferenceCodeException.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicatePageExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.wiki.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicatePageExternalReferenceCodeException
-	extends PortalException {
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicatePageExternalReferenceCodeException() {
 	}

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/exception/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 2.0.0

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 20.0.1
+Bundle-Version: 20.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/asset/kernel/exception/DuplicateCategoryExternalReferenceCodeException.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/exception/DuplicateCategoryExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.asset.kernel.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateCategoryExternalReferenceCodeException
-	extends PortalException {
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicateCategoryExternalReferenceCodeException() {
 	}

--- a/portal-kernel/src/com/liferay/asset/kernel/exception/DuplicateVocabularyExternalReferenceCodeException.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/exception/DuplicateVocabularyExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.asset.kernel.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateVocabularyExternalReferenceCodeException
-	extends PortalException {
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicateVocabularyExternalReferenceCodeException() {
 	}

--- a/portal-kernel/src/com/liferay/asset/kernel/exception/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.3.1

--- a/portal-kernel/src/com/liferay/document/library/kernel/exception/DuplicateFileEntryExternalReferenceCodeException.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/exception/DuplicateFileEntryExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.document.library.kernel.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateFileEntryExternalReferenceCodeException
-	extends PortalException {
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicateFileEntryExternalReferenceCodeException() {
 	}

--- a/portal-kernel/src/com/liferay/document/library/kernel/exception/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/exception/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.3.1

--- a/portal-kernel/src/com/liferay/portal/kernel/exception/DuplicateExternalReferenceCodeException.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/exception/DuplicateExternalReferenceCodeException.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.exception;
+
+/**
+ * @author Javier de Arcos
+ */
+public class DuplicateExternalReferenceCodeException extends PortalException {
+
+	public DuplicateExternalReferenceCodeException() {
+	}
+
+	public DuplicateExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateExternalReferenceCodeException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public DuplicateExternalReferenceCodeException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/exception/DuplicateExternalReferenceCodeException.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/exception/DuplicateExternalReferenceCodeException.java
@@ -26,7 +26,9 @@ public class DuplicateExternalReferenceCodeException extends PortalException {
 		super(msg);
 	}
 
-	public DuplicateExternalReferenceCodeException(String msg, Throwable throwable) {
+	public DuplicateExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
 		super(msg, throwable);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/exception/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/exception/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0


### PR DESCRIPTION
When a new POST request is made with an existing external reference code, the APIs are returning a 500 error instead of a 400 Bad Request error.

**Steps to reproduce:**
Create a blog entry like this through the API (sites/{siteId}/blog-postings):
```
{ "articleBody": "potato", "description": "something", "externalReferenceCode": "myCode", "headline": "my blog entry" }
```
Create another blog entry like this through the API (sites/{siteId}/blog-postings):
```
{ "articleBody": "potato", "description": "something", "externalReferenceCode": "myCode", "headline": "my blog entry 2"}
```

**Expected result:** 400 Bad Request

**Result:** 500 Internal Server Error

I've created a new Exception Mapper to catch this kind of exceptions and return the correct error code. To handle all different Duplicate...ExternalReferenceCode exceptions I had to add a new exception in the middle of the hierarchy between those exceptions and PortalException.

**This change causes breaking changes in the exception packages**. I'm not sure if these are dangerous breaking changes for clients...