### PR TITLE
LPS-145898 Fix getting Object relationships from GraphQL

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -212,7 +212,7 @@ public class ObjectDefinitionGraphQLDTOContributor
 		}
 
 		return (T)_toMap(
-			_objectEntryManager.getObjectEntry(
+			_objectEntryManager.fetchObjectEntry(
 				dtoConverterContext, null, (long)relationshipId),
 			relationshipIdName);
 	}
@@ -271,6 +271,10 @@ public class ObjectDefinitionGraphQLDTOContributor
 
 	private Map<String, Object> _toMap(
 		ObjectEntry objectEntry, String objectEntryIdName) {
+
+		if (objectEntry == null) {
+			return null;
+		}
 
 		Map<String, Object> properties = objectEntry.getProperties();
 


### PR DESCRIPTION
Recently we added a check to verify that the object entries were being handled by the APIs with the same objectDefinition id.

Here, as we are getting the relationships of an object entry, this check fails as we are getting one type of object entry from another object entry API. To avoid this I've changed the code to use the fetch method that avoids this check.

Original Message:
---
We found a bug or strange behavior as we were testing object relationships in GraphQL.

When a new relation is created, the GraphQL field is not recognized and causes the query to be invalid until the server is restarted. That is because the GraphQLDTOContributor, that is the object that maps the GraphQL type to the Object Definition type, is created when the ObjectDefinition is deployed, that is, when it is published.

If new fields are added after the publication, these fields are not available in GraphQL, and as the relationship creates the new field, we need to deploy again the ObjectDefinition to be available in runtime without restarting the server.

Please, take a look at the PR to see if I didn't miss any other consequence redeploying the ObjectDefinition, and also to check if this is necessary for some other part of the code. From my understanding, once the ObjectDefinition is published it is not possible to add any new field so we don't have this problem in any other use case.

More information could be found in the Jira ticket: [LPS-145898](https://issues.liferay.com/browse/LPS-145898)

Thank you very much! 🙂