### PR TITLE
LPS-144176 Add tests to REST Builder module to check the hyphens and XML support

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -235,7 +235,7 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 			</#if>
 		)
 		<#if propertySchema.xml??>
-			@XmlElement(name="${propertySchema.xml.name}")
+			@XmlElement(name = "${propertySchema.xml.name}")
 		</#if>
 		<#if schema.requiredPropertySchemaNames?? && schema.requiredPropertySchemaNames?seq_contains(propertyName)>
 			<#if stringUtil.equals(propertyType, "String")>
@@ -285,14 +285,23 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 		</#list>
 
 		<#list properties?keys as propertyName>
-			<#assign propertyType = properties[propertyName] />
+			<#assign
+				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema)
+				propertyType = properties[propertyName]
+			/>
 
 			if (${propertyName} != null) {
 				if (sb.length() > 1) {
 					sb.append(", ");
 				}
 
-				sb.append("\"${propertyName}\": ");
+				<#if propertySchema.name?? && !stringUtil.equals(propertyName, propertySchema.name)>
+					<#assign key = propertySchema.name />
+				<#else>
+					<#assign key = propertyName />
+				</#if>
+
+				sb.append("\"${key}\": ");
 
 				<#if allSchemas[propertyType]??>
 					sb.append(String.valueOf(${propertyName}));

--- a/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/RESTBuilderTest.java
+++ b/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/RESTBuilderTest.java
@@ -120,7 +120,7 @@ public class RESTBuilderTest {
 		Assert.assertTrue(
 			stream.anyMatch(
 				line -> line.contains(
-					"sb.append(\"" + propertyName + "\": \");")));
+					"sb.append(\"\\\"" + propertyName + "\\\": \");")));
 	}
 
 	private void _assertResourceFilesExist(

--- a/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/RESTBuilderTest.java
+++ b/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/RESTBuilderTest.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
@@ -66,6 +65,8 @@ public class RESTBuilderTest {
 
 		_assertHyphensSupportInProperties(
 			filesPath, "Test", "property-with-hyphens");
+
+		_assertXMLSupportInProperties(filesPath, "Test", "xmlProperty");
 
 		File sampleApiDir = new File(filesPath + "/sample-api");
 
@@ -108,21 +109,18 @@ public class RESTBuilderTest {
 
 		Stream<String> stream = lines.stream();
 
-		Optional<String> propertyWithHyphensOptional = stream.filter(
-			line -> line.contains(
-				"access = JsonProperty.Access.READ_WRITE, value = \"" +
-					propertyName + "\"")
-		).findFirst();
-
-		Assert.assertTrue(propertyWithHyphensOptional.isPresent());
+		Assert.assertTrue(
+			stream.anyMatch(
+				line -> line.contains(
+					"access = JsonProperty.Access.READ_WRITE, value = \"" +
+						propertyName + "\"")));
 
 		stream = lines.stream();
 
-		Optional<String> serializePropertyWithHyphensOptional = stream.filter(
-			line -> line.contains("sb.append(\"" + propertyName + "\": \");")
-		).findFirst();
-
-		Assert.assertTrue(serializePropertyWithHyphensOptional.isPresent());
+		Assert.assertTrue(
+			stream.anyMatch(
+				line -> line.contains(
+					"sb.append(\"" + propertyName + "\": \");")));
 	}
 
 	private void _assertResourceFilesExist(
@@ -169,6 +167,26 @@ public class RESTBuilderTest {
 				resourceName, "Resource.java"));
 
 		Assert.assertTrue(resourceFolderFile.exists());
+	}
+
+	private void _assertXMLSupportInProperties(
+			String filesPath, String resourceName, String xmlPropertyName)
+		throws Exception {
+
+		File dtoResourceFile = new File(
+			_getResourcePath(
+				filesPath,
+				"/sample-api/src/main/java/com/example/sample/dto/v1_0_0/",
+				resourceName, ".java"));
+
+		List<String> lines = Files.readAllLines(dtoResourceFile.toPath());
+
+		Stream<String> stream = lines.stream();
+
+		Assert.assertTrue(
+			stream.anyMatch(
+				line -> line.contains(
+					"@XmlElement(name = \"" + xmlPropertyName + "\")")));
 	}
 
 	private String _getDependenciesPath() {

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/rest-openapi.yaml
@@ -45,6 +45,19 @@ components:
                 subFolders:
                     $ref: "#/components/schemas/Folder"
             type: object
+        Test:
+            description:
+                Test Component to test the REST Builder support for advanced features
+            properties:
+                id:
+                    format: int64
+                    type: integer
+                jsonProperty:
+                    type: string
+                    xml:
+                        name: xmlProperty
+                property-with-hyphens:
+                    type: string
 info:
     title: ""
     version: "1.0.0"
@@ -112,5 +125,22 @@ paths:
                         "application/json":
                             schema:
                                 $ref: "#/components/schemas/Folder"
+                    description:
+                        "OK"
+    /tests/{testId}:
+        get:
+            parameters:
+                - in: path
+                  name: testId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                200:
+                    content:
+                        "application/json":
+                            schema:
+                                $ref: "#/components/schemas/Test"
                     description:
                         "OK"


### PR DESCRIPTION
I've added checks in the tests to assert the support of properties with hyphens and for OpenAPI XML name property (the one that we support right now)

For this purpose, I've created a new Component called test that will grow to check the support of new features. I've created a new one to don't mess with the already created Document and Folder components.

Thanks to the tests, I've detected that I miss the correct serialization of properties with hyphens in the DTO toString method, so I fix it in the last commit.

Sorry for that... A new version of REST Builder is needed to include this fix.