### PR TITLE
LPS-144537 - Keep MT info button fixed to the right

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1007,21 +1007,6 @@ public class ManagementToolbarTag extends BaseContainerTag {
 
 			jspWriter.write("</button></li>");
 
-			if (isShowInfoButton()) {
-				jspWriter.write("<li class=\"nav-item\"><button class=\"");
-				jspWriter.write(" nav-link nav-link-monospaced btn");
-				jspWriter.write(" btn-monospaced btn-unstyled\" type=\"button");
-				jspWriter.write("\">");
-
-				iconTag = new IconTag();
-
-				iconTag.setSymbol("info-circle-open");
-
-				iconTag.doTag(pageContext);
-
-				jspWriter.write("</button></li>");
-			}
-
 			if (getViewTypeItems() != null) {
 				jspWriter.write("<li class=\"nav-item\"><div class=\"dropdown");
 				jspWriter.write("\"><button class=\"dropdown-toggle nav-link");
@@ -1055,6 +1040,21 @@ public class ManagementToolbarTag extends BaseContainerTag {
 				linkTag.doTag(pageContext);
 
 				jspWriter.write("</li>");
+			}
+
+			if (isShowInfoButton()) {
+				jspWriter.write("<li class=\"nav-item\"><button class=\"");
+				jspWriter.write(" nav-link nav-link-monospaced btn");
+				jspWriter.write(" btn-monospaced btn-unstyled\" type=\"button");
+				jspWriter.write("\">");
+
+				iconTag = new IconTag();
+
+				iconTag.setSymbol("info-circle-open");
+
+				iconTag.doTag(pageContext);
+
+				jspWriter.write("</button></li>");
 			}
 
 			jspWriter.write("</ul>");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/InfoPanelControl.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/InfoPanelControl.js
@@ -14,9 +14,10 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayManagementToolbar from '@clayui/management-toolbar';
+import classNames from 'classnames';
 import React, {useEffect, useRef} from 'react';
 
-const InfoPanelControl = ({infoPanelId, onInfoButtonClick}) => {
+const InfoPanelControl = ({infoPanelId, onInfoButtonClick, separator}) => {
 	const infoButtonRef = useRef();
 
 	useEffect(() => {
@@ -42,7 +43,11 @@ const InfoPanelControl = ({infoPanelId, onInfoButtonClick}) => {
 	}, [infoButtonRef, infoPanelId]);
 
 	return (
-		<ClayManagementToolbar.Item>
+		<ClayManagementToolbar.Item
+			className={classNames('d-none d-md-flex', {
+				'management-bar-separator-left': separator,
+			})}
+		>
 			<ClayButtonWithIcon
 				className="nav-link nav-link-monospaced"
 				displayType="unstyled"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -142,13 +142,6 @@ function ManagementToolbar({
 						/>
 					)}
 
-					{showInfoButton && (
-						<InfoPanelControl
-							infoPanelId={infoPanelId}
-							onInfoButtonClick={onInfoButtonClick}
-						/>
-					)}
-
 					{active ? (
 						<>
 							<ActionControls
@@ -204,6 +197,13 @@ function ManagementToolbar({
 								</ClayManagementToolbar.Item>
 							)}
 						</>
+					)}
+
+					{showInfoButton && (
+						<InfoPanelControl
+							infoPanelId={infoPanelId}
+							onInfoButtonClick={onInfoButtonClick}
+						/>
 					)}
 				</ClayManagementToolbar.ItemList>
 			</ClayManagementToolbar>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -26,6 +26,8 @@ import ResultsBar from './ResultsBar';
 import SearchControls from './SearchControls';
 import SelectionControls from './SelectionControls';
 
+import './ManagementToolbar.scss';
+
 function ManagementToolbar({
 	clearResultsURL,
 	clearSelectionURL,
@@ -203,6 +205,7 @@ function ManagementToolbar({
 						<InfoPanelControl
 							infoPanelId={infoPanelId}
 							onInfoButtonClick={onInfoButtonClick}
+							separator={active}
 						/>
 					)}
 				</ClayManagementToolbar.ItemList>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
@@ -1,0 +1,9 @@
+@import 'atlas-variables';
+
+.management-bar-separator-left::before {
+	background-color: $gray-500;
+	content: '';
+	height: 16px;
+	margin: 0 10px;
+	width: 1px;
+}


### PR DESCRIPTION
### References

- [LPS-144537](https://issues.liferay.com/browse/LPS-144537)

### What is the goal?

* Move Management Toolbar info button to the right, both in normal and contextual mode
* Add separator to the left of MT info button in contextual mode
* Hide info button in mobile

### What does it look like?


https://user-images.githubusercontent.com/6642927/147652937-fec55f54-3376-4239-b5be-646d7b40ebf0.mov




### How to replicate
* Log into portal, go to `Content & Data > Web Content` 
* See that the rightmost element in the toolbar at the top is now the info button
* Click on select all, see that the rightmost element is still the info button
* Shrink window to mobile size, see that the info button is not visible
* Click again on select all, see that the info button is not visible either