### PR TITLE
[TECHNICAL SUPPORT] LPS-143672 TinyMCE displays video as img

### DIFF
--- a/modules/apps/archived/frontend-editor-tinymce-web/build.gradle
+++ b/modules/apps/archived/frontend-editor-tinymce-web/build.gradle
@@ -7,7 +7,7 @@ configurations {
 
 task buildTinyMCE(type: Copy)
 
-String tinyMCEVersion = "5.1.6"
+String tinyMCEVersion = "5.10.2"
 
 File editorDestinationDir = file("tmp/META-INF/resources")
 File editorSrcDir = file("src/main/resources/META-INF/resources")
@@ -34,6 +34,7 @@ buildTinyMCE {
 		exclude "META-INF/resources/webjars/tinymce/${tinyMCEVersion}/tinymce.jquery.min.js"
 
 		include "META-INF/resources/webjars/tinymce/${tinyMCEVersion}/*.min.js"
+		include "META-INF/resources/webjars/tinymce/${tinyMCEVersion}/icons/**/*.min.js"
 		include "META-INF/resources/webjars/tinymce/${tinyMCEVersion}/license.txt"
 		include "META-INF/resources/webjars/tinymce/${tinyMCEVersion}/plugins/**/*.css"
 		include "META-INF/resources/webjars/tinymce/${tinyMCEVersion}/plugins/**/*.gif"


### PR DESCRIPTION
Hello,
[LPS-143672](https://issues.liferay.com/browse/LPS-143672)
TinyMCE does not display videos properly and it has been fixed in v5.7.0
https://github.com/tinymce/tinymce/pull/6279

In order to fix this issue on DXP 7.2, where we still use and support tinyMCE, I updated tinyMCE to the latest version. I sent this PR to master to ask wether we should make this change here as well and backport it to 7.2.x ?

Please review my change,

Thanks!

/cc @georgel-pop-lr
