### PR TITLE
LPS-143763 Fix ListTypeEntry filter by name in Headless Admin List Type API 

### DIFF
--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeEntryEntityModel.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeEntryEntityModel.java
@@ -41,7 +41,9 @@ public class ListTypeEntryEntityModel implements EntityModel {
 			new IntegerEntityField("userId", locale -> Field.USER_ID),
 			new StringEntityField("key", locale -> "key"),
 			new StringEntityField(
-				"name", locale -> Field.getLocalizedName(locale, Field.NAME)));
+				Field.NAME,
+				locale -> Field.getSortableFieldName(
+					Field.getLocalizedName(locale, "localized_name"))));
 	}
 
 	@Override

--- a/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/internal/search/spi/model/index/contributor/ListTypeEntryModelDocumentContributor.java
+++ b/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/internal/search/spi/model/index/contributor/ListTypeEntryModelDocumentContributor.java
@@ -34,10 +34,12 @@ public class ListTypeEntryModelDocumentContributor
 
 	@Override
 	public void contribute(Document document, ListTypeEntry listTypeEntry) {
-		document.addLocalizedText(Field.NAME, listTypeEntry.getNameMap());
 		document.addText("key", listTypeEntry.getKey());
 		document.addKeyword(
 			"listTypeDefinitionId", listTypeEntry.getListTypeDefinitionId());
+		document.addLocalizedText(Field.NAME, listTypeEntry.getNameMap());
+		document.addLocalizedKeyword(
+			"localized_name", listTypeEntry.getNameMap(), true, true);
 		document.remove(Field.USER_NAME);
 	}
 


### PR DESCRIPTION
The name property filter is not working for ListTypeEntry API. Modified to consider the name field as sortable and localized. This way it works for multiple word names.

**Steps to reproduce**:
1. Create a ListTypeDefinition "experience"
2. Create multiple ListTypeEntries with names like: junior, mid level, senior, staff
3. Make an API request using one of the ListTypeEntry names above like:  filter 'name eq "junior". You will need to update the curl command with your ListTypeDefinitionId
```
curl -X 'GET' 'http://localhost:8080/o/headless-admin-list-type/v1.0/list-type-definitions/42548/list-type-entries?filter=name%20eq%20%27junior%27' -u 'test@liferay.com:test'
```
**Expected result:** Response has one result
**Result:** No results are shown

This scenario is covered by the ListTypeEntryResourceTest.testGetListTypeDefinitionListTypeEntriesPageWithFilterStringEquals integration test.