### PR TITLE
LPS-141280 Fix Remote Apps Workflow notifications

### DIFF
--- a/modules/apps/remote-app/remote-app-api/bnd.bnd
+++ b/modules/apps/remote-app/remote-app-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Remote App API
 Bundle-SymbolicName: com.liferay.remote.app.api
-Bundle-Version: 6.0.1
+Bundle-Version: 7.0.0
 Export-Package:\
 	com.liferay.remote.app.constants,\
 	com.liferay.remote.app.deployer,\

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalService.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalService.java
@@ -368,7 +368,7 @@ public interface RemoteAppEntryLocalService
 
 	@Indexable(type = IndexableType.REINDEX)
 	public RemoteAppEntry updateCustomElementRemoteAppEntry(
-			long remoteAppEntryId, String customElementCSSURLs,
+			long userId, long remoteAppEntryId, String customElementCSSURLs,
 			String customElementHTMLElementName, String customElementURLs,
 			String description, String friendlyURLMapping,
 			Map<Locale, String> nameMap, String portletCategoryName,
@@ -377,7 +377,7 @@ public interface RemoteAppEntryLocalService
 
 	@Indexable(type = IndexableType.REINDEX)
 	public RemoteAppEntry updateIFrameRemoteAppEntry(
-			long remoteAppEntryId, String description,
+			long userId, long remoteAppEntryId, String description,
 			String friendlyURLMapping, String iFrameURL,
 			Map<Locale, String> nameMap, String portletCategoryName,
 			String properties, String sourceCodeURL)

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceUtil.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceUtil.java
@@ -429,7 +429,7 @@ public class RemoteAppEntryLocalServiceUtil {
 	}
 
 	public static RemoteAppEntry updateCustomElementRemoteAppEntry(
-			long remoteAppEntryId, String customElementCSSURLs,
+			long userId, long remoteAppEntryId, String customElementCSSURLs,
 			String customElementHTMLElementName, String customElementURLs,
 			String description, String friendlyURLMapping,
 			Map<java.util.Locale, String> nameMap, String portletCategoryName,
@@ -437,22 +437,22 @@ public class RemoteAppEntryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().updateCustomElementRemoteAppEntry(
-			remoteAppEntryId, customElementCSSURLs,
+			userId, remoteAppEntryId, customElementCSSURLs,
 			customElementHTMLElementName, customElementURLs, description,
 			friendlyURLMapping, nameMap, portletCategoryName, properties,
 			sourceCodeURL);
 	}
 
 	public static RemoteAppEntry updateIFrameRemoteAppEntry(
-			long remoteAppEntryId, String description,
+			long userId, long remoteAppEntryId, String description,
 			String friendlyURLMapping, String iFrameURL,
 			Map<java.util.Locale, String> nameMap, String portletCategoryName,
 			String properties, String sourceCodeURL)
 		throws PortalException {
 
 		return getService().updateIFrameRemoteAppEntry(
-			remoteAppEntryId, description, friendlyURLMapping, iFrameURL,
-			nameMap, portletCategoryName, properties, sourceCodeURL);
+			userId, remoteAppEntryId, description, friendlyURLMapping,
+			iFrameURL, nameMap, portletCategoryName, properties, sourceCodeURL);
 	}
 
 	/**

--- a/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceWrapper.java
+++ b/modules/apps/remote-app/remote-app-api/src/main/java/com/liferay/remote/app/service/RemoteAppEntryLocalServiceWrapper.java
@@ -497,7 +497,7 @@ public class RemoteAppEntryLocalServiceWrapper
 	@Override
 	public com.liferay.remote.app.model.RemoteAppEntry
 			updateCustomElementRemoteAppEntry(
-				long remoteAppEntryId, String customElementCSSURLs,
+				long userId, long remoteAppEntryId, String customElementCSSURLs,
 				String customElementHTMLElementName, String customElementURLs,
 				String description, String friendlyURLMapping,
 				java.util.Map<java.util.Locale, String> nameMap,
@@ -506,7 +506,7 @@ public class RemoteAppEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _remoteAppEntryLocalService.updateCustomElementRemoteAppEntry(
-			remoteAppEntryId, customElementCSSURLs,
+			userId, remoteAppEntryId, customElementCSSURLs,
 			customElementHTMLElementName, customElementURLs, description,
 			friendlyURLMapping, nameMap, portletCategoryName, properties,
 			sourceCodeURL);
@@ -515,7 +515,7 @@ public class RemoteAppEntryLocalServiceWrapper
 	@Override
 	public com.liferay.remote.app.model.RemoteAppEntry
 			updateIFrameRemoteAppEntry(
-				long remoteAppEntryId, String description,
+				long userId, long remoteAppEntryId, String description,
 				String friendlyURLMapping, String iFrameURL,
 				java.util.Map<java.util.Locale, String> nameMap,
 				String portletCategoryName, String properties,
@@ -523,8 +523,8 @@ public class RemoteAppEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _remoteAppEntryLocalService.updateIFrameRemoteAppEntry(
-			remoteAppEntryId, description, friendlyURLMapping, iFrameURL,
-			nameMap, portletCategoryName, properties, sourceCodeURL);
+			userId, remoteAppEntryId, description, friendlyURLMapping,
+			iFrameURL, nameMap, portletCategoryName, properties, sourceCodeURL);
 	}
 
 	/**

--- a/modules/apps/remote-app/remote-app-api/src/main/resources/com/liferay/remote/app/service/packageinfo
+++ b/modules/apps/remote-app/remote-app-api/src/main/resources/com/liferay/remote/app/service/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryLocalServiceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
@@ -34,6 +35,7 @@ import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -523,19 +525,19 @@ public class RemoteAppEntryLocalServiceImpl
 			long userId, RemoteAppEntry remoteAppEntry)
 		throws PortalException {
 
+		Company company = _companyLocalService.getCompany(
+			remoteAppEntry.getCompanyId());
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setAddGuestPermissions(true);
+
 		return WorkflowHandlerRegistryUtil.startWorkflowInstance(
-			remoteAppEntry.getCompanyId(), WorkflowConstants.DEFAULT_GROUP_ID,
-			userId, RemoteAppEntry.class.getName(),
+			remoteAppEntry.getCompanyId(), company.getGroupId(), userId,
+			RemoteAppEntry.class.getName(),
 			remoteAppEntry.getRemoteAppEntryId(), remoteAppEntry,
-			new ServiceContext() {
-				{
-					setAddGroupPermissions(true);
-					setAddGuestPermissions(true);
-					setCompanyId(remoteAppEntry.getCompanyId());
-					setScopeGroupId(WorkflowConstants.DEFAULT_GROUP_ID);
-					setUserId(userId);
-				}
-			},
+			serviceContext,
 			Collections.singletonMap(
 				WorkflowConstants.CONTEXT_URL,
 				Optional.ofNullable(
@@ -666,6 +668,9 @@ public class RemoteAppEntryLocalServiceImpl
 		"[A-Za-z0-9-_]*");
 
 	private BundleContext _bundleContext;
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private RemoteAppEntryDeployer _remoteAppEntryDeployer;

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryServiceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/impl/RemoteAppEntryServiceImpl.java
@@ -110,7 +110,7 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 			getPermissionChecker(), remoteAppEntryId, ActionKeys.UPDATE);
 
 		return remoteAppEntryLocalService.updateCustomElementRemoteAppEntry(
-			remoteAppEntryId, customElementCSSURLs,
+			getUserId(), remoteAppEntryId, customElementCSSURLs,
 			customElementHTMLElementName, customElementURLs, description,
 			friendlyURLMapping, nameMap, portletCategoryName, properties,
 			sourceCodeURL);
@@ -128,8 +128,8 @@ public class RemoteAppEntryServiceImpl extends RemoteAppEntryServiceBaseImpl {
 			getPermissionChecker(), remoteAppEntryId, ActionKeys.UPDATE);
 
 		return remoteAppEntryLocalService.updateIFrameRemoteAppEntry(
-			remoteAppEntryId, description, friendlyURLMapping, iFrameURL,
-			nameMap, portletCategoryName, properties, sourceCodeURL);
+			getUserId(), remoteAppEntryId, description, friendlyURLMapping,
+			iFrameURL, nameMap, portletCategoryName, properties, sourceCodeURL);
 	}
 
 	@Reference(


### PR DESCRIPTION
Change the way the ServiceContext was created because it was creating problems serializing and deserializing with the Portal JSONFactory and that was causing errors in the workflow notification flow.

Also, avoid deploying the remote app until the app is approved. This was done in the past but I guess we miss it in some PR. Add logic to the update methods to call again the workflow logic