### PR TITLE
LPS-146070 Cannot add link in Blogs coverImageCaptionEditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
@@ -314,9 +314,9 @@
 				const target = event.data.getTarget();
 
 				if (
-					!target.$.closest('.lfr-balloon-editor') &&
-					!target.$.closest('.lfr-balloon-editor-insert-button') &&
-					!target.$.closest('.liferay-editable')
+					!target.$.closest(
+						'.cke_toolgroup, .lfr-balloon-editor, .lfr-balloon-editor-insert-button, .liferay-editable'
+					)
 				) {
 					for (const editorName in CKEDITOR.instances) {
 						const editor = CKEDITOR.instances[editorName];

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
@@ -307,6 +307,40 @@
 
 				originalContextManagerCheck.call(this, selection);
 			};
+
+			const ckeditorWindow = CKEDITOR.document.getWindow();
+
+			ckeditorWindow.on('click', (event) => {
+				const target = event.data.getTarget();
+
+				if (
+					!target.$.closest('.lfr-balloon-editor') &&
+					!target.$.closest('.lfr-balloon-editor-insert-button') &&
+					!target.$.closest('.liferay-editable')
+				) {
+					for (const editorName in CKEDITOR.instances) {
+						const editor = CKEDITOR.instances[editorName];
+
+						editor.balloonToolbars.hide();
+
+						const liferayToolbars = editor.liferayToolbars;
+
+						if (liferayToolbars) {
+							for (const toolbar in liferayToolbars) {
+								liferayToolbars[toolbar].hide();
+							}
+						}
+					}
+
+					const insertButtons = CKEDITOR.document.$.querySelectorAll(
+						'.lfr-balloon-editor-insert-button'
+					);
+
+					for (const button of insertButtons) {
+						button.classList.add('hide');
+					}
+				}
+			});
 		},
 
 		requires: [

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/insertbutton/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/insertbutton/plugin.js
@@ -254,7 +254,7 @@
 				editor.liferayToolbars.insertToolbar?.hide();
 			};
 
-			const onFocusLoss = () => {
+			const onBlur = () => {
 				requestAnimationFrame(() => {
 					if (this._focusedEditorName !== editor.name) {
 						hide();
@@ -265,8 +265,8 @@
 			const eventListeners = [];
 
 			eventListeners.push(
-				button.on('blur', onFocusLoss),
-				editor.on('blur', onFocusLoss),
+				button.on('blur', onBlur),
+				editor.on('blur', onBlur),
 
 				button.on('click', (event) => {
 					event.cancel();

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/insertbutton/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/insertbutton/plugin.js
@@ -289,17 +289,6 @@
 
 				editor.on('change', hide),
 
-				CKEDITOR.document.getWindow().on('click', (event) => {
-					const target = event.data.getTarget();
-
-					if (
-						!target.$.closest('.lfr-balloon-editor') &&
-						!target.equals(button)
-					) {
-						hide();
-					}
-				}),
-
 				editor.on('contentDom', () => {
 					const body = editor.document.getBody();
 


### PR DESCRIPTION
### References

- [LPS-146070 Cannot add link in Blogs coverImageCaptionEditor](https://issues.liferay.com/browse/LPS-146070)

### What is the goal?

The root cause of the bug is that we were not properly supporting multiple CKEditor instances in the `linktoolbar` plugin. In this PR, we are fixing this.

In an addition commit, we are generalizing the logic of closing toolbars and insert button on click outside of editor areas. This is now applied to all BE toolbars. A notable change here is the addition of `'.liferay-editable'` as an excluded area. Without this, there is a race condition with  `_focusedEditorName` logic in two plugins. With the change in this PR, the case of moving focus from one editor to another is left exclusively to the `_focusedEditorName` logic.

### What does it look like?
#### Before PR
![before](https://user-images.githubusercontent.com/5435511/153192811-b1de9321-6e18-4497-95ce-61d94e7d35e2.gif)
#### After PR
![after](https://user-images.githubusercontent.com/5435511/153192825-ba9a67a7-aaf8-4e4b-9522-13150c470b44.gif)

### How to replicate

See steps to reproduce in [LPS-146070](https://issues.liferay.com/browse/LPS-146070)