### PR TITLE
LPS-147060 Update blade command to generate rest modules templates.

### DIFF
--- a/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-api/build.gradle
+++ b/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-api/build.gradle
@@ -1,9 +1,10 @@
 dependencies {
-	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.12.4"
+#if (${liferayVersion.startsWith("7.0")} || ${liferayVersion.startsWith("7.1")} || ${liferayVersion.startsWith("7.2")})
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.10.3"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.function"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.string"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.odata.api"
-	compileOnly group: "com.liferay", name: "com.liferay.portal.vulcan.api", version: "@com.liferay.portal.vulcan.api.version@"
+	compileOnly group: "com.liferay", name: "com.liferay.portal.vulcan.api"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
 	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3.2"
@@ -20,5 +21,8 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 #else
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning"
+#end
+#else
+	compileOnly group: "com.liferay.portal", name: "release.${product}.api"
 #end
 }

--- a/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-impl/build.gradle
+++ b/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-impl/build.gradle
@@ -1,11 +1,12 @@
 dependencies {
 	compile project("${apiPath}")
 
-	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.12.4"
+#if (${liferayVersion.startsWith("7.0")} || ${liferayVersion.startsWith("7.1")} || ${liferayVersion.startsWith("7.2")})
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.10.3"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.function"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.string"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.odata.api"
-	compileOnly group: "com.liferay", name: "com.liferay.portal.vulcan.api", version: "@com.liferay.portal.vulcan.api.version@"
+	compileOnly group: "com.liferay", name: "com.liferay.portal.vulcan.api"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel"
 	compileOnly group: "commons-collections", name: "commons-collections"
@@ -24,7 +25,10 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations"
 	compileOnly group: "org.osgi", name: "org.osgi.core"
 
-	restBuilder group: "com.liferay", name: "com.liferay.portal.tools.rest.builder", version: "@com.liferay.portal.tools.rest.builder.version@"
+	restBuilder group: "com.liferay", name: "com.liferay.portal.tools.rest.builder"
+#else
+	compileOnly group: "com.liferay.portal", name: "release.${product}.api"
+#end
 }
 
 group = "${package}"

--- a/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/build.gradle
+++ b/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/build.gradle
@@ -1,5 +1,12 @@
 subprojects {
 	configurations.all {
-		resolutionStrategy.force 'com.liferay:com.liferay.portal.vulcan.api:@com.liferay.portal.vulcan.api.version@'
+	#if (${liferayVersion.startsWith("7.3")})
+	resolutionStrategy.force 'com.liferay:com.liferay.portal.vulcan.api:7.19.2'
+	#elseif(${liferayVersion.startsWith("7.2")} || ${liferayVersion.startsWith("7.1")})
+	resolutionStrategy.force 'com.liferay:com.liferay.portal.vulcan.api:6.9.0'
+	resolutionStrategy.force 'com.liferay:com.liferay.portal.tools.rest.builder:1.0.93'
+	#else
+	resolutionStrategy.force 'com.liferay:com.liferay.portal.vulcan.api:@com.liferay.portal.vulcan.api.version@'
+	#end
 	}
 }


### PR DESCRIPTION
Related ticket -> [LPS-147060](https://issues.liferay.com/browse/LPS-147060)
____
This PR updates the rest modules generated by `blade`. For versions `7.4` and `7.3`, it uses the bom dependency `release.{product}.api`.
It is not using that dependency in the previous versions due to some problems finding it (sometimes the version requested is not released yet), making it less stable.
Also, take care of the community versions because it is possible that some dependencies are not updated due to it being updated in some FP/SP but not for the CE.