### PR TITLE
LPS-146462 Ensure that headless layer pass a friendlyURL to journal service when updating a StructuredContent

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -1049,6 +1049,10 @@ public class StructuredContentResourceImpl
 			structuredContent.getFriendlyUrlPath_i18n(),
 			journalArticle.getFriendlyURLMap());
 
+		friendlyUrlMap =
+			friendlyUrlMap.isEmpty() ? journalArticle.getFriendlyURLMap() :
+				friendlyUrlMap;
+
 		notFoundLocales.addAll(friendlyUrlMap.keySet());
 
 		LocalizedMapUtil.validateI18n(


### PR DESCRIPTION
Related ticket -> [LPS-146462](https://issues.liferay.com/browse/LPS-146462)
____
When trying to update an existing structured content without setting friendlyURL in the body (which is not mandatory) it returns an internal server error.

The purpose of this PR is to set the friendlyIURL of the journal article in case no friendlyURL is provided by the user when updating the StructuredContent