### PR TITLE
LPS-141234 | Verifies custom Remote App can be displayed on portlet after upgrade

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsUpgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsUpgrade.macro
@@ -1,5 +1,35 @@
 definition {
 
+	macro assertCustomRemoteAppEntryFields {
+		Click(
+			key_tableEntryName = "${upgradeName}",
+			locator1 = "RemoteApps#TABLE_ENTRY_NAME_REMOTE_TABLE");
+
+		AssertTextEquals(
+			custom_entryName = "${upgradeName}",
+			key_text = "Name",
+			locator1 = "TextInput#ANY",
+			value1 = "${upgradeName}");
+
+		AssertTextEquals(
+			custom_entryHTMLName = "${upgradeHTMLName}",
+			key_text = "HTML Element Name",
+			locator1 = "TextInput#ANY",
+			value1 = "${upgradeHTMLName}");
+
+		AssertTextEquals(
+			custom_entryURL = "${upgradeURL}",
+			key_id = "customElementURLs",
+			locator1 = "RemoteAppsEntry#URL",
+			value1 = "${upgradeURL}");
+
+		AssertTextEquals(
+			custom_entryCSSURL = "${upgradeCSSURL}",
+			key_text = "CSS URL",
+			locator1 = "TextInput#ANY",
+			value1 = "${upgradeCSSURL}");
+	}
+
 	macro assertRemoteAppEntry {
 		RemoteApps.goToRemoteAppsPortlet();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsUpgrade.testcase
@@ -17,6 +17,38 @@ definition {
 		SearchAdministration.executeReindex();
 	}
 
+	@description = "Upgrade to 7.4.13 and assert custom remote app can be viewed in portlet"
+	@priority = "4"
+	test CanViewRemoteAppCustomElementPortletAfterUpgrade7413 {
+		property portal.acceptance = "true";
+		property data.archive.type = "data-archive-remote-app";
+		property portal.version = "7.4.13";
+
+		task ("Assert custom remote app is present after upgrade") {
+			RemoteAppsUpgrade.assertRemoteAppEntry(
+				upgradeName = "Vanilla Counter",
+				upgradeType = "Custom Element");
+		}
+
+		task ("Assert custom remote app fields are saved after upgrade") {
+			RemoteAppsUpgrade.assertCustomRemoteAppEntryFields(
+				upgradeCSSURL = "https://liferay.github.io/liferay-frontend-projects/index.css",
+				upgradeHTMLName = "vanilla-counter",
+				upgradeName = "Vanilla Counter",
+				upgradeURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
+		}
+
+		task ("Navigate to content page") {
+			Navigator.openURL();
+
+			Navigator.gotoPage(pageName = "Test Page");
+		}
+
+		task ("Assert Vanilla Counter is present on page") {
+			AssertElementPresent(locator1 = "RemoteApps#VANILLA_COUNTER_REMOTE_APP");
+		}
+	}
+
 	@description = "Upgrade to 7.3.10.1 and assert remote app fields were saved properly"
 	@priority = "5"
 	test CanViewRemoteAppFieldsAfterUpgrade73101 {


### PR DESCRIPTION
**Background**
Create automation tests for Remote Apps

**Test Plan**

- Assert custom remote app entry is present 
- Assert custom remote app fields are saved 
- Navigate to content page 
- Assert Vanilla Counter is present on page

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-141234