### PR TITLE
LPS-146104 Avoid setting static and final fields on extended entities

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/EntityExtensionUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/EntityExtensionUtil.java
@@ -17,6 +17,7 @@ package com.liferay.portal.vulcan.util;
 import com.liferay.petra.function.UnsafeConsumer;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -51,6 +52,12 @@ public class EntityExtensionUtil {
 				Collectors.toMap(Field::getName, Function.identity()));
 
 		for (Field baseEntityField : baseEntityClass.getDeclaredFields()) {
+			int modifiers = baseEntityField.getModifiers();
+
+			if (Modifier.isStatic(modifiers) || Modifier.isFinal(modifiers)) {
+				continue;
+			}
+
 			Field extendedEntityField = extendedEntityFieldsMap.get(
 				baseEntityField.getName());
 


### PR DESCRIPTION
There are some problems serializing extended entities, that is, entities that extend existing DTOs adding some new fields. An example is the Structured Content return by the Headless Admin Content API.

**Steps to reproduce the issue:**

1. Create some web contents and update one of them to update the version
2. Make a request to the get structured-contents endpoint of the Headless Admin Content API to get the structured contents. You can execute the following curl command replacing the `siteId` with your siteId:
```
curl -u 'test@liferay.com:test' http://localhost:8080/o/headless-admin-content/v1.0/sites/\siteId/structured-contents -v
```
**Expected result:** The list of structured contents
**Result:** Internal server error response

The issue was caused by the addition of a new static final field on the DTOs in the generated code to escape the serialized JSON. More information in the [ticket](https://issues.liferay.com/browse/LPS-143571)

The issue is solved by avoiding setting the static and final fields on extended entities.