### PR TITLE
LPS-142381 Include test coverage for ckeditor localization

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/localization/LocalizationWithWebContentUI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/localization/LocalizationWithWebContentUI.testcase
@@ -123,11 +123,12 @@ definition {
 			value1 = "Space Program 大学生涯教育 地球から、宇宙の果てへ");
 	}
 
+	@description = "This test is assigned as usecase test for CKEditor and localization in LPS-141232."
 	@priority = "5"
 	test AddWCWithTranslation {
 		property portal.acceptance = "true";
 		property test.name.skip.portal.instance = "LocalizationWithWebContent#AddWCWithTranslation";
-		property testray.component.names = "Localization,Web Content Administration";
+		property testray.component.names = "Localization,Web Content Administration,WYSIWYG";
 
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
 


### PR DESCRIPTION
**Description**
Include ci test coverage to catch escaped issue LPS-142346, which involved changes to ckeditor that affected localization.

**Test Plan**

- [x] Have a localization test run for `ci:test:relevant` when changes to ckeditor are made.

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-142381