### PR TITLE
LPS-141820 | A11yTool - Verifies all violations are displayed after unchecking filter

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/A11yTool.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/A11yTool.macro
@@ -39,13 +39,9 @@ definition {
 	}
 
 	macro checkFilter {
-		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
-
 		Check.checkNotVisible(
 			key_filter = "${filterType}",
 			locator1 = "A11yTool#FILTER_CHECKBOX");
-
-		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
 	}
 
 	macro clickOnAllViolations {
@@ -60,14 +56,22 @@ definition {
 		}
 	}
 
-	macro uncheckFilter {
-		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
+	macro closeFilterPanel {
+		if (IsElementPresent(locator1 = "A11yTool#FILTER_DROPDOWN")) {
+			Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
+		}
+	}
 
-		Uncheck.uncheckVisible(
+	macro openFilterPanel {
+		if (IsElementNotPresent(locator1 = "A11yTool#FILTER_DROPDOWN")) {
+			Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
+		}
+	}
+
+	macro uncheckFilter {
+		Uncheck.uncheckNotVisible(
 			key_filter = "${filterType}",
 			locator1 = "A11yTool#FILTER_CHECKBOX");
-
-		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
 	}
 
 	macro waitForAllImpactViolationsPresentInSidePanel {

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/A11yTool.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/A11yTool.macro
@@ -1,13 +1,111 @@
 definition {
 
-	macro setFilter {
+	macro assertAllImpactViolationsPresentInSidePanel {
+		AssertElementPresent(
+			key_impact = "critical",
+			locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+
+		AssertElementPresent(
+			key_impact = "serious",
+			locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+
+		AssertElementPresent(
+			key_impact = "moderate",
+			locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+
+		AssertElementPresent(
+			key_impact = "minor",
+			locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+	}
+
+	macro assertAllImpactViolationsPresentOnPage {
+		A11yTool.clickOnAllViolations();
+
+		AssertElementPresent(
+			key_impact = "critical",
+			locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
+
+		AssertElementPresent(
+			key_impact = "serious",
+			locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
+
+		AssertElementPresent(
+			key_impact = "moderate",
+			locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
+
+		AssertElementPresent(
+			key_impact = "minor",
+			locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
+	}
+
+	macro checkFilter {
 		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
 
-		Click(
-			key_text = "${filterType}",
+		Check.checkNotVisible(
+			key_filter = "${filterType}",
 			locator1 = "A11yTool#FILTER_CHECKBOX");
 
 		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
+	}
+
+	macro clickOnAllViolations {
+		var count = "1";
+
+		while (IsElementPresent(key_index = "${count}", locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_INDEX")) {
+			Click(
+				key_index = "${count}",
+				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_INDEX");
+
+			var count = ${count} + 1;
+		}
+	}
+
+	macro uncheckFilter {
+		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
+
+		Uncheck.uncheckVisible(
+			key_filter = "${filterType}",
+			locator1 = "A11yTool#FILTER_CHECKBOX");
+
+		Click(locator1 = "A11yTool#FILTER_ELEMENT_ICON");
+	}
+
+	macro waitForAllImpactViolationsPresentInSidePanel {
+		WaitForElementPresent(
+			key_impact = "critical",
+			locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+
+		WaitForElementPresent(
+			key_impact = "serious",
+			locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+
+		WaitForElementPresent(
+			key_impact = "moderate",
+			locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+
+		WaitForElementPresent(
+			key_impact = "minor",
+			locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+	}
+
+	macro waitForAllImpactViolationsPresentOnPage {
+		A11yTool.clickOnAllViolations();
+
+		WaitForElementPresent(
+			key_impact = "critical",
+			locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
+
+		WaitForElementPresent(
+			key_impact = "serious",
+			locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
+
+		WaitForElementPresent(
+			key_impact = "moderate",
+			locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
+
+		WaitForElementPresent(
+			key_impact = "minor",
+			locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
 	}
 
 }

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/A11yTool.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/A11yTool.path
@@ -42,7 +42,7 @@
 	<td>//*[contains(@class,'a11y-panel') and contains(@class,'violations-header')]//*[*[name()='svg'][contains(@class,'lexicon-icon-filter')]]</td>
 	<td></td>
 </tr>
-<tr>you just
+<tr>
 	<td>FILTER_BY_IMPACT_HEADER</td>
 	<td>//*[contains(@class,'a11y-dropdown show')]//*[contains(@class, 'dropdown-subheader') and contains(., 'Filter by Impact')]</td>
 	<td></td>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/A11yTool.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/A11yTool.path
@@ -42,7 +42,7 @@
 	<td>//*[contains(@class,'a11y-panel') and contains(@class,'violations-header')]//*[*[name()='svg'][contains(@class,'lexicon-icon-filter')]]</td>
 	<td></td>
 </tr>
-<tr>
+<tr>you just
 	<td>FILTER_BY_IMPACT_HEADER</td>
 	<td>//*[contains(@class,'a11y-dropdown show')]//*[contains(@class, 'dropdown-subheader') and contains(., 'Filter by Impact')]</td>
 	<td></td>
@@ -59,7 +59,7 @@
 </tr>
 <tr>
 	<td>FILTER_CHECKBOX</td>
-	<td>//*[contains(@class,'a11y-dropdown show')]//*[contains(@data-testid,'')]//following-sibling::span/span[normalize-space()='${key_text}']</td>
+	<td>//*[contains(@class,'a11y-dropdown show')]//*[contains(@data-testid,'${key_filter}')]</td>
 	<td></td>
 </tr>
 <!--HIGHLIGHTED ELEMENTS-->
@@ -70,7 +70,7 @@
 </tr>
 <tr>
 	<td>HIGHLIGHTED_ELEMENT_INDEX</td>
-	<td>//*[contains(@id, 'a11yContainer')]//*[contains(@class, 'a11y-overlay')][${key_index}]</td>
+	<td>//*[contains(@id, 'a11yContainer')]//*[contains(@class, 'a11y-overlay')][${key_index}]//*[contains(@class, 'a11y-indicator')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/A11yTool.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/A11yTool.path
@@ -62,6 +62,11 @@
 	<td>//*[contains(@class,'a11y-dropdown show')]//*[contains(@data-testid,'${key_filter}')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>FILTER_DROPDOWN</td>
+	<td>//*[contains(@class,'a11y-dropdown show')]</td>
+	<td></td>
+</tr>
 <!--HIGHLIGHTED ELEMENTS-->
 <tr>
 	<td>HIGHLIGHTED_ELEMENT</td>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -376,7 +376,7 @@ definition {
 		takeScreenshot();
 	}
 
-	@description = "LPS-141820. Verifies violations can be filtered by 'Critical' only."
+	@description = "LPS-141820. Verifies violations can be filtered by 'Critical' only. Also verifies all violations are present when unfiltered."
 	@priority = "5"
 	test CanFilterViolationsByCriticalImpactOnly {
 		property osgi.module.configuration.file.names = "com.liferay.frontend.js.a11y.web.internal.configuration.FFA11yConfiguration.config";
@@ -408,6 +408,8 @@ definition {
 
 		task ("Filter impact by Critical") {
 			A11yTool.setFilter(filterType = "Critical");
+
+			FormFields.viewCheckboxChecked(fieldName = "Critical");
 		}
 
 		task ("Assert only critical violations are present on the side panel") {
@@ -462,6 +464,36 @@ definition {
 			AssertElementNotPresent(
 				key_impact = "serious",
 				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
+		}
+
+		task ("Unfilter impact by Critical") {
+			A11yTool.setFilter(filterType = "Critical");
+
+			FormFields.viewCheckboxNotChecked(fieldName = "Critical");
+		}
+
+		task ("Assert page has Minor, Moderate, Serious, and Critical set of violations") {
+			AssertElementPresent(
+				key_impact = "minor",
+				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+
+			AssertElementPresent(
+				key_impact = "moderate",
+				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+
+			AssertElementPresent(
+				key_impact = "serious",
+				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+
+			AssertElementPresent(
+				key_impact = "critical",
+				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+		}
+
+		task ("Assert violations are highlighted with an icon") {
+			AssertElementPresent(locator1 = "A11yTool#HIGHLIGHTED_ELEMENT");
+
+			AssertElementPresent(locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_ICON");
 		}
 
 		takeScreenshot();

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -388,28 +388,14 @@ definition {
 			Refresh();
 		}
 
-		task ("Verify page has Minor, Moderate, Serious, and Critical set of violations") {
-			VerifyElementPresent(
-				key_impact = "minor",
-				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+		task ("Verify the page has critical, serious, moderate, minor violations") {
+			A11yTool.waitForAllImpactViolationsPresentInSidePanel();
 
-			VerifyElementPresent(
-				key_impact = "moderate",
-				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
-
-			VerifyElementPresent(
-				key_impact = "serious",
-				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
-
-			VerifyElementPresent(
-				key_impact = "critical",
-				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+			A11yTool.waitForAllImpactViolationsPresentOnPage();
 		}
 
 		task ("Filter impact by Critical") {
-			A11yTool.setFilter(filterType = "Critical");
-
-			FormFields.viewCheckboxChecked(fieldName = "Critical");
+			A11yTool.checkFilter(filterType = "critical");
 		}
 
 		task ("Assert only critical violations are present on the side panel") {
@@ -418,7 +404,7 @@ definition {
 				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
 
 			AssertElementNotPresent(
-				key_impact = "minor",
+				key_impact = "serious",
 				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
 
 			AssertElementNotPresent(
@@ -426,35 +412,19 @@ definition {
 				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
 
 			AssertElementNotPresent(
-				key_impact = "serious",
+				key_impact = "minor",
 				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
 		}
 
-		task ("Assert only critical elements are highlighted") {
-			AssertClick(
-				key_index = "1",
-				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_INDEX",
-				value1 = "");
-
-			AssertClick(
-				key_index = "2",
-				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_INDEX",
-				value1 = "");
-
-			AssertElementNotPresent(
-				key_index = "3",
-				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_INDEX");
-
+		task ("Assert only critical elements are highlighted with an icon") {
 			AssertElementPresent(
 				key_impact = "critical",
 				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
 
 			AssertElementPresent(locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_ICON");
-		}
 
-		task ("Assert minor, moderate, serious violations are not highlighted") {
 			AssertElementNotPresent(
-				key_impact = "minor",
+				key_impact = "serious",
 				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
 
 			AssertElementNotPresent(
@@ -462,32 +432,28 @@ definition {
 				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
 
 			AssertElementNotPresent(
-				key_impact = "serious",
+				key_impact = "minor",
 				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_POPOVER_IMPACT");
+		}
+
+		task ("Close critical violations popovers") {
+			Click(
+				key_index = "1",
+				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_INDEX");
+
+			Click(
+				key_index = "2",
+				locator1 = "A11yTool#HIGHLIGHTED_ELEMENT_INDEX");
 		}
 
 		task ("Unfilter impact by Critical") {
-			A11yTool.setFilter(filterType = "Critical");
-
-			FormFields.viewCheckboxNotChecked(fieldName = "Critical");
+			A11yTool.uncheckFilter(filterType = "critical");
 		}
 
-		task ("Assert page has Minor, Moderate, Serious, and Critical set of violations") {
-			AssertElementPresent(
-				key_impact = "minor",
-				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+		task ("Assert the page has critical, serious, moderate, minor violations") {
+			A11yTool.assertAllImpactViolationsPresentInSidePanel();
 
-			AssertElementPresent(
-				key_impact = "moderate",
-				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
-
-			AssertElementPresent(
-				key_impact = "serious",
-				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
-
-			AssertElementPresent(
-				key_impact = "critical",
-				locator1 = "A11yTool#VIOLATION_PANEL_ITEM_IMPACT");
+			A11yTool.assertAllImpactViolationsPresentOnPage();
 		}
 
 		task ("Assert violations are highlighted with an icon") {

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -395,7 +395,11 @@ definition {
 		}
 
 		task ("Filter impact by Critical") {
+			A11yTool.openFilterPanel();
+
 			A11yTool.checkFilter(filterType = "critical");
+
+			A11yTool.closeFilterPanel();
 		}
 
 		task ("Assert only critical violations are present on the side panel") {
@@ -447,7 +451,11 @@ definition {
 		}
 
 		task ("Unfilter impact by Critical") {
+			A11yTool.openFilterPanel();
+
 			A11yTool.uncheckFilter(filterType = "critical");
+
+			A11yTool.closeFilterPanel();
 		}
 
 		task ("Assert the page has critical, serious, moderate, minor violations") {

--- a/portal-web/test/functional/com/liferay/portalweb/functions/Uncheck.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/Uncheck.function
@@ -87,4 +87,22 @@ definition {
 		}
 	}
 
+	function uncheckVisible {
+		WaitForSPARefresh();
+
+		selenium.waitForElementPresent();
+
+		selenium.mouseOver();
+
+		if (selenium.isChecked()) {
+			selenium.clickAt();
+		}
+
+		selenium.assertNotChecked();
+
+		selenium.assertJavaScriptErrors();
+
+		selenium.assertLiferayErrors();
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/functions/Uncheck.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/Uncheck.function
@@ -37,6 +37,24 @@ definition {
 		selenium.assertLiferayErrors();
 	}
 
+	function uncheckNotVisible {
+		WaitForSPARefresh();
+
+		selenium.waitForElementPresent();
+
+		selenium.mouseOver();
+
+		if (selenium.isChecked()) {
+			selenium.clickAt();
+		}
+
+		selenium.assertNotChecked();
+
+		selenium.assertJavaScriptErrors();
+
+		selenium.assertLiferayErrors();
+	}
+
 	function uncheckToggleSwitch {
 		WaitForSPARefresh();
 
@@ -85,24 +103,6 @@ definition {
 		if (selenium.isChecked()) {
 			selenium.clickAt();
 		}
-	}
-
-	function uncheckVisible {
-		WaitForSPARefresh();
-
-		selenium.waitForElementPresent();
-
-		selenium.mouseOver();
-
-		if (selenium.isChecked()) {
-			selenium.clickAt();
-		}
-
-		selenium.assertNotChecked();
-
-		selenium.assertJavaScriptErrors();
-
-		selenium.assertLiferayErrors();
 	}
 
 }


### PR DESCRIPTION
**Background**
Create automated tests for the A11y tool

**Test Plan**
- Verify page contains "Minor", "Moderate", "Serious", "Critical" set of violations
- Set impact filter for "Critical"
- Verify only "Critical" violations are present on the side panel
- Verify only "Critical" violations are highlighted with an icon
- Unset impact filter for "Critical"
- Assert all violations are present in the side panel
- Assert all violations are highlighted 
- Assert all highlighted violations have an icon

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-141820