### PR TITLE
LPS-143417 Enable keyboard shortcut for interacting with FDS `ActionLinkRenderer`

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionLinkRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionLinkRenderer.js
@@ -14,12 +14,12 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
-import {openToast} from 'frontend-js-web';
+import {navigate, openToast} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
 import DataSetContext from '../DataSetContext';
-import {formatActionURL, liferayNavigate} from '../utils/index';
+import {formatActionURL} from '../utils/index';
 import DefaultContent from './DefaultRenderer';
 
 function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
@@ -129,19 +129,16 @@ function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
 					isNotALink()
 						? handleClickOnLink
 						: (event) => {
-								event.preventDefault();
+								const confirmMessage =
+									currentAction.data?.confirmationMessage;
 
-								if (
-									currentAction.data &&
-									currentAction.data.confirmationMessage &&
-									!confirm(
-										currentAction.data.confirmationMessage
-									)
-								) {
-									return;
+								if (confirmMessage) {
+									event.preventDefault();
+
+									if (confirm(confirmMessage)) {
+										navigate(formattedHref);
+									}
 								}
-
-								liferayNavigate(formattedHref);
 						  }
 				}
 			>


### PR DESCRIPTION
This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/1737

As @diegonvs is on PTO, I'm jumping in to update the PR.

The previous solution was not entirely correct, as @victorg1991 noted in https://github.com/liferay-frontend/liferay-portal/pull/1737#issuecomment-994722801

In this PR:
- We are preventing default link behavior **only** if confirm message is set.
- We are using the standard `navigate` utility for navigation.