### PR TITLE
LPS-144538 - Add text to MT bulk actions in >=lg screens

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
@@ -14,10 +14,13 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
 import ClayManagementToolbar from '@clayui/management-toolbar';
-import React, {useMemo} from 'react';
+import classNames from 'classnames';
+import React, {useContext, useMemo} from 'react';
 
 import normalizeDropdownItems from '../normalize_dropdown_items';
+import FeatureFlagContext from './FeatureFlagContext';
 import LinkOrButton from './LinkOrButton';
 
 function addAction(item, onActionButtonClick) {
@@ -47,6 +50,8 @@ const ActionControls = ({
 	disabled,
 	onActionButtonClick,
 }) => {
+	const {showDesignImprovements} = useContext(FeatureFlagContext);
+
 	const items = useMemo(
 		() =>
 			normalizeDropdownItems(
@@ -68,11 +73,14 @@ const ActionControls = ({
 						.filter((item) => item.quickAction && item.icon)
 						.map((item, index) => (
 							<ClayManagementToolbar.Item
-								className="navbar-breakpoint-down-d-none"
+								className="d-md-flex d-none"
 								key={index}
 							>
 								<LinkOrButton
-									className="nav-link nav-link-monospaced"
+									className={classNames(
+										{'d-lg-none': showDesignImprovements},
+										'nav-link nav-link-monospaced'
+									)}
 									disabled={disabled || item.disabled}
 									displayType="unstyled"
 									href={item.href}
@@ -84,6 +92,27 @@ const ActionControls = ({
 									symbol={item.icon}
 									title={item.label}
 								/>
+
+								{showDesignImprovements && (
+									<LinkOrButton
+										className="align-items-center d-lg-inline d-none mr-2 nav-link"
+										disabled={disabled || item.disabled}
+										displayType="unstyled"
+										href={item.href}
+										onClick={(event) => {
+											onActionButtonClick(event, {
+												item,
+											});
+										}}
+										title={item.label}
+									>
+										<span className="inline-item inline-item-before">
+											<ClayIcon symbol={item.icon} />
+										</span>
+
+										<span>{item.label}</span>
+									</LinkOrButton>
+								)}
 							</ClayManagementToolbar.Item>
 						))}
 


### PR DESCRIPTION
### References

- [LPS-144538](https://issues.liferay.com/browse/LPS-144538)

### What is the goal?

* Add text labels to Management Toolbar bulk actions
* Display the labels only in >lg screens

### What does it look like?
#### Before PR
<img width="1792" alt="Captura de pantalla 2022-01-21 a las 10 39 59" src="https://user-images.githubusercontent.com/6642927/150503925-7a1921c0-9eb5-43fd-8156-78afc6585b7e.png">

#### After PR

https://user-images.githubusercontent.com/6642927/150504840-b9727d74-be43-422f-bfba-b0644ae22e27.mov




### How to replicate

* Enable feature flag
   * Download [this config file](https://issues.liferay.com/secure/attachment/436739/com.liferay.frontend.taglib.clay.internal.configuration.FFManagementToolbarConfiguration.config)
   * Move it to `bundles/osgi/config`
   * Restart portal
* Open browser in >lg screen size (>=1200px)
* Go to `Content & Data > Web Content`
* Create and select at least one element
* See that the bulk actions icons now have a text label
* Shrink the screen size
* See that now the text label isn't visible

