### PR TITLE
LPS-146656 Add test to cover Object GraphQL read only fields

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
@@ -130,6 +130,32 @@ public class ObjectDefinitionGraphQLTest {
 	}
 
 	@Test
+	public void testAddObjectEntryWithReadOnlyFieldsReturnsError()
+		throws Exception {
+
+		Assert.assertEquals(
+			"Bad Request",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"mutation",
+						new GraphQLField(
+							"c",
+							new GraphQLField(
+								"create" + _objectDefinitionName,
+								HashMapBuilder.<String, Object>put(
+									_objectDefinitionName,
+									StringBundler.concat(
+										"{", _objectFieldName, ": \"",
+										RandomTestUtil.randomString(), "\"",
+										", status: draft }")
+								).build(),
+								new GraphQLField(_objectFieldName))))),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	@Test
 	public void testDeleteObjectEntry() throws Exception {
 		GraphQLField graphQLField = new GraphQLField(
 			"mutation",


### PR DESCRIPTION
Add a new test to add test coverage a the read-only fields inside objects.

The test will check that one of these fields can't be used as a part of a mutation, as it is read-only, and returns the proper error, a 400 Bad Request