### PR TITLE
LPS-139334 Text Edition Toolbar does not appear when highlighting a text in a table row

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
@@ -295,10 +295,14 @@
 
 				const selectedElement = selection.getSelectedElement();
 
-				if (!selectedElement && !selection.getSelectedText()) {
-					editor.balloonToolbars.hide();
+				if (!selectedElement) {
+					const selectedText = selection.getSelectedText();
 
-					return;
+					if (!selectedText?.match(/\w/)) {
+						editor.balloonToolbars.hide();
+
+						return;
+					}
 				}
 
 				originalContextManagerCheck.call(this, selection);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/insertbutton/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/insertbutton/plugin.js
@@ -315,7 +315,8 @@
 					if (
 						type === CKEDITOR.SELECTION_TEXT &&
 						selection.getSelectedText() === '' &&
-						startElement.getText() === '\n'
+						startElement.getText() === '\n' &&
+						startElement.getName() !== 'td'
 					) {
 						this._positionButton({button, editor});
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -74,16 +74,6 @@ const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
 					});
 				}
 
-				if (editorConfig.toolbarTable) {
-					balloonToolbars.create({
-						buttons: editorConfig.toolbarTable,
-						cssSelector: 'td',
-						priority:
-							window.CKEDITOR.plugins.balloontoolbar.PRIORITY
-								.HIGH,
-					});
-				}
-
 				if (editorConfig.toolbarVideo) {
 					balloonToolbars.create({
 						buttons: editorConfig.toolbarVideo,

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/BalloonEditor.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/BalloonEditor.testcase
@@ -217,7 +217,7 @@ definition {
 		}
 
 		task ("Remove the table") {
-			TripleClick(locator1 = "CKEditorBalloonEditorSample#TABLE_CELL");
+			Click(locator1 = "CKEditorBalloonEditorSample#TABLE_CELL");
 
 			Click(locator1 = "CKEditor#REMOVE_TABLE_BUTTON");
 
@@ -246,7 +246,9 @@ definition {
 		task ("Assert text edition toolbar appearance when highlighting a text inside the cell") {
 			TripleClick(locator1 = "CKEditorBalloonEditorSample#TABLE_CELL");
 
-			AssertVisible(locator1 = "CKEditor#TOOLBAR_ANY_ITEM_BUTTON");
+			AssertElementPresent(
+				key_titleName = "",
+				locator1 = "CKEditor#TOOLBAR_ANY_ITEM_BUTTON");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/BalloonEditor.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/BalloonEditor.testcase
@@ -225,10 +225,7 @@ definition {
 		}
 	}
 
-	// Ignored because of the ticket LPS-139334
-
 	@description = "Assert text edition enabled in the table"
-	@ignore = "true"
 	@priority = "4"
 	@refactordone
 	test CanEditTextInTable {


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-139334

See steps to reproduce in the JIRA ticket.

In this PR, we are:
- Moving table tools handling from `balloonToolbars.create` API to own plugin. This is because `balloonToolbars.create` API relies on CSS selectors. To achieve the desired effect, we would need to set higher priority of text node trigger than a `td` node trigger. I believe this is impossible, as it is impossible to select a text node with a CSS selector.
- Disabling insert button creation within a table
- Disabling text toolbar if there is not a single alphanumeric in selection. Without this, or a similar restriction, text toolbar opens on multiple cell selection.
- Reverting temporary CI test ignore /cc @magjed4289 

Sidenote: I noticed during testing that the 'Headers' option in table toolbar does not work. This is not related to this PR, the feature never worked. We can fix this in a separate PR.

I'm flagging @carloslancha and @julien as reviewers. @diegonvs is the most familiar with the task, but he is on PTO.

Before PR:
![before](https://user-images.githubusercontent.com/5435511/146423323-af0d7f26-8b0c-482f-94c0-b04da7313823.gif)

After PR:
![after](https://user-images.githubusercontent.com/5435511/146423294-988e059c-01d8-405a-ab09-b9f004d5c159.gif)

