### PR TITLE
LPS-141461 LPS-141324 Fix TM dropdown position in mobile

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -225,6 +225,7 @@ AUI.add(
 						},
 						constrain: true,
 						hideClass: false,
+						modal: Util.isPhone() || Util.isTablet(),
 						preventOverlap: true,
 						zIndex: Liferay.zIndex.MENU,
 					}).render();
@@ -387,23 +388,15 @@ AUI.add(
 					var listNodeHeight = listNode.get('offsetHeight');
 					var listNodeWidth = listNode.get('offsetWidth');
 
-					var modalMask = false;
-
 					align.points = instance._getAlignPoints(cssClass);
 
 					menu.addClass('lfr-icon-menu-open');
-
-					if (Util.isPhone() || Util.isTablet()) {
-						overlay.hide();
-
-						modalMask = true;
-					}
 
 					overlay.setAttrs({
 						align,
 						centered: false,
 						height: listNodeHeight,
-						modal: modalMask,
+						modal: Util.isPhone() || Util.isTablet(),
 						width: listNodeWidth,
 					});
 


### PR DESCRIPTION
### References

- [LPS-141461](https://issues.liferay.com/browse/LPS-141461)
- [LPS-141324](https://issues.liferay.com/browse/LPS-141324)

### What is the goal?

* Fix Translation Manager dropdown position in mobile

### A picture is worth a thousand words

#### Before PR


https://user-images.githubusercontent.com/6642927/142866843-5ed6eb30-1e1c-4bf4-8c87-a2c0ee35568f.mov




#### After PR


https://user-images.githubusercontent.com/6642927/142866868-e5c2ddce-459f-4039-a67b-333c9580e3a7.mov


### Notes
There's another related bug, if you open the translation manager dropdown multiple times in mobile view, part of the rest of the content disappears because the position of the dropdown keeps moving further right and down as you open/close it. I tried to fix it although it's outside of the scope of these tickets, but it's AUI-related and it was taking me too long to even understand what's going on. It's still usable despite this, so 🤷‍♀️  

https://user-images.githubusercontent.com/6642927/142867169-424b1b59-ae3e-447c-92e4-0a3235d004f0.mov



### How to replicate
* Go to Content & Data > Web Content
* Add new content
* Click on translation manager button
* See that the dropdown opens

### Checklist

- ~~[ ] I have made corresponding changes to the documentation~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked this works in the corresponding browser