### PR TITLE
LPS-141229 Add test that verifies a Custom Element can be deleted

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -34,6 +34,13 @@ definition {
 		PortletEntry.publish();
 	}
 
+	macro assertTableEntryNameNotPresent {
+		AssertElementNotPresent(
+			key_tableEntryName = "${entryName}",
+			locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE",
+			value1 = "${entryName}");
+	}
+
 	macro deleteRemoteApp {
 		Click(locator1 = "RemoteApps#REMOTE_TABLE_ELLIPSIS");
 
@@ -49,7 +56,7 @@ definition {
 
 		RemoteApps.goToRemoteAppsPortlet();
 
-		RemoteApps.viewTableEntryNameNotPresent(entryName = "${remoteAppNameToBeRemoved}");
+		RemoteApps.assertTableEntryNameNotPresent(entryName = "${remoteAppNameToBeRemoved}");
 	}
 
 	macro getRemoteAppEntryName {
@@ -97,13 +104,6 @@ definition {
 
 	macro viewTableEntryName {
 		AssertTextEquals(
-			key_tableEntryName = "${entryName}",
-			locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE",
-			value1 = "${entryName}");
-	}
-
-	macro viewTableEntryNameNotPresent {
-		AssertElementNotPresent(
 			key_tableEntryName = "${entryName}",
 			locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE",
 			value1 = "${entryName}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteApp.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteApp.macro
@@ -1,5 +1,16 @@
 definition {
 
+	macro addCustomElementRemoteAppEntry {
+		Variables.assertDefined(parameterList = "${customElementName},${customElementHTMLName},${customElementURL}");
+
+		var response = JSONRemoteAppAPI._addCustomElementRemoteAppEntry(
+			customElementHTMLName = "${customElementHTMLName}",
+			customElementName = "${customElementName}",
+			customElementURL = "${customElementURL}");
+
+		return "{response}";
+	}
+
 	macro addIFrameRemoteAppEntry {
 		Variables.assertDefined(parameterList = "${iFrameURL},${name}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteAppAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteAppAPI.macro
@@ -1,5 +1,33 @@
 definition {
 
+	macro _addCustomElementRemoteAppEntry {
+		Variables.assertDefined(parameterList = "${customElementName},${customElementHTMLName},${customElementURL}");
+
+		var customElementURLModified = StringUtil.replace("${customElementURL}", ":", "%3A");
+		var nameModified = StringUtil.replace("${customElementName}", " ", "%20");
+		var htmlNameModified = StringUtil.replace("${customElementHTMLName}", " ", "%20");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/api/jsonws/remoteapp.remoteappentry/add-custom-element-remote-app-entry \
+				  -u test@liferay.com:test \
+				  -d customElementCSSURLs= \
+				  -d customElementHTMLElementName=${htmlNameModified} \
+				  -d customElementURLs=${customElementURLModified} \
+				  -d description= \
+				  -d friendlyURLMapping= \
+				  -d instanceable=true \
+				  -d nameMap='{\"en_US\":\"${nameModified}\"}' \
+				  -d portletCategoryName=RemoteApps \
+				  -d properties= \
+				  -d sourceCodeURL=
+		''';
+		var remoteAppEntryID = JSONCurlUtil.post("${curl}", "$.['remoteAppEntryId']");
+
+		return "${remoteAppEntryID}";
+	}
+
 	macro _addIFrameRemoteAppEntry {
 		Variables.assertDefined(parameterList = "${iFrameURL},${name}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -38,7 +38,7 @@ definition {
 
 		RemoteApps.deleteRemoteApp(tableEntry = "${remoteAppName}");
 
-		RemoteApps.viewTableEntryNameNotPresent(entryName = "${remoteAppName}");
+		RemoteApps.assertTableEntryNameNotPresent(entryName = "${remoteAppName}");
 	}
 
 	@description = "Verify that remote app of type Custom Element can be created"
@@ -75,12 +75,14 @@ definition {
 				customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
 		}
 
-		task ("Delete Vanilla Counter and check that has been deleted") {
+		task ("Delete Vanilla Counter") {
 			RemoteApps.goToRemoteAppsPortlet();
 
 			RemoteApps.deleteRemoteApp(tableEntry = "${customElementName}");
+		}
 
-			RemoteApps.viewTableEntryNameNotPresent(entryName = "${customElementName}");
+		task ("Assert that Vanilla Counter has been deleted") {
+			RemoteApps.assertTableEntryNameNotPresent(entryName = "${customElementName}");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -63,6 +63,28 @@ definition {
 			entryType = "${customElementType}");
 	}
 
+	@description = "Verify that remote app of type Custom Element can be deleted"
+	@priority = "4"
+	test CustomElementCanBeDeleted {
+		property portal.acceptance = "true";
+
+		var customElementName = "Vanilla Counter";
+		var customElementType = "Custom Element";
+		var customElementHTMLName = "vanilla-counter";
+		var customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js";
+
+		RemoteApps.goToRemoteAppsPortlet();
+
+		RemoteApps.addCustomElement(
+			entryHTMLName = "${customElementHTMLName}",
+			entryName = "${customElementName}",
+			entryURL = "${customElementURL}");
+
+		RemoteApps.deleteRemoteApp(tableEntry = "${customElementName}");
+
+		RemoteApps.viewTableEntryNameNotPresent(entryName = "${customElementName}");
+	}
+
 	@description = "Verify that remote app of type Custom Element can be displayed by portlet"
 	@priority = "5"
 	test CustomElementCanBeDisplayedByPortlet {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -68,21 +68,20 @@ definition {
 	test CustomElementCanBeDeleted {
 		property portal.acceptance = "true";
 
-		var customElementName = "Vanilla Counter";
-		var customElementType = "Custom Element";
-		var customElementHTMLName = "vanilla-counter";
-		var customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js";
+		task ("Create Vanilla Counter as a Custom Element") {
+			JSONRemoteApp.addCustomElementRemoteAppEntry(
+				customElementHTMLName = "vanilla-counter",
+				customElementName = "Vanilla Counter",
+				customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+		}
 
-		RemoteApps.goToRemoteAppsPortlet();
+		task ("Delete Vanilla Counter and check that has been deleted") {
+			RemoteApps.goToRemoteAppsPortlet();
 
-		RemoteApps.addCustomElement(
-			entryHTMLName = "${customElementHTMLName}",
-			entryName = "${customElementName}",
-			entryURL = "${customElementURL}");
+			RemoteApps.deleteRemoteApp(tableEntry = "${customElementName}");
 
-		RemoteApps.deleteRemoteApp(tableEntry = "${customElementName}");
-
-		RemoteApps.viewTableEntryNameNotPresent(entryName = "${customElementName}");
+			RemoteApps.viewTableEntryNameNotPresent(entryName = "${customElementName}");
+		}
 	}
 
 	@description = "Verify that remote app of type Custom Element can be displayed by portlet"


### PR DESCRIPTION
**Test Scenario**:
1. Using JSON, add a Custom Element (**Vanilla Counter**).
2. Delete **Vanilla Counter**.
3. Check that **Vanilla Counter** can be deleted.

**What new?**
- RemoteApps.CustomElementCanBeDeleted -> Test verifies that a Custom Element can be deleted.

**JIRA Ticket:** https://issues.liferay.com/browse/LPS-141229