### PR TITLE
LPS-144540 - Add responsive mode to + button

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1068,7 +1068,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 				linkTag = new LinkTag();
 
 				linkTag.setCssClass(
-					"nav-btn btn-content-spaced d-md-flex d-none btn btn-primary");
+					"nav-btn d-md-flex d-none pl-4 pr-4 btn btn-primary");
 				linkTag.setLabel(LanguageUtil.get(resourceBundle, "new"));
 
 				linkTag.doTag(pageContext);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1055,25 +1055,38 @@ public class ManagementToolbarTag extends BaseContainerTag {
 
 				LinkTag linkTag = new LinkTag();
 
-				linkTag.setCssClass(
-					"d-md-none nav-btn nav-btn-monospaced btn btn-primary");
+				if (FFManagementToolbarConfigurationUtil.
+						showDesignImprovements()) {
+
+					linkTag.setCssClass(
+						"d-md-none nav-btn nav-btn-monospaced btn btn-primary");
+				}
+				else {
+					linkTag.setCssClass(
+						"nav-btn nav-btn-monospaced btn btn-primary");
+				}
+
 				linkTag.setIcon("plus");
 
 				linkTag.doTag(pageContext);
 
 				jspWriter.write("</li>");
 
-				jspWriter.write("<li class=\"nav-item\">");
+				if (FFManagementToolbarConfigurationUtil.
+						showDesignImprovements()) {
 
-				linkTag = new LinkTag();
+					jspWriter.write("<li class=\"nav-item\">");
 
-				linkTag.setCssClass(
-					"nav-btn d-md-flex d-none pl-4 pr-4 btn btn-primary");
-				linkTag.setLabel(LanguageUtil.get(resourceBundle, "new"));
+					linkTag = new LinkTag();
 
-				linkTag.doTag(pageContext);
+					linkTag.setCssClass(
+						"nav-btn d-md-flex d-none pl-4 pr-4 btn btn-primary");
+					linkTag.setLabel(LanguageUtil.get(resourceBundle, "new"));
 
-				jspWriter.write("</li>");
+					linkTag.doTag(pageContext);
+
+					jspWriter.write("</li>");
+				}
 			}
 
 			if (FFManagementToolbarConfigurationUtil.showDesignImprovements() &&

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1056,8 +1056,20 @@ public class ManagementToolbarTag extends BaseContainerTag {
 				LinkTag linkTag = new LinkTag();
 
 				linkTag.setCssClass(
-					"nav-btn nav-btn-monospaced btn btn-primary");
+					"d-md-none nav-btn nav-btn-monospaced btn btn-primary");
 				linkTag.setIcon("plus");
+
+				linkTag.doTag(pageContext);
+
+				jspWriter.write("</li>");
+
+				jspWriter.write("<li class=\"nav-item\">");
+
+				linkTag = new LinkTag();
+
+				linkTag.setCssClass(
+					"nav-btn btn-content-spaced d-md-flex d-none btn btn-primary");
+				linkTag.setLabel(LanguageUtil.get(resourceBundle, "new"));
 
 				linkTag.doTag(pageContext);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -15,10 +15,13 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import classNames from 'classnames';
-import React, {useRef, useState} from 'react';
+import React, {useContext, useRef, useState} from 'react';
 
 import getDataAttributes from '../get_data_attributes';
+import FeatureFlagContext from './FeatureFlagContext';
 import LinkOrButton from './LinkOrButton';
+
+import './ManagementToolbar.scss';
 
 const CreationMenu = ({
 	maxPrimaryItems,
@@ -32,6 +35,7 @@ const CreationMenu = ({
 	viewMoreURL,
 }) => {
 	const [active, setActive] = useState(false);
+	const {showDesignImprovements} = useContext(FeatureFlagContext);
 
 	const secondaryItemsCountRef = useRef(
 		secondaryItems?.reduce((acc, cur) => {
@@ -166,12 +170,23 @@ const CreationMenu = ({
 					active={active}
 					onActiveChange={setActive}
 					trigger={
-						<ClayButtonWithIcon
-							aria-label={getPlusIconLabel()}
-							className="nav-btn nav-btn-monospaced"
-							symbol="plus"
-							title={getPlusIconLabel()}
-						/>
+						showDesignImprovements ? (
+							<LinkOrButton
+								aria-label={getPlusIconLabel()}
+								className="nav-btn"
+								symbol="plus"
+								title={getPlusIconLabel()}
+							>
+								{getPlusIconLabel()}
+							</LinkOrButton>
+						) : (
+							<ClayButtonWithIcon
+								aria-label={getPlusIconLabel()}
+								className="nav-btn nav-btn-monospaced"
+								symbol="plus"
+								title={getPlusIconLabel()}
+							/>
+						)
 					}
 				>
 					{visibleItemsCount < totalItemsCountRef.current ? (
@@ -224,6 +239,25 @@ const CreationMenu = ({
 						/>
 					)}
 				</ClayDropDown>
+			) : showDesignImprovements ? (
+				<>
+					<LinkOrButton
+						aria-label={getPlusIconLabel()}
+						button={true}
+						className="nav-btn"
+						displayType="primary"
+						href={firstItemRef.current.href}
+						onClick={(event) => {
+							onCreateButtonClick(event, {
+								item: firstItemRef.current,
+							});
+						}}
+						symbol="plus"
+						title={getPlusIconLabel()}
+					>
+						{Liferay.Language.get('new')}
+					</LinkOrButton>
+				</>
 			) : (
 				<LinkOrButton
 					aria-label={getPlusIconLabel()}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -22,6 +22,8 @@ import getDataAttributes from '../get_data_attributes';
 import FeatureFlagContext from './FeatureFlagContext';
 import LinkOrButton from './LinkOrButton';
 
+import './CreationMenu.scss';
+
 const CreationMenu = ({
 	maxPrimaryItems,
 	maxSecondaryItems,
@@ -167,17 +169,21 @@ const CreationMenu = ({
 			{totalItemsCountRef.current > 1 ? (
 				<ClayDropDown
 					active={active}
+					className="creation-menu"
 					onActiveChange={setActive}
 					trigger={
 						showDesignImprovements ? (
 							<ClayButton
 								aria-label={getPlusIconLabel()}
-								className="nav-btn nav-btn-monospaced"
+								className="nav-btn"
 								title={getPlusIconLabel()}
 							>
-								<ClayIcon className="d-md-none" symbol="plus" />
+								<ClayIcon
+									className="d-md-none dropdown-icon"
+									symbol="plus"
+								/>
 
-								<span className="d-md-block d-none pl-4 pr-4">
+								<span className="d-md-block d-none pl-3 pr-3">
 									{getPlusIconLabel()}
 								</span>
 							</ClayButton>
@@ -246,7 +252,7 @@ const CreationMenu = ({
 					<LinkOrButton
 						aria-label={getPlusIconLabel()}
 						button={true}
-						className="nav-btn nav-btn-monospaced"
+						className="nav-btn"
 						displayType="primary"
 						href={firstItemRef.current.href}
 						onClick={(event) => {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -12,8 +12,9 @@
  * details.
  */
 
-import {ClayButtonWithIcon} from '@clayui/button';
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
 import React, {useContext, useRef, useState} from 'react';
 
@@ -169,15 +170,17 @@ const CreationMenu = ({
 					onActiveChange={setActive}
 					trigger={
 						showDesignImprovements ? (
-							<LinkOrButton
+							<ClayButton
 								aria-label={getPlusIconLabel()}
-								className="nav-btn"
-								symbol="plus"
+								className="nav-btn nav-btn-monospaced"
 								title={getPlusIconLabel()}
-								wide
 							>
-								{getPlusIconLabel()}
-							</LinkOrButton>
+								<ClayIcon className="d-md-none" symbol="plus" />
+
+								<span className="d-md-block d-none pl-4 pr-4">
+									{getPlusIconLabel()}
+								</span>
+							</ClayButton>
 						) : (
 							<ClayButtonWithIcon
 								aria-label={getPlusIconLabel()}
@@ -243,7 +246,7 @@ const CreationMenu = ({
 					<LinkOrButton
 						aria-label={getPlusIconLabel()}
 						button={true}
-						className="nav-btn"
+						className="nav-btn nav-btn-monospaced"
 						displayType="primary"
 						href={firstItemRef.current.href}
 						onClick={(event) => {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -21,8 +21,6 @@ import getDataAttributes from '../get_data_attributes';
 import FeatureFlagContext from './FeatureFlagContext';
 import LinkOrButton from './LinkOrButton';
 
-import './ManagementToolbar.scss';
-
 const CreationMenu = ({
 	maxPrimaryItems,
 	maxSecondaryItems,
@@ -176,6 +174,7 @@ const CreationMenu = ({
 								className="nav-btn"
 								symbol="plus"
 								title={getPlusIconLabel()}
+								wide
 							>
 								{getPlusIconLabel()}
 							</LinkOrButton>
@@ -254,6 +253,7 @@ const CreationMenu = ({
 						}}
 						symbol="plus"
 						title={getPlusIconLabel()}
+						wide
 					>
 						{Liferay.Language.get('new')}
 					</LinkOrButton>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.scss
@@ -1,0 +1,7 @@
+.creation-menu {
+	.nav-btn {
+		.dropdown-icon {
+			font-size: 1rem;
+		}
+	}
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
@@ -21,11 +21,14 @@ import React, {useContext} from 'react';
 import FeatureFlagContext from './FeatureFlagContext';
 
 const LinkOrButton = ({
+	ariaLabel,
 	children,
 	className,
 	disabled,
 	href,
 	symbol,
+	title,
+	wide,
 	...otherProps
 }) => {
 	const {showDesignImprovements} = useContext(FeatureFlagContext);
@@ -35,13 +38,15 @@ const LinkOrButton = ({
 	return (
 		<>
 			<Wrapper
+				aria-label={symbol && ariaLabel}
 				block={otherProps.button?.block}
 				className={classNames(className, {
-					'btn-content-spaced': !symbol,
 					'd-md-none': showDesignImprovements && responsive,
+					'pl-4 pr-4': wide && !symbol,
 				})}
 				href={href}
 				{...otherProps}
+				title={symbol && title}
 			>
 				{symbol ? <ClayIcon symbol={symbol} /> : children}
 			</Wrapper>
@@ -49,7 +54,9 @@ const LinkOrButton = ({
 			{showDesignImprovements && responsive && (
 				<Wrapper
 					block={otherProps.button?.block}
-					className={classNames(className, 'btn-content-spaced d-md-flex d-none')}
+					className={classNames(className, 'd-md-flex d-none', {
+						'pl-4 pr-4': wide,
+					})}
 					href={href}
 					{...otherProps}
 				>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
@@ -15,33 +15,48 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
-import React from 'react';
+import classNames from 'classnames';
+import React, {useContext} from 'react';
+
+import FeatureFlagContext from './FeatureFlagContext';
 
 const LinkOrButton = ({
-	button,
 	children,
+	className,
 	disabled,
 	href,
 	symbol,
 	...otherProps
 }) => {
+	const {showDesignImprovements} = useContext(FeatureFlagContext);
+	const responsive = symbol && children;
+	const Wrapper = href && !disabled ? ClayLink : ClayButton;
+
 	return (
 		<>
-			{href && !disabled ? (
-				<ClayLink {...otherProps} button={button} href={href}>
-					{symbol ? <ClayIcon symbol={symbol} /> : children}
-				</ClayLink>
-			) : (
-				<ClayButton
+			<Wrapper
+				block={otherProps.button?.block}
+				className={classNames(className, {
+					'btn-content-spaced': !symbol,
+					'd-md-none': showDesignImprovements && responsive,
+				})}
+				href={href}
+				{...otherProps}
+			>
+				{symbol ? <ClayIcon symbol={symbol} /> : children}
+			</Wrapper>
+
+			{showDesignImprovements && responsive && (
+				<Wrapper
+					block={otherProps.button?.block}
+					className={classNames(className, 'btn-content-spaced d-md-flex d-none')}
+					href={href}
 					{...otherProps}
-					block={button?.block}
-					disabled={disabled}
 				>
-					{symbol ? <ClayIcon symbol={symbol} /> : children}
-				</ClayButton>
+					{children}
+				</Wrapper>
 			)}
 		</>
 	);
 };
-
 export default LinkOrButton;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
@@ -42,6 +42,7 @@ const LinkOrButton = ({
 				block={otherProps.button?.block}
 				className={classNames(className, {
 					'd-md-none': showDesignImprovements && responsive,
+					'nav-btn-monospaced': showDesignImprovements && responsive,
 					'pl-4 pr-4': wide && !symbol,
 				})}
 				href={href}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -202,7 +202,7 @@ function ManagementToolbar({
 										/>
 									) : showDesignImprovementsFF ? (
 										<LinkOrButton
-											className="nav-btn nav-btn-monospaced"
+											className="nav-btn"
 											displayType="primary"
 											onClick={onCreateButtonClick}
 											symbol="plus"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -206,6 +206,7 @@ function ManagementToolbar({
 											displayType="primary"
 											onClick={onCreateButtonClick}
 											symbol="plus"
+											wide
 										>
 											{Liferay.Language.get('new')}
 										</LinkOrButton>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -15,6 +15,7 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayManagementToolbar from '@clayui/management-toolbar';
+import {LinkOrButton} from '@clayui/shared';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
@@ -199,6 +200,15 @@ function ManagementToolbar({
 												onShowMoreButtonClick
 											}
 										/>
+									) : showDesignImprovementsFF ? (
+										<LinkOrButton
+											className="nav-btn nav-btn-monospaced"
+											displayType="primary"
+											onClick={onCreateButtonClick}
+											symbol="plus"
+										>
+											{Liferay.Language.get('new')}
+										</LinkOrButton>
 									) : (
 										<ClayButtonWithIcon
 											className="nav-btn nav-btn-monospaced"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
@@ -7,12 +7,3 @@
 	margin: 0 10px;
 	width: 1px;
 }
-
-.management-bar {
-	.btn {
-		&.btn-content-spaced {
-			padding-left: 1rem;
-			padding-right: 1rem;
-		}
-	}
-}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
@@ -7,3 +7,12 @@
 	margin: 0 10px;
 	width: 1px;
 }
+
+.management-bar {
+	.btn {
+		&.btn-content-spaced {
+			padding-left: 1rem;
+			padding-right: 1rem;
+		}
+	}
+}


### PR DESCRIPTION
### References

- [LPS-144540](https://issues.liferay.com/browse/LPS-144540)

### What is the goal?

* Add responsive mode to New button
   * In smaller screens it now displays the ➕ icon and shows a tooltip when hovered
   * In larger screens it has `New` as text and doesn't display the tooltip
* Hide this under the `showDesignImprovements` FF 

### What does it look like?

https://user-images.githubusercontent.com/6642927/149175115-7f2e2294-68b8-488e-8af8-abf4db2975a7.mov



### How to replicate
* Enable the feature flag
   * Download the FF file [from this epic](https://issues.liferay.com/browse/LPS-144527)
   * Paste that file in `/bundles/osgi/configs/`  
* Open desktop browser 
* Log into portal, go to `Content & Data > Web Content` 
* See that the blue button in the toolbar at the top now displays the text `New`
* Hover over that button, see that it doesn't display a tooltip
* Shrink browser width or open in mobile phone, go to the same section
* See that the blue button in the toolbar at the top now displays the icon `+`
* Hover over that button, see that it displays a tooltip with the text `New`


### Notes
[As I have commented in the corresponding confluence doc](https://liferay.atlassian.net/wiki/spaces/ENGLEXICON/pages/1942225402?focusedCommentId=1965261951#comment-1965261951), in the future product teams might want to customize the icon and label of this button. For now it's always "New" and "➕".