### PR TITLE
LPS-143417 Enable keyboard shortcut for interacting with ActionLinkRenderer

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionLinkRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionLinkRenderer.js
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
 import DataSetContext from '../DataSetContext';
-import {formatActionURL, liferayNavigate} from '../utils/index';
+import {formatActionURL} from '../utils/index';
 import DefaultContent from './DefaultRenderer';
 
 function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
@@ -128,9 +128,7 @@ function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
 				onClick={
 					isNotALink()
 						? handleClickOnLink
-						: (event) => {
-								event.preventDefault();
-
+						: () => {
 								if (
 									currentAction.data &&
 									currentAction.data.confirmationMessage &&
@@ -140,8 +138,6 @@ function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
 								) {
 									return;
 								}
-
-								liferayNavigate(formattedHref);
 						  }
 				}
 			>


### PR DESCRIPTION
# How to view my changes

1. Global Menu -> Control Panel -> Objects
2. Try to click in User link using (CMD + Left Click), inside the Dataset(a.k.a Table)

You'll notice that is impossible to open the link in another tab

# One video >>> words

https://user-images.githubusercontent.com/7663513/145468140-04c49e4a-4b55-4b8e-b017-bbd0cdb100d2.mov

# Changes

* This issue was caused due to a `event.preventDefault` on ClayLink component that disables the user to proper open the link in another tab
* When removing the `event.preventDefault` call, it still buggy because it will perform a SPA navigation even just trying to open the link in the new tab

# Questions

When examining possible regressions, I saw in the blame [this ticket](https://issues.liferay.com/browse/LPS-138619) containing [this commit](https://github.com/liferay/liferay-portal/commit/48105b2f236732f743e8392f78abe04c20da62cd) that introduces this bug. It is not reproducible even with my fix(removing a part of the old fix) but I'm not sure if I left something or not. /cc @guilhermedcamacho @gabrielwas @ rodrigocunhaa