### PR TITLE
LPS-146446 Subscribe to message without checking permissions because is not needed

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
@@ -415,20 +415,17 @@ public class MessageBoardThreadResourceImpl
 		MBThread mbThread = _mbThreadLocalService.getMBThread(
 			messageBoardThreadId);
 
-		MBMessage mbMessage = _mbMessageService.getMessage(
-			mbThread.getRootMessageId());
+		MBMessage mbMessage = _mbMessageService.updateMessage(
+			mbThread.getRootMessageId(), messageBoardThread.getHeadline(),
+			messageBoardThread.getArticleBody(), null,
+			_toPriority(
+				mbThread.getGroupId(), messageBoardThread.getThreadType()),
+			false,
+			_createServiceContext(mbThread.getGroupId(), messageBoardThread));
 
 		_updateQuestion(mbMessage, messageBoardThread);
 
-		return _toMessageBoardThread(
-			_mbMessageService.updateMessage(
-				mbThread.getRootMessageId(), messageBoardThread.getHeadline(),
-				messageBoardThread.getArticleBody(), null,
-				_toPriority(
-					mbThread.getGroupId(), messageBoardThread.getThreadType()),
-				false,
-				_createServiceContext(
-					mbThread.getGroupId(), messageBoardThread)));
+		return _toMessageBoardThread(mbMessage);
 	}
 
 	@Override
@@ -794,7 +791,8 @@ public class MessageBoardThreadResourceImpl
 		}
 
 		if (GetterUtil.getBoolean(messageBoardThread.getSubscribed())) {
-			_mbMessageService.subscribeMessage(mbMessage.getRootMessageId());
+			_mbMessageLocalService.subscribeMessage(
+				mbMessage.getUserId(), mbMessage.getRootMessageId());
 		}
 	}
 


### PR DESCRIPTION
Related ticket [LPS-146446](https://issues.liferay.com/browse/LPS-146446)
___
In this PR I remove the permissions checking to subscribe to a message because it is not needed as the user update the message previously.