### PR TITLE
LPS-142767 Workflow issue when leaving comment and assigning to Self

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
@@ -162,7 +162,7 @@ export default function Comments({
 			const data = Liferay.Util.ns(namespace, {
 				className,
 				classPK,
-				skipEditorLoading: true,
+				skipEditorLoading: false,
 			});
 
 			Liferay.Portlet.refresh(`#p_p_id_${portletDisplayId}_`, data, true);


### PR DESCRIPTION
Additional details on https://issues.liferay.com/browse/LPS-142767

### Steps to reproduce

1. Start liferay and enable the Single Approver workflow for Web Content Articles
1. Create a Web Content Article
1. Access the workflow for the Article
1. Add a comment to the workflow below
1. Assign the Review to yourself at top right corner

### Solution notes

We forced skipEditorLoading to true to resolve [LPS-81691](https://issues.liferay.com/browse/LPS-81691), but based on testing done by @fortunatomaldonado, the issue is no longer reproducible even when we set it to false, so this solution made sense to me.

Please let us know if there are any questions or anything else you'd like us to test.