### PR TITLE
LPS-141236 | Verify remote app can be displayed under a portlet category

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -71,6 +71,18 @@ definition {
 		PortletEntry.publish();
 	}
 
+	macro addEntryWithPortletCategory {
+		LexiconEntry.gotoAdd();
+
+		RemoteAppsEntry.addEntry(
+			entryName = "Test Remote App",
+			entryURL = "http://www.liferay.com");
+
+		RemoteAppsEntry.addPortletCategory(categoryName = "Collaboration");
+
+		PortletEntry.publish();
+	}
+
 	macro assertCustomElementFields {
 		AssertTextEquals(
 			custom_entryName = "${entryName}",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsEntry.macro
@@ -101,6 +101,12 @@ definition {
 			value1 = "${entryURL}");
 	}
 
+	macro addPortletCategory {
+		Select(
+			locator1 = "RemoteAppsEntry#REMOTE_APPS_PORTLET_CATEGORY_NAME",
+			value1 = "${categoryName}");
+	}
+
 	macro addURLRow {
 		Click(
 			key_id = "customElementURLs",

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
@@ -40,6 +40,11 @@
 	<td>//textarea[contains(@id,'properties')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>REMOTE_APPS_PORTLET_CATEGORY_NAME</td>
+	<td>//div[label[contains(.,'Portlet Category Name')]]/select</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -24,6 +24,46 @@ definition {
 		}
 	}
 
+	@description = "LPS-141236. Verify remote app can be displayed under a portlet category"
+	@priority = "3"
+	test CanBeAssignedAPortletCategory {
+		property portal.acceptance = "true";
+
+		task ("Create remote app entry with portlet category") {
+			RemoteApps.goToRemoteAppsPortlet();
+
+			RemoteApps.addEntryWithPortletCategory();
+		}
+
+		task ("Add a public widget page with JSON") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Test Page");
+
+			Navigator.openURL();
+
+			Navigator.gotoPage(pageName = "Test Page");
+		}
+
+		task ("Assert remote app is categorized under correct portlet category") {
+			Click(locator1 = "ControlMenu#ADD");
+
+			AssertElementPresent(locator1 = "ControlMenuAddPanel#SIDEBAR_HEADER");
+
+			Navigator.gotoNavTab(navTab = "Widgets");
+
+			Pause(locator1 = "3000");
+
+			Type(
+				locator1 = "NavBar#APPLICATION_SEARCH_FIELD",
+				value1 = "Test Remote App");
+
+			AssertElementPresent(
+				key_assetItem = "Collaboration",
+				locator1 = "ControlMenuAddPanel#ASSET_ITEM");
+		}
+	}
+
 	@description = "Verify remote app can be deleted"
 	@priority = "5"
 	@refactordone


### PR DESCRIPTION
**Background**
Create automation tests for Remote Apps

**Test Plan**

- Create a remote app with the "Collaboration" portlet category 
- Create and navigate to widget page 
- Open "Add" widget panel
- Assert the remote app entry is categorized under Collaboration category

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-141236