### PR TITLE
LPS-143005 fix API path name after moving package over FDS

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/FDSSampleDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/FDSSampleDisplayContext.java
@@ -38,7 +38,7 @@ public class FDSSampleDisplayContext {
 	}
 
 	public String getAPIURL() {
-		return "/o/c/datasetdisplaysamples";
+		return "/o/c/fdssamples";
 	}
 
 	public CreationMenu getCreationMenu() throws Exception {


### PR DESCRIPTION
There is a coupling between the Object name and the API so we have to rename both at the same time.