### PR TITLE
LPS-142748 Check for object contents instead of checking if null

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
@@ -196,7 +196,13 @@ Liferay = window.Liferay || {};
 			},
 			method: 'POST',
 		})
-			.then((response) => response.json())
+			.then((response) => {
+				if (!response.ok) {
+					ioConfig.error();
+				}
+
+				return response.json();
+			})
 			.then(ioConfig.complete)
 			.catch(ioConfig.error);
 	};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
@@ -196,14 +196,17 @@ Liferay = window.Liferay || {};
 			},
 			method: 'POST',
 		})
-			.then((response) => {
-				if (!response.ok) {
+			.then((response) =>
+				Promise.all([Promise.resolve(response), response.json()])
+			)
+			.then(([response, content]) => {
+				if (response.ok) {
+					ioConfig.complete(content);
+				}
+				else {
 					ioConfig.error();
 				}
-
-				return response.json();
 			})
-			.then(ioConfig.complete)
 			.catch(ioConfig.error);
 	};
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
@@ -123,7 +123,7 @@ Liferay = window.Liferay || {};
 
 			ioConfig.complete = function (response) {
 				if (
-					response !== null &&
+					Object.keys(response).length > 0 &&
 					!Object.prototype.hasOwnProperty.call(response, 'exception')
 				) {
 					if (callbackSuccess) {


### PR DESCRIPTION
Fixes https://issues.liferay.com/browse/LPS-142748

I changed the condition of the if statement to check if the `response` object is empty or not, instead of checking if its `null` or not. I assume the bug was caused by a change in how the `response` object is implemented in some recent change, making the `response` object be empty if it has no response, instead of being `null`.