### PR TITLE
LPS-144497 Fix NPE creating a structured content resource with no content fields

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
@@ -29,6 +29,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.headless.delivery.dto.v1_0.ContentField;
 import com.liferay.journal.service.JournalArticleService;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -211,11 +212,11 @@ public class DDMFormValuesUtil {
 		String valueString = Optional.ofNullable(
 			localizedValue.getString(localizedValue.getDefaultLocale())
 		).orElse(
-			""
+			StringPool.BLANK
 		);
 
 		if (Objects.equals(valueString, "[]")) {
-			valueString = "";
+			valueString = StringPool.BLANK;
 		}
 
 		if (ddmFormField.isLocalizable()) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
@@ -208,10 +208,13 @@ public class DDMFormValuesUtil {
 
 		LocalizedValue localizedValue = ddmFormField.getPredefinedValue();
 
-		String valueString = localizedValue.getString(
-			localizedValue.getDefaultLocale());
+		String valueString = Optional.ofNullable(
+			localizedValue.getString(localizedValue.getDefaultLocale())
+		).orElse(
+			""
+		);
 
-		if (valueString.equals("[]")) {
+		if (Objects.equals(valueString, "[]")) {
 			valueString = "";
 		}
 


### PR DESCRIPTION
When new structured content is created through the APIs without content fields, using a structure that allows it (non-required fields), a NPE is thrown if the field has no default value.

**Steps to reproduce:**

1. Create a Web Content Structure with one non-required field and no default value (or use Basic Web Content)
2. Create a Structured Content through APIs sending a request with only title and contentStructureId
```
curl -H "Content-Type: application/json" -X POST "http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/structured-contents" -d "{\"contentStructureId\": {contentStructureId}, \"title\": \"Test Article\"}" -u "test@liferay.com:test"
``` 
_Remember to replace the {siteId} in the path and the {contentStructureId} in the body with valid ids in your portal instance_

**Result:** A 500 Internal Server Error status code is returned and a NullPointerException is logged in the server

**Expected Result:** The Structured Content is created successfully and a 200 status code is returned

Use **Optional** to assign empty string default value when no default value is defined. I've tested to only fix the NPE and let the null value but this causes some problems when rendering the web content