### PR TITLE
LPS-144724 Improve accessibility for social buttons (Facebook, Linked…

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 9.1.15
+Bundle-Version: 9.2.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.data,\
 	com.liferay.frontend.taglib.clay.data.set,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -82,5 +82,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "9.1.15"
+	"version": "9.2.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
@@ -179,9 +179,11 @@ public class LinkTag extends BaseContainerTag {
 
 	@Override
 	protected Map<String, Object> prepareProps(Map<String, Object> props) {
-		props.put("icon", _icon);
-
+		props.put("block", _block);
+		props.put("borderless", _borderless);
 		props.put("button", _type.equals("button"));
+		props.put("displayType", _displayType);
+		props.put("icon", _icon);
 
 		if (Validator.isNotNull(_label)) {
 			props.put(
@@ -190,6 +192,10 @@ public class LinkTag extends BaseContainerTag {
 					TagResourceBundleUtil.getResourceBundle(pageContext),
 					_label));
 		}
+
+		props.put("monospaced", _monospaced);
+		props.put("outline", _outline);
+		props.put("small", _small);
 
 		return super.prepareProps(props);
 	}
@@ -202,6 +208,10 @@ public class LinkTag extends BaseContainerTag {
 			cssPrefix = "btn-";
 
 			cssClasses.add("btn");
+		}
+
+		if (_block) {
+			cssClasses.add(cssPrefix + "block");
 		}
 
 		if (_borderless) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
@@ -63,6 +63,10 @@ public class LinkTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
+	public boolean getBlock() {
+		return _block;
+	}
+
 	public boolean getBorderless() {
 		return _borderless;
 	}
@@ -101,6 +105,10 @@ public class LinkTag extends BaseContainerTag {
 
 	public String getType() {
 		return _type;
+	}
+
+	public void setBlock(boolean block) {
+		_block = block;
 	}
 
 	public void setBorderless(boolean borderless) {
@@ -147,6 +155,7 @@ public class LinkTag extends BaseContainerTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_block = false;
 		_borderless = false;
 		_displayType = null;
 		_download = null;
@@ -171,6 +180,8 @@ public class LinkTag extends BaseContainerTag {
 	@Override
 	protected Map<String, Object> prepareProps(Map<String, Object> props) {
 		props.put("icon", _icon);
+
+		props.put("button", _type.equals("button"));
 
 		if (Validator.isNotNull(_label)) {
 			props.put(
@@ -252,6 +263,7 @@ public class LinkTag extends BaseContainerTag {
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:link:";
 
+	private boolean _block;
 	private boolean _borderless;
 	private String _displayType;
 	private String _download;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
@@ -160,6 +160,30 @@ public class LinkTag extends BaseContainerTag {
 	}
 
 	@Override
+	protected String getHydratedModuleName() {
+		if ((getAdditionalProps() != null) || (getPropsTransformer() != null)) {
+			return "frontend-taglib-clay/Link";
+		}
+
+		return null;
+	}
+
+	@Override
+	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("icon", _icon);
+
+		if (Validator.isNotNull(_label)) {
+			props.put(
+				"label",
+				LanguageUtil.get(
+					TagResourceBundleUtil.getResourceBundle(pageContext),
+					_label));
+		}
+
+		return super.prepareProps(props);
+	}
+
+	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		String cssPrefix = "link-";
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1518,6 +1518,12 @@
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
+			<name>additionalProps</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>borderless</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1579,6 +1585,18 @@
 		<attribute>
 			<description></description>
 			<name>outline</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>propsTransformer</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>propsTransformerServletContext</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Link.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Link.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayIcon from '@clayui/icon';
+import ClayLink from '@clayui/link';
+import classNames from 'classnames';
+import React from 'react';
+
+export default function Link({
+	additionalProps: _additionalProps,
+	componentId: _componentId,
+	cssClass,
+	icon,
+	label,
+	locale: _locale,
+	portletId: _portletId,
+	portletNamespace: _portletNamespace,
+	...otherProps
+}) {
+	return (
+		<ClayLink className={cssClass} {...otherProps}>
+			{icon && (
+				<span
+					className={classNames('inline-item', {
+						'inline-item-before': label,
+					})}
+				>
+					<ClayIcon symbol={icon} />
+				</span>
+			)}
+
+			{label}
+		</ClayLink>
+	);
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 5.2.0

--- a/modules/apps/social/social-bookmark-facebook/package.json
+++ b/modules/apps/social/social-bookmark-facebook/package.json
@@ -1,12 +1,13 @@
 {
 	"dependencies": {
+		"frontend-js-web": "*",
+		"social-bookmarks-taglib": "*"
 	},
-	"main": "index.js",
-	"name": "social-bookmarks-taglib",
+	"name": "@liferay/social-bookmark-facebook",
 	"scripts": {
 		"build": "liferay-npm-scripts build",
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "4.0.15"
+	"version": "4.0.9"
 }

--- a/modules/apps/social/social-bookmark-facebook/package.json
+++ b/modules/apps/social/social-bookmark-facebook/package.json
@@ -1,7 +1,5 @@
 {
 	"dependencies": {
-		"frontend-js-web": "*",
-		"social-bookmarks-taglib": "*"
 	},
 	"name": "@liferay/social-bookmark-facebook",
 	"scripts": {

--- a/modules/apps/social/social-bookmark-facebook/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
+++ b/modules/apps/social/social-bookmark-facebook/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
@@ -1,4 +1,3 @@
-<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -12,11 +11,20 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
---%>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
+import {openSocialBookmark} from 'social-bookmarks-taglib';
 
-<%@ page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.social.bookmarks.SocialBookmark" %>
+export default function propsTransformer({
+	additionalProps: {className, classPK, postURL, type, url},
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		onClick(event) {
+			event.preventDefault();
+			event.stopPropagation();
 
-<%@ page import="java.util.HashMap" %>
+			return openSocialBookmark({className, classPK, postURL, type, url});
+		},
+	};
+}

--- a/modules/apps/social/social-bookmark-facebook/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-facebook/src/main/resources/META-INF/resources/page.jsp
@@ -26,10 +26,11 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 	additionalProps='<%= (HashMap)request.getAttribute("liferay-social-bookmarks:bookmark:additionalProps") %>'
 	aria-label="<%= socialBookmark.getName(request.getLocale()) %>"
 	borderless="<%= true %>"
-	cssClass="c-px-2 lfr-portal-tooltip"
+	cssClass="lfr-portal-tooltip"
 	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="social-facebook"
+	monospaced="<%= true %>"
 	outline="<%= true %>"
 	propsTransformer="js/OpenSocialBookmarkPropsTransformer"
 	small="<%= true %>"

--- a/modules/apps/social/social-bookmark-facebook/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-facebook/src/main/resources/META-INF/resources/page.jsp
@@ -23,12 +23,15 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 %>
 
 <clay:link
+	additionalProps='<%= (HashMap)request.getAttribute("liferay-social-bookmarks:bookmark:additionalProps") %>'
+	aria-label="<%= socialBookmark.getName(request.getLocale()) %>"
 	borderless="<%= true %>"
 	cssClass="c-px-2 lfr-portal-tooltip"
 	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="social-facebook"
 	outline="<%= true %>"
+	propsTransformer="js/OpenSocialBookmarkPropsTransformer"
 	small="<%= true %>"
 	title="<%= socialBookmark.getName(request.getLocale()) %>"
 	type="button"

--- a/modules/apps/social/social-bookmark-linkedin/package.json
+++ b/modules/apps/social/social-bookmark-linkedin/package.json
@@ -1,12 +1,13 @@
 {
 	"dependencies": {
+		"frontend-js-web": "*",
+		"social-bookmarks-taglib": "*"
 	},
-	"main": "index.js",
-	"name": "social-bookmarks-taglib",
+	"name": "@liferay/social-bookmark-linkedin",
 	"scripts": {
 		"build": "liferay-npm-scripts build",
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "4.0.15"
+	"version": "4.0.9"
 }

--- a/modules/apps/social/social-bookmark-linkedin/package.json
+++ b/modules/apps/social/social-bookmark-linkedin/package.json
@@ -1,7 +1,5 @@
 {
 	"dependencies": {
-		"frontend-js-web": "*",
-		"social-bookmarks-taglib": "*"
 	},
 	"name": "@liferay/social-bookmark-linkedin",
 	"scripts": {

--- a/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/init.jsp
@@ -18,3 +18,5 @@
 
 <%@ page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.social.bookmarks.SocialBookmark" %>
+
+<%@ page import="java.util.HashMap" %>

--- a/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
+++ b/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
@@ -12,19 +12,4 @@
  * details.
  */
 
-import {openSocialBookmark} from 'social-bookmarks-taglib';
-
-export default function propsTransformer({
-	additionalProps: {className, classPK, postURL, type, url},
-	...otherProps
-}) {
-	return {
-		...otherProps,
-		onClick(event) {
-			event.preventDefault();
-			event.stopPropagation();
-
-			return openSocialBookmark({className, classPK, postURL, type, url});
-		},
-	};
-}
+export {OpenSocialBookmarkPropsTransformer as default} from 'social-bookmarks-taglib';

--- a/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
+++ b/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
@@ -1,4 +1,3 @@
-<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -12,11 +11,20 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
---%>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
+import {openSocialBookmark} from 'social-bookmarks-taglib';
 
-<%@ page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.social.bookmarks.SocialBookmark" %>
+export default function propsTransformer({
+	additionalProps: {className, classPK, postURL, type, url},
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		onClick(event) {
+			event.preventDefault();
+			event.stopPropagation();
 
-<%@ page import="java.util.HashMap" %>
+			return openSocialBookmark({className, classPK, postURL, type, url});
+		},
+	};
+}

--- a/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/page.jsp
@@ -23,12 +23,15 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 %>
 
 <clay:link
+	additionalProps='<%= (HashMap)request.getAttribute("liferay-social-bookmarks:bookmark:additionalProps") %>'
+	aria-label="<%= socialBookmark.getName(request.getLocale()) %>"
 	borderless="<%= true %>"
 	cssClass="c-px-2 lfr-portal-tooltip"
 	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="social-linkedin"
 	outline="<%= true %>"
+	propsTransformer="js/OpenSocialBookmarkPropsTransformer"
 	small="<%= true %>"
 	title="<%= socialBookmark.getName(request.getLocale()) %>"
 	type="button"

--- a/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/page.jsp
@@ -26,10 +26,11 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 	additionalProps='<%= (HashMap)request.getAttribute("liferay-social-bookmarks:bookmark:additionalProps") %>'
 	aria-label="<%= socialBookmark.getName(request.getLocale()) %>"
 	borderless="<%= true %>"
-	cssClass="c-px-2 lfr-portal-tooltip"
+	cssClass="lfr-portal-tooltip"
 	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="social-linkedin"
+	monospaced="<%= true %>"
 	outline="<%= true %>"
 	propsTransformer="js/OpenSocialBookmarkPropsTransformer"
 	small="<%= true %>"

--- a/modules/apps/social/social-bookmark-twitter/package.json
+++ b/modules/apps/social/social-bookmark-twitter/package.json
@@ -1,7 +1,5 @@
 {
 	"dependencies": {
-		"frontend-js-web": "*",
-		"social-bookmarks-taglib": "*"
 	},
 	"name": "@liferay/social-bookmark-twitter",
 	"scripts": {

--- a/modules/apps/social/social-bookmark-twitter/package.json
+++ b/modules/apps/social/social-bookmark-twitter/package.json
@@ -1,12 +1,13 @@
 {
 	"dependencies": {
+		"frontend-js-web": "*",
+		"social-bookmarks-taglib": "*"
 	},
-	"main": "index.js",
-	"name": "social-bookmarks-taglib",
+	"name": "@liferay/social-bookmark-twitter",
 	"scripts": {
 		"build": "liferay-npm-scripts build",
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "4.0.15"
+	"version": "4.0.9"
 }

--- a/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/init.jsp
@@ -18,3 +18,5 @@
 
 <%@ page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.social.bookmarks.SocialBookmark" %>
+
+<%@ page import="java.util.HashMap" %>

--- a/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
+++ b/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
@@ -12,19 +12,4 @@
  * details.
  */
 
-import {openSocialBookmark} from 'social-bookmarks-taglib';
-
-export default function propsTransformer({
-	additionalProps: {className, classPK, postURL, type, url},
-	...otherProps
-}) {
-	return {
-		...otherProps,
-		onClick(event) {
-			event.preventDefault();
-			event.stopPropagation();
-
-			return openSocialBookmark({className, classPK, postURL, type, url});
-		},
-	};
-}
+export {OpenSocialBookmarkPropsTransformer as default} from 'social-bookmarks-taglib';

--- a/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
+++ b/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
@@ -1,4 +1,3 @@
-<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -12,11 +11,20 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
---%>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
+import {openSocialBookmark} from 'social-bookmarks-taglib';
 
-<%@ page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.social.bookmarks.SocialBookmark" %>
+export default function propsTransformer({
+	additionalProps: {className, classPK, postURL, type, url},
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		onClick(event) {
+			event.preventDefault();
+			event.stopPropagation();
 
-<%@ page import="java.util.HashMap" %>
+			return openSocialBookmark({className, classPK, postURL, type, url});
+		},
+	};
+}

--- a/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/page.jsp
@@ -23,12 +23,15 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 %>
 
 <clay:link
+	additionalProps='<%= (HashMap)request.getAttribute("liferay-social-bookmarks:bookmark:additionalProps") %>'
+	aria-label="<%= socialBookmark.getName(request.getLocale()) %>"
 	borderless="<%= true %>"
 	cssClass="c-px-2 lfr-portal-tooltip"
 	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="twitter"
 	outline="<%= true %>"
+	propsTransformer="js/OpenSocialBookmarkPropsTransformer"
 	small="<%= true %>"
 	title="<%= socialBookmark.getName(request.getLocale()) %>"
 	type="button"

--- a/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/page.jsp
@@ -26,10 +26,11 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 	additionalProps='<%= (HashMap)request.getAttribute("liferay-social-bookmarks:bookmark:additionalProps") %>'
 	aria-label="<%= socialBookmark.getName(request.getLocale()) %>"
 	borderless="<%= true %>"
-	cssClass="c-px-2 lfr-portal-tooltip"
+	cssClass="lfr-portal-tooltip"
 	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="twitter"
+	monospaced="<%= true %>"
 	outline="<%= true %>"
 	propsTransformer="js/OpenSocialBookmarkPropsTransformer"
 	small="<%= true %>"

--- a/modules/apps/social/social-bookmarks-taglib/bnd.bnd
+++ b/modules/apps/social/social-bookmarks-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Social Bookmarks Taglib
 Bundle-SymbolicName: com.liferay.social.bookmarks.taglib
-Bundle-Version: 4.0.15
+Bundle-Version: 4.1.0
 Export-Package: com.liferay.social.bookmarks.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/social/social-bookmarks-taglib/package.json
+++ b/modules/apps/social/social-bookmarks-taglib/package.json
@@ -8,5 +8,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "4.0.15"
+	"version": "4.1.0"
 }

--- a/modules/apps/social/social-bookmarks-taglib/src/main/java/com/liferay/social/bookmarks/taglib/internal/util/SocialBookmarksTagUtil.java
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/java/com/liferay/social/bookmarks/taglib/internal/util/SocialBookmarksTagUtil.java
@@ -16,7 +16,6 @@ package com.liferay.social.bookmarks.taglib.internal.util;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.social.bookmarks.SocialBookmark;
 
 import java.util.List;
@@ -26,17 +25,6 @@ import java.util.Locale;
  * @author Alejandro Tardín
  */
 public class SocialBookmarksTagUtil {
-
-	public static String getClickJSCall(
-		String className, long classPK, String type, String postURL,
-		String url) {
-
-		return String.format(
-			"socialBookmarks_handleItemClick(event, '%s', %d, '%s', '%s', " +
-				"'%s');",
-			HtmlUtil.escapeJS(className), classPK, HtmlUtil.escapeJS(type),
-			HtmlUtil.escapeJS(postURL), HtmlUtil.escapeJS(url));
-	}
 
 	public static List<DropdownItem> getDropdownItems(
 		Locale locale, String[] types, String className, long classPK,

--- a/modules/apps/social/social-bookmarks-taglib/src/main/java/com/liferay/social/bookmarks/taglib/servlet/taglib/SocialBookmarkTag.java
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/java/com/liferay/social/bookmarks/taglib/servlet/taglib/SocialBookmarkTag.java
@@ -22,6 +22,8 @@ import com.liferay.taglib.util.AttributesTagSupport;
 
 import java.io.IOException;
 
+import java.util.Map;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
@@ -42,6 +44,9 @@ public class SocialBookmarkTag extends AttributesTagSupport {
 			if (socialBookmark != null) {
 				HttpServletRequest httpServletRequest = getRequest();
 
+				httpServletRequest.setAttribute(
+					"liferay-social-bookmarks:bookmark:additionalProps",
+					_additionalProps);
 				httpServletRequest.setAttribute(
 					"liferay-social-bookmarks:bookmark:displayStyle",
 					_displayStyle);
@@ -68,6 +73,10 @@ public class SocialBookmarkTag extends AttributesTagSupport {
 		catch (IOException | ServletException exception) {
 			throw new JspException(exception);
 		}
+	}
+
+	public void setAdditionalProps(Map<String, Object> additionalProps) {
+		_additionalProps = additionalProps;
 	}
 
 	public void setDisplayStyle(String displayStyle) {
@@ -101,6 +110,7 @@ public class SocialBookmarkTag extends AttributesTagSupport {
 		return SocialBookmarksRegistryUtil.getSocialBookmark(_type);
 	}
 
+	private Map<String, Object> _additionalProps;
 	private String _displayStyle;
 	private String _target;
 	private String _title;

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/liferay-social-bookmarks.tld
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/liferay-social-bookmarks.tld
@@ -15,6 +15,11 @@
 		<tag-class>com.liferay.social.bookmarks.taglib.servlet.taglib.SocialBookmarkTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
+			<name>additionalProps</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>displayStyle</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
@@ -43,8 +43,9 @@
 					SocialBookmark socialBookmark = SocialBookmarksRegistryUtil.getSocialBookmark(types[i]);
 				%>
 
-					<li class="taglib-social-bookmark <%= "taglib-social-bookmark-" + types[i] %>" onClick="<%= SocialBookmarksTagUtil.getClickJSCall(className, classPK, types[i], socialBookmark.getPostURL(title, url), url) %>">
+					<li class="taglib-social-bookmark <%= "taglib-social-bookmark-" + types[i] %>">
 						<liferay-social-bookmarks:bookmark
+							additionalProps='<%= HashMapBuilder.<String, Object>put("className", HtmlUtil.escapeJS(className)).put("classPK", String.valueOf(classPK)).put("postURL", socialBookmark.getPostURL(title, url)).put("type", types[i]).put("url", HtmlUtil.escapeJS(url)).build() %>'
 							displayStyle="<%= displayStyle %>"
 							target="<%= target %>"
 							title="<%= title %>"
@@ -78,12 +79,4 @@
 			</c:if>
 		</c:otherwise>
 	</c:choose>
-
-	<liferay-util:html-bottom
-		outputKey="social_bookmarks"
-	>
-		<liferay-frontend:component
-			module="js/SocialBookmarksHandleItemClick"
-		/>
-	</liferay-util:html-bottom>
 </div>

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/index.js
@@ -12,4 +12,4 @@
  * details.
  */
 
-export {default as openSocialBookmark} from './js/openSocialBookmark';
+export {default as OpenSocialBookmarkPropsTransformer} from './js/OpenSocialBookmarkPropsTransformer';

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/index.js
@@ -12,20 +12,4 @@
  * details.
  */
 
-import openSocialBookmark from './openSocialBookmark';
-
-export default function () {
-	window.socialBookmarks_handleItemClick = function (
-		event,
-		className,
-		classPK,
-		type,
-		postURL,
-		url
-	) {
-		event.preventDefault();
-		event.stopPropagation();
-
-		openSocialBookmark({className, classPK, postURL, type, url});
-	};
-}
+export {default as openSocialBookmark} from './js/openSocialBookmark';

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -20,7 +20,6 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
-taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/social-bookmarks" prefix="liferay-social-bookmarks" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
@@ -31,6 +30,8 @@ page import="com.liferay.portal.kernel.configuration.Filter" %><%@
 page import="com.liferay.portal.kernel.servlet.BrowserSnifferUtil" %><%@
 page import="com.liferay.portal.kernel.util.ArrayUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.KeyValuePair" %><%@
 page import="com.liferay.portal.kernel.util.KeyValuePairComparator" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@
@@ -48,8 +49,6 @@ page import="java.util.Arrays" %><%@
 page import="java.util.HashSet" %><%@
 page import="java.util.List" %><%@
 page import="java.util.Set" %>
-
-<liferay-frontend:defineObjects />
 
 <liferay-theme:defineObjects />
 

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/js/OpenSocialBookmarkPropsTransformer.js
@@ -12,4 +12,19 @@
  * details.
  */
 
-export {OpenSocialBookmarkPropsTransformer as default} from 'social-bookmarks-taglib';
+import openSocialBookmark from './openSocialBookmark';
+
+export default function propsTransformer({
+	additionalProps: {className, classPK, postURL, type, url},
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		onClick(event) {
+			event.preventDefault();
+			event.stopPropagation();
+
+			return openSocialBookmark({className, classPK, postURL, type, url});
+		},
+	};
+}

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/com/liferay/social/bookmarks/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/com/liferay/social/bookmarks/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/npmscripts.config.js
+++ b/modules/npmscripts.config.js
@@ -275,6 +275,9 @@ module.exports = {
 					'item-selector-taglib': {
 						'/': '*',
 					},
+					'social-bookmarks-taglib': {
+						'/': '*',
+					},
 				},
 			},
 			exclude: {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/SocialBookmarks.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/SocialBookmarks.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>SOCIAL_BOOKMARK_ICON</td>
-	<td>//li[contains(@class,'taglib-social-bookmark-${key_socialBookmark}')]/a</td>
+	<td>//li[contains(@class,'taglib-social-bookmark-${key_socialBookmark}')]/*/a</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
LPS-144724 Improve accessibility for social buttons (Facebook, LinkedIn, Twitter), move onClick from li element to link element a.

Steps:
1. Add an asset publisher to a page, be sure you have at least one web content created
2. Open configuration of asset publisher go to Display Settings -> SOCIAL BOOKMARKS (add Facebook, Twitter and LinkedIn) 
3. Close the configuration and inspect the Facebook button (see the HTML DOM) when you click it should open a dialog with sharing post

