### PR TITLE
LPS-144497 Simplify using GetterUtil.getString

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
@@ -31,6 +31,7 @@ import com.liferay.journal.service.JournalArticleService;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
@@ -209,11 +210,8 @@ public class DDMFormValuesUtil {
 
 		LocalizedValue localizedValue = ddmFormField.getPredefinedValue();
 
-		String valueString = Optional.ofNullable(
-			localizedValue.getString(localizedValue.getDefaultLocale())
-		).orElse(
-			StringPool.BLANK
-		);
+		String valueString = GetterUtil.getString(
+			localizedValue.getString(localizedValue.getDefaultLocale()));
 
 		if (Objects.equals(valueString, "[]")) {
 			valueString = StringPool.BLANK;


### PR DESCRIPTION
I've simplified the code using GetterUtil.getString instead of Optional following Brian's suggestion https://github.com/brianchandotcom/liferay-portal/pull/111570

I will remember this one for future cases

Original message:
---
When new structured content is created through the APIs without content fields, using a structure that allows it (non-required fields), a NPE is thrown if the field has no default value.

Steps to reproduce:

Create a Web Content Structure with one non-required field and no default value (or use Basic Web Content)
Create a Structured Content through APIs sending a request with only title and contentStructureId
curl -H "Content-Type: application/json" -X POST "http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/structured-contents" -d "{\"contentStructureId\": {contentStructureId}, \"title\": \"Test Article\"}" -u "test@liferay.com:test"
Remember to replace the {siteId} in the path and the {contentStructureId} in the body with valid ids in your portal instance

Result: A 500 Internal Server Error status code is returned and a NullPointerException is logged in the server

Expected Result: The Structured Content is created successfully and a 200 status code is returned

Use Optional to assign empty string default value when no default value is defined. I've tested to only fix the NPE and let the null value but this causes some problems when rendering the web content