### PR TITLE
LPS-143655 frontend-data-set-web: Add extra open window option

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
@@ -111,6 +111,11 @@ export function handleAction(
 
 		window.open(url);
 	}
+	else if (target === 'self') {
+		event.preventDefault();
+
+		window.open(url, '_self');
+	}
 	else if (onClick) {
 		event.preventDefault();
 
@@ -410,6 +415,8 @@ ActionsDropdownRenderer.propTypes = {
 				'async',
 				'headless',
 				'inlineEdit',
+				'blank',
+				'self',
 			]),
 		})
 	),

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
@@ -111,7 +111,7 @@ export function handleAction(
 
 		window.open(url);
 	}
-	else if (target === 'self') {
+	else if (target === 'download') {
 		event.preventDefault();
 
 		window.open(url, '_self');
@@ -416,7 +416,7 @@ ActionsDropdownRenderer.propTypes = {
 				'headless',
 				'inlineEdit',
 				'blank',
-				'self',
+				'download',
 			]),
 		})
 	),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143655

Hello, for the search experiences module, we're interested in an extra option to open the window with the attribute of "_self" so that an export rest endpoint URL would open in the same frame that it was clicked. Could you let us know if this would be ok to merge? Thank you!

Related to: https://issues.liferay.com/browse/LPS-141042

@thektan