### PR TITLE
LPS-142886 Support to truncate the text if the field type is a Clob

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/DateRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/DateRenderer.js
@@ -14,9 +14,16 @@
 
 import PropType from 'prop-types';
 
+import {getDateFromDateString, prettifyDateObject} from '../utils/dates';
+
 function DateRenderer({options, value}) {
 	if (!value) {
 		return null;
+	}
+
+	if (options.withoutTime) {
+		const dateObject = getDateFromDateString(value.split('T')[0]);
+		value = prettifyDateObject(dateObject);
 	}
 
 	const locale = themeDisplay.getLanguageId().replace('_', '-');

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/DefaultRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/DefaultRenderer.js
@@ -13,16 +13,17 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import {logError} from '../utils/logError';
 import TooltipTextRenderer from './TooltipTextRenderer';
 
-function DefaultRenderer({value}) {
+function DefaultRenderer({options, value}) {
 	if (
 		typeof value === 'number' ||
-		typeof value === 'string' ||
+		(typeof value === 'string' && !options.truncate) ||
 		value === undefined ||
 		value === null
 	) {
@@ -36,6 +37,18 @@ function DefaultRenderer({value}) {
 	}
 	else if (value.label) {
 		return <>{value.label}</>;
+	}
+	else if (options.truncate) {
+		return (
+			<span
+				className={classNames(
+					'default-renderer__text-truncate',
+					'text-truncate'
+				)}
+			>
+				{value}
+			</span>
+		);
 	}
 
 	logError(

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/_data_renderers.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/_data_renderers.scss
@@ -32,3 +32,7 @@
 		color: $success-primary;
 	}
 }
+
+.default-renderer__text-truncate {
+	max-width: 400px;
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 8.1.3
+Bundle-Version: 9.0.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.data,\
 	com.liferay.frontend.taglib.clay.data.set,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -90,5 +90,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "8.1.3"
+	"version": "9.0.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/view/table/ClayTableSchemaBuilder.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/view/table/ClayTableSchemaBuilder.java
@@ -19,6 +19,12 @@ package com.liferay.frontend.taglib.clay.data.set.view.table;
  */
 public interface ClayTableSchemaBuilder {
 
+	public <T extends ClayTableSchemaField> T addClayTableSchemaField(
+		Class<T> clazz, String fieldName);
+
+	public <T extends ClayTableSchemaField> T addClayTableSchemaField(
+		Class<T> clazz, String fieldName, String label);
+
 	public void addClayTableSchemaField(
 		ClayTableSchemaField clayTableSchemaField);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/view/table/ClayTableSchemaField.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/view/table/ClayTableSchemaField.java
@@ -14,6 +14,11 @@
 
 package com.liferay.frontend.taglib.clay.data.set.view.table;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
 /**
  * @author Marco Leo
  */
@@ -81,6 +86,43 @@ public class ClayTableSchemaField {
 
 	public void setSortingOrder(SortingOrder sortingOrder) {
 		_sortingOrder = sortingOrder;
+	}
+
+	public JSONObject toJSONObject() {
+		return JSONUtil.put(
+			"actionId", getActionId()
+		).put(
+			"contentRenderer", getContentRenderer()
+		).put(
+			"contentRendererModuleURL", getContentRendererModuleURL()
+		).put(
+			"expand", isExpand()
+		).put(
+			"fieldName",
+			() -> {
+				String fieldName = getFieldName();
+
+				if (fieldName.contains(StringPool.PERIOD)) {
+					return StringUtil.split(fieldName, StringPool.PERIOD);
+				}
+
+				return fieldName;
+			}
+		).put(
+			"sortable", isSortable()
+		).put(
+			"sortingOrder",
+			() -> {
+				ClayTableSchemaField.SortingOrder sortingOrder =
+					getSortingOrder();
+
+				if (sortingOrder != null) {
+					return StringUtil.toLowerCase(sortingOrder.toString());
+				}
+
+				return null;
+			}
+		);
 	}
 
 	public enum SortingOrder {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/view/table/ClobTypeClayTableSchemaField.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/view/table/ClobTypeClayTableSchemaField.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.data.set.view.table;
+
+import com.liferay.portal.kernel.json.JSONObject;
+
+/**
+ * @author Marcela Cunha
+ */
+public class ClobTypeClayTableSchemaField extends ClayTableSchemaField {
+
+	public boolean isTruncate() {
+		return _truncate;
+	}
+
+	public void setTruncate(boolean truncate) {
+		_truncate = truncate;
+	}
+
+	@Override
+	public JSONObject toJSONObject() {
+		JSONObject clayTableSchemaFieldJSONObject = super.toJSONObject();
+
+		return clayTableSchemaFieldJSONObject.put("truncate", isTruncate());
+	}
+
+	private boolean _truncate;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/view/table/DateClayTableSchemaField.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/view/table/DateClayTableSchemaField.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.data.set.view.table;
+
+import com.liferay.portal.kernel.json.JSONObject;
+
+/**
+ * @author Guilherme Camacho
+ */
+public class DateClayTableSchemaField extends ClayTableSchemaField {
+
+	public DateClayTableSchemaField() {
+		setContentRenderer("date");
+	}
+
+	public String getFormat() {
+		return _format;
+	}
+
+	public boolean isWithoutTime() {
+		return _withoutTime;
+	}
+
+	public void setFormat(String format) {
+		_format = format;
+	}
+
+	public void setWithoutTime(boolean withoutTime) {
+		_withoutTime = withoutTime;
+	}
+
+	@Override
+	public JSONObject toJSONObject() {
+		JSONObject clayTableSchemaFieldJSONObject = super.toJSONObject();
+
+		return clayTableSchemaFieldJSONObject.put(
+			"format", getFormat()
+		).put(
+			"withoutTime", isWithoutTime()
+		);
+	}
+
+	private String _format;
+	private boolean _withoutTime;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/data/set/view/table/ClayTableSchemaBuilderImpl.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/data/set/view/table/ClayTableSchemaBuilderImpl.java
@@ -27,6 +27,38 @@ import java.util.Map;
 public class ClayTableSchemaBuilderImpl implements ClayTableSchemaBuilder {
 
 	@Override
+	public <T extends ClayTableSchemaField> T addClayTableSchemaField(
+		Class<T> clazz, String fieldName) {
+
+		ClayTableSchemaField clayTableSchemaField = null;
+
+		try {
+			clayTableSchemaField = clazz.newInstance();
+
+			clayTableSchemaField.setFieldName(fieldName);
+
+			_clayTableSchemaFieldsMap.put(fieldName, clayTableSchemaField);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+
+		return clazz.cast(clayTableSchemaField);
+	}
+
+	@Override
+	public <T extends ClayTableSchemaField> T addClayTableSchemaField(
+		Class<T> clazz, String fieldName, String label) {
+
+		ClayTableSchemaField clayTableSchemaField = addClayTableSchemaField(
+			clazz, fieldName);
+
+		clayTableSchemaField.setLabel(label);
+
+		return clazz.cast(clayTableSchemaField);
+	}
+
+	@Override
 	public void addClayTableSchemaField(
 		ClayTableSchemaField clayTableSchemaField) {
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/data/set/view/table/TableClayDataSetContentRendererContextContributor.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/data/set/view/table/TableClayDataSetContentRendererContextContributor.java
@@ -23,10 +23,10 @@ import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaField
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Collections;
@@ -83,46 +83,11 @@ public class TableClayDataSetContentRendererContextContributor
 				label = StringPool.BLANK;
 			}
 
+			JSONObject clayTableSchemaFieldJSONObject =
+				clayTableSchemaField.toJSONObject();
+
 			fieldsJSONArray.put(
-				JSONUtil.put(
-					"actionId", clayTableSchemaField.getActionId()
-				).put(
-					"contentRenderer", clayTableSchemaField.getContentRenderer()
-				).put(
-					"contentRendererModuleURL",
-					clayTableSchemaField.getContentRendererModuleURL()
-				).put(
-					"expand", clayTableSchemaField.isExpand()
-				).put(
-					"fieldName",
-					() -> {
-						String fieldName = clayTableSchemaField.getFieldName();
-
-						if (fieldName.contains(StringPool.PERIOD)) {
-							return StringUtil.split(
-								fieldName, StringPool.PERIOD);
-						}
-
-						return fieldName;
-					}
-				).put(
-					"label", label
-				).put(
-					"sortable", clayTableSchemaField.isSortable()
-				).put(
-					"sortingOrder",
-					() -> {
-						ClayTableSchemaField.SortingOrder sortingOrder =
-							clayTableSchemaField.getSortingOrder();
-
-						if (sortingOrder != null) {
-							return StringUtil.toLowerCase(
-								sortingOrder.toString());
-						}
-
-						return null;
-					}
-				));
+				clayTableSchemaFieldJSONObject.put("label", label));
 		}
 
 		return HashMapBuilder.<String, Object>put(

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/data/set/view/table/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/data/set/view/table/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 2.0.0

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectPortlet.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectPortlet.testcase
@@ -202,11 +202,11 @@ definition {
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject");
 
-		ObjectPortlet.addSingleFieldEntryViaUI(entry = "01-01-2001");
+		ObjectPortlet.addSingleFieldEntryViaUI(entry = "01/01/2001");
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject");
 
-		ObjectPortlet.viewEntry(entry = "2001-01-01");
+		ObjectPortlet.viewEntry(entry = "01/01/2001");
 	}
 
 	@description = "LPS-135396 - Verify it is possible to add a Double field on layout"
@@ -887,13 +887,13 @@ definition {
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject");
 
 		ObjectPortlet.updateEntry(
-			entry = "2001-01-01",
-			updateEntry = "02-02-2002");
+			entry = "01/01/2001",
+			updateEntry = "02/02/2002");
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject");
 
-		ObjectPortlet.assertEntryNotPresent(entry = "2001-01-01");
-		ObjectPortlet.viewEntry(entry = "2002-02-02");
+		ObjectPortlet.assertEntryNotPresent(entry = "01/01/2001");
+		ObjectPortlet.viewEntry(entry = "02/02/2002");
 	}
 
 	@description = "LPS-135396 - Verify it is possible to edit a Double entry on layout"
@@ -1770,11 +1770,11 @@ definition {
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject");
 
-		ObjectPortlet.viewEntryDetails(entry = "2001-01-01");
+		ObjectPortlet.viewEntryDetails(entry = "01/01/2001");
 
 		ObjectPortlet.assertEntryDetailsLabelPresent(entryLabel = "Field");
 
-		ObjectPortlet.assertEntryDetailsValuePresent(entryValue = "2001-01-01");
+		ObjectPortlet.assertEntryDetailsValuePresent(entryValue = "01/01/2001");
 	}
 
 	@description = "LPS-135396 - Verify it is possible to view a Double entry and label on layout"

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectsPopulating.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectsPopulating.testcase
@@ -256,7 +256,7 @@ definition {
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject");
 
-		ObjectPortlet.viewEntry(entry = "2001-01-01");
+		ObjectPortlet.viewEntry(entry = "01/01/2001");
 	}
 
 	@description = "LPS-133365 - Verify if it's possible to map an Object field of Double type and view its entries"
@@ -503,8 +503,6 @@ definition {
 	@description = "LPS-136451 - Verify if it's possible to see the entries of a field with capitalized letters in the name"
 	@priority = "4"
 	test FieldWithCapitalizedLetters {
-		property portal.acceptance = "true";
-
 		ObjectAdmin.addObjectViaAPI(
 			labelName = "Custom Object",
 			objectName = "CustomObject",
@@ -551,7 +549,7 @@ definition {
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject");
 
-		ObjectPortlet.viewEntry(entry = "2001-01-01");
+		ObjectPortlet.viewEntry(entry = "01/01/2001");
 	}
 
 }

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/taglib/clay/data/set/view/table/ObjectEntriesTableClayDataSetDisplayView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/taglib/clay/data/set/view/table/ObjectEntriesTableClayDataSetDisplayView.java
@@ -20,6 +20,7 @@ import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaBuild
 import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaBuilderFactory;
 import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaField;
 import com.liferay.frontend.taglib.clay.data.set.view.table.ClobTypeClayTableSchemaField;
+import com.liferay.frontend.taglib.clay.data.set.view.table.DateClayTableSchemaField;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -82,6 +83,17 @@ public class ObjectEntriesTableClayDataSetDisplayView
 				clobTypeClayTableSchemaField.setTruncate(true);
 
 				clayTableSchemaField = clobTypeClayTableSchemaField;
+			}
+			else if (Objects.equals(objectField.getType(), "Date")) {
+				DateClayTableSchemaField dateClayTableSchemaField =
+					clayTableSchemaBuilder.addClayTableSchemaField(
+						DateClayTableSchemaField.class, fieldName,
+						objectField.getLabel(locale, true));
+
+				dateClayTableSchemaField.setFormat("short");
+				dateClayTableSchemaField.setWithoutTime(true);
+
+				clayTableSchemaField = dateClayTableSchemaField;
 			}
 			else {
 				clayTableSchemaField =

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/taglib/clay/data/set/view/table/ObjectEntriesTableClayDataSetDisplayView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/taglib/clay/data/set/view/table/ObjectEntriesTableClayDataSetDisplayView.java
@@ -19,6 +19,7 @@ import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchema;
 import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaBuilder;
 import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaBuilderFactory;
 import com.liferay.frontend.taglib.clay.data.set.view.table.ClayTableSchemaField;
+import com.liferay.frontend.taglib.clay.data.set.view.table.ClobTypeClayTableSchemaField;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -70,14 +71,30 @@ public class ObjectEntriesTableClayDataSetDisplayView
 				fieldName = fieldName + ".name";
 			}
 
-			ClayTableSchemaField clayTableSchemaField =
+			ClayTableSchemaField clayTableSchemaField = null;
+
+			if (Objects.equals(objectField.getType(), "Clob")) {
+				ClobTypeClayTableSchemaField clobTypeClayTableSchemaField =
+					clayTableSchemaBuilder.addClayTableSchemaField(
+						ClobTypeClayTableSchemaField.class, fieldName,
+						objectField.getLabel(locale, true));
+
+				clobTypeClayTableSchemaField.setTruncate(true);
+
+				clayTableSchemaField = clobTypeClayTableSchemaField;
+			}
+			else {
 				clayTableSchemaField =
 					clayTableSchemaBuilder.addClayTableSchemaField(
 						fieldName, objectField.getLabel(locale, true));
 
-			if (Objects.equals(objectField.getType(), "Boolean")) {
-				clayTableSchemaField.setContentRenderer("boolean");
+				if (Objects.equals(objectField.getType(), "Boolean")) {
+					clayTableSchemaField.setContentRenderer("boolean");
+				}
 			}
+
+			clayTableSchemaBuilder.addClayTableSchemaField(
+				clayTableSchemaField);
 
 			if (!Objects.equals(objectField.getType(), "Blob") &&
 				objectField.isIndexed()) {


### PR DESCRIPTION
Resending #1712 

Hello team :smile: 

We, from the objects team, need to make some adjustments in the frontend-data-set taglib implementation because we need:

Truncate long text in the data table view (We have a story implementing a new field type named Clob, which accepts long text - [LPS-142659](https://issues.liferay.com/browse/LPS-142659))
Display the date field in a user-friendly format ([LPS-139738](https://issues.liferay.com/browse/LPS-139738))
We would like to ask for a review of our changes from the infra team, please. This PR is a proposal of a possible solution to our cases. If you have any questions, please let us know.

@liferay-objects @marcelabc 