### PR TITLE
LPS-147001 Fix "Error: Element dl is missing a required child element dt"

### DIFF
--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/descriptive.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/descriptive.jsp
@@ -39,21 +39,30 @@
 	%>
 
 		<dl class="<%= searchResultCssClass %>">
-			<c:if test="<%= Validator.isNotNull(resultRowSplitterEntry.getTitle()) %>">
-				<dt class="list-group-header">
-					<div class="list-group-header-title">
-						<liferay-ui:message key="<%= resultRowSplitterEntry.getTitle() %>" />
-					</div>
-				</dt>
-			</c:if>
+			<c:choose>
+				<c:when test="<%= Validator.isNotNull(resultRowSplitterEntry.getTitle()) || ((headerNames != null) && Validator.isNotNull(headerNames.get(0))) %>">
+					<c:if test="<%= Validator.isNotNull(resultRowSplitterEntry.getTitle()) %>">
+						<dt class="list-group-header">
+							<div class="list-group-header-title">
+								<liferay-ui:message key="<%= resultRowSplitterEntry.getTitle() %>" />
+							</div>
+						</dt>
+					</c:if>
 
-			<c:if test="<%= (headerNames != null) && Validator.isNotNull(headerNames.get(0)) %>">
-				<dt class="list-group-header">
-					<div class="list-group-header-title">
-						<liferay-ui:message key="<%= HtmlUtil.escape(headerNames.get(0)) %>" />
-					</div>
-				</dt>
-			</c:if>
+					<c:if test="<%= (headerNames != null) && Validator.isNotNull(headerNames.get(0)) %>">
+						<dt class="list-group-header">
+							<div class="list-group-header-title">
+								<liferay-ui:message key="<%= HtmlUtil.escape(headerNames.get(0)) %>" />
+							</div>
+						</dt>
+					</c:if>
+				</c:when>
+				<c:otherwise>
+					<dt class="sr-only">
+						<%= PortalUtil.getPortletTitle(portletRequest) %>
+					</dt>
+				</c:otherwise>
+			</c:choose>
 
 			<%
 			boolean allRowsIsChecked = true;

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/icon.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/icon.jsp
@@ -43,11 +43,18 @@ for (int i = 0; i < resultRowSplitterEntries.size(); i++) {
 %>
 
 	<dl class="<%= searchResultCssClass %>" data-qa-id="rows<%= i %>">
-		<c:if test="<%= Validator.isNotNull(resultRowSplitterEntry.getTitle()) %>">
-			<dt class="card-section-header container-fluid">
-				<liferay-ui:message key="<%= resultRowSplitterEntry.getTitle() %>" />
-			</dt>
-		</c:if>
+		<c:choose>
+			<c:when test="<%= Validator.isNotNull(resultRowSplitterEntry.getTitle()) %>">
+				<dt class="card-section-header container-fluid">
+					<liferay-ui:message key="<%= resultRowSplitterEntry.getTitle() %>" />
+				</dt>
+			</c:when>
+			<c:otherwise>
+				<dt class="sr-only">
+					<%= PortalUtil.getPortletTitle(portletRequest) %>
+				</dt>
+			</c:otherwise>
+		</c:choose>
 
 		<%
 		for (int j = 0; j < curResultRows.size(); j++) {


### PR DESCRIPTION
 Seems that after changing the ul to dl, dt element is always required.
 
Steps:
1. Do a search inside the portal
2. Inspect the search results

Actual: There is no dt element for the results and if validating the HTML with
https://validator.w3.org/#validate_by_input you will get the error "Error: Element dl is missing a required child element dt"

Expected: There is always a dt element available for accessibility readers