### PR TITLE
LPS-146459 Session auto-extension cannot be toggled in runtime

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -272,17 +272,18 @@ AUI.add(
 							elapsed >= sessionLength - sessionTimeoutOffset;
 						const hasWarned = elapsed >= warningTime;
 
-						if (autoExtend && hasExpiredTimeoutOffset) {
+						if (hasExpired && sessionState !== 'expired') {
+							instance.expire();
+						}
+						else if (autoExtend && hasExpiredTimeoutOffset) {
 							instance.extend();
 						}
-
-						if (!autoExtend) {
-							if (hasExpired && sessionState !== 'expired') {
-								instance.expire();
-							}
-							else if (hasWarned && sessionState !== 'warned') {
-								instance.warn();
-							}
+						else if (
+							!autoExtend &&
+							hasWarned &&
+							sessionState !== 'warned'
+						) {
+							instance.warn();
 						}
 
 						const registered = instance._registered;

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -248,6 +248,8 @@ AUI.add(
 						const sessionState = instance.get('sessionState');
 						const timestamp = instance.get('timestamp');
 
+						// LPS-82336 Maintain session state in multiple tabs
+
 						if (instance._initTimestamp !== timestamp) {
 							instance.set('timestamp', timestamp);
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -335,6 +335,10 @@ AUI.add(
 					instance._initEvents();
 
 					instance._startTimer();
+
+					Liferay.fire('sessionInitialized', {
+						session: instance,
+					});
 				},
 
 				registerInterval(fn) {

--- a/portal-web/docroot/html/common/themes/session_timeout.jspf
+++ b/portal-web/docroot/html/common/themes/session_timeout.jspf
@@ -19,23 +19,18 @@ String rememberMe = CookieKeys.getCookie(request, CookieKeys.REMEMBER_ME);
 %>
 
 <c:if test="<%= !themeDisplay.isSignedIn() || Validator.isNull(rememberMe) %>">
-
-	<%
-	boolean autoExtend = !themeDisplay.isSignedIn() || PropsValues.SESSION_TIMEOUT_AUTO_EXTEND;
-	%>
-
 	<aui:script require="frontend-js-web/liferay/toast/commands/OpenToast.es as toastCommands">
 		AUI().use(
 			'liferay-session',
 			function() {
 				Liferay.Session = new Liferay.SessionBase(
 					{
-						autoExtend: <%= autoExtend %>,
+						autoExtend: <%= !themeDisplay.isSignedIn() || PropsValues.SESSION_TIMEOUT_AUTO_EXTEND %>,
 						redirectOnExpire: <%= SSOUtil.isSessionRedirectOnExpire(themeDisplay.getCompanyId()) %>,
 						redirectUrl: '<%= HtmlUtil.escapeJS(SSOUtil.getSessionExpirationRedirectURL(themeDisplay.getCompanyId(), themeDisplay.getURLHome())) %>',
 						sessionLength: <%= PropsValues.SESSION_TIMEOUT * 60 %>,
-						sessionTimeoutOffset: <%= autoExtend ? PropsValues.SESSION_TIMEOUT_AUTO_EXTEND_OFFSET : 0 %>,
-						warningLength: <%= autoExtend ? 0 : PropsValues.SESSION_TIMEOUT_WARNING * 60 %>
+						sessionTimeoutOffset: <%= PropsValues.SESSION_TIMEOUT_AUTO_EXTEND_OFFSET %>,
+						warningLength: <%= PropsValues.SESSION_TIMEOUT_WARNING * 60 %>
 					}
 				);
 


### PR DESCRIPTION
### References

- [LPS-146459 Session auto-extension cannot be toggled in runtime](https://issues.liferay.com/browse/LPS-144538)
- [PTR-2707 Can the autoExtend variable be used to autoExtend the user session inside form builder?](https://issues.liferay.com/browse/PTR-2707)
- [LPS-134283 Forms: Expiring session not handled well in editor: Session is never extended](https://issues.liferay.com/browse/LPS-134283)
- [LPS-82336 Session Expiration Warning doesn't show on all windows after extending session](https://issues.liferay.com/browse/LPS-82336)

### What is the goal?

The main goal of the task, in technical terms, is to enable session auto-extension through JS API. You can find motivation for this feature in discussions in [LPS-134283](https://issues.liferay.com/browse/LPS-134283) and [PTR-2707](https://issues.liferay.com/browse/PTR-2707).

To achieve this, we need to remove the conditional attributes setting from Session instance creation, rewriting it to internal component logic.

In addition, in this PR we are:
- simplifying logic of the session handling, by trimming the unnecessary parts.
- adding a comment to explain the weird code related to `_initTimestamp`.
- making some minor SF
- adding firing of 'sessionInitialized' custom event, when the component is initialized. This allows us to hook onto the component in race condition environment, when we cannot be certain that `Liferay.Session` is initialized. See more about this in PTR-2707.

The code in a race condition environment can be something like:
```js
if (Liferay.Session) {
    Liferay.Session.set('autoExtend', true);
}
else {
    Liferay.once('sessionInitialized', (data) => {
        data.session.set('autoExtend', true);
    });
}
```

I was considering to rewrite the entire component from AUI to vanilla JS, but I think the scope of changes is already large enough for one task.

### What does it look like?
#### Before PR
![before](https://user-images.githubusercontent.com/5435511/151963791-9c9301a8-2897-425a-a599-9322d06f772f.gif)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/151963806-97fbac6e-2e7b-4e3f-a373-ef41ef0ffa1f.gif)


### How to replicate

See steps to reproduce in [LPS-146459](https://issues.liferay.com/browse/LPS-146459)

This PR is quite risky, as it touches several important use cases, related to session handling. @john-co @Esther-OC I am not sure if we have all of these covered by CI tests. If we don't, we should! I'll write here all the cases:

Case 1: User is not logged in
- session is extended indefinitely
- periodic 'extend_session' requests

Case 2: User is logged in, with 'remember me' option
- session is extended indefinitely
- no periodic requests
- session cookie

Case 3: User is logged in, without 'remember me' option, `session.timeout.auto.extend=false`
- session warning after `session.timeout.warning` time
- session expires after `session.timeout` time

Case 4: User is logged in, without 'remember me' option, `session.timeout.auto.extend=true`
- session is extended indefinitely
- periodic 'extend_session' requests

Case 5 (fixed in this PR): User is logged in, without 'remember me' option, `session.timeout.auto.extend=false`, `autoExtend` is toggled to `true` with JS.
- session is extended indefinitely
- periodic 'extend_session' requests

Case 6: Maintain session in multiple tabs. See [LPS-82336](https://issues.liferay.com/browse/LPS-82336) for steps to reproduce.

Case 7: If browser is suspended and session expires server-side, when browser recovers it should expire session. See [LPS-137264](https://issues.liferay.com/browse/LPS-137264)

Case 8: If browser has disabled cookies, the behavior is the same as in Case 1. See [LPS-71319](https://issues.liferay.com/browse/LPS-71319)