### PR TITLE
LPS-144012 FIX BLOCKER regression bug creating a portal instance through the APIs

### DIFF
--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.servlet.ServletContext;
 
@@ -102,8 +103,14 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 	public PortalInstance postPortalInstance(PortalInstance portalInstance)
 		throws Exception {
 
+		long companyId = Optional.ofNullable(
+			portalInstance.getCompanyId()
+		).orElse(
+			0L
+		);
+
 		Company company = _companyService.addCompany(
-			portalInstance.getCompanyId(), portalInstance.getPortalInstanceId(),
+			companyId, portalInstance.getPortalInstanceId(),
 			portalInstance.getVirtualHost(), portalInstance.getDomain(), false,
 			0, true);
 


### PR DESCRIPTION
Fix a NullPointerException creating a portal instance through the APIs when the companyId is not sent in the body of the request.

**Step to reproduce:**

1. Sign In
2. Access to http://localhost:8080/o/headless-portal-instances/v1.0/openapi.json
3. Add a virtual instance via postPortalInstance
```
{
  "domain": "liferay.com",
  "portalInstanceId": "test-1-26-49.lax.liferay.com",
  "virtualHost": "test-1-26-49.lax.liferay.com"
}

```

**Expected Results:**
The new virtual instance should be created successfully.

**Actual Results:**
INTERNAL_SERVER_ERROR happens.

/cc @SamZiemer