### PR TITLE
LPS-143763 Fix filter by name on ListTypeEntry API

### DIFF
--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeEntryEntityModel.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeEntryEntityModel.java
@@ -41,7 +41,7 @@ public class ListTypeEntryEntityModel implements EntityModel {
 			new IntegerEntityField("userId", locale -> Field.USER_ID),
 			new StringEntityField("key", locale -> "key"),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)));
+				"name", locale -> Field.getLocalizedName(locale, Field.NAME)));
 	}
 
 	@Override


### PR DESCRIPTION
The name property filter is not working for ListTypeEntry API

**Steps to reproduce:**

1. Create a ListTypeEntry with a name {givenName}
2. Make an API request using the filter 'name eq "{givenName}"
```
curl -X 'GET' 'http://localhost:8080/o/headless-admin-list-type/v1.0/list-type-definitions/42859/list-type-entries?filter=name%20eq%20%27{givenName}%27' -u 'test@liferay.com:test'
````

**Expected result:** Response has one result
**Result:** No results are shown

This scenario is covered by the **ListTypeEntryResourceTest.testGetListTypeDefinitionListTypeEntriesPageWithFilterStringEquals** integration test.

Modify name field in the ListTypeEntry Entity Model to be considered as a localized field