### PR TITLE
LPS-143005 Shorten `frontend.data.set.name` property to `fds.name` 

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/FDSFilterRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/FDSFilterRegistryImpl.java
@@ -67,7 +67,7 @@ public class FDSFilterRegistryImpl implements FDSFilterRegistry {
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openMultiValueMap(
-			bundleContext, FDSFilter.class, "frontend.data.set.name",
+			bundleContext, FDSFilter.class, "fds.name",
 			ServiceTrackerCustomizerFactory.<FDSFilter>serviceWrapper(
 				bundleContext));
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/FDSViewRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/FDSViewRegistryImpl.java
@@ -66,7 +66,7 @@ public class FDSViewRegistryImpl implements FDSViewRegistry {
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openMultiValueMap(
-			bundleContext, FDSView.class, "frontend.data.set.name",
+			bundleContext, FDSView.class, "fds.name",
 			ServiceTrackerCustomizerFactory.<FDSView>serviceWrapper(
 				bundleContext));
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/SampleCheckBoxFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/SampleCheckBoxFDSFilter.java
@@ -30,7 +30,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Javier de Arcos
  */
 @Component(
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	property = "fds.name=" + FDSSampleFDSNames.FDS_SAMPLES,
 	service = FDSFilter.class
 )
 public class SampleCheckBoxFDSFilter extends BaseCheckBoxFDSFilter {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/SampleDateRangeFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/SampleDateRangeFDSFilter.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Javier de Arcos
  */
 @Component(
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	property = "fds.name=" + FDSSampleFDSNames.FDS_SAMPLES,
 	service = FDSFilter.class
 )
 public class SampleDateRangeFDSFilter extends BaseDateRangeFDSFilter {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/SampleCardsFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/SampleCardsFDSView.java
@@ -24,8 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Javier de Arcos
  */
 @Component(
-	enabled = false,
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	enabled = false, property = "fds.name=" + FDSSampleFDSNames.FDS_SAMPLES,
 	service = FDSView.class
 )
 public class SampleCardsFDSView extends BaseCardsFDSView {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/SampleListFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/SampleListFDSView.java
@@ -24,8 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Javier de Arcos
  */
 @Component(
-	enabled = false,
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	enabled = false, property = "fds.name=" + FDSSampleFDSNames.FDS_SAMPLES,
 	service = FDSView.class
 )
 public class SampleListFDSView extends BaseListFDSView {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/SampleTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/SampleTableFDSView.java
@@ -32,8 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Javier de Arcos
  */
 @Component(
-	enabled = true,
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	enabled = true, property = "fds.name=" + FDSSampleFDSNames.FDS_SAMPLES,
 	service = FDSView.class
 )
 public class SampleTableFDSView extends BaseTableFDSView {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/SampleTimelineFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/SampleTimelineFDSView.java
@@ -24,8 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Javier de Arcos
  */
 @Component(
-	enabled = false,
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	enabled = false, property = "fds.name=" + FDSSampleFDSNames.FDS_SAMPLES,
 	service = FDSView.class
 )
 public class SampleTimelineFDSView extends BaseTimelineFDSView {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -107,12 +107,12 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					_fdsTableSchemaBuilderFactory, objectDefinition,
 					_objectFieldLocalService),
 				HashMapDictionaryBuilder.put(
-					"frontend.data.set.name", objectDefinition.getPortletId()
+					"fds.name", objectDefinition.getPortletId()
 				).build()),
 			_bundleContext.registerService(
 				FDSFilter.class, new ObjectEntryStatusCheckBoxFDSFilter(),
 				HashMapDictionaryBuilder.put(
-					"frontend.data.set.name", objectDefinition.getPortletId()
+					"fds.name", objectDefinition.getPortletId()
 				).build()),
 			_bundleContext.registerService(
 				InfoItemCapabilitiesProvider.class,

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/list/type/frontend/data/set/view/table/ListTypeDefinitionsTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/list/type/frontend/data/set/view/table/ListTypeDefinitionsTableFDSView.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Gabriel Albuquerque
  */
 @Component(
-	property = "frontend.data.set.name=" + ListTypeFDSNames.LIST_TYPE_DEFINITIONS,
+	property = "fds.name=" + ListTypeFDSNames.LIST_TYPE_DEFINITIONS,
 	service = FDSView.class
 )
 public class ListTypeDefinitionsTableFDSView extends BaseTableFDSView {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/list/type/frontend/data/set/view/table/ListTypeEntriesTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/list/type/frontend/data/set/view/table/ListTypeEntriesTableFDSView.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Gabriel Albuquerque
  */
 @Component(
-	property = "frontend.data.set.name=" + ListTypeFDSNames.LIST_TYPE_DEFINITION_ITEMS,
+	property = "fds.name=" + ListTypeFDSNames.LIST_TYPE_DEFINITION_ITEMS,
 	service = FDSView.class
 )
 public class ListTypeEntriesTableFDSView extends BaseTableFDSView {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectActionsTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectActionsTableFDSView.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Brian Wing Shun Chan
  */
 @Component(
-	property = "frontend.data.set.name=" + ObjectDefinitionsFDSNames.OBJECT_ACTIONS,
+	property = "fds.name=" + ObjectDefinitionsFDSNames.OBJECT_ACTIONS,
 	service = FDSView.class
 )
 public class ObjectActionsTableFDSView extends BaseTableFDSView {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectDefinitionsTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectDefinitionsTableFDSView.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Brian Wing Shun Chan
  */
 @Component(
-	property = "frontend.data.set.name=" + ObjectDefinitionsFDSNames.OBJECT_DEFINITIONS,
+	property = "fds.name=" + ObjectDefinitionsFDSNames.OBJECT_DEFINITIONS,
 	service = FDSView.class
 )
 public class ObjectDefinitionsTableFDSView extends BaseTableFDSView {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectFieldsTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectFieldsTableFDSView.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Gabriel Albuquerque
  */
 @Component(
-	property = "frontend.data.set.name=" + ObjectDefinitionsFDSNames.OBJECT_FIELDS,
+	property = "fds.name=" + ObjectDefinitionsFDSNames.OBJECT_FIELDS,
 	service = FDSView.class
 )
 public class ObjectFieldsTableFDSView extends BaseTableFDSView {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectLayoutsTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectLayoutsTableFDSView.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Gabriel Albuquerque
  */
 @Component(
-	property = "frontend.data.set.name=" + ObjectDefinitionsFDSNames.OBJECT_LAYOUTS,
+	property = "fds.name=" + ObjectDefinitionsFDSNames.OBJECT_LAYOUTS,
 	service = FDSView.class
 )
 public class ObjectLayoutsTableFDSView extends BaseTableFDSView {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectRelationshipsTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectRelationshipsTableFDSView.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Marco Leo
  */
 @Component(
-	property = "frontend.data.set.name=" + ObjectDefinitionsFDSNames.OBJECT_RELATIONSHIPS,
+	property = "fds.name=" + ObjectDefinitionsFDSNames.OBJECT_RELATIONSHIPS,
 	service = FDSView.class
 )
 public class ObjectRelationshipsTableFDSView extends BaseTableFDSView {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectViewsTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/data/set/view/table/ObjectViewsTableFDSView.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Gabriel Albuquerque
  */
 @Component(
-	property = "frontend.data.set.name=" + ObjectDefinitionsFDSNames.OBJECT_VIEWS,
+	property = "fds.name=" + ObjectDefinitionsFDSNames.OBJECT_VIEWS,
 	service = FDSView.class
 )
 public class ObjectViewsTableFDSView extends BaseTableFDSView {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/RelatedModelsTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/RelatedModelsTableFDSView.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Marco Leo
  */
 @Component(
-	property = "frontend.data.set.name=" + ObjectEntriesFDSNames.RELATED_MODELS,
+	property = "fds.name=" + ObjectEntriesFDSNames.RELATED_MODELS,
 	service = FDSView.class
 )
 public class RelatedModelsTableFDSView extends BaseTableFDSView {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/frontend/data/set/view/table/SXPBlueprintsTableFDSView.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/frontend/data/set/view/table/SXPBlueprintsTableFDSView.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	enabled = false,
-	property = "frontend.data.set.name=" + SXPBlueprintAdminFDSNames.SXP_BLUEPRINTS,
+	property = "fds.name=" + SXPBlueprintAdminFDSNames.SXP_BLUEPRINTS,
 	service = FDSView.class
 )
 public class SXPBlueprintsTableFDSView extends BaseTableFDSView {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/frontend/data/set/view/table/SXPElementsTableFDSView.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/frontend/data/set/view/table/SXPElementsTableFDSView.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	enabled = false,
-	property = "frontend.data.set.name=" + SXPBlueprintAdminFDSNames.SXP_ELEMENTS,
+	property = "fds.name=" + SXPBlueprintAdminFDSNames.SXP_ELEMENTS,
 	service = FDSView.class
 )
 public class SXPElementsTableFDSView extends BaseTableFDSView {


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-143005 (I reopened the ticket)

We should have done this change as a part of https://github.com/liferay-frontend/liferay-portal/pull/1705, this makes the property consistently named with `fds.data.provider.key` property, and `*FDSNames` constants.

As this is only renaming, there is no need to review PR. Feel free to push if CI is green.

@liferay-objects @liferay-search If you have a new FDS in progress, this will cause an error. In that case, please update property name after this PR is merged.