### PR TITLE
LPS-143761 - Apply Lexicon Review changes in Translator Manager

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -177,8 +177,11 @@ AUI.add(
 						(directionMatch && directionMatch[1]) || AUTO;
 
 					if (direction.startsWith('down')) {
-						alignPoints = MAP_ALIGN_DOWN[direction] || MAP_ALIGN_DOWN.downright;
-					} else {
+						alignPoints =
+							MAP_ALIGN_DOWN[direction] ||
+							MAP_ALIGN_DOWN.downright;
+					}
+					else {
 						var overlayHorizontal =
 							mapAlignHorizontalOverlay[direction] ||
 							defaultOverlayHorizontalAlign;

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -49,6 +49,11 @@ AUI.add(
 
 		var STR_TOP = 't';
 
+		var MAP_ALIGN_DOWN = {
+			downleft: ['tr', 'br'],
+			downright: DEFAULT_ALIGN_POINTS,
+		};
+
 		var MAP_ALIGN_HORIZONTAL_OVERLAY = {
 			left: STR_RIGHT,
 			right: STR_LEFT,
@@ -81,7 +86,7 @@ AUI.add(
 
 		var MAP_LIVE_SEARCH = {};
 
-		var REGEX_DIRECTION = /\bdirection-(down|left|right|up)\b/;
+		var REGEX_DIRECTION = /\bdirection-(downleft|downright|down|left|right|up)\b/;
 
 		var REGEX_MAX_DISPLAY_ITEMS = /max-display-items-(\d+)/;
 
@@ -171,7 +176,9 @@ AUI.add(
 					var direction =
 						(directionMatch && directionMatch[1]) || AUTO;
 
-					if (direction !== 'down') {
+					if (direction.startsWith('down')) {
+						alignPoints = MAP_ALIGN_DOWN[direction] || MAP_ALIGN_DOWN.downright;
+					} else {
 						var overlayHorizontal =
 							mapAlignHorizontalOverlay[direction] ||
 							defaultOverlayHorizontalAlign;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -120,6 +120,7 @@ const TranslationAdminContent = ({
 											key={availableLocale.label}
 											onClick={() => {
 												onAddLocale(availableLocale.id);
+												setCreationMenuActive(false);
 											}}
 											symbolLeft={availableLocale.symbol}
 										>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -102,6 +102,9 @@ const TranslationAdminContent = ({
 								availableLocales.length > 0
 							}
 							hasLeftSymbols
+							menuElementAttrs={{
+								className: 'dropdown-menu-width-shrink',
+							}}
 							onActiveChange={setCreationMenuActive}
 							trigger={
 								<ClayButtonWithIcon

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/data_engine/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/data_engine/basic_info.jsp
@@ -36,7 +36,7 @@ if (ddmStructure != null) {
 	<aui:input disabled="<%= ddmStructure != null %>" name="structureKey" />
 </c:if>
 
-<aui:input activeLanguageIds="<%= journalEditDDMStructuresDisplayContext.getAvailableLanguageIds() %>" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" localized="<%= true %>" name="description" type="text" />
+<aui:input activeLanguageIds="<%= journalEditDDMStructuresDisplayContext.getAvailableLanguageIds() %>" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" languagesDropdownDirection="downleft" localized="<%= true %>" name="description" type="text" />
 
 <c:if test="<%= ddmStructure != null %>">
 	<portlet:resourceURL id="/journal/get_ddm_structure" var="getDDMStructureURL">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -63,7 +63,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 		<clay:container-fluid>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
-					<aui:input autoFocus="<%= (article == null) || article.isNew() %>" cssClass="form-control-inline" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" languagesDropdownDirection="down" label="" localized="<%= true %>" name="titleMapAsXML" placeholder='<%= LanguageUtil.format(request, "untitled-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' required="<%= journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT %>" selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>" type="text" wrapperCssClass="article-content-title mb-0" />
+					<aui:input autoFocus="<%= (article == null) || article.isNew() %>" cssClass="form-control-inline" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" label="" languagesDropdownDirection="down" localized="<%= true %>" name="titleMapAsXML" placeholder='<%= LanguageUtil.format(request, "untitled-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' required="<%= journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT %>" selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>" type="text" wrapperCssClass="article-content-title mb-0" />
 				</li>
 				<li class="tbar-item">
 					<div class="journal-article-button-row tbar-section text-right">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -63,7 +63,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 		<clay:container-fluid>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
-					<aui:input autoFocus="<%= (article == null) || article.isNew() %>" cssClass="form-control-inline" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" label="" localized="<%= true %>" name="titleMapAsXML" placeholder='<%= LanguageUtil.format(request, "untitled-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' required="<%= journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT %>" selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>" type="text" wrapperCssClass="article-content-title mb-0" />
+					<aui:input autoFocus="<%= (article == null) || article.isNew() %>" cssClass="form-control-inline" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" languagesDropdownDirection="down" label="" localized="<%= true %>" name="titleMapAsXML" placeholder='<%= LanguageUtil.format(request, "untitled-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' required="<%= journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT %>" selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>" type="text" wrapperCssClass="article-content-title mb-0" />
 				</li>
 				<li class="tbar-item">
 					<div class="journal-article-button-row tbar-section text-right">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
@@ -69,7 +69,7 @@ editDDMStructureURL.setParameter("ddmStructureId", String.valueOf(ddmStructureId
 		<clay:container-fluid>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
-					<aui:input activeLanguageIds="<%= journalEditDDMStructuresDisplayContext.getAvailableLanguageIds() %>" adminMode="<%= true %>" cssClass="form-control-inline" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" label="" localized="<%= true %>" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "structure") %>' required="<%= true %>" type="text" wrapperCssClass="article-content-title mb-0" />
+					<aui:input activeLanguageIds="<%= journalEditDDMStructuresDisplayContext.getAvailableLanguageIds() %>" adminMode="<%= true %>" cssClass="form-control-inline" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" languagesDropdownDirection="down" label="" localized="<%= true %>" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "structure") %>' required="<%= true %>" type="text" wrapperCssClass="article-content-title mb-0" />
 				</li>
 				<li class="tbar-item">
 					<div class="journal-article-button-row tbar-section text-right">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
@@ -69,7 +69,7 @@ editDDMStructureURL.setParameter("ddmStructureId", String.valueOf(ddmStructureId
 		<clay:container-fluid>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
-					<aui:input activeLanguageIds="<%= journalEditDDMStructuresDisplayContext.getAvailableLanguageIds() %>" adminMode="<%= true %>" cssClass="form-control-inline" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" languagesDropdownDirection="down" label="" localized="<%= true %>" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "structure") %>' required="<%= true %>" type="text" wrapperCssClass="article-content-title mb-0" />
+					<aui:input activeLanguageIds="<%= journalEditDDMStructuresDisplayContext.getAvailableLanguageIds() %>" adminMode="<%= true %>" cssClass="form-control-inline" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" label="" languagesDropdownDirection="down" localized="<%= true %>" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "structure") %>' required="<%= true %>" type="text" wrapperCssClass="article-content-title mb-0" />
 				</li>
 				<li class="tbar-item">
 					<div class="journal-article-button-row tbar-section text-right">

--- a/portal-web/docroot/html/taglib/aui/input/init.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/init.jsp
@@ -50,6 +50,7 @@ java.lang.String inlineLabel = GetterUtil.getString((java.lang.String)request.ge
 java.lang.String label = GetterUtil.getString((java.lang.String)request.getAttribute("aui:input:label"));
 java.lang.String labelCssClass = GetterUtil.getString((java.lang.String)request.getAttribute("aui:input:labelCssClass"));
 java.lang.String languageId = GetterUtil.getString((java.lang.String)request.getAttribute("aui:input:languageId"));
+java.lang.String languagesDropdownDirection = GetterUtil.getString((java.lang.String)request.getAttribute("aui:input:languagesDropdownDirection"));
 boolean last = GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui:input:last")));
 boolean localized = GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui:input:localized")));
 boolean localizeLabel = GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui:input:localizeLabel")), true);

--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -252,6 +252,7 @@ boolean choiceField = checkboxField || radioField;
 			id="<%= id %>"
 			ignoreRequestValue="<%= ignoreRequestValue %>"
 			languageId="<%= languageId %>"
+			languagesDropdownDirection="<%= languagesDropdownDirection %>"
 			model="<%= model %>"
 			placeholder="<%= placeholder %>"
 			timeFormat='<%= GetterUtil.getString(dynamicAttributes.get("timeFormat")) %>'
@@ -383,6 +384,7 @@ boolean choiceField = checkboxField || radioField;
 					id="<%= id %>"
 					ignoreRequestValue="<%= ignoreRequestValue %>"
 					languageId="<%= languageId %>"
+					languagesDropdownDirection="<%= languagesDropdownDirection %>"
 					name="<%= name %>"
 					onChange="<%= onChange %>"
 					onClick="<%= onClick %>"

--- a/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
@@ -20,10 +20,11 @@
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:cssClass"));
 Map<String, Object> data = (Map<String, Object>)request.getAttribute("liferay-ui:icon-menu:data");
 String direction = (String)request.getAttribute("liferay-ui:icon-menu:direction");
-boolean hasMessage = (message != null) && !message.isEmpty();
 String icon = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:icon"));
 String id = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:id"));
 String message = (String)request.getAttribute("liferay-ui:icon-menu:message");
+
+boolean hasMessage = (message != null) && !message.isEmpty();
 boolean scroll = GetterUtil.getBoolean(request.getAttribute("liferay-ui:icon-menu:scroll"));
 String triggerCssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:triggerCssClass"));
 String triggerLabel = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:triggerLabel"));

--- a/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
@@ -37,7 +37,7 @@ if (Validator.isNull(icon)) {
 <div class="dropdown lfr-icon-menu <%= cssClass %>" <%= AUIUtil.buildData(data) %>>
 	<c:choose>
 		<c:when test='<%= triggerType.equals("button") %>'>
-			<button aria-expanded="false" aria-haspopup="<%= hasMessage %>" class="btn btn-monospaced btn-secondary dropdown-toggle <%= triggerCssClass %>" id="<%= id %>" <%= hasMessage ? "title=\"" + message + "\"" : StringPool.BLANK %> type="button">
+			<button aria-expanded="false" aria-haspopup="<%= hasMessage %>" class="btn btn-monospaced btn-secondary direction-<%= direction %> dropdown-toggle <%= triggerCssClass %>" id="<%= id %>" <%= hasMessage ? "title=\"" + message + "\"" : StringPool.BLANK %> type="button">
 				<aui:icon cssClass="inline-item" image="<%= icon %>" markupView="lexicon" />
 
 				<c:if test="<%= Validator.isNotNull(triggerLabel) %>">

--- a/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
@@ -36,7 +36,7 @@ if (Validator.isNull(icon)) {
 <div class="dropdown lfr-icon-menu <%= cssClass %>" <%= AUIUtil.buildData(data) %>>
 	<c:choose>
 		<c:when test='<%= triggerType.equals("button") %>'>
-			<button aria-expanded="false" aria-haspopup="true" class="btn btn-monospaced btn-secondary direction-<%= direction %> dropdown-toggle <%= triggerCssClass %>" id="<%= id %>" <%= (message != null) && !message.isEmpty() ? "title=\"" + message + "\"" : StringPool.BLANK %> type="button">
+			<button aria-expanded="false" aria-haspopup="true" class="btn btn-monospaced btn-secondary direction-<%= direction %> dropdown-toggle <%= triggerCssClass %>" id="<%= id %>" <%= ((message != null) && !message.isEmpty()) ? "title=\"" + message + "\"" : StringPool.BLANK %> type="button">
 				<aui:icon cssClass="inline-item" image="<%= icon %>" markupView="lexicon" />
 
 				<c:if test="<%= Validator.isNotNull(triggerLabel) %>">

--- a/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
@@ -20,10 +20,10 @@
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:cssClass"));
 Map<String, Object> data = (Map<String, Object>)request.getAttribute("liferay-ui:icon-menu:data");
 String direction = (String)request.getAttribute("liferay-ui:icon-menu:direction");
+boolean hasMessage = (message != null) && !message.isEmpty();
 String icon = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:icon"));
 String id = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:id"));
 String message = (String)request.getAttribute("liferay-ui:icon-menu:message");
-boolean hasMessage = message != null && !message.isEmpty();
 boolean scroll = GetterUtil.getBoolean(request.getAttribute("liferay-ui:icon-menu:scroll"));
 String triggerCssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:triggerCssClass"));
 String triggerLabel = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:triggerLabel"));

--- a/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
@@ -23,8 +23,6 @@ String direction = (String)request.getAttribute("liferay-ui:icon-menu:direction"
 String icon = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:icon"));
 String id = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:id"));
 String message = (String)request.getAttribute("liferay-ui:icon-menu:message");
-
-boolean hasMessage = (message != null) && !message.isEmpty();
 boolean scroll = GetterUtil.getBoolean(request.getAttribute("liferay-ui:icon-menu:scroll"));
 String triggerCssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:triggerCssClass"));
 String triggerLabel = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:triggerLabel"));
@@ -38,7 +36,7 @@ if (Validator.isNull(icon)) {
 <div class="dropdown lfr-icon-menu <%= cssClass %>" <%= AUIUtil.buildData(data) %>>
 	<c:choose>
 		<c:when test='<%= triggerType.equals("button") %>'>
-			<button aria-expanded="false" aria-haspopup="<%= hasMessage %>" class="btn btn-monospaced btn-secondary direction-<%= direction %> dropdown-toggle <%= triggerCssClass %>" id="<%= id %>" <%= hasMessage ? "title=\"" + message + "\"" : StringPool.BLANK %> type="button">
+			<button aria-expanded="false" aria-haspopup="true" class="btn btn-monospaced btn-secondary direction-<%= direction %> dropdown-toggle <%= triggerCssClass %>" id="<%= id %>" <%= (message != null) && !message.isEmpty() ? "title=\"" + message + "\"" : StringPool.BLANK %> type="button">
 				<aui:icon cssClass="inline-item" image="<%= icon %>" markupView="lexicon" />
 
 				<c:if test="<%= Validator.isNotNull(triggerLabel) %>">

--- a/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
@@ -23,6 +23,7 @@ String direction = (String)request.getAttribute("liferay-ui:icon-menu:direction"
 String icon = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:icon"));
 String id = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:id"));
 String message = (String)request.getAttribute("liferay-ui:icon-menu:message");
+boolean hasMessage = message != null && !message.isEmpty();
 boolean scroll = GetterUtil.getBoolean(request.getAttribute("liferay-ui:icon-menu:scroll"));
 String triggerCssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:triggerCssClass"));
 String triggerLabel = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:triggerLabel"));
@@ -36,7 +37,7 @@ if (Validator.isNull(icon)) {
 <div class="dropdown lfr-icon-menu <%= cssClass %>" <%= AUIUtil.buildData(data) %>>
 	<c:choose>
 		<c:when test='<%= triggerType.equals("button") %>'>
-			<button aria-expanded="false" aria-haspopup="true" class="btn btn-monospaced btn-secondary dropdown-toggle <%= triggerCssClass %>" id="<%= id %>" title="<%= message %>" type="button">
+			<button aria-expanded="false" aria-haspopup="<%= hasMessage %>" class="btn btn-monospaced btn-secondary dropdown-toggle <%= triggerCssClass %>" id="<%= id %>" <%= hasMessage ? "title=\"" + message + "\"" : StringPool.BLANK %> type="button">
 				<aui:icon cssClass="inline-item" image="<%= icon %>" markupView="lexicon" />
 
 				<c:if test="<%= Validator.isNotNull(triggerLabel) %>">

--- a/portal-web/docroot/html/taglib/ui/input_field/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_field/page.jsp
@@ -36,6 +36,7 @@ String formName = (String)request.getAttribute("liferay-ui:input-field:formName"
 String id = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-field:id"));
 boolean ignoreRequestValue = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-field:ignoreRequestValue"));
 String languageId = (String)request.getAttribute("liferay-ui:input-field:languageId");
+String languagesDropdownDirection = (String)request.getAttribute("liferay-ui:input-field:languagesDropdownDirection");
 String model = (String)request.getAttribute("liferay-ui:input-field:model");
 String placeholder = (String)request.getAttribute("liferay-ui:input-field:placeholder");
 
@@ -448,6 +449,7 @@ if (hints != null) {
 								id="<%= id %>"
 								ignoreRequestValue="<%= ignoreRequestValue %>"
 								languageId="<%= languageId %>"
+								languagesDropdownDirection="<%= languagesDropdownDirection %>"
 								maxLength="<%= maxLength %>"
 								name="<%= fieldParam %>"
 								placeholder="<%= placeholder %>"
@@ -495,6 +497,7 @@ if (hints != null) {
 								id="<%= id %>"
 								ignoreRequestValue="<%= ignoreRequestValue %>"
 								languageId="<%= languageId %>"
+								languagesDropdownDirection="<%= languagesDropdownDirection %>"
 								maxLength="<%= maxLength %>"
 								name="<%= fieldParam %>"
 								placeholder="<%= placeholder %>"
@@ -523,6 +526,7 @@ if (hints != null) {
 								id="<%= id %>"
 								ignoreRequestValue="<%= ignoreRequestValue %>"
 								languageId="<%= languageId %>"
+								languagesDropdownDirection="<%= languagesDropdownDirection %>"
 								maxLength="<%= maxLength %>"
 								name="<%= fieldParam %>"
 								onKeyDown='<%= (checkTab ? "Liferay.Util.checkTab(this); " : StringPool.BLANK) + "Liferay.Util.disableEsc();" %>'

--- a/portal-web/docroot/html/taglib/ui/input_localized/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/init.jsp
@@ -39,6 +39,7 @@ String id = HtmlUtil.getAUICompatibleId((String)request.getAttribute("liferay-ui
 boolean ignoreRequestValue = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-localized:ignoreRequestValue"));
 String inputAddon = (String)request.getAttribute("liferay-ui:input-localized:inputAddon");
 String languageId = (String)request.getAttribute("liferay-ui:input-localized:languageId");
+String languagesDropdownDirection = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-localized:languagesDropdownDirection"));
 String maxLength = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-localized:maxLength"));
 String name = (String)request.getAttribute("liferay-ui:input-localized:name");
 String placeholder = (String)request.getAttribute("liferay-ui:input-localized:placeholder");

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -134,7 +134,7 @@
 			%>
 
 			<liferay-ui:icon-menu
-				direction="left-side"
+				direction="<%= languagesDropdownDirection %>"
 				icon="<%= StringUtil.toLowerCase(normalizedSelectedLanguageId) %>"
 				id='<%= namespace + id + "Menu" %>'
 				markupView="lexicon"

--- a/util-taglib/bnd.bnd
+++ b/util-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 8.3.6
+Bundle-Version: 8.4.0
 Export-Package:\
 	com.liferay.alloy.taglib.*;version="3.0.0",\
 	com.liferay.taglib.*

--- a/util-taglib/src/META-INF/liferay-aui.tld
+++ b/util-taglib/src/META-INF/liferay-aui.tld
@@ -833,6 +833,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description><![CDATA[The direction the translation admin dropdown should open.]]></description>
+			<name>languagesDropdownDirection</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description><![CDATA[Whether the component should be the last element of the form.]]></description>
 			<name>last</name>
 			<required>false</required>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -1319,6 +1319,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>languagesDropdownDirection</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>maxLength</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseInputTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseInputTag.java
@@ -156,6 +156,10 @@ public abstract class BaseInputTag extends com.liferay.taglib.BaseValidatorTagSu
 		return _languageId;
 	}
 
+	public java.lang.String getLanguagesDropdownDirection() {
+		return _languagesDropdownDirection;
+	}
+
 	public boolean getLast() {
 		return _last;
 	}
@@ -376,6 +380,10 @@ public abstract class BaseInputTag extends com.liferay.taglib.BaseValidatorTagSu
 		_languageId = languageId;
 	}
 
+	public void setLanguagesDropdownDirection(java.lang.String languagesDropdownDirection) {
+		_languagesDropdownDirection = languagesDropdownDirection;
+	}
+
 	public void setLast(boolean last) {
 		_last = last;
 	}
@@ -503,6 +511,7 @@ public abstract class BaseInputTag extends com.liferay.taglib.BaseValidatorTagSu
 		_label = null;
 		_labelCssClass = null;
 		_languageId = null;
+		_languagesDropdownDirection = null;
 		_last = false;
 		_localized = false;
 		_localizeLabel = true;
@@ -566,6 +575,7 @@ public abstract class BaseInputTag extends com.liferay.taglib.BaseValidatorTagSu
 		setNamespacedAttribute(request, "label", _label);
 		setNamespacedAttribute(request, "labelCssClass", _labelCssClass);
 		setNamespacedAttribute(request, "languageId", _languageId);
+		setNamespacedAttribute(request, "languagesDropdownDirection", _languagesDropdownDirection);
 		setNamespacedAttribute(request, "last", _last);
 		setNamespacedAttribute(request, "localized", _localized);
 		setNamespacedAttribute(request, "localizeLabel", _localizeLabel);
@@ -627,6 +637,7 @@ public abstract class BaseInputTag extends com.liferay.taglib.BaseValidatorTagSu
 	private java.lang.String _label = null;
 	private java.lang.String _labelCssClass = null;
 	private java.lang.String _languageId = null;
+	private java.lang.String _languagesDropdownDirection = null;
 	private boolean _last = false;
 	private boolean _localized = false;
 	private boolean _localizeLabel = true;

--- a/util-taglib/src/com/liferay/taglib/aui/base/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/aui/base/packageinfo
@@ -1,1 +1,1 @@
-version 11.2.0
+version 11.3.0

--- a/util-taglib/src/com/liferay/taglib/aui/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/aui/packageinfo
@@ -1,1 +1,1 @@
-version 11.2.0
+version 11.3.0

--- a/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
@@ -185,7 +185,9 @@ public class InputFieldTag extends IncludeTag {
 		_languageId = languageId;
 	}
 
-	public void setLanguagesDropdownDirection(String languagesDropdownDirection) {
+	public void setLanguagesDropdownDirection(
+		String languagesDropdownDirection) {
+
 		_languagesDropdownDirection = languagesDropdownDirection;
 	}
 
@@ -281,7 +283,8 @@ public class InputFieldTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-field:languageId", _languageId);
 		httpServletRequest.setAttribute(
-			"liferay-ui:input-field:languagesDropdownDirection", _languagesDropdownDirection);
+			"liferay-ui:input-field:languagesDropdownDirection",
+			_languagesDropdownDirection);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-field:model", _model.getName());
 		httpServletRequest.setAttribute(

--- a/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
@@ -81,6 +81,10 @@ public class InputFieldTag extends IncludeTag {
 		return _languageId;
 	}
 
+	public String getLanguagesDropdownDirection() {
+		return _languagesDropdownDirection;
+	}
+
 	public Class<?> getModel() {
 		return _model;
 	}
@@ -181,6 +185,10 @@ public class InputFieldTag extends IncludeTag {
 		_languageId = languageId;
 	}
 
+	public void setLanguagesDropdownDirection(String languagesDropdownDirection) {
+		_languagesDropdownDirection = languagesDropdownDirection;
+	}
+
 	public void setModel(Class<?> model) {
 		_model = model;
 	}
@@ -211,6 +219,7 @@ public class InputFieldTag extends IncludeTag {
 		_id = null;
 		_ignoreRequestValue = false;
 		_languageId = null;
+		_languagesDropdownDirection = null;
 		_model = null;
 		_placeholder = null;
 	}
@@ -272,6 +281,8 @@ public class InputFieldTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-field:languageId", _languageId);
 		httpServletRequest.setAttribute(
+			"liferay-ui:input-field:languagesDropdownDirection", _languagesDropdownDirection);
+		httpServletRequest.setAttribute(
 			"liferay-ui:input-field:model", _model.getName());
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-field:placeholder", _placeholder);
@@ -297,6 +308,7 @@ public class InputFieldTag extends IncludeTag {
 	private String _id;
 	private boolean _ignoreRequestValue;
 	private String _languageId;
+	private String _languagesDropdownDirection;
 	private Class<?> _model;
 	private String _placeholder;
 

--- a/util-taglib/src/com/liferay/taglib/ui/InputLocalizedTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputLocalizedTag.java
@@ -211,7 +211,9 @@ public class InputLocalizedTag extends IncludeTag {
 		_languageId = languageId;
 	}
 
-	public void setLanguagesDropdownDirection(String languagesDropdownDirection) {
+	public void setLanguagesDropdownDirection(
+		String languagesDropdownDirection) {
+
 		_languagesDropdownDirection = languagesDropdownDirection;
 	}
 
@@ -346,7 +348,8 @@ public class InputLocalizedTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-localized:languageId", _languageId);
 		httpServletRequest.setAttribute(
-			"liferay-ui:input-localized:languagesDropdownDirection", _languagesDropdownDirection);
+			"liferay-ui:input-localized:languagesDropdownDirection",
+			_languagesDropdownDirection);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-localized:maxLength", _maxLength);
 		httpServletRequest.setAttribute(

--- a/util-taglib/src/com/liferay/taglib/ui/InputLocalizedTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputLocalizedTag.java
@@ -87,6 +87,10 @@ public class InputLocalizedTag extends IncludeTag {
 		return _languageId;
 	}
 
+	public String getLanguagesDropdownDirection() {
+		return _languagesDropdownDirection;
+	}
+
 	public String getMaxLength() {
 		return _maxLength;
 	}
@@ -207,6 +211,10 @@ public class InputLocalizedTag extends IncludeTag {
 		_languageId = languageId;
 	}
 
+	public void setLanguagesDropdownDirection(String languagesDropdownDirection) {
+		_languagesDropdownDirection = languagesDropdownDirection;
+	}
+
 	public void setMaxLength(String maxLength) {
 		_maxLength = maxLength;
 	}
@@ -257,6 +265,7 @@ public class InputLocalizedTag extends IncludeTag {
 		_ignoreRequestValue = false;
 		_inputAddon = null;
 		_languageId = null;
+		_languagesDropdownDirection = null;
 		_maxLength = null;
 		_name = null;
 		_placeholder = null;
@@ -337,6 +346,8 @@ public class InputLocalizedTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-localized:languageId", _languageId);
 		httpServletRequest.setAttribute(
+			"liferay-ui:input-localized:languagesDropdownDirection", _languagesDropdownDirection);
+		httpServletRequest.setAttribute(
 			"liferay-ui:input-localized:maxLength", _maxLength);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-localized:name", _name);
@@ -376,6 +387,7 @@ public class InputLocalizedTag extends IncludeTag {
 	private boolean _ignoreRequestValue;
 	private String _inputAddon;
 	private String _languageId;
+	private String _languagesDropdownDirection;
 	private String _maxLength;
 	private String _name;
 	private String _placeholder;

--- a/util-taglib/src/com/liferay/taglib/ui/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/ui/packageinfo
@@ -1,1 +1,1 @@
-version 12.2.0
+version 12.3.0


### PR DESCRIPTION
### References

- [LPS-143761](https://issues.liferay.com/browse/LPS-143761)

### What is the goal?

* Hide add language dropdown after adding a language
* Change input-localized languages dropdown direction
   * In the input-localized that controls the Web Content title it should show under the button, but in the description input of the side bar it should open to the left 
   * Added a `dropdownDirection` attribute to `aui:input`/`liferay-ui:input-localized`/`liferay-ui:icon-menu` to customize this
* Remove white space from add language dropdown
   * [⚠️This requires pending changes from Clay⚠️](https://github.com/liferay/clay/issues/4501). For now, added the `dropdown-menu-width-shrink` class so it will work as soon as we get a new release of Clay
* Fix empty tooltip being displayed in input-localized button
   * The cause for this is that [the button receives an empty string as a message/title](https://github.com/liferay-frontend/liferay-portal/blob/master/portal-web/docroot/html/taglib/ui/input_localized/page.jsp#L141), so I changed the component to not display the tooltip if this attribute is null or empty. There are two issues with this:
      * If we pass a title, it will show the tooltip (which design doesn't want)
      * If we don't pass a title, the button is not accessible


### A picture is worth a thousand words

https://user-images.githubusercontent.com/6642927/146969325-fd28c3c4-84cb-4286-b8d4-605f67513648.mov


### How to replicate
Add language dropdown:
* Log into portal, go to `Content & Data > Web Content` 
* Select the `Structures` tab
* Click on `+` button
* Click on the flag button, select `Manage translations` in the dropdown
* A modal should open, click on the `+` button
* See that when you select a language, the dropdown closes

Dropdown direction:
* Log into portal, go to `Content & Data > Web Content` 
* Select the `Structures` tab
* Click on `+` button
* Click on the flag icon next to the title input, see that the dropdown opens under the button with both left sides aligned, close outside to close the dropdown
* Click on the gear icon to the right of the page, click on the flag icon next to the description input, see that the dropdown opens under the button, with both right sides aligned

Add language dropdown width:
* Cannot be replicated until Clay release

Empty tooltip:
* Log into portal, go to `Content & Data > Web Content` 
* Select the `Structures` tab
* Click on `+` button
* Click on the gear icon to the right of the page, hover over the flag icon next to the description input, see that there is no tooltip

### Checklist

- ~~[ ] I have made corresponding changes to the documentation~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked this works in the corresponding browser