### PR TITLE
LPS-141232 Add test CustomElementCanInjectHTMLProperties

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -27,7 +27,7 @@
 </tr>
 <tr>
 	<td>REMOTE_APP_PROPERTY_HTML</td>
-	<td>//vanilla-counter[contains(@test-data-user,'${key_customElementProperty}')]</td>
+	<td>//${key_customElementHTMLName}[contains(@test-data-user,'${key_customElementProperty}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -26,6 +26,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>REMOTE_APP_PROPERTY_HTML</td>
+	<td>//vanilla-counter[contains(@test-data-user,'QAuser')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>REMOTE_TABLE_DELETE</td>
 	<td>//a[contains(@class,'dropdown-item') and contains(.,'Delete')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -27,7 +27,7 @@
 </tr>
 <tr>
 	<td>REMOTE_APP_PROPERTY_HTML</td>
-	<td>//vanilla-counter[contains(@test-data-user,'QAuser')]</td>
+	<td>//vanilla-counter[contains(@test-data-user,'${key_customElementProperty}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -404,8 +404,7 @@ definition {
 		task ("Add a public page with JSON") {
 			JSONLayout.addPublicLayout(
 				groupName = "Guest",
-				layoutName = "Test Page",
-				type = "content");
+				layoutName = "Test Page");
 		}
 
 		task ("Create Vanilla Counter as a Custom Element") {
@@ -418,21 +417,21 @@ definition {
 		}
 
 		task ("Add Vanilla Counter to Test Page") {
-			ContentPagesNavigator.openEditContentPage(
-				pageName = "Test Page",
-				siteName = "Guest");
+			var remoteAppEntryIdValue = RemoteApps.getRemoteAppEntryIdValue();
 
-			PageEditor.addWidget(portletName = "Vanilla Counter");
-
-			PageEditor.clickPublish();
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Test Page",
+				remoteAppEntryId = "${remoteAppEntryIdValue}",
+				widgetName = "Vanilla Counter");
 		}
 
 		task ("Assert Vanilla Counter's property is present") {
 			Navigator.gotoPage(pageName = "Test Page");
 
-			AssertElementPresent(locator1 = "RemoteApps#VANILLA_COUNTER_REMOTE_APP");
-
-			AssertElementPresent(locator1 = "RemoteApps#REMOTE_APP_PROPERTY_HTML");
+			AssertElementPresent(
+				key_customElementProperty = "QAuser",
+				locator1 = "RemoteApps#REMOTE_APP_PROPERTY_HTML");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -430,6 +430,7 @@ definition {
 			Navigator.gotoPage(pageName = "Test Page");
 
 			AssertElementPresent(
+				key_customElementHTMLName = "vanilla-counter",
 				key_customElementProperty = "QAuser",
 				locator1 = "RemoteApps#REMOTE_APP_PROPERTY_HTML");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -396,6 +396,46 @@ definition {
 		}
 	}
 
+	@description = "Verify that remote app of type Custom Element can displayed properties in HTML"
+	@priority = "3"
+	test CustomElementCanInjectHTMLProperties {
+		property portal.acceptance = "true";
+
+		task ("Add a public page with JSON") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Test Page",
+				type = "content");
+		}
+
+		task ("Create Vanilla Counter as a Custom Element") {
+			JSONRemoteApp.addCustomElementRemoteAppAllFields(
+				customElementCSSURL = "http://remote-component-test.wincent.com/index.css",
+				customElementHTMLName = "vanilla-counter",
+				customElementName = "Vanilla Counter",
+				customElementProperties = "test-data-user=QAuser",
+				customElementURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
+		}
+
+		task ("Add Vanilla Counter to Test Page") {
+			ContentPagesNavigator.openEditContentPage(
+				pageName = "Test Page",
+				siteName = "Guest");
+
+			PageEditor.addWidget(portletName = "Vanilla Counter");
+
+			PageEditor.clickPublish();
+		}
+
+		task ("Assert Vanilla Counter's property is present") {
+			Navigator.gotoPage(pageName = "Test Page");
+
+			AssertElementPresent(locator1 = "RemoteApps#VANILLA_COUNTER_REMOTE_APP");
+
+			AssertElementPresent(locator1 = "RemoteApps#REMOTE_APP_PROPERTY_HTML");
+		}
+	}
+
 	@description = "Verify that remote app of type Custom Element can save multiple URLs"
 	@priority = "4"
 	test CustomElementCanSaveMultipleURLs {


### PR DESCRIPTION
**Test Scenario:**
**Given**: A created Custom Element Widget referencing Vanilla Counter Custom Element
**And Given:**
**Properties**: test-data-user=QAuser
**And Given:** Custom Element Widget on content page
**When**: Navigate to content page
**Then**: test-data-user=QAuser element is present in html

**What is new?:**
`RemoteApss#CustomElementCanInjectHTMLProperties `-> Test that verifies a HTML property is present in when Custom Element is displayed in a Content Page.

**JIRA TICKET:** https://issues.liferay.com/browse/LPS-141232