### PR TITLE
LPS-142527 Mantain selected vocabularies when moving them from one box to another

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/VocabulariesSelectionBox.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/VocabulariesSelectionBox.js
@@ -36,6 +36,11 @@ const VocabulariesSelectionBox = ({
 
 	const selectorRef = useRef();
 
+	const previousLeftElementsRef = useRef();
+	useEffect(() => {
+		previousLeftElementsRef.current = leftElements;
+	});
+
 	const enableAllOptions = () => {
 		const options = Array.from(
 			selectorRef.current.querySelectorAll(
@@ -124,6 +129,35 @@ const VocabulariesSelectionBox = ({
 			(allSitesAreNonGlobal && mixedNonGlobalSites)
 		);
 	};
+
+	const maintainSelectedVocabularies = () => {
+		const previousLeftElements = previousLeftElementsRef.current;
+
+		if (
+			typeof previousLeftElements !== 'undefined' &&
+			previousLeftElements.length < leftElements.length
+		) {
+			const intersection = leftElements.filter(
+				(x) => !previousLeftElements.includes(x)
+			);
+			const newLeftSelection = intersection.map((elem) => elem.value);
+			previousLeftElementsRef.current = leftElements;
+			setLeftSelected(newLeftSelection);
+		}
+		else if (
+			typeof previousLeftElements !== 'undefined' &&
+			previousLeftElements.length > leftElements.length
+		) {
+			const intersection = previousLeftElements.filter(
+				(x) => !leftElements.includes(x)
+			);
+			const newRightSelection = intersection.map((elem) => elem.value);
+			previousLeftElementsRef.current = leftElements;
+			setRightSelected(newRightSelection);
+		}
+	};
+
+	maintainSelectedVocabularies();
 
 	useEffect(() => {
 		enableAllOptions();


### PR DESCRIPTION
Motivation
=======
When moving from 'Available' to 'In Use', selected status it's lost.
[Link to story or ticket](https://issues.liferay.com/browse/LPS-142527)

Proposed Solution
========
We needed to update the selected vocabularies in each box after moving a vocabulary from left to right or right to left.
