### PR TITLE
LPS-144176 Add support for hyphens in Schema properties and partial support for OpenAPI XML object

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-yaml", version: "2.9.8"
 	compileInclude group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jdk8", version: "2.9.8"
 	compileInclude group: "com.fasterxml.jackson.jaxrs", name: "jackson-jaxrs-xml-provider", version: "2.9.8"
+	compileInclude group: "com.fasterxml.jackson.module", name: "jackson-module-jaxb-annotations", version: "2.9.8"
 	compileInclude group: "com.google.guava", name: "failureaccess", version: "1.0.1"
 	compileInclude group: "com.google.guava", name: "guava", version: "30.1.1-jre"
 	compileInclude group: "com.graphql-java", name: "graphql-java", version: "12.0"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/XmlMapperContextResolver.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/XmlMapperContextResolver.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
@@ -38,6 +39,7 @@ public class XmlMapperContextResolver implements ContextResolver<XmlMapper> {
 		private static final XmlMapper _XML_MAPPER = new XmlMapper() {
 			{
 				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				registerModule(new JaxbAnnotationModule());
 				setDateFormat(new ISO8601DateFormat());
 				setDefaultUseWrapper(false);
 				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -193,6 +194,15 @@ public class DTOOpenAPIParser {
 		if (propertySchemas == null) {
 			return Collections.emptyMap();
 		}
+
+		Set<Map.Entry<String, Schema>> entries = propertySchemas.entrySet();
+
+		entries.forEach(
+			entry -> {
+				Schema propertySchema = entry.getValue();
+
+				propertySchema.setName(entry.getKey());
+			});
 
 		return propertySchemas;
 	}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/YAMLUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/YAMLUtil.java
@@ -23,6 +23,7 @@ import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.OpenAPIYAML;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Parameter;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.PathItem;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Schema;
+import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.XML;
 
 import java.util.List;
 import java.util.Map;
@@ -178,6 +179,12 @@ public class YAMLUtil {
 
 		schemaTypeDescription.substituteProperty(
 			"x-json-map", boolean.class, "getJsonMap", "setJsonMap");
+
+		schemaTypeDescription.substituteProperty(
+			"xml", XML.class, "getXML", "setXML");
+
+		schemaTypeDescription.addPropertyParameters(
+			"xml", String.class, XML.class);
 
 		openAPIYAMLConstructor.addTypeDescription(schemaTypeDescription);
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/Schema.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/Schema.java
@@ -102,6 +102,10 @@ public class Schema {
 		return _type;
 	}
 
+	public XML getXml() {
+		return _xml;
+	}
+
 	public boolean isDeprecated() {
 		return _deprecated;
 	}
@@ -205,6 +209,10 @@ public class Schema {
 		_writeOnly = writeOnly;
 	}
 
+	public void setXML(XML xml) {
+		_xml = xml;
+	}
+
 	private Schema _additionalPropertySchema;
 	private List<Schema> _allOfSchemas;
 	private List<Schema> _anyOfSchemas;
@@ -225,5 +233,6 @@ public class Schema {
 	private List<String> _requiredPropertySchemaNames;
 	private String _type;
 	private boolean _writeOnly;
+	private XML _xml;
 
 }

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/Schema.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/Schema.java
@@ -82,6 +82,10 @@ public class Schema {
 		return _minimum;
 	}
 
+	public String getName() {
+		return _name;
+	}
+
 	public List<Schema> getOneOfSchemas() {
 		return _oneOfSchemas;
 	}
@@ -179,6 +183,10 @@ public class Schema {
 		_minimum = minimum;
 	}
 
+	public void setName(String name) {
+		_name = name;
+	}
+
 	public void setOneOfSchemas(List<Schema> oneOfSchemas) {
 		_oneOfSchemas = oneOfSchemas;
 	}
@@ -226,6 +234,7 @@ public class Schema {
 	private boolean _jsonMap;
 	private Double _maximum;
 	private Double _minimum;
+	private String _name;
 	private List<Schema> _oneOfSchemas;
 	private Map<String, Schema> _propertySchemas;
 	private boolean _readOnly;

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/XML.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/XML.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.rest.builder.internal.yaml.openapi;
+
+/**
+ * @author Javier de Arcos
+ */
+public class XML {
+
+	public String getName() {
+		return _name;
+	}
+
+	public void setName(String name) {
+		_name = name;
+	}
+
+	private String _name;
+
+}

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
@@ -73,7 +73,10 @@ public class ${schemaName}SerDes {
 		</#list>
 
 		<#list properties?keys as propertyName>
-			<#assign capitalizedPropertyName = propertyName?cap_first />
+			<#assign
+				capitalizedPropertyName = propertyName?cap_first
+				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema)
+			/>
 
 			<#if enumSchemas?keys?seq_contains(properties[propertyName])>
 				<#assign capitalizedPropertyName = properties[propertyName] />
@@ -84,7 +87,13 @@ public class ${schemaName}SerDes {
 					sb.append(", ");
 				}
 
-				sb.append("\"${propertyName}\": ");
+				<#if propertySchema.name??>
+					<#assign key = propertySchema.name />
+				<#else>
+					<#assign key = propertyName />
+				</#if>
+
+				sb.append("\"${key}\": ");
 
 				<#assign propertyType = properties[propertyName] />
 
@@ -182,22 +191,31 @@ public class ${schemaName}SerDes {
 		</#list>
 
 		<#list properties?keys as propertyName>
-			<#assign capitalizedPropertyName = propertyName?cap_first />
+			<#assign
+				capitalizedPropertyName = propertyName?cap_first
+				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema)
+			/>
 
 			<#if enumSchemas?keys?seq_contains(properties[propertyName])>
 				<#assign capitalizedPropertyName = properties[propertyName] />
 			</#if>
 
+			<#if propertySchema.name??>
+				<#assign key = propertySchema.name />
+			<#else>
+				<#assign key = propertyName />
+			</#if>
+
 			if (${schemaVarName}.get${capitalizedPropertyName}() == null) {
-				map.put("${propertyName}", null);
+				map.put("${key}", null);
 			}
 			else {
 				<#if allSchemas[properties[propertyName]]??>
-					map.put("${propertyName}", String.valueOf(${schemaVarName}.get${capitalizedPropertyName}()));
+					map.put("${key}", String.valueOf(${schemaVarName}.get${capitalizedPropertyName}()));
 				<#elseif stringUtil.equals(properties[propertyName], "Date")>
-					map.put("${propertyName}", liferayToJSONDateFormat.format(${schemaVarName}.get${capitalizedPropertyName}()));
+					map.put("${key}", liferayToJSONDateFormat.format(${schemaVarName}.get${capitalizedPropertyName}()));
 				<#else>
-					map.put("${propertyName}", String.valueOf(${schemaVarName}.get${capitalizedPropertyName}()));
+					map.put("${key}", String.valueOf(${schemaVarName}.get${capitalizedPropertyName}()));
 				</#if>
 			}
 		</#list>
@@ -220,11 +238,19 @@ public class ${schemaName}SerDes {
 		@Override
 		protected void setField(${schemaName} ${schemaVarName}, String jsonParserFieldName, Object jsonParserFieldValue) {
 			<#list properties?keys as propertyName>
+				<#assign propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema) />
+
 				<#if !propertyName?is_first>
 					else
 				</#if>
 
-				if (Objects.equals(jsonParserFieldName, "${propertyName}")) {
+				<#if propertySchema.name??>
+					<#assign fieldName = propertySchema.name />
+				<#else>
+					<#assign fieldName = propertyName />
+				</#if>
+
+				if (Objects.equals(jsonParserFieldName, "${fieldName}")) {
 					if (jsonParserFieldValue != null) {
 						<#assign capitalizedPropertyName = propertyName?cap_first />
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -52,6 +52,7 @@ import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -229,6 +230,9 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 				access = JsonProperty.Access.READ_WRITE
 			</#if>
 		)
+		<#if propertySchema.xml??>
+			@XmlElement(name="${propertySchema.xml.name}")
+		</#if>
 		<#if schema.requiredPropertySchemaNames?? && schema.requiredPropertySchemaNames?seq_contains(propertyName)>
 			<#if stringUtil.equals(propertyType, "String")>
 				@NotEmpty

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -229,6 +229,9 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 			<#else>
 				access = JsonProperty.Access.READ_WRITE
 			</#if>
+			<#if propertySchema.name?? && !stringUtil.equals(propertyName, propertySchema.name)>
+				, value = "${propertySchema.name}"
+			</#if>
 		)
 		<#if propertySchema.xml??>
 			@XmlElement(name="${propertySchema.xml.name}")


### PR DESCRIPTION
We had a current limitation in REST Builder that transform each property found in the OpenAPI with hyphens for a camelCase version of it. An example could be the `legal-test-with-hyphen` property that we converted to legalTestWithHyphen on the following OpenAPI fragment:
```
TestObjectWithPropertiesWithHyphens:
    type: object
    properties:
        legal-test-with-hyphen:
            type: string
```

We also didn't support the XML object that can be used to select another property name for the XML representation like
```
TestObjectWithPropertiesWithXmlRenamed:
    type: object
    properties:
        shouldNotBeInXml:
            type: string
            xml:
                name: 'shouldBeInXml'
```

With these changes, we support the hyphens in both XML and JSON representations and also take into account the XML object to override the property name in XML

I've used the XmlElement annotation to allow different property names in XML and also take into account the hyphens in the client serializer and deserializer