### PR TITLE
LPS-141237 Add test CustomElementCanConfigurePortletName

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -195,7 +195,9 @@ definition {
 
 		RemoteApps.goToRemoteAppsPortlet();
 
-		Click(locator1 = "xPath=(//div[@class='table-list-title']//a)");
+		Click(
+			key_tableEntryName = "Vanilla Counter",
+			locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE");
 
 		var currentURL = Navigator.getCurrentURL();
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -190,6 +190,21 @@ definition {
 		PortletEntry.publish();
 	}
 
+	macro getRemoteAppEntryIdValue {
+		WaitForSPARefresh();
+
+		RemoteApps.goToRemoteAppsPortlet();
+
+		Click(locator1 = "xPath=(//div[@class='table-list-title']//a)");
+
+		var currentURL = Navigator.getCurrentURL();
+
+		var findWhereIdBegins = StringUtil.extractLast("${currentURL}", "remoteAppEntryId=");
+		var remoteAppEntryIdValue = StringUtil.extractFirst("${findWhereIdBegins}", "&_com_liferay_remote_app_admin_web_portlet_RemoteAppAdminPortlet_redirect");
+
+		return "${remoteAppEntryIdValue}";
+	}
+
 	macro getRemoteAppEntryName {
 		WaitForSPARefresh();
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayout.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayout.macro
@@ -126,6 +126,7 @@ definition {
 			groupId = "${groupId}",
 			layoutName = "${layoutName}",
 			privateLayout = "false",
+			remoteAppEntryId = "${remoteAppEntryId}",
 			widgetName = "${widgetName}");
 
 		JSONLayoutAPI._updateTypeSettings(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutSetter.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutSetter.macro
@@ -114,12 +114,6 @@ definition {
 		if (isSet(widgetName)) {
 			var typeSettings = JSONLayoutUtil._addWidgetToTypeSettings(
 				column = "${column}",
-				typeSettings = "${typeSettings}",
-				widgetName = "${widgetName}");
-		}
-		else if (isSet(widgetName) && isSet(remoteAppEntryId)) {
-			var typeSettings = JSONLayoutUtil._addWidgetToTypeSettings(
-				column = "${column}",
 				remoteAppEntryId = "${remoteAppEntryId}",
 				typeSettings = "${typeSettings}",
 				widgetName = "${widgetName}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutSetter.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutSetter.macro
@@ -117,6 +117,13 @@ definition {
 				typeSettings = "${typeSettings}",
 				widgetName = "${widgetName}");
 		}
+		else if (isSet(widgetName) && isSet(remoteAppEntryId)) {
+			var typeSettings = JSONLayoutUtil._addWidgetToTypeSettings(
+				column = "${column}",
+				remoteAppEntryId = "${remoteAppEntryId}",
+				typeSettings = "${typeSettings}",
+				widgetName = "${widgetName}");
+		}
 
 		if (!(isSet(layoutTemplate)) && !(isSet(widgetName))) {
 			fail("typeSettings will not be updated.");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutUtil.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutUtil.macro
@@ -10,13 +10,10 @@ definition {
 
 		Variables.assertDefined(parameterList = "${typeSettings}");
 
+		var widget = JSONLayoutUtil._generateWidget(widgetName = "${widgetName}");
+
 		if (isSet(remoteAppEntryId)) {
-			var widget = JSONLayoutUtil._generateWidget(
-				remoteAppEntryId = "${remoteAppEntryId}",
-				widgetName = "${widgetName}");
-		}
-		else {
-			var widget = JSONLayoutUtil._generateWidget(widgetName = "${widgetName}");
+			var widget = StringUtil.replace("${widget}", "remoteAppEntryId", "${remoteAppEntryId}");
 		}
 
 		if (contains("${typeSettings}", "column-${column}=")) {
@@ -189,7 +186,7 @@ definition {
 			var portletId = "com_liferay_social_user_statistics_web_portlet_SocialUserStatisticsPortlet";
 		}
 		else if ("${widgetName}" == "Vanilla Counter") {
-			var portletId = "com_liferay_remote_app_web_internal_portlet_RemoteAppEntryPortlet_${remoteAppEntryId}";
+			var portletId = "com_liferay_remote_app_web_internal_portlet_RemoteAppEntryPortlet_remoteAppEntryId";
 		}
 		else if ("${widgetName}" == "Web Content Display") {
 			var portletId = "com_liferay_journal_content_web_portlet_JournalContentPortlet";

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutUtil.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutUtil.macro
@@ -10,7 +10,14 @@ definition {
 
 		Variables.assertDefined(parameterList = "${typeSettings}");
 
-		var widget = JSONLayoutUtil._generateWidget(widgetName = "${widgetName}");
+		if (isSet(remoteAppEntryId)) {
+			var widget = JSONLayoutUtil._generateWidget(
+				remoteAppEntryId = "${remoteAppEntryId}",
+				widgetName = "${widgetName}");
+		}
+		else {
+			var widget = JSONLayoutUtil._generateWidget(widgetName = "${widgetName}");
+		}
 
 		if (contains("${typeSettings}", "column-${column}=")) {
 			var typeSettings = StringUtil.regexReplaceFirst("${typeSettings}", "(column-${column}=[^%]*)", "$1,${widget}");
@@ -180,6 +187,9 @@ definition {
 		}
 		else if ("${widgetName}" == "User Statistics") {
 			var portletId = "com_liferay_social_user_statistics_web_portlet_SocialUserStatisticsPortlet";
+		}
+		else if ("${widgetName}" == "Vanilla Counter") {
+			var portletId = "com_liferay_remote_app_web_internal_portlet_RemoteAppEntryPortlet_${remoteAppEntryId}";
 		}
 		else if ("${widgetName}" == "Web Content Display") {
 			var portletId = "com_liferay_journal_content_web_portlet_JournalContentPortlet";

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -21,8 +21,8 @@
 	<td></td>
 </tr>
 <tr>
-	<td>PAGE_EDITOR_WIDGET_SEARCH_REMOTE_APP</td>
-	<td>//div[contains(@class,'page-editor__sidebar')]//li[contains(@class,'page-editor__fragments-widget')]//div[contains(@class, 'text-truncate title')][contains(text(),'${key_remoteAppName}')]</td>
+	<td>APPLICATION_SEARCH_FIELD_WIDGET_SEARCH_REMOTE_APP</td>
+	<td>//div[contains(@class,'sidebar-body__add-panel')]//div[contains(@class, 'text-truncate title')][contains(text(),'${key_remoteAppName}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -21,6 +21,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>PAGE_EDITOR_WIDGET_SEARCH_REMOTE_APP</td>
+	<td>//div[contains(@class,'page-editor__sidebar')]//li[contains(@class,'page-editor__fragments-widget')]//div[contains(@class, 'text-truncate title')][contains(text(),'${key_remoteAppName}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>REMOTE_TABLE_DELETE</td>
 	<td>//a[contains(@class,'dropdown-item') and contains(.,'Delete')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -308,6 +308,81 @@ definition {
 		}
 	}
 
+	@description = "Verify remote app can be configured one its portlet name has been changed"
+	@priority = "3"
+	test CustomElementCanConfigurePortletName {
+		property portal.acceptance = "true";
+
+		task ("Add a public page with JSON") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Test Page",
+				type = "content");
+
+			JSONLayout.publishLayout(
+				groupName = "Guest",
+				layoutName = "Test Page");
+		}
+
+		task ("Create Vanilla Counter as a Custom Element") {
+			JSONRemoteApp.addCustomElementRemoteAppEntry(
+				customElementHTMLName = "vanilla-counter",
+				customElementName = "Vanilla Counter",
+				customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+		}
+
+		task ("Add Vanilla Counter to Test Page") {
+			ContentPagesNavigator.openEditContentPage(
+				pageName = "Test Page",
+				siteName = "Guest");
+
+			PageEditor.addWidget(portletName = "Vanilla Counter");
+
+			PageEditor.clickPublish();
+
+			Navigator.gotoPage(pageName = "Test Page");
+		}
+
+		task ("Change Vanilla Counter portlet name") {
+			RemoteApps.goToRemoteAppsPortlet();
+
+			Click(
+				key_tableEntryName = "Vanilla Counter",
+				locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE");
+
+			Type(
+				key_text = "Name",
+				locator1 = "TextInput#ANY",
+				value1 = "Vanilla Counter Modified");
+
+			PortletEntry.publish();
+		}
+
+		task ("Assert that Vanilla Counter name has been changed in Widget Page Editor") {
+			ContentPagesNavigator.openEditContentPage(
+				pageName = "Test Page",
+				siteName = "Guest");
+
+			PageEditor.gotoTab(tabName = "Fragments and Widgets");
+
+			Navigator.gotoNavTab(navTab = "Widgets");
+
+			Type.sendKeysApplicationSearch(
+				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_SEARCH_FIELD",
+				value1 = "Vanilla Counter Modified");
+
+			AssertElementPresent(
+				key_remoteAppName = "Vanilla Counter Modified",
+				locator1 = "RemoteApps#PAGE_EDITOR_WIDGET_SEARCH_REMOTE_APP");
+		}
+
+		task ("Assert Vanilla Counter continues displayed") {
+			Navigator.gotoPage(pageName = "Test Page");
+
+			AssertElementPresent(locator1 = "RemoteApps#VANILLA_COUNTER_REMOTE_APP");
+		}
+	}
+
 	@description = "Verify an iframe remote app can be created"
 	@priority = "5"
 	test IFrameCanBeCreated {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -286,6 +286,76 @@ definition {
 		}
 	}
 
+	@description = "Verify remote app can be configured one its portlet name has been changed"
+	@priority = "3"
+	test CustomElementCanConfigurePortletName {
+		property portal.acceptance = "true";
+
+		task ("Add a public page with JSON") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Test Page");
+		}
+
+		task ("Create Vanilla Counter as a Custom Element") {
+			JSONRemoteApp.addCustomElementRemoteAppEntry(
+				customElementHTMLName = "vanilla-counter",
+				customElementName = "Vanilla Counter",
+				customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+		}
+
+		task ("Obtain Vanilla Counter's remoteAppEntryId") {
+			var remoteAppEntryIdValue = RemoteApps.getRemoteAppEntryIdValue();
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Test Page",
+				remoteAppEntryId = "${remoteAppEntryIdValue}",
+				widgetName = "Vanilla Counter");
+		}
+
+		task ("Change Vanilla Counter portlet name") {
+			RemoteApps.goToRemoteAppsPortlet();
+
+			Click(
+				key_tableEntryName = "Vanilla Counter",
+				locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE");
+
+			Type(
+				key_text = "Name",
+				locator1 = "TextInput#ANY",
+				value1 = "Vanilla Counter Modified");
+
+			PortletEntry.publish();
+		}
+
+		task ("Assert that Vanilla Counter name has been changed in Widget Page Editor") {
+			Navigator.gotoPage(pageName = "Test Page");
+
+			Click(locator1 = "ControlMenu#ADD");
+
+			AssertElementPresent(locator1 = "ControlMenuAddPanel#SIDEBAR_HEADER");
+
+			Navigator.gotoNavTab(navTab = "Widgets");
+
+			Pause(locator1 = "3000");
+
+			Type(
+				locator1 = "NavBar#APPLICATION_SEARCH_FIELD",
+				value1 = "Vanilla Counter Modified");
+
+			AssertElementPresent(
+				key_remoteAppName = "Vanilla Counter Modified",
+				locator1 = "RemoteApps#APPLICATION_SEARCH_FIELD_WIDGET_SEARCH_REMOTE_APP");
+		}
+
+		task ("Assert Vanilla Counter continues displayed") {
+			Navigator.gotoPage(pageName = "Test Page");
+
+			AssertElementPresent(locator1 = "RemoteApps#VANILLA_COUNTER_REMOTE_APP");
+		}
+	}
+
 	@description = "Verify that remote app of type Custom Element can save multiple URLs"
 	@priority = "4"
 	test CustomElementCanSaveMultipleURLs {
@@ -305,81 +375,6 @@ definition {
 
 		task ("Assert multiple URL fields are saved") {
 			RemoteApps.assertCustomElementMultipleURLFields();
-		}
-	}
-
-	@description = "Verify remote app can be configured one its portlet name has been changed"
-	@priority = "3"
-	test CustomElementCanConfigurePortletName {
-		property portal.acceptance = "true";
-
-		task ("Add a public page with JSON") {
-			JSONLayout.addPublicLayout(
-				groupName = "Guest",
-				layoutName = "Test Page",
-				type = "content");
-
-			JSONLayout.publishLayout(
-				groupName = "Guest",
-				layoutName = "Test Page");
-		}
-
-		task ("Create Vanilla Counter as a Custom Element") {
-			JSONRemoteApp.addCustomElementRemoteAppEntry(
-				customElementHTMLName = "vanilla-counter",
-				customElementName = "Vanilla Counter",
-				customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
-		}
-
-		task ("Add Vanilla Counter to Test Page") {
-			ContentPagesNavigator.openEditContentPage(
-				pageName = "Test Page",
-				siteName = "Guest");
-
-			PageEditor.addWidget(portletName = "Vanilla Counter");
-
-			PageEditor.clickPublish();
-
-			Navigator.gotoPage(pageName = "Test Page");
-		}
-
-		task ("Change Vanilla Counter portlet name") {
-			RemoteApps.goToRemoteAppsPortlet();
-
-			Click(
-				key_tableEntryName = "Vanilla Counter",
-				locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE");
-
-			Type(
-				key_text = "Name",
-				locator1 = "TextInput#ANY",
-				value1 = "Vanilla Counter Modified");
-
-			PortletEntry.publish();
-		}
-
-		task ("Assert that Vanilla Counter name has been changed in Widget Page Editor") {
-			ContentPagesNavigator.openEditContentPage(
-				pageName = "Test Page",
-				siteName = "Guest");
-
-			PageEditor.gotoTab(tabName = "Fragments and Widgets");
-
-			Navigator.gotoNavTab(navTab = "Widgets");
-
-			Type.sendKeysApplicationSearch(
-				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_SEARCH_FIELD",
-				value1 = "Vanilla Counter Modified");
-
-			AssertElementPresent(
-				key_remoteAppName = "Vanilla Counter Modified",
-				locator1 = "RemoteApps#PAGE_EDITOR_WIDGET_SEARCH_REMOTE_APP");
-		}
-
-		task ("Assert Vanilla Counter continues displayed") {
-			Navigator.gotoPage(pageName = "Test Page");
-
-			AssertElementPresent(locator1 = "RemoteApps#VANILLA_COUNTER_REMOTE_APP");
 		}
 	}
 


### PR DESCRIPTION
**Test Scenario:**
- Given: Remote App
- When: change the portlet alias (Name field)
- Then: the portlet alias is reflected on the remote app in the add widget panel

**What is new?**
RemoteApps#CustomElementCanConfigurePortletName: When Custom Element is displayed with a specific name, this name could be changeable and been viewed adding Widget in Page Editor.

**JIRA Ticket:** 
https://issues.liferay.com/browse/LPS-141237