### PR TITLE
LRQA-62928 | Replace ClayAlert test steps to navigate to System Settings

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -28,7 +28,15 @@ definition {
 
 		var portalURL = PropsUtil.get("portal.url");
 
-		Navigator.openSpecificURL(url = "${portalURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fedit_configuration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_factoryPid=com.liferay.frontend.js.spa.web.internal.configuration.SPAConfiguration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_pid=com.liferay.frontend.js.spa.web.internal.configuration.SPAConfiguration");
+		ApplicationsMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "System Settings");
+
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Infrastructure",
+			configurationName = "Frontend SPA Infrastructure",
+			configurationScope = "System Scope");
 
 		SystemSettings.saveConfiguration();
 
@@ -43,7 +51,15 @@ definition {
 
 		var portalURL = PropsUtil.get("portal.url");
 
-		Navigator.openSpecificURL(url = "${portalURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fedit_configuration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_factoryPid=com.liferay.frontend.js.spa.web.internal.configuration.SPAConfiguration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_pid=com.liferay.frontend.js.spa.web.internal.configuration.SPAConfiguration");
+		ApplicationsMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "System Settings");
+
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Infrastructure",
+			configurationName = "Frontend SPA Infrastructure",
+			configurationScope = "System Scope");
 
 		if (IsElementPresent(locator1 = "Button#SAVE")) {
 			PortletEntry.save();


### PR DESCRIPTION
**Background**
The URL to the System Settings config changed. So it is necessary to access it without needing a specific URL. 
**Replace the macro in ClayAlert**:
**Before**: Navigator.openSpecificURL
**Now**: ApplicationsMenu.gotoPortlet and SystemSettings.gotoConfiguration

And run ci:test:frontend:nocompile and make sure ClayAlert tests pass

**JIRA** Ticket:
https://issues.liferay.com/browse/LRQA-62928