### PR TITLE
LPS-XXXXX Adds more editors to ckeditor-sample-web

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/Editor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/Editor.js
@@ -1,4 +1,3 @@
-<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -12,15 +11,12 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
---%>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
-taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
-taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
-taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
+import {Editor} from 'frontend-editor-ckeditor-web';
+import React from 'react';
 
-<%@ page import="com.liferay.portal.kernel.util.HashMapBuilder" %>
+function EditorComponent(props) {
+	return <Editor {...props} />;
+}
 
-<liferay-theme:defineObjects />
+export default EditorComponent;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/alloyeditor.jsp
@@ -1,0 +1,42 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-util:buffer
+	var="sampleEditorContents"
+>
+	<strong>Alloy Editor is deprecated</strong>
+
+	<h1>Alloy Editor</h1>
+
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
+	</p>
+
+	<p>
+		This paragraph contains a <a href="https://example.com">link</a>.
+	</p>
+
+	<img src="https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=300" />
+</liferay-util:buffer>
+
+<liferay-editor:editor
+	contents="<%= sampleEditorContents %>"
+	editorName="alloyeditor"
+	name="sampleAlloyEditor"
+	placeholder="content"
+/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/ballooneditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/ballooneditor.jsp
@@ -1,0 +1,40 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-util:buffer
+	var="sampleEditorContents"
+>
+	<h1>Balloon Editor</h1>
+
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
+	</p>
+
+	<p>
+		This paragraph contains a <a href="https://example.com">link</a>.
+	</p>
+
+	<img src="https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=300" />
+</liferay-util:buffer>
+
+<liferay-editor:editor
+	contents="<%= sampleEditorContents %>"
+	editorName="ballooneditor"
+	name="sampleBalloonEditor"
+	placeholder="content"
+/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/ckeditor_bbcode.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/ckeditor_bbcode.jsp
@@ -1,0 +1,40 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-util:buffer
+	var="sampleEditorContents"
+>
+	<h1>CKEditor BBCode</h1>
+
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
+	</p>
+
+	<p>
+		This paragraph contains a <a href="https://example.com">link</a>.
+	</p>
+
+	<img src="https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=300" />
+</liferay-util:buffer>
+
+<liferay-editor:editor
+	contents="<%= sampleEditorContents %>"
+	editorName="ckeditor_bbcode"
+	name="sampleCKEditorBBCode"
+	placeholder="content"
+/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/ckeditor_classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/ckeditor_classic.jsp
@@ -1,0 +1,40 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-util:buffer
+	var="sampleEditorContents"
+>
+	<h1>CKEditor Classic</h1>
+
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
+	</p>
+
+	<p>
+		This paragraph contains a <a href="https://example.com">link</a>.
+	</p>
+
+	<img src="https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=300" />
+</liferay-util:buffer>
+
+<liferay-editor:editor
+	contents="<%= sampleEditorContents %>"
+	editorName="ckeditor_classic"
+	name="sampleCKEditorClassic"
+	placeholder="content"
+/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/ckeditor_editor_react_component.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/ckeditor_editor_react_component.jsp
@@ -1,0 +1,44 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-util:buffer
+	var="sampleEditorContents"
+>
+	<h1>CKEditor Editor React Component</h1>
+
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
+	</p>
+
+	<p>
+		This paragraph contains a <a href="https://example.com">link</a>.
+	</p>
+
+	<img src="https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=300" />
+</liferay-util:buffer>
+
+<react:component
+	module="js/Editor"
+	props='<%=
+		HashMapBuilder.<String, Object>put(
+			"contents", sampleEditorContents
+		).put(
+			"name", "sampleCKEditorReactComponent"
+		).build()
+	%>'
+/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/inputeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/inputeditor.jsp
@@ -1,0 +1,40 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-util:buffer
+	var="sampleEditorContents"
+>
+	<h1>Input Editor</h1>
+
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
+	</p>
+
+	<p>
+		This paragraph contains a <a href="https://example.com">link</a>.
+	</p>
+
+	<img src="https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=300" />
+</liferay-util:buffer>
+
+<liferay-ui:input-editor
+	contents="<%= sampleEditorContents %>"
+	editorName="inputeditor"
+	name="sampleInputEditor"
+	placeholder="content"
+/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,25 +16,25 @@
 
 <%@ include file="/init.jsp" %>
 
-<liferay-util:buffer
-	var="sampleEditorContents"
+<liferay-ui:tabs
+	names="Balloon Editor Tag,Alloy Editor Tag,Input Editor Tag,CKEditor Classic Editor Tag,CKEditor BBCode Tag,Editor React Component"
+	refresh="<%= false %>"
 >
-	<h1>Balloon Editor</h1>
 
-	<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
-	</p>
+	<%
+	String[] sections = {"ballooneditor", "alloyeditor", "inputeditor", "ckeditor_classic", "ckeditor_bbcode", "ckeditor_editor_react_component"};
 
-	<p>
-		This paragraph contains a <a href="https://example.com">link</a>.
-	</p>
+	for (int i = 0; i < sections.length; i++) {
+	%>
 
-	<img src="https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=300" />
-</liferay-util:buffer>
+		<liferay-ui:section>
+			<clay:container-fluid>
+				<liferay-util:include page='<%= "/partials/" + sections[i] + ".jsp" %>' servletContext="<%= application %>" />
+			</clay:container-fluid>
+		</liferay-ui:section>
 
-<liferay-editor:editor
-	contents="<%= sampleEditorContents %>"
-	editorName="ballooneditor"
-	name="sampleBalloonEditor"
-	placeholder="content"
-/>
+	<%
+	}
+	%>
+
+</liferay-ui:tabs>


### PR DESCRIPTION
It adds more editors to ckeditor-sample-web

https://user-images.githubusercontent.com/7663513/151631193-3adfdefe-34d9-4787-8073-106817828abc.mov

**Why?**

I would check/test more editors when changing something in a Editor React component or internally on CKEditor(our DXP plugins or our patches under liferay-ckeditor)

It will reduce the number of issues like this one: https://github.com/liferay-frontend/liferay-portal/pull/1871