### PR TITLE
LPS-144622 Set isScopeable to false in RemoteAppEntryWorkflowHandler

### DIFF
--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/workflow/RemoteAppEntryWorkflowHandler.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/internal/workflow/RemoteAppEntryWorkflowHandler.java
@@ -52,6 +52,11 @@ public class RemoteAppEntryWorkflowHandler
 	}
 
 	@Override
+	public boolean isScopeable() {
+		return false;
+	}
+
+	@Override
 	public RemoteAppEntry updateStatus(
 			int status, Map<String, Serializable> workflowContext)
 		throws PortalException {


### PR DESCRIPTION
Related ticket [LPS-144622](https://issues.liferay.com/browse/LPS-144622)
____
In this PR, I override the attribute `isScopeable` to set it to false (by default is true) for Remote Apps.