### PR TITLE
LPS-143975 Integrate Object relationships in GraphQL

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 9.4.1
+Bundle-Version: 9.5.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/dto/GraphQLDTOContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/dto/GraphQLDTOContributor.java
@@ -22,6 +22,7 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.osgi.annotation.versioning.ProviderType;
@@ -51,7 +52,19 @@ public interface GraphQLDTOContributor<D, R> {
 
 	public List<GraphQLDTOProperty> getGraphQLDTOProperties();
 
+	public default List<GraphQLDTOProperty> getGraphQLDTORelationships() {
+		return Collections.emptyList();
+	}
+
 	public String getIdName();
+
+	public default <T> T getRelationshipValue(
+			DTOConverterContext dtoConverterContext, long id,
+			String relationshipName, Class<T> relationshipClass)
+		throws Exception {
+
+		return null;
+	}
 
 	public String getResourceName();
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/dto/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/dto/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
With this PR we integrate the object relationships in GraphQL.

I've added two new methods to the interface, that allow getting the relationships and the relationship value
```
public default List<GraphQLDTOProperty> getGraphQLDTORelationships() {
	return Collections.emptyList();
}

public default <T> T getRelationshipValue(
		DTOConverterContext dtoConverterContext, long id,
		String relationshipName, Class<T> relationshipClass)
	throws Exception {

	return null;
}
```

With the new methods, we can get the relationship names to register them as GraphQL fields and register a Data Fetcher to get the relationship value.

The current implementation has the limitation that it is not possible to select the fields you want to get from the related object, you have to get it as a whole. We can approach this as a second iteration, but considering the difficulty of this feature, I think it is a big step forward.

A working example with an Object Manager that has a "One to Many" relationship with Employes is:

GraphQL query
```
{
  c {
    employees {
      items {
        employeeId
        name
        manager
      }
    }
  }
}
```
And the response
```
{
  "data": {
    "c": {
      "employees": {
        "items": [
          {
            "employeeId": 42729,
            "name": "Luismi",
            "manager": {
              "name": "Javi",
              "team": "Headless",
              "managerId": 42724
            }
          },
          {
            "employeeId": 42731,
            "name": "Alicia",
            "manager": {
              "name": "Adolfo",
              "team": "Lima",
              "managerId": 42726
            }
          }
        ]
      }
    }
  }
}
```

I will be on PTO from tomorrow to the 10 of January. Feel free to shelve the PR if you want to discuss something or you think it is risky. About the risk, I test it and I'm confident it works correctly.