### PR TITLE
[TS] LPS-143091 - Cards Dropdown is shown when no elements are passed

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -40,7 +40,7 @@ export default function DropdownMenu({
 				className={classNames({
 					'dropdown-action': actionsDropdown,
 				})}
-				items={normalizeDropdownItems(items)}
+				items={normalizeDropdownItems(items) || []}
 				trigger={
 					<ClayButton
 						className={classNames(cssClass, {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/UserCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/UserCard.js
@@ -13,7 +13,7 @@
  */
 
 import {ClayCardWithUser} from '@clayui/card';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS} from '../constants';
 import normalizeDropdownItems from '../normalize_dropdown_items';
@@ -33,6 +33,10 @@ export default function UserCard({
 	symbol,
 	...otherProps
 }) {
+	const normalizedActions = useMemo(() => normalizeDropdownItems(actions), [
+		actions,
+	]);
+
 	const [selected, setSelected] = useState(initialSelected);
 
 	const handleToggleAllItems = useCallback(
@@ -58,7 +62,7 @@ export default function UserCard({
 
 	return (
 		<ClayCardWithUser
-			actions={normalizeDropdownItems(actions)}
+			actions={normalizedActions}
 			checkboxProps={{
 				name: inputName ?? '',
 				value: inputValue ?? '',

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
@@ -54,6 +54,10 @@ export default function VerticalCard({
 	title,
 	...otherProps
 }) {
+	const normalizedActions = useMemo(() => normalizeDropdownItems(actions), [
+		actions,
+	]);
+
 	const [selected, setSelected] = useState(initialSelected);
 
 	const stickerProps = useMemo(() => {
@@ -110,7 +114,7 @@ export default function VerticalCard({
 
 	return (
 		<ClayCardWithInfo
-			actions={normalizeDropdownItems(actions)}
+			actions={normalizedActions}
 			checkboxProps={{
 				name: inputName ?? '',
 				value: inputValue ?? '',

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
@@ -15,7 +15,7 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayManagementToolbar from '@clayui/management-toolbar';
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import normalizeDropdownItems from '../normalize_dropdown_items';
 import LinkOrButton from './LinkOrButton';
@@ -47,6 +47,16 @@ const ActionControls = ({
 	disabled,
 	onActionButtonClick,
 }) => {
+	const items = useMemo(
+		() =>
+			normalizeDropdownItems(
+				actionDropdownItems?.map((item) =>
+					addAction(item, onActionButtonClick)
+				)
+			) || [],
+		[actionDropdownItems, onActionButtonClick]
+	);
+
 	return (
 		<>
 			{actionDropdownItems && (
@@ -79,11 +89,7 @@ const ActionControls = ({
 
 					<ClayManagementToolbar.Item>
 						<ClayDropDownWithItems
-							items={normalizeDropdownItems(
-								actionDropdownItems?.map((item) =>
-									addAction(item, onActionButtonClick)
-								)
-							)}
+							items={items}
 							trigger={
 								<ClayButtonWithIcon
 									className="nav-link nav-link-monospaced"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/normalize_dropdown_items.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/normalize_dropdown_items.js
@@ -81,7 +81,7 @@ export default function normalizeDropdownItems(items) {
 	const filteredItems = filterEmptyGroups(items);
 
 	if (filteredItems.length === 0) {
-		return [];
+		return null;
 	}
 
 	return addSeparators(filteredItems.map(spreadDataAttributes));


### PR DESCRIPTION
This is a resend from: https://github.com/liferay-frontend/liferay-portal/pull/1714

> This fixes case https://issues.liferay.com/browse/LPS-143091
> 
> List options is showed when users have only view permissions over webcontent templates. Since they have no permissions, it is empty (see image attached)
> 
> Steps to reproduce:
> 
> 1. Create a new site 'editor' rol including only view permissions for web content structures and web content templates.
> 2. Add a new user, make him member of Liferay DXP site and assign him with the new role.
> 3. Add a new structure 'test' and template 'test' for that structure.
> 4. Log in with the new user.
> 5. Acces web content templates tab and configure the cards/icon view.
> 
> **Expected result**: user just sees 'test' with no dropdown menu available.
> 
> **Current result:** user sees 'test' and is able to click on the actions menu (three ellipsis button), and an empty list shows up.
> ![empty_list](https://user-images.githubusercontent.com/29747802/144405806-a8963c69-139a-4b21-95a9-fad2cdfbc257.PNG)
> 
> It does not break https://issues.liferay.com/browse/LPS-136174