### PR TITLE
LPS-134172 Change value of the relationship name of nestedFields and allow filter by relationshipId

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -219,7 +220,8 @@ public class ObjectEntryDTOConverter
 				if (serializable != null) {
 					objectEntryId = (long)serializable;
 
-					String relationshipName = objectFieldNameParts[1];
+					String relationshipName = StringUtil.replaceLast(
+						relationshipIdName, "Id", "");
 
 					Optional<UriInfo> uriInfoOptional =
 						dtoConverterContext.getUriInfoOptional();

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -20,6 +20,7 @@ import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.internal.odata.entity.v1_0.ObjectEntryEntityModel;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.scope.ObjectScopeProvider;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -41,6 +42,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -62,11 +64,32 @@ public class ObjectDefinitionGraphQLDTOContributor
 				objectDefinition.getPKObjectFieldName(), Long.class));
 
 		for (ObjectField objectField : objectFields) {
-			graphQLDTOProperties.add(
-				GraphQLDTOProperty.of(
-					objectField.getName(),
-					_typedClasses.getOrDefault(
-						objectField.getType(), Object.class)));
+			if (Objects.equals(
+					objectField.getRelationshipType(), "oneToMany")) {
+
+				String objectFieldName = objectField.getName();
+
+				String[] objectFieldNameParts = objectFieldName.split(
+					StringPool.UNDERLINE);
+
+				String relationshipIdName = objectFieldNameParts[3];
+
+				graphQLDTOProperties.add(
+					GraphQLDTOProperty.of(relationshipIdName, Long.class));
+
+				String relationshipName = StringUtil.replaceLast(
+					relationshipIdName, "Id", "");
+
+				graphQLDTOProperties.add(
+					GraphQLDTOProperty.of(relationshipName, Object.class));
+			}
+			else {
+				graphQLDTOProperties.add(
+					GraphQLDTOProperty.of(
+						objectField.getName(),
+						_typedClasses.getOrDefault(
+							objectField.getType(), Object.class)));
+			}
 		}
 
 		return new ObjectDefinitionGraphQLDTOContributor(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -15,6 +15,7 @@
 package com.liferay.object.rest.internal.odata.entity.v1_0;
 
 import com.liferay.object.model.ObjectField;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.odata.entity.BooleanEntityField;
@@ -73,12 +74,29 @@ public class ObjectEntryEntityModel implements EntityModel {
 		).build();
 
 		for (ObjectField objectField : objectFields) {
-			_getEntityField(
-				objectField
-			).ifPresent(
-				entityField -> _entityFieldsMap.put(
-					objectField.getName(), entityField)
-			);
+			if (Objects.equals(
+					objectField.getRelationshipType(), "oneToMany")) {
+
+				String objectFieldName = objectField.getName();
+
+				String[] objectFieldNameParts = objectFieldName.split(
+					StringPool.UNDERLINE);
+
+				_entityFieldsMap.put(
+					objectFieldNameParts[3],
+					new IntegerEntityField(
+						objectFieldNameParts[3],
+						locale ->
+							"nestedFieldArray.value_long#" + objectFieldName));
+			}
+			else {
+				_getEntityField(
+					objectField
+				).ifPresent(
+					entityField -> _entityFieldsMap.put(
+						objectField.getName(), entityField)
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
After experimenting with the usage of object relationship nested fields we felt necessary to change the value used by the nestedField to be the name of the relation object.

I've also added the relationship object id to GraphQL and allow to filter by it

/cc @guilhermedcamacho