### PR TITLE
LPS-141789 Hide quick links on mobile to avoid chrome/safari bug

### DIFF
--- a/portal-web/docroot/html/taglib/ui/quick_access/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/quick_access/page.jsp
@@ -21,7 +21,7 @@ String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 %>
 
 <c:if test="<%= ((quickAccessEntries != null) && !quickAccessEntries.isEmpty()) || Validator.isNotNull(contentId) %>">
-	<nav aria-label="<liferay-ui:message key="quick-links" />" class="quick-access-nav" id="<%= randomNamespace %>quickAccessNav">
+	<nav aria-label="<liferay-ui:message key="quick-links" />" class="d-none d-xl-block quick-access-nav" id="<%= randomNamespace %>quickAccessNav">
 		<h1 class="hide-accessible"><liferay-ui:message key="navigation" /></h1>
 
 		<ul>


### PR DESCRIPTION
### References

- [LPS-141789](https://issues.liferay.com/browse/LPS-141789)
- [PTR-2692](https://issues.liferay.com/browse/PTR-2692)

### What is the goal?

* Hide quick links on mobile/tablet browsers to circumvent [this Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=657157) and an equivalent bug in Safari mobile versions.
   * To summarize, hidden links that display when focused don't work on mobile browsers when using a screen reader because the element grabs the accessibility focus, but not the DOM focus. Thus, the element doesn't get the `:focus/:active` pseudo-class and the styles that make it visible aren't applied. 
   * There's no way to detect the accessibility focus, so we cannot use JS to add/remove styles or classes.
   * Only fix is to not display these elements at all.

### A picture is worth a thousand words

**🔉 These videos have sound, hope you enjoy them as much as I did while working on this 🔉**

#### Before PR

The skip link grabs a11y focus and skips to content when clicked, but it's not visible.


##### Chrome in Android with Talkback enabled:

https://user-images.githubusercontent.com/6642927/143059565-c95f7c9d-c2ae-44e7-b642-8646c59fee42.mp4


##### Safari in iOS/iPadOS with Voiceover enabled:


https://user-images.githubusercontent.com/6642927/143061332-faf80a9a-54aa-4dd2-be46-94e515fbb1e2.MP4



#### After PR
The skip link doesn't grab focus.

##### Chrome in Android with Talkback enabled:

https://user-images.githubusercontent.com/6642927/143059576-193ba906-db85-46ec-8108-4f20e4ed4d88.mp4


##### Safari in iOS/iPadOS with Voiceover enabled:


https://user-images.githubusercontent.com/6642927/143061375-f2ca2dfe-b7f8-4043-bbd1-e11b80105ead.MP4


### How to replicate
* Connect your phone/tablet to the same wifi network as your computer
* Enable Talkback/Voiceover in your mobile device
* Somehow open Chrome/Safari in your mobile device and access DXP using your computer's private IP
* Move around the screen by swiping right/left, see that if you swipe right from the search bar focus isn't suddenly invisible and you don't hear "Skip to content".
* Do the same from your computer, see that the "Skip to content" button is visible and you can click it.

### Checklist

- ~~[ ] I have made corresponding changes to the documentation~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked this works in the corresponding browser

### Notes
Thanks to this bug I found out that the "Skip to content" link doesn't work on Firefox Desktop.