### PR TITLE
LPS-142295 Create sample Vanilla Counter remote app

### DIFF
--- a/modules/apps/remote-app/remote-app-api/bnd.bnd
+++ b/modules/apps/remote-app/remote-app-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Remote App API
 Bundle-SymbolicName: com.liferay.remote.app.api
-Bundle-Version: 5.0.1
+Bundle-Version: 5.1.0
 Export-Package:\
 	com.liferay.remote.app.constants,\
 	com.liferay.remote.app.deployer,\

--- a/modules/apps/remote-app/remote-app-api/bnd.bnd
+++ b/modules/apps/remote-app/remote-app-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Remote App API
 Bundle-SymbolicName: com.liferay.remote.app.api
-Bundle-Version: 5.1.0
+Bundle-Version: 6.0.0
 Export-Package:\
 	com.liferay.remote.app.constants,\
 	com.liferay.remote.app.deployer,\

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalService.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalService.java
@@ -98,6 +98,8 @@ public interface RemoteAppEntryLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public RemoteAppEntry addRemoteAppEntry(RemoteAppEntry remoteAppEntry);
 
+	public int countByCompanyId(long companyId) throws PortalException;
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalService.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalService.java
@@ -75,7 +75,7 @@ public interface RemoteAppEntryLocalService
 			String customElementHTMLElementName, String customElementURLs,
 			String description, String friendlyURLMapping, boolean instanceable,
 			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties, String sourceCodeURL)
+			String properties, String sourceCodeURL, int status)
 		throws PortalException;
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceUtil.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceUtil.java
@@ -87,6 +87,10 @@ public class RemoteAppEntryLocalServiceUtil {
 		return getService().addRemoteAppEntry(remoteAppEntry);
 	}
 
+	public static int countByCompanyId(long companyId) throws PortalException {
+		return getService().countByCompanyId(companyId);
+	}
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceUtil.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceUtil.java
@@ -50,13 +50,13 @@ public class RemoteAppEntryLocalServiceUtil {
 			String customElementHTMLElementName, String customElementURLs,
 			String description, String friendlyURLMapping, boolean instanceable,
 			Map<java.util.Locale, String> nameMap, String portletCategoryName,
-			String properties, String sourceCodeURL)
+			String properties, String sourceCodeURL, int status)
 		throws PortalException {
 
 		return getService().addCustomElementRemoteAppEntry(
 			userId, customElementCSSURLs, customElementHTMLElementName,
 			customElementURLs, description, friendlyURLMapping, instanceable,
-			nameMap, portletCategoryName, properties, sourceCodeURL);
+			nameMap, portletCategoryName, properties, sourceCodeURL, status);
 	}
 
 	public static RemoteAppEntry addIFrameRemoteAppEntry(

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceWrapper.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceWrapper.java
@@ -42,13 +42,13 @@ public class RemoteAppEntryLocalServiceWrapper
 				boolean instanceable,
 				java.util.Map<java.util.Locale, String> nameMap,
 				String portletCategoryName, String properties,
-				String sourceCodeURL)
+				String sourceCodeURL, int status)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _remoteAppEntryLocalService.addCustomElementRemoteAppEntry(
 			userId, customElementCSSURLs, customElementHTMLElementName,
 			customElementURLs, description, friendlyURLMapping, instanceable,
-			nameMap, portletCategoryName, properties, sourceCodeURL);
+			nameMap, portletCategoryName, properties, sourceCodeURL, status);
 	}
 
 	@Override

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceWrapper.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceWrapper.java
@@ -81,6 +81,13 @@ public class RemoteAppEntryLocalServiceWrapper
 		return _remoteAppEntryLocalService.addRemoteAppEntry(remoteAppEntry);
 	}
 
