### PR TITLE
LPS-144539 - Add responsive mode to MT clear action button

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -14,9 +14,10 @@
 
 import {ClayCheckbox} from '@clayui/form';
 import ClayManagementToolbar from '@clayui/management-toolbar';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useContext, useEffect, useRef, useState} from 'react';
 
 import {EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS} from '../constants';
+import FeatureFlagContext from './FeatureFlagContext';
 import LinkOrButton from './LinkOrButton';
 
 function disableActionIfNeeded(item, event, bulkSelection) {
@@ -56,6 +57,7 @@ const SelectionControls = ({
 	showCheckBoxLabel,
 	supportsBulkActions,
 }) => {
+	const {showDesignImprovements} = useContext(FeatureFlagContext);
 	const [selectedItems, setSelectedItems] = useState(initialSelectedItems);
 	const [checkboxStatus, setCheckboxStatus] = useState(initialCheckboxStatus);
 	const [selectAllButtonVisible, setSelectAllButtonVisible] = useState(
@@ -194,6 +196,10 @@ const SelectionControls = ({
 						<>
 							<ClayManagementToolbar.Item className="nav-item-shrink">
 								<LinkOrButton
+									aria-label={
+										showDesignImprovements &&
+										Liferay.Language.get('clear')
+									}
 									className="nav-link"
 									displayType="unstyled"
 									href={clearSelectionURL}
@@ -209,6 +215,13 @@ const SelectionControls = ({
 
 										onClearButtonClick(event);
 									}}
+									symbol={
+										showDesignImprovements && 'times-circle'
+									}
+									title={
+										showDesignImprovements &&
+										Liferay.Language.get('clear')
+									}
 								>
 									<span className="text-truncate-inline">
 										<span className="text-truncate">


### PR DESCRIPTION
### References

- [LPS-144539](https://issues.liferay.com/browse/LPS-144539)

### What is the goal?

* Add a responsive mode to the Management Toolbar `Clear` action button
   * In smaller screens, the `Clear` button now gets replaced by an `x` icon with a tooltip

### What does it look like?

https://user-images.githubusercontent.com/6642927/151349417-975c801a-387b-4c56-b419-afbb6c080537.mov



### How to replicate

* Enable feature flag
   * Download [this flag](https://issues.liferay.com/secure/attachment/436739/com.liferay.frontend.taglib.clay.internal.configuration.FFManagementToolbarConfiguration.config)
   * Move it to `bundles/osgi/config`
   * Restart portal
* Go to `Content & Data > Dynamic Data Lists`
* Create and select at least one element in the table
* See that there's a button next to the selector with `Clear` as a label
* Open the website in mobile, follow same steps, see that the button now has a `x` icon and no text
* Hover over the button, see that it displays a tooltip with `Clear` 
