### PR TITLE
LPS-145387 Indexing translations by id instead of by label

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.js
@@ -140,7 +140,7 @@ const TranslationAdminSelector = ({
 						const isDefaultLocale =
 							activeLocale.id === defaultLanguageId;
 
-						const localeValue = translations[label];
+						const localeValue = translations[activeLocale.id];
 
 						return (
 							<ClayDropDown.Item


### PR DESCRIPTION
**Steps to reproduce:**

1. Go to Content & Data > Web Content > Structures.
2. Create new Structure with a default title and save it.
3. Edit the structure and select a new Locale (ie. es-ES) and change the title Language. Save it.
4. Go again to the structure and see in the Translation Admin Selector es-ES is translated.

**Expected Result**.
It will have the same behaviour but instead of being indexed by its label, it will be indexed by its id.

https://user-images.githubusercontent.com/44723449/152178045-5a79c164-030f-4d77-82e8-7c7855592768.mov

**JIRA TICKET:** https://issues.liferay.com/browse/LPS-145387