### PR TITLE
LPS-144949 Autogenerate componentId when it is null in <liferay-frontend:component> tag

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTag.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.taglib.util.ParamAndPropertyAncestorTagImpl;
 
 import java.io.IOException;
@@ -39,6 +40,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -197,8 +199,14 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 	private String _getRenderInvocation(String variableName) {
 		StringBundler sb = new StringBundler(14);
 
+		String componentId = Optional.ofNullable(
+			getComponentId()
+		).orElse(
+			_UNNAMED_COMPONENT_NAME + PortalUUIDUtil.generate()
+		);
+
 		sb.append("Liferay.component('");
-		sb.append(getComponentId());
+		sb.append(componentId);
 		sb.append("', new ");
 
 		sb.append(variableName);
@@ -305,6 +313,9 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 				module + " as " + variableName, ScriptData.ModulesType.ES6);
 		}
 	}
+
+	private static final String _UNNAMED_COMPONENT_NAME =
+		"__UNNAMED_COMPONENT__";
 
 	private static final char[] _UNSAFE_MODULE_NAME_CHARS = {
 		CharPool.PERIOD, CharPool.DASH

--- a/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTagTest.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/ComponentTagTest.java
@@ -25,8 +25,10 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.PortalImpl;
+import com.liferay.portal.uuid.PortalUUIDImpl;
 
 import java.io.StringWriter;
 
@@ -67,6 +69,10 @@ public class ComponentTagTest {
 		PortalUtil portalUtil = new PortalUtil();
 
 		portalUtil.setPortal(new PortalImpl());
+
+		PortalUUIDUtil portalUUIDUtil = new PortalUUIDUtil();
+
+		portalUUIDUtil.setPortalUUID(new PortalUUIDImpl());
 	}
 
 	@Test


### PR DESCRIPTION
ATM if a liferay-component is created without componentId is created, this is registered as "null" in the Liferay.component infraestructure. This may work when we only have one component without id, but having two it results in one of them not destroying properly when navigating away from the page.

In this pr, the id is generated is none is provided.

### How to test this?

This is an example I've found to be easy:

- Go to https://github.com/liferay/liferay-portal/blob/f02a4dce37aa9fc5c3c3b09ddae43e7cc5f6ffe5/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/move_articles_and_folders.jsp#L185-L194 and duplicate the component
- Deploy journal-web
 - Create a web content article
 - Click on the kebab menu 
 - Click Move
 - Open console

Before the pr:
There is a message warning that the component with id "null" is registered twice

After the pr:
There is no message