### PR TITLE
LRQA-66242 | Take a screenshot of all the rendered pages in each tab of clay sample portlet.

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClaySmoke.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClaySmoke.testcase
@@ -45,11 +45,13 @@ definition {
 	@description = "Check if each nav section of clay sample portlet looks normal from screenshot"
 	@priority = "3"
 	test CanRenderUI {
-        task("Change tabs and take a screenshot") {
-            for(var tabs : list "Alerts,Badges,Buttons,Cards,Dropdowns,Form Elements,Icons,Labels,Links,Management Toolbars,Navigation Bars,Pagination Bars,Progress Bars,Stickers") {
-                Navigator.gotoNavTab(navTab = "${tabs}");
-                takeScreenshot();
-            }
-        }
+		task ("Change tabs and take a screenshot") {
+			for (var tabs : list "Alerts,Badges,Buttons,Cards,Dropdowns,Form Elements,Icons,Labels,Links,Management Toolbars,Navigation Bars,Pagination Bars,Progress Bars,Stickers") {
+				Navigator.gotoNavTab(navTab = "${tabs}");
+
+				takeScreenshot();
+			}
+		}
 	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClaySmoke.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClaySmoke.testcase
@@ -1,0 +1,55 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-taglib-clay-sample-web";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Clay";
+	property testray.main.component.name = "User Interface";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		JSONLayout.addPublicLayout(
+			groupName = "Guest",
+			layoutName = "Clay Sample Test Page");
+
+		JSONLayout.updateLayoutTemplateOfPublicLayout(
+			groupName = "Guest",
+			layoutName = "Clay Sample Test Page",
+			layoutTemplate = "1 Column");
+
+		JSONLayout.addWidgetToPublicLayout(
+			groupName = "Guest",
+			layoutName = "Clay Sample Test Page",
+			widgetName = "Clay Sample");
+
+		Navigator.gotoPage(pageName = "Clay Sample Test Page");
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		}
+	}
+
+	@description = "Check if each nav section of clay sample portlet looks normal from screenshot"
+	@priority = "3"
+	test CanRenderUI {
+        task("Change tabs and take a screenshot") {
+            for(var tabs : list "Alerts,Badges,Buttons,Cards,Dropdowns,Form Elements,Icons,Labels,Links,Management Toolbars,Navigation Bars,Pagination Bars,Progress Bars,Stickers") {
+                Navigator.gotoNavTab(navTab = "${tabs}");
+                takeScreenshot();
+            }
+        }
+	}
+}


### PR DESCRIPTION
Background
Create automation tests for take a screenshot of all the rendered pages in each tab of clay sample portlet.

Test Plan
Given: clay sample portlet deployed on page
When: navigate to each page
And when: viewing each screenshot
Then: each nav section of clay sample portlet looks normal

JIRA Ticket:
[LRQA-66242](https://issues.liferay.com/browse/LRQA-66242)
