### PR TITLE
LPS-144537 - Keep MT info button fixed to the right

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1011,7 +1011,10 @@ public class ManagementToolbarTag extends BaseContainerTag {
 
 			jspWriter.write("</button></li>");
 
-			if (isShowInfoButton()) {
+			if (!FFManagementToolbarConfigurationUtil.
+					showDesignImprovements() &&
+				isShowInfoButton()) {
+
 				jspWriter.write("<li class=\"nav-item\"><button class=\"");
 				jspWriter.write(" nav-link nav-link-monospaced btn");
 				jspWriter.write(" btn-monospaced btn-unstyled\" type=\"button");
@@ -1059,6 +1062,23 @@ public class ManagementToolbarTag extends BaseContainerTag {
 				linkTag.doTag(pageContext);
 
 				jspWriter.write("</li>");
+			}
+
+			if (FFManagementToolbarConfigurationUtil.showDesignImprovements() &&
+				isShowInfoButton()) {
+
+				jspWriter.write("<li class=\"nav-item\"><button class=\"");
+				jspWriter.write(" nav-link nav-link-monospaced btn");
+				jspWriter.write(" btn-monospaced btn-unstyled\" type=\"button");
+				jspWriter.write("\">");
+
+				iconTag = new IconTag();
+
+				iconTag.setSymbol("info-circle-open");
+
+				iconTag.doTag(pageContext);
+
+				jspWriter.write("</button></li>");
 			}
 
 			jspWriter.write("</ul>");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/InfoPanelControl.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/InfoPanelControl.js
@@ -14,9 +14,13 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayManagementToolbar from '@clayui/management-toolbar';
-import React, {useEffect, useRef} from 'react';
+import classNames from 'classnames';
+import React, {useContext, useEffect, useRef} from 'react';
 
-const InfoPanelControl = ({infoPanelId, onInfoButtonClick}) => {
+import FeatureFlagContext from './FeatureFlagContext';
+
+const InfoPanelControl = ({infoPanelId, onInfoButtonClick, separator}) => {
+	const {showDesignImprovements} = useContext(FeatureFlagContext);
 	const infoButtonRef = useRef();
 
 	useEffect(() => {
@@ -42,7 +46,14 @@ const InfoPanelControl = ({infoPanelId, onInfoButtonClick}) => {
 	}, [infoButtonRef, infoPanelId]);
 
 	return (
-		<ClayManagementToolbar.Item>
+		<ClayManagementToolbar.Item
+			className={
+				showDesignImprovements &&
+				classNames('d-none d-md-flex', {
+					'management-bar-separator-left': separator,
+				})
+			}
+		>
 			<ClayButtonWithIcon
 				className="nav-link nav-link-monospaced"
 				displayType="unstyled"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -27,6 +27,8 @@ import ResultsBar from './ResultsBar';
 import SearchControls from './SearchControls';
 import SelectionControls from './SelectionControls';
 
+import './ManagementToolbar.scss';
+
 function ManagementToolbar({
 	clearResultsURL,
 	clearSelectionURL,
@@ -214,6 +216,7 @@ function ManagementToolbar({
 						<InfoPanelControl
 							infoPanelId={infoPanelId}
 							onInfoButtonClick={onInfoButtonClick}
+							separator={active}
 						/>
 					)}
 				</ClayManagementToolbar.ItemList>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -146,7 +146,7 @@ function ManagementToolbar({
 						/>
 					)}
 
-					{showInfoButton && (
+					{!showDesignImprovementsFF && showInfoButton && (
 						<InfoPanelControl
 							infoPanelId={infoPanelId}
 							onInfoButtonClick={onInfoButtonClick}
@@ -208,6 +208,13 @@ function ManagementToolbar({
 								</ClayManagementToolbar.Item>
 							)}
 						</>
+					)}
+
+					{showDesignImprovementsFF && showInfoButton && (
+						<InfoPanelControl
+							infoPanelId={infoPanelId}
+							onInfoButtonClick={onInfoButtonClick}
+						/>
 					)}
 				</ClayManagementToolbar.ItemList>
 			</ClayManagementToolbar>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
@@ -1,0 +1,9 @@
+@import 'atlas-variables';
+
+.management-bar-separator-left::before {
+	background-color: $gray-500;
+	content: '';
+	height: 16px;
+	margin: 0 10px;
+	width: 1px;
+}


### PR DESCRIPTION
If this rings a bell, it's because I'm resending this PR because the previous one didn't use a feature flag

### References

- [LPS-144537](https://issues.liferay.com/browse/LPS-144537)

### What is the goal?

* Move Management Toolbar info button to the right, both in normal and contextual mode
* Add separator to the left of MT info button in contextual mode
* Hide info button in mobile
* Use epic FF to hide these changes

### What does it look like?


https://user-images.githubusercontent.com/6642927/147652937-fec55f54-3376-4239-b5be-646d7b40ebf0.mov




### How to replicate
* Enable the feature flag
   * Download the FF file [from this epic](https://issues.liferay.com/browse/LPS-144527)
   * Paste that file in `/bundles/osgi/configs/`  
* Log into portal, go to `Content & Data > Web Content` 
* See that the rightmost element in the toolbar at the top is now the info button
* Click on select all, see that the rightmost element is still the info button
* Shrink window to mobile size, see that the info button is not visible
* Click again on select all, see that the info button is not visible either