### PR TITLE
LPS-139740 Improves a11y on input-localized and fieldset-group tags

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset_group/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset_group/start.jsp
@@ -16,4 +16,4 @@
 
 <%@ include file="/fieldset_group/init.jsp" %>
 
-<div aria-multiselectable="true" role="tablist">
+<div aria-multiselectable="true">

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -127,7 +127,7 @@
 		}
 		%>
 
-		<div class="input-group-item input-group-item-shrink input-localized-content" role="menu">
+		<div class="input-group-item input-group-item-shrink input-localized-content">
 
 			<%
 			String normalizedSelectedLanguageId = StringUtil.replace(selectedLanguageId, '_', '-');


### PR DESCRIPTION
## Why you did this?

* We shouldn't add role="menu" inside the element that wraps the dropdown with the button. We should move this to the dropdown menu element or just remove it.
* Inside fieldset-group tag, in this case doesn't make sense adding a role as tablist since it simply wraps some input/label elements that aren't tabs

## Questions

I'm worried about removing those things. What I'm thinking is to creating a property inside each tag but I don't have too much idea how I should name it.

I'm thinking to create a property inside fieldset-group tag named as "isNotATab"(?) I'm not creative today 😂 

## Result

<img width="500" alt="Screen Shot 2022-01-20 at 18 13 36" src="https://user-images.githubusercontent.com/7663513/150423086-f252afb6-9ac8-44c0-a773-0f7d68a206b0.png">

No more critical issues 🏄🏼 