### PR TITLE
LPS-141185 Stabilizes the analysis of violations during SPA navigation of the A11y tool

### DIFF
--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/java/com/liferay/frontend/js/a11y/web/internal/servlet/taglib/A11yTopHeadJSPDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/java/com/liferay/frontend/js/a11y/web/internal/servlet/taglib/A11yTopHeadJSPDynamicInclude.java
@@ -46,7 +46,7 @@ import org.osgi.service.component.annotations.Reference;
 	configurationPid = "com.liferay.frontend.js.a11y.web.internal.configuration.A11yConfiguration",
 	service = DynamicInclude.class
 )
-public class A11yBottomJSPDynamicInclude implements DynamicInclude {
+public class A11yTopHeadJSPDynamicInclude implements DynamicInclude {
 
 	@Override
 	public void include(
@@ -143,7 +143,7 @@ public class A11yBottomJSPDynamicInclude implements DynamicInclude {
 
 		if (FFA11yConfigurationUtil.getEnable()) {
 			dynamicIncludeRegistry.register(
-				"/html/common/themes/bottom.jsp#post");
+				"/html/common/themes/top_head.jsp#post");
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/java/com/liferay/frontend/js/a11y/web/internal/servlet/taglib/A11yTopHeadJSPDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/java/com/liferay/frontend/js/a11y/web/internal/servlet/taglib/A11yTopHeadJSPDynamicInclude.java
@@ -121,8 +121,6 @@ public class A11yTopHeadJSPDynamicInclude implements DynamicInclude {
 				)
 			)
 		).put(
-			"portletId", "frontend-js-a11y-web"
-		).put(
 			"targets", new String[] {_a11yConfiguration.target()}
 		);
 

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
@@ -461,6 +461,8 @@ export class A11yChecker {
 
 		if (this.scheduler.isPaused) {
 			this.scheduler.continueExecution();
+
+			this.recordCallback(document.body);
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
@@ -437,6 +437,7 @@ export class A11yChecker {
 		this.axeOptions = {
 			...defaultOptions,
 			...options,
+			absolutePaths: true,
 			runOnly: runOnlyArray?.length ? runOnlyArray : undefined,
 		};
 

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
@@ -112,6 +112,7 @@ export class Scheduler<T> {
 	 */
 	private readonly yieldInterval = 100;
 	public deadline = 0;
+	public isPaused = false;
 
 	cancelHostCallback() {
 		window.cancelIdleCallback(this.scheduledHostHandle);
@@ -153,7 +154,7 @@ export class Scheduler<T> {
 
 			const hasMoreWork = await this.flushWork();
 
-			if (hasMoreWork) {
+			if (hasMoreWork && !this.isPaused) {
 
 				// If there's more work, schedule the next callback at the
 				// end of the preceding one.
@@ -184,7 +185,7 @@ export class Scheduler<T> {
 	private async workLoop() {
 		this.currentTask = this.queue.peek();
 
-		while (this.currentTask !== null) {
+		while (this.currentTask !== null && !this.isPaused) {
 			if (this.shouldYieldToHost()) {
 
 				// We no longer have time to run currentTask now
@@ -212,6 +213,21 @@ export class Scheduler<T> {
 		// Return whether there's additional work
 
 		return this.currentTask !== null;
+	}
+
+	continueExecution(): void {
+		this.isPaused = false;
+
+		if (!this.isCallbackScheduled && !this.isPerformingWork) {
+			this.isCallbackScheduled = true;
+			this.requestHostCallback();
+		}
+	}
+
+	pauseExecution(): void {
+		this.isPaused = true;
+
+		this.isCallbackScheduled = false;
 	}
 
 	scheduleCallback(callback: Function, target: T) {
@@ -441,6 +457,10 @@ export class A11yChecker {
 			targets,
 			this.mutationCallback.bind(this)
 		);
+
+		if (this.scheduler.isPaused) {
+			this.scheduler.continueExecution();
+		}
 	}
 
 	private async run(target: HTMLElement) {
@@ -571,6 +591,7 @@ export class A11yChecker {
 	}
 
 	unobserve() {
+		this.scheduler.pauseExecution();
 		this.scheduler.cancelHostCallback();
 		this.observers.unobserve();
 	}

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
@@ -391,6 +391,8 @@ export interface A11yCheckerOptions {
 	targets: Array<string>;
 }
 
+const scheduler = new Scheduler();
+
 export class A11yChecker {
 	private callback: A11yCheckerOptions['callback'];
 	private scheduler: Scheduler<Node>;
@@ -431,7 +433,7 @@ export class A11yChecker {
 		// A11yChecker to share the same queue to avoid bottlenecks and
 		// performance issues.
 
-		this.scheduler = new Scheduler();
+		this.scheduler = scheduler as Scheduler<Node>;
 
 		this.mutations = mutations;
 

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
@@ -542,65 +542,71 @@ export class A11yChecker {
 		});
 	}
 
+	private mutationFunnel(
+		node: Node,
+		record: MutationRecord,
+		denylistTargets?: Array<Array<Element>>
+	) {
+		const {attributeName, type} = record;
+
+		if (type === 'attributes') {
+			const attributes =
+				this.mutations[node.nodeName.toLowerCase()] ??
+				this.mutations?.any;
+
+			const attributeValue = (node as Element).getAttribute(
+				attributeName as string
+			);
+
+			if (
+				attributes[attributeName as string]?.some((value) =>
+					value === '*' ? true : attributeValue?.includes(value)
+				)
+			) {
+				return;
+			}
+		}
+
+		// Ignores the mutation if the target was through some element
+		// within the denylist.
+
+		const hasTargetInDenylist = denylistTargets?.some((targets) =>
+			targets?.some((target) => target.contains(node))
+		);
+
+		if (hasTargetInDenylist) {
+			return;
+		}
+
+		// If the node belongs to an iframe analyze the iframe instead of
+		// the element. `axe-core` cannot directly analyze the element.
+
+		if (node.ownerDocument !== document) {
+			node = ((node.ownerDocument as Document).defaultView as Window)
+				.frameElement as Node;
+		}
+
+		this.observeIframes(node);
+
+		this.recordCallback(node);
+	}
+
 	private mutationCallback(records: Array<MutationRecord>) {
 		const denylistTargets = this.denylist?.map((selector) => [
 			...document.querySelectorAll(selector.join(' ')),
 		]);
 
 		records.forEach((record) => {
-			const {
-				addedNodes,
-				attributeName,
-				removedNodes,
-				target,
-				type,
-			} = record;
+			const {addedNodes, removedNodes, target, type} = record;
 
-			let node =
+			const nodes =
 				type === 'attributes' || removedNodes.length > 0
-					? target
-					: addedNodes[0];
+					? [target]
+					: addedNodes;
 
-			if (type === 'attributes') {
-				const attributes =
-					this.mutations[node.nodeName.toLowerCase()] ??
-					this.mutations?.any;
-
-				const attributeValue = (node as Element).getAttribute(
-					attributeName as string
-				);
-
-				if (
-					attributes[attributeName as string]?.some((value) =>
-						value === '*' ? true : attributeValue?.includes(value)
-					)
-				) {
-					return;
-				}
-			}
-
-			// Ignores the mutation if the target was through some element
-			// within the denylist.
-
-			const hasTargetInDenylist = denylistTargets?.some((targets) =>
-				targets?.some((target) => target.contains(node))
+			nodes.forEach((node: Node) =>
+				this.mutationFunnel(node, record, denylistTargets)
 			);
-
-			if (hasTargetInDenylist) {
-				return;
-			}
-
-			// If the node belongs to an iframe analyze the iframe instead of
-			// the element. `axe-core` cannot directly analyze the element.
-
-			if (node.ownerDocument !== document) {
-				node = ((node.ownerDocument as Document).defaultView as Window)
-					.frameElement as Node;
-			}
-
-			this.observeIframes(node);
-
-			this.recordCallback(node);
 		});
 	}
 

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/A11yChecker.ts
@@ -519,9 +519,26 @@ export class A11yChecker {
 			? (node as Element).querySelectorAll('iframe')
 			: [];
 
-		iframes.forEach((iframe: HTMLIFrameElement) =>
-			this.observers.add(`#${iframe.getAttribute('id')}`)
-		);
+		iframes.forEach((iframe: HTMLIFrameElement) => {
+			let selector = 'iframe';
+
+			const id = iframe.getAttribute('id');
+
+			if (id) {
+				selector += `#${id}`;
+			}
+
+			const className = iframe
+				.getAttribute('class')
+				?.split(' ')
+				.join('.');
+
+			if (className) {
+				selector += `.${className}`;
+			}
+
+			this.observers.add(selector);
+		});
 	}
 
 	private mutationCallback(records: Array<MutationRecord>) {

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/hooks/useA11y.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/hooks/useA11y.ts
@@ -38,23 +38,15 @@ export type Violations = {
 	rules: Record<RuleId, RuleRaw>;
 };
 
-function segmentViolationsByRulesAndNodes(
-	violations: Array<Result>,
-	previousViolations: Violations
+/**
+ * Validates the previous list of violations by removing elements that are
+ * no longer visible in the DOM.
+ */
+function revalidateViolations(
+	previousViolations: Violations,
+	elements?: WeakMap<Element, string>
 ) {
-
-	// Maintains a list of target elements to ensure that targets are unique
-	// and we don't add violations with different selectors for the
-	// same element.
-
-	const elements = new WeakMap<Element, string>();
-
-	// Validates the previous list of violations by removing elements that are
-	// no longer visible in the DOM.
-
-	const revalidatedViolations = Object.values(
-		previousViolations.rules
-	).reduce(
+	return Object.values(previousViolations.rules).reduce(
 		(previousViolation, rule) => {
 
 			// Revalidation if the target exists on the DOM
@@ -95,7 +87,9 @@ function segmentViolationsByRulesAndNodes(
 						];
 					}
 
-					elements.set(element, node);
+					if (elements) {
+						elements.set(element, node);
+					}
 				}
 
 				return element;
@@ -112,7 +106,13 @@ function segmentViolationsByRulesAndNodes(
 		},
 		{iframes: {}, nodes: {}, rules: {}} as Violations
 	);
+}
 
+function segmentViolationsByRulesAndNodes(
+	violations: Array<Result>,
+	previousViolations: Violations,
+	elements: WeakMap<Element, string>
+) {
 	return violations.reduce<Violations>((previousViolation, current) => {
 		const {nodes, ...rule} = current;
 
@@ -213,7 +213,7 @@ function segmentViolationsByRulesAndNodes(
 		staleTargets.clear();
 
 		return previousViolation;
-	}, revalidatedViolations);
+	}, previousViolations);
 }
 
 const defaultState = {
@@ -227,14 +227,29 @@ export default function useA11y(props: Omit<A11yCheckerOptions, 'callback'>) {
 
 	useEffect(() => {
 		const checker = new A11yChecker({
-			callback: (results) =>
-				results.violations.length &&
-				setViolations((prevViolations) =>
-					segmentViolationsByRulesAndNodes(
-						results.violations,
-						prevViolations
-					)
-				),
+			callback: (results) => {
+				if (results.violations.length) {
+
+					// Maintains a list of target elements to ensure that targets
+					// are unique and we don't add violations with different
+					// selectors for the same element.
+
+					const elements = new WeakMap<Element, string>();
+
+					setViolations((prevViolations) =>
+						segmentViolationsByRulesAndNodes(
+							results.violations,
+							revalidateViolations(prevViolations, elements),
+							elements
+						)
+					);
+				}
+				else {
+					setViolations((prevViolations) =>
+						revalidateViolations(prevViolations)
+					);
+				}
+			},
 			...props,
 		});
 

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/hooks/useA11y.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/hooks/useA11y.ts
@@ -147,9 +147,20 @@ function segmentViolationsByRulesAndNodes(
 				previousViolation.nodes[target][current.id] = node;
 			}
 			else {
-				const element = document.querySelector(
-					node.target[node.target.length - 1]
-				);
+				const lastTarget = node.target[node.target.length - 1];
+
+				let element: Element | undefined | null;
+
+				if (node.target.length > 1) {
+					element = (document.querySelector(node.target[0]) as
+						| HTMLIFrameElement
+						| undefined)?.contentDocument?.querySelector(
+						lastTarget
+					);
+				}
+				else {
+					element = document.querySelector(lastTarget);
+				}
 
 				// The selector can be different for each analysis, but the
 				// element will be the same, we just keep the target updated

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/index.tsx
@@ -56,7 +56,7 @@ export default function main(
 	props: Omit<A11yCheckerOptions, 'callback' | 'targets'>
 ) {
 	render(
-		window.themeDisplay.isStatePopUp() ? A11yIframe : A11y,
+		window.frameElement ? A11yIframe : A11y,
 		props,
 		getDefaultContainer()
 	);

--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/index.tsx
@@ -27,6 +27,7 @@ declare global {
 		Util: {
 			sub(...value: string[]): string;
 		};
+		on: (event: string, fn: Function) => void;
 	};
 
 	interface ThemeDisplay {
@@ -60,4 +61,12 @@ export default function main(
 		props,
 		getDefaultContainer()
 	);
+
+	Liferay.on('endNavigate', () => {
+		render(
+			window.frameElement ? A11yIframe : A11y,
+			props,
+			getDefaultContainer()
+		);
+	});
 }

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/A11yChecker.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/A11yChecker.d.ts
@@ -158,6 +158,7 @@ export declare class A11yChecker {
 	 * Modal, we need to monitor iframes as they appear during their lifecycle.
 	 */
 	private observeIframes;
+	private mutationFunnel;
 	private mutationCallback;
 	observe(): void;
 	unobserve(): void;

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/A11yChecker.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/A11yChecker.d.ts
@@ -85,12 +85,15 @@ export declare class Scheduler<T> {
 	 */
 	private readonly yieldInterval;
 	deadline: number;
+	isPaused: boolean;
 	cancelHostCallback(): void;
 	hasCallback(selector: Selector<Task<T>>): Task<T> | undefined;
 	private flushWork;
 	private requestHostCallback;
 	private shouldYieldToHost;
 	private workLoop;
+	continueExecution(): void;
+	pauseExecution(): void;
 	scheduleCallback(callback: Function, target: T): void;
 }
 

--- a/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/types/src/main/resources/META-INF/resources/index.d.ts
@@ -21,6 +21,7 @@ declare global {
 		Util: {
 			sub(...value: string[]): string;
 		};
+		on: (event: string, fn: Function) => void;
 	};
 	interface ThemeDisplay {
 		isStatePopUp(): boolean;

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -3,7 +3,7 @@ definition {
 
 	property osgi.modules.includes = "frontend-js-a11y-sample-web,frontend-js-a11y-web";
 	property portal.release = "false";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.component.names = "A11y Tool";
 	property testray.main.component.name = "User Interface";
 


### PR DESCRIPTION
I changed some strategies here that I added in the description of each commit the reason, so it's worth reading why and I'm still marking this PR as a draft because I still need to make some improvements to finish the inconsistent analysis while browsing with SPA vs refresh a page, this is very much related to mutating the DOM elements and the scheduler that was having problems.

Some strategies I've adopted here like moving A11y to be added to `top_head` again and making the scheduler a singleton help the reliability of A11y's analytics, ie in not losing some elements to analyze.

### ToDo 

- [x] ~Improve the violations revalidation mechanism to identify if the element has already passed the test (the `axe-core` it sometimes returns the elements that are passing, we can use that for revalidation)~
- [x] Improves the funnel for identifying nodes to be analyzed (During mutation validation when a `child` change event that was added happens, we only consider the first node and not all, we may lose many elements here to be analyzed).