### PR TITLE
LPS-144832 - Add selectedLanguageIdAtom and use it in input_localized 

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -443,12 +443,6 @@ AUI.add(
 						);
 				},
 
-				_onSelectedLanguageIdChange(languageId) {
-					var instance = this;
-
-					instance.selectFlag(languageId);
-				},
-
 				_onSelectFlag(event) {
 					var instance = this;
 
@@ -463,7 +457,16 @@ AUI.add(
 
 					var languageId = event.item.getAttribute('data-value');
 
-					State.writeAtom(instance._selectedLanguageIdAtom, languageId);
+					State.writeAtom(
+						instance._selectedLanguageIdAtom,
+						languageId
+					);
+				},
+
+				_onSelectedLanguageIdChange(languageId) {
+					var instance = this;
+
+					instance.selectFlag(languageId);
 				},
 
 				_onSubmit(event, input) {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -443,6 +443,12 @@ AUI.add(
 						);
 				},
 
+				_onSelectedLanguageIdChange(languageId) {
+					var instance = this;
+
+					instance.selectFlag(languageId);
+				},
+
 				_onSelectFlag(event) {
 					var instance = this;
 
@@ -452,6 +458,12 @@ AUI.add(
 							source: instance,
 						});
 					}
+
+					var State = instance._State;
+
+					var languageId = event.item.getAttribute('data-value');
+
+					State.writeAtom(instance._selectedLanguageIdAtom, languageId);
 				},
 
 				_onSubmit(event, input) {
@@ -541,6 +553,10 @@ AUI.add(
 						instance._bindManageTranslationsButton();
 					}
 				},
+
+				_selectedLanguageIdAtom: null,
+
+				_selectedLanguageIdSubscription: null,
 
 				_updateHelpMessage(languageId) {
 					var instance = this;
@@ -676,6 +692,10 @@ AUI.add(
 					if (instance._availableLanguagesSubscription) {
 						instance._availableLanguagesSubscription.dispose();
 					}
+
+					if (instance._selectedLanguageIdSubscription) {
+						instance._selectedLanguageIdSubscription.dispose();
+					}
 				},
 
 				getSelectedLanguageId() {
@@ -756,6 +776,24 @@ AUI.add(
 					);
 					instance._flags = boundingBox.one('.palette-container');
 
+					instance._State = instance.get(
+						'frontendJsStateWebModule'
+					).State;
+
+					var State = instance._State;
+
+					instance._selectedLanguageIdAtom = instance.get(
+						'frontendJsComponentsWebModule'
+					).selectedLanguageIdAtom;
+
+					var selectedLanguageIdAtom =
+						instance._selectedLanguageIdAtom;
+
+					instance._selectedLanguageIdSubscription = State.subscribe(
+						selectedLanguageIdAtom,
+						A.bind('_onSelectedLanguageIdChange', instance)
+					);
+
 					var activeLanguageIds = instance.get('activeLanguageIds');
 
 					if (activeLanguageIds) {
@@ -763,17 +801,12 @@ AUI.add(
 							'frontendJsComponentsWebModule'
 						).activeLanguageIdsAtom;
 
-						instance._State = instance.get(
-							'frontendJsStateWebModule'
-						).State;
-
 						instance._flagsInitialContent = instance._flags.cloneNode(
 							true
 						);
 
 						instance._renderActiveLanguageIds();
 
-						var State = instance._State;
 						var activeLanguageIdsAtom =
 							instance._activeLanguageIdsAtom;
 

--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/TranslationManagerSamples.js
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/TranslationManagerSamples.js
@@ -17,6 +17,7 @@ import {State} from '@liferay/frontend-js-state-web';
 import {
 	TranslationAdminSelector,
 	activeLanguageIdsAtom,
+	selectedLanguageIdAtom,
 } from 'frontend-js-components-web';
 import React, {useEffect, useState} from 'react';
 
@@ -33,11 +34,16 @@ export default function TranslationManagerSamples({
 
 	useEffect(() => {
 		State.subscribe(activeLanguageIdsAtom, setActiveLanguageIds);
+		State.subscribe(selectedLanguageIdAtom, setSelectedLanguageId);
 	}, []);
 
 	useEffect(() => {
 		State.writeAtom(activeLanguageIdsAtom, activeLanguageIds);
 	}, [activeLanguageIds]);
+
+	useEffect(() => {
+		State.writeAtom(selectedLanguageIdAtom, selectedLanguageId);
+	}, [selectedLanguageId]);
 
 	return (
 		<>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.js
@@ -14,6 +14,9 @@
 
 export {default as Treeview} from './treeview/Treeview';
 
-export {activeLanguageIdsAtom} from './translation_manager/state';
+export {
+	activeLanguageIdsAtom,
+	selectedLanguageIdAtom,
+} from './translation_manager/state';
 export {default as TranslationAdminModal} from './translation_manager/TranslationAdminModal';
 export {default as TranslationAdminSelector} from './translation_manager/TranslationAdminSelector';

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/state.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/state.js
@@ -15,3 +15,4 @@
 import {State} from '@liferay/frontend-js-state-web';
 
 export const activeLanguageIdsAtom = State.atom('activeLocaleIds', []);
+export const selectedLanguageIdAtom = State.atom('selectedLocaleId', []);

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -354,10 +354,22 @@
 					});
 				</c:when>
 				<c:otherwise>
-					Liferay.InputLocalized.register(
-						'<%= namespace + id + HtmlUtil.getAUICompatibleId(fieldSuffix) %>',
-						inputLocalizedProps
-					);
+					Liferay.Loader.require(
+					[
+						A.config.groups.components.mainModule,
+						A.config.groups.state.mainModule,
+					],
+					(frontendJsComponentsWebModule, frontendJsStateWebModule) => {
+
+						Liferay.InputLocalized.register(
+							'<%= namespace + id + HtmlUtil.getAUICompatibleId(fieldSuffix) %>',
+							{
+								frontendJsComponentsWebModule,
+								frontendJsStateWebModule,
+								...inputLocalizedProps
+							}
+						);
+					});
 				</c:otherwise>
 			</c:choose>
 


### PR DESCRIPTION
### References

- [LPS-144832](https://issues.liferay.com/browse/LPS-144832)

### What is the goal?

* Add `selectedLanguageIdAtom` to share state between localized React and tag components.

### What does it look like?

https://user-images.githubusercontent.com/6642927/152391083-995568ea-b2d7-481a-8252-19a6bbddcc0b.mov



### How to replicate
* Launch portal
* Deploy `frontend-js-components-sample-web` (I don't think this should be necessary, but otherwise the sample widget wasn't appearing for me, even after an `ant all` 🤷‍♀️) 
   * `cd {PORTAL_ROOT}/modules/apps/frontend-js/frontend-js-components-sample-web`
   * `gradlew clean deploy`
* Edit the Home page
* Add the `JS Components Sample` widget from the fragments and widget side bar 
* Save, go to home page
* See that if you select a language in the `React Component`, `AUI Tag` or `Liferay UI Tag`, the language changes in all other elements

