### PR TITLE
LPS-145183 frontend-data-set-web: Change DateTime from input

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/index.js
@@ -29,7 +29,7 @@ import QuantitySelectorRenderer from './QuantitySelectorRenderer';
 import StatusRenderer from './StatusRenderer';
 import TooltipSummaryRenderer from './TooltipSummaryRenderer';
 
-const dataRenderers = {
+export const dataRenderers = {
 	actionLink: ActionsLinkRenderer,
 	actionsDropdown: ActionsDropdownRenderer,
 	boolean: BooleanRenderer,
@@ -49,9 +49,4 @@ export const inputRenderers = {
 	checkbox: InputCheckboxRenderer,
 	dateTime: InputDateTimeRenderer,
 	text: InputTextRenderer,
-};
-
-export default {
-	...dataRenderers,
-	...inputRenderers,
 };

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.js
@@ -76,7 +76,10 @@ export {App as DataSet};
 
 // Renderers API
 
-export {default as DataRenderers} from './data_renderers/index';
+export {
+	dataRenderers as DataRenderers,
+	inputRenderers as InputRenderers,
+} from './data_renderers/index';
 export {default as DateTimeRenderer} from './data_renderers/DateTimeRenderer';
 export {default as StatusRenderer} from './data_renderers/StatusRenderer';
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/dataRenderers.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/dataRenderers.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import dataRenderers, {inputRenderers} from '../data_renderers/index';
+import {dataRenderers, inputRenderers} from '../data_renderers/index';
 import {getJsModule} from './modules';
 
 export function getInputRendererById(id) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-145183 - DateTime in FDS table schema is shown as an input

Hi, the other day @thektan noticed that the dates in the FDS table look like an input instead of a basic string. It seems like the inputRenderer for `dateTime` will always be used over the dataRenderer `dateTime`, so I just updated the name of the former to `dateTimeInput`. Not sure if that's the best way, but feel free to change it ⭐ 

Example table is visible on Objects.

<img width="1218" alt="Screen Shot 2022-01-11 at 3 02 11 PM" src="https://user-images.githubusercontent.com/14063502/149036563-2a613908-d18a-46af-a64a-76d6b6c30ecc.png">
 