### PR TITLE
LPS-142702 Fix bug with duplicate externalReferenceCode in APIs returning 500 instead of 400 Bad Request

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/ExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/ExceptionMapper.java
@@ -30,6 +30,22 @@ public class ExceptionMapper extends BaseExceptionMapper<Exception> {
 
 	@Override
 	public Response toResponse(Exception exception) {
+		Class<? extends Exception> exceptionClass = exception.getClass();
+
+		String exceptionClassName = exceptionClass.getSimpleName();
+
+		if (exceptionClassName.startsWith("Duplicate") &&
+			exceptionClassName.endsWith("ExternalReferenceCodeException")) {
+
+			return Response.status(
+				Response.Status.BAD_REQUEST
+			).entity(
+				exception.getMessage()
+			).type(
+				getMediaType()
+			).build();
+		}
+
 		Throwable throwable = exception.getCause();
 
 		if (throwable == null) {


### PR DESCRIPTION
A new approach just adding the condition to the general ExceptionMapper in Vulcan Impl.

The resulting code is a little ugly but this way we avoid changing so many classes and breaking major versions.

Should be an exception to avoid this class getting bigger with a lot of conditions.

---

Original messages:

When a new POST request is made with an existing external reference code, the APIs are returning a 500 error instead of a 400 Bad Request error.

Steps to reproduce:
Create a blog entry like this through the API (sites/{siteId}/blog-postings):

{ "articleBody": "potato", "description": "something", "externalReferenceCode": "myCode", "headline": "my blog entry" }
Create another blog entry like this through the API (sites/{siteId}/blog-postings):

{ "articleBody": "potato", "description": "something", "externalReferenceCode": "myCode", "headline": "my blog entry 2"}
Expected result: 400 Bad Request

Result: 500 Internal Server Error

I've created a new Exception Mapper to catch this kind of exceptions and return the correct error code. To handle all different Duplicate...ExternalReferenceCode exceptions I had to add a new exception in the middle of the hierarchy between those exceptions and PortalException.

This change causes breaking changes in the exception packages. I'm not sure if these are dangerous breaking changes for clients...