### PR TITLE
LPS-144735 Add useOnClickOutside hook

### DIFF
--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useOnClickOutside.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useOnClickOutside.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {useEffect} from 'react';
+
+/**
+ * Hook for excuting a function callback when clicking outside
+ * some DOM elements (for example, a ClayPopover)
+ */
+export default function useOnClickOutside(
+	elements: Array<any>,
+	handler: (...args: any[]) => any
+) {
+	useEffect(() => {
+		const listener = (event: any) => {
+			const {target} = event;
+
+			/**
+			 * Detect clicks on elements or their descendent elements.
+			 */
+			const filtered = elements.filter((element: any) => {
+				if (typeof element === 'string') {
+					return !!target.closest(element);
+				}
+
+				return element && element.contains(target);
+			});
+
+			if (!filtered.length) {
+				handler(event);
+			}
+		};
+
+		document.addEventListener('mousedown', listener);
+		document.addEventListener('touchstart', listener);
+
+		return () => {
+			document.removeEventListener('mousedown', listener);
+			document.removeEventListener('touchstart', listener);
+		};
+	}, [elements, handler]);
+}

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useOnClickOutside.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useOnClickOutside.ts
@@ -14,13 +14,15 @@
 
 import {useEffect} from 'react';
 
+import {useEventListener} from './useEventListener';
+
 /**
  * Hook for excuting a function callback when clicking outside
  * some DOM elements (for example, a ClayPopover)
  */
 export default function useOnClickOutside(
-	elements: Array<any>,
-	handler: (...args: any[]) => any
+	elements: Array<Node>,
+	handler: (event: Event) => void
 ) {
 	useEffect(() => {
 		const listener = (event: any) => {
@@ -29,7 +31,7 @@ export default function useOnClickOutside(
 			/**
 			 * Detect clicks on elements or their descendent elements.
 			 */
-			const filtered = elements.filter((element: any) => {
+			const filtered = elements.filter((element: Node) => {
 				if (typeof element === 'string') {
 					return !!target.closest(element);
 				}

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts
@@ -20,6 +20,7 @@ export {default as useEventListener} from './hooks/useEventListener';
 export {default as useInterval} from './hooks/useInterval';
 export {default as useIsMounted} from './hooks/useIsMounted';
 export {default as useLiferayState} from './hooks/useLiferayState';
+export {default as useOnClickOutside} from './hooks/useOnClickOutside';
 export {default as usePrevious} from './hooks/usePrevious';
 export {default as useStateSafe} from './hooks/useStateSafe';
 export {default as useThunk} from './hooks/useThunk';

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useOnClickOutside.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useOnClickOutside.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+/**
+ * Hook for excuting a function callback when clicking outside
+ * some DOM elements (for example, a ClayPopover)
+ */
+export default function useOnClickOutside(
+	elements: Array<any>,
+	handler: (...args: any[]) => any
+): void;

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useOnClickOutside.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useOnClickOutside.d.ts
@@ -17,6 +17,6 @@
  * some DOM elements (for example, a ClayPopover)
  */
 export default function useOnClickOutside(
-	elements: Array<any>,
-	handler: (...args: any[]) => any
+	elements: Array<Node>,
+	handler: (event: Event) => void
 ): void;

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/index.d.ts
@@ -18,6 +18,7 @@ export {default as useEventListener} from './hooks/useEventListener';
 export {default as useInterval} from './hooks/useInterval';
 export {default as useIsMounted} from './hooks/useIsMounted';
 export {default as useLiferayState} from './hooks/useLiferayState';
+export {default as useOnClickOutside} from './hooks/useOnClickOutside';
 export {default as usePrevious} from './hooks/usePrevious';
 export {default as useStateSafe} from './hooks/useStateSafe';
 export {default as useThunk} from './hooks/useThunk';


### PR DESCRIPTION
Motivation
=======
In some places of the portal we need to close Popovers when clicking outside of them.
[Link to story or ticket](https://issues.liferay.com/browse/LPS-144735)

Proposed Solution
========
We have reused a hook already develop in other portal modules and put it in frontend-js-react-module so that everybody can use it in their modules.