### PR TITLE
LPS-142430 Fix: printing all the pages not only one page

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
@@ -9,6 +9,10 @@
 		right: 0;
 		top: 0;
 		-webkit-overflow-scrolling: touch;
+
+		@media print {
+			position: initial;
+		}
 	}
 }
 


### PR DESCRIPTION
Hi Team,

could you please review my fix?

**Steps to reproduce:**

1. Start the bundle and login as admin
2. Go to Content & Data → Web Content and create a new web content in a multiple page length
3. Go to Home page and place a web content display widget
4. Set the widget to display the created web content and enable print button in User Tools
5. Click on the print button

**Actual behavior:** It only displays one page and the rest is not there, if it is saved as PDF, the result is the same.

**Expected behavior:** It should display all the pages.

**Root cause:**

The frontend-theme unstyled theme's portal_pop_up.ftl is responsible for displaying the pop_up/print content.

The portal-popup css class sets the print layout.

https://github.com/liferay/liferay-portal/blob/master/portal-web/test/functional/com/liferay/portalweb/dependencies/test-theme.war/templates/portal_pop_up.ftl#L13


The frontend-theme styled theme's _modal.scss .portal-popup:not(.article-preview) #main-content rule defines the css for the print layout.

https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss#L1-L13

**Solution:**

Using **position:static** is solving the issue

https://issues.liferay.com/browse/LPS-142430