### PR TITLE
LPS-142823 Update Remote App testcase with new Custom Element URL

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -96,7 +96,7 @@ definition {
 				entryHTMLName = "vanilla-counter",
 				entryName = "Vanilla Counter",
 				entryProperties = "test-data-user=QAuser",
-				entryURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+				entryURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
 		}
 
 		task ("Assert that the Vanilla Counter is listed") {
@@ -115,7 +115,7 @@ definition {
 				entryHTMLName = "vanilla-counter",
 				entryName = "Vanilla Counter",
 				entryProperties = "test-data-user=QAuser",
-				entryURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+				entryURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
 		}
 	}
 
@@ -128,7 +128,7 @@ definition {
 			JSONRemoteApp.addCustomElementRemoteAppEntry(
 				customElementHTMLName = "vanilla-counter",
 				customElementName = "Vanilla Counter",
-				customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+				customElementURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
 		}
 
 		task ("Delete Vanilla Counter") {
@@ -184,7 +184,7 @@ definition {
 
 		var customElementName = "Vanilla Counter";
 		var customElementHTMLName = "vanilla-counter";
-		var customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js";
+		var customElementURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js";
 
 		task ("Add a public page with JSON") {
 			JSONLayout.addPublicLayout(
@@ -230,7 +230,7 @@ definition {
 			JSONRemoteApp.addCustomElementRemoteAppEntry(
 				customElementHTMLName = "new-counter",
 				customElementName = "New Counter",
-				customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+				customElementURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
 		}
 
 		task ("Edit the fields of the Custom Element") {
@@ -261,7 +261,7 @@ definition {
 				entryHTMLName = "vanilla-counter-edited",
 				entryName = "Vanilla Counter Edited",
 				entryProperties = "test-data-user=QAuser",
-				entryURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+				entryURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
 		}
 	}
 
@@ -285,7 +285,7 @@ definition {
 			JSONRemoteApp.addCustomElementRemoteAppEntry(
 				customElementHTMLName = "vanilla-counter",
 				customElementName = "Vanilla Counter",
-				customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+				customElementURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
 		}
 
 		task ("Add a Grid to page") {
@@ -341,7 +341,7 @@ definition {
 			JSONRemoteApp.addCustomElementRemoteAppEntry(
 				customElementHTMLName = "vanilla-counter",
 				customElementName = "Vanilla Counter",
-				customElementURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+				customElementURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
 		}
 
 		task ("Obtain Vanilla Counter's remoteAppEntryId") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -92,7 +92,7 @@ definition {
 			RemoteApps.goToRemoteAppsPortlet();
 
 			RemoteApps.addCustomElementAllFields(
-				entryCSSURL = "http://remote-component-test.wincent.com/index.css",
+				entryCSSURL = "https://liferay.github.io/liferay-frontend-projects/index.css",
 				entryHTMLName = "vanilla-counter",
 				entryName = "Vanilla Counter",
 				entryProperties = "test-data-user=QAuser",
@@ -111,7 +111,7 @@ definition {
 				locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE");
 
 			RemoteApps.assertCustomElementFields(
-				entryCSSURL = "http://remote-component-test.wincent.com/index.css",
+				entryCSSURL = "https://liferay.github.io/liferay-frontend-projects/index.css",
 				entryHTMLName = "vanilla-counter",
 				entryName = "Vanilla Counter",
 				entryProperties = "test-data-user=QAuser",
@@ -241,7 +241,7 @@ definition {
 				locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE");
 
 			RemoteApps.editCustomElement(
-				entryCSSURL = "http://remote-component-test.wincent.com/index.css",
+				entryCSSURL = "https://liferay.github.io/liferay-frontend-projects/index.css",
 				entryHTMLName = "vanilla-counter-edited",
 				entryName = "Vanilla Counter Edited",
 				entryProperties = "test-data-user=QAuser");
@@ -257,7 +257,7 @@ definition {
 				locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE");
 
 			RemoteApps.assertCustomElementFields(
-				entryCSSURL = "http://remote-component-test.wincent.com/index.css",
+				entryCSSURL = "https://liferay.github.io/liferay-frontend-projects/index.css",
 				entryHTMLName = "vanilla-counter-edited",
 				entryName = "Vanilla Counter Edited",
 				entryProperties = "test-data-user=QAuser",


### PR DESCRIPTION
**What's new?**
Update Custom Element URL in RemoteApps.testcase. It includes the new one: `https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js`.

**Change in:**
- CustomElementCanBeCreated.
- CustomElementCanBeEdited.
- CustomElementCanBeDeleted.
- CustomElementCanBeDisplayedByPortlet.
- CustomElementCanBeInstanceable.
- CustomElementCanBeConfigureByPortletName.

**JIRA Ticket:** https://issues.liferay.com/browse/LPS-142823