### PR TITLE
LPS-139565 Update liferay-ckeditor to 4.16.2-liferay.4

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"ckeditor4-react": "1.4.2",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.16.2-liferay.1",
+		"liferay-ckeditor": "4.16.2-liferay.4",
 		"prop-types": "15.7.2"
 	},
 	"main": "index.js",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -9557,10 +9557,10 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
-liferay-ckeditor@4.16.2-liferay.1:
-  version "4.16.2-liferay.1"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.16.2-liferay.1.tgz#f78cdb74d3f8802d691acb072e1f026c196a1aa1"
-  integrity sha512-k6M0sNJbx+sWOBDwgTBUcwuROfkopBb5QXvR/tLtZ4aWGTI6prqX/LKAe4gSvGy0p9Q/AyYQU7SMzeb+WlgJzQ==
+liferay-ckeditor@4.16.2-liferay.4:
+  version "4.16.2-liferay.4"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.16.2-liferay.4.tgz#da0553ae5bbcfad93ebc5da051a182190ad4e631"
+  integrity sha512-zrTwUS/dUjDprr/UX6CVjmqJZjTvKr0e6lATg1nzpTQZVDSr55DeZQVdaRUQvW4q0jEAuqDF4eG6ZgL8EMxTBA==
 
 liferay-font-awesome@3.5.0:
   version "3.5.0"


### PR DESCRIPTION
It cames from: https://github.com/liferay-frontend/liferay-portal/pull/1576

# Changelog

## [v4.16.2-liferay.4](https://github.com/liferay/liferay-ckeditor/tree/v4.16.2-liferay.4) (2021-11-24)

[Full changelog](https://github.com/liferay/liferay-ckeditor/compare/v4.16.2-liferay.3...v4.16.2-liferay.4)

**Pause your reading here**

Does it looks weird, yes? It's because was needed to release a new version for fixing wrong build artifacts in liferay.2, liferay.3 versions. So, when upgrading this dep, the true changelog is:

**Continue your normal flow**

## [v4.16.2-liferay.3](https://github.com/liferay/liferay-ckeditor/tree/v4.16.2-liferay.3) (2021-11-10)

[Full changelog](https://github.com/liferay/liferay-ckeditor/compare/v4.16.2-liferay.2...v4.16.2-liferay.3)

### :wrench: Bug fixes

-   fix: makes codemirror and codemirrordialog plugin and dialog work with BalloonEditor ([\#192](https://github.com/liferay/liferay-ckeditor/pull/192))

## [v4.16.2-liferay.2](https://github.com/liferay/liferay-ckeditor/tree/v4.16.2-liferay.2) (2021-10-13)

[Full changelog](https://github.com/liferay/liferay-ckeditor/compare/v4.16.2-liferay.1...v4.16.2-liferay.2)

### :wrench: Bug fixes

-   fix: [TS] LPS-139565 ([\#191](https://github.com/liferay/liferay-ckeditor/pull/191))


/cc @holatuwol

It fixes the following tickets:

* [LPS-137763](https://issues.liferay.com/browse/LPS-137763)
* [LPS-139665](https://issues.liferay.com/browse/LPS-139565)