### PR TITLE
LPS-141231 Add test CustomElementCanBeInstanceable

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -56,6 +56,16 @@
 	<td></td>
 </tr>
 <tr>
+	<td>VANILLA_COUNTER_PAGE_COLUMN_1</td>
+	<td>//div[contains(@id,'main-content')]//div[contains(@class, 'col')][1]//vanilla-counter</td>
+	<td></td>
+</tr>
+<tr>
+	<td>VANILLA_COUNTER_PAGE_COLUMN_2</td>
+	<td>//div[contains(@id,'main-content')]//div[contains(@class, 'col')][2]//vanilla-counter</td>
+	<td></td>
+</tr>
+<tr>
 	<td>VANILLA_COUNTER_REMOTE_APP</td>
 	<td>//vanilla-counter</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -56,13 +56,8 @@
 	<td></td>
 </tr>
 <tr>
-	<td>VANILLA_COUNTER_PAGE_COLUMN_1</td>
-	<td>//div[contains(@id,'main-content')]//div[contains(@class, 'col')][1]//vanilla-counter</td>
-	<td></td>
-</tr>
-<tr>
-	<td>VANILLA_COUNTER_PAGE_COLUMN_2</td>
-	<td>//div[contains(@id,'main-content')]//div[contains(@class, 'col')][2]//vanilla-counter</td>
+	<td>VANILLA_COUNTER_PAGE_COLUMN_N</td>
+	<td>//div[contains(@id,'main-content')]//div[contains(@class, 'col')]['${column_number}']//vanilla-counter</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -129,6 +129,70 @@ definition {
 		}
 	}
 
+	@description = "Verify that remote app of type Custom Element can be instanceable in a Content Page"
+	@priority = "3"
+	test CustomElementCanBeInstanceable {
+		property portal.acceptance = "true";
+
+		task ("Add a public page with JSON") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Test Page",
+				type = "content");
+
+			JSONLayout.publishLayout(
+				groupName = "Guest",
+				layoutName = "Test Page");
+		}
+
+		task ("Create Vanilla Counter as a Custom Element") {
+			JSONRemoteApp.addCustomElementRemoteAppEntry(
+				customElementHTMLName = "vanilla-counter",
+				customElementName = "Vanilla Counter",
+				customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+		}
+
+		task ("Add a Grid to page") {
+			ContentPagesNavigator.openEditContentPage(
+				pageName = "Test Page",
+				siteName = "Guest");
+
+			PageEditor.addFragment(
+				collectionName = "Layout Elements",
+				fragmentName = "Grid");
+		}
+
+		task ("Change the Number of Modules to 2") {
+			PageEditor.editLayoutGrid(
+				columnCount = "2",
+				panel = "General");
+		}
+
+		task ("Add Vanilla Counter in each module") {
+			for (var n : list "1,2") {
+				PageEditor.addElementToColumn(
+					columnNumber = "${n}",
+					navTab = "Widgets",
+					portletName = "Vanilla Counter");
+
+				AssertElementPresent(
+					key_columnNumber = "${n}",
+					key_position = "1",
+					locator1 = "PageEditor#GRID_COLUMN");
+			}
+
+			PageEditor.clickPublish();
+		}
+
+		task ("Assert Vanilla Counter is instanceable") {
+			Navigator.gotoPage(pageName = "Test Page");
+
+			AssertElementPresent(locator1 = "RemoteApps#VANILLA_COUNTER_PAGE_COLUMN_1");
+
+			AssertElementPresent(locator1 = "RemoteApps#VANILLA_COUNTER_PAGE_COLUMN_2");
+		}
+	}
+
 	@description = "Verify an iframe remote app can be created"
 	@priority = "5"
 	test IFrameCanBeCreated {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -174,11 +174,6 @@ definition {
 					columnNumber = "${n}",
 					navTab = "Widgets",
 					portletName = "Vanilla Counter");
-
-				AssertElementPresent(
-					key_columnNumber = "${n}",
-					key_position = "1",
-					locator1 = "PageEditor#GRID_COLUMN");
 			}
 
 			PageEditor.clickPublish();
@@ -187,9 +182,11 @@ definition {
 		task ("Assert Vanilla Counter is instanceable") {
 			Navigator.gotoPage(pageName = "Test Page");
 
-			AssertElementPresent(locator1 = "RemoteApps#VANILLA_COUNTER_PAGE_COLUMN_1");
-
-			AssertElementPresent(locator1 = "RemoteApps#VANILLA_COUNTER_PAGE_COLUMN_2");
+			for (var n : list "1,2") {
+				AssertElementPresent(
+					column_number = "${n}",
+					locator1 = "RemoteApps#VANILLA_COUNTER_PAGE_COLUMN_N");
+			}
 		}
 	}
 


### PR DESCRIPTION
**Test Scenario:**

Using JSON, add a Custom Element (Vanilla Counter) instanceable.
Using JSON, create a Content Page.
Add a Grid widget with two modules in the Content Page.
Display two Vanilla Counters in both modules
Check that Vanilla Counter can be instanceable.

**What new?**

RemoteApps.CustomElementCanBeInstanceable -> Test verifies that a Custom Element can be instanceable.

**JIRA Ticket**: https://issues.liferay.com/browse/LPS-141231