+	@Override
+	public int countByCompanyId(long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _remoteAppEntryLocalService.countByCompanyId(companyId);
+	}
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/persistence/RemoteAppEntryPersistence.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/persistence/RemoteAppEntryPersistence.java
@@ -474,6 +474,213 @@ public interface RemoteAppEntryPersistence
 	public int filterCountByUuid_C(String uuid, long companyId);
 
 	/**
+	 * Returns all the remote app entries where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the matching remote app entries
+	 */
+	public java.util.List<RemoteAppEntry> findByCompanyId(long companyId);
+
+	/**
+	 * Returns a range of all the remote app entries where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries
+	 */
+	public java.util.List<RemoteAppEntry> findByCompanyId(
+		long companyId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the remote app entries where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries
+	 */
+	public java.util.List<RemoteAppEntry> findByCompanyId(
+		long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the remote app entries where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching remote app entries
+	 */
+	public java.util.List<RemoteAppEntry> findByCompanyId(
+		long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a matching remote app entry could not be found
+	 */
+	public RemoteAppEntry findByCompanyId_First(
+			long companyId,
+			com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+				orderByComparator)
+		throws NoSuchRemoteAppEntryException;
+
+	/**
+	 * Returns the first remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching remote app entry, or <code>null</code> if a matching remote app entry could not be found
+	 */
+	public RemoteAppEntry fetchByCompanyId_First(
+		long companyId,
+		com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the last remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a matching remote app entry could not be found
+	 */
+	public RemoteAppEntry findByCompanyId_Last(
+			long companyId,
+			com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+				orderByComparator)
+		throws NoSuchRemoteAppEntryException;
+
+	/**
+	 * Returns the last remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching remote app entry, or <code>null</code> if a matching remote app entry could not be found
+	 */
+	public RemoteAppEntry fetchByCompanyId_Last(
+		long companyId,
+		com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	public RemoteAppEntry[] findByCompanyId_PrevAndNext(
+			long remoteAppEntryId, long companyId,
+			com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+				orderByComparator)
+		throws NoSuchRemoteAppEntryException;
+
+	/**
+	 * Returns all the remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the matching remote app entries that the user has permission to view
+	 */
+	public java.util.List<RemoteAppEntry> filterFindByCompanyId(long companyId);
+
+	/**
+	 * Returns a range of all the remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries that the user has permission to view
+	 */
+	public java.util.List<RemoteAppEntry> filterFindByCompanyId(
+		long companyId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the remote app entries that the user has permissions to view where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries that the user has permission to view
+	 */
+	public java.util.List<RemoteAppEntry> filterFindByCompanyId(
+		long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set of remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	public RemoteAppEntry[] filterFindByCompanyId_PrevAndNext(
+			long remoteAppEntryId, long companyId,
+			com.liferay.portal.kernel.util.OrderByComparator<RemoteAppEntry>
+				orderByComparator)
+		throws NoSuchRemoteAppEntryException;
+
+	/**
+	 * Removes all the remote app entries where companyId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 */
+	public void removeByCompanyId(long companyId);
+
+	/**
+	 * Returns the number of remote app entries where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the number of matching remote app entries
+	 */
+	public int countByCompanyId(long companyId);
+
+	/**
+	 * Returns the number of remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the number of matching remote app entries that the user has permission to view
+	 */
+	public int filterCountByCompanyId(long companyId);
+
+	/**
 	 * Caches the remote app entry in the entity cache if it is enabled.
 	 *
 	 * @param remoteAppEntry the remote app entry

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/persistence/RemoteAppEntryUtil.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/persistence/RemoteAppEntryUtil.java
@@ -631,6 +631,252 @@ public class RemoteAppEntryUtil {
 	}
 
 	/**
+	 * Returns all the remote app entries where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the matching remote app entries
+	 */
+	public static List<RemoteAppEntry> findByCompanyId(long companyId) {
+		return getPersistence().findByCompanyId(companyId);
+	}
+
+	/**
+	 * Returns a range of all the remote app entries where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries
+	 */
+	public static List<RemoteAppEntry> findByCompanyId(
+		long companyId, int start, int end) {
+
+		return getPersistence().findByCompanyId(companyId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the remote app entries where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries
+	 */
+	public static List<RemoteAppEntry> findByCompanyId(
+		long companyId, int start, int end,
+		OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		return getPersistence().findByCompanyId(
+			companyId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the remote app entries where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching remote app entries
+	 */
+	public static List<RemoteAppEntry> findByCompanyId(
+		long companyId, int start, int end,
+		OrderByComparator<RemoteAppEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByCompanyId(
+			companyId, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a matching remote app entry could not be found
+	 */
+	public static RemoteAppEntry findByCompanyId_First(
+			long companyId, OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws com.liferay.remote.app.exception.NoSuchRemoteAppEntryException {
+
+		return getPersistence().findByCompanyId_First(
+			companyId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching remote app entry, or <code>null</code> if a matching remote app entry could not be found
+	 */
+	public static RemoteAppEntry fetchByCompanyId_First(
+		long companyId, OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		return getPersistence().fetchByCompanyId_First(
+			companyId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a matching remote app entry could not be found
+	 */
+	public static RemoteAppEntry findByCompanyId_Last(
+			long companyId, OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws com.liferay.remote.app.exception.NoSuchRemoteAppEntryException {
+
+		return getPersistence().findByCompanyId_Last(
+			companyId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching remote app entry, or <code>null</code> if a matching remote app entry could not be found
+	 */
+	public static RemoteAppEntry fetchByCompanyId_Last(
+		long companyId, OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		return getPersistence().fetchByCompanyId_Last(
+			companyId, orderByComparator);
+	}
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	public static RemoteAppEntry[] findByCompanyId_PrevAndNext(
+			long remoteAppEntryId, long companyId,
+			OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws com.liferay.remote.app.exception.NoSuchRemoteAppEntryException {
+
+		return getPersistence().findByCompanyId_PrevAndNext(
+			remoteAppEntryId, companyId, orderByComparator);
+	}
+
+	/**
+	 * Returns all the remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the matching remote app entries that the user has permission to view
+	 */
+	public static List<RemoteAppEntry> filterFindByCompanyId(long companyId) {
+		return getPersistence().filterFindByCompanyId(companyId);
+	}
+
+	/**
+	 * Returns a range of all the remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries that the user has permission to view
+	 */
+	public static List<RemoteAppEntry> filterFindByCompanyId(
+		long companyId, int start, int end) {
+
+		return getPersistence().filterFindByCompanyId(companyId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the remote app entries that the user has permissions to view where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries that the user has permission to view
+	 */
+	public static List<RemoteAppEntry> filterFindByCompanyId(
+		long companyId, int start, int end,
+		OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		return getPersistence().filterFindByCompanyId(
+			companyId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set of remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	public static RemoteAppEntry[] filterFindByCompanyId_PrevAndNext(
+			long remoteAppEntryId, long companyId,
+			OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws com.liferay.remote.app.exception.NoSuchRemoteAppEntryException {
+
+		return getPersistence().filterFindByCompanyId_PrevAndNext(
+			remoteAppEntryId, companyId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the remote app entries where companyId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 */
+	public static void removeByCompanyId(long companyId) {
+		getPersistence().removeByCompanyId(companyId);
+	}
+
+	/**
+	 * Returns the number of remote app entries where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the number of matching remote app entries
+	 */
+	public static int countByCompanyId(long companyId) {
+		return getPersistence().countByCompanyId(companyId);
+	}
+
+	/**
+	 * Returns the number of remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the number of matching remote app entries that the user has permission to view
+	 */
+	public static int filterCountByCompanyId(long companyId) {
+		return getPersistence().filterCountByCompanyId(companyId);
+	}
+
+	/**
 	 * Caches the remote app entry in the entity cache if it is enabled.
 	 *
 	 * @param remoteAppEntry the remote app entry

--- a/modules/apps/remote-app/remote-app-api/src/main/resources/com/liferay/remote/app/service/packageinfo
+++ b/modules/apps/remote-app/remote-app-api/src/main/resources/com/liferay/remote/app/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 5.0.0

--- a/modules/apps/remote-app/remote-app-api/src/main/resources/com/liferay/remote/app/service/packageinfo
+++ b/modules/apps/remote-app/remote-app-api/src/main/resources/com/liferay/remote/app/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/remote-app/remote-app-api/src/main/resources/com/liferay/remote/app/service/persistence/packageinfo
+++ b/modules/apps/remote-app/remote-app-api/src/main/resources/com/liferay/remote/app/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/remote-app/remote-app-service/build.gradle
+++ b/modules/apps/remote-app/remote-app-service/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:portal:portal-aop-api")
+	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:remote-app:remote-app-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/remote-app/remote-app-service/service.xml
+++ b/modules/apps/remote-app/remote-app-service/service.xml
@@ -35,6 +35,12 @@
 		<column name="statusByUserId" type="long" />
 		<column name="statusByUserName" type="String" />
 		<column name="statusDate" type="Date" />
+
+		<!-- Finder methods -->
+
+		<finder name="CompanyId" return-type="Collection">
+			<finder-column name="companyId" />
+		</finder>
 	</entity>
 	<exceptions>
 		<exception>RemoteAppEntryCustomElementCSSURLs</exception>

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/instance/lifecycle/RemoteAppPortalInstanceLifecycleListener.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/instance/lifecycle/RemoteAppPortalInstanceLifecycleListener.java
@@ -21,8 +21,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
 import com.liferay.portal.kernel.util.LocalizationUtil;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
-import com.liferay.remote.app.model.RemoteAppEntry;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.remote.app.service.RemoteAppEntryLocalService;
 
 import org.osgi.service.component.annotations.Component;
@@ -52,7 +51,8 @@ public class RemoteAppPortalInstanceLifecycleListener
 			false,
 			LocalizationUtil.getMap(new LocalizedValuesMap("Vanilla Counter")),
 			"category.remote-apps", "friendly-url-mapping=vanilla_counter",
-			"https://liferay.github.io/liferay-frontend-projects");
+			"https://liferay.github.io/liferay-frontend-projects",
+			WorkflowConstants.STATUS_APPROVED);
 	}
 
 	@Reference
@@ -60,10 +60,5 @@ public class RemoteAppPortalInstanceLifecycleListener
 
 	@Reference
 	private UserLocalService _userLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.remote.app.model.RemoteAppEntry)"
-	)
-	private WorkflowHandler<RemoteAppEntry> _workflowHandler;
 
 }

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/instance/lifecycle/RemoteAppPortalInstanceLifecycleListener.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/instance/lifecycle/RemoteAppPortalInstanceLifecycleListener.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.internal.instance.lifecycle;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.settings.LocalizedValuesMap;
+import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.remote.app.service.RemoteAppEntryLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+@Component(immediate = true, service = PortalInstanceLifecycleListener.class)
+public class RemoteAppPortalInstanceLifecycleListener
+	extends BasePortalInstanceLifecycleListener {
+
+	public void portalInstanceRegistered(Company company) throws Exception {
+		long count = _remoteAppEntryLocalService.countByCompanyId(
+			company.getCompanyId());
+
+		if (count != 0) {
+			return;
+		}
+
+		_remoteAppEntryLocalService.addCustomElementRemoteAppEntry(
+			_userLocalService.getDefaultUserId(company.getCompanyId()),
+			StringPool.BLANK, "vanilla-counter",
+			"https://liferay.github.io/liferay-frontend-projects" +
+				"/vanilla-counter/index.js",
+			StringPool.BLANK, "vanilla_counter", false,
+			LocalizationUtil.getMap(new LocalizedValuesMap("Vanilla Counter")),
+			"category.remote-apps", "friendly-url-mapping=vanilla_counter",
+			"https://liferay.github.io/liferay-frontend-projects");
+	}
+
+	@Reference
+	private RemoteAppEntryLocalService _remoteAppEntryLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/instance/lifecycle/RemoteAppPortalInstanceLifecycleListener.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/instance/lifecycle/RemoteAppPortalInstanceLifecycleListener.java
@@ -21,13 +21,12 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
 import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.remote.app.model.RemoteAppEntry;
 import com.liferay.remote.app.service.RemoteAppEntryLocalService;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-
-import java.util.Locale;
-import java.util.Map;
 
 /**
  * @author Iván Zaera Avellón
@@ -49,7 +48,8 @@ public class RemoteAppPortalInstanceLifecycleListener
 			StringPool.BLANK, "vanilla-counter",
 			"https://liferay.github.io/liferay-frontend-projects" +
 				"/vanilla-counter/index.js",
-			StringPool.BLANK, "vanilla_counter", false,
+			"Sample vanilla counter remote application", "vanilla_counter",
+			false,
 			LocalizationUtil.getMap(new LocalizedValuesMap("Vanilla Counter")),
 			"category.remote-apps", "friendly-url-mapping=vanilla_counter",
 			"https://liferay.github.io/liferay-frontend-projects");
@@ -60,5 +60,10 @@ public class RemoteAppPortalInstanceLifecycleListener
 
 	@Reference
 	private UserLocalService _userLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.remote.app.model.RemoteAppEntry)"
+	)
+	private WorkflowHandler<RemoteAppEntry> _workflowHandler;
 
 }

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
@@ -186,6 +186,11 @@ public class RemoteAppEntryLocalServiceImpl
 	}
 
 	@Override
+	public int countByCompanyId(long companyId) throws PortalException {
+		return remoteAppEntryPersistence.countByCompanyId(companyId);
+	}
+
+	@Override
 	public RemoteAppEntry deleteRemoteAppEntry(long remoteAppEntryId)
 		throws PortalException {
 

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
@@ -92,7 +92,7 @@ public class RemoteAppEntryLocalServiceImpl
 			String customElementHTMLElementName, String customElementURLs,
 			String description, String friendlyURLMapping, boolean instanceable,
 			Map<Locale, String> nameMap, String portletCategoryName,
-			String properties, String sourceCodeURL)
+			String properties, String sourceCodeURL, int status)
 		throws PortalException {
 
 		customElementCSSURLs = StringUtil.trim(customElementCSSURLs);
@@ -127,7 +127,7 @@ public class RemoteAppEntryLocalServiceImpl
 		remoteAppEntry.setProperties(properties);
 		remoteAppEntry.setSourceCodeURL(sourceCodeURL);
 		remoteAppEntry.setType(RemoteAppConstants.TYPE_CUSTOM_ELEMENT);
-		remoteAppEntry.setStatus(WorkflowConstants.STATUS_DRAFT);
+		remoteAppEntry.setStatus(status);
 		remoteAppEntry.setStatusByUserId(userId);
 		remoteAppEntry.setStatusDate(new Date());
 
@@ -472,6 +472,10 @@ public class RemoteAppEntryLocalServiceImpl
 	private RemoteAppEntry _startWorkflowInstance(
 			long userId, RemoteAppEntry remoteAppEntry)
 		throws PortalException {
+
+		if (remoteAppEntry.getStatus() == WorkflowConstants.STATUS_APPROVED) {
+			return remoteAppEntry;
+		}
 
 		return WorkflowHandlerRegistryUtil.startWorkflowInstance(
 			remoteAppEntry.getCompanyId(), WorkflowConstants.DEFAULT_GROUP_ID,

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryServiceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryServiceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.remote.app.constants.RemoteAppConstants;
 import com.liferay.remote.app.model.RemoteAppEntry;
 import com.liferay.remote.app.service.base.RemoteAppEntryServiceBaseImpl;
@@ -56,7 +57,8 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 		return remoteAppEntryLocalService.addCustomElementRemoteAppEntry(
 			getUserId(), customElementCSSURLs, customElementHTMLElementName,
 			customElementURLs, description, friendlyURLMapping, instanceable,
-			nameMap, portletCategoryName, properties, sourceCodeURL);
+			nameMap, portletCategoryName, properties, sourceCodeURL,
+			WorkflowConstants.STATUS_DRAFT);
 	}
 
 	@Override

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/persistence/impl/RemoteAppEntryPersistenceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/persistence/impl/RemoteAppEntryPersistenceImpl.java
@@ -2091,6 +2091,882 @@ public class RemoteAppEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_UUID_C_COMPANYID_2 =
 		"remoteAppEntry.companyId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
+
+	/**
+	 * Returns all the remote app entries where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the matching remote app entries
+	 */
+	@Override
+	public List<RemoteAppEntry> findByCompanyId(long companyId) {
+		return findByCompanyId(
+			companyId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the remote app entries where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries
+	 */
+	@Override
+	public List<RemoteAppEntry> findByCompanyId(
+		long companyId, int start, int end) {
+
+		return findByCompanyId(companyId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the remote app entries where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries
+	 */
+	@Override
+	public List<RemoteAppEntry> findByCompanyId(
+		long companyId, int start, int end,
+		OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		return findByCompanyId(companyId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the remote app entries where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching remote app entries
+	 */
+	@Override
+	public List<RemoteAppEntry> findByCompanyId(
+		long companyId, int start, int end,
+		OrderByComparator<RemoteAppEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByCompanyId;
+				finderArgs = new Object[] {companyId};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByCompanyId;
+			finderArgs = new Object[] {
+				companyId, start, end, orderByComparator
+			};
+		}
+
+		List<RemoteAppEntry> list = null;
+
+		if (useFinderCache) {
+			list = (List<RemoteAppEntry>)finderCache.getResult(
+				finderPath, finderArgs);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (RemoteAppEntry remoteAppEntry : list) {
+					if (companyId != remoteAppEntry.getCompanyId()) {
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					3 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(3);
+			}
+
+			sb.append(_SQL_SELECT_REMOTEAPPENTRY_WHERE);
+
+			sb.append(_FINDER_COLUMN_COMPANYID_COMPANYID_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				list = (List<RemoteAppEntry>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a matching remote app entry could not be found
+	 */
+	@Override
+	public RemoteAppEntry findByCompanyId_First(
+			long companyId, OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws NoSuchRemoteAppEntryException {
+
+		RemoteAppEntry remoteAppEntry = fetchByCompanyId_First(
+			companyId, orderByComparator);
+
+		if (remoteAppEntry != null) {
+			return remoteAppEntry;
+		}
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append("}");
+
+		throw new NoSuchRemoteAppEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the first remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching remote app entry, or <code>null</code> if a matching remote app entry could not be found
+	 */
+	@Override
+	public RemoteAppEntry fetchByCompanyId_First(
+		long companyId, OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		List<RemoteAppEntry> list = findByCompanyId(
+			companyId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a matching remote app entry could not be found
+	 */
+	@Override
+	public RemoteAppEntry findByCompanyId_Last(
+			long companyId, OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws NoSuchRemoteAppEntryException {
+
+		RemoteAppEntry remoteAppEntry = fetchByCompanyId_Last(
+			companyId, orderByComparator);
+
+		if (remoteAppEntry != null) {
+			return remoteAppEntry;
+		}
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append("}");
+
+		throw new NoSuchRemoteAppEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the last remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching remote app entry, or <code>null</code> if a matching remote app entry could not be found
+	 */
+	@Override
+	public RemoteAppEntry fetchByCompanyId_Last(
+		long companyId, OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		int count = countByCompanyId(companyId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<RemoteAppEntry> list = findByCompanyId(
+			companyId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set where companyId = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	@Override
+	public RemoteAppEntry[] findByCompanyId_PrevAndNext(
+			long remoteAppEntryId, long companyId,
+			OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws NoSuchRemoteAppEntryException {
+
+		RemoteAppEntry remoteAppEntry = findByPrimaryKey(remoteAppEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			RemoteAppEntry[] array = new RemoteAppEntryImpl[3];
+
+			array[0] = getByCompanyId_PrevAndNext(
+				session, remoteAppEntry, companyId, orderByComparator, true);
+
+			array[1] = remoteAppEntry;
+
+			array[2] = getByCompanyId_PrevAndNext(
+				session, remoteAppEntry, companyId, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected RemoteAppEntry getByCompanyId_PrevAndNext(
+		Session session, RemoteAppEntry remoteAppEntry, long companyId,
+		OrderByComparator<RemoteAppEntry> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				4 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(3);
+		}
+
+		sb.append(_SQL_SELECT_REMOTEAPPENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_COMPANYID_COMPANYID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(RemoteAppEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(companyId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						remoteAppEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<RemoteAppEntry> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public List<RemoteAppEntry> filterFindByCompanyId(long companyId) {
+		return filterFindByCompanyId(
+			companyId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @return the range of matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public List<RemoteAppEntry> filterFindByCompanyId(
+		long companyId, int start, int end) {
+
+		return filterFindByCompanyId(companyId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the remote app entries that the user has permissions to view where companyId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>RemoteAppEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param start the lower bound of the range of remote app entries
+	 * @param end the upper bound of the range of remote app entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public List<RemoteAppEntry> filterFindByCompanyId(
+		long companyId, int start, int end,
+		OrderByComparator<RemoteAppEntry> orderByComparator) {
+
+		if (!InlineSQLHelperUtil.isEnabled(companyId, 0)) {
+			return findByCompanyId(companyId, start, end, orderByComparator);
+		}
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				3 + (orderByComparator.getOrderByFields().length * 2));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_REMOTEAPPENTRY_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_COMPANYID_COMPANYID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator, true);
+			}
+			else {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_TABLE, orderByComparator, true);
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), RemoteAppEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_ALIAS, RemoteAppEntryImpl.class);
+			}
+			else {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_TABLE, RemoteAppEntryImpl.class);
+			}
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(companyId);
+
+			return (List<RemoteAppEntry>)QueryUtil.list(
+				sqlQuery, getDialect(), start, end);
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the remote app entries before and after the current remote app entry in the ordered set of remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * @param remoteAppEntryId the primary key of the current remote app entry
+	 * @param companyId the company ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next remote app entry
+	 * @throws NoSuchRemoteAppEntryException if a remote app entry with the primary key could not be found
+	 */
+	@Override
+	public RemoteAppEntry[] filterFindByCompanyId_PrevAndNext(
+			long remoteAppEntryId, long companyId,
+			OrderByComparator<RemoteAppEntry> orderByComparator)
+		throws NoSuchRemoteAppEntryException {
+
+		if (!InlineSQLHelperUtil.isEnabled(companyId, 0)) {
+			return findByCompanyId_PrevAndNext(
+				remoteAppEntryId, companyId, orderByComparator);
+		}
+
+		RemoteAppEntry remoteAppEntry = findByPrimaryKey(remoteAppEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			RemoteAppEntry[] array = new RemoteAppEntryImpl[3];
+
+			array[0] = filterGetByCompanyId_PrevAndNext(
+				session, remoteAppEntry, companyId, orderByComparator, true);
+
+			array[1] = remoteAppEntry;
+
+			array[2] = filterGetByCompanyId_PrevAndNext(
+				session, remoteAppEntry, companyId, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected RemoteAppEntry filterGetByCompanyId_PrevAndNext(
+		Session session, RemoteAppEntry remoteAppEntry, long companyId,
+		OrderByComparator<RemoteAppEntry> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_REMOTEAPPENTRY_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_COMPANYID_COMPANYID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_REMOTEAPPENTRY_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByConditionFields[i],
+							true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByConditionFields[i],
+							true));
+				}
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByFields[i], true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByFields[i], true));
+				}
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(RemoteAppEntryModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), RemoteAppEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+		sqlQuery.setFirstResult(0);
+		sqlQuery.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, RemoteAppEntryImpl.class);
+		}
+		else {
+			sqlQuery.addEntity(_FILTER_ENTITY_TABLE, RemoteAppEntryImpl.class);
+		}
+
+		QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+		queryPos.add(companyId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						remoteAppEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<RemoteAppEntry> list = sqlQuery.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the remote app entries where companyId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 */
+	@Override
+	public void removeByCompanyId(long companyId) {
+		for (RemoteAppEntry remoteAppEntry :
+				findByCompanyId(
+					companyId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			remove(remoteAppEntry);
+		}
+	}
+
+	/**
+	 * Returns the number of remote app entries where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the number of matching remote app entries
+	 */
+	@Override
+	public int countByCompanyId(long companyId) {
+		FinderPath finderPath = _finderPathCountByCompanyId;
+
+		Object[] finderArgs = new Object[] {companyId};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(2);
+
+			sb.append(_SQL_COUNT_REMOTEAPPENTRY_WHERE);
+
+			sb.append(_FINDER_COLUMN_COMPANYID_COMPANYID_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
+	 * Returns the number of remote app entries that the user has permission to view where companyId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @return the number of matching remote app entries that the user has permission to view
+	 */
+	@Override
+	public int filterCountByCompanyId(long companyId) {
+		if (!InlineSQLHelperUtil.isEnabled(companyId, 0)) {
+			return countByCompanyId(companyId);
+		}
+
+		StringBundler sb = new StringBundler(2);
+
+		sb.append(_FILTER_SQL_COUNT_REMOTEAPPENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_COMPANYID_COMPANYID_2);
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), RemoteAppEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addScalar(
+				COUNT_COLUMN_NAME, com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(companyId);
+
+			Long count = (Long)sqlQuery.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	private static final String _FINDER_COLUMN_COMPANYID_COMPANYID_2 =
+		"remoteAppEntry.companyId = ?";
+
 	public RemoteAppEntryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -2719,6 +3595,24 @@ public class RemoteAppEntryPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
 			new String[] {String.class.getName(), Long.class.getName()},
 			new String[] {"uuid_", "companyId"}, false);
+
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
 
 		_setRemoteAppEntryUtilPersistence(this);
 	}

--- a/modules/apps/remote-app/remote-app-test/src/testIntegration/java/com/liferay/remote/app/service/persistence/test/RemoteAppEntryPersistenceTest.java
+++ b/modules/apps/remote-app/remote-app-test/src/testIntegration/java/com/liferay/remote/app/service/persistence/test/RemoteAppEntryPersistenceTest.java
@@ -263,6 +263,13 @@ public class RemoteAppEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByCompanyId() throws Exception {
+		_persistence.countByCompanyId(RandomTestUtil.nextLong());
+
+		_persistence.countByCompanyId(0L);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		RemoteAppEntry newRemoteAppEntry = addRemoteAppEntry();
 

--- a/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/deployer/RemoteAppEntryDeployerImpl.java
+++ b/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/deployer/RemoteAppEntryDeployerImpl.java
@@ -16,22 +16,28 @@ package com.liferay.remote.app.web.internal.deployer;
 
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.FriendlyURLMapper;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.remote.app.constants.RemoteAppConstants;
 import com.liferay.remote.app.deployer.RemoteAppEntryDeployer;
 import com.liferay.remote.app.model.RemoteAppEntry;
+import com.liferay.remote.app.web.internal.language.RemoteAppEntryResourceBundle;
 import com.liferay.remote.app.web.internal.portlet.RemoteAppEntryFriendlyURLMapper;
 import com.liferay.remote.app.web.internal.portlet.RemoteAppEntryPortlet;
 import com.liferay.remote.app.web.internal.portlet.action.RemoteAppEntryConfigurationAction;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Dictionary;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.ResourceBundle;
 
 import javax.portlet.Portlet;
 
@@ -61,6 +67,8 @@ public class RemoteAppEntryDeployerImpl implements RemoteAppEntryDeployer {
 		}
 
 		serviceRegistrations.add(_registerPortlet(remoteAppEntry));
+
+		serviceRegistrations.addAll(_registerResourceBundles(remoteAppEntry));
 
 		return serviceRegistrations;
 	}
@@ -120,9 +128,9 @@ public class RemoteAppEntryDeployerImpl implements RemoteAppEntryDeployer {
 			).put(
 				"com.liferay.portlet.instanceable",
 				remoteAppEntry.isInstanceable()
-			).put(
-				"javax.portlet.display-name",
-				remoteAppEntry.getName(LocaleUtil.US)
+			//).put(
+			//	"javax.portlet.display-name",
+			//	remoteAppEntry.getName(LocaleUtil.US)
 			).put(
 				"javax.portlet.name", _getPortletId(remoteAppEntry)
 			).put(
@@ -164,6 +172,24 @@ public class RemoteAppEntryDeployerImpl implements RemoteAppEntryDeployer {
 			Portlet.class,
 			new RemoteAppEntryPortlet(_npmResolver, remoteAppEntry),
 			dictionary);
+	}
+
+	private Collection<? extends ServiceRegistration<?>>
+		_registerResourceBundles(RemoteAppEntry remoteAppEntry) {
+
+		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
+
+		for (Locale locale : LanguageUtil.getAvailableLocales()) {
+			serviceRegistrations.add(
+				_bundleContext.registerService(
+					ResourceBundle.class,
+					new RemoteAppEntryResourceBundle(
+						locale, _getPortletId(remoteAppEntry), remoteAppEntry),
+					MapUtil.singletonDictionary(
+						"language.id", LocaleUtil.toLanguageId(locale))));
+		}
+
+		return serviceRegistrations;
 	}
 
 	private BundleContext _bundleContext;

--- a/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/language/RemoteAppEntryResourceBundle.java
+++ b/modules/apps/remote-app/remote-app-web/src/main/java/com/liferay/remote/app/web/internal/language/RemoteAppEntryResourceBundle.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.remote.app.web.internal.language;
+
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.remote.app.model.RemoteAppEntry;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+public class RemoteAppEntryResourceBundle extends ResourceBundle {
+
+	public RemoteAppEntryResourceBundle(
+		Locale locale, String portletId, RemoteAppEntry remoteAppEntry) {
+
+		_map = HashMapBuilder.put(
+			"javax.portlet.title." + portletId, remoteAppEntry.getName(locale)
+		).build();
+	}
+
+	@Override
+	public Enumeration<String> getKeys() {
+		return Collections.enumeration(_map.keySet());
+	}
+
+	@Override
+	protected Object handleGetObject(String key) {
+		return _map.get(key);
+	}
+
+	private final Map<String, String> _map;
+
+}

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -1775,7 +1775,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 						group.getName(LocaleUtil.getSiteDefault()) + ": ",
 						jsonObject.getString("name_i18n")),
 					jsonObject.getString("portletCategoryName"), sb.toString(),
-					StringPool.BLANK);
+					StringPool.BLANK, WorkflowConstants.STATUS_APPROVED);
 
 			remoteAppEntryIdsStringUtilReplaceValues.put(
 				"REMOTE_APP_ENTRY_ID:" +

--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -43,6 +43,8 @@ definition {
 	macro deleteRemoteAppAPI {
 		Click(locator1 = "xPath=(//div[@class='table-list-title']//a)");
 
+		WaitForSPARefresh();
+
 		var remoteAppNameToBeRemoved = RemoteApps.getRemoteAppEntryName();
 
 		RemoteApps._deleteRemoteAppAPI();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -30,6 +30,8 @@ definition {
 
 		var remoteAppName = "My New Remote App To Delete";
 
+		RemoteApps.tearDown();
+
 		JSONRemoteApp.addIFrameRemoteAppEntry(
 			iFrameURL = "http://www.liferay.com/my_new_remote_app",
 			name = "${remoteAppName}");


### PR DESCRIPTION
We create a sample row pointing to our Vanilla Counter app per company,
but only when the table is empty (ie: on fresh installations).

Note that this will recreate the sample if it is deleted, no other
remote app is created and portal is restarted. PM thinks this is a fair
behaviour but, if we see it creates any problem, we may change it in
the future.