### PR TITLE
LPS-146407 Bring table headers functionallity to BalloonEditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/toolbarbuttons/plugin.js
@@ -13,14 +13,246 @@
  */
 
 (function () {
+	const HEADING_BOTH = 'Both';
+	const HEADING_COL = 'Column';
+	const HEADING_NONE = 'None';
+	const HEADING_ROW = 'Row';
+
 	const pluginName = 'toolbarbuttons';
 
 	if (CKEDITOR.plugins.get(pluginName)) {
 		return;
 	}
 
+	/**
+	 * Creates a new CKEDITOR.dom.element using the passed tag name.
+	 *
+	 * @instance
+	 * @memberof CKEDITOR.Table
+	 * @protected
+	 * @method _createElement
+	 * @param {String} name The tag name from which an element should be created
+	 * @param {Object} editor The CKEditor instance.
+	 * @return {CKEDITOR.dom.element} Instance of CKEDITOR DOM element class
+	 */
+	function _createElement(name, editor) {
+		return new CKEDITOR.dom.element(name, editor.document);
+	}
+
+	/**
+	 * Returns which heading style is set for the given table.
+	 *
+	 * @instance
+	 * @memberof CKEDITOR.Table
+	 * @method getHeading
+	 * @param {CKEDITOR.dom.element} table The table to gather the heading from. If null, it will be retrieved from the current selection.
+	 * @param {Object} editor The CKEditor instance.
+	 * @return {String} The heading of the table. Expected values are `CKEDITOR.Table.NONE`, `CKEDITOR.Table.ROW`, `CKEDITOR.Table.COL` and `CKEDITOR.Table.BOTH`.
+	 */
+	function getHeading(table, editor) {
+		table = table || getFromSelection(editor);
+
+		if (!table) {
+			return null;
+		}
+
+		const rowHeadingSettings = table.$.tHead !== null;
+
+		let colHeadingSettings = true;
+
+		// Check if all of the first cells in every row are TH
+
+		for (let row = 0; row < table.$.rows.length; row++) {
+
+			// If just one cell isn't a TH then it isn't a header column
+
+			const cell = table.$.rows[row].cells[0];
+
+			if (cell && cell.nodeName.toLowerCase() !== 'th') {
+				colHeadingSettings = false;
+				break;
+			}
+		}
+
+		let headingSettings = HEADING_NONE;
+
+		if (rowHeadingSettings) {
+			headingSettings = HEADING_ROW;
+		}
+
+		if (colHeadingSettings) {
+			headingSettings =
+				headingSettings === HEADING_ROW ? HEADING_BOTH : HEADING_COL;
+		}
+
+		return headingSettings;
+	}
+
+	/**
+	 * Retrieves a table from the current selection.
+	 *
+	 * @instance
+	 * @memberof CKEDITOR.Table
+	 * @method getFromSelection
+	 * @param {Object} editor The CKEditor instance.
+	 * @return {CKEDITOR.dom.element} The retrieved table or null if not found.
+	 */
+	function getFromSelection(editor) {
+		let table;
+		const selection = editor.getSelection();
+		const selected = selection.getSelectedElement();
+
+		if (selected && selected.is('table')) {
+			table = selected;
+		}
+		else {
+			const ranges = selection.getRanges();
+
+			if (ranges.length > 0) {
+
+				// Webkit could report the following range on cell selection (#4948):
+				// <table><tr><td>[&nbsp;</td></tr></table>]
+
+				/* istanbul ignore else */
+				if (CKEDITOR.env.webkit) {
+					ranges[0].shrink(CKEDITOR.NODE_ELEMENT);
+				}
+
+				table = editor
+					.elementPath(ranges[0].getCommonAncestor(true))
+					.contains('table', 1);
+			}
+		}
+
+		return table;
+	}
+
+	function setHeading(table, heading, editor) {
+		table = table || getFromSelection(editor);
+
+		let i;
+		let newCell;
+		let tableHead;
+		const tableBody = table.getElementsByTag('tbody').getItem(0);
+
+		let tableHeading = getHeading(table, editor);
+		const hadColHeading =
+			tableHeading === HEADING_COL || tableHeading === HEADING_BOTH;
+
+		const needColHeading =
+			heading === HEADING_COL || heading === HEADING_BOTH;
+		const needRowHeading =
+			heading === HEADING_ROW || heading === HEADING_BOTH;
+
+		// If we need row heading and don't have a <thead> element yet, move the
+		// first row of the table to the head and convert the nodes to <th> ones.
+
+		if (!table.$.tHead && needRowHeading) {
+			const tableFirstRow = tableBody.getElementsByTag('tr').getItem(0);
+			const tableFirstRowChildCount = tableFirstRow.getChildCount();
+
+			// Change TD to TH:
+
+			for (i = 0; i < tableFirstRowChildCount; i++) {
+				const cell = tableFirstRow.getChild(i);
+
+				// Skip bookmark nodes. (#6155)
+
+				if (
+					cell.type === CKEDITOR.NODE_ELEMENT &&
+					!cell.data('cke-bookmark')
+				) {
+					cell.renameNode('th');
+					cell.setAttribute('scope', 'col');
+				}
+			}
+
+			tableHead = _createElement(table.$.createTHead(), editor);
+			tableHead.append(tableFirstRow.remove());
+		}
+
+		// If we don't need row heading and we have a <thead> element, move the
+		// row out of there and into the <tbody> element.
+
+		if (table.$.tHead !== null && !needRowHeading) {
+
+			// Move the row out of the THead and put it in the TBody:
+
+			tableHead = _createElement(table.$.tHead, editor);
+
+			const previousFirstRow = tableBody.getFirst();
+
+			while (tableHead.getChildCount() > 0) {
+				const newFirstRow = tableHead.getFirst();
+				const newFirstRowChildCount = newFirstRow.getChildCount();
+
+				for (i = 0; i < newFirstRowChildCount; i++) {
+					newCell = newFirstRow.getChild(i);
+
+					if (newCell.type === CKEDITOR.NODE_ELEMENT) {
+						newCell.renameNode('td');
+						newCell.removeAttribute('scope');
+					}
+				}
+
+				newFirstRow.insertBefore(previousFirstRow);
+			}
+
+			tableHead.remove();
+		}
+
+		tableHeading = getHeading(table, editor);
+		const hasColHeading =
+			tableHeading === HEADING_COL || tableHeading === HEADING_BOTH;
+
+		// If we need column heading and the table doesn't have it, convert every first cell in
+		// every row into a `<th scope="row">` element.
+
+		if (!hasColHeading && needColHeading) {
+			for (i = 0; i < table.$.rows.length; i++) {
+				if (table.$.rows[i].cells[0].nodeName.toLowerCase() !== 'th') {
+					newCell = new CKEDITOR.dom.element(
+						table.$.rows[i].cells[0]
+					);
+					newCell.renameNode('th');
+					newCell.setAttribute('scope', 'row');
+				}
+			}
+		}
+
+		// If we don't need column heading but the table has it, convert every first cell in every
+		// row back into a `<td>` element.
+
+		if (hadColHeading && !needColHeading) {
+			for (i = 0; i < table.$.rows.length; i++) {
+				const row = new CKEDITOR.dom.element(table.$.rows[i]);
+
+				if (row.getParent().getName() === 'tbody') {
+					newCell = new CKEDITOR.dom.element(row.$.cells[0]);
+					newCell.renameNode('td');
+					newCell.removeAttribute('scope');
+				}
+			}
+		}
+	}
+
 	CKEDITOR.plugins.add(pluginName, {
 		init(editor) {
+			const headingCommands = [
+				HEADING_NONE,
+				HEADING_ROW,
+				HEADING_COL,
+				HEADING_BOTH,
+			];
+
+			headingCommands.forEach((heading) => {
+				editor.addCommand('tableHeading' + heading, {
+					exec(_editor) {
+						setHeading(null, heading, editor);
+					},
+				});
+			});
+
 			editor.ui.addBalloonToolbarButton('ImageAlignLeft', {
 				command: 'justifyleft',
 				icon: 'align-image-left',
@@ -50,21 +282,67 @@
 			});
 
 			editor.ui.addRichCombo('TableHeaders', {
+				_headersLabels: {
+					[HEADING_BOTH]: `${editor.lang.table.headers}: ${editor.lang.table.headersBoth}`,
+					[HEADING_COL]: `${editor.lang.table.headers}: ${editor.lang.table.headersColumn}`,
+					[HEADING_NONE]: `${editor.lang.table.headers}: ${editor.lang.table.headersNone}`,
+					[HEADING_ROW]: `${editor.lang.table.headers}: ${editor.lang.table.headersRow}`,
+				},
+
+				_setHeading(heading, editor) {
+					editor.execCommand(`tableHeading${heading}`);
+
+					this.setValue(heading, this._headersLabels[heading]);
+				},
+
 				init() {
-					const headersPrefix = editor.lang.table.headers;
+					this.add(
+						HEADING_NONE,
+						this._headersLabels[HEADING_NONE],
+						this._headersLabels[HEADING_NONE]
+					);
+					this.add(
+						HEADING_ROW,
+						this._headersLabels[HEADING_ROW],
+						this._headersLabels[HEADING_ROW]
+					);
+					this.add(
+						HEADING_COL,
+						this._headersLabels[HEADING_COL],
+						this._headersLabels[HEADING_COL]
+					);
+					this.add(
+						HEADING_BOTH,
+						this._headersLabels[HEADING_BOTH],
+						this._headersLabels[HEADING_BOTH]
+					);
 
-					const headersNone = `${headersPrefix}: ${editor.lang.table.headersNone}`;
-					const headersRow = `${headersPrefix}: ${editor.lang.table.headersRow}`;
-					const headersColumn = `${headersPrefix}: ${editor.lang.table.headersColumn}`;
-					const headersBoth = `${headersPrefix}: ${editor.lang.table.headersBoth}`;
+					const currentHeading = getHeading(null, editor);
 
-					this.add(headersNone, headersNone, headersNone);
-					this.add(headersRow, headersRow, headersRow);
-					this.add(headersColumn, headersColumn, headersColumn);
-					this.add(headersBoth, headersBoth, headersBoth);
+					this._setHeading(currentHeading, editor);
 				},
 
 				label: editor.lang.table.headers,
+
+				onClick(selectedHeading) {
+					this._setHeading(selectedHeading, editor);
+				},
+
+				onRender() {
+					const currentHeading = getHeading(null, editor);
+
+					this._setHeading(currentHeading, editor);
+
+					editor.on(
+						'selectionChange',
+						function (_) {
+							const currentHeading = getHeading(null, editor);
+
+							this._setHeading(currentHeading, editor);
+						},
+						this
+					);
+				},
 
 				panel: {
 					attributes: {'aria-label': editor.lang.table.title},


### PR DESCRIPTION
👇🏼 👇🏼 👇🏼 👇🏼 👇🏼 👇🏼 👇🏼 
***Warning:* Yes, I left some comments in order to see my tries and I'll remove them before sending an "official" revision of this PR.**
👆🏼 👆🏼 👆🏼 👆🏼 👆🏼 👆🏼 👆🏼 

> **It requires: https://github.com/liferay/liferay-ckeditor/pull/195**

# What needs to be done?

- [x] **Solve `this.add` issue**

~~In an ideal world, this.add function receives three arguments:~~

~~1. `value`: to be like a key to match when receveing the onClick callback~~
~~2. `text`: the text to be added to the options~~
~~3. `html`: I still not knowing but we should set it with the same value as `text`. ~~

~~But on our side, the selected test will be the value even when calling `this.setValue` or `this.select(myCallback)`. I decided to transform our value/key the same of our messages. So, we could have appropriated selected text but it is very dirty :/~~

~~I tried all possible combinations of `this.add` but It still not working. I decided to force the value but it was introducing other issues that I couldn't understand.~~

~~**I would have help here.** /cc @markocikos @julien ~~

Fixed! the usages of `this.setValue` are partially wrong:

I could pass two args to this.setValue

First: value(our value, in this case can be Both,Column,Row whatever

Second: label(where we can pass our label)

So, we're now passing the correct value(Row,Column,Both) in this first argument and we're passing the translated label as the second argument and it worked!

- [x] **When adding new rows using other buttons, the selection isn't updated**

Apparently `selectionChange` is not called when we add more rows. It needs to be verified

# Current status

https://user-images.githubusercontent.com/7663513/153681219-7bff95d6-84e5-4168-bff9-11075e6dd9b6.mov


