### PR TITLE
LPS-141963 Fix random redirections to .map files when signing in

### DIFF
--- a/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java
+++ b/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java
@@ -550,7 +550,14 @@ public class PortalRequestProcessor {
 							httpServletRequest.getParameterMap()));
 				}
 
-				httpSession.setAttribute(WebKeys.LAST_PATH, lastPath);
+				String lastPathPath = lastPath.getPath();
+
+				// Ignore lastPath if it is pointing to a .map file (see
+				// LPS-141963)
+
+				if (!lastPathPath.endsWith(".map")) {
+					httpSession.setAttribute(WebKeys.LAST_PATH, lastPath);
+				}
 			}
 		}
 


### PR DESCRIPTION
This fixes the problem and it's apparently safe. In any case, I'm not an expert
in the logic involved so there may be a better solution.

What I've found is that the browser asks for the legit URL to be redirected
after login, then for the .map files. As a consequence, the VirtualHostFilter
set the lastPath for each request, which causes this code to overwrite the first
lastPath (the legit one) with the second (the .map).

So, I'm bypassing the setAttribute() if the saved lastPath is for a .map file,
assuming that it has been set before for a valid URL.

Other options could be:

1. Modifying the VirtualHostFilter so that it doesn't save the lastPath if it is
   for a .map file. I discarded this because that could fix it for some scenarios,
   but not others if they are routed through a different path.

2. Fix the login logic to make it ignore requests not involved in the login
   lifecycle. I discarded this because I don't have the knowledge to do it.

3. Don't overwrite the lastPath if it is already set in the session. This seems
   less safe than 1 because it would fail if the .map is requested before the
   valid URL.