### PR TITLE
LPS-145994 Consider TermQuery filters to adapt the filter to the new DDM indexing way

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/search/filter/FilterUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/search/filter/FilterUtil.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.QueryTerm;
+import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.DateRangeTermFilter;
@@ -135,6 +136,16 @@ public class FilterUtil {
 				return _createNestedQueryFilter(
 					queryTerm.getField(), queryFilter,
 					nestedFieldName -> new WildcardQueryImpl(
+						nestedFieldName, queryTerm.getValue()));
+			}
+			else if (query instanceof TermQuery) {
+				TermQuery termQuery = (TermQuery)query;
+
+				QueryTerm queryTerm = termQuery.getQueryTerm();
+
+				return _createNestedQueryFilter(
+					queryTerm.getField(), queryFilter,
+					nestedFieldName -> new TermQueryImpl(
 						nestedFieldName, queryTerm.getValue()));
 			}
 


### PR DESCRIPTION
The contentFields filter of the content structures structured contents is not working on the Headless APIs.

Added code to consider the TermQuery filter class that is being using with this kind of contentFields filter

**Steps to reproduce:**

1. Create a new Web Content Structure like "Article" with a text field and a rich text field. Name the Field References as "title" and "body" in the Advanced tab. Get the id of the created content structure.
2. Create a new Web Content with the new Structure with the title "Test" and another one with another title.
3. Use the Headless Delivery API to get the content structure structured contents filtering by the ones with contentFields/title eq 'Test'. In the following lines, there is a curl command where you can replace the contentStructureId in the path with your structure id:
```
curl 'http://localhost:8080/o/headless-delivery/v1.0/content-structures/{{contentStructureId}}/structured-contents?filter=contentFields/title%20eq%20%27Test%27' --header 'Authorization: Basic dGVzdEBsaWZlcmF5LmNvbTp0ZXN0' -v
```
**Expected result:** A 200 response with one item, the Test structured content
**Result:** A 200 response without any structured contents