### PR TITLE
LPS-141238 | Assert multiple URLs can be saved in a Custom Element Remote App

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -61,12 +61,12 @@ definition {
 			value1 = "Custom Element");
 
 		RemoteAppsEntry.addCustomElementMultipleURLs(
-			entryCSSURL1 = "${entryCSSURL1}",
-			entryCSSURL2 = "${entryCSSURL2}",
-			entryHTMLName = "${entryHTMLName}",
-			entryName = "${entryName}",
-			entryURL1 = "${entryURL1}",
-			entryURL2 = "${entryURL2}");
+			entryCSSURL1 = "https://liferay.github.io/liferay-frontend-projects/index1.css",
+			entryCSSURL2 = "https://liferay.github.io/liferay-frontend-projects/index2.css",
+			entryHTMLName = "vanilla-counter",
+			entryName = "Vanilla Counter",
+			entryURL1 = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index1.js",
+			entryURL2 = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index2.js");
 
 		PortletEntry.publish();
 	}
@@ -105,40 +105,40 @@ definition {
 
 	macro assertCustomElementMultipleURLFields {
 		AssertTextEquals(
-			custom_entryName = "${entryName}",
+			custom_entryName = "Vanilla Counter",
 			key_text = "Name",
 			locator1 = "TextInput#ANY",
-			value1 = "${entryName}");
+			value1 = "Vanilla Counter");
 
 		AssertTextEquals(
-			custom_entryHTMLName = "${entryHTMLName}",
+			custom_entryHTMLName = "vanilla-counter",
 			key_text = "HTML Element Name",
 			locator1 = "TextInput#ANY",
-			value1 = "${entryHTMLName}");
+			value1 = "vanilla-counter");
 
 		AssertTextEquals(
 			key_id = "customElementURLs",
 			key_index = "1",
-			locator1 = "RemoteAppsEntry#URL_ROW",
-			value1 = "${entryURL1}");
+			locator1 = "RemoteAppsEntry#URL_ROW_INDEX",
+			value1 = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index1.js");
 
 		AssertTextEquals(
 			key_id = "customElementURLs",
 			key_index = "2",
-			locator1 = "RemoteAppsEntry#URL_ROW",
-			value1 = "${entryURL2}");
+			locator1 = "RemoteAppsEntry#URL_ROW_INDEX",
+			value1 = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index2.js");
 
 		AssertTextEquals(
 			key_id = "customElementCSSURLs",
 			key_index = "1",
-			locator1 = "RemoteAppsEntry#URL_ROW",
-			value1 = "${entryCSSURL1}");
+			locator1 = "RemoteAppsEntry#URL_ROW_INDEX",
+			value1 = "https://liferay.github.io/liferay-frontend-projects/index1.css");
 
 		AssertTextEquals(
 			key_id = "customElementCSSURLs",
 			key_index = "2",
-			locator1 = "RemoteAppsEntry#URL_ROW",
-			value1 = "${entryCSSURL2}");
+			locator1 = "RemoteAppsEntry#URL_ROW_INDEX",
+			value1 = "https://liferay.github.io/liferay-frontend-projects/index2.css");
 	}
 
 	macro assertTableEntryNameNotPresent {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -53,6 +53,24 @@ definition {
 		PortletEntry.publish();
 	}
 
+	macro addCustomElementMultipleURLs {
+		LexiconEntry.gotoAdd();
+
+		Select(
+			locator1 = "Select#TYPE",
+			value1 = "Custom Element");
+
+		RemoteAppsEntry.addCustomElementMultipleURLs(
+			entryCSSURL1 = "${entryCSSURL1}",
+			entryCSSURL2 = "${entryCSSURL2}",
+			entryHTMLName = "${entryHTMLName}",
+			entryName = "${entryName}",
+			entryURL1 = "${entryURL1}",
+			entryURL2 = "${entryURL2}");
+
+		PortletEntry.publish();
+	}
+
 	macro assertCustomElementFields {
 		AssertTextEquals(
 			custom_entryName = "${entryName}",
@@ -83,6 +101,44 @@ definition {
 			key_text = "Properties",
 			locator1 = "RemoteAppsEntry#REMOTE_APPS_PROPERTIES",
 			value1 = "${entryProperties}");
+	}
+
+	macro assertCustomElementMultipleURLFields {
+		AssertTextEquals(
+			custom_entryName = "${entryName}",
+			key_text = "Name",
+			locator1 = "TextInput#ANY",
+			value1 = "${entryName}");
+
+		AssertTextEquals(
+			custom_entryHTMLName = "${entryHTMLName}",
+			key_text = "HTML Element Name",
+			locator1 = "TextInput#ANY",
+			value1 = "${entryHTMLName}");
+
+		AssertTextEquals(
+			key_id = "customElementURLs",
+			key_index = "1",
+			locator1 = "RemoteAppsEntry#URL_ROW",
+			value1 = "${entryURL1}");
+
+		AssertTextEquals(
+			key_id = "customElementURLs",
+			key_index = "2",
+			locator1 = "RemoteAppsEntry#URL_ROW",
+			value1 = "${entryURL2}");
+
+		AssertTextEquals(
+			key_id = "customElementCSSURLs",
+			key_index = "1",
+			locator1 = "RemoteAppsEntry#URL_ROW",
+			value1 = "${entryCSSURL1}");
+
+		AssertTextEquals(
+			key_id = "customElementCSSURLs",
+			key_index = "2",
+			locator1 = "RemoteAppsEntry#URL_ROW",
+			value1 = "${entryCSSURL2}");
 	}
 
 	macro assertTableEntryNameNotPresent {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsEntry.macro
@@ -67,25 +67,25 @@ definition {
 		Type(
 			key_id = "customElementURLs",
 			key_index = "1",
-			locator1 = "RemoteAppsEntry#URL_ROW",
+			locator1 = "RemoteAppsEntry#URL_ROW_INDEX",
 			value1 = "${entryURL1}");
 
 		Type(
 			key_id = "customElementURLs",
 			key_index = "2",
-			locator1 = "RemoteAppsEntry#URL_ROW",
+			locator1 = "RemoteAppsEntry#URL_ROW_INDEX",
 			value1 = "${entryURL2}");
 
 		Type(
 			key_id = "customElementCSSURLs",
 			key_index = "1",
-			locator1 = "RemoteAppsEntry#URL_ROW",
+			locator1 = "RemoteAppsEntry#URL_ROW_INDEX",
 			value1 = "${entryCSSURL1}");
 
 		Type(
 			key_id = "customElementCSSURLs",
 			key_index = "2",
-			locator1 = "RemoteAppsEntry#URL_ROW",
+			locator1 = "RemoteAppsEntry#URL_ROW_INDEX",
 			value1 = "${entryCSSURL2}");
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsEntry.macro
@@ -1,5 +1,11 @@
 definition {
 
+	macro addCSSURLRow {
+		Click(
+			key_id = "customElementCSSURLs",
+			locator1 = "RemoteAppsEntry#ADD_URL_ROW");
+	}
+
 	macro addCustomElement {
 		Type(
 			key_text = "Name",
@@ -43,6 +49,46 @@ definition {
 			value1 = "${entryProperties}");
 	}
 
+	macro addCustomElementMultipleURLs {
+		Type(
+			key_text = "Name",
+			locator1 = "TextInput#ANY",
+			value1 = "${entryName}");
+
+		Type(
+			key_text = "HTML Element Name",
+			locator1 = "TextInput#ANY",
+			value1 = "${entryHTMLName}");
+
+		RemoteAppsEntry.addURLRow();
+
+		RemoteAppsEntry.addCSSURLRow();
+
+		Type(
+			key_id = "customElementURLs",
+			key_index = "1",
+			locator1 = "RemoteAppsEntry#URL_ROW",
+			value1 = "${entryURL1}");
+
+		Type(
+			key_id = "customElementURLs",
+			key_index = "2",
+			locator1 = "RemoteAppsEntry#URL_ROW",
+			value1 = "${entryURL2}");
+
+		Type(
+			key_id = "customElementCSSURLs",
+			key_index = "1",
+			locator1 = "RemoteAppsEntry#URL_ROW",
+			value1 = "${entryCSSURL1}");
+
+		Type(
+			key_id = "customElementCSSURLs",
+			key_index = "2",
+			locator1 = "RemoteAppsEntry#URL_ROW",
+			value1 = "${entryCSSURL2}");
+	}
+
 	macro addEntry {
 		Type(
 			key_text = "Name",
@@ -53,6 +99,12 @@ definition {
 			key_id = "iFrameURL",
 			locator1 = "RemoteAppsEntry#URL",
 			value1 = "${entryURL}");
+	}
+
+	macro addURLRow {
+		Click(
+			key_id = "customElementURLs",
+			locator1 = "RemoteAppsEntry#ADD_URL_ROW");
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
@@ -17,8 +17,8 @@
 </tr>
 <tr>
 	<td>URL</td>
-<td>//input[(contains(@id,'${key_id}'))]</td>
-<td></td>
+	<td>//input[(contains(@id,'${key_id}'))]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>REMOTE_APPS_INSTANCEABLE</td>
@@ -28,6 +28,16 @@
 <tr>
 	<td>REMOTE_APPS_PROPERTIES</td>
 	<td>//textarea[contains(@id,'properties')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ADD_URL_ROW</td>
+	<td>//*[contains(@id,'${key_id}')]//button[contains(@class,'add-row')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>URL_ROW</td>
+	<td>//*[contains(@class,'form-row')][${key_index}]//input[(contains(@id,'${key_id}'))]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
@@ -16,8 +16,18 @@
 	<td></td>
 </tr>
 <tr>
+	<td>ADD_URL_ROW</td>
+	<td>//*[contains(@id,'${key_id}')]//button[contains(@class,'add-row')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>URL</td>
 	<td>//input[(contains(@id,'${key_id}'))]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>URL_ROW_INDEX</td>
+	<td>//*[contains(@class,'form-row')][${key_index}]//input[(contains(@id,'${key_id}'))]</td>
 	<td></td>
 </tr>
 <tr>
@@ -28,16 +38,6 @@
 <tr>
 	<td>REMOTE_APPS_PROPERTIES</td>
 	<td>//textarea[contains(@id,'properties')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>ADD_URL_ROW</td>
-	<td>//*[contains(@id,'${key_id}')]//button[contains(@class,'add-row')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>URL_ROW</td>
-	<td>//*[contains(@class,'form-row')][${key_index}]//input[(contains(@id,'${key_id}'))]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -291,39 +291,20 @@ definition {
 	test CustomElementCanSaveMultipleURLs {
 		property portal.acceptance = "true";
 
-		var customElementName = "Vanilla Counter";
-		var customElementHTMLName = "vanilla-counter";
-		var customElementURL1 = "http://remote-component-test.wincent.com/packages/vanilla-counter/index1.js";
-		var customElementURL2 = "http://remote-component-test.wincent.com/packages/vanilla-counter/index2.js";
-		var customElementCSSURL1 = "http://remote-component-test.wincent.com/index1.css";
-		var customElementCSSURL2 = "http://remote-component-test.wincent.com/index2.css";
-
 		task ("Create Vanilla Counter as a Custom Element") {
 			RemoteApps.goToRemoteAppsPortlet();
 
-			RemoteApps.addCustomElementMultipleURLs(
-				entryCSSURL1 = "${customElementCSSURL1}",
-				entryCSSURL2 = "${customElementCSSURL2}",
-				entryHTMLName = "${customElementHTMLName}",
-				entryName = "${customElementName}",
-				entryURL1 = "${customElementURL1}",
-				entryURL2 = "${customElementURL2}");
+			RemoteApps.addCustomElementMultipleURLs();
 		}
 
-		task ("Edit the entry") {
+		task ("Go to edit entry") {
 			Click(
-				key_tableEntryName = "${customElementName}",
+				key_tableEntryName = "Vanilla Counter",
 				locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE");
 		}
 
 		task ("Assert multiple URL fields are saved") {
-			RemoteApps.assertCustomElementMultipleURLFields(
-				entryCSSURL1 = "${customElementCSSURL1}",
-				entryCSSURL2 = "${customElementCSSURL2}",
-				entryHTMLName = "${customElementHTMLName}",
-				entryName = "${customElementName}",
-				entryURL1 = "${customElementURL1}",
-				entryURL2 = "${customElementURL2}");
+			RemoteApps.assertCustomElementMultipleURLFields();
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -286,6 +286,47 @@ definition {
 		}
 	}
 
+	@description = "Verify that remote app of type Custom Element can save multiple URLs"
+	@priority = "4"
+	test CustomElementCanSaveMultipleURLs {
+		property portal.acceptance = "true";
+
+		var customElementName = "Vanilla Counter";
+		var customElementHTMLName = "vanilla-counter";
+		var customElementURL1 = "http://remote-component-test.wincent.com/packages/vanilla-counter/index1.js";
+		var customElementURL2 = "http://remote-component-test.wincent.com/packages/vanilla-counter/index2.js";
+		var customElementCSSURL1 = "http://remote-component-test.wincent.com/index1.css";
+		var customElementCSSURL2 = "http://remote-component-test.wincent.com/index2.css";
+
+		task ("Create Vanilla Counter as a Custom Element") {
+			RemoteApps.goToRemoteAppsPortlet();
+
+			RemoteApps.addCustomElementMultipleURLs(
+				entryCSSURL1 = "${customElementCSSURL1}",
+				entryCSSURL2 = "${customElementCSSURL2}",
+				entryHTMLName = "${customElementHTMLName}",
+				entryName = "${customElementName}",
+				entryURL1 = "${customElementURL1}",
+				entryURL2 = "${customElementURL2}");
+		}
+
+		task ("Edit the entry") {
+			Click(
+				key_tableEntryName = "${customElementName}",
+				locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE");
+		}
+
+		task ("Assert multiple URL fields are saved") {
+			RemoteApps.assertCustomElementMultipleURLFields(
+				entryCSSURL1 = "${customElementCSSURL1}",
+				entryCSSURL2 = "${customElementCSSURL2}",
+				entryHTMLName = "${customElementHTMLName}",
+				entryName = "${customElementName}",
+				entryURL1 = "${customElementURL1}",
+				entryURL2 = "${customElementURL2}");
+		}
+	}
+
 	@description = "Verify an iframe remote app can be created"
 	@priority = "5"
 	test IFrameCanBeCreated {


### PR DESCRIPTION
**Background**
Create automation tests for the Remote App portlet

**Test Plan**

- Navigate to remote app portlet
- Create Custom Element remote app with two URLs and two CSS URLs
- Edit the app entry
- Assert all URLs are saved

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-141238