### PR TITLE
LPS-139741 | Verifies Remote App fields match after upgrade

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsUpgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsUpgrade.macro
@@ -1,0 +1,29 @@
+definition {
+
+	macro assertRemoteAppEntry {
+		RemoteApps.goToRemoteAppsPortlet();
+
+		RemoteApps.viewTableEntries(
+			entryName = "${upgradeName}",
+			entryType = "${upgradeType}");
+	}
+
+	macro assertRemoteAppEntryFields {
+		Click(
+			key_tableEntryName = "${upgradeName}",
+			locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE");
+
+		AssertTextEquals(
+			custom_entryName = "${upgradeName}",
+			key_text = "Name",
+			locator1 = "TextInput#ANY",
+			value1 = "${upgradeName}");
+
+		AssertTextEquals(
+			custom_entryURL = "${upgradeURL}",
+			key_id = "iFrameURL",
+			locator1 = "RemoteAppsEntry#URL",
+			value1 = "${upgradeURL}");
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsUpgrade.testcase
@@ -1,0 +1,44 @@
+@component-name = "portal-upgrades"
+definition {
+
+	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Remote Apps";
+	property testray.main.component.name = "Upgrades Remote Apps";
+
+	setUp {
+		SignIn.signIn();
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		AssertLocation.assertPartialLocation(value1 = "${portalURL}/web/guest");
+
+		SearchAdministration.executeReindex();
+	}
+
+	@description = "Upgrade to 7.3.10.1 and assert remote app fields were saved properly"
+	@priority = "5"
+	test CanViewRemoteAppFieldsAfterUpgrade73101 {
+		property portal.acceptance = "true";
+		property data.archive.type = "data-archive-remote-app";
+		property portal.version = "7.3.10.1";
+
+		var remoteAppName = "Test Remote App";
+		var remoteAppType = "IFrame";
+		var remoteAppURL = "http://www.liferay.com";
+
+		task ("Assert remote app is present after upgrade") {
+			RemoteAppsUpgrade.assertRemoteAppEntry(
+				upgradeName = "${remoteAppName}",
+				upgradeType = "${remoteAppType}");
+		}
+
+		task ("Assert remote app fields are saved after upgrade") {
+			RemoteAppsUpgrade.assertRemoteAppEntryFields(
+				upgradeName = "${remoteAppName}",
+				upgradeURL = "${remoteAppURL}");
+		}
+	}
+
+}

--- a/test.properties
+++ b/test.properties
@@ -3085,6 +3085,7 @@
             (testray.main.component.name ~ "AMD Loader") OR \
             (testray.main.component.name ~ "Remote Apps") OR \
             (testray.main.component.name ~ "Theme") OR \
+            (testray.main.component.name ~ "Upgrades Remote Apps") OR \
             (testray.main.component.name ~ "User Interface")\
         )
 
@@ -6363,6 +6364,7 @@
         Clay,\
         Remote Apps,\
         Theme,\
+        Upgrades Remote Apps,\
         User Interface
 
     testray.team.headless.component.names=\


### PR DESCRIPTION
**Background** 
Add test coverage for [LPS-139734](https://issues.liferay.com/browse/LPS-139734)

**Test Plan**

- Navigate to Remote Apps portlet
- Assert Test Remote App table entry is present
- Click on the Test Remote App entry
- Assert the correct name, type, and url

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-139741