### PR TITLE
LPS-142327 | A11yTool - Verifies correct violation details are displayed in the popup

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/A11yTool.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/A11yTool.path
@@ -86,12 +86,22 @@
 <!--POPOVERS-->
 <tr>
 	<td>HIGHLIGHTED_ELEMENT_POPOVER_IMPACT</td>
-	<td>//*[contains(@class, 'clay-popover-bottom show')]//*[contains(@class,'text-secondary') and contains(.,'${key_impact}')]</td>
+	<td>//*[contains(@class, 'a11y-popover')]//*[contains(@class,'text-secondary') and contains(.,'${key_impact}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>HIGHLIGHTED_ELEMENT_POPOVER_ITEM</td>
-	<td>//*[contains(@class, 'clay-popover-bottom show')]//*[contains(@class,'popover-body')]//*[contains(@class,'list-group-item')]</td>
+	<td>//*[contains(@class, 'a11y-popover')]//*[contains(@class,'popover-body')]//*[contains(@class,'list-group-item')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>HIGHLIGHTED_ELEMENT_POPOVER_TITLE</td>
+	<td>//*[contains(@class, 'a11y-popover')]//*[contains(@class,'list-group-title') and contains(.,'${key_text}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>HIGHLIGHTED_ELEMENT_POPOVER_DESCRIPTION</td>
+	<td>//*[contains(@class, 'a11y-popover')]//*[contains(@class,'list-group-subtext') and contains(.,'${key_text}')]</td>
 	<td></td>
 </tr>
 <!--SIDE PANEL COMPONENT VIEW-->

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -231,6 +231,57 @@ definition {
 		takeScreenshot();
 	}
 
+	@description = "LPS-142327. Verifies the pop up displays detail information about the violation."
+	@priority = "3"
+	test CanDisplayViolationDetailsInPopUp {
+		property osgi.module.configuration.file.names = "com.liferay.frontend.js.a11y.web.internal.configuration.FFA11yConfiguration.config";
+		property osgi.module.configurations = "enable=B&quot;true&quot;";
+
+		// Workaround for side panel sometimes not displaying LPS-141442
+
+		while (IsElementNotPresent(locator1 = "A11yTool#VIOLATION_PANEL_HEADER")) {
+			Refresh();
+		}
+
+		task ("Verfies there are violations on the page") {
+			VerifyElementPresent(locator1 = "A11yTool#HIGHLIGHTED_ELEMENT");
+
+			VerifyElementPresent(locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_ICON");
+		}
+
+		task ("Click on the icon next to the highlighted violation") {
+			Click(locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_ICON");
+		}
+
+		task ("Assert the rule name is displayed") {
+			AssertElementPresent(
+				key_text = "button-name",
+				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_TITLE");
+		}
+
+		task ("Assert the impact is displayed") {
+			AssertElementPresent(
+				key_impact = "critical",
+				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
+		}
+
+		task ("Assert a brief description is displayed") {
+			AssertElementPresent(
+				key_text = "Buttons must have discernible text",
+				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_DESCRIPTION");
+		}
+
+		task ("Assert link to occurrence side panel is displayed") {
+			Click(locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_ITEM");
+
+			AssertElementPresent(
+				key_text = "Occurrence 1",
+				locator1 = "A11yTool#VIOLATION_PANEL_COMPONENT_TITLE");
+		}
+
+		takeScreenshot();
+	}
+
 	@description = "LPS-142323. Verifies the side panel shows the violation occurrence when clicked from pop up."
 	@priority = "4"
 	test CanDisplayViolationDetailsInSidePanel {


### PR DESCRIPTION
**Background**
Create automated tests for the A11y tool

**Test Plan**
- Verify there are violations on the page
- Click on the icon on a violation
- Assert the rule name is displayed
- Assert the impact is displayed
- Assert a brief description is displayed
- Assert a link to the occurrence in the side panel is present

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-142327