### PR TITLE
LPS-143592 Add support for aggregations of Object Fields and Object Relationships

### DIFF
--- a/modules/apps/object/object-rest-impl/build.gradle
+++ b/modules/apps/object/object-rest-impl/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:object:object-rest-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
+	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
@@ -21,6 +21,7 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.internal.dto.v1_0.converter.ObjectEntryDTOConverter;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
+import com.liferay.object.rest.internal.search.aggregation.AggregationUtil;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
@@ -40,6 +41,10 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.aggregation.Aggregations;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -199,6 +204,12 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 					objectDefinition.getObjectDefinitionId());
 				searchContext.setCompanyId(companyId);
 				searchContext.setGroupIds(new long[] {groupId});
+
+				SearchRequestBuilder searchRequestBuilder =
+					_searchRequestBuilderFactory.builder(searchContext);
+
+				AggregationUtil.processVulcanAggregation(
+					_aggregations, _queries, searchRequestBuilder, aggregation);
 			},
 			sorts,
 			document -> getObjectEntry(
@@ -393,6 +404,9 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 	}
 
 	@Reference
+	private Aggregations _aggregations;
+
+	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
@@ -409,5 +423,11 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 
 	@Reference
 	private ObjectScopeProviderRegistry _objectScopeProviderRegistry;
+
+	@Reference
+	private Queries _queries;
+
+	@Reference
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/search/aggregation/AggregationUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/search/aggregation/AggregationUtil.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.search.aggregation;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.search.aggregation.Aggregations;
+import com.liferay.portal.search.aggregation.bucket.FilterAggregation;
+import com.liferay.portal.search.aggregation.bucket.NestedAggregation;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregation;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.vulcan.aggregation.Aggregation;
+
+import java.util.Map;
+
+/**
+ * @author Javier de Arcos
+ */
+public class AggregationUtil {
+
+	public static void processVulcanAggregation(
+		Aggregations aggregations, Queries queries,
+		SearchRequestBuilder searchRequestBuilder,
+		Aggregation vulcanAggregation) {
+
+		if (vulcanAggregation == null) {
+			return;
+		}
+
+		Map<String, String> vulcanAggregationTerms =
+			vulcanAggregation.getAggregationTerms();
+
+		for (Map.Entry<String, String> vulcanAggregationEntry :
+				vulcanAggregationTerms.entrySet()) {
+
+			String aggregationEntryValue = vulcanAggregationEntry.getValue();
+
+			if (!aggregationEntryValue.startsWith("nestedFieldArray")) {
+				continue;
+			}
+
+			String[] aggregationEntryValueParts = aggregationEntryValue.split(
+				StringPool.POUND);
+
+			TermsAggregation termsAggregation = aggregations.terms(
+				vulcanAggregationEntry.getKey(), aggregationEntryValueParts[0]);
+
+			FilterAggregation filterAggregation = aggregations.filter(
+				"filterAggregation",
+				queries.term(
+					"nestedFieldArray.fieldName",
+					aggregationEntryValueParts[1]));
+
+			filterAggregation.addChildAggregation(termsAggregation);
+
+			NestedAggregation nestedAggregation = aggregations.nested(
+				vulcanAggregationEntry.getKey(), "nestedFieldArray");
+
+			nestedAggregation.addChildAggregation(filterAggregation);
+
+			searchRequestBuilder.addAggregation(nestedAggregation);
+		}
+	}
+
+}


### PR DESCRIPTION
The goal of this PR is to provide support for aggregations of Object fields and Object relationships.

These fields were not taken into account because they are nested documents in Elastic.

With this PR we should be capable of aggregating by any object field or relatedObjectId just providing the name of the field or the name of the relationship ending with id. Like "aggregationTerms: name" or "aggregationTerms: churchId".

I follow the same strategy we used in other Headless APIs for content fields and custom fields to provide a quick solution.

Once this solution is validated we can initiate a conversation with the Search team to explore the possibility to provide some kind of infrastructure to allow aggregations of nestedFieldArrays fields by default, as it is supported by the filter and search features