### PR TITLE
LPS-145247 | Fix tests due to modified logic for table toolbar

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/BalloonEditor.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/BalloonEditor.testcase
@@ -217,7 +217,7 @@ definition {
 		}
 
 		task ("Remove the table") {
-			TripleClick(locator1 = "CKEditorBalloonEditorSample#TABLE_CELL");
+			Click(locator1 = "CKEditorBalloonEditorSample#TABLE_CELL");
 
 			Click(locator1 = "CKEditor#REMOVE_TABLE_BUTTON");
 
@@ -249,7 +249,9 @@ definition {
 		task ("Assert text edition toolbar appearance when highlighting a text inside the cell") {
 			TripleClick(locator1 = "CKEditorBalloonEditorSample#TABLE_CELL");
 
-			AssertVisible(locator1 = "CKEditor#TOOLBAR_ANY_ITEM_BUTTON");
+			AssertElementPresent(
+				key_titleName = "",
+				locator1 = "CKEditor#TOOLBAR_ANY_ITEM_BUTTON");
 		}
 	}
 


### PR DESCRIPTION
**Background:** 
Fix tests failing on https://github.com/liferay-frontend/liferay-portal/pull/1761 

**Test Plan:**
- `BalloonEditor#CanEditTable`: Change triple click to single click in table cell for table toolbar
- `BalloonEditor#CanEditTextInTable`: Fix assert for text toolbar

**JIRA Ticket:** 
https://issues.liferay.com/browse/LPS-145247
