### PR TITLE
LPS-145231 Dropdown displays incorrectly

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -151,7 +151,7 @@ const CreationMenu = ({
 						})}
 
 						{secondaryItemsGroup.separator && (
-							<ClayDropDown.Item className="dropdown-divider" />
+							<ClayDropDown.Divider />
 						)}
 					</ClayDropDown.Group>
 				))}


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-145231
In this PR `<ClayDropDown.Item className="dropdown-divider" />` has been replaced by `<ClayDropDown.Divider />` when there is a separator for `secondaryItems` in the dropdown.

Let me know what do you think :)