### PR TITLE
LPS-144455 Decrease ExceptionMapper priority so other more specific m…

### DIFF
--- a/modules/apps/portal-remote/portal-remote-jaxrs-security-impl/src/main/java/com/liferay/portal/remote/jaxrs/security/internal/container/response/filter/AccessControlledContainerRequestResponseFilter.java
+++ b/modules/apps/portal-remote/portal-remote-jaxrs-security-impl/src/main/java/com/liferay/portal/remote/jaxrs/security/internal/container/response/filter/AccessControlledContainerRequestResponseFilter.java
@@ -12,13 +12,12 @@
  * details.
  */
 
-package com.liferay.portal.remote.jaxrs.security.internal.exception.mapper;
+package com.liferay.portal.remote.jaxrs.security.internal.container.response.filter;
 
 import com.liferay.petra.reflect.AnnotationLocator;
 import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
 import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.security.auth.AccessControlContext;
-import com.liferay.portal.remote.jaxrs.security.internal.entity.ForbiddenEntity;
 import com.liferay.portal.security.access.control.AccessControlAdvisor;
 import com.liferay.portal.security.access.control.AccessControlAdvisorImpl;
 
@@ -27,7 +26,6 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
-import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.container.ContainerRequestContext;
@@ -36,13 +34,7 @@ import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.MessageBodyWriter;
-import javax.ws.rs.ext.Providers;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
@@ -56,14 +48,10 @@ import org.osgi.service.component.annotations.ServiceScope;
 		"osgi.jaxrs.extension=true", "osgi.jaxrs.name=Liferay.Access.Control"
 	},
 	scope = ServiceScope.PROTOTYPE,
-	service = {
-		ContainerRequestFilter.class, ContainerResponseFilter.class,
-		ExceptionMapper.class
-	}
+	service = {ContainerRequestFilter.class, ContainerResponseFilter.class}
 )
-public class AccessControlledContainerRequestResponseFilterExceptionMapper
-	implements ContainerRequestFilter, ContainerResponseFilter,
-			   ExceptionMapper<SecurityException> {
+public class AccessControlledContainerRequestResponseFilter
+	implements ContainerRequestFilter, ContainerResponseFilter {
 
 	@Override
 	public void filter(ContainerRequestContext containerRequestContext)
@@ -90,37 +78,6 @@ public class AccessControlledContainerRequestResponseFilterExceptionMapper
 		throws IOException {
 
 		_decrementServiceDepth();
-	}
-
-	@Override
-	public Response toResponse(SecurityException securityException) {
-		MediaType mediaType = null;
-
-		List<MediaType> mediaTypes = _httpHeaders.getAcceptableMediaTypes();
-
-		for (MediaType currentMediaType : mediaTypes) {
-			MessageBodyWriter<ForbiddenEntity> messageBodyWriter =
-				_providers.getMessageBodyWriter(
-					ForbiddenEntity.class, null, null, currentMediaType);
-
-			if (messageBodyWriter != null) {
-				mediaType = currentMediaType;
-
-				break;
-			}
-		}
-
-		if (mediaType == null) {
-			mediaType = MediaType.APPLICATION_XML_TYPE;
-		}
-
-		return Response.status(
-			Response.Status.FORBIDDEN
-		).entity(
-			new ForbiddenEntity(securityException)
-		).type(
-			mediaType
-		).build();
 	}
 
 	private void _decrementServiceDepth() {
@@ -194,12 +151,6 @@ public class AccessControlledContainerRequestResponseFilterExceptionMapper
 
 	private final AccessControlAdvisor _accessControlAdvisor =
 		new AccessControlAdvisorImpl();
-
-	@Context
-	private HttpHeaders _httpHeaders;
-
-	@Context
-	private Providers _providers;
 
 	@Context
 	private Request _request;

--- a/modules/apps/portal-remote/portal-remote-jaxrs-security-impl/src/main/java/com/liferay/portal/remote/jaxrs/security/internal/exception/mapper/SecurityExceptionMapper.java
+++ b/modules/apps/portal-remote/portal-remote-jaxrs-security-impl/src/main/java/com/liferay/portal/remote/jaxrs/security/internal/exception/mapper/SecurityExceptionMapper.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.remote.jaxrs.security.internal.exception.mapper;
+
+import com.liferay.portal.remote.jaxrs.security.internal.entity.ForbiddenEntity;
+
+import java.util.List;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Providers;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Víctor Galán
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(!(liferay.access.control.disable=true))",
+		"osgi.jaxrs.extension=true"
+	},
+	service = ExceptionMapper.class
+)
+public class SecurityExceptionMapper
+	implements ExceptionMapper<SecurityException> {
+
+	@Override
+	public Response toResponse(SecurityException securityException) {
+		MediaType mediaType = null;
+
+		List<MediaType> mediaTypes = _httpHeaders.getAcceptableMediaTypes();
+
+		for (MediaType currentMediaType : mediaTypes) {
+			MessageBodyWriter<ForbiddenEntity> messageBodyWriter =
+				_providers.getMessageBodyWriter(
+					ForbiddenEntity.class, null, null, currentMediaType);
+
+			if (messageBodyWriter != null) {
+				mediaType = currentMediaType;
+
+				break;
+			}
+		}
+
+		if (mediaType == null) {
+			mediaType = MediaType.APPLICATION_XML_TYPE;
+		}
+
+		return Response.status(
+			Response.Status.FORBIDDEN
+		).entity(
+			new ForbiddenEntity(securityException)
+		).type(
+			mediaType
+		).build();
+	}
+
+	@Context
+	private HttpHeaders _httpHeaders;
+
+	@Context
+	private Providers _providers;
+
+}


### PR DESCRIPTION
…appers are called before

For a given Exception, when there is more than one ExceptionMapper, the priority is compared. For reference:
* https://github.com/apache/cxf/blob/master/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java#L192
* https://github.com/apache/cxf/blob/master/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java#L638

Currently none of ours ExceptionMapper have a priority assigned, that means that the value given is `Priorities.User` which is 5000. 

This pr set a lower priority for the default ExceptionMapper to allow other more specific Mapper handle their corresponding exception first ([lower priorities values means higher priority  ¯\_(ツ)_/¯](https://docs.oracle.com/javaee/7/api/javax/ws/rs/Priorities.html) ). 10 value is arbitrary, 1 would suffice, but having more we can have other priorities available in the future in case we need it
