### PR TITLE
[TS] LPS-143091 - Cards Dropdown is shown when no elements are passed

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/normalize_dropdown_items.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/normalize_dropdown_items.js
@@ -81,7 +81,7 @@ export default function normalizeDropdownItems(items) {
 	const filteredItems = filterEmptyGroups(items);
 
 	if (filteredItems.length === 0) {
-		return [];
+		return null;
 	}
 
 	return addSeparators(filteredItems.map(spreadDataAttributes));


### PR DESCRIPTION
This fixes case https://issues.liferay.com/browse/LPS-143091

List options is showed when users have only view permissions over webcontent templates. Since they have no permissions, it is empty (see image attached)

Steps to reproduce:

1. Create a new site 'editor' rol including only view permissions for web content structures and web content templates.
2. Add a new user, make him member of Liferay DXP site and assign him with the new role.
3. Add a new structure 'test' and template 'test' for that structure.
4. Log in with the new user.
5. Acces web content templates tab and configure the cards/icon view.

**Expected result**: user just sees 'test' with no dropdown menu available.

**Current result:** user sees 'test' and is able to click on the actions menu (three ellipsis button), and an empty list shows up.
![empty_list](https://user-images.githubusercontent.com/29747802/144405806-a8963c69-139a-4b21-95a9-fad2cdfbc257.PNG)

It does not break https://issues.liferay.com/browse/LPS-136174