### PR TITLE
LPS-145939 - Show disabled styles in MT bulk action if disabled

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
@@ -45,6 +45,7 @@ const LinkOrButton = ({
 					'nav-btn-monospaced': showDesignImprovements && responsive,
 					'pl-4 pr-4': wide && !symbol,
 				})}
+				disabled={disabled}
 				href={href}
 				{...otherProps}
 				title={symbol && title}
@@ -58,6 +59,7 @@ const LinkOrButton = ({
 					className={classNames(className, 'd-md-flex d-none', {
 						'pl-4 pr-4': wide,
 					})}
+					disabled={disabled}
 					href={href}
 					{...otherProps}
 				>


### PR DESCRIPTION
### References

- [LPS-145939](https://issues.liferay.com/browse/LPS-145939)

### What is the goal?

* Show MT bulk actions button as disabled if `disabled` prop is true

### What does it look like?

https://user-images.githubusercontent.com/6642927/150957967-6ced9b80-e733-478e-9f32-bb10288c42c3.mov



### How to replicate
* Go to `Site Builder > Pages` 
* Click on select all checkbox in MT
* See that if you hover over the `Convert to Content Page` icon it shows as disabled and cannot be clicked 
