### PR TITLE
LPS-146407 Icons in balloon editor toolbar for table don't work in Blogs contentEditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -85,16 +85,6 @@ const BalloonEditor = ({
 					});
 				}
 
-				if (editorConfig.toolbarTable) {
-					balloonToolbars.create({
-						buttons: editorConfig.toolbarTable,
-						cssSelector: 'td',
-						priority:
-							window.CKEDITOR.plugins.balloontoolbar.PRIORITY
-								.HIGH,
-					});
-				}
-
 				if (editorConfig.toolbarVideo) {
 					balloonToolbars.create({
 						buttons: editorConfig.toolbarVideo,


### PR DESCRIPTION
### References

- [LPS-146407 Icons in balloon editor toolbar for table don't work in Blogs contentEditor](https://issues.liferay.com/browse/LPS-146407)
- [LPS-139334 Text Edition Toolbar does not appear when highlighting a text in a table row](https://issues.liferay.com/browse/LPS-139334)

### What is the goal?

This bug happened because a part of code added in LPS-139334 was reverted by accident. Our implementation of toolbars in a table cell is different now, and clashing with out-of-the-box implementation if enabled.

In this PR, we are restoring the solution of LPS-139334, by again removing the default implementation. This fixes the ticket, and also restores behavior of opening text toolbar on text selection (see gifs).

### What does it look like?
#### Before PR
![before](https://user-images.githubusercontent.com/5435511/153429842-f7ee6006-5698-4629-b4b3-119b235fb2c8.gif)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/153429855-d6fe932c-ae38-4f24-9a4e-ef18b1d5fff2.gif)

### How to replicate

See steps to reproduce in  [LPS-146407](https://issues.liferay.com/browse/LPS-146407)
