### PR TITLE
LRQA-72424 test-fix for No results for path in LocalFile.RemoteApps#CustomElementCanBeCreated

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteAppAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteAppAPI.macro
@@ -18,6 +18,7 @@ definition {
 				  -d customElementHTMLElementName=${htmlNameModified} \
 				  -d customElementURLs=${customElementURLModified} \
 				  -d description= \
+				  -d externalReferenceCode= \
 				  -d friendlyURLMapping= \
 				  -d instanceable=true \
 				  -d nameMap='{\"en_US\":\"${nameModified}\"}' \
@@ -46,6 +47,7 @@ definition {
 				  -d customElementHTMLElementName=${htmlNameModified} \
 				  -d customElementURLs=${customElementURLModified} \
 				  -d description= \
+				  -d externalReferenceCode= \
 				  -d friendlyURLMapping= \
 				  -d instanceable=true \
 				  -d nameMap='{\"en_US\":\"${nameModified}\"}' \


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-72424

[Testray](https://testray.liferay.com/home/-/testray/case_results/1594806341)
[Jenkins](https://testray.liferay.com/reports/production/logs/2021-12/test-1-1/test-portal-acceptance-upstream-dxp(master)/2751/functional-tomcat90-mysql57-jdk8/17/14/jenkins-console.txt.gz)

```
[exec] com.liferay.poshi.runner.PoshiRunner > test[LocalFile.RemoteApps#CustomElementCanBeCreated] STANDARD_ERROR
     [exec]     java.lang.Exception: No results for path: $['remoteAppEntryId']
     [exec]     	at com.liferay.poshi.core.util.ExternalMethod.execute(ExternalMethod.java:46)
     [exec]     	at com.liferay.poshi.core.util.ExternalMethod.execute(ExternalMethod.java:91)
     [exec]     	at com.liferay.poshi.core.PoshiGetterUtil.getMethodReturnValue(PoshiGetterUtil.java:297)
     [exec]     	at com.liferay.poshi.runner.PoshiRunnerExecutor.getVarMethodValue(PoshiRunnerExecutor.java:1137)
     [exec]     	at com.liferay.poshi.runner.PoshiRunnerExecutor._getVarValue(PoshiRunnerExecutor.java:1261)
     [exec]     	at com.liferay.poshi.runner.PoshiRunnerExecutor.runCommandVarElement(PoshiRunnerExecutor.java:224)
     [exec]     	at com.liferay.poshi.runner.PoshiRunnerExecutor.parseElement(PoshiRunnerExecutor.java:207)
```
