### PR TITLE
LPS-137441 Icon Provisioning Part.1

### DIFF
--- a/modules/apps/frontend-icon/app.bnd
+++ b/modules/apps/frontend-icon/app.bnd
@@ -1,0 +1,15 @@
+Liferay-Releng-App-Description:
+Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Frontend Icon
+Liferay-Releng-Bundle: true
+Liferay-Releng-Category: Utility
+Liferay-Releng-Demo-Url:
+Liferay-Releng-Deprecated: false
+Liferay-Releng-Fix-Delivery-Method: core
+Liferay-Releng-Labs: false
+Liferay-Releng-Marketplace: true
+Liferay-Releng-Portal-Required: true
+Liferay-Releng-Public: ${liferay.releng.public}
+Liferay-Releng-Restart-Required: true
+Liferay-Releng-Suite: foundation
+Liferay-Releng-Support-Url: http://www.liferay.com
+Liferay-Releng-Supported: ${liferay.releng.supported}

--- a/modules/apps/frontend-icon/build.gradle
+++ b/modules/apps/frontend-icon/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: "com.liferay.app.defaults.plugin"

--- a/modules/apps/frontend-icon/frontend-icon-admin-web/.gitignore
+++ b/modules/apps/frontend-icon/frontend-icon-admin-web/.gitignore
@@ -1,0 +1,1 @@
+/src/main/resources/META-INF/resources/images/*

--- a/modules/apps/frontend-icon/frontend-icon-admin-web/bnd.bnd
+++ b/modules/apps/frontend-icon/frontend-icon-admin-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Frontend Icon Admin Web
+Bundle-SymbolicName: com.liferay.frontend.icon.admin.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /frontend-icon-admin-web

--- a/modules/apps/frontend-icon/frontend-icon-admin-web/build.gradle
+++ b/modules/apps/frontend-icon/frontend-icon-admin-web/build.gradle
@@ -1,3 +1,27 @@
+import com.liferay.gradle.util.copy.StripPathSegmentsAction
+
+task buildClayIcons(type: Copy)
+
+buildClayIcons {
+	File destinationDir = file("src/main/resources/META-INF/resources/images");
+
+	dependsOn npmInstall
+
+	doFirst {
+		delete destinationDir
+	}
+
+	eachFile new StripPathSegmentsAction(5)
+	from npmInstall.nodeModulesDir
+	include "@clayui/css/lib/images/icons/icons.svg"
+	includeEmptyDirs = false
+	into destinationDir
+}
+
+classes {
+	dependsOn buildClayIcons
+}
+
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/frontend-icon/frontend-icon-admin-web/build.gradle
+++ b/modules/apps/frontend-icon/frontend-icon-admin-web/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+}

--- a/modules/apps/frontend-icon/frontend-icon-admin-web/src/main/java/com/liferay/frontend/icon/admin/web/internal/servlet/SVGServlet.java
+++ b/modules/apps/frontend-icon/frontend-icon-admin-web/src/main/java/com/liferay/frontend/icon/admin/web/internal/servlet/SVGServlet.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.icon.admin.web.internal.servlet;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.PrintWriter;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bryce Osterhaus
+ */
+@Component(
+	immediate = true,
+	property = {
+		"osgi.http.whiteboard.context.path=/icons",
+		"osgi.http.whiteboard.servlet.pattern=/icons/*"
+	},
+	service = Servlet.class
+)
+public class SVGServlet extends HttpServlet {
+
+	@Override
+	protected void doGet(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		try {
+			httpServletResponse.setCharacterEncoding("UTF-8");
+			httpServletResponse.setContentType(ContentTypes.IMAGE_SVG_XML);
+			httpServletResponse.setStatus(HttpServletResponse.SC_OK);
+
+			PrintWriter printWriter = httpServletResponse.getWriter();
+
+			String path = httpServletRequest.getPathInfo();
+
+			Matcher matcher = _pattern.matcher(path);
+
+			if (!matcher.matches() ||
+				!Objects.equals(matcher.group(1), "clay")) {
+
+				httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
+			}
+			else {
+				String spritemap = StringUtil.read(
+					SVGServlet.class, "/META-INF/resources/images/icons.svg");
+
+				printWriter.write(spritemap);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
+
+			exception.printStackTrace();
+
+			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(SVGServlet.class);
+
+	private static final Pattern _pattern = Pattern.compile("^/(.*).svg");
+
+	@Reference
+	private Portal _portal;
+
+}


### PR DESCRIPTION
This aims to be a small PR to start the work on converting the PoC from https://github.com/liferay-frontend/liferay-portal/pull/1608

For now It is just add a servlet that serves the clay spritemap. I wanted to make this as simple as possible so we can send this right away to brin to get feedback the module naming. 

It changes a bit the approach from the PoC where we had the clay icons served from a different module. That had some problems with clustering, and also user may disable the module and the clay spritemap would just not be there. This way we make sure the clay spritemap is always there.

