### PR TITLE
LPS-141042 Create a download option for exporting blueprints/elements

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
@@ -24,7 +24,7 @@ import React, {useContext, useState} from 'react';
 
 import DataSetContext from '../DataSetContext';
 import {ACTION_ITEM_TARGETS} from '../utils/actionItems/constants';
-import {formatActionURL} from '../utils/index';
+import {executeAsyncAction, formatActionURL} from '../utils/index';
 import {openPermissionsModal, resolveModalSize} from '../utils/modals/index';
 
 const {MODAL_PERMISSIONS} = ACTION_ITEM_TARGETS;
@@ -110,6 +110,60 @@ export function handleAction(
 		event.preventDefault();
 
 		window.open(url);
+	}
+	else if (target === 'download') {
+		event.preventDefault();
+
+		setLoading(true);
+		let filename = '';
+
+		executeAsyncAction(url, method)
+			.then((response) => {
+				const disposition = response.headers.get('Content-Disposition');
+
+				if (disposition && disposition.indexOf('attachment') !== -1) {
+					const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+					const matchesRegex = filenameRegex.exec(disposition);
+					if (matchesRegex !== null && matchesRegex[1]) {
+						filename = matchesRegex[1].replace(/['"]/g, '');
+					}
+				}
+
+				return response.blob();
+			})
+			.then((responseBlob) => {
+				const downloadUrl = URL.createObjectURL(responseBlob);
+				const downloadElement = document.createElement('a');
+
+				if (
+					filename &&
+					typeof downloadElement.download !== 'undefined'
+				) {
+					downloadElement.href = downloadUrl;
+					downloadElement.download = filename;
+					document.body.appendChild(downloadElement);
+					downloadElement.click();
+				}
+				else {
+					window.location.href = downloadUrl;
+				}
+
+				openToast({
+					message:
+						successMessage ||
+						Liferay.Language.get('action-completed'),
+					type: 'success',
+				});
+
+				setLoading(false);
+			})
+			.catch((_) => {
+				openToast({
+					message: Liferay.Language.get('unexpected-error'),
+					type: 'danger',
+				});
+				setLoading(false);
+			});
 	}
 	else if (onClick) {
 		event.preventDefault();

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
@@ -115,6 +115,7 @@ export function handleAction(
 		event.preventDefault();
 
 		setLoading(true);
+
 		let filename = '';
 
 		executeAsyncAction(url, method)
@@ -122,8 +123,15 @@ export function handleAction(
 				const disposition = response.headers.get('Content-Disposition');
 
 				if (disposition && disposition.indexOf('attachment') !== -1) {
+
+					// Captures the filename from the Content-Disposition header.
+					// For example, "attachment; filename="Filename.json" will capture
+					// "Filename.json".
+
 					const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+
 					const matchesRegex = filenameRegex.exec(disposition);
+
 					if (matchesRegex !== null && matchesRegex[1]) {
 						filename = matchesRegex[1].replace(/['"]/g, '');
 					}
@@ -139,9 +147,11 @@ export function handleAction(
 					filename &&
 					typeof downloadElement.download !== 'undefined'
 				) {
-					downloadElement.href = downloadUrl;
 					downloadElement.download = filename;
+					downloadElement.href = downloadUrl;
+
 					document.body.appendChild(downloadElement);
+
 					downloadElement.click();
 				}
 				else {
@@ -157,11 +167,12 @@ export function handleAction(
 
 				setLoading(false);
 			})
-			.catch((_) => {
+			.catch(() => {
 				openToast({
 					message: Liferay.Language.get('unexpected-error'),
 					type: 'danger',
 				});
+
 				setLoading(false);
 			});
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContext.java
@@ -90,7 +90,7 @@ public class ViewSXPBlueprintsDisplayContext {
 			new FDSActionDropdownItem(
 				getAPIURL() + "/{id}/export", "download", "export",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "export"),
-				"get", null, "blank"),
+				"get", null, "download"),
 			new FDSActionDropdownItem(
 				LanguageUtil.get(
 					_sxpRequestHelper.getRequest(),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPElementsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPElementsDisplayContext.java
@@ -88,7 +88,7 @@ public class ViewSXPElementsDisplayContext {
 			new FDSActionDropdownItem(
 				getAPIURL() + "/{id}/export", "download", "export",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "export"),
-				"get", null, "blank"),
+				"get", null, "download"),
 			new FDSActionDropdownItem(
 				LanguageUtil.get(
 					_sxpRequestHelper.getRequest(),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-141042 - Export Blueprint/Element

Hi again, you might remember me from https://github.com/liferay-frontend/liferay-portal/pull/1738

It seems that opening a new window with "blank" (what we were doing previously) actually removes the authentication headers for our export API, causing an internal server error. So in these changes to ActionsDropdownRenderer, we have a dedicated action for "download" where the fetch call for export is done on the same page, and the download link is created upon success. Included a success/error toast too. 

Please let us know what you think of these changes, thank you!

@thektan